### PR TITLE
Painted images don't get tone mapped down to the level supported by the display.

### DIFF
--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -369,6 +369,13 @@ bool CachedImage::hasHDRContent() const
     return m_image && m_image->hasHDRContent();
 }
 
+Headroom CachedImage::currentFrameHeadroom() const
+{
+    if (!m_image)
+        return Headroom::None;
+    return m_image->currentFrameHeadroom();
+}
+
 void CachedImage::notifyObservers(const IntRect* changeRect)
 {
     CachedResourceClientWalker<CachedImageClient> walker(*this);

--- a/Source/WebCore/loader/cache/CachedImage.h
+++ b/Source/WebCore/loader/cache/CachedImage.h
@@ -98,6 +98,7 @@ public:
     void computeIntrinsicDimensions(Length& intrinsicWidth, Length& intrinsicHeight, FloatSize& intrinsicRatio);
 
     bool hasHDRContent() const;
+    Headroom currentFrameHeadroom() const;
 
     bool isManuallyCached() const { return m_isManuallyCached; }
     RevalidationDecision makeRevalidationDecision(CachePolicy) const override;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1720,6 +1720,9 @@ void Page::screenPropertiesDidChange()
         element.setPreferredDynamicRangeMode(mode);
     });
 #endif
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    updateDisplayEDRHeadroom();
+#endif
 
     setNeedsRecalcStyleInAllFrames();
 }
@@ -5752,5 +5755,27 @@ bool Page::requiresUserGestureForVideoPlayback() const
         return autoplayPolicy == AutoplayPolicy::Deny;
     return m_settings->requiresUserGestureForVideoPlayback();
 }
+
+#if HAVE(SUPPORT_HDR_DISPLAY)
+void Page::updateDisplayEDRHeadroom()
+{
+    float headroom = currentEDRHeadroomForDisplay(m_displayID);
+    if (headroom == m_displayEDRHeadroom.headroom)
+        return;
+
+    LOG_WITH_STREAM(HDR, stream << "Page " << this << " updateDisplayEDRHeadroom " << m_displayEDRHeadroom.headroom << " to " << headroom);
+    m_displayEDRHeadroom = headroom;
+
+    for (auto& rootFrame : m_rootFrames) {
+        ASSERT(rootFrame->isRootFrame());
+        RefPtr view = rootFrame->view();
+        if (!view)
+            continue;
+
+        view->setDescendantsNeedUpdateBackingAndHierarchyTraversal();
+
+    }
+}
+#endif
 
 } // namespace WebCore

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -29,6 +29,7 @@
 #include "FindOptions.h"
 #include "FrameLoaderTypes.h"
 #include "HistoryItem.h"
+#include "ImageTypes.h"
 #include "IntRectHash.h"
 #include "LoadSchedulingMode.h"
 #include "MediaSessionGroupIdentifier.h"
@@ -1343,6 +1344,11 @@ public:
     bool requiresUserGestureForAudioPlayback() const;
     bool requiresUserGestureForVideoPlayback() const;
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    Headroom displayEDRHeadroom() const { return m_displayEDRHeadroom; }
+    void updateDisplayEDRHeadroom();
+#endif
+
 private:
     explicit Page(PageConfiguration&&);
 
@@ -1770,6 +1776,10 @@ private:
 
 #if ENABLE(WRITING_TOOLS)
     const UniqueRef<WritingToolsController> m_writingToolsController;
+#endif
+
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    Headroom m_displayEDRHeadroom { Headroom::None };
 #endif
 
     UncheckedKeyHashSet<std::pair<URL, ScriptTelemetryCategory>> m_reportedScriptsWithTelemetry;

