### PR TITLE
[Style] Reduce duplication in style building/extraction/serialization when delegating to strong types

### DIFF
--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -3672,7 +3672,7 @@
                 "accepts-quirky-length": true,
                 "animation-wrapper": "StyleTypeWrapper",
                 "render-style-initial": "initialInset",
-                "style-builder-converter": "InsetEdge",
+                "style-builder-converter": "StyleType<InsetEdge>",
                 "style-extractor-custom": true,
                 "parser-grammar": "auto | <length-percentage anchor=allowed anchor-size=allowed>"
             },
@@ -4035,7 +4035,7 @@
                 "disables-native-appearance": true,
                 "parser-grammar": "<corner-shape-value>",
                 "render-style-initial": "initialCornerShapeValue",
-                "style-converter": "CornerShapeValue",
+                "style-converter": "StyleType<CornerShapeValue>",
                 "settings-flag": "cssCornerShapeEnabled"
             },
             "specification": {
@@ -4055,7 +4055,7 @@
                 "disables-native-appearance": true,
                 "parser-grammar": "<corner-shape-value>",
                 "render-style-initial": "initialCornerShapeValue",
-                "style-converter": "CornerShapeValue",
+                "style-converter": "StyleType<CornerShapeValue>",
                 "settings-flag": "cssCornerShapeEnabled"
             },
             "specification": {
@@ -4075,7 +4075,7 @@
                 "disables-native-appearance": true,
                 "parser-grammar": "<corner-shape-value>",
                 "render-style-initial": "initialCornerShapeValue",
-                "style-converter": "CornerShapeValue",
+                "style-converter": "StyleType<CornerShapeValue>",
                 "settings-flag": "cssCornerShapeEnabled"
             },
             "specification": {
@@ -4095,7 +4095,7 @@
                 "disables-native-appearance": true,
                 "parser-grammar": "<corner-shape-value>",
                 "render-style-initial": "initialCornerShapeValue",
-                "style-converter": "CornerShapeValue",
+                "style-converter": "StyleType<CornerShapeValue>",
                 "settings-flag": "cssCornerShapeEnabled"
             },
             "specification": {
@@ -4408,7 +4408,7 @@
             "codegen-properties": {
                 "animation-wrapper-comment": "FIXME: Use StyleTypeWrapper when dynamic-range-limit-mix() is implemented; see webkit.org/b/293339",
                 "settings-flag": "supportHDRDisplayEnabled",
-                "style-converter": "DynamicRangeLimit",
+                "style-converter": "StyleType<DynamicRangeLimit>",
                 "parser-function": "consumeDynamicRangeLimit",
                 "parser-grammar-unused": "<<values>> | <dynamic-range-limit-mix()>",
                 "parser-grammar-unused-reason": "Needs support for the strong value representation and recursive grammars."
@@ -4657,7 +4657,7 @@
                 "accepts-quirky-length": true,
                 "animation-wrapper": "StyleTypeWrapper",
                 "render-style-initial": "initialSize",
-                "style-builder-converter": "PreferredSize",
+                "style-builder-converter": "StyleType<PreferredSize>",
                 "style-extractor-custom": true,
                 "parser-grammar": "<width-or-height>"
             },
@@ -4921,7 +4921,7 @@
                 "accepts-quirky-length": true,
                 "animation-wrapper": "StyleTypeWrapper",
                 "render-style-initial": "initialInset",
-                "style-builder-converter": "InsetEdge",
+                "style-builder-converter": "StyleType<InsetEdge>",
                 "style-extractor-custom": true,
                 "parser-grammar": "auto | <length-percentage anchor=allowed anchor-size=allowed>"
             },
@@ -5281,7 +5281,7 @@
                 "accepts-quirky-length": true,
                 "animation-wrapper": "StyleTypeWrapper",
                 "render-style-initial": "initialMargin",
-                "style-builder-converter": "MarginEdge",
+                "style-builder-converter": "StyleType<MarginEdge>",
                 "style-extractor-custom": true,
                 "parser-grammar": "<length-percentage anchor-size=allowed> | auto"
             },
@@ -5363,7 +5363,7 @@
                 "accepts-quirky-length": true,
                 "animation-wrapper": "StyleTypeWrapper",
                 "render-style-initial": "initialMargin",
-                "style-builder-converter": "MarginEdge",
+                "style-builder-converter": "StyleType<MarginEdge>",
                 "style-extractor-custom": true,
                 "parser-grammar": "<length-percentage anchor-size=allowed> | auto"
             },
@@ -5386,7 +5386,7 @@
                 "accepts-quirky-length": true,
                 "animation-wrapper": "StyleTypeWrapper",
                 "render-style-initial": "initialMargin",
-                "style-builder-converter": "MarginEdge",
+                "style-builder-converter": "StyleType<MarginEdge>",
                 "style-extractor-custom": true,
                 "parser-grammar": "<length-percentage anchor-size=allowed> | auto"
             },
@@ -5409,7 +5409,7 @@
                 "accepts-quirky-length": true,
                 "animation-wrapper": "StyleTypeWrapper",
                 "render-style-initial": "initialMargin",
-                "style-builder-converter": "MarginEdge",
+                "style-builder-converter": "StyleType<MarginEdge>",
                 "style-extractor-custom": true,
                 "parser-grammar": "<length-percentage anchor-size=allowed> | auto"
             },
@@ -6061,7 +6061,7 @@
                 "accepts-quirky-length": true,
                 "animation-wrapper": "StyleTypeWrapper",
                 "render-style-initial": "initialMaxSize",
-                "style-builder-converter": "MaximumSize",
+                "style-builder-converter": "StyleType<MaximumSize>",
                 "style-extractor-custom": true,
                 "parser-grammar": "<max-width-or-height>"
             },
@@ -6195,7 +6195,7 @@
                 "accepts-quirky-length": true,
                 "animation-wrapper": "StyleTypeWrapper",
                 "render-style-initial": "initialMaxSize",
-                "style-builder-converter": "MaximumSize",
+                "style-builder-converter": "StyleType<MaximumSize>",
                 "style-extractor-custom": true,
                 "parser-grammar": "<max-width-or-height>"
             },
@@ -6310,7 +6310,7 @@
                 "accepts-quirky-length": true,
                 "animation-wrapper": "StyleTypeWrapper",
                 "render-style-initial": "initialMinSize",
-                "style-builder-converter": "MinimumSize",
+                "style-builder-converter": "StyleType<MinimumSize>",
                 "style-extractor-custom": true,
                 "parser-grammar": "<width-or-height>"
             },
@@ -6425,7 +6425,7 @@
                 "accepts-quirky-length": true,
                 "animation-wrapper": "StyleTypeWrapper",
                 "render-style-initial": "initialMinSize",
-                "style-builder-converter": "MinimumSize",
+                "style-builder-converter": "StyleType<MinimumSize>",
                 "style-extractor-custom": true,
                 "parser-grammar": "<width-or-height>"
             },
@@ -7044,7 +7044,7 @@
                 "accepts-quirky-length": true,
                 "animation-wrapper": "StyleTypeWrapper",
                 "render-style-initial": "initialPadding",
-                "style-builder-converter": "PaddingEdge",
+                "style-builder-converter": "StyleType<PaddingEdge>",
                 "style-builder-custom": "All",
                 "style-extractor-custom": true,
                 "parser-grammar": "<length-percentage [0,inf]>"
@@ -7118,7 +7118,7 @@
                 "accepts-quirky-length": true,
                 "animation-wrapper": "StyleTypeWrapper",
                 "render-style-initial": "initialPadding",
