### PR TITLE
HDR images don't get dimmed when Safari goes to background

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.h
+++ b/Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.h
@@ -49,7 +49,7 @@ public:
     static constexpr PlatformDynamicRangeLimit initialValue() { return noLimit(); }
     static constexpr PlatformDynamicRangeLimit initialValueForVideos() { return noLimit(); }
 
-    static constexpr PlatformDynamicRangeLimit defaultWhenSuppressingHDR() { return standard(); }
+    static constexpr PlatformDynamicRangeLimit defaultWhenSuppressingHDR() { return constrained(); }
     static constexpr PlatformDynamicRangeLimit defaultWhenSuppressingHDRInVideos() { return constrained(); }
 
     // `dynamic-range-limit` mapped to PlatformDynamicRangeLimit.value():

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -1186,9 +1186,13 @@ void PlatformCALayerCocoa::updateContentsFormat()
             [m_layer setContentsFormat:formatString];
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
         if (contentsFormat == ContentsFormat::RGBA16F) {
+#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
+            [m_layer setPreferredDynamicRange:CADynamicRangeHigh];
+#else
             ALLOW_DEPRECATED_DECLARATIONS_BEGIN
             [m_layer setWantsExtendedDynamicRangeContent:true];
             ALLOW_DEPRECATED_DECLARATIONS_END
+#endif
             [m_layer setToneMapMode:CAToneMapModeIfSupported];
         }
 #endif

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -555,9 +555,13 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, Remo
             [layer setContentsFormat:formatString.get()];
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
         if (contentsFormat == ContentsFormat::RGBA16F) {
+#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
+            [layer setPreferredDynamicRange:CADynamicRangeHigh];
+#else
             ALLOW_DEPRECATED_DECLARATIONS_BEGIN
             [layer setWantsExtendedDynamicRangeContent:true];
             ALLOW_DEPRECATED_DECLARATIONS_END
+#endif
             [layer setToneMapMode:CAToneMapModeIfSupported];
         }
 #endif

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -106,6 +106,10 @@ public:
 #endif
 
     void remotePageProcessDidTerminate(WebCore::ProcessIdentifier);
+#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
+    void updateHDRStateForAllLayers() const;
+    void updateHDRStateForLayer(WebCore::PlatformLayerIdentifier) const;
+#endif
 
 private:
     Ref<RemoteLayerTreeDrawingAreaProxy> protectedDrawingArea() const;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