--- a/Source/WebCore/platform/Logging.h
+++ b/Source/WebCore/platform/Logging.h
@@ -115,6 +115,7 @@ namespace WebCore {
     M(FTP) \
     M(Fullscreen) \
     M(Gamepad) \
+    M(HDR) \
     M(HID) \
     M(History) \
     M(IOSurface) \

--- a/Source/WebCore/platform/PlatformScreen.h
+++ b/Source/WebCore/platform/PlatformScreen.h
@@ -115,6 +115,9 @@ WEBCORE_EXPORT PlatformDisplayID primaryScreenDisplayID();
 #if HAVE(SUPPORT_HDR_DISPLAY)
 WEBCORE_EXPORT void setScreenContentsFormatsForTesting(OptionSet<ContentsFormat>);
 OptionSet<ContentsFormat> screenContentsFormatsForTesting();
+
+WEBCORE_EXPORT float currentEDRHeadroomForDisplay(PlatformDisplayID);
+WEBCORE_EXPORT float maxEDRHeadroomForDisplay(PlatformDisplayID);
 #endif
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/platform/ScreenProperties.h
+++ b/Source/WebCore/platform/ScreenProperties.h
@@ -43,6 +43,10 @@ struct ScreenData {
     bool screenSupportsExtendedColor { false };
     bool screenHasInvertedColors { false };
     bool screenSupportsHighDynamicRange { false };
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    float currentEDRHeadroom { 1 };
+    float maxEDRHeadroom { 1 };
+#endif
 #if PLATFORM(MAC)
     FloatSize screenSize; // In millimeters.
     bool screenIsMonochrome { false };

--- a/Source/WebCore/platform/graphics/BitmapImage.h
+++ b/Source/WebCore/platform/graphics/BitmapImage.h
@@ -60,7 +60,7 @@ public:
     unsigned currentFrameIndex() const { return m_source->currentFrameIndex(); }
     bool currentFrameHasAlpha() const { return m_source->currentImageFrame().hasAlpha(); }
     ImageOrientation currentFrameOrientation() const { return m_source->currentImageFrame().orientation(); }
-    Headroom currentFrameHeadroom() const { return m_source->currentImageFrame().headroom(); }
+    Headroom currentFrameHeadroom() const final { return m_source->currentImageFrame().headroom(); }
     DecodingOptions currentFrameDecodingOptions() const { return m_source->currentImageFrame().decodingOptions(); }
 
     // Primary & current NativeImage

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -239,6 +239,10 @@ public:
     virtual void setLineJoin(LineJoin) = 0;
     virtual void setMiterLimit(float) = 0;
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    virtual void setMaxEDRHeadroom(float) { }
+#endif
+
     // Images, Patterns, ControlParts, and Media
 
     IntSize compatibleImageBufferSize(const FloatSize&) const;

--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -453,6 +453,12 @@ void GraphicsLayer::setDrawsHDRContent(bool b)
     ASSERT(m_type != Type::Structural);
     m_drawsHDRContent = b;
 }
+
+void GraphicsLayer::setEDRHeadroom(float headroom)
+{
+    ASSERT(m_type != Type::Structural);
+    m_edrHeadroom = headroom;
+}
 #endif
 
 const TransformationMatrix& GraphicsLayer::transform() const
@@ -998,6 +1004,8 @@ void GraphicsLayer::dumpProperties(TextStream& ts, OptionSet<LayerTreeAsTextOpti
 #if HAVE(SUPPORT_HDR_DISPLAY)
     if (m_drawsHDRContent)
         ts << indent << "(drawsHDRContent "_s << m_drawsHDRContent << ")\n"_s;
+    if (m_edrHeadroom != 1)
+        ts << indent << "(edrHeadroom"_s << m_edrHeadroom << ")\n"_s;
 #endif
 
     if (!m_contentsVisible)

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -427,6 +427,9 @@ public:
 #if HAVE(SUPPORT_HDR_DISPLAY)
     bool drawsHDRContent() const { return m_drawsHDRContent; }
     WEBCORE_EXPORT virtual void setDrawsHDRContent(bool);
+
+    float edrHeadroom() const { return m_edrHeadroom; }
+    WEBCORE_EXPORT virtual void setEDRHeadroom(float);
 #endif
 
     bool contentsAreVisible() const { return m_contentsVisible; }
@@ -874,6 +877,9 @@ protected:
     ScalingFilter m_contentsMagnificationFilter = ScalingFilter::Linear;
     FloatRoundedRect m_backdropFiltersRect;
     std::optional<FloatRect> m_animationExtent;
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    float m_edrHeadroom { 1.0f };
+#endif
 
     EventRegion m_eventRegion;
 #if USE(CA)

--- a/Source/WebCore/platform/graphics/Image.h
+++ b/Source/WebCore/platform/graphics/Image.h
@@ -125,6 +125,7 @@ public:
 
     virtual DestinationColorSpace colorSpace();
     virtual bool hasHDRContent() const { return false; }
+    virtual Headroom currentFrameHeadroom() const { return Headroom::None; }
 
     // Animation begins whenever someone draws the image, so startAnimation() is not normally called.
     // It will automatically pause once all observers no longer want to render the image anywhere.

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -464,6 +464,14 @@ SkSurface* ImageBuffer::surface() const
 }
 #endif
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+void ImageBuffer::setEDRHeadroom(float headroom)
+{
+    if (m_backend)
+        m_backend->setEDRHeadroom(headroom);
+}
+#endif
+
 #if USE(CAIRO)
 RefPtr<cairo_surface_t> ImageBuffer::createCairoSurface()
 {

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -189,6 +189,10 @@ public:
     IOSurface* surface();
 #endif
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    WEBCORE_EXPORT void setEDRHeadroom(float);
+#endif
+
 #if USE(CAIRO)
     WEBCORE_EXPORT RefPtr<cairo_surface_t> createCairoSurface();
 #endif

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -138,6 +138,10 @@ public:
     virtual IOSurface* surface() { return nullptr; }
 #endif
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    virtual void setEDRHeadroom(float) { }
+#endif
+
 #if USE(CAIRO)
     virtual RefPtr<cairo_surface_t> createCairoSurface() { return nullptr; }
 #endif

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -738,6 +738,16 @@ void GraphicsLayerCA::setDrawsHDRContent(bool drawsHDRContent)
     GraphicsLayer::setDrawsHDRContent(drawsHDRContent);
     noteLayerPropertyChanged(DrawsHDRContentChanged | DebugIndicatorsChanged);
 }
+
+void GraphicsLayerCA::setEDRHeadroom(float headroom)
+{
+    if (headroom == m_edrHeadroom)
+        return;
+
+    GraphicsLayer::setEDRHeadroom(headroom);
+    setNeedsDisplay();
+    noteLayerPropertyChanged(EDRHeadroomChanged);
+}
 #endif
 
 void GraphicsLayerCA::setContentsVisible(bool contentsVisible)
@@ -2143,6 +2153,9 @@ void GraphicsLayerCA::commitLayerChangesBeforeSublayers(CommitState& commitState
 #if HAVE(SUPPORT_HDR_DISPLAY)
     if (m_uncommittedChanges & DrawsHDRContentChanged)
         updateDrawsHDRContent();
+
+    if (m_uncommittedChanges & EDRHeadroomChanged)
+        updateEDRHeadroom();
 #endif
 
     if (m_uncommittedChanges & NameChanged)
@@ -3322,6 +3335,11 @@ void GraphicsLayerCA::updateDrawsHDRContent()
 {
     auto contentsFormat = PlatformCALayer::contentsFormatForLayer(nullptr, this);
     protectedLayer()->setContentsFormat(contentsFormat);
+}
+
+void GraphicsLayerCA::updateEDRHeadroom()
+{
+    protectedLayer()->setEDRHeadroom(m_edrHeadroom);
 }
 #endif
 
@@ -4652,6 +4670,7 @@ ASCIILiteral GraphicsLayerCA::layerChangeAsString(LayerChange layerChange)
 #endif
 #if HAVE(SUPPORT_HDR_DISPLAY)
     case LayerChange::DrawsHDRContentChanged: return "DrawsHDRContentChanged"_s;
+    case LayerChange::EDRHeadroomChanged: return "EDRHeadroomChanged"_s;
 #endif
     }
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -102,6 +102,7 @@ public:
     WEBCORE_EXPORT void setDrawsContent(bool) override;
 #if HAVE(SUPPORT_HDR_DISPLAY)
     WEBCORE_EXPORT void setDrawsHDRContent(bool) override;
+    WEBCORE_EXPORT void setEDRHeadroom(float) override;
 #endif
     WEBCORE_EXPORT void setContentsVisible(bool) override;
     WEBCORE_EXPORT void setAcceleratesDrawing(bool) override;
@@ -280,6 +281,7 @@ private:
 #if HAVE(SUPPORT_HDR_DISPLAY)
     bool drawsHDRContent() const override { return m_drawsHDRContent; }
     void updateDrawsHDRContent();
+    void updateEDRHeadroom();
 #endif
 
     WEBCORE_EXPORT void setAllowsBackingStoreDetaching(bool) override;
@@ -668,6 +670,7 @@ private:
 #endif
 #if HAVE(SUPPORT_HDR_DISPLAY)
         DrawsHDRContentChanged                  = 1LLU << 47,
+        EDRHeadroomChanged                      = 1LLU << 48,
 #endif
     };
     typedef uint64_t LayerChangeFlags;

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
@@ -300,6 +300,11 @@ public:
     virtual GraphicsLayer::CustomAppearance customAppearance() const = 0;
     virtual void updateCustomAppearance(GraphicsLayer::CustomAppearance) = 0;
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    virtual float edrHeadroom();
+    virtual void setEDRHeadroom(float);
+#endif
+
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
     virtual bool isSeparated() const = 0;
     virtual void setIsSeparated(bool) = 0;

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
@@ -253,6 +253,17 @@ void PlatformCALayer::setAcceleratedEffectsAndBaseValues(const AcceleratedEffect
 }
 #endif
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+float PlatformCALayer::edrHeadroom()
+{
+    return 1.0;
+}
+
+void PlatformCALayer::setEDRHeadroom(float)
+{
+}
+#endif
+
 void PlatformCALayer::dumpAdditionalProperties(TextStream&, OptionSet<PlatformLayerTreeAsTextFlags>)
 {
 }

