### PR TITLE
Unreviewed, reverting 296171@main (460ef7c5d333)

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.h
+++ b/Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.h
@@ -49,7 +49,7 @@ public:
     static constexpr PlatformDynamicRangeLimit initialValue() { return noLimit(); }
     static constexpr PlatformDynamicRangeLimit initialValueForVideos() { return noLimit(); }
 
-    static constexpr PlatformDynamicRangeLimit defaultWhenSuppressingHDR() { return constrained(); }
+    static constexpr PlatformDynamicRangeLimit defaultWhenSuppressingHDR() { return standard(); }
     static constexpr PlatformDynamicRangeLimit defaultWhenSuppressingHDRInVideos() { return constrained(); }
 
     // `dynamic-range-limit` mapped to PlatformDynamicRangeLimit.value():

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -106,9 +106,6 @@ public:
 #endif
 
     void remotePageProcessDidTerminate(WebCore::ProcessIdentifier);
-#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
-    void updateLayerHDRState() const;
-#endif
 
 private:
     Ref<RemoteLayerTreeDrawingAreaProxy> protectedDrawingArea() const;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -41,7 +41,6 @@
 #import <WebCore/DestinationColorSpace.h>
 #import <WebCore/GraphicsContextCG.h>
 #import <WebCore/IOSurface.h>
-#import <WebCore/PlatformDynamicRangeLimitCocoa.h>
 #import <WebCore/PlatformLayer.h>
 #import <WebCore/ShareableBitmap.h>
 #import <WebCore/WebCoreCALayerExtras.h>
@@ -163,29 +162,6 @@ bool RemoteLayerTreeHost::updateBannerLayers(const RemoteLayerTreeTransaction& t
 }
 #endif
 
-#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
-static void setDynamicRangeLimitRecursive(CALayer *layer, PlatformDynamicRangeLimit platformDynamicRangeLimit)
-{
-    if ([layer toneMapMode] == CAToneMapModeIfSupported)
-        setLayerDynamicRangeLimit(layer, platformDynamicRangeLimit);
-
-    for (CALayer *sublayer in [layer sublayers])
-        setDynamicRangeLimitRecursive(sublayer, platformDynamicRangeLimit);
-}
-
-void RemoteLayerTreeHost::updateLayerHDRState() const
-{
-    RefPtr page = m_drawingArea->page();
-    if (!page || !m_rootNode)
-        return;
-
-    PlatformDynamicRangeLimit platformDynamicRangeLimit = page->shouldSuppressHDR() ? PlatformDynamicRangeLimit::defaultWhenSuppressingHDR() : PlatformDynamicRangeLimit::noLimit();
-    [CATransaction begin];
-    setDynamicRangeLimitRecursive(rootLayer(), platformDynamicRangeLimit);
-    [CATransaction commit];
-}
-#endif
-
 bool RemoteLayerTreeHost::updateLayerTree(const IPC::Connection& connection, const RemoteLayerTreeTransaction& transaction, float indicatorScaleFactor)
 {
     if (!m_drawingArea)
@@ -291,10 +267,6 @@ bool RemoteLayerTreeHost::updateLayerTree(const IPC::Connection& connection, con
         rootLayerChanged = true;
 #endif
 
-#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
-    updateLayerHDRState();
-#endif
-
     return rootLayerChanged;
 }
 
@@ -360,10 +332,6 @@ void RemoteLayerTreeHost::layerWillBeRemoved(WebCore::ProcessIdentifier processI
             modelPresentationManager->invalidateModel(layerID);
         m_modelLayers.remove(layerID);
     }
-#endif
-
-#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
-    updateLayerHDRState();
 #endif
 }
 
@@ -464,10 +432,6 @@ void RemoteLayerTreeHost::createLayer(const RemoteLayerTreeTransaction::LayerCre
     }
 
     m_nodes.add(*properties.layerID, node.releaseNonNull());
-
-#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
-    updateLayerHDRState();
-#endif
 }
 
 #if !PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1696,10 +1696,8 @@ void WebPageProxy::setDrawingArea(RefPtr<DrawingAreaProxy>&& drawingArea)
     m_drawingArea->setSize(viewSize());
 
 #if ENABLE(ASYNC_SCROLLING) && PLATFORM(COCOA)
