### PR TITLE
Require MallocPtr parameter type to be trivially destructible, correctly destroy FuncRefTable

### DIFF
--- a/Source/JavaScriptCore/bytecode/ExpressionInfo.h
+++ b/Source/JavaScriptCore/bytecode/ExpressionInfo.h
@@ -29,7 +29,6 @@
 #include <wtf/HashMap.h>
 #include <wtf/HashTraits.h>
 #include <wtf/IterationStatus.h>
-#include <wtf/MallocPtr.h>
 #include <wtf/PrintStream.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>

--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -43,7 +43,6 @@
 #include "UnlinkedModuleProgramCodeBlock.h"
 #include "UnlinkedProgramCodeBlock.h"
 #include <wtf/FileHandle.h>
-#include <wtf/MallocPtr.h>
 #include <wtf/MallocSpan.h>
 #include <wtf/Packed.h>
 #include <wtf/RobinHoodHashMap.h>

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -68,12 +68,12 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <wtf/BumpPointerAllocator.h>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/DoublyLinkedList.h>
+#include <wtf/FixedVector.h>
 #include <wtf/Forward.h>
 #include <wtf/Gigacage.h>
 #include <wtf/HashMap.h>
 #include <wtf/LazyRef.h>
 #include <wtf/LazyUniqueRef.h>
-#include <wtf/MallocPtr.h>
 #include <wtf/SetForScope.h>
 #include <wtf/StackPointer.h>
 #include <wtf/Stopwatch.h>
@@ -749,9 +749,9 @@ public:
     EncodedJSValue* exceptionFuzzingBuffer(size_t size)
     {
         ASSERT(Options::useExceptionFuzz());
-        if (!m_exceptionFuzzBuffer)
-            m_exceptionFuzzBuffer = MallocPtr<EncodedJSValue, VMMalloc>::malloc(size);
-        return m_exceptionFuzzBuffer.get();
+        if (m_exceptionFuzzBuffer.size() < size)
+            m_exceptionFuzzBuffer = FixedVector<EncodedJSValue, VMMalloc>(size);
+        return &m_exceptionFuzzBuffer.first();
     }
 
     void gatherScratchBufferRoots(ConservativeRoots&);
@@ -1079,7 +1079,7 @@ private:
     FunctionHasExecutedCache m_functionHasExecutedCache;
     std::unique_ptr<ControlFlowProfiler> m_controlFlowProfiler;
     unsigned m_controlFlowProfilerEnabledCount { 0 };
-    MallocPtr<EncodedJSValue, VMMalloc> m_exceptionFuzzBuffer;
+    FixedVector<EncodedJSValue, VMMalloc> m_exceptionFuzzBuffer;
     LazyRef<VM, Watchdog> m_watchdog;
     LazyUniqueRef<VM, HeapProfiler> m_heapProfiler;
     LazyUniqueRef<VM, AdaptiveStringSearcherTables> m_stringSearcherTables;