--- a/Source/WebCore/platform/graphics/ca/TileController.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileController.cpp
@@ -235,6 +235,17 @@ void TileController::setAcceleratesDrawing(bool acceleratesDrawing)
     tileGrid().updateTileLayerProperties();
 }
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+void TileController::setEDRHeadroom(float headroom)
+{
+    if (m_edrHeadroom == headroom)
+        return;
+
+    m_edrHeadroom = headroom;
+    tileGrid().updateTileLayerProperties();
+}
+#endif
+
 void TileController::setContentsFormat(ContentsFormat contentsFormat)
 {
     if (m_contentsFormat == contentsFormat)
@@ -860,6 +871,9 @@ Ref<PlatformCALayer> TileController::createTileLayer(const IntRect& tileRect, Ti
     layer->setContentsScale(m_deviceScaleFactor * temporaryScaleFactor);
     layer->setAcceleratesDrawing(m_acceleratesDrawing);
     layer->setContentsFormat(m_contentsFormat);
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    layer->setEDRHeadroom(m_edrHeadroom);
+#endif
     layer->setNeedsDisplay();
     return layer;
 }

--- a/Source/WebCore/platform/graphics/ca/TileController.h
+++ b/Source/WebCore/platform/graphics/ca/TileController.h
@@ -80,6 +80,11 @@ public:
     WEBCORE_EXPORT void setContentsScale(float);
     WEBCORE_EXPORT float contentsScale() const;
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    float edrHeadroom() { return m_edrHeadroom; }
+    WEBCORE_EXPORT void setEDRHeadroom(float);
+#endif
+
     bool acceleratesDrawing() const { return m_acceleratesDrawing; }
     WEBCORE_EXPORT void setAcceleratesDrawing(bool);
 
@@ -231,6 +236,10 @@ private:
 
     float m_zoomedOutContentsScale { 0 };
     float m_deviceScaleFactor;
+
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    float m_edrHeadroom { 1 };
+#endif
 
     std::unique_ptr<TileCoverageMap> m_coverageMap;
 

--- a/Source/WebCore/platform/graphics/ca/TileGrid.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.cpp
@@ -208,6 +208,9 @@ void TileGrid::updateTileLayerProperties()
     bool acceleratesDrawing = m_controller->acceleratesDrawing();
     auto contentsFormat = m_controller->contentsFormat();
     bool opaque = m_controller->tilesAreOpaque();
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    float headroom = m_controller->edrHeadroom();
+#endif
     Color tileDebugBorderColor = m_controller->tileDebugBorderColor();
     float tileDebugBorderWidth = m_controller->tileDebugBorderWidth();
     for (auto& tileInfo : m_tiles.values()) {
@@ -216,6 +219,9 @@ void TileGrid::updateTileLayerProperties()
         tileInfo.layer->setOpaque(opaque);
         tileInfo.layer->setBorderColor(tileDebugBorderColor);
         tileInfo.layer->setBorderWidth(tileDebugBorderWidth);
+#if HAVE(SUPPORT_HDR_DISPLAY)
+        tileInfo.layer->setEDRHeadroom(headroom);
+#endif
     }
 }
 

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -402,8 +402,12 @@ void GraphicsContextCG::drawNativeImageInternal(NativeImage& nativeImage, const 
     if (headroom == Headroom::FromImage)
         headroom = nativeImage.headroom();
 
-    if (headroom > Headroom::None)
+    if (headroom > Headroom::None) {
+        if (m_maxEDRHeadroom > 0.0f)
+            headroom = std::min(headroom.headroom, m_maxEDRHeadroom);
+        LOG_WITH_STREAM(HDR, stream << "GraphicsContextCG::drawNativeImageInternal setEDRTargetHeadroom " << headroom << " max(" << m_maxEDRHeadroom << ")");
         CGContextSetEDRTargetHeadroom(context, headroom);
+    }
 
     if (options.dynamicRangeLimit() == PlatformDynamicRangeLimit::standard())
         setCGDynamicRangeLimitForImage(context, subImage.get(), options.dynamicRangeLimit().value());
@@ -1550,6 +1554,14 @@ bool GraphicsContextCG::consumeHasDrawn()
     m_hasDrawn = false;
     return hasDrawn;
 }
+
+#if HAVE(SUPPORT_HDR_DISPLAY)
+void GraphicsContextCG::setMaxEDRHeadroom(float headroom)
+{
+    m_maxEDRHeadroom = headroom;
+}
+#endif
+
 
 }
 

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
@@ -145,6 +145,10 @@ public:
     // Returns true if there has been potential draws since last call.
     bool consumeHasDrawn();
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    void setMaxEDRHeadroom(float) final;
+#endif
+
 protected:
     void setCGShadow(const std::optional<GraphicsDropShadow>&, bool shadowsIgnoreTransforms);
     void setCGStyle(const std::optional<GraphicsStyle>&, bool shadowsIgnoreTransforms);
