### PR TITLE
Allow profiling of libpas allocations on local allocator granularity

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator.h
@@ -53,9 +53,10 @@ struct pas_local_allocator {
     pas_local_allocator_scavenger_data scavenger_data;
     
     uint8_t alignment_shift;
-    pas_local_allocator_config_kind config_kind : 8;
-    bool current_word_is_valid; /* This is just used by enumeration. */
-    bool is_small_bumpable; /* Marks that the bumpable region in this local allocator is part of a small page. */
+    pas_local_allocator_config_kind config_kind : 6;
+    bool current_word_is_valid : 1; /* This is just used by enumeration. */
+    bool is_small : 1; /* Marks that this local allocator is used to allocate small objects. */
+    bool is_profiled; /* Marks that allocations coming out of this local allocator should be profiled. */
 
     /* This has to have a pointer to our index within the view. We can get to the view using
        page_ish. Maybe worth reconsidering that, but then again maybe it's good enough. 
@@ -93,6 +94,8 @@ struct pas_local_allocator {
         .view = NULL, \
         .alignment_shift = 0, \
         .current_word_is_valid = false, \
+        .is_small = 0, \
+        .is_profiled = 0, \
         .current_word = 0, \
         .config_kind = pas_local_allocator_config_kind_null \
     })

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_heap.c
@@ -209,6 +209,7 @@ void pas_segregated_heap_construct(pas_segregated_heap* segregated_heap,
     PAS_ASSERT(runtime_config->sharing_mode != pas_invalid_sharing_mode);
 
     segregated_heap->runtime_config = runtime_config;
+    segregated_heap->parent_heap = parent_heap;
     
     pas_compact_atomic_segregated_size_directory_ptr_store(
         &segregated_heap->basic_size_directory_and_head, NULL);

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_heap.h
@@ -80,6 +80,7 @@ PAS_DEFINE_COMPACT_ATOMIC_PTR(pas_segregated_heap_medium_directory_tuple,
 
 struct pas_segregated_heap {
     pas_heap_runtime_config* runtime_config;
+    pas_heap* parent_heap;
     
     pas_allocator_index* index_to_small_allocator_index;
     pas_compact_atomic_segregated_size_directory_ptr* index_to_small_size_directory;

--- a/Source/bmalloc/libpas/src/libpas/pas_try_allocate_intrinsic.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_allocate_intrinsic.h
@@ -49,6 +49,7 @@ PAS_BEGIN_EXTERN_C;
 
 #define PAS_INTRINSIC_SEGREGATED_HEAP_INITIALIZER(parent_heap_ptr, support, passed_runtime_config) { \
         .runtime_config = (passed_runtime_config), \
+        .parent_heap = parent_heap_ptr, \
         .index_to_small_allocator_index = (support).index_to_allocator_index, \
         .index_to_small_size_directory = (support).index_to_size_directory, \
         .basic_size_directory_and_head = PAS_COMPACT_ATOMIC_PTR_INITIALIZER, \
@@ -179,6 +180,7 @@ pas_try_allocate_intrinsic_impl_casual_case(
     fake_heap_ref.type = heap->type;
     fake_heap_ref.heap = heap;
     fake_heap_ref.allocator_index = 0;
+    fake_heap_ref.is_non_compact_heap = true;
 
     return try_allocate_common_slow(&fake_heap_ref, aligned_size, alignment, allocation_mode);
 }

--- a/Source/bmalloc/libpas/src/libpas/pas_utility_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_utility_heap.c
@@ -52,6 +52,7 @@ pas_heap_runtime_config pas_utility_heap_runtime_config = {
 
 pas_segregated_heap pas_utility_segregated_heap = {
     .runtime_config = &pas_utility_heap_runtime_config,
+    .parent_heap = NULL,
     .basic_size_directory_and_head = PAS_COMPACT_ATOMIC_PTR_INITIALIZER,
     .index_to_small_size_directory = pas_utility_heap_support_instance.index_to_size_directory,
     .rare_data = PAS_COMPACT_ATOMIC_PTR_INITIALIZER,


### PR DESCRIPTION
#### e9f91e5173918196bef2c6a55f49a366c0958276
<pre>
Allow profiling of libpas allocations on local allocator granularity
<a href="https://bugs.webkit.org/show_bug.cgi?id=294348">https://bugs.webkit.org/show_bug.cgi?id=294348</a>
<a href="https://rdar.apple.com/153125216">rdar://153125216</a>

Reviewed by Keith Miller.

Adds a new field to libpas local allocators to determine whether we should
profile them, allowing a profiling implementation to decide on a smaller
granularity which allocations should and should not get profiling applied.

* Source/bmalloc/libpas/src/libpas/pas_local_allocator.h:
* Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h:
(pas_local_allocator_set_up_bump):
(pas_local_allocator_scan_bits_to_set_up_free_bits):
(pas_local_allocator_make_bump):
(pas_local_allocator_prepare_to_allocate):
(pas_local_allocator_set_up_primordial_bump):
(pas_local_allocator_start_allocating_in_primordial_partial_view):
(pas_local_allocator_try_allocate_with_free_bits):
* Source/bmalloc/libpas/src/libpas/pas_segregated_heap.c:
(pas_segregated_heap_construct):
* Source/bmalloc/libpas/src/libpas/pas_segregated_heap.h:
* Source/bmalloc/libpas/src/libpas/pas_try_allocate_intrinsic.h:
(pas_try_allocate_intrinsic_impl_casual_case):
* Source/bmalloc/libpas/src/libpas/pas_utility_heap.c:

Canonical link: <a href="https://commits.webkit.org/296285@main">https://commits.webkit.org/296285@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0739ca4b90d6f521f864489d5e307e8d10423974

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107545 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27228 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17638 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112762 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58087 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27919 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35729 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81648 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110474 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22125 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96932 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62029 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21563 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15071 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57525 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/100137 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91495 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15105 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115863 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/106094 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34613 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25525 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90686 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34989 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93183 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90427 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23149 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35343 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13122 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30376 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34534 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/130408 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34280 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35460 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37639 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35943 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->