### PR TITLE
Add SPI to control webpage color extension into scroll pocket

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3201,8 +3201,12 @@ static WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::Fixe
             _fixedColorExtensionViews.setAt(side, extensionView);
         }
 
-        RetainPtr predominantColor = cocoaColorOrNil(_fixedContainerEdges.predominantColor(side));
-        [extensionView updateColor:predominantColor.get() ?: self.underPageBackgroundColor];
+        if (_shouldSuppressTopFixedColorExtensionView || side != WebCore::BoxSide::Top) {
+            RetainPtr predominantColor = cocoaColorOrNil(_fixedContainerEdges.predominantColor(side));
+            [extensionView updateColor:predominantColor.get() ?: self.underPageBackgroundColor];
+        } else
+            [extensionView fadeOut];
+
         return;
     };
 
@@ -3660,6 +3664,29 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKCONTENTVIEW)
             return completionHandler(nil);
         completionHandler(wrapper(API::FrameInfo::create(WTFMove(*data), WTFMove(page))).get());
     });
+}
+
+- (BOOL)_shouldSuppressTopFixedColorExtensionView
+{
+    return _shouldSuppressTopFixedColorExtensionView;
+}
+
+- (void)_setShouldSuppressTopFixedColorExtensionView:(BOOL)shouldSuppressTopFixedColorExtensionView
+{
+    if (_shouldSuppressTopFixedColorExtensionView == shouldSuppressTopFixedColorExtensionView)
+        return;
+
+    _shouldSuppressTopFixedColorExtensionView = shouldSuppressTopFixedColorExtensionView;
+
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+    [self _updateFixedColorExtensionViews];
+    [self _updateTopScrollPocketCaptureColor];
+#endif
+}
+
+- (BOOL)_prefersHardScrollPocketStyle
+{
+    return !self._usesAutomaticContentInsetBackgroundFill && !self._shouldSuppressTopFixedColorExtensionView;
 }
 
 - (BOOL)_isEditable

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -281,6 +281,7 @@ struct PerWebProcessState {
     _WKRenderingProgressEvents _observedRenderingProgressEvents;
     BOOL _usePlatformFindUI;
     BOOL _usesAutomaticContentInsetBackgroundFill;
+    BOOL _shouldSuppressTopFixedColorExtensionView;
 
     CocoaEdgeInsets _minimumViewportInset;
     CocoaEdgeInsets _maximumViewportInset;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -216,6 +216,8 @@ typedef NS_ENUM(NSInteger, _WKImmediateActionType) {
 @property (nonatomic, readonly) pid_t _modelProcessIdentifier WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));
 
 @property (nonatomic, getter=_isEditable, setter=_setEditable:) BOOL _editable WK_API_AVAILABLE(macos(10.11), ios(9.0));
+@property (nonatomic, setter=_setShouldSuppressTopFixedColorExtensionView:) BOOL _shouldSuppressTopFixedColorExtensionView WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+@property (nonatomic, readonly) BOOL _prefersHardScrollPocketStyle WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 /*! @abstract A Boolean value indicating whether any resource on the page
 has been loaded over a connection using TLS 1.0 or TLS 1.1.

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2421,6 +2421,15 @@ void WebViewImpl::updateScrollPocketVisibilityWhenScrolledToTop()
 void WebViewImpl::updateTopScrollPocketCaptureColor()
 {
     RetainPtr view = m_view.get();
+    if (![view _shouldSuppressTopFixedColorExtensionView]) {
+        if (topScrollPocket().captureColor) {
+            // FIXME: This works around a bug where the scroll pocket's captureColor can't be cleared: rdar://153231250.
+            m_topScrollPocket = nil;
+            updateScrollPocket();
+        }
+        return;
+    }
+
     RetainPtr captureColor = [view _sampledTopFixedPositionContentColor];
     if (!captureColor && (m_pageIsScrolledToTop || [view _hasVisibleColorExtensionView:BoxSide::Top]))
         captureColor = cocoaColor(m_page->underPageBackgroundColor());
@@ -7015,7 +7024,7 @@ void WebViewImpl::updateScrollPocket()
 
 void WebViewImpl::updateTopScrollPocketStyle()
 {
-    [m_topScrollPocket setStyle:[m_view _usesAutomaticContentInsetBackgroundFill] ? NSScrollPocketStyleAutomatic : NSScrollPocketStyleHard];
+    [m_topScrollPocket setStyle:[m_view _prefersHardScrollPocketStyle] ? NSScrollPocketStyleHard : NSScrollPocketStyleAutomatic];
 }
 
 void WebViewImpl::registerViewAboveScrollPocket(NSView *containerView)


### PR DESCRIPTION
#### a8f45448ddb4d9b6d1ff8d7d89063f0bac383a5e
<pre>
Add SPI to control webpage color extension into scroll pocket
<a href="https://bugs.webkit.org/show_bug.cgi?id=294411">https://bugs.webkit.org/show_bug.cgi?id=294411</a>
<a href="https://rdar.apple.com/153231564">rdar://153231564</a>

Reviewed by NOBODY (OOPS!).

This patch adds SPI to control whether color appears in the toolbar. When color is disabled, we disable titlebar color
sampling as well as fixed element color extension. We also force a hard-edged scroll pocket.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _updateFixedColorExtensionViews]):
        When showing color in the toolbar is disabled, don&apos;t fill the top fixed element extension view.

(-[WKWebView _shouldSuppressTopFixedColorExtensionView]):
(-[WKWebView _setShouldSuppressTopFixedColorExtensionView:]):
(-[WKWebView _prefersHardScrollPocketStyle]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
        Add and expose the SPI.

* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::updateTopScrollPocketCaptureColor):
        Clearing the captureColor on the scroll pocket doesn&apos;t work. For now, we&apos;ll tear-down and re-create it when showing
        color in the toolbar is disabled. See <a href="https://rdar.apple.com/153231250">rdar://153231250</a> for more info.
(WebKit::WebViewImpl::updateTopScrollPocketStyle):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8f45448ddb4d9b6d1ff8d7d89063f0bac383a5e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107763 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27435 "Hash a8f45448 for PR 46690 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17850 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112971 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58297 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28129 "Hash a8f45448 for PR 46690 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35975 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81809 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110697 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/28129 "Hash a8f45448 for PR 46690 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97102 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62209 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/28129 "Hash a8f45448 for PR 46690 does not build (failure)") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57733 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/28129 "Hash a8f45448 for PR 46690 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15284 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116092 "Built successfully") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34837 "Hash a8f45448 for PR 46690 does not build (failure)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25664 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90843 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35214 "Hash a8f45448 for PR 46690 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93360 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90613 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13284 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30592 "The change is no longer eligible for processing.") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34742 "Hash a8f45448 for PR 46690 does not build (failure)") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40298 "Built successfully") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34487 "Hash a8f45448 for PR 46690 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37849 "Hash a8f45448 for PR 46690 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36150 "Hash a8f45448 for PR 46690 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->