@@ -158,6 +162,9 @@ private:
 
     const RetainPtr<CGContextRef> m_cgContext;
     mutable std::optional<DestinationColorSpace> m_colorSpace;
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    float m_maxEDRHeadroom { 0.0f };
+#endif
     const RenderingMode m_renderingMode : 2; // NOLINT
     const bool m_isLayerCGContext : 1;
     mutable bool m_userToDeviceTransformKnownToBeIdentity : 1 { false };

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
@@ -112,6 +112,9 @@ GraphicsContext& ImageBufferIOSurfaceBackend::context()
 {
     if (!m_context) {
         m_context = makeUnique<GraphicsContextCG>(ensurePlatformContext());
+#if HAVE(SUPPORT_HDR_DISPLAY)
+        m_context->setMaxEDRHeadroom(m_surface->edrHeadroom());
+#endif
         applyBaseTransform(*m_context);
     }
     return *m_context;
@@ -314,6 +317,15 @@ RetainPtr<CGImageRef> ImageBufferIOSurfaceBackend::createImageReference()
     CGImageSetCachingFlags(image.get(), kCGImageCachingTransient);
     return image;
 }
+
+#if HAVE(SUPPORT_HDR_DISPLAY)
+void ImageBufferIOSurfaceBackend::setEDRHeadroom(float headroom)
+{
+    m_surface->setEDRHeadroom(headroom);
+    if (m_context)
+        m_context->setMaxEDRHeadroom(headroom);
+}
+#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
@@ -54,6 +54,10 @@ public:
     GraphicsContext& context() override;
     void flushContext() override;
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    void setEDRHeadroom(float) override;
+#endif
+
 protected:
     ImageBufferIOSurfaceBackend(const Parameters&, std::unique_ptr<IOSurface>, RetainPtr<CGContextRef> platformContext, PlatformDisplayID, IOSurfacePool*);
     CGContextRef ensurePlatformContext();

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.h
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.h
@@ -195,6 +195,11 @@ public:
     IntSize size() const { return m_size; }
     size_t totalBytes() const { return m_totalBytes; }
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    void setEDRHeadroom(float);
+    float edrHeadroom() const { return m_edrHeadroom; }
+#endif
+
     WEBCORE_EXPORT DestinationColorSpace colorSpace();
     WEBCORE_EXPORT IOSurfaceID surfaceID() const;
     WEBCORE_EXPORT size_t bytesPerRow() const;