--- a/Source/JavaScriptCore/wasm/WasmTable.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTable.cpp
@@ -40,9 +40,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC { namespace Wasm {
 
-WTF_MAKE_TZONE_ALLOCATED_IMPL(Table);
-WTF_MAKE_TZONE_ALLOCATED_IMPL(ExternOrAnyRefTable);
-WTF_MAKE_TZONE_ALLOCATED_IMPL(FuncRefTable);
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(WasmTable);
 
 template<typename Visitor> constexpr decltype(auto) Table::visitDerived(Visitor&& visitor)
 {
@@ -111,6 +109,20 @@ RefPtr<Table> Table::tryCreate(uint32_t initial, std::optional<uint32_t> maximum
     RELEASE_ASSERT_NOT_REACHED();
 }
 
+template<typename T>
+static bool reallocate(std::unique_ptr<T, Table::StorageDeleter<T>>& ptr, uint32_t newLength)
+{
+    ASSERT(ptr.get_deleter().ownsStorage);
+    CheckedUint32 reallocSizeChecked = newLength;
+    reallocSizeChecked *= sizeof(T);
+    if (reallocSizeChecked.hasOverflowed())
+        return false;
+    auto* storage = ptr.release();
+    void* reallocated = Table::MallocOps::realloc(storage, reallocSizeChecked);
+    ptr = std::unique_ptr<T, Table::StorageDeleter<T>>(static_cast<T*>(reallocated), { newLength, true });
+    return true;
+}
+
 std::optional<uint32_t> Table::grow(uint32_t delta, JSValue defaultValue)
 {
     RELEASE_ASSERT(m_owner);
@@ -130,16 +142,15 @@ std::optional<uint32_t> Table::grow(uint32_t delta, JSValue defaultValue)
     if (!isValidLength(newLength))
         return std::nullopt;
 
+    uint32_t actualNewLength = allocatedLength(newLength);
     auto checkedGrow = [&] (auto& container, auto initializer) {
-        if (newLengthChecked > allocatedLength(m_length)) {
-            CheckedUint32 reallocSizeChecked = allocatedLength(newLengthChecked);
-            reallocSizeChecked *= sizeof(*container.get());
-            if (reallocSizeChecked.hasOverflowed())
-                return false;
+        if (newLength > allocatedLength(m_length)) {
             // FIXME this over-allocates and could be smarter about not committing all of that memory https://bugs.webkit.org/show_bug.cgi?id=181425
-            container.realloc(reallocSizeChecked);
+            bool success = reallocate(container, actualNewLength);
+            if (!success)
+                return false;
         }
-        for (uint32_t i = m_length; i < allocatedLength(newLength); ++i) {
+        for (uint32_t i = m_length; i < actualNewLength; ++i) {
             new (&container.get()[i]) std::remove_reference_t<decltype(*container.get())>();
             initializer(container.get()[i]);
         }
@@ -241,7 +252,9 @@ ExternOrAnyRefTable::ExternOrAnyRefTable(uint32_t initial, std::optional<uint32_
     // FIXME: It might be worth trying to pre-allocate maximum here. The spec recommends doing so.
     // But for now, we're not doing that.
     // FIXME this over-allocates and could be smarter about not committing all of that memory https://bugs.webkit.org/show_bug.cgi?id=181425
-    m_jsValues = MallocPtr<WriteBarrier<Unknown>, VMMalloc>::malloc(sizeof(WriteBarrier<Unknown>) * Checked<size_t>(allocatedLength(m_length)));
+    size_t allocationSize = sizeof(WriteBarrier<Unknown>) * Checked<size_t>(allocatedLength(m_length));
+    WriteBarrier<Unknown>* storage = static_cast<WriteBarrier<Unknown>*>(MallocOps::malloc(allocationSize));
+    m_jsValues = std::unique_ptr<WriteBarrier<Unknown>, Deleter>(storage, { m_length, true });
     for (uint32_t i = 0; i < allocatedLength(m_length); ++i)
         new (&m_jsValues.get()[i]) WriteBarrier<Unknown>(NullWriteBarrierTag);
 }
@@ -263,25 +276,20 @@ FuncRefTable::FuncRefTable(uint32_t initial, std::optional<uint32_t> maximum, Ty
     // FIXME: It might be worth trying to pre-allocate maximum here. The spec recommends doing so.
     // But for now, we're not doing that.
     // FIXME this over-allocates and could be smarter about not committing all of that memory https://bugs.webkit.org/show_bug.cgi?id=181425
+    uint32_t actualLength = allocatedLength(m_length);
     if (isFixedSized())
-        m_importableFunctions = adoptMallocPtr<Function, VMMalloc>(tailPointer());
-    else
-        m_importableFunctions = MallocPtr<Function, VMMalloc>::malloc(sizeof(Function) * Checked<size_t>(allocatedLength(m_length)));
+        m_importableFunctions = std::unique_ptr<Function, Deleter>(tailPointer(), { actualLength, false });
+    else {
+        size_t allocationSize = sizeof(Function) * Checked<size_t>(actualLength);
+        Function* storage = static_cast<Function*>(MallocOps::malloc(allocationSize));
+        m_importableFunctions = std::unique_ptr<Function, Deleter>(storage, { actualLength, true });
+    }
 
-    for (uint32_t i = 0; i < allocatedLength(m_length); ++i) {
+    for (uint32_t i = 0; i < actualLength; ++i) {
         new (&m_importableFunctions.get()[i]) Function();
         ASSERT(m_importableFunctions.get()[i].m_function.typeIndex == Wasm::TypeDefinition::invalidIndex); // We rely on this in compiled code.
         ASSERT(!m_importableFunctions.get()[i].m_instance);
         ASSERT(m_importableFunctions.get()[i].m_value.isNull());
-    }
-}
-
-FuncRefTable::~FuncRefTable()
-{
-    // If FuncRefTable is fixed-sized, this pointer is not managed by this handle.
-    if (isFixedSized()) {
-        auto* unmanagedPointer = m_importableFunctions.leakPtr();
-        UNUSED_PARAM(unmanagedPointer);
     }
 }
 

--- a/Source/JavaScriptCore/wasm/WasmTable.h
+++ b/Source/JavaScriptCore/wasm/WasmTable.h
@@ -32,7 +32,6 @@
 #include "WasmFormat.h"
 #include "WasmLimits.h"
 #include "WriteBarrier.h"
-#include <wtf/MallocPtr.h>
 #include <wtf/Ref.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
@@ -48,13 +47,35 @@ namespace Wasm {
 
 class FuncRefTable;
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(WasmTable);
+
 class Table : public ThreadSafeRefCounted<Table> {
     WTF_MAKE_NONCOPYABLE(Table);
-    WTF_MAKE_TZONE_ALLOCATED(Table);
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(WasmTable);
 public:
+    using MallocOps = WasmTableMalloc;
+
     static RefPtr<Table> tryCreate(uint32_t initial, std::optional<uint32_t> maximum, TableElementType, Type);
 
-    JS_EXPORT_PRIVATE ~Table() = default;
+    JS_EXPORT_PRIVATE ~Table() = default; // The applicable subclass destructor is called by operator delete().
+
+    DECLARE_VISIT_AGGREGATE;
+    void operator delete(Table*, std::destroying_delete_t);
+
+    template<typename T>
+    struct StorageDeleter {
+        void operator()(T* ptr)
+        {
+            // The operator is defined here not because it must be inlined,
+            // but because if it isn't, the Windows build fails with a linker error.
+            std::destroy_n(ptr, count);
+            if (ownsStorage)
+                MallocOps::free(ptr);
+        }
+
+        size_t count { 0 };
+        bool ownsStorage { false };
+    };
 
     std::optional<uint32_t> maximum() const { return m_maximum; }
     uint32_t length() const { return m_length; }
@@ -86,10 +107,6 @@ public:
     std::optional<uint32_t> grow(uint32_t delta, JSValue defaultValue);
     void copy(const Table* srcTable, uint32_t dstIndex, uint32_t srcIndex);
 
-    DECLARE_VISIT_AGGREGATE;
-
-    void operator delete(Table*, std::destroying_delete_t);
-
 protected:
     Table(uint32_t initial, std::optional<uint32_t> maximum, Type, TableElementType = TableElementType::Externref);
 
@@ -109,7 +126,7 @@ protected:
 };
 
 class ExternOrAnyRefTable final : public Table {
-    WTF_MAKE_TZONE_ALLOCATED(ExternOrAnyRefTable);
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(WasmTable);
 public:
     friend class Table;
 
@@ -120,15 +137,16 @@ public:
 private:
     ExternOrAnyRefTable(uint32_t initial, std::optional<uint32_t> maximum, Type wasmType);
 
-    MallocPtr<WriteBarrier<Unknown>, VMMalloc> m_jsValues;
+    using Deleter = StorageDeleter<WriteBarrier<Unknown>>;
+    std::unique_ptr<WriteBarrier<Unknown>, Deleter> m_jsValues;
 };
 
 class FuncRefTable final : public Table {
-    WTF_MAKE_TZONE_ALLOCATED(FuncRefTable);
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(WasmTable);
 public:
     friend class Table;
 
-    JS_EXPORT_PRIVATE ~FuncRefTable();
+    JS_EXPORT_PRIVATE ~FuncRefTable() = default;
 
     // call_indirect needs to do an Instance check to potentially context switch when calling a function to another instance. We can hold raw pointers to JSWebAssemblyInstance here because the js ensures that Table keeps all the instances alive.
     struct Function {
@@ -172,7 +190,8 @@ private:
 
     static Ref<FuncRefTable> createFixedSized(uint32_t size, Type wasmType);
 
-    MallocPtr<Function, VMMalloc> m_importableFunctions;
+    using Deleter = StorageDeleter<Function>;
+    std::unique_ptr<Function, Deleter> m_importableFunctions;
 };
 
 } } // namespace JSC::Wasm

--- a/Source/WTF/wtf/MallocPtr.h
+++ b/Source/WTF/wtf/MallocPtr.h
@@ -29,16 +29,15 @@
 #include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
 
-// MallocPtr is a smart pointer class that calls fastFree in its destructor.
-// It is intended to be used for pointers where the C++ lifetime semantics
-// (calling constructors and destructors) is not desired. 
-
 namespace WTF {
 
-// We shouldn't use this class in new code and should just use std::unique_ptr. It's the same when T has no destructor and MallocPtr is likely the wrong
-// container if T does.
-// FIXME: Remove this class https://bugs.webkit.org/show_bug.cgi?id=294022
+// MallocPtr is a smart pointer associated with a particular allocator,
+// for situations where calling C++ destructors is not required.
+// The referent type {T} must be trivially destructible.
+// The owned memory is freed by calling {Malloc}::free().
 template<typename T, typename Malloc = FastMalloc> class MallocPtr {
+    static_assert(std::is_trivially_destructible_v<T>);
+
     WTF_MAKE_NONCOPYABLE(MallocPtr);
 public:
     MallocPtr() = default;


### PR DESCRIPTION
#### a892900ddc2177f2283f274756a5816d8a5208f1
<pre>
Require MallocPtr parameter type to be trivially destructible, correctly destroy FuncRefTable
<a href="https://bugs.webkit.org/show_bug.cgi?id=294022">https://bugs.webkit.org/show_bug.cgi?id=294022</a>
<a href="https://rdar.apple.com/152575154">rdar://152575154</a>

Reviewed by Keith Miller.

This patch changes `MallocPtr` to require the parameter type `T` to be trivially destructible.

The usage of `MallocPtr` in `WasmTable` which was responsible for a callee leak is now
incompatible with that requirement. `WasmTable` is changed to use `std::unique_ptr`
with a custom deleter that correctly destroys the table contents.

Additionally, `VM` is changed to use a `FixedVector` instead of a `MallocPtr` to allocate
the exception fuzzing buffer.

* Source/JavaScriptCore/bytecode/ExpressionInfo.h:
* Source/JavaScriptCore/runtime/CachedTypes.cpp:
* Source/JavaScriptCore/runtime/VM.h:
(JSC::VM::exceptionFuzzingBuffer):
* Source/JavaScriptCore/wasm/WasmTable.cpp:
(JSC::Wasm::reallocate):
(JSC::Wasm::Table::grow):
(JSC::Wasm::ExternOrAnyRefTable::ExternOrAnyRefTable):
(JSC::Wasm::FuncRefTable::FuncRefTable):
(JSC::Wasm::FuncRefTable::~FuncRefTable): Deleted.
* Source/JavaScriptCore/wasm/WasmTable.h:
(JSC::Wasm::Table::StorageDeleter::operator()):
* Source/WTF/wtf/MallocPtr.h:

Canonical link: <a href="https://commits.webkit.org/297550@main">https://commits.webkit.org/297550@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cd5055032438f3fa6750f9068995bd5170df720

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30895 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21346 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117260 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61497 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31576 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39477 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84547 "Found 3 new test failures: imported/w3c/web-platform-tests/wasm/core/linking.wast.js.html imported/w3c/web-platform-tests/wasm/core/table_copy.wast.js.html imported/w3c/web-platform-tests/wasm/core/table_init.wast.js.html (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114176 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25215 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100140 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64993 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24557 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18281 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61080 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/103720 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94593 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18350 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120358 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109782 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38278 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28444 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93479 "Found 3 new test failures: imported/w3c/web-platform-tests/wasm/core/linking.wast.js.html imported/w3c/web-platform-tests/wasm/core/table_copy.wast.js.html imported/w3c/web-platform-tests/wasm/core/table_init.wast.js.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38654 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96417 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93304 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/23960 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38389 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16158 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/34263 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18075 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38167 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43644 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/134058 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37832 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36151 "Found 207 new JSC stress test failures: microbenchmarks/wasm-cc-int-to-int.js.default-wasm, wasm.yaml/wasm/extended-const-spec-tests/elem.wast.js.wasm-bbq, wasm.yaml/wasm/extended-const-spec-tests/elem.wast.js.wasm-bbq-no-consts, wasm.yaml/wasm/function-tests/context-switch.js.default-wasm, wasm.yaml/wasm/function-tests/context-switch.js.wasm-bbq, wasm.yaml/wasm/function-tests/context-switch.js.wasm-bbq-no-consts, wasm.yaml/wasm/function-tests/context-switch.js.wasm-collect-continuously, wasm.yaml/wasm/function-tests/context-switch.js.wasm-eager, wasm.yaml/wasm/function-tests/context-switch.js.wasm-eager-jettison, wasm.yaml/wasm/function-tests/context-switch.js.wasm-no-cjit ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41165 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39534 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->