### PR TITLE
Add new onTestStarted and onTestFinished event listeners to the browser.test namespace

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionEventListenerType.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionEventListenerType.h
@@ -76,6 +76,8 @@ enum class WebExtensionEventListenerType : uint8_t {
     TabsOnReplaced,
     TabsOnUpdated,
     TestOnMessage,
+    TestOnTestStarted,
+    TestOnTestFinished,
     WebNavigationOnBeforeNavigate,
     WebNavigationOnCommitted,
     WebNavigationOnCompleted,
@@ -182,6 +184,10 @@ inline String toAPIString(WebExtensionEventListenerType eventType)
         return "onUpdated"_s;
     case WebExtensionEventListenerType::TestOnMessage:
         return "onMessage"_s;
+    case WebExtensionEventListenerType::TestOnTestStarted:
+        return "onTestStarted"_s;
+    case WebExtensionEventListenerType::TestOnTestFinished:
+        return "onTestFinished"_s;
     case WebExtensionEventListenerType::WebNavigationOnBeforeNavigate:
         return "onBeforeNavigate"_s;
     case WebExtensionEventListenerType::WebNavigationOnCommitted:

--- a/Source/WebKit/Shared/Extensions/WebExtensionEventListenerType.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionEventListenerType.serialization.in
@@ -67,6 +67,8 @@ enum class WebKit::WebExtensionEventListenerType : uint8_t {
     TabsOnReplaced,
     TabsOnUpdated,
     TestOnMessage,
+    TestOnTestStarted,
+    TestOnTestFinished,
     WebNavigationOnBeforeNavigate,
     WebNavigationOnCommitted,
     WebNavigationOnCompleted,

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
@@ -851,6 +851,16 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(WKWeb
     self._protectedWebExtensionContext->sendTestMessage(message, argument);
 }
 
+- (void)_sendTestStartedWithArgument:(id)argument
+{
+    self._protectedWebExtensionContext->sendTestStarted(argument);
+}
+
+- (void)_sendTestFinishedWithArgument:(id)argument
+{
+    self._protectedWebExtensionContext->sendTestFinished(argument);
+}
+
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 - (nullable _WKWebExtensionSidebar *)sidebarForTab:(id<WKWebExtensionTab>)tab
 {
@@ -1272,6 +1282,14 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(WKWeb
 }
 
 - (void)_sendTestMessage:(NSString *)message withArgument:(id)argument
+{
+}
+
+- (void)_sendTestStartedWithArgument:(nullable id)argument
+{
+}
+
+- (void)_sendTestFinishedWithArgument:(nullable id)argument
 {
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContextPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContextPrivate.h
@@ -45,6 +45,20 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
  */
 - (void)_sendTestMessage:(NSString *)message withArgument:(nullable id)argument;
 
+/*!
+ @abstract Sends data to the JavaScript `browser.test.onTestStarted` API.
+ @discussion Allows code to trigger a `browser.test.onTestStarted` event during testing.
+ @param argument The optional JSON-serializable argument to include with the message. Must be JSON-serializable according to \c NSJSONSerialization.
+ */
+- (void)_sendTestStartedWithArgument:(nullable id)argument;
+
+/*!
+ @abstract Sends data to the JavaScript `browser.test.onTestFinished` API.
+ @discussion Allows code to trigger a `browser.test.onTestFinished` event during testing.
+ @param argument The optional JSON-serializable argument to include with the message. Must be JSON-serializable according to \c NSJSONSerialization.
+ */
+- (void)_sendTestFinishedWithArgument:(nullable id)argument;
+
 /*! @abstract Resets the commands back to the state provided by the manifest. */
 - (void)_resetCommands;
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -526,6 +526,8 @@ public:
 
 #if PLATFORM(COCOA)
     void sendTestMessage(const String& message, id argument);
+    void sendTestStarted(id argument);
+    void sendTestFinished(id argument);
 #endif
 
 #if PLATFORM(COCOA)
@@ -1100,10 +1102,18 @@ private:
     };
 
     size_t m_testMessageListenersCount { 0 };
-    Deque<TestMessage> m_testMessageQueue;
+    size_t m_testStartedListenersCount { 0 };
+    size_t m_testFinishedListenersCount { 0 };
 
-    bool hasTestMessageEventListeners() { return m_testMessageListenersCount; }
-    void flushTestMessageQueueIfNeeded();
+    Deque<TestMessage> m_testMessageQueue;
+    Deque<TestMessage> m_testStartedQueue;
+    Deque<TestMessage> m_testFinishedQueue;
+
+    bool hasTestEventListeners(WebExtensionEventListenerType);
+    void sendQueuedTestMessagesIfNeeded(WebExtensionEventListenerType);
+#if PLATFORM(COCOA)
+    void addTestMessageToQueue(const String& message, id argument, WebExtensionEventListenerType);
+#endif
 };
 
 template<typename T>

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -47,6 +47,8 @@ public:
 
     void sendMessage(JSContextRef, NSString *message, JSValue *argument);
     WebExtensionAPIEvent& onMessage();
+    WebExtensionAPIEvent& onTestStarted();
+    WebExtensionAPIEvent& onTestFinished();
 
     JSValue *runWithUserGesture(WebFrame&, JSValue *function);
     bool isProcessingUserGesture();
@@ -75,6 +77,8 @@ public:
 
 private:
     RefPtr<WebExtensionAPIEvent> m_onMessage;
+    RefPtr<WebExtensionAPIEvent> m_onTestStarted;
+    RefPtr<WebExtensionAPIEvent> m_onTestFinished;
 
     struct Test {
         String testName;

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,6 +39,12 @@
 
     // Event for receiving messages from the test harness.
     readonly attribute WebExtensionAPIEvent onMessage;
+
+    // Event for receiving messages from the test harness when a test has started.
+    readonly attribute WebExtensionAPIEvent onTestStarted;
+
+    // Event for receiving messages from the test harness when a test has finished.
+    readonly attribute WebExtensionAPIEvent onTestFinished;
 
     // Runs the provided function in the context of a user gesture.
     [NeedsFrame] any runWithUserGesture([ValuesAllowed] any function);

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -211,6 +211,8 @@ private:
 
     // Test
     void dispatchTestMessageEvent(const String& message, const String& argumentJSON, WebExtensionContentWorldType);
+    void dispatchTestStartedEvent(const String& argumentJSON, WebExtensionContentWorldType);
+    void dispatchTestFinishedEvent(const String& argumentJSON, WebExtensionContentWorldType);
 
     // Web Navigation
     void dispatchWebNavigationEvent(WebExtensionEventListenerType, WebExtensionTabIdentifier, const WebExtensionFrameParameters&, WallTime);

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
@@ -92,6 +92,8 @@ messages -> WebExtensionContextProxy {
 
     // Test Events
     DispatchTestMessageEvent(String message, String argumentJSON, WebKit::WebExtensionContentWorldType contentWorldType)
+    DispatchTestStartedEvent(String argumentJSON, WebKit::WebExtensionContentWorldType contentWorldType)
+    DispatchTestFinishedEvent(String argumentJSON, WebKit::WebExtensionContentWorldType contentWorldType)
 
     // Web Navigation
     DispatchWebNavigationEvent(WebKit::WebExtensionEventListenerType type, WebKit::WebExtensionTabIdentifier tabID, struct WebKit::WebExtensionFrameParameters frameParamaters, WallTime timestamp)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITest.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,6 +49,48 @@ static auto *manifest = @{
         @"js": @[ @"content.js" ]
     }]
 };
+
+TEST(WKWebExtensionAPITest, TestStartedEvent)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.onTestStarted.addListener((data) => {",
+        @"  browser.test.assertEq(data?.testName, 'test', 'data.testName should be')",
+
+        @"  browser.test.notifyPass()",
+        @"})",
+
+        @"browser.test.sendMessage('Send Test Message')"
+    ]);
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+
+    [manager runUntilTestMessage:@"Send Test Message"];
+
+    [manager sendTestStartedWithArgument:@{ @"testName": @"test" }];
+
+    [manager run];
+}
+
+TEST(WKWebExtensionAPITest, TestFinishedEvent)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.onTestFinished.addListener((data) => {",
+        @"  browser.test.assertEq(data?.testName, 'test', 'data.testName should be')",
+
+        @"  browser.test.notifyPass()",
+        @"})",
+
+        @"browser.test.sendMessage('Send Test Message')"
+    ]);
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+
+    [manager runUntilTestMessage:@"Send Test Message"];
+
+    [manager sendTestFinishedWithArgument:@{ @"testName": @"test" }];
+
+    [manager run];
+}
 
 TEST(WKWebExtensionAPITest, MessageEvent)
 {

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
@@ -63,6 +63,8 @@
 
 - (void)sendTestMessage:(NSString *)message;
 - (void)sendTestMessage:(NSString *)message withArgument:(id)argument;
+- (void)sendTestStartedWithArgument:(id)argument;
+- (void)sendTestFinishedWithArgument:(id)argument;
 
 - (void)loadAndRun;
 

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -244,6 +244,16 @@ static constexpr BOOL shouldEnableSiteIsolation = NO;
     [_context _sendTestMessage:message withArgument:argument];
 }
 