@@ -45,6 +45,10 @@ OBJC_CLASS UIView;
 
 namespace WebKit {
 
+#ifdef __OBJC__
+static NSString *const WKRemoteLayerTreeNodePropertyKey = @"WKRemoteLayerTreeNode";
+#endif
+
 class RemoteLayerTreeHost;
 class RemoteLayerTreeScrollbars;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
@@ -46,7 +46,6 @@
 
 namespace WebKit {
 
-static NSString *const WKRemoteLayerTreeNodePropertyKey = @"WKRemoteLayerTreeNode";
 #if ENABLE(GAZE_GLOW_FOR_INTERACTION_REGIONS)
 static NSString *const WKInteractionRegionContainerKey = @"WKInteractionRegionContainer";
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1696,8 +1696,10 @@ void WebPageProxy::setDrawingArea(RefPtr<DrawingAreaProxy>&& drawingArea)
     m_drawingArea->setSize(viewSize());
 
 #if ENABLE(ASYNC_SCROLLING) && PLATFORM(COCOA)
-    if (RefPtr drawingAreaProxy = dynamicDowncast<RemoteLayerTreeDrawingAreaProxy>(*m_drawingArea))
-        m_scrollingCoordinatorProxy = drawingAreaProxy->createScrollingCoordinatorProxy();
+    if (m_drawingArea) {
+        if (RefPtr drawingAreaProxy = dynamicDowncast<RemoteLayerTreeDrawingAreaProxy>(*m_drawingArea))
+            m_scrollingCoordinatorProxy = drawingAreaProxy->createScrollingCoordinatorProxy();
+    }
 #endif
 }
 
@@ -2805,8 +2807,17 @@ Color WebPageProxy::underlayColor() const
 
 void WebPageProxy::setShouldSuppressHDR(bool shouldSuppressHDR)
 {
+    if (m_shouldSuppressHDR == shouldSuppressHDR)
+        return;
+
+    m_shouldSuppressHDR = shouldSuppressHDR;
     if (hasRunningProcess())
         send(Messages::WebPage::SetShouldSuppressHDR(shouldSuppressHDR));
+
+#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
+    if (RefPtr drawingAreaProxy = dynamicDowncast<RemoteLayerTreeDrawingAreaProxy>(*m_drawingArea))
+        drawingAreaProxy->remoteLayerTreeHost().updateHDRStateForAllLayers();
+#endif
 }
 
 void WebPageProxy::setUnderlayColor(const Color& color)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -957,6 +957,7 @@ public:
     std::optional<WebCore::SpatialBackdropSource> spatialBackdropSource() const;
 #endif
 
+    bool shouldSuppressHDR() const { return m_shouldSuppressHDR; }
     void setShouldSuppressHDR(bool);
 
     WebCore::Color underlayColor() const;
@@ -3913,6 +3914,7 @@ private:
 
     const Ref<AboutSchemeHandler> m_aboutSchemeHandler;
     RefPtr<WebPageProxyTesting> m_pageForTesting;
+    bool m_shouldSuppressHDR { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -1267,34 +1267,6 @@ static bool isInRecoveryOS()
     return os_variant_is_basesystem("WebKit");
 }
 
-#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
-static void setDynamicRangeLimitRecursive(CALayer* layer, LayerDynamicRangeLimitSetter layerDynamicRangeLimitSetter)
-{
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    if ([layer wantsExtendedDynamicRangeContent]) {
-    ALLOW_DEPRECATED_DECLARATIONS_END
-        layerDynamicRangeLimitSetter(layer);
-    }
-    for (CALayer* sublayer in [layer sublayers])
-        setDynamicRangeLimitRecursive(sublayer, layerDynamicRangeLimitSetter);
-}
-#endif
-
-static void setDynamicRangeLimit(CALayer* layer, PlatformDynamicRangeLimit platformDynamicRangeLimit, bool animate)
-{
-#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
-    if (animate)
-        [CATransaction begin];
-    setDynamicRangeLimitRecursive(layer, layerDynamicRangeLimitSetter(platformDynamicRangeLimit));
-    if (animate)
-        [CATransaction commit];
-#else
-    UNUSED_PARAM(layer);
-    UNUSED_PARAM(platformDynamicRangeLimit);
-    UNUSED_PARAM(animate);
-#endif
-}
-
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebViewImpl);
 
 WebViewImpl::WebViewImpl(WKWebView *view, WebProcessPool& processPool, Ref<API::PageConfiguration>&& configuration)
@@ -2201,8 +2173,6 @@ void WebViewImpl::screenDidChangeColorSpace()
 void WebViewImpl::applicationShouldSuppressHDR(bool suppress)
 {
     m_page->setShouldSuppressHDR(suppress);
-    if (m_page->protectedPreferences()->acceleratedDrawingEnabled())
-        setDynamicRangeLimit(m_rootLayer.get(), suppress ? PlatformDynamicRangeLimit::defaultWhenSuppressingHDR() : PlatformDynamicRangeLimit::noLimit(), true);
 }
 
 bool WebViewImpl::mightBeginDragWhileInactive()

--- a/Tools/TestWebKitAPI/Tests/WebCore/PlatformDynamicRangeLimitTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PlatformDynamicRangeLimitTests.cpp
@@ -47,7 +47,7 @@ TEST(PlatformDynamicRangeLimit, Values)
     static_assert(WebCore::PlatformDynamicRangeLimit::initialValue().value() == WebCore::PlatformDynamicRangeLimit::noLimit().value());
     static_assert(WebCore::PlatformDynamicRangeLimit::initialValueForVideos().value() == WebCore::PlatformDynamicRangeLimit::noLimit().value());
 