-                "style-builder-converter": "PaddingEdge",
+                "style-builder-converter": "StyleType<PaddingEdge>",
                 "style-builder-custom": "All",
                 "style-extractor-custom": true,
                 "parser-grammar": "<length-percentage [0,inf]>"
@@ -7139,7 +7139,7 @@
                 "accepts-quirky-length": true,
                 "animation-wrapper": "StyleTypeWrapper",
                 "render-style-initial": "initialPadding",
-                "style-builder-converter": "PaddingEdge",
+                "style-builder-converter": "StyleType<PaddingEdge>",
                 "style-builder-custom": "All",
                 "style-extractor-custom": true,
                 "parser-grammar": "<length-percentage [0,inf]>"
@@ -7160,7 +7160,7 @@
                 "accepts-quirky-length": true,
                 "animation-wrapper": "StyleTypeWrapper",
                 "render-style-initial": "initialPadding",
-                "style-builder-converter": "PaddingEdge",
+                "style-builder-converter": "StyleType<PaddingEdge>",
                 "style-builder-custom": "All",
                 "style-extractor-custom": true,
                 "parser-grammar": "<length-percentage [0,inf]>"
@@ -7381,7 +7381,7 @@
                 "accepts-quirky-length": true,
                 "animation-wrapper": "StyleTypeWrapper",
                 "render-style-initial": "initialInset",
-                "style-builder-converter": "InsetEdge",
+                "style-builder-converter": "StyleType<InsetEdge>",
                 "style-extractor-custom": true,
                 "parser-grammar": "auto | <length-percentage anchor=allowed anchor-size=allowed>"
             },
@@ -8068,7 +8068,7 @@
                 "accepts-quirky-length": true,
                 "animation-wrapper": "StyleTypeWrapper",
                 "render-style-initial": "initialInset",
-                "style-builder-converter": "InsetEdge",
+                "style-builder-converter": "StyleType<InsetEdge>",
                 "style-extractor-custom": true,
                 "parser-grammar": "auto | <length-percentage anchor=allowed anchor-size=allowed>"
             },
@@ -8411,7 +8411,7 @@
                 "accepts-quirky-length": true,
                 "animation-wrapper": "StyleTypeWrapper",
                 "render-style-initial": "initialSize",
-                "style-builder-converter": "PreferredSize",
+                "style-builder-converter": "StyleType<PreferredSize>",
                 "style-extractor-custom": true,
                 "parser-grammar": "<width-or-height>"
             },
@@ -9672,7 +9672,7 @@
                     "-webkit-flex-basis"
                 ],
                 "animation-wrapper": "StyleTypeWrapper",