-    if (m_drawingArea) {
-        if (RefPtr drawingAreaProxy = dynamicDowncast<RemoteLayerTreeDrawingAreaProxy>(*m_drawingArea))
-            m_scrollingCoordinatorProxy = drawingAreaProxy->createScrollingCoordinatorProxy();
-    }
+    if (RefPtr drawingAreaProxy = dynamicDowncast<RemoteLayerTreeDrawingAreaProxy>(*m_drawingArea))
+        m_scrollingCoordinatorProxy = drawingAreaProxy->createScrollingCoordinatorProxy();
 #endif
 }
 
@@ -2807,14 +2805,8 @@ Color WebPageProxy::underlayColor() const
 
 void WebPageProxy::setShouldSuppressHDR(bool shouldSuppressHDR)
 {
-    m_shouldSuppressHDR = shouldSuppressHDR;
     if (hasRunningProcess())
         send(Messages::WebPage::SetShouldSuppressHDR(shouldSuppressHDR));
-
-#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
-    if (RefPtr drawingAreaProxy = dynamicDowncast<RemoteLayerTreeDrawingAreaProxy>(*m_drawingArea))
-        drawingAreaProxy->remoteLayerTreeHost().updateLayerHDRState();
-#endif
 }
 
 void WebPageProxy::setUnderlayColor(const Color& color)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -957,7 +957,6 @@ public:
     std::optional<WebCore::SpatialBackdropSource> spatialBackdropSource() const;
 #endif
 
-    bool shouldSuppressHDR() const { return m_shouldSuppressHDR; }
     void setShouldSuppressHDR(bool);
 
     WebCore::Color underlayColor() const;
@@ -3914,7 +3913,6 @@ private:
 
     const Ref<AboutSchemeHandler> m_aboutSchemeHandler;
     RefPtr<WebPageProxyTesting> m_pageForTesting;
-    bool m_shouldSuppressHDR { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -1267,6 +1267,34 @@ static bool isInRecoveryOS()
     return os_variant_is_basesystem("WebKit");
 }
 
+#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
+static void setDynamicRangeLimitRecursive(CALayer* layer, LayerDynamicRangeLimitSetter layerDynamicRangeLimitSetter)
+{
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    if ([layer wantsExtendedDynamicRangeContent]) {
+    ALLOW_DEPRECATED_DECLARATIONS_END
+        layerDynamicRangeLimitSetter(layer);
+    }
+    for (CALayer* sublayer in [layer sublayers])
+        setDynamicRangeLimitRecursive(sublayer, layerDynamicRangeLimitSetter);
+}
+#endif
+
+static void setDynamicRangeLimit(CALayer* layer, PlatformDynamicRangeLimit platformDynamicRangeLimit, bool animate)
+{
+#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
+    if (animate)
+        [CATransaction begin];
+    setDynamicRangeLimitRecursive(layer, layerDynamicRangeLimitSetter(platformDynamicRangeLimit));
+    if (animate)
+        [CATransaction commit];
+#else
+    UNUSED_PARAM(layer);
+    UNUSED_PARAM(platformDynamicRangeLimit);
+    UNUSED_PARAM(animate);
+#endif
+}
+
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebViewImpl);
 
 WebViewImpl::WebViewImpl(WKWebView *view, WebProcessPool& processPool, Ref<API::PageConfiguration>&& configuration)
@@ -2173,6 +2201,8 @@ void WebViewImpl::screenDidChangeColorSpace()
 void WebViewImpl::applicationShouldSuppressHDR(bool suppress)
 {
     m_page->setShouldSuppressHDR(suppress);
+    if (m_page->protectedPreferences()->acceleratedDrawingEnabled())
+        setDynamicRangeLimit(m_rootLayer.get(), suppress ? PlatformDynamicRangeLimit::defaultWhenSuppressingHDR() : PlatformDynamicRangeLimit::noLimit(), true);
 }
 
 bool WebViewImpl::mightBeginDragWhileInactive()

