### PR TITLE
[macOS] [Liquid Glass] Safari: tab bar background is the wrong color after toggling dark mode

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2820,12 +2820,22 @@ void WebPageProxy::setUnderlayColor(const Color& color)
         send(Messages::WebPage::SetUnderlayColor(color));
 }
 
-Color WebPageProxy::underPageBackgroundColor() const
+Color WebPageProxy::underPageBackgroundColorIgnoringPlatformColor() const
 {
     if (internals().underPageBackgroundColorOverride.isValid())
         return internals().underPageBackgroundColorOverride;
+
     if (internals().pageExtendedBackgroundColor.isValid())
         return internals().pageExtendedBackgroundColor;
+
+    return { };
+}
+
+Color WebPageProxy::underPageBackgroundColor() const
+{
+    if (auto color = underPageBackgroundColorIgnoringPlatformColor(); color.isValid())
+        return color;
+
     return platformUnderPageBackgroundColor();
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -972,6 +972,7 @@ public:
     WebCore::Color sampledPageTopColor() const;
 
     WebCore::Color underPageBackgroundColor() const;
+    WebCore::Color underPageBackgroundColorIgnoringPlatformColor() const;
     WebCore::Color underPageBackgroundColorOverride() const;
     void setUnderPageBackgroundColorOverride(WebCore::Color&&);
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2422,8 +2422,12 @@ void WebViewImpl::updateTopScrollPocketCaptureColor()
 {
     RetainPtr view = m_view.get();
     RetainPtr captureColor = [view _sampledTopFixedPositionContentColor];
-    if (!captureColor && (m_pageIsScrolledToTop || [view _hasVisibleColorExtensionView:BoxSide::Top]))
-        captureColor = cocoaColor(m_page->underPageBackgroundColor());
+    if (!captureColor && (m_pageIsScrolledToTop || [view _hasVisibleColorExtensionView:BoxSide::Top])) {
+        if (auto backgroundColor = m_page->underPageBackgroundColorIgnoringPlatformColor(); backgroundColor.isValid())
+            captureColor = cocoaColor(backgroundColor);
+        else
+            captureColor = NSColor.controlBackgroundColor;
+    }
     [m_topScrollPocket setCaptureColor:captureColor.get()];
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ObscuredContentInsets.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ObscuredContentInsets.mm
@@ -186,21 +186,28 @@ TEST(ObscuredContentInsets, ResizeScrollPocket)
 
 TEST(ObscuredContentInsets, ScrollPocketCaptureColor)
 {
-    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 400)]);
+    RetainPtr webView = adoptNS([TestWKWebView new]);
+
     [webView _setAutomaticallyAdjustsContentInsets:NO];
     [webView _setObscuredContentInsets:NSEdgeInsetsMake(100, 0, 0, 0) immediate:NO];
+    [webView setFrame:NSMakeRect(0, 0, 600, 400)];
+    [webView waitForNextPresentationUpdate];
+
+    RetainPtr initialColor = [[webView _scrollPocketForTesting] captureColor];
+
     [webView synchronouslyLoadTestPageNamed:@"simple"];
     [webView waitForNextPresentationUpdate];
 
-    auto initialColor = WebCore::colorFromCocoaColor([[webView _scrollPocketForTesting] captureColor]);
+    auto colorBeforeChangingBackground = WebCore::colorFromCocoaColor([[webView _scrollPocketForTesting] captureColor]);
 
     [webView stringByEvaluatingJavaScript:@"document.body.style.backgroundColor = '#222'"];
     [webView waitForNextPresentationUpdate];
 
-    auto finalColor = WebCore::colorFromCocoaColor([[webView _scrollPocketForTesting] captureColor]);
+    auto colorAfterChangingBackground = WebCore::colorFromCocoaColor([[webView _scrollPocketForTesting] captureColor]);
 
-    EXPECT_EQ(WebCore::serializationForCSS(initialColor), "rgb(255, 255, 255)"_s);
-    EXPECT_EQ(WebCore::serializationForCSS(finalColor), "rgb(34, 34, 34)"_s);
+    EXPECT_TRUE([initialColor isEqual:NSColor.controlBackgroundColor]);
+    EXPECT_EQ(WebCore::serializationForCSS(colorBeforeChangingBackground), "rgb(255, 255, 255)"_s);
+    EXPECT_EQ(WebCore::serializationForCSS(colorAfterChangingBackground), "rgb(34, 34, 34)"_s);
 }
 
 #endif // ENABLE(CONTENT_INSET_BACKGROUND_FILL)


### PR DESCRIPTION
#### 4aa18d17c49cf630bf160a0d0e410d15aa346d03
<pre>
[macOS] [Liquid Glass] Safari: tab bar background is the wrong color after toggling dark mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=294431">https://bugs.webkit.org/show_bug.cgi?id=294431</a>
<a href="https://rdar.apple.com/153116362">rdar://153116362</a>

Reviewed by Aditya Keerthi.

When switching between dark and light mode, the scroll pocket (i.e. the view behind the scroll edge
effect in the top obscured content area of the web view) can end up with an incorrect
`-captureColor` if the new tab just loads an empty page. This happens if `underPageBackgroundColor`
returns the wrong color (white in dark mode, or dark gray in light mode), which in turn happens if:

1.  `underPageBackgroundColorOverride` is invalid (the client has not customized the color)
2.  `pageExtendedBackgroundColor` is invalid (the web page is totally empty)
3.  `+controlBackgroundColor`, a semantic color, gets mapped to the wrong `WebCore::Color` before
    being round-tripped back into a non-semantic `NSColor`, due to `roundAndClampToSRGBALossy`.

Work around this for now by splitting out existing logic in `underPageBackgroundColor()` into
`underPageBackgroundColorIgnoringPlatformColor()` (the latter of which ignores the platform color,
which is `+controlBackgroundColor` on macOS). Then adjust `updateTopScrollPocketCaptureColor()` to
set the capture color to `underPageBackgroundColorIgnoringPlatformColor()`, and directly fall back
to `+controlBackgroundColor` (without round-tripping through `WebCore::Color`) if the former color
is invalid.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::underPageBackgroundColorIgnoringPlatformColor const):
(WebKit::WebPageProxy::underPageBackgroundColor const):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::updateTopScrollPocketCaptureColor):

See above for more detail.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/ObscuredContentInsets.mm:
(TestWebKitAPI::TEST(ObscuredContentInsets, ScrollPocketCaptureColor)):

Augment an existing API test to verify that the initial scroll edge effect capture color is equal to
the semantic `+[NSColor controlBackgroundColor]`.

Canonical link: <a href="https://commits.webkit.org/296199@main">https://commits.webkit.org/296199@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c9b00bc3f849024507781eac7479b093b47a9db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27347 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17762 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112883 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58209 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109628 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28039 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35870 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81756 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110607 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97051 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62134 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21658 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15192 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57645 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91596 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15224 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116004 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34749 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25614 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90796 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35126 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93301 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90546 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23090 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35460 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13238 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30504 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34653 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40209 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34399 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37760 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36062 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->