@@ -234,6 +239,9 @@ private:
     std::optional<DestinationColorSpace> m_colorSpace;
     IntSize m_size;
     size_t m_totalBytes;
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    float m_edrHeadroom { 1.0f };
+#endif
 
     ProcessIdentity m_resourceOwner;
 

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
@@ -685,6 +685,18 @@ void IOSurface::ensureColorSpace()
     m_colorSpace = surfaceColorSpace().value_or(DestinationColorSpace::SRGB());
 }
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+void IOSurface::setEDRHeadroom(float headroom)
+{
+    if (headroom == m_edrHeadroom)
+        return;
+
+    LOG_WITH_STREAM(HDR, stream << "IOSurface::setEDRHeadroom " << *this << " " << headroom);
+    m_edrHeadroom = headroom;
+    IOSurfaceSetValue(m_surface.get(), CFSTR("IOSurfaceContentHeadroom"), @(headroom));
+}
+#endif
+
 std::optional<DestinationColorSpace> IOSurface::surfaceColorSpace() const
 {
     auto propertyList = adoptCF(IOSurfaceCopyValue(m_surface.get(), kIOSurfaceColorSpace));

--- a/Source/WebCore/platform/ios/PlatformScreenIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformScreenIOS.mm
@@ -120,6 +120,24 @@ bool screenSupportsHighDynamicRange(Widget*)
     return false;
 }
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+float currentEDRHeadroomForDisplay(PlatformDisplayID)
+{
+    if (auto data = screenData(primaryScreenDisplayID()))
+        return data->currentEDRHeadroom;
+
+    return [[PAL::getUIScreenClass() mainScreen] currentEDRHeadroom];
+}
+
+float maxEDRHeadroomForDisplay(PlatformDisplayID)
+{
+    if (auto data = screenData(primaryScreenDisplayID()))
+        return data->maxEDRHeadroom;
+
+    return [[PAL::getUIScreenClass() mainScreen] potentialEDRHeadroom];
+}
+#endif
+
 DestinationColorSpace screenColorSpace(Widget* widget)
 {
     UNUSED_PARAM(widget);
@@ -251,6 +269,10 @@ ScreenProperties collectScreenProperties()
         screenData.screenHasInvertedColors = WebCore::screenHasInvertedColors();
         screenData.screenSupportsHighDynamicRange = WebCore::screenSupportsHighDynamicRange(nullptr);
         screenData.scaleFactor = WebCore::screenPPIFactor();
+#if HAVE(SUPPORT_HDR_DISPLAY)
+        screenData.maxEDRHeadroom = [screen potentialEDRHeadroom];
+        screenData.currentEDRHeadroom = [screen currentEDRHeadroom];
+#endif
 
         screenProperties.screenDataMap.set(++displayID, WTFMove(screenData));
 

--- a/Source/WebCore/platform/mac/PlatformScreenMac.mm
+++ b/Source/WebCore/platform/mac/PlatformScreenMac.mm
@@ -175,6 +175,10 @@ ScreenProperties collectScreenProperties()
         screenData.screenSize = FloatSize { CGDisplayScreenSize(displayID) };
         screenData.scaleFactor = screen.backingScaleFactor;
         screenData.screenSupportsHighDynamicRange = screenSupportsHighDynamicRange(displayID, screenData.preferredDynamicRangeMode);
+#if HAVE(SUPPORT_HDR_DISPLAY)
+        screenData.maxEDRHeadroom = [screen maximumPotentialExtendedDynamicRangeColorComponentValue];
+        screenData.currentEDRHeadroom = [screen maximumExtendedDynamicRangeColorComponentValue];
+#endif
 
         screenProperties.screenDataMap.set(displayID, WTFMove(screenData));
         if (!screenProperties.primaryDisplayID)
@@ -320,6 +324,26 @@ FloatRect screenRectForPrimaryScreen()
 {
     return screenRectForDisplay(primaryScreenDisplayID());
 }
+
+#if HAVE(SUPPORT_HDR_DISPLAY)
+float currentEDRHeadroomForDisplay(PlatformDisplayID displayID)
+{
+    if (auto data = screenData(displayID))
+        return data->currentEDRHeadroom;
+
+    ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
+    return screen(displayID).maximumExtendedDynamicRangeColorComponentValue;
+}
+
+float maxEDRHeadroomForDisplay(PlatformDisplayID displayID)
+{
+    if (auto data = screenData(displayID))
+        return data->maxEDRHeadroom;
+
+    ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
+    return screen(displayID).maximumPotentialExtendedDynamicRangeColorComponentValue;
+}
+#endif
 
 FloatRect screenRect(Widget* widget)
 {

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -241,6 +241,11 @@ public:
     bool hasPausedImageAnimations() const { return m_hasPausedImageAnimations; }
     void setHasPausedImageAnimations(bool b) { m_hasPausedImageAnimations = b; }
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    bool hasHDRImages() const { return m_hasHDRImages; }
+    void setHasHDRImages(bool b) { m_hasHDRImages = b; }
+#endif
+
     bool hasCounterNodeMap() const { return m_hasCounterNodeMap; }
     void setHasCounterNodeMap(bool f) { m_hasCounterNodeMap = f; }
 
@@ -441,6 +446,9 @@ private:
     unsigned m_hasPausedImageAnimations : 1;
     unsigned m_hasCounterNodeMap : 1;
     unsigned m_hasContinuationChainNode : 1;
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    unsigned m_hasHDRImages : 1;
+#endif
 
     unsigned m_isContinuation : 1;
     unsigned m_isFirstLetter : 1;

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -2054,8 +2054,14 @@ void RenderLayerBacking::updateDrawsContent(PaintedContentsInfo& contentsInfo)
         m_backgroundLayer->setDrawsContent(m_backgroundLayerPaintsFixedRootBackground ? hasPaintedContent : contentsInfo.paintsBoxDecorations());
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
-    if (contentsInfo.paintsHDRContent() || contentsInfo.rendererHasHDRContent())
+    if (contentsInfo.paintsHDRContent() || contentsInfo.rendererHasHDRContent()) {
         m_graphicsLayer->setDrawsHDRContent(true);
+        // FIXME: This uses the highest requested headroom in the Document, but could be restricted
+        // to just the layer (but that's more expensive to compute and track).
+        float clampedHeadroom = std::min(m_owningLayer.page().displayEDRHeadroom(), renderer().view().highestRequestedHeadroom());
+        LOG_WITH_STREAM(HDR, stream << "RenderLayerBacking " << *this << " updateDrawContent headroom " << clampedHeadroom);
+        m_graphicsLayer->setEDRHeadroom(clampedHeadroom);
+    }
 #endif
 }
 

--- a/Source/WebCore/rendering/RenderView.h
+++ b/Source/WebCore/rendering/RenderView.h
@@ -189,6 +189,13 @@ public:
     void removeRendererWithPausedImageAnimations(RenderElement&);
     void removeRendererWithPausedImageAnimations(RenderElement&, CachedImage&);
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    void addRendererWithHDRImages(RenderElement&, CachedImage&);
+    void removeRendererWithHDRImages(RenderElement&, CachedImage*);
+    bool hasRendererWithHDRImages() const { return !m_renderersWithHDRImages.isEmptyIgnoringNullReferences(); }
+    Headroom highestRequestedHeadroom();
+#endif
+
     class RepaintRegionAccumulator {
         WTF_MAKE_NONCOPYABLE(RepaintRegionAccumulator);
     public:
@@ -287,6 +294,11 @@ private:
     SingleThreadWeakHashMap<RenderElement, Vector<WeakPtr<CachedImage>>> m_renderersWithPausedImageAnimation;
     WeakHashSet<SVGSVGElement, WeakPtrImplWithEventTargetData> m_SVGSVGElementsWithPausedImageAnimation;
     SingleThreadWeakHashSet<RenderElement> m_visibleInViewportRenderers;
+
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    SingleThreadWeakHashMap<RenderElement, Vector<WeakPtr<CachedImage>>> m_renderersWithHDRImages;
+    std::optional<Headroom> m_highestRequestedHeadroom;
+#endif
 
     SingleThreadWeakHashSet<const RenderBox> m_boxesWithScrollSnapPositions;
     SingleThreadWeakHashSet<const RenderBox> m_containerQueryBoxes;

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
@@ -90,6 +90,18 @@ IPC::StreamConnectionWorkQueue& RemoteImageBufferSet::workQueue() const
 
 void RemoteImageBufferSet::updateConfiguration(const RemoteImageBufferSetConfiguration& configuration)
 {
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    if (m_configuration.canUseExistingImageBuffers(configuration)) {
+        m_configuration = configuration;
+        if (m_frontBuffer)
+            m_frontBuffer->setEDRHeadroom(m_configuration.edrHeadroom);
+        if (m_backBuffer)
+            m_backBuffer->setEDRHeadroom(m_configuration.edrHeadroom);
+        if (m_secondaryBackBuffer)
+            m_secondaryBackBuffer->setEDRHeadroom(m_configuration.edrHeadroom);
+        return;
+    }
+#endif
     m_configuration = configuration;
     clearBuffers();
 }
@@ -143,6 +155,9 @@ void RemoteImageBufferSet::ensureBufferForDisplay(ImageBufferSetPrepareBufferFor
             creationContext.dynamicContentScalingResourceCache = ensureDynamicContentScalingResourceCache();
 #endif
         m_frontBuffer = m_renderingBackend->allocateImageBuffer(m_configuration.logicalSize, m_configuration.renderingMode, m_configuration.renderingPurpose, m_configuration.resolutionScale, m_configuration.colorSpace, m_configuration.pixelFormat, WTFMove(creationContext));
+#if HAVE(SUPPORT_HDR_DISPLAY)
+        m_frontBuffer->setEDRHeadroom(m_configuration.edrHeadroom);
+#endif
         m_frontBufferIsCleared = true;
     }
 

--- a/Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h
@@ -200,6 +200,9 @@ struct LayerProperties {
 #if ENABLE(SCROLLING_THREAD)
     Markable<WebCore::ScrollingNodeID> scrollingNodeID;
 #endif
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    float edrHeadroom { 1.0f };
+#endif
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
     bool isSeparated { false };
 #if HAVE(CORE_ANIMATION_SEPARATED_PORTALS)

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -104,6 +104,9 @@ public:
         WebCore::ContentsFormat contentsFormat { WebCore::ContentsFormat::RGBA8 };
         float scale { 1.0f };
         bool isOpaque { false };
+#if HAVE(SUPPORT_HDR_DISPLAY)
+        float edrHeadroom { 1.0f };
+#endif
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
         WebCore::IncludeDynamicContentScalingDisplayList includeDisplayList { WebCore::IncludeDynamicContentScalingDisplayList::No };
@@ -254,6 +257,9 @@ private:
 
     bool m_isOpaque;
     RemoteLayerBackingStore::Type m_type;
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    float m_edrHeadroom;
+#endif
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, BackingStoreNeedsDisplayReason);

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -102,6 +102,9 @@ header: "RemoteLayerBackingStore.h"
 [CustomEncoder, CustomHeader, LegacyPopulateFromEmptyConstructor, Nested] class WebKit::RemoteLayerBackingStoreProperties {
     bool m_isOpaque;
     WebKit::RemoteLayerBackingStore::Type m_type;
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    float m_edrHeadroom;
+#endif
     std::optional<WebKit::ImageBufferBackendHandle> m_bufferHandle;
     std::optional<WebKit::RemoteImageBufferSetIdentifier> m_bufferSet;
     std::optional<WebKit::BufferAndBackendInfo> m_frontBufferInfo;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
@@ -128,6 +128,9 @@ void RemoteLayerWithRemoteRenderingBackingStore::ensureBackingStore(const Parame
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
             .includeDisplayList = m_parameters.includeDisplayList,
 #endif
+#if HAVE(SUPPORT_HDR_DISPLAY)
+            .edrHeadroom = m_parameters.edrHeadroom,
+#endif
         };
         m_bufferSet->setConfiguration(WTFMove(configuration));
     }
@@ -170,6 +173,9 @@ void RemoteLayerWithRemoteRenderingBackingStore::dump(WTF::TextStream& ts) const
     ts.dumpProperty("buffer set"_s, m_bufferSet);
     ts.dumpProperty("cache identifiers"_s, m_bufferCacheIdentifiers);
     ts.dumpProperty("is opaque"_s, isOpaque());
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    ts.dumpProperty("headroom", m_parameters.edrHeadroom);
+#endif
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2492,6 +2492,10 @@ header: <WebCore/ScreenProperties.h>
     bool screenSupportsExtendedColor;
     bool screenHasInvertedColors;
     bool screenSupportsHighDynamicRange;
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    float currentEDRHeadroom;
+    float maxEDRHeadroom;
+#endif
 #if PLATFORM(MAC)
     WebCore::FloatSize screenSize;
     bool screenIsMonochrome;

--- a/Source/WebKit/Shared/graphics/RemoteImageBufferSetConfiguration.h
+++ b/Source/WebKit/Shared/graphics/RemoteImageBufferSetConfiguration.h
@@ -51,6 +51,27 @@ struct RemoteImageBufferSetConfiguration {
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
     WebCore::IncludeDynamicContentScalingDisplayList includeDisplayList { WebCore::IncludeDynamicContentScalingDisplayList::No };
 #endif
+
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    float edrHeadroom { 1.0f };
+
+    bool canUseExistingImageBuffers(const RemoteImageBufferSetConfiguration& other)
+    {
+        if (logicalSize != other.logicalSize
+            || resolutionScale != other.resolutionScale
+            || colorSpace != other.colorSpace
+            || contentsFormat != other.contentsFormat
+            || pixelFormat != other.pixelFormat
+            || renderingMode != other.renderingMode
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+            || includeDisplayList != other.includeDisplayList
+#endif
+            || renderingPurpose != other.renderingPurpose) {
+            return false;
+        }
+        return true;
+    }
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/graphics/RemoteImageBufferSetConfiguration.serialization.in
+++ b/Source/WebKit/Shared/graphics/RemoteImageBufferSetConfiguration.serialization.in
@@ -36,6 +36,9 @@ header: "RemoteImageBufferSetConfiguration.h"
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
     WebCore::IncludeDynamicContentScalingDisplayList includeDisplayList;
 #endif
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    float edrHeadroom;
+#endif
 };
 
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -850,6 +850,10 @@ void WebProcessPool::registerNotificationObservers()
         setApplicationIsActive(false);
     }];
 