+- (void)sendTestStartedWithArgument:(id)argument
+{
+    [_context _sendTestStartedWithArgument:argument];
+}
+
+- (void)sendTestFinishedWithArgument:(id)argument
+{
+    [_context _sendTestFinishedWithArgument:argument];
+}
+
 - (void)load
 {
     NSError *error;


### PR DESCRIPTION
#### 1a5e68c92a29757c9a63b716382ce2c54b5839c3
<pre>
Add new onTestStarted and onTestFinished event listeners to the browser.test namespace
<a href="https://bugs.webkit.org/show_bug.cgi?id=294398">https://bugs.webkit.org/show_bug.cgi?id=294398</a>
<a href="https://rdar.apple.com/152970507">rdar://152970507</a>

Reviewed by Timothy Hatcher.

Instead of using the browser.test.onMessage event listener for bidirectional communication, create
new event listeners specially for reporting when a test has started and finished.

* Source/WebKit/Shared/Extensions/WebExtensionEventListenerType.h:
(WebKit::toAPIString):
* Source/WebKit/Shared/Extensions/WebExtensionEventListenerType.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm:
(-[WKWebExtensionContext _sendTestMessage:withArgument:]):
(-[WKWebExtensionContext _sendTestStartedMessageWithArgument:]):
(-[WKWebExtensionContext _sendTestFinishedMessageWithArgument:]):

* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContextPrivate.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm:
(WebKit::isTestEventListener):
(WebKit::WebExtensionContext::addListener):
(WebKit::WebExtensionContext::removeListener):

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::sendTestMessage):
(WebKit::WebExtensionContext::addTestMessageToQueue):
(WebKit::WebExtensionContext::sendQueuedTestMessagesIfNeeded):
(WebKit::WebExtensionContext::hasTestEventListeners):
Update these methods to handle testOnStarted and testOnFinished messages.

(WebKit::WebExtensionContext::flushTestMessageQueueIfNeeded): Deleted. Renamed.

* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::hasTestMessageEventListeners): Deleted.

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm:
(WebKit::WebExtensionAPITest::onTestStarted):
(WebKit::WebExtensionAPITest::onTestFinished):
Create new event listeners.

(WebKit::WebExtensionContextProxy::dispatchTestMessageEvent):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in:
Pass the event type so we can know which event listener to call for the message.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITest.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPITest, TestStartedEvent)):
(TestWebKitAPI::TEST(WKWebExtensionAPITest, TestFinishedEvent)):
Add new tests.

* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionManager sendTestStartedMessageWithArgument:]):
(-[TestWebExtensionManager sendTestFinishedMessageWithArgument:]):

Canonical link: <a href="https://commits.webkit.org/296322@main">https://commits.webkit.org/296322@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/885c30bfb25c54cf16bc802670fdf7321513c035

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108196 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113407 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/58681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110159 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36410 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/82153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/58681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111144 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/22630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/97463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/62584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/22045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/15599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/58143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/91996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/15655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116533 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35262 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/91179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35636 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/93739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/90974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/35865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/13625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17471 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35161 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40717 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34895 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/38252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36562 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->