-    static_assert(WebCore::PlatformDynamicRangeLimit::defaultWhenSuppressingHDR().value() == WebCore::PlatformDynamicRangeLimit::standard().value());
+    static_assert(WebCore::PlatformDynamicRangeLimit::defaultWhenSuppressingHDR().value() == WebCore::PlatformDynamicRangeLimit::constrained().value());
     static_assert(WebCore::PlatformDynamicRangeLimit::defaultWhenSuppressingHDRInVideos().value() == WebCore::PlatformDynamicRangeLimit::constrained().value());
 }
 
@@ -96,7 +96,7 @@ TEST(PlatformDynamicRangeLimit, StaticValues)
     EXPECT_EQ(WebCore::PlatformDynamicRangeLimit::initialValue(), WebCore::Style::DynamicRangeLimit(WebCore::RenderStyle::initialDynamicRangeLimit()).toPlatformDynamicRangeLimit());
     EXPECT_GE(WebCore::PlatformDynamicRangeLimit::initialValueForVideos(), WebCore::Style::DynamicRangeLimit(WebCore::RenderStyle::initialDynamicRangeLimit()).toPlatformDynamicRangeLimit());
 
-    EXPECT_EQ(WebCore::PlatformDynamicRangeLimit::defaultWhenSuppressingHDR(), WebCore::Style::DynamicRangeLimit(WebCore::CSS::Keyword::Standard()).toPlatformDynamicRangeLimit());
+    EXPECT_EQ(WebCore::PlatformDynamicRangeLimit::defaultWhenSuppressingHDR(), WebCore::Style::DynamicRangeLimit(WebCore::CSS::Keyword::Constrained()).toPlatformDynamicRangeLimit());
     EXPECT_EQ(WebCore::PlatformDynamicRangeLimit::defaultWhenSuppressingHDRInVideos(), WebCore::Style::DynamicRangeLimit(WebCore::CSS::Keyword::Constrained()).toPlatformDynamicRangeLimit());
 }
 


### PR DESCRIPTION
#### 438667f2bf275e93dd10dc122b28fc92de24e62b
<pre>
HDR images don&apos;t get dimmed when Safari goes to background
<a href="https://bugs.webkit.org/show_bug.cgi?id=294092">https://bugs.webkit.org/show_bug.cgi?id=294092</a>
<a href="https://rdar.apple.com/151892044">rdar://151892044</a>

Reviewed by NOBODY (OOPS!).

We were failing to adjust the preferred dynamic range of the layer
during layer updates, resulting in mistmatched appearances during
background / foregrounding.

* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm:
(WebCore::PlatformCALayerCocoa::updateContentsFormat):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::setDynamicRangeLimitRecursive):
(WebKit::setDynamicRangeLimit):
(WebKit::RemoteLayerTreeHost::layerWillBeRemoved):
Largely moved from WebViewImpl

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setShouldSuppressHDR):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::applicationShouldSuppressHDR):
(WebKit::setDynamicRangeLimitRecursive): Deleted.
(WebKit::setDynamicRangeLimit): Deleted.
Moved to RemoteLayerTreeHost.

* Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.h:
(WebCore::PlatformDynamicRangeLimit::defaultWhenSuppressingHDR):
Default to constrained now.

* Tools/TestWebKitAPI/Tests/WebCore/PlatformDynamicRangeLimitTests.cpp:
(TestWebKitAPI::TEST(PlatformDynamicRangeLimit, Values)):
(TestWebKitAPI::TEST(PlatformDynamicRangeLimit, StaticValues)):
Update expected values.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/438667f2bf275e93dd10dc122b28fc92de24e62b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108071 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27736 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18155 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113281 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58582 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110034 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36285 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82050 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111019 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22532 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97364 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62482 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21944 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15505 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58027 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91887 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15563 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116406 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35140 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25875 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91077 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35515 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93642 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90872 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35768 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13529 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30975 "Build was cancelled. Recent messages:Running configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35040 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40594 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34778 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38136 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36441 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->