+    m_didChangeScreenParametersNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSApplicationDidChangeScreenParametersNotification object:NSApp queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
+        screenPropertiesChanged();
+    }];
+
     addCFNotificationObserver(colorPreferencesDidChangeCallback, AppleColorPreferencesChangedNotification, CFNotificationCenterGetDistributedCenter());
 
     const char* messages[] = { kNotifyDSCacheInvalidation, kNotifyDSCacheInvalidationGroup, kNotifyDSCacheInvalidationHost, kNotifyDSCacheInvalidationService, kNotifyDSCacheInvalidationUser };
@@ -979,6 +983,7 @@ void WebProcessPool::unregisterNotificationObservers()
     [[NSWorkspace.sharedWorkspace notificationCenter] removeObserver:m_accessibilityDisplayOptionsNotificationObserver.get()];
     [[NSNotificationCenter defaultCenter] removeObserver:m_scrollerStyleNotificationObserver.get()];
     [[NSNotificationCenter defaultCenter] removeObserver:m_deactivationObserver.get()];
+    [[NSWorkspace.sharedWorkspace notificationCenter] removeObserver:m_didChangeScreenParametersNotificationObserver.get()];
     removeCFNotificationObserver(AppleColorPreferencesChangedNotification, CFNotificationCenterGetDistributedCenter());
     for (auto token : m_openDirectoryNotifyTokens)
         notify_cancel(token);
@@ -1322,6 +1327,19 @@ void WebProcessPool::registerHighDynamicRangeChangeCallback()
     } };
 }
 #endif // PLATFORM(IOS) || PLATFORM(VISION)
+
+#if PLATFORM(IOS_FAMILY)
+void WebProcessPool::willRefreshDisplay()
+{
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    float headroom = currentEDRHeadroomForDisplay(primaryScreenDisplayID());
+    if (m_currentEDRHeadroom != headroom) {
+        m_currentEDRHeadroom = headroom;
+        screenPropertiesChanged();
+    }
+#endif
+}
+#endif
 
 #if ENABLE(EXTENSION_CAPABILITIES)
 ExtensionCapabilityGranter& WebProcessPool::extensionCapabilityGranter()

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
@@ -127,6 +127,9 @@ public:
     struct CachedContentsBuffer {
         BufferAndBackendInfo imageBufferInfo;
         RetainPtr<id> buffer;
+#if HAVE(SUPPORT_HDR_DISPLAY)
+        float edrHeadroom { 1.0f };
+#endif
     };
 
     Vector<CachedContentsBuffer> takeCachedContentsBuffers() { return std::exchange(m_cachedContentsBuffers, { }); }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