--- a/Tools/TestWebKitAPI/Tests/WebCore/PlatformDynamicRangeLimitTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PlatformDynamicRangeLimitTests.cpp
@@ -47,7 +47,7 @@ TEST(PlatformDynamicRangeLimit, Values)
     static_assert(WebCore::PlatformDynamicRangeLimit::initialValue().value() == WebCore::PlatformDynamicRangeLimit::noLimit().value());
     static_assert(WebCore::PlatformDynamicRangeLimit::initialValueForVideos().value() == WebCore::PlatformDynamicRangeLimit::noLimit().value());
 
-    static_assert(WebCore::PlatformDynamicRangeLimit::defaultWhenSuppressingHDR().value() == WebCore::PlatformDynamicRangeLimit::constrained().value());
+    static_assert(WebCore::PlatformDynamicRangeLimit::defaultWhenSuppressingHDR().value() == WebCore::PlatformDynamicRangeLimit::standard().value());
     static_assert(WebCore::PlatformDynamicRangeLimit::defaultWhenSuppressingHDRInVideos().value() == WebCore::PlatformDynamicRangeLimit::constrained().value());
 }
 
@@ -96,7 +96,7 @@ TEST(PlatformDynamicRangeLimit, StaticValues)
     EXPECT_EQ(WebCore::PlatformDynamicRangeLimit::initialValue(), WebCore::Style::DynamicRangeLimit(WebCore::RenderStyle::initialDynamicRangeLimit()).toPlatformDynamicRangeLimit());
     EXPECT_GE(WebCore::PlatformDynamicRangeLimit::initialValueForVideos(), WebCore::Style::DynamicRangeLimit(WebCore::RenderStyle::initialDynamicRangeLimit()).toPlatformDynamicRangeLimit());
 
-    EXPECT_EQ(WebCore::PlatformDynamicRangeLimit::defaultWhenSuppressingHDR(), WebCore::Style::DynamicRangeLimit(WebCore::CSS::Keyword::Constrained()).toPlatformDynamicRangeLimit());
+    EXPECT_EQ(WebCore::PlatformDynamicRangeLimit::defaultWhenSuppressingHDR(), WebCore::Style::DynamicRangeLimit(WebCore::CSS::Keyword::Standard()).toPlatformDynamicRangeLimit());
     EXPECT_EQ(WebCore::PlatformDynamicRangeLimit::defaultWhenSuppressingHDRInVideos(), WebCore::Style::DynamicRangeLimit(WebCore::CSS::Keyword::Constrained()).toPlatformDynamicRangeLimit());
 }
 


### PR DESCRIPTION
#### 6b51e52f83158045a2bf3e040ccc91ef8388a7dd
<pre>
Unreviewed, reverting 296171@main (460ef7c5d333)
<a href="https://bugs.webkit.org/show_bug.cgi?id=294422">https://bugs.webkit.org/show_bug.cgi?id=294422</a>
<a href="https://rdar.apple.com/153250909">rdar://153250909</a>

Unreviewed revert due to perf regression from full layer tranversal.

* Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.h:
(WebCore::PlatformDynamicRangeLimit::defaultWhenSuppressingHDR):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::updateLayerTree):
(WebKit::RemoteLayerTreeHost::layerWillBeRemoved):
(WebKit::RemoteLayerTreeHost::createLayer):
(WebKit::setDynamicRangeLimitRecursive): Deleted.
(WebKit::RemoteLayerTreeHost::updateLayerHDRState const): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setDrawingArea):
(WebKit::WebPageProxy::setShouldSuppressHDR):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::setDynamicRangeLimitRecursive):
(WebKit::setDynamicRangeLimit):
(WebKit::WebViewImpl::applicationShouldSuppressHDR):
* Tools/TestWebKitAPI/Tests/WebCore/PlatformDynamicRangeLimitTests.cpp:
(TestWebKitAPI::TEST(PlatformDynamicRangeLimit, Values)):
(TestWebKitAPI::TEST(PlatformDynamicRangeLimit, StaticValues)):

Canonical link: <a href="https://commits.webkit.org/296176@main">https://commits.webkit.org/296176@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b405c7d6d08655bdae3d466060ca3bff099b81c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17685 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/112808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/58133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109555 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27966 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35776 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/112808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/58133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110520 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/22164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/96977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/112808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/21601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/15116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/57572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/91535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/15150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/115909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34659 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/115909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35035 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/93227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/115909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/35381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/13166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17402 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34580 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/40136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/34326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/37686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/35989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->