### PR TITLE
Stop using UncheckedKey containers in WebCore/platform

### DIFF
--- a/Source/WebCore/platform/DragData.h
+++ b/Source/WebCore/platform/DragData.h
@@ -68,7 +68,7 @@ enum class DragApplicationFlags : uint8_t {
 class PasteboardContext;
 
 #if PLATFORM(WIN)
-typedef UncheckedKeyHashMap<unsigned, Vector<String>> DragDataMap;
+using DragDataMap = HashMap<unsigned, Vector<String>>;
 #endif
 
 class DragData {

--- a/Source/WebCore/platform/LegacySchemeRegistry.h
+++ b/Source/WebCore/platform/LegacySchemeRegistry.h
@@ -32,8 +32,8 @@
 
 namespace WebCore {
 
-// FIXME: Make UncheckedKeyHashSet<String>::contains(StringView) work and use StringViews here.
-using URLSchemesMap = UncheckedKeyHashSet<String, ASCIICaseInsensitiveHash>;
+// FIXME: Make HashSet<String>::contains(StringView) work and use StringViews here.
+using URLSchemesMap = HashSet<String, ASCIICaseInsensitiveHash>;
 
 class LegacySchemeRegistry {
 public:

--- a/Source/WebCore/platform/Length.cpp
+++ b/Source/WebCore/platform/Length.cpp
@@ -146,7 +146,7 @@ private:
     };
 
     unsigned m_nextAvailableHandle;
-    UncheckedKeyHashMap<unsigned, Entry> m_map;
+    HashMap<unsigned, Entry> m_map;
 };
 
 inline CalculationValueMap::Entry::Entry(Ref<CalculationValue>&& value)

--- a/Source/WebCore/platform/MIMETypeRegistry.cpp
+++ b/Source/WebCore/platform/MIMETypeRegistry.cpp
@@ -277,11 +277,11 @@ FixedVector<ASCIILiteral> MIMETypeRegistry::unsupportedTextMIMETypes()
     return makeFixedVector(unsupportedTextMIMETypeArray);
 }
 
-static const UncheckedKeyHashMap<String, Vector<String>, ASCIICaseInsensitiveHash>& commonMimeTypesMap()
+static const HashMap<String, Vector<String>, ASCIICaseInsensitiveHash>& commonMimeTypesMap()
 {
     ASSERT(isMainThread());
-    static NeverDestroyed<UncheckedKeyHashMap<String, Vector<String>, ASCIICaseInsensitiveHash>> mimeTypesMap = [] {
-        UncheckedKeyHashMap<String, Vector<String>, ASCIICaseInsensitiveHash> map;
+    static NeverDestroyed<HashMap<String, Vector<String>, ASCIICaseInsensitiveHash>> mimeTypesMap = [] {
+        HashMap<String, Vector<String>, ASCIICaseInsensitiveHash> map;
         // A table of common media MIME types and file extensions used when a platform's
         // specific MIME type lookup doesn't have a match for a media file extension.
         static constexpr TypeExtensionPair commonMediaTypes[] = {

--- a/Source/WebCore/platform/PasteboardCustomData.cpp
+++ b/Source/WebCore/platform/PasteboardCustomData.cpp
@@ -115,7 +115,7 @@ PasteboardCustomData PasteboardCustomData::fromPersistenceDecoder(WTF::Persisten
         return { };
     result.m_origin = WTFMove(*origin);
 
-    std::optional<UncheckedKeyHashMap<String, String>> sameOriginCustomStringData;
+    std::optional<HashMap<String, String>> sameOriginCustomStringData;
     decoder >> sameOriginCustomStringData;
     if (!sameOriginCustomStringData)
         return { };
@@ -201,9 +201,9 @@ bool PasteboardCustomData::hasSameOriginCustomData() const
     });
 }
 
-UncheckedKeyHashMap<String, String> PasteboardCustomData::sameOriginCustomStringData() const
+HashMap<String, String> PasteboardCustomData::sameOriginCustomStringData() const
 {
-    UncheckedKeyHashMap<String, String> customData;
+    HashMap<String, String> customData;
     for (auto& entry : m_data)
         customData.set(entry.type, entry.customData);
     return customData;

--- a/Source/WebCore/platform/PasteboardCustomData.h
+++ b/Source/WebCore/platform/PasteboardCustomData.h
@@ -98,7 +98,7 @@ public:
     const Vector<Entry>& data() const { return m_data; }
 
 private:
-    UncheckedKeyHashMap<String, String> sameOriginCustomStringData() const;
+    HashMap<String, String> sameOriginCustomStringData() const;
     Entry& addOrMoveEntryToEnd(const String&);
 
     String m_origin;

--- a/Source/WebCore/platform/PreviewConverter.cpp
+++ b/Source/WebCore/platform/PreviewConverter.cpp
@@ -48,7 +48,7 @@ bool PreviewConverter::supportsMIMEType(const String& mimeType)
     if (equalLettersIgnoringASCIICase(mimeType, "text/html"_s) || equalLettersIgnoringASCIICase(mimeType, "text/plain"_s))
         return false;
 
-    static NeverDestroyed<UncheckedKeyHashSet<String, ASCIICaseInsensitiveHash>> supportedMIMETypes = platformSupportedMIMETypes();
+    static NeverDestroyed<HashSet<String, ASCIICaseInsensitiveHash>> supportedMIMETypes = platformSupportedMIMETypes();
     return supportedMIMETypes->contains(mimeType);
 }
 

--- a/Source/WebCore/platform/PreviewConverter.h
+++ b/Source/WebCore/platform/PreviewConverter.h
@@ -95,7 +95,7 @@ public:
     WEBCORE_EXPORT static void setPasswordForTesting(const String&);
 
 private:
-    static UncheckedKeyHashSet<String, ASCIICaseInsensitiveHash> platformSupportedMIMETypes();
+    static HashSet<String, ASCIICaseInsensitiveHash> platformSupportedMIMETypes();
 
     PreviewConverter(const ResourceResponse&, PreviewConverterProvider&);
 

--- a/Source/WebCore/platform/PublicSuffixStore.h
+++ b/Source/WebCore/platform/PublicSuffixStore.h
@@ -58,10 +58,10 @@ private:
     String platformTopPrivatelyControlledDomain(StringView host) const;
 
     mutable Lock m_HostTopPrivatelyControlledDomainCacheLock;
-    mutable UncheckedKeyHashMap<String, String, ASCIICaseInsensitiveHash> m_hostTopPrivatelyControlledDomainCache WTF_GUARDED_BY_LOCK(m_HostTopPrivatelyControlledDomainCacheLock);
+    mutable HashMap<String, String, ASCIICaseInsensitiveHash> m_hostTopPrivatelyControlledDomainCache WTF_GUARDED_BY_LOCK(m_HostTopPrivatelyControlledDomainCacheLock);
 #if PLATFORM(COCOA)
     mutable Lock m_publicSuffixCacheLock;
-    std::optional<UncheckedKeyHashSet<PublicSuffix>> m_publicSuffixCache WTF_GUARDED_BY_LOCK(m_publicSuffixCacheLock);
+    std::optional<HashSet<PublicSuffix>> m_publicSuffixCache WTF_GUARDED_BY_LOCK(m_publicSuffixCacheLock);
 #endif
 };
 

--- a/Source/WebCore/platform/RemoteCommandListener.h
+++ b/Source/WebCore/platform/RemoteCommandListener.h
@@ -50,7 +50,7 @@ public:
     void addSupportedCommand(PlatformMediaSession::RemoteControlCommandType);
     void removeSupportedCommand(PlatformMediaSession::RemoteControlCommandType);
 
-    using RemoteCommandsSet = UncheckedKeyHashSet<PlatformMediaSession::RemoteControlCommandType, IntHash<PlatformMediaSession::RemoteControlCommandType>, WTF::StrongEnumHashTraits<PlatformMediaSession::RemoteControlCommandType>>;
+    using RemoteCommandsSet = HashSet<PlatformMediaSession::RemoteControlCommandType, IntHash<PlatformMediaSession::RemoteControlCommandType>, WTF::StrongEnumHashTraits<PlatformMediaSession::RemoteControlCommandType>>;
     void setSupportedCommands(const RemoteCommandsSet&);
     const RemoteCommandsSet& supportedCommands() const;
 

--- a/Source/WebCore/platform/ScrollSnapAnimatorState.cpp
+++ b/Source/WebCore/platform/ScrollSnapAnimatorState.cpp
@@ -127,9 +127,9 @@ Vector<SnapOffset<LayoutUnit>> ScrollSnapAnimatorState::currentlySnappedOffsetsF
     return currentlySnappedOffsets;
 }
 
-UncheckedKeyHashSet<ElementIdentifier> ScrollSnapAnimatorState::currentlySnappedBoxes(const Vector<SnapOffset<LayoutUnit>>& horizontalOffsets, const Vector<SnapOffset<LayoutUnit>>& verticalOffsets) const
+HashSet<ElementIdentifier> ScrollSnapAnimatorState::currentlySnappedBoxes(const Vector<SnapOffset<LayoutUnit>>& horizontalOffsets, const Vector<SnapOffset<LayoutUnit>>& verticalOffsets) const
 {
-    UncheckedKeyHashSet<ElementIdentifier> snappedBoxIDs;
+    HashSet<ElementIdentifier> snappedBoxIDs;
         
     for (auto offset : horizontalOffsets) {
         if (!offset.snapTargetID)
@@ -163,7 +163,7 @@ void ScrollSnapAnimatorState::updateCurrentlySnappedBoxes()
     m_currentlySnappedBoxes = currentlySnappedBoxes(horizontalOffsets, verticalOffsets);
 }
 
-static ElementIdentifier chooseBoxToResnapTo(const UncheckedKeyHashSet<ElementIdentifier>& snappedBoxes, const Vector<SnapOffset<LayoutUnit>>& horizontalOffsets, const Vector<SnapOffset<LayoutUnit>>& verticalOffsets)
+static ElementIdentifier chooseBoxToResnapTo(const HashSet<ElementIdentifier>& snappedBoxes, const Vector<SnapOffset<LayoutUnit>>& horizontalOffsets, const Vector<SnapOffset<LayoutUnit>>& verticalOffsets)
 {
     ASSERT(snappedBoxes.size());
 

--- a/Source/WebCore/platform/ScrollSnapAnimatorState.h
+++ b/Source/WebCore/platform/ScrollSnapAnimatorState.h
@@ -101,7 +101,7 @@ private:
     bool preserveCurrentTargetForAxis(ScrollEventAxis, ElementIdentifier);
 
     Vector<SnapOffset<LayoutUnit>> currentlySnappedOffsetsForAxis(ScrollEventAxis) const;
-    UncheckedKeyHashSet<ElementIdentifier> currentlySnappedBoxes(const Vector<SnapOffset<LayoutUnit>>& horizontalOffsets, const Vector<SnapOffset<LayoutUnit>>& verticalOffsets) const;
+    HashSet<ElementIdentifier> currentlySnappedBoxes(const Vector<SnapOffset<LayoutUnit>>& horizontalOffsets, const Vector<SnapOffset<LayoutUnit>>& verticalOffsets) const;
 
     bool setNearestScrollSnapIndexForAxisAndOffsetInternal(ScrollEventAxis, ScrollOffset, const ScrollExtents&, float pageScale);
     void updateCurrentlySnappedBoxes();
@@ -122,7 +122,7 @@ private:
     
     std::optional<unsigned> m_activeSnapIndexX;
     std::optional<unsigned> m_activeSnapIndexY;
-    UncheckedKeyHashSet<ElementIdentifier> m_currentlySnappedBoxes;
+    HashSet<ElementIdentifier> m_currentlySnappedBoxes;
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, const ScrollSnapAnimatorState&);

--- a/Source/WebCore/platform/ScrollView.h
+++ b/Source/WebCore/platform/ScrollView.h
@@ -103,7 +103,7 @@ public:
     virtual IntRect windowClipRect() const = 0;
 
     // Functions for child manipulation and inspection.
-    const UncheckedKeyHashSet<Ref<Widget>>& children() const { return m_children; }
+    const HashSet<Ref<Widget>>& children() const { return m_children; }
     WEBCORE_EXPORT virtual void addChild(Widget&);
     WEBCORE_EXPORT virtual void removeChild(Widget&);
 
@@ -522,7 +522,7 @@ private:
             didFinishProhibitingScrollingWhenChangingContentSize();
     }
 
-    UncheckedKeyHashSet<Ref<Widget>> m_children;
+    HashSet<Ref<Widget>> m_children;
 
     RefPtr<Scrollbar> m_horizontalScrollbar;
     RefPtr<Scrollbar> m_verticalScrollbar;

--- a/Source/WebCore/platform/SharedStringHash.h
+++ b/Source/WebCore/platform/SharedStringHash.h
@@ -33,7 +33,7 @@ namespace WebCore {
 
 using SharedStringHash = uint32_t;
 
-// This is a hash value, but it can be used as a key in UncheckedKeyHashMap. So, we need to avoid producing deleted-value in UncheckedKeyHashMap, which is -1.
+// This is a hash value, but it can be used as a key in HashMap. So, we need to avoid producing deleted-value in HashMap, which is -1.
 struct SharedStringHashHash {
     static unsigned hash(SharedStringHash key) { return static_cast<unsigned>(key); }
     static bool equal(SharedStringHash a, SharedStringHash b) { return a == b; }

--- a/Source/WebCore/platform/Supplementable.h
+++ b/Source/WebCore/platform/Supplementable.h
@@ -116,7 +116,7 @@ protected:
 #endif
 
 private:
-    using SupplementMap = UncheckedKeyHashMap<ASCIILiteral, std::unique_ptr<Supplement<T>>>;
+    using SupplementMap = HashMap<ASCIILiteral, std::unique_ptr<Supplement<T>>>;
     SupplementMap m_supplements;
 #if ASSERT_ENABLED
     const Ref<Thread> m_thread { Thread::currentSingleton() };

--- a/Source/WebCore/platform/audio/HRTFDatabaseLoader.cpp
+++ b/Source/WebCore/platform/audio/HRTFDatabaseLoader.cpp
@@ -40,9 +40,9 @@
 namespace WebCore {
 
 // Keeps track of loaders on a per-sample-rate basis.
-static UncheckedKeyHashMap<double, HRTFDatabaseLoader*>& loaderMap()
+static HashMap<double, HRTFDatabaseLoader*>& loaderMap()
 {
-    static NeverDestroyed<UncheckedKeyHashMap<double, HRTFDatabaseLoader*>> loaderMap;
+    static NeverDestroyed<HashMap<double, HRTFDatabaseLoader*>> loaderMap;
     return loaderMap;
 }
 

--- a/Source/WebCore/platform/audio/HRTFElevation.cpp
+++ b/Source/WebCore/platform/audio/HRTFElevation.cpp
@@ -60,9 +60,9 @@ constexpr size_t ResponseFrameSize = 256;
 constexpr float ResponseSampleRate = 44100;
 
 static Lock audioBusMapLock;
-static UncheckedKeyHashMap<String, RefPtr<AudioBus>>& concatenatedImpulseResponsesMap() WTF_REQUIRES_LOCK(audioBusMapLock)
+static HashMap<String, RefPtr<AudioBus>>& concatenatedImpulseResponsesMap() WTF_REQUIRES_LOCK(audioBusMapLock)
 {
-    static NeverDestroyed<UncheckedKeyHashMap<String, RefPtr<AudioBus>>> audioBusMap;
+    static NeverDestroyed<HashMap<String, RefPtr<AudioBus>>> audioBusMap;
     return audioBusMap;
 }
 

--- a/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h
+++ b/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h
@@ -104,7 +104,7 @@ private:
     Markable<MediaUniqueIdentifier> m_lastUpdatedNowPlayingInfoUniqueIdentifier;
 
     const std::unique_ptr<NowPlayingManager> m_nowPlayingManager;
-    UncheckedKeyHashMap<MediaSessionIdentifier, std::unique_ptr<MediaSessionGLib>> m_sessions;
+    HashMap<MediaSessionIdentifier, std::unique_ptr<MediaSessionGLib>> m_sessions;
 
     bool m_dbusNotificationsEnabled { true };
 };

--- a/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
@@ -77,7 +77,7 @@ private:
     std::span<const uint8_t> m_data;
     float m_sampleRate { 0 };
     int m_channels { 0 };
-    UncheckedKeyHashMap<int, GRefPtr<GstBufferList>> m_buffers;
+    HashMap<int, GRefPtr<GstBufferList>> m_buffers;
     GRefPtr<GstElement> m_pipeline;
     std::optional<int> m_firstChannelType;
     unsigned m_channelSize { 0 };

--- a/Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.h
+++ b/Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.h
@@ -84,7 +84,7 @@ private:
     GRefPtr<GstElement> m_audioSinkBin;
     WeakPtr<AudioSourceProviderClient> m_client;
     int m_deinterleaveSourcePads { 0 };
-    UncheckedKeyHashMap<int, GRefPtr<GstAdapter>> m_adapters WTF_GUARDED_BY_LOCK(m_adapterLock);
+    HashMap<int, GRefPtr<GstAdapter>> m_adapters WTF_GUARDED_BY_LOCK(m_adapterLock);
     unsigned long m_deinterleavePadAddedHandlerId { 0 };
     unsigned long m_deinterleaveNoMorePadsHandlerId { 0 };
     unsigned long m_deinterleavePadRemovedHandlerId { 0 };

--- a/Source/WebCore/platform/cocoa/MIMETypeRegistryCocoa.mm
+++ b/Source/WebCore/platform/cocoa/MIMETypeRegistryCocoa.mm
@@ -80,10 +80,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 // Specify MIME type <-> extension mappings for type identifiers recognized by the system that are missing MIME type values.
-static const UncheckedKeyHashMap<String, String, ASCIICaseInsensitiveHash>& additionalMimeTypesMap()
+static const HashMap<String, String, ASCIICaseInsensitiveHash>& additionalMimeTypesMap()
 {
-    static NeverDestroyed<UncheckedKeyHashMap<String, String, ASCIICaseInsensitiveHash>> mimeTypesMap = [] {
-        UncheckedKeyHashMap<String, String, ASCIICaseInsensitiveHash> map;
+    static NeverDestroyed<HashMap<String, String, ASCIICaseInsensitiveHash>> mimeTypesMap = [] {
+        HashMap<String, String, ASCIICaseInsensitiveHash> map;
         static constexpr TypeExtensionPair additionalTypes[] = {
             // FIXME: Remove this list once rdar://112044000 (Many camera RAW image type identifiers are missing MIME types) is resolved.
             { "image/x-canon-cr2"_s, "cr2"_s },
@@ -112,10 +112,10 @@ static const UncheckedKeyHashMap<String, String, ASCIICaseInsensitiveHash>& addi
     return mimeTypesMap;
 }
 
-static const UncheckedKeyHashMap<String, Vector<String>, ASCIICaseInsensitiveHash>& additionalExtensionsMap()
+static const HashMap<String, Vector<String>, ASCIICaseInsensitiveHash>& additionalExtensionsMap()
 {
-    static NeverDestroyed<UncheckedKeyHashMap<String, Vector<String>, ASCIICaseInsensitiveHash>> extensionsMap = [] {
-        UncheckedKeyHashMap<String, Vector<String>, ASCIICaseInsensitiveHash> map;
+    static NeverDestroyed<HashMap<String, Vector<String>, ASCIICaseInsensitiveHash>> extensionsMap = [] {
+        HashMap<String, Vector<String>, ASCIICaseInsensitiveHash> map;
         for (auto& [extension, type] : additionalMimeTypesMap()) {
             map.ensure(type, [] {
                 return Vector<String>();

--- a/Source/WebCore/platform/cocoa/PasteboardCocoa.mm
+++ b/Source/WebCore/platform/cocoa/PasteboardCocoa.mm
@@ -79,7 +79,7 @@ static ImageType cocoaTypeToImageType(const String& cocoaType)
 }
 
 // String literals returned by this function must be defined exactly once
-// since read(PasteboardFileReader&) uses UncheckedKeyHashMap<const char*> to check uniqueness.
+// since read(PasteboardFileReader&) uses HashMap<const char*> to check uniqueness.
 static ASCIILiteral imageTypeToMIMEType(ImageType type)
 {
     switch (type) {

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
@@ -158,7 +158,7 @@ private:
 
     RefPtr<HTMLMediaElement> m_mediaElement;
     bool m_isListening { false };
-    UncheckedKeyHashSet<CheckedPtr<PlaybackSessionModelClient>> m_clients;
+    HashSet<CheckedPtr<PlaybackSessionModelClient>> m_clients;
     Vector<RefPtr<TextTrack>> m_legibleTracksForMenu;
     Vector<RefPtr<AudioTrack>> m_audioTracksForMenu;
     AudioSessionSoundStageSize m_soundStageSize;

--- a/Source/WebCore/platform/cocoa/PublicSuffixStoreCocoa.mm
+++ b/Source/WebCore/platform/cocoa/PublicSuffixStoreCocoa.mm
@@ -72,7 +72,7 @@ void PublicSuffixStore::enablePublicSuffixCache()
 
     Locker locker { m_publicSuffixCacheLock };
     ASSERT(!m_publicSuffixCache);
-    m_publicSuffixCache = UncheckedKeyHashSet<PublicSuffix> { };
+    m_publicSuffixCache = HashSet<PublicSuffix> { };
 }
 
 void PublicSuffixStore::addPublicSuffix(const PublicSuffix& publicSuffix)

--- a/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h
@@ -142,7 +142,7 @@ private:
     RefPtr<HTMLVideoElement> m_videoElement;
     RetainPtr<PlatformLayer> m_videoFullscreenLayer;
     bool m_isListening { false };
-    UncheckedKeyHashSet<CheckedPtr<VideoPresentationModelClient>> m_clients;
+    HashSet<CheckedPtr<VideoPresentationModelClient>> m_clients;
     bool m_hasVideo { false };
     bool m_documentIsVisible { true };
     bool m_isChildOfElementFullscreen { false };

--- a/Source/WebCore/platform/encryptedmedia/CDMProxy.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMProxy.h
@@ -190,7 +190,7 @@ public:
     auto end() const LIFETIME_BOUND { return m_keys.end(); }
 
 protected:
-    UncheckedKeyHashMap<KeyIDType, RefPtr<T>> m_keys;
+    HashMap<KeyIDType, RefPtr<T>> m_keys;
 
 private:
     KeyStoreIDType m_id;
@@ -231,7 +231,7 @@ private:
         m_references.remove(id);
     }
 
-    UncheckedKeyHashSet<KeyStoreIDType> m_references;
+    HashSet<KeyStoreIDType> m_references;
 };
 
 class ReferenceAwareKeyStore : public KeyStoreBase<ReferenceAwareKeyHandle> {

--- a/Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.h
@@ -93,7 +93,7 @@ private:
     Timer m_inputNotificationTimer;
 
 #if HAVE(MULTIGAMEPADPROVIDER_SUPPORT)
-    UncheckedKeyHashSet<IOHIDDeviceRef> m_gameControllerManagedGamepads;
+    HashSet<IOHIDDeviceRef> m_gameControllerManagedGamepads;
 #endif // HAVE(MULTIGAMEPADPROVIDER_SUPPORT)
 };
 

--- a/Source/WebCore/platform/generic/KeyedDecoderGeneric.cpp
+++ b/Source/WebCore/platform/generic/KeyedDecoderGeneric.cpp
@@ -47,7 +47,7 @@ public:
     Node* get(const String& key) { return m_map.get(key); }
 
 private:
-    UncheckedKeyHashMap<String, std::unique_ptr<Node>> m_map;
+    HashMap<String, std::unique_ptr<Node>> m_map;
 };
 
 static std::optional<String> readString(WTF::Persistence::Decoder& decoder)

--- a/Source/WebCore/platform/glib/KeyedDecoderGlib.cpp
+++ b/Source/WebCore/platform/glib/KeyedDecoderGlib.cpp
@@ -50,9 +50,9 @@ KeyedDecoderGlib::~KeyedDecoderGlib()
     ASSERT(m_arrayIndexStack.isEmpty());
 }
 
-UncheckedKeyHashMap<String, GRefPtr<GVariant>> KeyedDecoderGlib::dictionaryFromGVariant(GVariant* variant)
+HashMap<String, GRefPtr<GVariant>> KeyedDecoderGlib::dictionaryFromGVariant(GVariant* variant)
 {
-    UncheckedKeyHashMap<String, GRefPtr<GVariant>> dictionary;
+    HashMap<String, GRefPtr<GVariant>> dictionary;
     GVariantIter iter;
     g_variant_iter_init(&iter, variant);
     const char* key;

--- a/Source/WebCore/platform/glib/KeyedDecoderGlib.h
+++ b/Source/WebCore/platform/glib/KeyedDecoderGlib.h
@@ -60,9 +60,9 @@ private:
     void endArray() override;
 
     template<typename T, typename F> WARN_UNUSED_RETURN bool decodeSimpleValue(const String& key, T& result, F getFunction);
-    UncheckedKeyHashMap<String, GRefPtr<GVariant>> dictionaryFromGVariant(GVariant*);
+    HashMap<String, GRefPtr<GVariant>> dictionaryFromGVariant(GVariant*);
 
-    Vector<UncheckedKeyHashMap<String, GRefPtr<GVariant>>> m_dictionaryStack;
+    Vector<HashMap<String, GRefPtr<GVariant>>> m_dictionaryStack;
     Vector<GVariant*, 16> m_arrayStack;
     Vector<unsigned> m_arrayIndexStack;
 };

--- a/Source/WebCore/platform/glib/SelectionData.h
+++ b/Source/WebCore/platform/glib/SelectionData.h
@@ -62,7 +62,7 @@ public:
     bool canSmartReplace() const { return m_canSmartReplace; }
 
     void addBuffer(const String& type, const Ref<SharedBuffer>& buffer) { m_buffers.add(type, buffer.get()); }
-    const UncheckedKeyHashMap<String, Ref<SharedBuffer>>& buffers() const { return m_buffers; }
+    const HashMap<String, Ref<SharedBuffer>>& buffers() const { return m_buffers; }
     SharedBuffer* buffer(const String& type) { return m_buffers.get(type); }
     void clearBuffers() { m_buffers.clear(); }
 
@@ -86,7 +86,7 @@ private:
     RefPtr<Image> m_image;
     bool m_canSmartReplace { false };
     RefPtr<SharedBuffer> m_customData;
-    UncheckedKeyHashMap<String, Ref<SharedBuffer>> m_buffers;
+    HashMap<String, Ref<SharedBuffer>> m_buffers;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/glib/SystemSettings.h
+++ b/Source/WebCore/platform/glib/SystemSettings.h
@@ -88,7 +88,7 @@ private:
     SystemSettings();
 
     State m_state;
-    UncheckedKeyHashMap<void*, Function<void(const State&)>> m_observers;
+    HashMap<void*, Function<void(const State&)>> m_observers;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/AV1Utilities.cpp
+++ b/Source/WebCore/platform/graphics/AV1Utilities.cpp
@@ -439,7 +439,7 @@ struct AV1PerLevelConstraints {
 
 // Derived from "AV1 Bitstream & Decoding Process Specification", Version 1.0.0 with Errata 1
 // Annex A: Profiles and levels
-using AV1PerLevelConstraintsMap = UncheckedKeyHashMap<AV1ConfigurationLevel, AV1PerLevelConstraints, WTF::IntHash<AV1ConfigurationLevel>, WTF::StrongEnumHashTraits<AV1ConfigurationLevel>>;
+using AV1PerLevelConstraintsMap = HashMap<AV1ConfigurationLevel, AV1PerLevelConstraints, WTF::IntHash<AV1ConfigurationLevel>, WTF::StrongEnumHashTraits<AV1ConfigurationLevel>>;
 static const AV1PerLevelConstraintsMap& perLevelConstraints()
 {
     static NeverDestroyed<AV1PerLevelConstraintsMap> perLevelConstraints = AV1PerLevelConstraintsMap {

--- a/Source/WebCore/platform/graphics/DisplayRefreshMonitor.h
+++ b/Source/WebCore/platform/graphics/DisplayRefreshMonitor.h
@@ -96,8 +96,8 @@ private:
     std::optional<FramesPerSecond> maximumClientPreferredFramesPerSecond() const;
     void computeMaxPreferredFramesPerSecond();
 
-    UncheckedKeyHashSet<CheckedPtr<DisplayRefreshMonitorClient>> m_clients;
-    UncheckedKeyHashSet<CheckedPtr<DisplayRefreshMonitorClient>>* m_clientsToBeNotified { nullptr };
+    HashSet<CheckedPtr<DisplayRefreshMonitorClient>> m_clients;
+    HashSet<CheckedPtr<DisplayRefreshMonitorClient>>* m_clientsToBeNotified { nullptr };
 
     PlatformDisplayID m_displayID { 0 };
     std::optional<FramesPerSecond> m_maxClientPreferredFramesPerSecond;

--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -324,7 +324,7 @@ private:
 
     const FontPlatformData m_platformData;
 
-    mutable UncheckedKeyHashMap<unsigned, RefPtr<GlyphPage>, IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> m_glyphPages;
+    mutable HashMap<unsigned, RefPtr<GlyphPage>, IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> m_glyphPages;
     mutable GlyphMetricsMap<float> m_glyphToWidthMap;
     mutable std::unique_ptr<GlyphMetricsMap<FloatRect>> m_glyphToBoundsMap;
     // FIXME: Find a more efficient way to represent std::optional<Path>.

--- a/Source/WebCore/platform/graphics/FontCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCache.cpp
@@ -118,10 +118,10 @@ struct FontDataCacheKeyTraits : WTF::GenericHashTraits<FontPlatformData> {
     }
 };
 
-using FontPlatformDataCache = UncheckedKeyHashMap<FontPlatformDataCacheKey, std::unique_ptr<FontPlatformData>, FontPlatformDataCacheKeyHash, FontPlatformDataCacheKeyHashTraits>;
-using FontDataCache = UncheckedKeyHashMap<FontPlatformData, Ref<Font>, FontDataCacheKeyHash, FontDataCacheKeyTraits>;
+using FontPlatformDataCache = HashMap<FontPlatformDataCacheKey, std::unique_ptr<FontPlatformData>, FontPlatformDataCacheKeyHash, FontPlatformDataCacheKeyHashTraits>;
+using FontDataCache = HashMap<FontPlatformData, Ref<Font>, FontDataCacheKeyHash, FontDataCacheKeyTraits>;
 #if ENABLE(OPENTYPE_VERTICAL)
-using FontVerticalDataCache = UncheckedKeyHashMap<FontPlatformData, RefPtr<OpenTypeVerticalData>, FontDataCacheKeyHash, FontDataCacheKeyTraits>;
+using FontVerticalDataCache = HashMap<FontPlatformData, RefPtr<OpenTypeVerticalData>, FontDataCacheKeyHash, FontDataCacheKeyTraits>;
 #endif
 
 struct FontCache::FontDataCaches {

--- a/Source/WebCore/platform/graphics/FontCache.h
+++ b/Source/WebCore/platform/graphics/FontCache.h
@@ -254,14 +254,14 @@ private:
 #endif
 
 #if PLATFORM(MAC)
-    UncheckedKeyHashSet<AtomString> m_knownFamilies;
+    HashSet<AtomString> m_knownFamilies;
 #endif
 
 #if PLATFORM(COCOA)
     FontDatabase m_databaseAllowingUserInstalledFonts { AllowUserInstalledFonts::Yes };
     FontDatabase m_databaseDisallowingUserInstalledFonts { AllowUserInstalledFonts::No };
 
-    using FallbackFontSet = UncheckedKeyHashSet<RetainPtr<CTFontRef>, WTF::RetainPtrObjectHash<CTFontRef>, WTF::RetainPtrObjectHashTraits<CTFontRef>>;
+    using FallbackFontSet = HashSet<RetainPtr<CTFontRef>, WTF::RetainPtrObjectHash<CTFontRef>, WTF::RetainPtrObjectHashTraits<CTFontRef>>;
     FallbackFontSet m_fallbackFonts;
 
     ListHashSet<String> m_seenFamiliesForPrewarming;

--- a/Source/WebCore/platform/graphics/FontCascadeCache.h
+++ b/Source/WebCore/platform/graphics/FontCascadeCache.h
@@ -274,7 +274,7 @@ public:
     Ref<FontCascadeFonts> retrieveOrAddCachedFonts(const FontCascadeDescription&, FontSelector*);
 
 private:
-    UncheckedKeyHashMap<FontCascadeCacheKey, std::unique_ptr<FontCascadeCacheEntry>, FontCascadeCacheKeyHash, FontCascadeCacheKeyHashTraits> m_entries;
+    HashMap<FontCascadeCacheKey, std::unique_ptr<FontCascadeCacheEntry>, FontCascadeCacheKeyHash, FontCascadeCacheKeyHashTraits> m_entries;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.h
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.h
@@ -112,9 +112,9 @@ private:
         std::unique_ptr<MixedFontGlyphPage> m_mixedFont;
     };
 
-    EnumeratedArray<ResolvedEmojiPolicy, UncheckedKeyHashMap<unsigned, GlyphPageCacheEntry, IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>>, ResolvedEmojiPolicy::RequireEmoji> m_cachedPages;
+    EnumeratedArray<ResolvedEmojiPolicy, HashMap<unsigned, GlyphPageCacheEntry, IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>>, ResolvedEmojiPolicy::RequireEmoji> m_cachedPages;
 
-    UncheckedKeyHashSet<RefPtr<Font>> m_systemFallbackFontSet;
+    HashSet<RefPtr<Font>> m_systemFallbackFontSet;
 
     SingleThreadWeakPtr<const Font> m_cachedPrimaryFont;
 

--- a/Source/WebCore/platform/graphics/FontFeatureValues.h
+++ b/Source/WebCore/platform/graphics/FontFeatureValues.h
@@ -45,7 +45,7 @@ enum class FontFeatureValuesType {
 
 class FontFeatureValues : public RefCounted<FontFeatureValues> {
 public:
-    using Tags = UncheckedKeyHashMap<String, Vector<unsigned>>;
+    using Tags = HashMap<String, Vector<unsigned>>;
     static Ref<FontFeatureValues> create() { return adoptRef(*new FontFeatureValues()); }
     virtual ~FontFeatureValues() = default;
 

--- a/Source/WebCore/platform/graphics/FontGenericFamilies.h
+++ b/Source/WebCore/platform/graphics/FontGenericFamilies.h
@@ -43,7 +43,7 @@ struct UScriptCodeHashTraits : HashTraits<int> {
     static bool isDeletedValue(int value) { return value == -3; }
 };
 
-typedef UncheckedKeyHashMap<int, String, DefaultHash<int>, UScriptCodeHashTraits> ScriptFontFamilyMap;
+using ScriptFontFamilyMap = HashMap<int, String, DefaultHash<int>, UScriptCodeHashTraits>;
 
 class FontGenericFamilies {
     WTF_MAKE_TZONE_ALLOCATED(FontGenericFamilies);

--- a/Source/WebCore/platform/graphics/FontPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontPlatformData.h
@@ -473,7 +473,7 @@ private:
     TextRenderingMode m_textRenderingMode { TextRenderingMode::AutoTextRendering };
 
     // This is conceptually const, but we can't make it actually const,
-    // because FontPlatformData is used as a key in a UncheckedKeyHashMap.
+    // because FontPlatformData is used as a key in a HashMap.
     RefPtr<const FontCustomPlatformData> m_customPlatformData;
 
     bool m_syntheticBold { false };

--- a/Source/WebCore/platform/graphics/GlyphMetricsMap.h
+++ b/Source/WebCore/platform/graphics/GlyphMetricsMap.h
@@ -102,7 +102,7 @@ private:
 
     bool m_filledPrimaryPage { false };
     GlyphMetricsPage m_primaryPage; // We optimize for the page that contains glyph indices 0-255.
-    UncheckedKeyHashMap<int, std::unique_ptr<GlyphMetricsPage>> m_pages;
+    HashMap<int, std::unique_ptr<GlyphMetricsPage>> m_pages;
 };
 
 WTF_MAKE_TZONE_ALLOCATED_TEMPLATE_IMPL(template<class T>, GlyphMetricsMap<T>);

--- a/Source/WebCore/platform/graphics/GraphicsContextGLState.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGLState.h
@@ -39,7 +39,7 @@ struct GraphicsContextGLState {
     GCGLuint boundDrawFBO { 0 };
     GCGLenum activeTextureUnit { GraphicsContextGL::TEXTURE0 };
 
-    using BoundTextureMap = UncheckedKeyHashMap<GCGLenum,
+    using BoundTextureMap = HashMap<GCGLenum,
         std::pair<GCGLuint, GCGLenum>,
         IntHash<GCGLenum>,
         WTF::UnsignedWithZeroKeyHashTraits<GCGLuint>,

--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -121,7 +121,7 @@ String animatedPropertyIDAsString(AnimatedProperty property)
     return ""_s;
 }
 
-typedef UncheckedKeyHashMap<const GraphicsLayer*, Vector<FloatRect>> RepaintMap;
+using RepaintMap = HashMap<const GraphicsLayer*, Vector<FloatRect>>;
 static RepaintMap& repaintRectMap()
 {
     static NeverDestroyed<RepaintMap> map;

--- a/Source/WebCore/platform/graphics/MIMETypeCache.cpp
+++ b/Source/WebCore/platform/graphics/MIMETypeCache.cpp
@@ -91,7 +91,7 @@ MediaPlayerEnums::SupportsType MIMETypeCache::canDecodeType(const String& mimeTy
     } while (0);
 
     if (!m_cachedResults)
-        m_cachedResults = UncheckedKeyHashMap<String, MediaPlayerEnums::SupportsType>();
+        m_cachedResults = HashMap<String, MediaPlayerEnums::SupportsType>();
     m_cachedResults->add(mimeType, result);
 
     return result;

--- a/Source/WebCore/platform/graphics/MIMETypeCache.h
+++ b/Source/WebCore/platform/graphics/MIMETypeCache.h
@@ -61,7 +61,7 @@ private:
     bool shouldOverrideExtendedType(const ContentType&);
 
     std::optional<HashSet<String>> m_supportedTypes;
-    std::optional<UncheckedKeyHashMap<String, MediaPlayerEnums::SupportsType>> m_cachedResults;
+    std::optional<HashMap<String, MediaPlayerEnums::SupportsType>> m_cachedResults;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -244,9 +244,9 @@ public:
     virtual unsigned audioDecodedByteCount() const { return 0; }
     virtual unsigned videoDecodedByteCount() const { return 0; }
 
-    UncheckedKeyHashSet<SecurityOriginData> originsInMediaCache(const String&) { return { }; }
+    HashSet<SecurityOriginData> originsInMediaCache(const String&) { return { }; }
     void clearMediaCache(const String&, WallTime) { }
-    void clearMediaCacheForOrigins(const String&, const UncheckedKeyHashSet<SecurityOriginData>&) { }
+    void clearMediaCacheForOrigins(const String&, const HashSet<SecurityOriginData>&) { }
 
     virtual void setPrivateBrowsingMode(bool) { }
 

--- a/Source/WebCore/platform/graphics/PlatformDisplay.cpp
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.cpp
@@ -78,9 +78,9 @@ PlatformDisplay* PlatformDisplay::sharedDisplayIfExists()
 }
 #endif
 
-static UncheckedKeyHashSet<PlatformDisplay*>& eglDisplays()
+static HashSet<PlatformDisplay*>& eglDisplays()
 {
-    static NeverDestroyed<UncheckedKeyHashSet<PlatformDisplay*>> displays;
+    static NeverDestroyed<HashSet<PlatformDisplay*>> displays;
     return displays;
 }
 

--- a/Source/WebCore/platform/graphics/SystemFallbackFontCache.h
+++ b/Source/WebCore/platform/graphics/SystemFallbackFontCache.h
@@ -82,9 +82,9 @@ private:
 
     // Fonts are not ref'd to avoid cycles.
     // FIXME: Consider changing these maps to use WeakPtr instead of raw pointers.
-    using CharacterFallbackMap = UncheckedKeyHashMap<CharacterFallbackMapKey, Font*, CharacterFallbackMapKeyHash, CharacterFallbackMapKeyHashTraits>;
+    using CharacterFallbackMap = HashMap<CharacterFallbackMapKey, Font*, CharacterFallbackMapKeyHash, CharacterFallbackMapKeyHashTraits>;
 
-    UncheckedKeyHashMap<const Font*, CharacterFallbackMap> m_characterFallbackMaps;
+    HashMap<const Font*, CharacterFallbackMap> m_characterFallbackMaps;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/WidthCache.h
+++ b/Source/WebCore/platform/graphics/WidthCache.h
@@ -221,8 +221,8 @@ private:
         return false;
     }
 
-    using Map = UncheckedKeyHashMap<SmallStringKey, float, SmallStringKeyHash, SmallStringKeyHashTraits, WTF::FloatWithZeroEmptyKeyHashTraits<float>>;
-    using SingleCharMap = UncheckedKeyHashMap<uint32_t, float, DefaultHash<uint32_t>, HashTraits<uint32_t>, WTF::FloatWithZeroEmptyKeyHashTraits<float>>;
+    using Map = HashMap<SmallStringKey, float, SmallStringKeyHash, SmallStringKeyHashTraits, WTF::FloatWithZeroEmptyKeyHashTraits<float>>;
+    using SingleCharMap = HashMap<uint32_t, float, DefaultHash<uint32_t>, HashTraits<uint32_t>, WTF::FloatWithZeroEmptyKeyHashTraits<float>>;
 
     static constexpr int s_minInterval = -3; // A cache hit pays for about 3 cache misses.
     static constexpr int s_maxInterval = 20; // Sampling at this interval has almost no overhead.

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -60,9 +60,9 @@ namespace WebCore {
 // List of displays ever instantiated from EGL. When terminating all EGL resources, we need to
 // terminate all displays. However, we cannot ask EGL all the displays it has created.
 // We must know all the displays via this set.
-static UncheckedKeyHashSet<GCGLDisplay>& usedDisplays()
+static HashSet<GCGLDisplay>& usedDisplays()
 {
-    static NeverDestroyed<UncheckedKeyHashSet<GCGLDisplay>> s_usedDisplays;
+    static NeverDestroyed<HashSet<GCGLDisplay>> s_usedDisplays;
     return s_usedDisplays;
 }
 

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -418,9 +418,9 @@ protected:
     void prepareForDrawingBufferWriteIfBound();
     virtual void prepareForDrawingBufferWrite();
 
-    UncheckedKeyHashSet<String> m_availableExtensions;
-    UncheckedKeyHashSet<String> m_requestableExtensions;
-    UncheckedKeyHashSet<String> m_enabledExtensions;
+    HashSet<String> m_availableExtensions;
+    HashSet<String> m_requestableExtensions;
+    HashSet<String> m_enabledExtensions;
     bool m_webglColorBufferFloatRGB { false };
     bool m_webglColorBufferFloatRGBA { false };
     GCGLuint m_texture { 0 };
@@ -453,8 +453,8 @@ protected:
     GCGLboolean m_packReverseRowOrder { false };
     uint32_t m_nextExternalImageName { 0 };
     uint32_t m_nextExternalSyncName { 0 };
-    UncheckedKeyHashMap<uint32_t, void*, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_eglImages;
-    UncheckedKeyHashMap<uint32_t, void*, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_eglSyncs;
+    HashMap<uint32_t, void*, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_eglImages;
+    HashMap<uint32_t, void*, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_eglSyncs;
     IntSize m_maxInternalFramebufferSize;
 };
 

--- a/Source/WebCore/platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.h
@@ -78,7 +78,7 @@ public:
 
     void updateOptions(const Vector<String>& characteristics);
 
-    using OptionContainer = UncheckedKeyHashMap<CFTypeRef, RefPtr<MediaSelectionOptionAVFObjC>>;
+    using OptionContainer = HashMap<CFTypeRef, RefPtr<MediaSelectionOptionAVFObjC>>;
     typename OptionContainer::ValuesIteratorRange options() { return m_options.values(); }
 
     AVMediaSelectionGroup *avMediaSelectionGroup() const { return m_mediaSelectionGroup.get(); }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
@@ -170,7 +170,7 @@ private:
     bool m_persistentStateAllowed { true };
     RetainPtr<NSURL> m_storageURL;
     Vector<WeakPtr<CDMInstanceSessionFairPlayStreamingAVFObjC>> m_sessions;
-    UncheckedKeyHashSet<RetainPtr<AVContentKeyRequest>> m_unexpectedKeyRequests;
+    HashSet<RetainPtr<AVContentKeyRequest>> m_unexpectedKeyRequests;
     WeakHashSet<KeyStatusesChangedObserver> m_keyStatusChangedObservers;
     String m_mediaKeysHashSalt;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -309,7 +309,7 @@ class CDMInstanceSessionFairPlayStreamingAVFObjC::UpdateResponseCollector {
 public:
     using KeyType = RetainPtr<AVContentKeyRequest>;
     using ValueType = RetainPtr<NSData>;
-    using ResponseMap = UncheckedKeyHashMap<KeyType, ValueType>;
+    using ResponseMap = HashMap<KeyType, ValueType>;
     using UpdateCallback = WTF::Function<void(std::optional<ResponseMap>&&)>;
     UpdateResponseCollector(size_t numberOfExpectedResponses, UpdateCallback&& callback)
         : m_numberOfExpectedResponses(numberOfExpectedResponses)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -427,7 +427,7 @@ private:
     std::unique_ptr<PixelBufferConformerCV> m_pixelBufferConformer;
 
     friend class WebCoreAVFResourceLoader;
-    UncheckedKeyHashMap<RetainPtr<CFTypeRef>, RefPtr<WebCoreAVFResourceLoader>> m_resourceLoaderMap;
+    HashMap<RetainPtr<CFTypeRef>, RefPtr<WebCoreAVFResourceLoader>> m_resourceLoaderMap;
     RetainPtr<WebCoreAVFLoaderDelegate> m_loaderDelegate;
     MemoryCompactRobinHoodHashMap<String, RetainPtr<AVAssetResourceLoadingRequest>> m_keyURIToRequestMap;
     MemoryCompactRobinHoodHashMap<String, RetainPtr<AVAssetResourceLoadingRequest>> m_sessionIDToRequestMap;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -373,7 +373,7 @@ private:
         bool hasAudibleSample { false };
     };
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
-    UncheckedKeyHashMap<RetainPtr<CFTypeRef>, AudioRendererProperties> m_sampleBufferAudioRendererMap;
+    HashMap<RetainPtr<CFTypeRef>, AudioRendererProperties> m_sampleBufferAudioRendererMap;
     RetainPtr<AVSampleBufferRenderSynchronizer> m_synchronizer;
 ALLOW_NEW_API_WITHOUT_GUARDS_END
     mutable MediaPlayer::CurrentTimeDidChangeCallback m_currentTimeDidChangeCallback;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
@@ -154,7 +154,7 @@ private:
     uint64_t m_nextSourceBufferID { 0 };
 #endif
 
-    UncheckedKeyHashMap<SourceBufferPrivate*, Vector<PlatformTimeRanges>> m_bufferedRanges;
+    HashMap<SourceBufferPrivate*, Vector<PlatformTimeRanges>> m_bufferedRanges;
     ProcessIdentity m_resourceOwner;
 };
 

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -382,7 +382,7 @@ Ref<PlatformCAAnimation> GraphicsLayerCA::createPlatformCAAnimation(PlatformCAAn
     return PlatformCAAnimationCocoa::create(type, keyPath);
 }
 
-typedef UncheckedKeyHashMap<const GraphicsLayerCA*, std::pair<FloatRect, Ref<const DisplayList::DisplayList>>> LayerDisplayListHashMap;
+using LayerDisplayListHashMap = HashMap<const GraphicsLayerCA*, std::pair<FloatRect, Ref<const DisplayList::DisplayList>>>;
 
 static LayerDisplayListHashMap& layerDisplayListMap()
 {

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -328,10 +328,10 @@ private:
 
     WEBCORE_EXPORT void setTileCoverage(TileCoverage) override;
 
-    typedef String CloneID; // Identifier for a given clone, based on original/replica branching down the tree.
+    using CloneID = String; // Identifier for a given clone, based on original/replica branching down the tree.
     static bool isReplicatedRootClone(const CloneID& cloneID) { return cloneID[0U] & 1; }
 
-    typedef UncheckedKeyHashMap<CloneID, RefPtr<PlatformCALayer>> LayerMap;
+    using LayerMap = HashMap<CloneID, RefPtr<PlatformCALayer>>;
     LayerMap* primaryLayerClones() const;
     LayerMap* animatedLayerClones(AnimatedProperty) const;
     static void clearClones(LayerMap&);

--- a/Source/WebCore/platform/graphics/ca/LayerPool.cpp
+++ b/Source/WebCore/platform/graphics/ca/LayerPool.cpp
@@ -50,10 +50,10 @@ LayerPool::~LayerPool()
     allLayerPools().remove(this);
 }
 
-UncheckedKeyHashSet<CheckedPtr<LayerPool>>& LayerPool::allLayerPools()
+HashSet<CheckedPtr<LayerPool>>& LayerPool::allLayerPools()
 {
     RELEASE_ASSERT(isMainThread());
-    static NeverDestroyed<UncheckedKeyHashSet<CheckedPtr<LayerPool>>> allLayerPools;
+    static NeverDestroyed<HashSet<CheckedPtr<LayerPool>>> allLayerPools;
     return allLayerPools.get();
 }
 
@@ -64,7 +64,7 @@ unsigned LayerPool::backingStoreBytesForSize(const IntSize& size)
 
 LayerPool::LayerList& LayerPool::listOfLayersWithSize(const IntSize& size, AccessType accessType)
 {
-    UncheckedKeyHashMap<IntSize, LayerList>::iterator it = m_reuseLists.find(size);
+    HashMap<IntSize, LayerList>::iterator it = m_reuseLists.find(size);
     if (it == m_reuseLists.end()) {
         it = m_reuseLists.add(size, LayerList()).iterator;
         m_sizesInPruneOrder.append(size);

--- a/Source/WebCore/platform/graphics/ca/LayerPool.h
+++ b/Source/WebCore/platform/graphics/ca/LayerPool.h
@@ -47,7 +47,7 @@ public:
     WEBCORE_EXPORT LayerPool();
     WEBCORE_EXPORT ~LayerPool();
 
-    static UncheckedKeyHashSet<CheckedPtr<LayerPool>>& allLayerPools();
+    static HashSet<CheckedPtr<LayerPool>>& allLayerPools();
     
     void addLayer(const RefPtr<PlatformCALayer>&);
     RefPtr<PlatformCALayer> takeLayerWithSize(const IntSize&);
@@ -71,7 +71,7 @@ private:
 
     static unsigned backingStoreBytesForSize(const IntSize&);
 
-    UncheckedKeyHashMap<IntSize, LayerList> m_reuseLists;
+    HashMap<IntSize, LayerList> m_reuseLists;
     // Ordered by recent use. The last size is the most recently used.
     Vector<IntSize> m_sizesInPruneOrder;
     unsigned m_totalBytes { 0 };

--- a/Source/WebCore/platform/graphics/ca/TileGrid.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.cpp
@@ -597,7 +597,7 @@ IntRect TileGrid::ensureTilesForRect(const FloatRect& rect, HashSet<TileIndex>& 
 
             IntRect tileRect = rectForTileIndex(tileIndex);
 
-            UncheckedKeyHashMap<TileIndex, TileInfo>::iterator it;
+            HashMap<TileIndex, TileInfo>::iterator it;
             constexpr size_t kMaxTileCountPerGrid = 6 * 1024;
             if (m_tiles.size() >= kMaxTileCountPerGrid) [[unlikely]] {
                 it = m_tiles.find(tileIndex);

--- a/Source/WebCore/platform/graphics/ca/TileGrid.h
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.h
@@ -170,7 +170,7 @@ private:
     const Ref<PlatformCALayer> m_containerLayer;
 #endif
 
-    UncheckedKeyHashMap<TileIndex, TileInfo> m_tiles;
+    HashMap<TileIndex, TileInfo> m_tiles;
 
     IntRect m_primaryTileCoverageRect;
     Vector<FloatRect> m_secondaryTileCoverageRects;

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -74,7 +74,7 @@
 
 namespace WebCore {
 
-using LayerToPlatformCALayerMap = UncheckedKeyHashMap<void*, PlatformCALayer*>;
+using LayerToPlatformCALayerMap = HashMap<void*, PlatformCALayer*>;
 
 static Lock layerToPlatformLayerMapLock;
 static LayerToPlatformCALayerMap& layerToPlatformLayerMap() WTF_REQUIRES_LOCK(layerToPlatformLayerMapLock)

--- a/Source/WebCore/platform/graphics/cg/CGSubimageCacheWithTimer.h
+++ b/Source/WebCore/platform/graphics/cg/CGSubimageCacheWithTimer.h
@@ -94,7 +94,7 @@ private:
     static constexpr Seconds cacheEntryLifetime { 500_ms };
     static constexpr int maxCacheSize = 300;
 
-    typedef UncheckedKeyHashSet<CacheEntry, CacheHash, CacheEntryTraits> CacheHashSet;
+    using CacheHashSet = HashSet<CacheEntry, CacheHash, CacheEntryTraits>;
 
     CGSubimageCacheWithTimer();
     void pruneCacheTimerFired();

--- a/Source/WebCore/platform/graphics/cg/ColorSpaceCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ColorSpaceCG.cpp
@@ -155,7 +155,7 @@ std::optional<ColorSpace> colorSpaceForCGColorSpace(CGColorSpaceRef colorSpace)
 {
     // First test for the four most common spaces, sRGB, Extended sRGB, DisplayP3 and Linear sRGB, and then test
     // the reset in alphabetical order.
-    // FIXME: Consider using a UncheckedKeyHashMap (with CFHash based keys) rather than the linear set of tests.
+    // FIXME: Consider using a HashMap (with CFHash based keys) rather than the linear set of tests.
 
     if (CGColorSpaceEqualToColorSpace(colorSpace, sRGBColorSpaceSingleton()))
         return ColorSpace::SRGB;

--- a/Source/WebCore/platform/graphics/cg/IOSurfacePool.h
+++ b/Source/WebCore/platform/graphics/cg/IOSurfacePool.h
@@ -76,9 +76,9 @@ private:
         bool hasMarkedPurgeable;
     };
 
-    typedef Deque<std::unique_ptr<IOSurface>> CachedSurfaceQueue;
-    typedef UncheckedKeyHashMap<IntSize, CachedSurfaceQueue> CachedSurfaceMap;
-    typedef UncheckedKeyHashMap<IOSurface*, CachedSurfaceDetails> CachedSurfaceDetailsMap;
+    using CachedSurfaceQueue = Deque<std::unique_ptr<IOSurface>>;
+    using CachedSurfaceMap = HashMap<IntSize, CachedSurfaceQueue>;
+    using CachedSurfaceDetailsMap = HashMap<IOSurface*, CachedSurfaceDetails>;
 
 #if PLATFORM(MAC)
     static constexpr size_t defaultMaximumBytesCached { 256 * MB };

--- a/Source/WebCore/platform/graphics/cg/UTIRegistry.mm
+++ b/Source/WebCore/platform/graphics/cg/UTIRegistry.mm
@@ -54,10 +54,10 @@ static MemoryCompactLookupOnlyRobinHoodHashSet<String> filterSupportedImageTypes
     auto systemSupportedCFImageTypes = adoptCF(CGImageSourceCopyTypeIdentifiers());
     CFIndex count = CFArrayGetCount(systemSupportedCFImageTypes.get());
 
-    UncheckedKeyHashSet<String> systemSupportedImageTypes;
+    HashSet<String> systemSupportedImageTypes;
     CFArrayApplyFunction(systemSupportedCFImageTypes.get(), CFRangeMake(0, count), [](const void *value, void *context) {
         String imageType = static_cast<CFStringRef>(value);
-        static_cast<UncheckedKeyHashSet<String>*>(context)->add(imageType);
+        static_cast<HashSet<String>*>(context)->add(imageType);
     }, &systemSupportedImageTypes);
 
     MemoryCompactLookupOnlyRobinHoodHashSet<String> filtered;

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -291,7 +291,7 @@ public:
     static Lock lock;
 
 private:
-    UncheckedKeyHashSet<String, ASCIICaseInsensitiveHash> m_families;
+    HashSet<String, ASCIICaseInsensitiveHash> m_families;
 };
 
 Lock FontCacheAllowlist::lock;

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.h
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.h
@@ -74,7 +74,7 @@ struct VariationDefaults {
     }
 };
 
-typedef UncheckedKeyHashMap<FontTag, VariationDefaults, FourCharacterTagHash, FourCharacterTagHashTraits> VariationDefaultsMap;
+using VariationDefaultsMap = HashMap<FontTag, VariationDefaults, FourCharacterTagHash, FourCharacterTagHashTraits>;
 
 enum class FontTypeForPreparation : bool {
     SystemFont,

--- a/Source/WebCore/platform/graphics/cocoa/FontFamilySpecificationCoreTextCache.h
+++ b/Source/WebCore/platform/graphics/cocoa/FontFamilySpecificationCoreTextCache.h
@@ -79,7 +79,7 @@ public:
     void clear();
 
 private:
-    UncheckedKeyHashMap<FontFamilySpecificationKey, std::unique_ptr<FontPlatformData>, FontFamilySpecificationKeyHash, SimpleClassHashTraits<FontFamilySpecificationKey>> m_fonts;
+    HashMap<FontFamilySpecificationKey, std::unique_ptr<FontPlatformData>, FontFamilySpecificationKeyHash, SimpleClassHashTraits<FontFamilySpecificationKey>> m_fonts;
 };
 
 template<typename Functor> FontPlatformData& FontFamilySpecificationCoreTextCache::ensure(FontFamilySpecificationKey&& key, Functor&& functor)

--- a/Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.h
+++ b/Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.h
@@ -117,7 +117,7 @@ private:
     static Vector<RetainPtr<CTFontDescriptorRef>> computeCascadeList(CTFontRef, CFStringRef locale);
     static CascadeListParameters systemFontParameters(const FontDescription&, const AtomString& familyName, SystemFontKind, AllowUserInstalledFonts);
 
-    UncheckedKeyHashMap<CascadeListParameters, Vector<RetainPtr<CTFontDescriptorRef>>, CascadeListParameters::Hash, SimpleClassHashTraits<CascadeListParameters>> m_systemFontCache;
+    HashMap<CascadeListParameters, Vector<RetainPtr<CTFontDescriptorRef>>, CascadeListParameters::Hash, SimpleClassHashTraits<CascadeListParameters>> m_systemFontCache;
 
     MemoryCompactRobinHoodHashMap<String, String> m_serifFamilies;
     MemoryCompactRobinHoodHashMap<String, String> m_sansSeriferifFamilies;

--- a/Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.h
+++ b/Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.h
@@ -83,7 +83,7 @@ private:
 
     static void modifyFromContext(CFMutableDictionaryRef attributes, const FontDescription&, const FontCreationContext&, ApplyTraitsVariations, float weight, float width, float slope, CGFloat size, const OpticalSizingType&);
 
-    using VariationsMap = UncheckedKeyHashMap<FontTag, float, FourCharacterTagHash, FourCharacterTagHashTraits>;
+    using VariationsMap = HashMap<FontTag, float, FourCharacterTagHash, FourCharacterTagHashTraits>;
     static void addAttributesForOpticalSizing(CFMutableDictionaryRef attributes, VariationsMap& variationsToBeApplied, const OpticalSizingType&, CGFloat size);
     static void applyVariations(CFMutableDictionaryRef attributes, const VariationsMap& variationsToBeApplied);
 

--- a/Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.h
+++ b/Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.h
@@ -85,7 +85,7 @@ private:
 
         friend bool operator==(const TextureContent&, const TextureContent&) = default;
     };
-    using TextureContentMap = UncheckedKeyHashMap<GCGLuint, TextureContent, IntHash<GCGLuint>, WTF::UnsignedWithZeroKeyHashTraits<GCGLuint>>;
+    using TextureContentMap = HashMap<GCGLuint, TextureContent, IntHash<GCGLuint>, WTF::UnsignedWithZeroKeyHashTraits<GCGLuint>>;
     TextureContentMap m_knownContent;
 };
 

--- a/Source/WebCore/platform/graphics/filters/FilterEffectGeometry.h
+++ b/Source/WebCore/platform/graphics/filters/FilterEffectGeometry.h
@@ -85,6 +85,6 @@ private:
     OptionSet<Flags> m_flags;
 };
 
-using FilterEffectGeometryMap = UncheckedKeyHashMap<Ref<FilterEffect>, FilterEffectGeometry>;
+using FilterEffectGeometryMap = HashMap<Ref<FilterEffect>, FilterEffectGeometry>;
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/FilterResults.h
+++ b/Source/WebCore/platform/graphics/filters/FilterResults.h
@@ -52,11 +52,11 @@ private:
     size_t memoryCost() const;
     bool canCacheResult(const FilterImage&) const;
 
-    UncheckedKeyHashMap<Ref<FilterEffect>, Ref<FilterImage>> m_results;
+    HashMap<Ref<FilterEffect>, Ref<FilterImage>> m_results;
 
     // The value is a list of FilterEffects, whose FilterImages depend on the key FilterImage.
-    using FilterEffectSet = UncheckedKeyHashSet<Ref<FilterEffect>>;
-    UncheckedKeyHashMap<Ref<FilterImage>, FilterEffectSet> m_resultReferences;
+    using FilterEffectSet = HashSet<Ref<FilterEffect>>;
+    HashMap<Ref<FilterImage>, FilterEffectSet> m_resultReferences;
 
     std::unique_ptr<ImageBufferAllocator> m_allocator;
 };

--- a/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.h
+++ b/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.h
@@ -36,8 +36,8 @@ struct VariationDefaults {
     float maximumValue;
 };
 
-typedef UncheckedKeyHashMap<FontTag, VariationDefaults, FourCharacterTagHash, FourCharacterTagHashTraits> VariationDefaultsMap;
-typedef UncheckedKeyHashMap<FontTag, float, FourCharacterTagHash, FourCharacterTagHashTraits> VariationsMap;
+using VariationDefaultsMap = HashMap<FontTag, VariationDefaults, FourCharacterTagHash, FourCharacterTagHashTraits>;
+using VariationsMap = HashMap<FontTag, float, FourCharacterTagHash, FourCharacterTagHashTraits>;
 
 VariationDefaultsMap defaultVariationValues(FT_Face, ShouldLocalizeAxisNames);
 

--- a/Source/WebCore/platform/graphics/freetype/FontSetCache.h
+++ b/Source/WebCore/platform/graphics/freetype/FontSetCache.h
@@ -85,7 +85,7 @@ private:
         Vector<std::pair<FcPattern*, FcCharSet*>> patterns;
     };
 
-    UncheckedKeyHashMap<FontSetCacheKey, std::unique_ptr<FontSet>, FontSetCacheKeyHash, SimpleClassHashTraits<FontSetCacheKey>> m_cache;
+    HashMap<FontSetCacheKey, std::unique_ptr<FontSet>, FontSetCacheKeyHash, SimpleClassHashTraits<FontSetCacheKey>> m_cache;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -562,9 +562,9 @@ void registerWebKitGStreamerVideoEncoder()
 // We use a recursive lock because the removal of a pipeline can trigger the removal of another one,
 // from the same thread, specially when using chained element harnesses.
 static RecursiveLock s_activePipelinesMapLock;
-static UncheckedKeyHashMap<String, GRefPtr<GstElement>>& activePipelinesMap()
+static HashMap<String, GRefPtr<GstElement>>& activePipelinesMap()
 {
-    static NeverDestroyed<UncheckedKeyHashMap<String, GRefPtr<GstElement>>> activePipelines;
+    static NeverDestroyed<HashMap<String, GRefPtr<GstElement>>> activePipelines;
     return activePipelines.get();
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -1190,7 +1190,7 @@ Vector<RTCRtpCapabilities::HeaderExtensionCapability> GStreamerRegistryScanner::
 
 GStreamerRegistryScanner::RegistryLookupResult GStreamerRegistryScanner::isRtpPacketizerSupported(const String& encoding)
 {
-    static UncheckedKeyHashMap<String, ASCIILiteral> mapping = {
+    static HashMap<String, ASCIILiteral> mapping = {
         { "h264"_s, "video/x-h264"_s }, { "vp8"_s, "video/x-vp8"_s }, { "vp9"_s, "video/x-vp9"_s }, { "av1"_s, "video/x-av1"_s }, { "h265"_s, "video/x-h265"_s },
         { "avc1"_s, "video/x-h264"_s }, { "vp08"_s, "video/x-vp8"_s }, { "vp09"_s, "video/x-vp9"_s }, { "av01"_s, "video/x-av1"_s }, { "hvc1"_s, "video/x-h265"_s },
         { "opus"_s, "audio/x-opus"_s }, { "g722"_s, "audio/G722"_s }, { "pcma"_s, "audio/x-alaw"_s }, { "pcmu"_s, "audio/x-mulaw"_s } };

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
@@ -210,9 +210,9 @@ private:
 
     bool m_isMediaSource { false };
     HashSet<String> m_decoderMimeTypeSet;
-    UncheckedKeyHashMap<String, RegistryLookupResult> m_decoderCodecMap;
+    HashMap<String, RegistryLookupResult> m_decoderCodecMap;
     HashSet<String> m_encoderMimeTypeSet;
-    UncheckedKeyHashMap<String, RegistryLookupResult> m_encoderCodecMap;
+    HashMap<String, RegistryLookupResult> m_encoderCodecMap;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -677,7 +677,7 @@ private:
     Ref<PlatformMediaResourceLoader> m_loader;
 
     RefPtr<GStreamerQuirksManager> m_quirksManagerForTesting;
-    UncheckedKeyHashMap<const GStreamerQuirk*, std::unique_ptr<GStreamerQuirkBase::GStreamerQuirkState>> m_quirkStates;
+    HashMap<const GStreamerQuirk*, std::unique_ptr<GStreamerQuirkBase::GStreamerQuirkState>> m_quirkStates;
 
     MediaTime m_estimatedVideoFrameDuration { MediaTime::zeroTime() };
 

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp
@@ -36,7 +36,7 @@ struct VideoFrameMetadataPrivate {
     VideoFrame::Rotation rotation { VideoFrame::Rotation::None };
     bool isMirrored { false };
     Lock lock;
-    UncheckedKeyHashMap<GstElement*, std::pair<GstClockTime, GstClockTime>> processingTimes WTF_GUARDED_BY_LOCK(lock);
+    HashMap<GstElement*, std::pair<GstClockTime, GstClockTime>> processingTimes WTF_GUARDED_BY_LOCK(lock);
 };
 
 WEBKIT_DEFINE_ASYNC_DATA_STRUCT(VideoFrameMetadataPrivate);

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
@@ -123,7 +123,7 @@ struct WebKitWebSrcPrivate {
         uint64_t stopPosition { UINT64_MAX };
 
         bool isRequestPending { true };
-        UncheckedKeyHashSet<RefPtr<WebCore::SecurityOrigin>> origins;
+        HashSet<RefPtr<WebCore::SecurityOrigin>> origins;
 
         RefPtr<PlatformMediaResource> resource;
     };

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -542,9 +542,9 @@ void AppendPipeline::didReceiveInitializationSegment()
                 linkPadWithTrack(pad, *track);
         }
     } else {
-        UncheckedKeyHashSet<String> videoPadStreamIDs;
-        UncheckedKeyHashSet<String> audioPadStreamIDs;
-        UncheckedKeyHashSet<String> textPadStreamIDs;
+        HashSet<String> videoPadStreamIDs;
+        HashSet<String> audioPadStreamIDs;
+        HashSet<String> textPadStreamIDs;
         for (auto pad : GstIteratorAdaptor<GstPad>(gst_element_iterate_src_pads(m_demux.get()))) {
             auto [parsedCaps, streamType, presentationSize] = parseDemuxerSrcPadCaps(adoptGRef(gst_pad_get_current_caps(pad)).get());
             UNUSED_VARIABLE(parsedCaps);

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
@@ -138,7 +138,7 @@ private:
     //    - how {Audio,Video,Text}TrackList stores its tracks
     //    - prevents a potential out-of-bounds crash in TextTrackList
     //    Just like for IDs, we store known indices here to enforce uniqueness by player.
-    UncheckedKeyHashMap<TrackID, RegisteredTrack, WTF::IntHash<TrackID>, WTF::UnsignedWithZeroKeyHashTraits<TrackID>> m_trackRegistry;
+    HashMap<TrackID, RegisteredTrack, WTF::IntHash<TrackID>, WTF::UnsignedWithZeroKeyHashTraits<TrackID>> m_trackRegistry;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/opentype/OpenTypeVerticalData.cpp
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeVerticalData.cpp
@@ -130,7 +130,7 @@ struct LookupTable : TableBase {
     OpenType::Offset subTableOffsets[1];
     // OpenType::UInt16 markFilteringSet; this field comes after variable length, so offset is determined dynamically.
 
-    bool getSubstitutions(UncheckedKeyHashMap<Glyph, Glyph>* map, const SharedBuffer& buffer) const
+    bool getSubstitutions(HashMap<Glyph, Glyph>* map, const SharedBuffer& buffer) const
     {
         uint16_t countSubTable = subTableCount;
         if (!isValidEnd(buffer, &subTableOffsets[countSubTable]))
@@ -207,7 +207,7 @@ struct FeatureTable : TableBase {
     OpenType::UInt16 lookupCount;
     OpenType::UInt16 lookupListIndex[1];
 
-    bool getGlyphSubstitutions(const LookupList* lookups, UncheckedKeyHashMap<Glyph, Glyph>* map, const SharedBuffer& buffer) const
+    bool getGlyphSubstitutions(const LookupList* lookups, HashMap<Glyph, Glyph>* map, const SharedBuffer& buffer) const
     {
         uint16_t count = lookupCount;
         if (!isValidEnd(buffer, &lookupListIndex[count]))
@@ -364,7 +364,7 @@ struct GSUBTable : TableBase {
         return feature;
     }
 
-    bool getVerticalGlyphSubstitutions(UncheckedKeyHashMap<Glyph, Glyph>* map, const SharedBuffer& buffer) const
+    bool getVerticalGlyphSubstitutions(HashMap<Glyph, Glyph>* map, const SharedBuffer& buffer) const
     {
         const FeatureTable* verticalFeatureTable = feature(OpenType::VertFeatureTag, buffer);
         if (!verticalFeatureTable)
@@ -550,7 +550,7 @@ void OpenTypeVerticalData::getVerticalTranslationsForGlyphs(const Font* font, co
 
 void OpenTypeVerticalData::substituteWithVerticalGlyphs(const Font* font, GlyphPage* glyphPage) const
 {
-    const UncheckedKeyHashMap<Glyph, Glyph>& map = m_verticalGlyphMap;
+    const HashMap<Glyph, Glyph>& map = m_verticalGlyphMap;
     if (map.isEmpty())
         return;
 

--- a/Source/WebCore/platform/graphics/opentype/OpenTypeVerticalData.h
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeVerticalData.h
@@ -54,12 +54,12 @@ private:
     void loadVerticalGlyphSubstitutions(const FontPlatformData&);
     bool hasVORG() const { return !m_vertOriginY.isEmpty(); }
 
-    UncheckedKeyHashMap<Glyph, Glyph> m_verticalGlyphMap;
+    HashMap<Glyph, Glyph> m_verticalGlyphMap;
     Vector<uint16_t> m_advanceWidths;
     Vector<uint16_t> m_advanceHeights;
     Vector<int16_t> m_topSideBearings;
     int16_t m_defaultVertOriginY { 0 };
-    UncheckedKeyHashMap<Glyph, int16_t> m_vertOriginY;
+    HashMap<Glyph, int16_t> m_vertOriginY;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/FontVariationsSkia.h
+++ b/Source/WebCore/platform/graphics/skia/FontVariationsSkia.h
@@ -45,7 +45,7 @@ struct FontVariationDefaults {
     float maximumValue;
 };
 
-typedef UncheckedKeyHashMap<FontTag, FontVariationDefaults, FourCharacterTagHash, FourCharacterTagHashTraits> FontVariationDefaultsMap;
+using FontVariationDefaultsMap = HashMap<FontTag, FontVariationDefaults, FourCharacterTagHash, FourCharacterTagHashTraits>;
 FontVariationDefaultsMap defaultFontVariationValues(const SkTypeface&);
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/SkiaHarfBuzzFontCache.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaHarfBuzzFontCache.h
@@ -43,7 +43,7 @@ public:
     void clear();
 
 private:
-    UncheckedKeyHashMap<SkTypefaceID, RefPtr<SkiaHarfBuzzFont>> m_cache;
+    HashMap<SkTypefaceID, RefPtr<SkiaHarfBuzzFont>> m_cache;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
@@ -109,7 +109,7 @@ private:
     private:
         friend class TextureMapperGLData;
 
-        using GLContextDataMap = UncheckedKeyHashMap<void*, SharedGLData*>;
+        using GLContextDataMap = HashMap<void*, SharedGLData*>;
         static GLContextDataMap& contextDataMap()
         {
             static NeverDestroyed<GLContextDataMap> map;
@@ -121,13 +121,13 @@ private:
             glGetIntegerv(GL_MAX_TEXTURE_SIZE, &m_maxTextureSize);
         }
 
-        UncheckedKeyHashMap<unsigned, RefPtr<TextureMapperShaderProgram>> m_programs;
+        HashMap<unsigned, RefPtr<TextureMapperShaderProgram>> m_programs;
         int32_t m_maxTextureSize;
     };
 
     const Ref<SharedGLData> m_sharedGLData;
-    UncheckedKeyHashMap<const void*, GLuint> m_vbos;
-    UncheckedKeyHashMap<uint64_t, Vector<Ref<TextureMapperGPUBuffer>>> m_buffers;
+    HashMap<const void*, GLuint> m_vbos;
+    HashMap<uint64_t, Vector<Ref<TextureMapperGPUBuffer>>> m_buffers;
 };
 
 TextureMapperGLData::TextureMapperGLData(void* platformContext)

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperAnimation.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperAnimation.cpp
@@ -156,7 +156,7 @@ static KeyframeValueList createThreadsafeKeyFrames(const KeyframeValueList& orig
 
     // Currently translation operations are the only transform operations that store a non-fixed
     // Length. Some Lengths, in particular those for calc() operations, are not thread-safe or
-    // multiprocess safe, because they maintain indices into a shared UncheckedKeyHashMap of CalculationValues.
+    // multiprocess safe, because they maintain indices into a shared HashMap of CalculationValues.
     // This code converts all possible unsafe Length parameters to fixed Lengths, which are safe to
     // use in other threads and across IPC channels.
     KeyframeValueList keyframes = originalKeyframes;

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.h
@@ -138,7 +138,7 @@ private:
     GLuint getLocation(VariableID, ASCIILiteral, VariableType);
 
     GLuint m_id;
-    UncheckedKeyHashMap<VariableID, GLuint, IntHash<VariableID>, WTF::StrongEnumHashTraits<VariableID>> m_variables;
+    HashMap<VariableID, GLuint, IntHash<VariableID>, WTF::StrongEnumHashTraits<VariableID>> m_variables;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperSparseBackingStore.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperSparseBackingStore.h
@@ -53,7 +53,7 @@ private:
     TransformationMatrix adjustedTransformForRect(const FloatRect&);
 
     IntSize m_size;
-    UncheckedKeyHashMap<TileIndex, std::unique_ptr<TextureMapperTile>> m_tiles;
+    HashMap<TileIndex, std::unique_ptr<TextureMapperTile>> m_tiles;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
@@ -52,7 +52,7 @@ public:
 private:
     CoordinatedBackingStore() = default;
 
-    UncheckedKeyHashMap<uint32_t, CoordinatedBackingStoreTile> m_tiles;
+    HashMap<uint32_t, CoordinatedBackingStoreTile> m_tiles;
     FloatSize m_size;
     float m_scale { 1. };
 };

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
@@ -149,7 +149,7 @@ private:
     IntRect m_visibleRect;
     IntRect m_coverRect;
     IntRect m_keepRect;
-    UncheckedKeyHashMap<IntPoint, Tile> m_tiles;
+    HashMap<IntPoint, Tile> m_tiles;
     struct {
         Lock lock;
         Update pending WTF_GUARDED_BY_LOCK(lock);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp
@@ -139,10 +139,10 @@ struct YUVPlaneInfo {
     IntSize subsampling;
 };
 
-static const UncheckedKeyHashMap<uint32_t, Vector<YUVPlaneInfo>>& yuvFormatPlaneInfo()
+static const HashMap<uint32_t, Vector<YUVPlaneInfo>>& yuvFormatPlaneInfo()
 {
-    static NeverDestroyed<UncheckedKeyHashMap<uint32_t, Vector<YUVPlaneInfo>>> yuvFormatsMap = [] {
-        UncheckedKeyHashMap<uint32_t, Vector<YUVPlaneInfo>> map;
+    static NeverDestroyed<HashMap<uint32_t, Vector<YUVPlaneInfo>>> yuvFormatsMap = [] {
+        HashMap<uint32_t, Vector<YUVPlaneInfo>> map;
         // 1 plane formats.
         map.set(DRM_FORMAT_AYUV, Vector<YUVPlaneInfo> {
             { DRM_FORMAT_ABGR8888, 0, 0, { 1, 1 } },

--- a/Source/WebCore/platform/graphics/win/FontCacheWin.cpp
+++ b/Source/WebCore/platform/graphics/win/FontCacheWin.cpp
@@ -99,7 +99,7 @@ WEBCORE_EXPORT void appendLinkedFonts(WCHAR* linkedFonts, unsigned length, Vecto
 
 static const Vector<String>* getLinkedFonts(String& family)
 {
-    static UncheckedKeyHashMap<String, Vector<String>*> systemLinkMap;
+    static HashMap<String, Vector<String>*> systemLinkMap;
     Vector<String>* result = systemLinkMap.get(family);
     if (result)
         return result;

--- a/Source/WebCore/platform/graphics/x11/XErrorTrapper.cpp
+++ b/Source/WebCore/platform/graphics/x11/XErrorTrapper.cpp
@@ -34,9 +34,9 @@
 
 namespace WebCore {
 
-static UncheckedKeyHashMap<Display*, Vector<XErrorTrapper*>>& xErrorTrappersMap()
+static HashMap<Display*, Vector<XErrorTrapper*>>& xErrorTrappersMap()
 {
-    static NeverDestroyed<UncheckedKeyHashMap<Display*, Vector<XErrorTrapper*>>> trappersMap;
+    static NeverDestroyed<HashMap<Display*, Vector<XErrorTrapper*>>> trappersMap;
     return trappersMap;
 }
 

--- a/Source/WebCore/platform/gtk/RenderThemeScrollbar.cpp
+++ b/Source/WebCore/platform/gtk/RenderThemeScrollbar.cpp
@@ -37,9 +37,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderThemeScrollbar);
 
-static UncheckedKeyHashMap<unsigned, std::unique_ptr<RenderThemeScrollbar>>& widgetMap()
+static HashMap<unsigned, std::unique_ptr<RenderThemeScrollbar>>& widgetMap()
 {
-    static NeverDestroyed<UncheckedKeyHashMap<unsigned, std::unique_ptr<RenderThemeScrollbar>>> map;
+    static NeverDestroyed<HashMap<unsigned, std::unique_ptr<RenderThemeScrollbar>>> map;
     return map;
 }
 

--- a/Source/WebCore/platform/ios/LegacyTileGrid.h
+++ b/Source/WebCore/platform/ios/LegacyTileGrid.h
@@ -118,7 +118,7 @@ private:
 
     float m_scale;
 
-    typedef UncheckedKeyHashMap<TileIndex, RefPtr<LegacyTileGridTile>> TileMap;
+    using TileMap = HashMap<TileIndex, RefPtr<LegacyTileGridTile>>;
     TileMap m_tiles;
 
     IntRect m_validBounds;

--- a/Source/WebCore/platform/ios/LegacyTileLayerPool.h
+++ b/Source/WebCore/platform/ios/LegacyTileLayerPool.h
@@ -70,7 +70,7 @@ private:
     typedef enum { LeaveUnchanged, MarkAsUsed } AccessType;
     LayerList& listOfLayersWithSize(const IntSize&, AccessType = LeaveUnchanged);
 
-    UncheckedKeyHashMap<IntSize, LayerList> m_reuseLists;
+    HashMap<IntSize, LayerList> m_reuseLists;
     // Ordered by recent use. The last size is the most recently used.
     Vector<IntSize> m_sizesInPruneOrder;
     unsigned m_totalBytes;

--- a/Source/WebCore/platform/ios/LegacyTileLayerPool.mm
+++ b/Source/WebCore/platform/ios/LegacyTileLayerPool.mm
@@ -59,7 +59,7 @@ unsigned LegacyTileLayerPool::bytesBackingLayerWithPixelSize(const IntSize& size
 LegacyTileLayerPool::LayerList& LegacyTileLayerPool::listOfLayersWithSize(const IntSize& size, AccessType accessType)
 {
     ASSERT(!m_layerPoolMutex.tryLock());
-    UncheckedKeyHashMap<IntSize, LayerList>::iterator it = m_reuseLists.find(size);
+    HashMap<IntSize, LayerList>::iterator it = m_reuseLists.find(size);
     if (it == m_reuseLists.end()) {
         it = m_reuseLists.add(size, LayerList()).iterator;
         m_sizesInPruneOrder.append(size);

--- a/Source/WebCore/platform/ios/PreviewConverterIOS.mm
+++ b/Source/WebCore/platform/ios/PreviewConverterIOS.mm
@@ -92,9 +92,9 @@ PreviewConverter::PreviewConverter(const ResourceResponse& response, PreviewConv
 {
 }
 
-UncheckedKeyHashSet<String, ASCIICaseInsensitiveHash> PreviewConverter::platformSupportedMIMETypes()
+HashSet<String, ASCIICaseInsensitiveHash> PreviewConverter::platformSupportedMIMETypes()
 {
-    UncheckedKeyHashSet<String, ASCIICaseInsensitiveHash> supportedMIMETypes;
+    HashSet<String, ASCIICaseInsensitiveHash> supportedMIMETypes;
     for (NSString *mimeType in QLPreviewGetSupportedMIMETypesSet())
         supportedMIMETypes.add(mimeType);
     return supportedMIMETypes;

--- a/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
+++ b/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
@@ -230,8 +230,8 @@ private:
     void didCleanupFullscreen() final;
     void fullscreenMayReturnToInline() final;
 
-    UncheckedKeyHashSet<CheckedPtr<PlaybackSessionModelClient>> m_playbackClients;
-    UncheckedKeyHashSet<CheckedPtr<VideoPresentationModelClient>> m_presentationClients;
+    HashSet<CheckedPtr<PlaybackSessionModelClient>> m_playbackClients;
+    HashSet<CheckedPtr<VideoPresentationModelClient>> m_presentationClients;
     RefPtr<VideoPresentationInterfaceIOS> m_interface;
     RefPtr<VideoPresentationModelVideoElement> m_presentationModel;
     RefPtr<PlaybackSessionModelMediaElement> m_playbackModel;

--- a/Source/WebCore/platform/mac/HIDDevice.cpp
+++ b/Source/WebCore/platform/mac/HIDDevice.cpp
@@ -75,7 +75,7 @@ HIDDevice::HIDDevice(IOHIDDeviceRef device)
 
 Vector<HIDElement> HIDDevice::uniqueInputElementsInDeviceTreeOrder() const
 {
-    UncheckedKeyHashSet<IOHIDElementCookie> encounteredCookies;
+    HashSet<IOHIDElementCookie> encounteredCookies;
     Deque<IOHIDElementRef> elementQueue;
 
     RetainPtr<CFArrayRef> elements = adoptCF(IOHIDDeviceCopyMatchingElements(m_rawDevice.get(), NULL, kIOHIDOptionsTypeNone));

--- a/Source/WebCore/platform/mac/PasteboardMac.mm
+++ b/Source/WebCore/platform/mac/PasteboardMac.mm
@@ -444,7 +444,7 @@ void Pasteboard::read(PasteboardWebContentReader& reader, WebContentReadingPolic
 {
     auto& strategy = *platformStrategies()->pasteboardStrategy();
     auto platformTypesFromItems = [](const Vector<PasteboardItemInfo>& items) {
-        UncheckedKeyHashSet<String> types;
+        HashSet<String> types;
         for (auto& item : items) {
             for (auto& type : item.platformTypesByFidelity)
                 types.add(type);
@@ -452,7 +452,7 @@ void Pasteboard::read(PasteboardWebContentReader& reader, WebContentReadingPolic
         return types;
     };
 
-    UncheckedKeyHashSet<String> nonTranscodedTypes;
+    HashSet<String> nonTranscodedTypes;
     Vector<String> types;
     if (itemIndex) {
         if (auto itemInfo = strategy.informationForItemAtIndex(*itemIndex, m_pasteboardName, m_changeCount, context())) {

--- a/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
@@ -54,7 +54,7 @@
 
 namespace WebCore {
 
-using ScrollbarSet = UncheckedKeyHashSet<SingleThreadWeakRef<Scrollbar>>;
+using ScrollbarSet = HashSet<SingleThreadWeakRef<Scrollbar>>;
 
 static ScrollbarSet& scrollbarMap()
 {

--- a/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.h
+++ b/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.h
@@ -46,7 +46,7 @@ public:
 
     WEBCORE_EXPORT SerializedPlatformDataCueValue encodableValue() const final;
 
-    WEBCORE_EXPORT static const UncheckedKeyHashSet<RetainPtr<Class>>& allowedClassesForNativeValues();
+    WEBCORE_EXPORT static const HashSet<RetainPtr<Class>>& allowedClassesForNativeValues();
 
 private:
     SerializedPlatformDataCueValue m_value;

--- a/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm
+++ b/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm
@@ -101,9 +101,9 @@ const SerializedPlatformDataCueMac* toSerializedPlatformDataCueMac(const Seriali
     return static_cast<const SerializedPlatformDataCueMac*>(rep);
 }
 
-const UncheckedKeyHashSet<RetainPtr<Class>>& SerializedPlatformDataCueMac::allowedClassesForNativeValues()
+const HashSet<RetainPtr<Class>>& SerializedPlatformDataCueMac::allowedClassesForNativeValues()
 {
-    static NeverDestroyed<UncheckedKeyHashSet<RetainPtr<Class>>> allowedClasses(UncheckedKeyHashSet<RetainPtr<Class>> { [NSString class], [NSNumber class], [NSLocale class], [NSDictionary class], [NSArray class], [NSData class] });
+    static NeverDestroyed<HashSet<RetainPtr<Class>>> allowedClasses(HashSet<RetainPtr<Class>> { [NSString class], [NSNumber class], [NSLocale class], [NSDictionary class], [NSArray class], [NSData class] });
     return allowedClasses;
 }
 

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -399,7 +399,7 @@ private:
     WeakHashSet<RealtimeMediaSourceObserver> m_observers;
 
     mutable Lock m_audioSampleObserversLock;
-    UncheckedKeyHashSet<CheckedPtr<AudioSampleObserver>> m_audioSampleObservers WTF_GUARDED_BY_LOCK(m_audioSampleObserversLock);
+    HashSet<CheckedPtr<AudioSampleObserver>> m_audioSampleObservers WTF_GUARDED_BY_LOCK(m_audioSampleObserversLock);
 
     mutable Lock m_videoFrameObserversLock;
     HashMap<VideoFrameObserver*, std::unique_ptr<VideoFrameAdaptor>> m_videoFrameObservers WTF_GUARDED_BY_LOCK(m_videoFrameObserversLock);

--- a/Source/WebCore/platform/mediastream/RealtimeOutgoingAudioSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeOutgoingAudioSource.h
@@ -133,7 +133,7 @@ private:
     bool m_enabled { true };
 
     mutable Lock m_sinksLock;
-    UncheckedKeyHashSet<webrtc::AudioTrackSinkInterface*> m_sinks WTF_GUARDED_BY_LOCK(m_sinksLock);
+    HashSet<webrtc::AudioTrackSinkInterface*> m_sinks WTF_GUARDED_BY_LOCK(m_sinksLock);
 
 #if !RELEASE_LOG_DISABLED
     size_t m_chunksSent { 0 };

--- a/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h
@@ -145,7 +145,7 @@ private:
     rtc::scoped_refptr<webrtc::VideoFrameBuffer> m_blackFrame;
 
     mutable Lock m_sinksLock;
-    UncheckedKeyHashSet<rtc::VideoSinkInterface<webrtc::VideoFrame>*> m_sinks WTF_GUARDED_BY_LOCK(m_sinksLock);
+    HashSet<rtc::VideoSinkInterface<webrtc::VideoFrame>*> m_sinks WTF_GUARDED_BY_LOCK(m_sinksLock);
     bool m_areSinksAskingToApplyRotation { false };
 
     bool m_enabled { true };

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.h
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.h
@@ -99,7 +99,7 @@ private:
         OSStatus render(size_t sampleCount, AudioBufferList&, uint64_t sampleTime, double hostTime, AudioUnitRenderActionFlags&) final;
         void reset() final;
 
-        UncheckedKeyHashSet<Ref<AudioSampleDataSource>> m_sources WTF_GUARDED_BY_CAPABILITY(mainThread);
+        HashSet<Ref<AudioSampleDataSource>> m_sources WTF_GUARDED_BY_CAPABILITY(mainThread);
         Vector<Ref<AudioSampleDataSource>> m_renderSources;
 
         Lock m_pendingRenderSourcesLock;

--- a/Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.h
+++ b/Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.h
@@ -91,7 +91,7 @@ private:
     const Ref<WTF::WorkQueue> m_queue;
 
     struct Mixer {
-        UncheckedKeyHashSet<Ref<AudioSampleDataSource>> sources;
+        HashSet<Ref<AudioSampleDataSource>> sources;
         RefPtr<AudioSampleDataSource> registeredMixedSource;
         String deviceID;
     };

--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp
@@ -43,13 +43,13 @@ static constexpr double s_HumVolume = 0.1;
 static constexpr double s_NoiseFrequency = 3000;
 static constexpr double s_NoiseVolume = 0.05;
 
-static UncheckedKeyHashSet<MockRealtimeAudioSource*>& allMockRealtimeAudioSourcesStorage()
+static HashSet<MockRealtimeAudioSource*>& allMockRealtimeAudioSourcesStorage()
 {
-    static MainThreadNeverDestroyed<UncheckedKeyHashSet<MockRealtimeAudioSource*>> audioSources;
+    static MainThreadNeverDestroyed<HashSet<MockRealtimeAudioSource*>> audioSources;
     return audioSources;
 }
 
-const UncheckedKeyHashSet<MockRealtimeAudioSource*>& MockRealtimeAudioSourceGStreamer::allMockRealtimeAudioSources()
+const HashSet<MockRealtimeAudioSource*>& MockRealtimeAudioSourceGStreamer::allMockRealtimeAudioSources()
 {
     return allMockRealtimeAudioSourcesStorage();
 }

--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.h
@@ -35,7 +35,7 @@ class MockRealtimeAudioSourceGStreamer final : public MockRealtimeAudioSource, G
 public:
     static Ref<MockRealtimeAudioSource> createForMockAudioCapturer(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&&);
 
-    static const UncheckedKeyHashSet<MockRealtimeAudioSource*>& allMockRealtimeAudioSources();
+    static const HashSet<MockRealtimeAudioSource*>& allMockRealtimeAudioSources();
 
     ~MockRealtimeAudioSourceGStreamer();
 

--- a/Source/WebCore/platform/mock/GeolocationClientMock.h
+++ b/Source/WebCore/platform/mock/GeolocationClientMock.h
@@ -90,7 +90,8 @@ private:
         PermissionStateAllowed,
         PermissionStateDenied,
     } m_permissionState;
-    typedef UncheckedKeyHashSet<RefPtr<Geolocation>> GeolocationSet;
+
+    using GeolocationSet = HashSet<RefPtr<Geolocation>>;
     GeolocationSet m_pendingPermission;
 };
 

--- a/Source/WebCore/platform/network/DNSResolveQueue.cpp
+++ b/Source/WebCore/platform/network/DNSResolveQueue.cpp
@@ -122,7 +122,7 @@ void DNSResolveQueue::timerFired()
 
     for (; !m_names.isEmpty() && requestsAllowed > 0; --requestsAllowed) {
         ++m_requestsInFlight;
-        UncheckedKeyHashSet<String>::iterator currentName = m_names.begin();
+        HashSet<String>::iterator currentName = m_names.begin();
         platformResolve(*currentName);
         m_names.remove(currentName);
     }

--- a/Source/WebCore/platform/network/DNSResolveQueue.h
+++ b/Source/WebCore/platform/network/DNSResolveQueue.h
@@ -68,7 +68,7 @@ private:
 
     Timer m_timer;
 
-    UncheckedKeyHashSet<String> m_names;
+    HashSet<String> m_names;
     std::atomic<int> m_requestsInFlight;
     MonotonicTime m_lastProxyEnabledStatusCheckTime;
 };

--- a/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.h
+++ b/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.h
@@ -78,8 +78,8 @@ WEBCORE_EXPORT @interface WebCoreNSURLSession : NSObject {
     RetainPtr<NSOperationQueue> _queue;
     RetainPtr<NSString> _sessionDescription;
     Lock _dataTasksLock;
-    UncheckedKeyHashSet<RetainPtr<WebCoreNSURLSessionDataTask>> _dataTasks WTF_GUARDED_BY_LOCK(_dataTasksLock);
-    UncheckedKeyHashSet<RefPtr<WebCore::SecurityOrigin>> _origins WTF_GUARDED_BY_LOCK(_dataTasksLock);
+    HashSet<RetainPtr<WebCoreNSURLSessionDataTask>> _dataTasks WTF_GUARDED_BY_LOCK(_dataTasksLock);
+    HashSet<RefPtr<WebCore::SecurityOrigin>> _origins WTF_GUARDED_BY_LOCK(_dataTasksLock);
     BOOL _invalidated; // Access on multiple thread, must be accessed via ObjC property.
     NSUInteger _nextTaskIdentifier;
     RefPtr<WTF::WorkQueue> _internalQueue;

--- a/Source/WebCore/platform/network/curl/CurlRequestScheduler.h
+++ b/Source/WebCore/platform/network/curl/CurlRequestScheduler.h
@@ -71,7 +71,7 @@ private:
     bool m_runThread { false };
 
     Vector<Function<void()>> m_taskQueue;
-    UncheckedKeyHashSet<CurlRequestSchedulerClient*> m_activeJobs;
+    HashSet<CurlRequestSchedulerClient*> m_activeJobs;
     HashMap<CURL*, CurlRequestSchedulerClient*> m_clientMaps;
 
     Lock m_multiHandleMutex;

--- a/Source/WebCore/platform/network/mac/UTIUtilities.h
+++ b/Source/WebCore/platform/network/mac/UTIUtilities.h
@@ -30,7 +30,7 @@
 namespace WebCore {
 
 WEBCORE_EXPORT String MIMETypeFromUTI(const String&);
-WEBCORE_EXPORT UncheckedKeyHashSet<String> RequiredMIMETypesFromUTI(const String&);
+WEBCORE_EXPORT HashSet<String> RequiredMIMETypesFromUTI(const String&);
 RetainPtr<CFStringRef> mimeTypeFromUTITree(CFStringRef);
 WEBCORE_EXPORT String UTIFromMIMEType(const String&);
 bool isDeclaredUTI(const String&);

--- a/Source/WebCore/platform/network/mac/UTIUtilities.mm
+++ b/Source/WebCore/platform/network/mac/UTIUtilities.mm
@@ -52,9 +52,9 @@ String MIMETypeFromUTI(const String& uti)
     return type.get().preferredMIMEType;
 }
 
-UncheckedKeyHashSet<String> RequiredMIMETypesFromUTI(const String& uti)
+HashSet<String> RequiredMIMETypesFromUTI(const String& uti)
 {
-    UncheckedKeyHashSet<String> mimeTypes;
+    HashSet<String> mimeTypes;
 
     auto mainMIMEType = MIMETypeFromUTI(uti);
     if (!mainMIMEType.isEmpty())

--- a/Source/WebCore/platform/network/soup/ResourceResponseSoup.cpp
+++ b/Source/WebCore/platform/network/soup/ResourceResponseSoup.cpp
@@ -120,7 +120,7 @@ static String sanitizeFilename(const String& filename)
         ASSERT(U_SUCCESS(errorCode));
     }
 
-    UncheckedKeyHashSet<uint16_t> illegalCharactersInFilename;
+    HashSet<uint16_t> illegalCharactersInFilename;
     for (unsigned i = 0; i < result.length(); ++i) {
         auto character = result[i];
         if (uset_contains(illegalCharacterSet, character))

--- a/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
+++ b/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
@@ -94,7 +94,7 @@ private:
         return base64EncodeToString(digest->computeHash());
     }
 
-    UncheckedKeyHashSet<String> m_certificates;
+    HashSet<String> m_certificates;
 };
 
 SoupNetworkSession::SoupNetworkSession(PAL::SessionID sessionID)

--- a/Source/WebCore/platform/text/BidiResolver.h
+++ b/Source/WebCore/platform/text/BidiResolver.h
@@ -262,7 +262,7 @@ protected:
     WhitespaceCollapsingState<Iterator> m_whitespaceCollapsingState;
 
     unsigned m_nestedIsolateCount { 0 };
-    UncheckedKeyHashMap<Run*, unsigned> m_whitespaceCollapsingTransitionForIsolatedRun;
+    HashMap<Run*, unsigned> m_whitespaceCollapsingTransitionForIsolatedRun;
 
 private:
     void raiseExplicitEmbeddingLevel(UCharDirection from, UCharDirection to);

--- a/Source/WebCore/platform/text/TextFlags.h
+++ b/Source/WebCore/platform/text/TextFlags.h
@@ -462,7 +462,7 @@ enum class FontStyleAxis : uint8_t {
 
 enum class AllowUserInstalledFonts : bool { No, Yes };
 
-using FeaturesMap = UncheckedKeyHashMap<FontTag, int, FourCharacterTagHash, FourCharacterTagHashTraits>;
+using FeaturesMap = HashMap<FontTag, int, FourCharacterTagHash, FourCharacterTagHashTraits>;
 FeaturesMap computeFeatureSettingsFromVariants(const FontVariantSettings&, RefPtr<FontFeatureValues>);
 
 enum class ResolvedEmojiPolicy : uint8_t {

--- a/Source/WebCore/platform/text/cocoa/LocaleCocoa.mm
+++ b/Source/WebCore/platform/text/cocoa/LocaleCocoa.mm
@@ -269,7 +269,7 @@ const Vector<String>& LocaleCocoa::timeAMPMLabels()
     return m_timeAMPMLabels;
 }
 
-using CanonicalLocaleMap = UncheckedKeyHashMap<AtomString, RetainPtr<CFStringRef>>;
+using CanonicalLocaleMap = HashMap<AtomString, RetainPtr<CFStringRef>>;
 
 struct LocaleCache {
     AtomString m_key;

--- a/Source/WebCore/platform/text/cocoa/LocalizedDateCache.h
+++ b/Source/WebCore/platform/text/cocoa/LocalizedDateCache.h
@@ -55,8 +55,8 @@ private:
     // Using int instead of DateComponentsType for the key because the enum
     // does not have a default hash and hash traits. Usage of the maps
     // casts the DateComponents::Type into an int as the key.
-    typedef UncheckedKeyHashMap<int, RetainPtr<NSDateFormatter>> DateTypeFormatterMap;
-    typedef UncheckedKeyHashMap<int, float> DateTypeMaxWidthMap;
+    using DateTypeFormatterMap = HashMap<int, RetainPtr<NSDateFormatter>>;
+    using DateTypeMaxWidthMap = HashMap<int, float>;
     DateTypeFormatterMap m_formatterMap;
     DateTypeMaxWidthMap m_maxWidthMap;
     FontCascade m_font;

--- a/Source/WebCore/platform/text/hyphen/HyphenationLibHyphen.cpp
+++ b/Source/WebCore/platform/text/hyphen/HyphenationLibHyphen.cpp
@@ -67,7 +67,7 @@ static AtomString extractLocaleFromDictionaryFileName(const String& fileName)
     return StringView(fileName).substring(prefixLength, fileName.length() - prefixLength - suffixLength).convertToASCIILowercaseAtom();
 }
 
-static void scanDirectoryForDictionaries(const char* directoryPath, UncheckedKeyHashMap<AtomString, Vector<String>>& availableLocales)
+static void scanDirectoryForDictionaries(const char* directoryPath, HashMap<AtomString, Vector<String>>& availableLocales)
 {
     auto directoryPathString = String::fromUTF8(directoryPath);
     for (auto& fileName : FileSystem::listDirectory(directoryPathString)) {
@@ -104,7 +104,7 @@ static CString webkitBuildDirectory()
 }
 #endif // PLATFORM(GTK)
 
-static void scanTestDictionariesDirectoryIfNecessary(UncheckedKeyHashMap<AtomString, Vector<String>>& availableLocales)
+static void scanTestDictionariesDirectoryIfNecessary(HashMap<AtomString, Vector<String>>& availableLocales)
 {
     // It's unfortunate that we need to look for the dictionaries this way, but
     // libhyphen doesn't have the concept of installed dictionaries. Instead,
@@ -137,10 +137,10 @@ static void scanTestDictionariesDirectoryIfNecessary(UncheckedKeyHashMap<AtomStr
 }
 #endif
 
-static UncheckedKeyHashMap<AtomString, Vector<String>>& availableLocales()
+static HashMap<AtomString, Vector<String>>& availableLocales()
 {
     static bool scannedLocales = false;
-    static UncheckedKeyHashMap<AtomString, Vector<String>> availableLocales;
+    static HashMap<AtomString, Vector<String>> availableLocales;
 
     if (!scannedLocales) {
         for (size_t i = 0; i < std::size(gDictionaryDirectories); i++)

--- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
+++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
@@ -682,7 +682,7 @@ struct ClipboardDataItem {
     ClipboardDataItem(FORMATETC* format, GetStringFunction getString, SetStringFunction setString): format(format), getString(getString), setString(setString) { }
 };
 
-typedef UncheckedKeyHashMap<UINT, ClipboardDataItem*> ClipboardFormatMap;
+using ClipboardFormatMap = HashMap<UINT, ClipboardDataItem*>;
 
 // Getter functions.
 

--- a/Source/WebCore/platform/win/MIMETypeRegistryWin.cpp
+++ b/Source/WebCore/platform/win/MIMETypeRegistryWin.cpp
@@ -72,7 +72,7 @@ String MIMETypeRegistry::mimeTypeForExtension(StringView string)
         return String();
 
     auto ext = string.toString();
-    static UncheckedKeyHashMap<String, String> mimetypeMap;
+    static HashMap<String, String> mimetypeMap;
     if (mimetypeMap.isEmpty()) {
         //fill with initial values
         mimetypeMap.add("txt"_s, "text/plain"_s);

--- a/Source/WebCore/platform/win/WindowMessageBroadcaster.cpp
+++ b/Source/WebCore/platform/win/WindowMessageBroadcaster.cpp
@@ -33,7 +33,7 @@
 
 namespace WebCore {
 
-typedef UncheckedKeyHashMap<HWND, WindowMessageBroadcaster*> InstanceMap;
+using InstanceMap = HashMap<HWND, WindowMessageBroadcaster*>;
 
 static InstanceMap& instancesMap()
 {

--- a/Source/WebCore/platform/win/WindowMessageBroadcaster.h
+++ b/Source/WebCore/platform/win/WindowMessageBroadcaster.h
@@ -44,7 +44,7 @@ namespace WebCore {
         WEBCORE_EXPORT static void removeListener(HWND, WindowMessageListener*);
 
     private:
-        typedef UncheckedKeyHashSet<WindowMessageListener*> ListenerSet;
+        using ListenerSet = HashSet<WindowMessageListener*>;
 
         static LRESULT CALLBACK SubclassedWndProc(HWND, UINT, WPARAM, LPARAM);
 

--- a/Source/WebCore/platform/win/WindowsKeyNames.h
+++ b/Source/WebCore/platform/win/WindowsKeyNames.h
@@ -54,7 +54,7 @@ private:
     bool m_hasAltGraph = false;
 
     using VirtualKeyModifierSetPair = std::pair<unsigned, KeyModifierSet>;
-    using VirtualKeyToKeyMap = UncheckedKeyHashMap<VirtualKeyModifierSetPair, String, DefaultHash<VirtualKeyModifierSetPair>, PairHashTraits<WTF::UnsignedWithZeroKeyHashTraits<unsigned>, HashTraits<KeyModifierSet>>>;
+    using VirtualKeyToKeyMap = HashMap<VirtualKeyModifierSetPair, String, DefaultHash<VirtualKeyModifierSetPair>, PairHashTraits<WTF::UnsignedWithZeroKeyHashTraits<unsigned>, HashTraits<KeyModifierSet>>>;
     VirtualKeyToKeyMap m_printableKeyCodeToKey;
 };
 

--- a/Source/WebCore/platform/xr/openxr/OpenXRInputSource.h
+++ b/Source/WebCore/platform/xr/openxr/OpenXRInputSource.h
@@ -34,7 +34,7 @@ class OpenXRInputSource {
     WTF_MAKE_TZONE_ALLOCATED(OpenXRInputSource);
     WTF_MAKE_NONCOPYABLE(OpenXRInputSource);
 public:
-    using SuggestedBindings = UncheckedKeyHashMap<const char*, Vector<XrActionSuggestedBinding>>;
+    using SuggestedBindings = HashMap<const char*, Vector<XrActionSuggestedBinding>>;
     static std::unique_ptr<OpenXRInputSource> create(XrInstance, XrSession, XRHandedness, InputSourceHandle);
     ~OpenXRInputSource();
 
@@ -76,9 +76,9 @@ private:
     XrSpace m_gripSpace { XR_NULL_HANDLE };
     XrAction m_pointerAction { XR_NULL_HANDLE };
     XrSpace m_pointerSpace { XR_NULL_HANDLE };
-    using OpenXRButtonActionsMap = UncheckedKeyHashMap<OpenXRButtonType, OpenXRButtonActions, IntHash<OpenXRButtonType>, WTF::StrongEnumHashTraits<OpenXRButtonType>>;
+    using OpenXRButtonActionsMap = HashMap<OpenXRButtonType, OpenXRButtonActions, IntHash<OpenXRButtonType>, WTF::StrongEnumHashTraits<OpenXRButtonType>>;
     OpenXRButtonActionsMap m_buttonActions;
-    using OpenXRAxesMap = UncheckedKeyHashMap<OpenXRAxisType, XrAction, IntHash<OpenXRAxisType>, WTF::StrongEnumHashTraits<OpenXRAxisType>>;
+    using OpenXRAxesMap = HashMap<OpenXRAxisType, XrAction, IntHash<OpenXRAxisType>, WTF::StrongEnumHashTraits<OpenXRAxisType>>;
     OpenXRAxesMap m_axisActions;
     Vector<String> m_profiles;
 };


### PR DESCRIPTION
#### c7c0c362bfa5c97b717e103eeee548027c27c856
<pre>
Stop using UncheckedKey containers in WebCore/platform
<a href="https://bugs.webkit.org/show_bug.cgi?id=294394">https://bugs.webkit.org/show_bug.cgi?id=294394</a>

Reviewed by Ryosuke Niwa.

Stop using UncheckedKey containers in WebCore/platform, for memory safety.
This tested as performance neutral on MotionMark and Speedometer.

* Source/WebCore/platform/DragData.h:
* Source/WebCore/platform/LegacySchemeRegistry.h:
* Source/WebCore/platform/Length.cpp:
* Source/WebCore/platform/MIMETypeRegistry.cpp:
(WebCore::commonMimeTypesMap):
* Source/WebCore/platform/PasteboardCustomData.cpp:
(WebCore::PasteboardCustomData::fromPersistenceDecoder):
(WebCore::PasteboardCustomData::sameOriginCustomStringData const):
* Source/WebCore/platform/PasteboardCustomData.h:
* Source/WebCore/platform/PreviewConverter.cpp:
(WebCore::PreviewConverter::supportsMIMEType):
* Source/WebCore/platform/PreviewConverter.h:
* Source/WebCore/platform/PublicSuffixStore.h:
* Source/WebCore/platform/RemoteCommandListener.h:
* Source/WebCore/platform/ScrollSnapAnimatorState.cpp:
(WebCore::ScrollSnapAnimatorState::currentlySnappedBoxes const):
(WebCore::chooseBoxToResnapTo):
* Source/WebCore/platform/ScrollSnapAnimatorState.h:
* Source/WebCore/platform/ScrollView.h:
(WebCore::ScrollView::children const):
* Source/WebCore/platform/SharedStringHash.h:
* Source/WebCore/platform/Supplementable.h:
* Source/WebCore/platform/audio/HRTFDatabaseLoader.cpp:
* Source/WebCore/platform/audio/HRTFElevation.cpp:
(WebCore::WTF_REQUIRES_LOCK):
* Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h:
* Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp:
* Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.h:
* Source/WebCore/platform/cocoa/MIMETypeRegistryCocoa.mm:
(WebCore::additionalMimeTypesMap):
(WebCore::additionalExtensionsMap):
* Source/WebCore/platform/cocoa/PasteboardCocoa.mm:
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h:
* Source/WebCore/platform/cocoa/PublicSuffixStoreCocoa.mm:
(WebCore::PublicSuffixStore::enablePublicSuffixCache):
* Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h:
* Source/WebCore/platform/encryptedmedia/CDMProxy.h:
* Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.h:
* Source/WebCore/platform/generic/KeyedDecoderGeneric.cpp:
* Source/WebCore/platform/glib/KeyedDecoderGlib.cpp:
(WebCore::KeyedDecoderGlib::dictionaryFromGVariant):
* Source/WebCore/platform/glib/KeyedDecoderGlib.h:
* Source/WebCore/platform/glib/SelectionData.h:
(WebCore::SelectionData::buffers const):
* Source/WebCore/platform/glib/SystemSettings.h:
* Source/WebCore/platform/graphics/AV1Utilities.cpp:
* Source/WebCore/platform/graphics/DisplayRefreshMonitor.h:
* Source/WebCore/platform/graphics/Font.h:
* Source/WebCore/platform/graphics/FontCache.cpp:
* Source/WebCore/platform/graphics/FontCache.h:
* Source/WebCore/platform/graphics/FontCascadeCache.h:
* Source/WebCore/platform/graphics/FontCascadeFonts.h:
* Source/WebCore/platform/graphics/FontFeatureValues.h:
* Source/WebCore/platform/graphics/FontGenericFamilies.h:
* Source/WebCore/platform/graphics/FontPlatformData.h:
* Source/WebCore/platform/graphics/GlyphMetricsMap.h:
* Source/WebCore/platform/graphics/GraphicsContextGLState.h:
* Source/WebCore/platform/graphics/GraphicsLayer.cpp:
* Source/WebCore/platform/graphics/MIMETypeCache.cpp:
(WebCore::MIMETypeCache::canDecodeType):
* Source/WebCore/platform/graphics/MIMETypeCache.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h:
(WebCore::MediaPlayerPrivateInterface::originsInMediaCache):
(WebCore::MediaPlayerPrivateInterface::clearMediaCacheForOrigins):
* Source/WebCore/platform/graphics/PlatformDisplay.cpp:
* Source/WebCore/platform/graphics/SystemFallbackFontCache.h:
* Source/WebCore/platform/graphics/WidthCache.h:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::usedDisplays):
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:
* Source/WebCore/platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h:
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/graphics/ca/LayerPool.cpp:
(WebCore::LayerPool::allLayerPools):
(WebCore::LayerPool::listOfLayersWithSize):
* Source/WebCore/platform/graphics/ca/LayerPool.h:
* Source/WebCore/platform/graphics/ca/TileGrid.cpp:
(WebCore::TileGrid::ensureTilesForRect):
* Source/WebCore/platform/graphics/ca/TileGrid.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm:
* Source/WebCore/platform/graphics/cg/CGSubimageCacheWithTimer.h:
* Source/WebCore/platform/graphics/cg/ColorSpaceCG.cpp:
(WebCore::colorSpaceForCGColorSpace):
* Source/WebCore/platform/graphics/cg/IOSurfacePool.h:
* Source/WebCore/platform/graphics/cg/UTIRegistry.mm:
(WebCore::filterSupportedImageTypes):
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.h:
* Source/WebCore/platform/graphics/cocoa/FontFamilySpecificationCoreTextCache.h:
* Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.h:
* Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.h:
* Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.h:
* Source/WebCore/platform/graphics/filters/FilterEffectGeometry.h:
* Source/WebCore/platform/graphics/filters/FilterResults.h:
* Source/WebCore/platform/graphics/freetype/FontCacheFreeType.h:
* Source/WebCore/platform/graphics/freetype/FontSetCache.h:
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::activePipelinesMap):
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::GStreamerRegistryScanner::isRtpPacketizerSupported):
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h:
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::didReceiveInitializationSegment):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h:
* Source/WebCore/platform/graphics/opentype/OpenTypeVerticalData.cpp:
(WebCore::OpenType::LookupTable::getSubstitutions const):
(WebCore::OpenType::FeatureTable::getGlyphSubstitutions const):
(WebCore::OpenType::GSUBTable::getVerticalGlyphSubstitutions const):
(WebCore::OpenTypeVerticalData::substituteWithVerticalGlyphs const):
* Source/WebCore/platform/graphics/opentype/OpenTypeVerticalData.h:
* Source/WebCore/platform/graphics/skia/FontVariationsSkia.h:
* Source/WebCore/platform/graphics/skia/SkiaHarfBuzzFontCache.h:
* Source/WebCore/platform/graphics/texmap/TextureMapper.cpp:
* Source/WebCore/platform/graphics/texmap/TextureMapperAnimation.cpp:
(WebCore::createThreadsafeKeyFrames):
* Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperSparseBackingStore.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp:
(WebCore::yuvFormatPlaneInfo):
* Source/WebCore/platform/graphics/win/FontCacheWin.cpp:
(WebCore::getLinkedFonts):
* Source/WebCore/platform/graphics/x11/XErrorTrapper.cpp:
(WebCore::xErrorTrappersMap):
* Source/WebCore/platform/gtk/RenderThemeScrollbar.cpp:
(WebCore::widgetMap):
* Source/WebCore/platform/ios/LegacyTileGrid.h:
* Source/WebCore/platform/ios/LegacyTileLayerPool.h:
* Source/WebCore/platform/ios/LegacyTileLayerPool.mm:
(WebCore::LegacyTileLayerPool::listOfLayersWithSize):
* Source/WebCore/platform/ios/PreviewConverterIOS.mm:
(WebCore::PreviewConverter::platformSupportedMIMETypes):
* Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm:
* Source/WebCore/platform/mac/HIDDevice.cpp:
(WebCore::HIDDevice::uniqueInputElementsInDeviceTreeOrder const):
* Source/WebCore/platform/mac/PasteboardMac.mm:
(WebCore::Pasteboard::read):
* Source/WebCore/platform/mac/ScrollbarThemeMac.mm:
* Source/WebCore/platform/mac/SerializedPlatformDataCueMac.h:
* Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm:
(WebCore::SerializedPlatformDataCueMac::allowedClassesForNativeValues):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
* Source/WebCore/platform/mediastream/RealtimeOutgoingAudioSource.h:
* Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h:
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.h:
* Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.h:
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp:
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.h:
* Source/WebCore/platform/mock/GeolocationClientMock.h:
* Source/WebCore/platform/network/DNSResolveQueue.cpp:
(WebCore::DNSResolveQueue::timerFired):
* Source/WebCore/platform/network/DNSResolveQueue.h:
* Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.h:
* Source/WebCore/platform/network/curl/CurlRequestScheduler.h:
* Source/WebCore/platform/network/mac/UTIUtilities.h:
* Source/WebCore/platform/network/mac/UTIUtilities.mm:
(WebCore::RequiredMIMETypesFromUTI):
* Source/WebCore/platform/network/soup/ResourceResponseSoup.cpp:
(WebCore::sanitizeFilename):
* Source/WebCore/platform/network/soup/SoupNetworkSession.cpp:
* Source/WebCore/platform/text/BidiResolver.h:
* Source/WebCore/platform/text/TextFlags.h:
* Source/WebCore/platform/text/cocoa/LocaleCocoa.mm:
* Source/WebCore/platform/text/cocoa/LocalizedDateCache.h:
* Source/WebCore/platform/text/hyphen/HyphenationLibHyphen.cpp:
(WebCore::scanDirectoryForDictionaries):
(WebCore::scanTestDictionariesDirectoryIfNecessary):
(WebCore::availableLocales):
* Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp:
* Source/WebCore/platform/win/MIMETypeRegistryWin.cpp:
(WebCore::MIMETypeRegistry::mimeTypeForExtension):
* Source/WebCore/platform/win/WindowMessageBroadcaster.cpp:
* Source/WebCore/platform/win/WindowMessageBroadcaster.h:
* Source/WebCore/platform/win/WindowsKeyNames.h:
* Source/WebCore/platform/xr/openxr/OpenXRInputSource.h:

Canonical link: <a href="https://commits.webkit.org/296163@main">https://commits.webkit.org/296163@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aecf40345f6a5cd8908e0bbab8e81647ed3036bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107519 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27201 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17610 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112735 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58055 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109483 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35702 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81623 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110448 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22093 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96901 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62007 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15041 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57499 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91461 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15073 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115835 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34586 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25490 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90667 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34961 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93156 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90408 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23063 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35318 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13093 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30344 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34507 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40067 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34254 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37609 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35914 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->