-                "style-converter": "FlexBasis",
+                "style-converter": "StyleType<FlexBasis>",
                 "parser-grammar": "auto | content | <width-or-height-keyword> | <length-percentage [0,inf]>"
             },
             "specification": {
@@ -10615,7 +10615,7 @@
                 "aliases": [
                     "supported-color-schemes"
                 ],
-                "style-converter": "ColorScheme",
+                "style-converter": "StyleType<ColorScheme>",
                 "style-builder-custom": "Value",
                 "enable-if": "ENABLE_DARK_MODE_CSS",
                 "top-priority": true,
@@ -11463,8 +11463,6 @@
             "animation-type-comment": "Current spec animation type is 'by computed value'",
             "initial": "0px",
             "codegen-properties": {
-                "render-style-initial": "initialScrollMargin",
-                "style-converter": "ScrollMarginEdge",
                 "aliases": [
                     "scroll-snap-margin-bottom"
                 ],
@@ -11472,6 +11470,8 @@
                     "name": "scroll-margin",
                     "resolver": "bottom"
                 },
+                "render-style-initial": "initialScrollMargin",
+                "style-converter": "StyleType<ScrollMarginEdge>",
                 "parser-grammar": "<length>"
             },
             "specification": {
@@ -11484,8 +11484,6 @@
             "animation-type-comment": "Current spec animation type is 'by computed value'",
             "initial": "0px",
             "codegen-properties": {
-                "render-style-initial": "initialScrollMargin",
-                "style-converter": "ScrollMarginEdge",
                 "aliases": [
                     "scroll-snap-margin-left"
                 ],
@@ -11493,6 +11491,8 @@
                     "name": "scroll-margin",
                     "resolver": "left"
                 },
+                "render-style-initial": "initialScrollMargin",
+                "style-converter": "StyleType<ScrollMarginEdge>",
                 "parser-grammar": "<length>"
             },
             "specification": {
@@ -11505,8 +11505,6 @@
             "animation-type-comment": "Current spec animation type is 'by computed value'",
             "initial": "0px",
             "codegen-properties": {
-                "render-style-initial": "initialScrollMargin",
-                "style-converter": "ScrollMarginEdge",
                 "aliases": [
                     "scroll-snap-margin-right"
                 ],
@@ -11514,6 +11512,8 @@
                     "name": "scroll-margin",
                     "resolver": "right"
                 },
+                "render-style-initial": "initialScrollMargin",
+                "style-converter": "StyleType<ScrollMarginEdge>",
                 "parser-grammar": "<length>"
             },
             "specification": {
@@ -11526,8 +11526,6 @@
             "animation-type-comment": "Current spec animation type is 'by computed value'",
             "initial": "0px",
             "codegen-properties": {
-                "render-style-initial": "initialScrollMargin",
-                "style-converter": "ScrollMarginEdge",
                 "aliases": [
                     "scroll-snap-margin-top"
                 ],
@@ -11535,6 +11533,8 @@
                     "name": "scroll-margin",
                     "resolver": "top"
                 },
+                "render-style-initial": "initialScrollMargin",
+                "style-converter": "StyleType<ScrollMarginEdge>",
                 "parser-grammar": "<length>"
             },
             "specification": {
@@ -11665,12 +11665,12 @@
                 "auto"
             ],
             "codegen-properties": {
-                "render-style-initial": "initialScrollPadding",
-                "style-converter": "ScrollPaddingEdge",
                 "logical-property-group": {
                     "name": "scroll-padding",
                     "resolver": "bottom"
                 },
+                "render-style-initial": "initialScrollPadding",
+                "style-converter": "StyleType<ScrollPaddingEdge>",
                 "parser-grammar": "auto | <length-percentage [0,inf]>"
             },
             "specification": {
@@ -11686,12 +11686,12 @@
                 "auto"
             ],
             "codegen-properties": {
-                "render-style-initial": "initialScrollPadding",
-                "style-converter": "ScrollPaddingEdge",
                 "logical-property-group": {
                     "name": "scroll-padding",
                     "resolver": "left"
                 },
+                "render-style-initial": "initialScrollPadding",
+                "style-converter": "StyleType<ScrollPaddingEdge>",
                 "parser-grammar": "auto | <length-percentage [0,inf]>"
             },
             "specification": {
@@ -11707,12 +11707,12 @@
                 "auto"
             ],
             "codegen-properties": {
-                "render-style-initial": "initialScrollPadding",
-                "style-converter": "ScrollPaddingEdge",
                 "logical-property-group": {
                     "name": "scroll-padding",
                     "resolver": "right"
                 },
+                "render-style-initial": "initialScrollPadding",
+                "style-converter": "StyleType<ScrollPaddingEdge>",
                 "parser-grammar": "auto | <length-percentage [0,inf]>"
             },
             "specification": {
@@ -11728,12 +11728,12 @@
                 "auto"
             ],
             "codegen-properties": {
-                "render-style-initial": "initialScrollPadding",
-                "style-converter": "ScrollPaddingEdge",
                 "logical-property-group": {
                     "name": "scroll-padding",
                     "resolver": "top"
                 },
+                "render-style-initial": "initialScrollPadding",
+                "style-converter": "StyleType<ScrollPaddingEdge>",
                 "parser-grammar": "auto | <length-percentage [0,inf]>"
             },
             "specification": {

--- a/Source/WebCore/css/scripts/process-css-properties.py
+++ b/Source/WebCore/css/scripts/process-css-properties.py
@@ -4338,7 +4338,7 @@ class GenerateStyleExtractorGenerated:
         elif property.codegen_properties.fill_layer_property:
             return f"ExtractorConverter::convertFillLayer{property.codegen_properties.fill_layer_name_for_methods}(extractorState, {value})"
         elif property.codegen_properties.color_property:
-            return f"ExtractorConverter::convertColor(extractorState, {value})"
+            return f"ExtractorConverter::convertStyleType<Color>(extractorState, {value})"
         else:
             return f"ExtractorConverter::convert(extractorState, {value})"
 
@@ -4351,7 +4351,7 @@ class GenerateStyleExtractorGenerated:
         elif property.codegen_properties.fill_layer_property:
             return f"ExtractorSerializer::serializeFillLayer{property.codegen_properties.fill_layer_name_for_methods}(extractorState, builder, context, {value})"
         elif property.codegen_properties.color_property:
-            return f"ExtractorSerializer::serializeColor(extractorState, builder, context, {value})"
+            return f"ExtractorSerializer::serializeStyleType<Color>(extractorState, builder, context, {value})"
         else:
             return f"ExtractorSerializer::serialize(extractorState, builder, context, {value})"
 

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -720,7 +720,7 @@ inline void BuilderCustom::applyValueWebkitTextZoom(BuilderState& builderState, 
 #if ENABLE(DARK_MODE_CSS)
 inline void BuilderCustom::applyValueColorScheme(BuilderState& builderState, CSSValue& value)
 {
-    builderState.style().setColorScheme(BuilderConverter::convertColorScheme(builderState, value));
+    builderState.style().setColorScheme(BuilderConverter::convertStyleType<ColorScheme>(builderState, value));
     builderState.style().setHasExplicitlySetColorScheme();
 }
 #endif
@@ -1891,7 +1891,7 @@ inline void BuilderCustom::applyInheritPaddingBottom(BuilderState& builderState)
 
 inline void BuilderCustom::applyValuePaddingBottom(BuilderState& builderState, CSSValue& value)
 {
-    builderState.style().setPaddingBottom(BuilderConverter::convertPaddingEdge(builderState, value));
+    builderState.style().setPaddingBottom(BuilderConverter::convertStyleType<PaddingEdge>(builderState, value));
     builderState.style().setHasExplicitlySetPaddingBottom(builderState.isAuthorOrigin());
 }
 
@@ -1909,7 +1909,7 @@ inline void BuilderCustom::applyInheritPaddingLeft(BuilderState& builderState)
 
 inline void BuilderCustom::applyValuePaddingLeft(BuilderState& builderState, CSSValue& value)
 {
-    builderState.style().setPaddingLeft(BuilderConverter::convertPaddingEdge(builderState, value));
+    builderState.style().setPaddingLeft(BuilderConverter::convertStyleType<PaddingEdge>(builderState, value));
     builderState.style().setHasExplicitlySetPaddingLeft(builderState.isAuthorOrigin());
 }
 
@@ -1927,7 +1927,7 @@ inline void BuilderCustom::applyInheritPaddingRight(BuilderState& builderState)
 
 inline void BuilderCustom::applyValuePaddingRight(BuilderState& builderState, CSSValue& value)
 {
-    builderState.style().setPaddingRight(BuilderConverter::convertPaddingEdge(builderState, value));
+    builderState.style().setPaddingRight(BuilderConverter::convertStyleType<PaddingEdge>(builderState, value));
     builderState.style().setHasExplicitlySetPaddingRight(builderState.isAuthorOrigin());
 }
 
@@ -1945,7 +1945,7 @@ inline void BuilderCustom::applyInheritPaddingTop(BuilderState& builderState)
 
 inline void BuilderCustom::applyValuePaddingTop(BuilderState& builderState, CSSValue& value)
 {
-    builderState.style().setPaddingTop(BuilderConverter::convertPaddingEdge(builderState, value));
+    builderState.style().setPaddingTop(BuilderConverter::convertStyleType<PaddingEdge>(builderState, value));
     builderState.style().setHasExplicitlySetPaddingTop(builderState.isAuthorOrigin());
 }
 

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -136,6 +136,10 @@ template<typename T> requires std::is_enum_v<T> struct CSSValueCreation<T> {
 
 class ExtractorConverter {
 public:
+    // MARK: Strong value conversions
+
+    template<typename T> static Ref<CSSValue> convertStyleType(ExtractorState&, const T&);
+
     // MARK: Primitive conversions
 
     template<typename ConvertibleType>
@@ -176,24 +180,6 @@ public:
     static Ref<CSSValue> convertTransformationMatrix(const RenderStyle&, const TransformationMatrix&);
     static RefPtr<CSSValue> convertTransformOperation(ExtractorState&, const TransformOperation&);
     static RefPtr<CSSValue> convertTransformOperation(const RenderStyle&, const TransformOperation&);
-
-    // MARK: Strong value conversions
-
-    static Ref<CSSValue> convertColor(ExtractorState&, const Color&);
-    static Ref<CSSValue> convertInsetEdge(ExtractorState&, const InsetEdge&);
-    static Ref<CSSValue> convertMarginEdge(ExtractorState&, const MarginEdge&);
-    static Ref<CSSValue> convertPaddingEdge(ExtractorState&, const PaddingEdge&);
-    static Ref<CSSValue> convertScrollMarginEdge(ExtractorState&, const ScrollMarginEdge&);
-    static Ref<CSSValue> convertScrollPaddingEdge(ExtractorState&, const ScrollPaddingEdge&);
-    static Ref<CSSValue> convertCornerShapeValue(ExtractorState&, const CornerShapeValue&);
-    static Ref<CSSValue> convertDynamicRangeLimit(ExtractorState&, const DynamicRangeLimit&);
-    static Ref<CSSValue> convertPreferredSize(ExtractorState&, const PreferredSize&);
-    static Ref<CSSValue> convertMaximumSize(ExtractorState&, const MaximumSize&);
-    static Ref<CSSValue> convertMinimumSize(ExtractorState&, const MinimumSize&);
-    static Ref<CSSValue> convertFlexBasis(ExtractorState&, const FlexBasis&);
-#if ENABLE(DARK_MODE_CSS)
-    static Ref<CSSValue> convertColorScheme(ExtractorState&, const ColorScheme&);
-#endif
 
     // MARK: Shared conversions
 
@@ -349,6 +335,13 @@ public:
     static Ref<CSSValue> convertGridTrackSizeList(ExtractorState&, const Vector<GridTrackSize>&);
 };
 
+// MARK: - Strong value conversions
+
+template<typename T> Ref<CSSValue> ExtractorConverter::convertStyleType(ExtractorState& state, const T& value)
+{
+    return createCSSValue(state.pool, state.style, value);
+}
+
 // MARK: - Primitive conversions
 
 template<typename ConvertibleType>
@@ -495,12 +488,12 @@ inline Ref<CSSValue> ExtractorConverter::convertSVGPaint(ExtractorState& state, 
         if (paintType == SVGPaintType::URINone)
             values.append(CSSPrimitiveValue::create(CSSValueNone));
         else if (paintType == SVGPaintType::URICurrentColor || paintType == SVGPaintType::URIRGBColor)
-            values.append(convertColor(state, color));
+            values.append(convertStyleType(state, color));
         return CSSValueList::createSpaceSeparated(WTFMove(values));
     }
     if (paintType == SVGPaintType::None)
         return CSSPrimitiveValue::create(CSSValueNone);
-    return convertColor(state, color);
+    return convertStyleType(state, color);
 }
 
 // MARK: - Transform conversions
@@ -633,75 +626,6 @@ inline RefPtr<CSSValue> ExtractorConverter::convertTransformOperation(const Rend
     ASSERT_NOT_REACHED();
     return nullptr;
 }
-
-// MARK: - Strong value conversions
-
-inline Ref<CSSValue> ExtractorConverter::convertColor(ExtractorState& state, const Color& value)
-{
-    return createCSSValue(state.pool, state.style, value);
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertInsetEdge(ExtractorState& state, const InsetEdge& value)
-{
-    return createCSSValue(state.pool, state.style, value);
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertMarginEdge(ExtractorState& state, const MarginEdge& value)
-{
-    return createCSSValue(state.pool, state.style, value);
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertPaddingEdge(ExtractorState& state, const PaddingEdge& value)
-{
-    return createCSSValue(state.pool, state.style, value);
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertScrollMarginEdge(ExtractorState& state, const ScrollMarginEdge& value)
-{
-    return createCSSValue(state.pool, state.style, value);
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertScrollPaddingEdge(ExtractorState& state, const ScrollPaddingEdge& value)
-{
-    return createCSSValue(state.pool, state.style, value);
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertCornerShapeValue(ExtractorState& state, const CornerShapeValue& value)
-{
-    return createCSSValue(state.pool, state.style, value);
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertDynamicRangeLimit(ExtractorState& state, const DynamicRangeLimit& value)
-{
-    return createCSSValue(state.pool, state.style, value);
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertPreferredSize(ExtractorState& state, const PreferredSize& value)
-{
-    return createCSSValue(state.pool, state.style, value);
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertMaximumSize(ExtractorState& state, const MaximumSize& value)
-{
-    return createCSSValue(state.pool, state.style, value);
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertMinimumSize(ExtractorState& state, const MinimumSize& value)
-{
-    return createCSSValue(state.pool, state.style, value);
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertFlexBasis(ExtractorState& state, const FlexBasis& value)
-{
-    return createCSSValue(state.pool, state.style, value);
-}
-
-#if ENABLE(DARK_MODE_CSS)
-inline Ref<CSSValue> ExtractorConverter::convertColorScheme(ExtractorState& state, const ColorScheme& value)
-{
-    return createCSSValue(state.pool, state.style, value);
-}
-#endif
 
 // MARK: - Shared conversions
 
@@ -1247,8 +1171,8 @@ inline Ref<CSSValue> ExtractorConverter::convertScrollbarColor(ExtractorState& s
     if (!scrollbarColor)
         return CSSPrimitiveValue::create(CSSValueAuto);
     return CSSValuePair::createNoncoalescing(
-        convertColor(state, scrollbarColor->thumbColor),
-        convertColor(state, scrollbarColor->trackColor)
+        convertStyleType(state, scrollbarColor->thumbColor),
+        convertStyleType(state, scrollbarColor->trackColor)
     );
 }
 

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -430,7 +430,7 @@ template<CSSPropertyID propertyID, typename InsetEdgeApplier, typename NumberAsP
 template<CSSPropertyID propertyID> Ref<CSSValue> extractZoomAdjustedInsetValue(ExtractorState& state)
 {
     return extractZoomAdjustedInset<propertyID>(state,
-        [&](const auto& edge)   -> Ref<CSSValue> { return ExtractorConverter::convertInsetEdge(state, edge); },
+        [&](const auto& edge)   -> Ref<CSSValue> { return ExtractorConverter::convertStyleType(state, edge); },
         [&](const auto& number) -> Ref<CSSValue> { return ExtractorConverter::convertNumberAsPixels(state, number); },
         [&](const auto& value)  -> Ref<CSSValue> { return CSSPrimitiveValue::create(value); }
     );
@@ -439,7 +439,7 @@ template<CSSPropertyID propertyID> Ref<CSSValue> extractZoomAdjustedInsetValue(E
 template<CSSPropertyID propertyID> void extractZoomAdjustedInsetSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
 {
     extractZoomAdjustedInset<propertyID>(state,
-        [&](const auto& edge)   { ExtractorSerializer::serializeInsetEdge(state, builder, context, edge); },
+        [&](const auto& edge)   { ExtractorSerializer::serializeStyleType(state, builder, context, edge); },
         [&](const auto& number) { ExtractorSerializer::serializeNumberAsPixels(state, builder, context, number); },
         [&](const auto& value)  { builder.append(nameLiteralForSerialization(value)); }
     );
@@ -500,7 +500,7 @@ template<auto styleGetter, auto computedCSSValueGetter> Ref<CSSValue> extractZoo
 {
     auto* renderBox = dynamicDowncast<RenderBox>(state.renderer);
     if (!renderBox)
-        return ExtractorConverter::convertMarginEdge(state, (state.style.*styleGetter)());
+        return ExtractorConverter::convertStyleType(state, (state.style.*styleGetter)());
     return ExtractorConverter::convertNumberAsPixels(state, (renderBox->*computedCSSValueGetter)());
 }
 
@@ -508,7 +508,7 @@ template<auto styleGetter, auto computedCSSValueGetter> void extractZoomAdjusted
 {
     auto* renderBox = dynamicDowncast<RenderBox>(state.renderer);
     if (!renderBox) {
-        ExtractorSerializer::serializeMarginEdge(state, builder, context, (state.style.*styleGetter)());
+        ExtractorSerializer::serializeStyleType(state, builder, context, (state.style.*styleGetter)());
         return;
     }
 
@@ -520,7 +520,7 @@ template<auto styleGetter, auto computedCSSValueGetter> Ref<CSSValue> extractZoo
     auto& paddingEdge  = (state.style.*styleGetter)();
     auto* renderBox = dynamicDowncast<RenderBox>(state.renderer);
     if (!renderBox || paddingEdge.isFixed())
-        return ExtractorConverter::convertPaddingEdge(state, paddingEdge);
+        return ExtractorConverter::convertStyleType(state, paddingEdge);
     return ExtractorConverter::convertNumberAsPixels(state, (renderBox->*computedCSSValueGetter)());
 }
 
@@ -529,7 +529,7 @@ template<auto styleGetter, auto computedCSSValueGetter> void extractZoomAdjusted
     auto paddingEdge = (state.style.*styleGetter)();
     auto* renderBox = dynamicDowncast<RenderBox>(state.renderer);
     if (!renderBox || paddingEdge.isFixed()) {
-        ExtractorSerializer::serializePaddingEdge(state, builder, context, paddingEdge);
+        ExtractorSerializer::serializeStyleType(state, builder, context, paddingEdge);
         return;
     }
     ExtractorSerializer::serializeNumberAsPixels(state, builder, context, (renderBox->*computedCSSValueGetter)());
@@ -554,7 +554,7 @@ template<auto styleGetter, auto boxGetter> Ref<CSSValue> extractZoomAdjustedPref
         if (!isNonReplacedInline(*state.renderer))
             return ExtractorConverter::convertNumberAsPixels(state, (sizingBox(*state.renderer).*boxGetter)());
     }
-    return ExtractorConverter::convertPreferredSize(state, (state.style.*styleGetter)());
+    return ExtractorConverter::convertStyleType(state, (state.style.*styleGetter)());
 }
 
 template<auto styleGetter, auto boxGetter> void extractZoomAdjustedPreferredSizeSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
@@ -579,7 +579,7 @@ template<auto styleGetter, auto boxGetter> void extractZoomAdjustedPreferredSize
         }
     }
 
-    ExtractorSerializer::serializePreferredSize(state, builder, context, (state.style.*styleGetter)());
+    ExtractorSerializer::serializeStyleType(state, builder, context, (state.style.*styleGetter)());
 }
 
 template<auto styleGetter> Ref<CSSValue> extractZoomAdjustedMaxSizeValue(ExtractorState& state)
@@ -587,7 +587,7 @@ template<auto styleGetter> Ref<CSSValue> extractZoomAdjustedMaxSizeValue(Extract
     auto unzoomedLength = (state.style.*styleGetter)();
     if (unzoomedLength.isNone())
         return CSSPrimitiveValue::create(CSSValueNone);
-    return ExtractorConverter::convertMaximumSize(state, unzoomedLength);
+    return ExtractorConverter::convertStyleType(state, unzoomedLength);
 }
 
 template<auto styleGetter> void extractZoomAdjustedMaxSizeSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
@@ -598,7 +598,7 @@ template<auto styleGetter> void extractZoomAdjustedMaxSizeSerialization(Extracto
         return;
     }
 
-    ExtractorSerializer::serializeMaximumSize(state, builder, context, unzoomedLength);
+    ExtractorSerializer::serializeStyleType(state, builder, context, unzoomedLength);
 }
 
 template<auto styleGetter> Ref<CSSValue> extractZoomAdjustedMinSizeValue(ExtractorState& state)
@@ -614,7 +614,7 @@ template<auto styleGetter> Ref<CSSValue> extractZoomAdjustedMinSizeValue(Extract
             return CSSPrimitiveValue::create(CSSValueAuto);
         return ExtractorConverter::convertNumberAsPixels(state, 0);
     }
-    return ExtractorConverter::convertMinimumSize(state, unzoomedLength);
+    return ExtractorConverter::convertStyleType(state, unzoomedLength);
 }
 
 template<auto styleGetter> void extractZoomAdjustedMinSizeSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
@@ -635,7 +635,7 @@ template<auto styleGetter> void extractZoomAdjustedMinSizeSerialization(Extracto
         return;
     }
 
-    ExtractorSerializer::serializeMinimumSize(state, builder, context, unzoomedLength);
+    ExtractorSerializer::serializeStyleType(state, builder, context, unzoomedLength);
 }
 
 template<CSSPropertyID propertyID> Ref<CSSValue> extractCounterValue(ExtractorState& state)
@@ -1962,7 +1962,7 @@ inline Ref<CSSValue> ExtractorCustom::extractMarginRight(ExtractorState& state)
 
     auto& marginRight = state.style.marginRight();
     if (marginRight.isFixed() || !box)
-        return ExtractorConverter::convertMarginEdge(state, marginRight);
+        return ExtractorConverter::convertStyleType(state, marginRight);
 
     float value;
     if (marginRight.isPercentOrCalculated()) {
@@ -1985,7 +1985,7 @@ inline void ExtractorCustom::extractMarginRightSerialization(ExtractorState& sta
 
     auto& marginRight = state.style.marginRight();
     if (marginRight.isFixed() || !box) {
-        ExtractorSerializer::serializeMarginEdge(state, builder, context, marginRight);
+        ExtractorSerializer::serializeStyleType(state, builder, context, marginRight);
         return;
     }
 

--- a/Source/WebCore/style/StyleExtractorSerializer.h
+++ b/Source/WebCore/style/StyleExtractorSerializer.h
@@ -46,6 +46,10 @@ template<typename T> requires std::is_enum_v<T> struct Serialize<T> {
 
 class ExtractorSerializer {
 public:
+    // MARK: Strong value conversions
+
+    template<typename T> static void serializeStyleType(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const T&);
+
     // MARK: Primitive serializations
 
     template<typename ConvertibleType>
@@ -86,24 +90,6 @@ public:
     static void serializeTransformationMatrix(const RenderStyle&, StringBuilder&, const CSS::SerializationContext&, const TransformationMatrix&);
     static void serializeTransformOperation(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const TransformOperation&);
     static void serializeTransformOperation(const RenderStyle&, StringBuilder&, const CSS::SerializationContext&, const TransformOperation&);
-
-    // MARK: Strong value conversions
-
-    static void serializeColor(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const Color&);
-    static void serializeInsetEdge(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const InsetEdge&);
-    static void serializeMarginEdge(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const MarginEdge&);
-    static void serializePaddingEdge(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const PaddingEdge&);
-    static void serializeScrollMarginEdge(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const ScrollMarginEdge&);
-    static void serializeScrollPaddingEdge(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const ScrollPaddingEdge&);
-    static void serializeCornerShapeValue(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const CornerShapeValue&);
-    static void serializeDynamicRangeLimit(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const DynamicRangeLimit&);
-    static void serializePreferredSize(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const PreferredSize&);
-    static void serializeMaximumSize(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const MaximumSize&);
-    static void serializeMinimumSize(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const MinimumSize&);
-    static void serializeFlexBasis(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const FlexBasis&);
-#if ENABLE(DARK_MODE_CSS)
-    static void serializeColorScheme(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const ColorScheme&);
-#endif
 
     // MARK: Shared serializations
 
@@ -257,6 +243,13 @@ public:
     static void serializeGridTrackSize(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const GridTrackSize&);
     static void serializeGridTrackSizeList(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const Vector<GridTrackSize>&);
 };
+
+// MARK: - Strong value serializations
+
+template<typename T> void ExtractorSerializer::serializeStyleType(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const T& value)
+{
+    serializationForCSS(builder, context, state.style, value);
+}
 
 // MARK: - Primitive serializations
 
@@ -515,7 +508,7 @@ inline void ExtractorSerializer::serializeSVGPaint(ExtractorState& state, String
         [[fallthrough]];
     case SVGPaintType::RGBColor:
     case SVGPaintType::CurrentColor:
-        serializeColor(state, builder, context, color);
+        serializeStyleType(state, builder, context, color);
         return;
     }
 
@@ -744,75 +737,6 @@ inline void ExtractorSerializer::serializeTransformOperation(const RenderStyle& 
 
     RELEASE_ASSERT_NOT_REACHED();
 }
-
-// MARK: - Strong value serializations
-
-inline void ExtractorSerializer::serializeColor(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const Color& value)
-{
-    serializationForCSS(builder, context, state.style, value);
-}
-
-inline void ExtractorSerializer::serializeInsetEdge(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const InsetEdge& value)
-{
-    serializationForCSS(builder, context, state.style, value);
-}
-
-inline void ExtractorSerializer::serializeMarginEdge(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const MarginEdge& value)
-{
-    serializationForCSS(builder, context, state.style, value);
-}
-
-inline void ExtractorSerializer::serializePaddingEdge(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const PaddingEdge& value)
-{
-    serializationForCSS(builder, context, state.style, value);
-}
-
-inline void ExtractorSerializer::serializeScrollMarginEdge(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const ScrollMarginEdge& value)
-{
-    serializationForCSS(builder, context, state.style, value);
-}
-
-inline void ExtractorSerializer::serializeScrollPaddingEdge(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const ScrollPaddingEdge& value)
-{
-    serializationForCSS(builder, context, state.style, value);
-}
-
-inline void ExtractorSerializer::serializeCornerShapeValue(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const CornerShapeValue& value)
-{
-    serializationForCSS(builder, context, state.style, value);
-}
-
-inline void ExtractorSerializer::serializeDynamicRangeLimit(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const DynamicRangeLimit& value)
-{
-    serializationForCSS(builder, context, state.style, value);
-}
-
-inline void ExtractorSerializer::serializePreferredSize(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const PreferredSize& value)
-{
-    serializationForCSS(builder, context, state.style, value);
-}
-
-inline void ExtractorSerializer::serializeMaximumSize(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const MaximumSize& value)
-{
-    serializationForCSS(builder, context, state.style, value);
-}
-
-inline void ExtractorSerializer::serializeMinimumSize(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const MinimumSize& value)
-{
-    serializationForCSS(builder, context, state.style, value);
-}
-
-inline void ExtractorSerializer::serializeFlexBasis(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const FlexBasis& value)
-{
-    serializationForCSS(builder, context, state.style, value);
-}
-
-#if ENABLE(DARK_MODE_CSS)
-inline void ExtractorSerializer::serializeColorScheme(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const ColorScheme& value)
-{
-    serializationForCSS(builder, context, state.style, value);
-}
-#endif
 
 // MARK: - Shared serializations
 
@@ -1527,9 +1451,9 @@ inline void ExtractorSerializer::serializeScrollbarColor(ExtractorState& state, 
         return;
     }
 
-    serializeColor(state, builder, context, scrollbarColor->thumbColor);
+    serializeStyleType(state, builder, context, scrollbarColor->thumbColor);
     builder.append(' ');
-    serializeColor(state, builder, context, scrollbarColor->trackColor);
+    serializeStyleType(state, builder, context, scrollbarColor->trackColor);
 }
 
 inline void ExtractorSerializer::serializeScrollbarGutter(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const ScrollbarGutter& gutter)

--- a/Source/WebCore/style/values/borders/StyleCornerShapeValue.h
+++ b/Source/WebCore/style/values/borders/StyleCornerShapeValue.h
@@ -67,6 +67,10 @@ struct CornerShapeValue {
     bool operator==(const CornerShapeValue&) const = default;
 };
 
+// MARK: - Conversion
+
+template<> struct CSSValueConversion<CornerShapeValue> { auto operator()(BuilderState&, const CSSValue&) -> CornerShapeValue; };
+
 // MARK: - Blending
 
 template<> struct Blending<CornerShapeValue> {

--- a/Source/WebCore/style/values/box/StyleMargin.cpp
+++ b/Source/WebCore/style/values/box/StyleMargin.cpp
@@ -34,7 +34,7 @@ namespace Style {
 
 // MARK: - Conversion
 
-MarginEdge marginEdgeFromCSSValue(const CSSValue& value, BuilderState& state)
+auto CSSValueConversion<MarginEdge>::operator()(BuilderState& state, const CSSValue& value) -> MarginEdge
 {
     return MarginEdge { BuilderConverter::convertLengthOrAuto(state, value) };
 }

--- a/Source/WebCore/style/values/box/StyleMargin.h
+++ b/Source/WebCore/style/values/box/StyleMargin.h
@@ -154,7 +154,7 @@ using MarginBox = MinimallySerializingSpaceSeparatedRectEdges<MarginEdge>;
 
 // MARK: - Conversion
 
-MarginEdge marginEdgeFromCSSValue(const CSSValue&, BuilderState&);
+template<> struct CSSValueConversion<MarginEdge> { auto operator()(BuilderState&, const CSSValue&) -> MarginEdge; };
 
 // MARK: - Evaluation
 

--- a/Source/WebCore/style/values/box/StylePadding.cpp
+++ b/Source/WebCore/style/values/box/StylePadding.cpp
@@ -34,7 +34,7 @@ namespace Style {
 
 // MARK: - Conversion
 
-PaddingEdge paddingEdgeFromCSSValue(const CSSValue& value, BuilderState& state)
+auto CSSValueConversion<PaddingEdge>::operator()(BuilderState& state, const CSSValue& value) -> PaddingEdge
 {
     return PaddingEdge { BuilderConverter::convertLength(state, value) };
 }

--- a/Source/WebCore/style/values/box/StylePadding.h
+++ b/Source/WebCore/style/values/box/StylePadding.h
@@ -148,7 +148,7 @@ using PaddingBox = MinimallySerializingSpaceSeparatedRectEdges<PaddingEdge>;
 
 // MARK: - Conversion
 
-PaddingEdge paddingEdgeFromCSSValue(const CSSValue&, BuilderState&);
+template<> struct CSSValueConversion<PaddingEdge> { auto operator()(BuilderState&, const CSSValue&) -> PaddingEdge; };
 
 // MARK: - Evaluation
 

--- a/Source/WebCore/style/values/color-adjust/StyleColorScheme.cpp
+++ b/Source/WebCore/style/values/color-adjust/StyleColorScheme.cpp
@@ -30,6 +30,8 @@
 #include "CSSColorSchemeValue.h"
 #include "CSSToLengthConversionData.h"
 #include "CSSValueKeywords.h"
+#include "StyleBuilderConverter.h"
+#include "StyleBuilderState.h"
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
@@ -47,10 +49,22 @@ OptionSet<WebCore::ColorScheme> ColorScheme::colorScheme() const
     return result;
 }
 
+// MARK: - Conversion
+
 Ref<CSSValue> CSSValueCreation<ColorScheme>::operator()(CSSValuePool&, const RenderStyle& style, const ColorScheme& value)
 {
     return CSSColorSchemeValue::create(toCSS(value, style));
 }
+
+auto CSSValueConversion<ColorScheme>::operator()(BuilderState& state, const CSSValue& value) -> ColorScheme
+{
+    RefPtr colorSchemeValue = BuilderConverter::requiredDowncast<CSSColorSchemeValue>(state, value);
+    if (!colorSchemeValue)
+        return { };
+    return toStyle(colorSchemeValue->colorScheme(), state);
+}
+
+// MARK: - Serialization
 
 void Serialize<ColorScheme>::operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const ColorScheme& value)
 {
@@ -65,6 +79,8 @@ void Serialize<ColorScheme>::operator()(StringBuilder& builder, const CSS::Seria
         serializationForCSS(builder, context, style, *value.only);
     }
 }
+
+// MARK: - Logging
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, const ColorScheme& value)
 {

--- a/Source/WebCore/style/values/color-adjust/StyleColorScheme.h
+++ b/Source/WebCore/style/values/color-adjust/StyleColorScheme.h
@@ -60,10 +60,17 @@ template<size_t I> const auto& get(const ColorScheme& colorScheme)
 
 DEFINE_TYPE_MAPPING(CSS::ColorScheme, ColorScheme)
 
+// MARK: - Conversion
+
 // `ColorScheme` is special-cased to return a `CSSColorSchemeValue`.
 template<> struct CSSValueCreation<ColorScheme> { Ref<CSSValue> operator()(CSSValuePool&, const RenderStyle&, const ColorScheme&); };
+template<> struct CSSValueConversion<ColorScheme> { auto operator()(BuilderState&, const CSSValue&) -> ColorScheme; };
+
+// MARK: - Serialization
 
 template<> struct Serialize<ColorScheme> { void operator()(StringBuilder&, const CSS::SerializationContext&, const RenderStyle&, const ColorScheme&); };
+
+// MARK: - Logging
 
 TextStream& operator<<(TextStream&, const ColorScheme&);
 

--- a/Source/WebCore/style/values/color/StyleDynamicRangeLimit.h
+++ b/Source/WebCore/style/values/color/StyleDynamicRangeLimit.h
@@ -138,6 +138,7 @@ template<> struct ToStyle<CSS::DynamicRangeLimit> { auto operator()(const CSS::D
 
 // `DynamicRangeLimit` is special-cased to return a `CSSDynamicRangeLimitValue`.
 template<> struct CSSValueCreation<DynamicRangeLimit> { Ref<CSSValue> operator()(CSSValuePool&, const RenderStyle&, const DynamicRangeLimit&); };
+template<> struct CSSValueConversion<DynamicRangeLimit> { auto operator()(BuilderState&, const CSSValue&) -> DynamicRangeLimit; };
 
 // MARK: Serialization
 

--- a/Source/WebCore/style/values/flexbox/StyleFlexBasis.cpp
+++ b/Source/WebCore/style/values/flexbox/StyleFlexBasis.cpp
@@ -41,7 +41,7 @@ std::optional<PreferredSize> FlexBasis::tryPreferredSize() const
 
 // MARK: - Conversion
 
-FlexBasis flexBasisFromCSSValue(const CSSValue& value, BuilderState& state)
+auto CSSValueConversion<FlexBasis>::operator()(BuilderState& state, const CSSValue& value) -> FlexBasis
 {
     return FlexBasis { BuilderConverter::convertLengthSizing(state, value) };
 }

--- a/Source/WebCore/style/values/flexbox/StyleFlexBasis.h
+++ b/Source/WebCore/style/values/flexbox/StyleFlexBasis.h
@@ -91,7 +91,6 @@ struct FlexBasis {
     ALWAYS_INLINE bool isIntrinsicOrLegacyIntrinsicOrAuto() const { return m_value.isIntrinsicOrLegacyIntrinsicOrAuto(); }
     ALWAYS_INLINE bool isSpecifiedOrIntrinsic() const { return m_value.isSpecifiedOrIntrinsic(); }
 
-    // For the following three functions, attempt to match the behaviors of the ones in WebCore::Length.
     ALWAYS_INLINE bool isZero() const { return m_value.isZero(); }
     ALWAYS_INLINE bool isPositive() const { return m_value.isPositive(); }
     ALWAYS_INLINE bool isNegative() const { return m_value.isNegative(); }
@@ -188,7 +187,7 @@ private:
 
 // MARK: - Conversion
 
-FlexBasis flexBasisFromCSSValue(const CSSValue&, BuilderState&);
+template<> struct CSSValueConversion<FlexBasis> { auto operator()(BuilderState&, const CSSValue&) -> FlexBasis; };
 
 // MARK: - Evaluation
 

--- a/Source/WebCore/style/values/position/StyleInset.cpp
+++ b/Source/WebCore/style/values/position/StyleInset.cpp
@@ -34,7 +34,7 @@ namespace Style {
 
 // MARK: - Conversion
 
-InsetEdge insetEdgeFromCSSValue(const CSSValue& value, BuilderState& state)
+auto CSSValueConversion<InsetEdge>::operator()(BuilderState& state, const CSSValue& value) -> InsetEdge
 {
     return InsetEdge { BuilderConverter::convertLengthOrAuto(state, value) };
 }

--- a/Source/WebCore/style/values/position/StyleInset.h
+++ b/Source/WebCore/style/values/position/StyleInset.h
@@ -152,7 +152,7 @@ using InsetBox = MinimallySerializingSpaceSeparatedRectEdges<InsetEdge>;
 
 // MARK: - Conversion
 
-InsetEdge insetEdgeFromCSSValue(const CSSValue&, BuilderState&);
+template<> struct CSSValueConversion<InsetEdge> { auto operator()(BuilderState&, const CSSValue&) -> InsetEdge; };
 
 // MARK: - Evaluation
 

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueCreation.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueCreation.h
@@ -39,6 +39,13 @@ template<Numeric StyleType> struct CSSValueCreation<StyleType> {
     }
 };
 
+template<DimensionPercentageNumeric StyleType> struct CSSValueCreation<StyleType> {
+    Ref<CSSValue> operator()(CSSValuePool& pool, const RenderStyle& style, const StyleType& value)
+    {
+        return CSS::createCSSValue(pool, toCSS(value, style));
+    }
+};
+
 template<Calc StyleType> struct CSSValueCreation<StyleType> {
     Ref<CSSValue> operator()(CSSValuePool& pool, const RenderStyle& style, const StyleType& value)
     {

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Serialization.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Serialization.h
@@ -41,6 +41,14 @@ template<Numeric StyleType> struct Serialize<StyleType> {
     }
 };
 
+template<DimensionPercentageNumeric StyleType> struct Serialize<StyleType> {
+    void operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const StyleType& value)
+    {
+        // FIXME: Do this more efficiently without creating and destroying a CSS::Numeric object.
+        CSS::serializationForCSS(builder, context, toCSS(value, style));
+    }
+};
+
 template<Calc StyleType> struct Serialize<StyleType> {
     void operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const StyleType& value)
     {

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.cpp
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.cpp
@@ -92,7 +92,7 @@ float Evaluation<ScrollMarginEdge>::operator()(const ScrollMarginEdge& edge, flo
     return 0.0f;
 }
 
-ScrollMarginEdge scrollMarginEdgeFromCSSValue(const CSSValue& value, BuilderState& state)
+auto CSSValueConversion<ScrollMarginEdge>::operator()(BuilderState& state, const CSSValue& value) -> ScrollMarginEdge
 {
     return ScrollMarginEdge { BuilderConverter::convertLength(state, value) };
 }

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h
@@ -103,7 +103,7 @@ using ScrollMarginBox = MinimallySerializingSpaceSeparatedRectEdges<ScrollMargin
 
 // MARK: - Conversion
 
-ScrollMarginEdge scrollMarginEdgeFromCSSValue(const CSSValue&, BuilderState&);
+template<> struct CSSValueConversion<ScrollMarginEdge> { auto operator()(BuilderState&, const CSSValue&) -> ScrollMarginEdge; };
 
 // MARK: - Evaluation
 

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.cpp
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.cpp
@@ -96,7 +96,7 @@ float Evaluation<ScrollPaddingEdge>::operator()(const ScrollPaddingEdge& edge, f
     return 0;
 }
 
-ScrollPaddingEdge scrollPaddingEdgeFromCSSValue(const CSSValue& value, BuilderState& state)
+auto CSSValueConversion<ScrollPaddingEdge>::operator()(BuilderState& state, const CSSValue& value) -> ScrollPaddingEdge
 {
     return ScrollPaddingEdge { BuilderConverter::convertLengthOrAuto(state, value) };
 }

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h
@@ -152,7 +152,7 @@ using ScrollPaddingBox = MinimallySerializingSpaceSeparatedRectEdges<ScrollPaddi
 
 // MARK: - Conversion
 
-ScrollPaddingEdge scrollPaddingEdgeFromCSSValue(const CSSValue&, BuilderState&);
+template<> struct CSSValueConversion<ScrollPaddingEdge> { auto operator()(BuilderState&, const CSSValue&) -> ScrollPaddingEdge; };
 
 // MARK: - Evaluation
 

--- a/Source/WebCore/style/values/sizing/StyleMaximumSize.cpp
+++ b/Source/WebCore/style/values/sizing/StyleMaximumSize.cpp
@@ -34,9 +34,11 @@ namespace Style {
 
 // MARK: - Conversion
 
-MaximumSize maximumSizeFromCSSValue(const CSSValue& value, BuilderState& state)
+auto CSSValueConversion<MaximumSize>::operator()(BuilderState& state, const CSSValue& value) -> MaximumSize
 {
-    return MaximumSize { BuilderConverter::convertLengthMaxSizing(state, value) };
+    if (value.valueID() == CSSValueNone)
+        return MaximumSize { CSS::Keyword::None { } };
+    return MaximumSize { BuilderConverter::convertLengthSizing(state, value) };
 }
 
 // MARK: - Blending

--- a/Source/WebCore/style/values/sizing/StyleMaximumSize.h
+++ b/Source/WebCore/style/values/sizing/StyleMaximumSize.h
@@ -197,7 +197,7 @@ using MaximumSizePair = SpaceSeparatedSize<MaximumSize>;
 
 // MARK: - Conversion
 
-MaximumSize maximumSizeFromCSSValue(const CSSValue&, BuilderState&);
+template<> struct CSSValueConversion<MaximumSize> { auto operator()(BuilderState&, const CSSValue&) -> MaximumSize; };
 
 // MARK: - Evaluation
 

--- a/Source/WebCore/style/values/sizing/StyleMinimumSize.cpp
+++ b/Source/WebCore/style/values/sizing/StyleMinimumSize.cpp
@@ -45,7 +45,7 @@ MinimumSize::MinimumSize(const PreferredSize& other)
 
 // MARK: - Conversion
 
-MinimumSize minimumSizeFromCSSValue(const CSSValue& value, BuilderState& state)
+auto CSSValueConversion<MinimumSize>::operator()(BuilderState& state, const CSSValue& value) -> MinimumSize
 {
     return MinimumSize { BuilderConverter::convertLengthSizing(state, value) };
 }

--- a/Source/WebCore/style/values/sizing/StyleMinimumSize.h
+++ b/Source/WebCore/style/values/sizing/StyleMinimumSize.h
@@ -109,7 +109,6 @@ struct MinimumSize {
     ALWAYS_INLINE bool isIntrinsicOrLegacyIntrinsicOrAuto() const { return m_value.isIntrinsicOrLegacyIntrinsicOrAuto(); }
     ALWAYS_INLINE bool isSpecifiedOrIntrinsic() const { return m_value.isSpecifiedOrIntrinsic(); }
 
-    // For the following three functions, attempt to match the behaviors of the ones in WebCore::Length.
     ALWAYS_INLINE bool isZero() const { return m_value.isZero(); }
     ALWAYS_INLINE bool isPositive() const { return m_value.isPositive(); }
     ALWAYS_INLINE bool isNegative() const { return m_value.isNegative(); }
@@ -205,7 +204,7 @@ using MinimumSizePair = SpaceSeparatedSize<MinimumSize>;
 
 // MARK: - Conversion
 
-MinimumSize minimumSizeFromCSSValue(const CSSValue&, BuilderState&);
+template<> struct CSSValueConversion<MinimumSize> { auto operator()(BuilderState&, const CSSValue&) -> MinimumSize; };
 
 // MARK: - Evaluation
 

--- a/Source/WebCore/style/values/sizing/StylePreferredSize.cpp
+++ b/Source/WebCore/style/values/sizing/StylePreferredSize.cpp
@@ -40,7 +40,7 @@ FlexBasis PreferredSize::asFlexBasis() const
 
 // MARK: - Conversion
 
-PreferredSize preferredSizeFromCSSValue(const CSSValue& value, BuilderState& state)
+auto CSSValueConversion<PreferredSize>::operator()(BuilderState& state, const CSSValue& value) -> PreferredSize
 {
     return PreferredSize { BuilderConverter::convertLengthSizing(state, value) };
 }

--- a/Source/WebCore/style/values/sizing/StylePreferredSize.h
+++ b/Source/WebCore/style/values/sizing/StylePreferredSize.h
@@ -107,7 +107,6 @@ struct PreferredSize {
     ALWAYS_INLINE bool isIntrinsicOrLegacyIntrinsicOrAuto() const { return m_value.isIntrinsicOrLegacyIntrinsicOrAuto(); }
     ALWAYS_INLINE bool isSpecifiedOrIntrinsic() const { return m_value.isSpecifiedOrIntrinsic(); }
 
-    // For the following three functions, attempt to match the behaviors of the ones in WebCore::Length.
     ALWAYS_INLINE bool isZero() const { return m_value.isZero(); }
     ALWAYS_INLINE bool isPositive() const { return m_value.isPositive(); }
     ALWAYS_INLINE bool isNegative() const { return m_value.isNegative(); }
@@ -207,7 +206,7 @@ using PreferredSizePair = SpaceSeparatedSize<PreferredSize>;
 
 // MARK: - Conversion
 
-PreferredSize preferredSizeFromCSSValue(const CSSValue&, BuilderState&);
+template<> struct CSSValueConversion<PreferredSize> { auto operator()(BuilderState&, const CSSValue&) -> PreferredSize; };
 
 // MARK: - Evaluation
 


### PR DESCRIPTION
#### 8ce27174e473a6d7a53ce852e28035f0bbf15a90
<pre>
[Style] Reduce duplication in style building/extraction/serialization when delegating to strong types
<a href="https://bugs.webkit.org/show_bug.cgi?id=294265">https://bugs.webkit.org/show_bug.cgi?id=294265</a>

Reviewed by Darin Adler.

Uses a single template function in each of the style builder/extractor/serializer
for style value types to reduce unnecessary duplication and to allow types to define
their behaviors locally.

For Style::BuilderConverter, the function is Style::BuilderConverter::convertStyleType&lt;T&gt;().
For Style::ExtractorConverter, the function is Style::ExtractorConverter::convertStyleType&lt;T&gt;().
For Style::ExtractorSerializer, the function is Style::ExtractorSerializer::serializeStyleType&lt;T&gt;().

To allow delegation in Style::BuilderConverter, a new Style::CSSValueConversion interface
was added that allows types of specialize direct conversion from CSSValue to StyleType. This
replaces some of the adhoc `Style::{type name}FromCSSValue()` functions that had developed.

Delegation for Style::ExtractorConverter and Style::ExtractorSerializer continues to use
the Style::CSSValueCreation and Style::Serialize interfaces respectively.

* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/scripts/process-css-properties.py:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleBuilderCustom.h:
* Source/WebCore/style/StyleExtractorConverter.h:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/StyleExtractorSerializer.h:
* Source/WebCore/style/values/StyleValueTypes.h:
* Source/WebCore/style/values/borders/StyleCornerShapeValue.cpp:
* Source/WebCore/style/values/borders/StyleCornerShapeValue.h:
* Source/WebCore/style/values/box/StyleMargin.cpp:
* Source/WebCore/style/values/box/StyleMargin.h:
* Source/WebCore/style/values/box/StylePadding.cpp:
* Source/WebCore/style/values/box/StylePadding.h:
* Source/WebCore/style/values/color-adjust/StyleColorScheme.cpp:
* Source/WebCore/style/values/color-adjust/StyleColorScheme.h:
* Source/WebCore/style/values/color/StyleDynamicRangeLimit.cpp:
* Source/WebCore/style/values/color/StyleDynamicRangeLimit.h:
* Source/WebCore/style/values/flexbox/StyleFlexBasis.cpp:
* Source/WebCore/style/values/flexbox/StyleFlexBasis.h:
* Source/WebCore/style/values/position/StyleInset.cpp:
* Source/WebCore/style/values/position/StyleInset.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueCreation.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Serialization.h:
* Source/WebCore/style/values/scroll-snap/StyleScrollMargin.cpp:
* Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h:
* Source/WebCore/style/values/scroll-snap/StyleScrollPadding.cpp:
* Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h:
* Source/WebCore/style/values/sizing/StyleMaximumSize.cpp:
* Source/WebCore/style/values/sizing/StyleMaximumSize.h:
* Source/WebCore/style/values/sizing/StyleMinimumSize.cpp:
* Source/WebCore/style/values/sizing/StyleMinimumSize.h:
* Source/WebCore/style/values/sizing/StylePreferredSize.cpp:
* Source/WebCore/style/values/sizing/StylePreferredSize.h:

Canonical link: <a href="https://commits.webkit.org/296186@main">https://commits.webkit.org/296186@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6567e44524f05ca996961d0337577865d449d987

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107587 "14 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27270 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112804 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58129 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109551 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27962 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35772 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81688 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110516 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22162 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96973 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62068 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21599 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15112 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57568 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91533 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15146 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115905 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34655 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25558 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90721 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35031 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93223 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90462 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23076 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35379 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13162 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30418 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34576 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40132 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34322 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37682 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35985 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->