@@ -229,6 +229,9 @@ void RemoteLayerTreeDrawingAreaProxyIOS::setPreferredFramesPerSecond(IPC::Connec
 
 void RemoteLayerTreeDrawingAreaProxyIOS::didRefreshDisplay()
 {
+    if (RefPtr page = this->page())
+        page->willRefreshDisplay();
+
     if (m_needsDisplayRefreshCallbacksForDrawing)
         RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay();
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2712,6 +2712,8 @@ public:
 
 #if PLATFORM(IOS_FAMILY)
     void isPotentialTapInProgress(CompletionHandler<void(bool)>&&);
+
+    void willRefreshDisplay();
 #endif
 
 #if PLATFORM(COCOA) && ENABLE(ASYNC_SCROLLING)

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -632,6 +632,10 @@ public:
     void registerAdditionalFonts(NSArray *fontNames);
 #endif
 
+#if PLATFORM(IOS_FAMILY)
+    void willRefreshDisplay();
+#endif
+
 private:
     enum class NeedsGlobalStaticInitialization : bool { No, Yes };
     void platformInitialize(NeedsGlobalStaticInitialization);
@@ -837,9 +841,14 @@ private:
     RetainPtr<NSObject> m_accessibilityDisplayOptionsNotificationObserver;
     RetainPtr<NSObject> m_scrollerStyleNotificationObserver;
     RetainPtr<NSObject> m_deactivationObserver;
+    RetainPtr<NSObject> m_didChangeScreenParametersNotificationObserver;
     RetainPtr<WKWebInspectorPreferenceObserver> m_webInspectorPreferenceObserver;
 
     UniqueRef<PerActivityStateCPUUsageSampler> m_perActivityStateCPUUsageSampler;
+#endif
+
+#if PLATFORM(IOS_FAMILY) && HAVE(SUPPORT_HDR_DISPLAY)
+    float m_currentEDRHeadroom { 1 };
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1799,6 +1799,11 @@ FloatSize WebPageProxy::viewLayoutSize() const
     return internals().viewportConfigurationViewLayoutSize;
 }
 
+void WebPageProxy::willRefreshDisplay()
+{
+    m_configuration->protectedProcessPool()->willRefreshDisplay();
+}
+
 #if ENABLE(PDF_PAGE_NUMBER_INDICATOR)
 
 void WebPageProxy::createPDFPageNumberIndicator(PDFPluginIdentifier identifier, const IntRect& rect, size_t pageCount)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
@@ -222,6 +222,11 @@ public:
     void setScrollingNodeID(std::optional<WebCore::ScrollingNodeID>) override;
 #endif
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    float edrHeadroom() override;
+    void setEDRHeadroom(float) override;
+#endif
+
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
     bool isSeparated() const override;
     void setIsSeparated(bool) override;
@@ -299,6 +304,9 @@ private:
     WeakPtr<PlatformCALayerRemote> m_superlayer;
     HashMap<String, RefPtr<WebCore::PlatformCAAnimation>> m_animations;
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    float m_edrHeadroom { 1.0f };
+#endif
     bool m_acceleratesDrawing { false };
     WeakPtr<RemoteLayerTreeContext> m_context;
 };

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -343,6 +343,9 @@ void PlatformCALayerRemote::updateBackingStore()
     parameters.contentsFormat = contentsFormat();
     parameters.scale = m_properties.contentsScale;
     parameters.isOpaque = m_properties.opaque;
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    parameters.edrHeadroom = m_edrHeadroom;
+#endif
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
     parameters.includeDisplayList = shouldIncludeDisplayListInBackingStore();
