### PR TITLE
[iOS] [Liquid Glass] baidu.com: Fixed color extensions appear after moving "百度APP内播放" to the bottom

### DIFF
--- a/LayoutTests/fast/page-color-sampling/page-color-sampling-skips-small-elements.html
+++ b/LayoutTests/fast/page-color-sampling/page-color-sampling-skips-small-elements.html
@@ -20,6 +20,17 @@
             border-bottom-right-radius: 6px;
         }
 
+        .top {
+            position: fixed;
+            top: 0;
+            left: calc(50% - 50px);
+            width: 100px;
+            height: 20px;
+            background: red;
+            border-bottom-left-radius: 6px;
+            border-bottom-right-radius: 6px;
+        }
+
         .tall {
             width: 10px;
             height: 5000px;
@@ -41,6 +52,7 @@
     </script>
 </head>
 <body>
+<div class="top"></div>
 <div class="left"></div>
 <div class="tall"></div>
 </body>

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2122,10 +2122,8 @@ std::pair<FixedContainerEdges, WeakElementEdges> LocalFrameView::fixedContainerE
             isProbablyDimmingContainer = box->hasBackground() && !box->firstChild() && box->isTransparent();
         }
 
-        if (side == BoxSide::Left || side == BoxSide::Right) {
-            if (!isNearlyViewportSized(side, renderer))
-                return TooSmall;
-        }
+        if (!isNearlyViewportSized(side, renderer))
+            return TooSmall;
 
         if (!isProbablyDimmingContainer && isNearlyViewportSized(adjacentSideInClockwiseOrder(side), renderer))
             return TooLarge;


### PR DESCRIPTION
#### b4e25f1796cb897fdcfb2a726dcd50fac4968fb1
<pre>
[iOS] [Liquid Glass] baidu.com: Fixed color extensions appear after moving &quot;百度APP内播放&quot; to the bottom
<a href="https://bugs.webkit.org/show_bug.cgi?id=294414">https://bugs.webkit.org/show_bug.cgi?id=294414</a>
<a href="https://rdar.apple.com/152741332">rdar://152741332</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

On baidu.com, after following a link to a video article from the front page and then dragging to
reposition the purple &quot;百度APP内播放&quot; (&quot;Play in Baidu app&quot;) dialog against the edges of the viewport,
white fixed color extension views will appear on the sides of any viewport edges that have nonzero
obscured insets. This happens because:

1.  When dragging the dialog against a viewport edge, it gets detected as a fixed container
2.  This causes us to sample the fixed edge color, which results in a multi-color result; we handle
    this by falling back to page background color — white.
3.  Due to color sampling stability heuristics in 295099@main, we end up keeping the sampled colors
    stable even if the dialog is repositioned by the user, such that it&apos;s no longer near the edge.

To fix this, we broaden the heuristic in 294382@main to also apply to top and bottom viewport edges.
This was initially limited to left/right edges to limit risk (e.g. it would have broken sampling for
the fixed header on wallflowersanfrancisco.com, where the fixed-position container itself is empty
but contains visual overflow). However, this is no longer a risk after the changes in 294820@main,
which adjusted `isNearlyViewportSized` to only check _either_ the width _or_ height of the element,
instead of the ratio of the rect that overlaps.

As such, it should now be safe to remove the `side == BoxSide::Left || side == BoxSide::Right` check
for this `TooSmall` case.

* LayoutTests/fast/page-color-sampling/page-color-sampling-skips-small-elements.html:

Augment an existing layout test to cover this case as well.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fixedContainerEdges const):

Canonical link: <a href="https://commits.webkit.org/296175@main">https://commits.webkit.org/296175@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b35c28d1b83b77a405deb2cd6ebf739a65e6757

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107575 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27258 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17668 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112792 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/58117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109539 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27949 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35760 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/81673 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/58117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110504 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22151 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96958 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62053 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21588 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15096 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57556 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91530 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15131 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115893 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34643 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/90706 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35019 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93208 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90447 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23071 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35369 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13147 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30406 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34564 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40120 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34310 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37670 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35973 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->