@@ -1076,6 +1079,22 @@ void PlatformCALayerRemote::setScrollingNodeID(std::optional<ScrollingNodeID> no
 
     m_properties.scrollingNodeID = nodeID;
     m_properties.notePropertiesChanged(LayerChange::ScrollingNodeIDChanged);
+}
+#endif
+
+#if HAVE(SUPPORT_HDR_DISPLAY)
+float PlatformCALayerRemote::edrHeadroom()
+{
+    return m_properties.edrHeadroom;
+}
+
+void PlatformCALayerRemote::setEDRHeadroom(float headroom)
+{
+    if (headroom == m_edrHeadroom)
+        return;
+
+    m_edrHeadroom = headroom;
+    updateBackingStore();
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteTiledBacking.cpp
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteTiledBacking.cpp
@@ -87,6 +87,19 @@ void PlatformCALayerRemoteTiledBacking::setAcceleratesDrawing(bool acceleratesDr
     m_tileController->setAcceleratesDrawing(acceleratesDrawing);
 }
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+float PlatformCALayerRemoteTiledBacking::edrHeadroom()
+{
+    return m_tileController->edrHeadroom();
+}
+
+void PlatformCALayerRemoteTiledBacking::setEDRHeadroom(float headroom)
+{
+    m_tileController->setEDRHeadroom(headroom);
+}
+#endif
+
+
 ContentsFormat PlatformCALayerRemoteTiledBacking::contentsFormat() const
 {
     return m_tileController->contentsFormat();

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteTiledBacking.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteTiledBacking.h
@@ -53,6 +53,11 @@ private:
     bool acceleratesDrawing() const override;
     void setAcceleratesDrawing(bool) override;
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    float edrHeadroom() override;
+    void setEDRHeadroom(float) override;
+#endif
+
     WebCore::ContentsFormat contentsFormat() const override;
     void setContentsFormat(WebCore::ContentsFormat) override;
 


### PR DESCRIPTION
#### a6ffdbb3e13fa71b196035ffc61447909a157507
<pre>
Painted images don&apos;t get tone mapped down to the level supported by the display.
<a href="https://bugs.webkit.org/show_bug.cgi?id=294419">https://bugs.webkit.org/show_bug.cgi?id=294419</a>
&lt;<a href="https://rdar.apple.com/152695267">rdar://152695267</a>&gt;

Reviewed by NOBODY (OOPS!).

Add support for getting the currently available EDR headroom to PlatformScreen,
and synchronize it to all processes. Use
NSApplicationDidChangeScreenParametersNotification to detect change on macos,
use a poll on every displaylink update on iOS.

Track the set of decoded images with HDR in a Document in RenderView, and
compute the highest requested EDR value for the set. This could be done on a
per-layer (or even per-tile) basis for reduced invalidations, but adds
significant runtime cost to compute.

RenderLayerBacking takes the lower of the display headroom, and the highest
image value and sets that value on the GraphicsLayer.

Setting headroom on a GraphicsLayer results in the IOSurface (via
PlatformCALayer -&gt; RemoteLayerBackingStore -&gt; RemoteImageBufferSet)  having
metadata updated to match, and also requests to the GraphicsContext that any
painting into it have headroom clamped to this value. Any changes to the value
will request a full repaint of the layer. In theory we could track exactly what
had been actually drawn in the past and only repaint if the new value would
result in new clamping, but this gets complicated.

We also serialize the resulting headroom of the layer to the UI process via
RemoteLayerBackingStoreProperties. We use CAIOSurface to cache a CoreAnimation
wrapper around an IOSurface, and we need to recreate these if the IOSurface
headroom metadata has changed.

* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::currentFrameHeadroom const):
* Source/WebCore/loader/cache/CachedImage.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::screenPropertiesDidChange):
(WebCore::Page::updateDisplayEDRHeadroom):
* Source/WebCore/page/Page.h:
(WebCore::Page::displayEDRHeadroom const):
* Source/WebCore/platform/Logging.h:
* Source/WebCore/platform/PlatformScreen.h:
* Source/WebCore/platform/ScreenProperties.h:
* Source/WebCore/platform/graphics/BitmapImage.h:
* Source/WebCore/platform/graphics/GraphicsContext.h:
(WebCore::GraphicsContext::setMaxEDRHeadroom):
* Source/WebCore/platform/graphics/GraphicsLayer.cpp:
(WebCore::GraphicsLayer::setEDRHeadroom):
(WebCore::GraphicsLayer::dumpProperties const):
* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::edrHeadroom const):
* Source/WebCore/platform/graphics/Image.h:
(WebCore::Image::currentFrameHeadroom const):
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::setEDRHeadroom):
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
(WebCore::ImageBufferBackend::setEDRHeadroom):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::setEDRHeadroom):
(WebCore::GraphicsLayerCA::commitLayerChangesBeforeSublayers):
(WebCore::GraphicsLayerCA::ensureStructuralLayer):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayer.h:
* Source/WebCore/platform/graphics/ca/TileController.cpp:
(WebCore::TileController::setEDRHeadroom):
(WebCore::TileController::createTileLayer):
* Source/WebCore/platform/graphics/ca/TileController.h:
* Source/WebCore/platform/graphics/ca/TileGrid.cpp:
(WebCore::TileGrid::updateTileLayerProperties):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::drawNativeImageInternal):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.h:
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::context):
(WebCore::ImageBufferIOSurfaceBackend::setEDRHeadroom):
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h:
* Source/WebCore/platform/graphics/cocoa/IOSurface.h:
* Source/WebCore/platform/graphics/cocoa/IOSurface.mm:
(WebCore::IOSurface::setEDRHeadroom):
* Source/WebCore/platform/ios/PlatformScreenIOS.mm:
(WebCore::currentEDRHeadroomForDisplay):
(WebCore::maxEDRHeadroomForDisplay):
(WebCore::collectScreenProperties):
* Source/WebCore/platform/mac/PlatformScreenMac.mm:
(WebCore::collectScreenProperties):
(WebCore::currentEDRHeadroomForDisplay):
(WebCore::maxEDRHeadroomForDisplay):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::RenderElement):
(WebCore::RenderElement::willBeDestroyed):
(WebCore::RenderElement::imageFrameAvailable):
(WebCore::RenderElement::imageContentChanged):
* Source/WebCore/rendering/RenderElement.h:
(WebCore::RenderElement::hasHDRImages const):
(WebCore::RenderElement::setHasHDRImages):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateDrawsContent):
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::addRendererWithHDRImages):
(WebCore::RenderView::removeRendererWithHDRImages):
(WebCore::RenderView::highestRequestedHeadroom):
* Source/WebCore/rendering/RenderView.h:
* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp:
(WebKit::RemoteImageBufferSet::updateConfiguration):
(WebKit::RemoteImageBufferSet::ensureBufferForDisplay):
* Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::encode const):
(WebKit::RemoteLayerBackingStoreProperties::dump const):
(WebKit::RemoteLayerBackingStoreProperties::updateCachedBuffers):
(WebKit::RemoteLayerBackingStoreProperties::setBackendHandle): Deleted.
(WebKit::RemoteLayerBackingStore::takePendingFlushers): Deleted.
(WebKit::RemoteLayerBackingStore::purgeFrontBufferForTesting): Deleted.
(WebKit::RemoteLayerBackingStore::purgeBackBufferForTesting): Deleted.
(WebKit::RemoteLayerBackingStore::markFrontBufferVolatileForTesting): Deleted.
(WebKit::operator&lt;&lt;): Deleted.
(WebKit::RemoteLayerBackingStoreOrProperties::RemoteLayerBackingStoreOrProperties): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm:
(WebKit::RemoteLayerWithRemoteRenderingBackingStore::ensureBackingStore):
(WebKit::RemoteLayerWithRemoteRenderingBackingStore::dump const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/graphics/RemoteImageBufferSetConfiguration.h:
(WebKit::RemoteImageBufferSetConfiguration::canUseExistingImageBuffers):
* Source/WebKit/Shared/graphics/RemoteImageBufferSetConfiguration.serialization.in:
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::registerNotificationObservers):
(WebKit::WebProcessPool::unregisterNotificationObservers):
(WebKit::WebProcessPool::willRefreshDisplay):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::didRefreshDisplay):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::willRefreshDisplay):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm:
(WebKit::PlatformCALayerRemote::updateBackingStore):
(WebKit::PlatformCALayerRemote::edrHeadroom):
(WebKit::PlatformCALayerRemote::setEDRHeadroom):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteTiledBacking.cpp:
(WebKit::PlatformCALayerRemoteTiledBacking::edrHeadroom):
(WebKit::PlatformCALayerRemoteTiledBacking::setEDRHeadroom):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteTiledBacking.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6ffdbb3e13fa71b196035ffc61447909a157507

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107606 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27289 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17700 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112823 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58148 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109570 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27981 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35791 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81703 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110535 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22177 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96991 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62083 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21613 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15130 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57587 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91549 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15164 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115924 "Built successfully") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34674 "Hash a6ffdbb3 for PR 46685 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25573 "Found 2 new test failures: ipc/remotedisplaylistrecorder-drawcontrolpart-slidertrackpart-crash.html remote-layer-tree/image-buffer-backend-size-area-overflow-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90736 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35050 "Hash a6ffdbb3 for PR 46685 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93241 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90477 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13180 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30437 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34595 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40151 "Found 4 new failures in GPUProcess/graphics/RemoteImageBufferSet.cpp") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34341 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37701 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36004 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->