### PR TITLE
WebKit is failing to register a service worker if script fetch is not fetched when document is being reloaded

### DIFF
--- a/LayoutTests/http/wpt/service-workers/register-then-reload-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/register-then-reload-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Register a service worker while reloading
+

--- a/LayoutTests/http/wpt/service-workers/register-then-reload.html
+++ b/LayoutTests/http/wpt/service-workers/register-then-reload.html
@@ -1,0 +1,46 @@
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+function with_iframe(url) {
+    return new Promise(function(resolve) {
+        var frame = document.createElement('iframe');
+        frame.src = url;
+        frame.onload = function() { resolve(frame); };
+        document.body.appendChild(frame);
+    });
+}
+
+async function getOneRegistration(counter)
+{
+    if (!counter)
+        counter = 0;
+    else if (counter > 50)
+         return Promise.reject("no registration found");
+
+    const registrations = await navigator.serviceWorker.getRegistrations();
+    if (registrations.length && registrations[0].active)
+        return registrations[0];
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+    return getOneRegistration(++counter);
+}
+
+promise_test(async (t) => {
+    const frame = await with_iframe("resources/register-then-reload-iframe.html");
+    frame.contentWindow.startTest();
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    const registration = await getOneRegistration();
+    t.add_cleanup(() => registration.unregister());
+
+    const scriptURL = new URL(registration.active.scriptURL);
+    assert_equals(scriptURL.pathname, "/WebKit/service-workers/resources/lengthy-worker.py");
+}, "Register a service worker while reloading");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/service-workers/resources/lengthy-worker.py
+++ b/LayoutTests/http/wpt/service-workers/resources/lengthy-worker.py
@@ -1,0 +1,19 @@
+import time
+
+
+def main(request, response):
+    delay = 0.1
+    headers = []
+    if b"delay" in request.GET:
+        delay = float(request.GET.first(b"delay"))
+    response.headers.set(b"Content-type", b"text/javascript")
+    response.headers.append(b"Access-Control-Allow-Origin", b"*")
+    response.write_status_headers()
+    time.sleep(delay)
+    response.writer.write_content("self.onfetch = ")
+    time.sleep(delay)
+    response.writer.write_content("e")
+    time.sleep(delay)
+    response.writer.write_content(" => ")
+    time.sleep(delay)
+    response.writer.write_content(" { };")

--- a/LayoutTests/http/wpt/service-workers/resources/register-then-reload-iframe.html
+++ b/LayoutTests/http/wpt/service-workers/resources/register-then-reload-iframe.html
@@ -1,0 +1,17 @@
+<html>
+<head>
+</head>
+<body>
+<script>
+async function startTest()
+{
+    window.internals?.setTopDocumentURLForQuirks("https://www.capitalgroup.com");
+
+    const scope = "";
+    const registration = navigator.serviceWorker.register("lengthy-worker.py", { scope });
+    await new Promise(resolve => setTimeout(resolve, 100));
+    window.location.reload();
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1917,6 +1917,11 @@ bool Quirks::shouldEnterNativeFullscreenWhenCallingElementRequestFullscreenQuirk
     return needsQuirks() && m_quirksData.shouldEnterNativeFullscreenWhenCallingElementRequestFullscreen;
 }
 
+bool Quirks::shouldDelayReloadWhenRegisteringServiceWorker() const
+{
+    return needsQuirks() && m_quirksData.shouldDelayReloadWhenRegisteringServiceWorker;
+}
+
 URL Quirks::topDocumentURL() const
 {
     if (!m_topDocumentURLForTesting.isEmpty()) [[unlikely]]
@@ -2873,6 +2878,13 @@ static void handleZoomQuirks(QuirksData& quirksData, const URL& quirksURL, const
 #endif
 }
 
+static void handleCapitalGroupQuirks(QuirksData& quirksData, const URL&, const String& quirksDomainString, const URL&)
+{
+    if (quirksDomainString != "capitalgroup.com"_s)
+        return;
+    quirksData.shouldDelayReloadWhenRegisteringServiceWorker = true;
+}
+
 void Quirks::determineRelevantQuirks()
 {
     RELEASE_ASSERT(m_document);
@@ -2918,6 +2930,7 @@ void Quirks::determineRelevantQuirks()
         { "bankofamerica"_s, &handleBankOfAmericaQuirks },
         { "bing"_s, &handleBingQuirks },
         { "bungalow"_s, &handleBungalowQuirks },
+        { "capitalgroup"_s, &handleCapitalGroupQuirks },
 #if PLATFORM(IOS_FAMILY)
         { "cbssports"_s, &handleCBSSportsQuirks },
         { "cnn"_s, &handleCNNQuirks },

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -264,6 +264,7 @@ public:
     bool shouldSupportHoverMediaQueries() const;
 
     bool shouldRewriteMediaRangeRequestForURL(const URL&) const;
+    bool shouldDelayReloadWhenRegisteringServiceWorker() const;
 
     bool shouldPreventKeyframeEffectAcceleration(const KeyframeEffect&) const;
 

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -189,6 +189,7 @@ struct WEBCORE_EXPORT QuirksData {
     bool needsWebKitMediaTextTrackDisplayQuirk : 1 { false };
     bool needsMediaRewriteRangeRequestQuirk : 1 { false };
     bool shouldEnterNativeFullscreenWhenCallingElementRequestFullscreen : 1 { false };
+    bool shouldDelayReloadWhenRegisteringServiceWorker : 1 { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.h
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.h
@@ -119,6 +119,8 @@ public:
     void removeCookieChangeSubscriptions(ServiceWorkerRegistrationIdentifier, Vector<CookieChangeSubscription>&&, Ref<DeferredPromise>&&);
     void cookieChangeSubscriptions(ServiceWorkerRegistrationIdentifier, Ref<DeferredPromise>&&);
 
+    void whenRegisterJobsAreFinished(CompletionHandler<void()>&&);
+
 private:
     ServiceWorkerContainer(ScriptExecutionContext*, NavigatorBase&);
 
@@ -176,6 +178,7 @@ private:
     HashMap<uint64_t, ServiceWorkerRegistrationKey> m_ongoingSettledRegistrations;
     bool m_shouldDeferMessageEvents { false };
     Vector<MessageEvent::MessageEventWithStrongData> m_deferredMessageEvents;
+    CompletionHandler<void()> m_whenRegisterJobsAreFinished;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/ServiceWorkerJob.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerJob.cpp
@@ -198,4 +198,9 @@ bool ServiceWorkerJob::cancelPendingLoad()
     return false;
 }
 
+bool ServiceWorkerJob::isRegistering() const
+{
+    return !m_completed && m_jobData.type == ServiceWorkerJobType::Register;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/workers/service/ServiceWorkerJob.h
+++ b/Source/WebCore/workers/service/ServiceWorkerJob.h
@@ -74,6 +74,8 @@ public:
 
     WEBCORE_EXPORT static ResourceError validateServiceWorkerResponse(const ServiceWorkerJobData&, const ResourceResponse&);
 
+    bool isRegistering() const;
+
 private:
     // WorkerScriptLoaderClient
     void didReceiveResponse(ScriptExecutionContextIdentifier, std::optional<ResourceLoaderIdentifier>, const ResourceResponse&) final;


### PR DESCRIPTION
#### c53ee10740bf00f166a5b0e0b5daab3933bcd7e4
<pre>
WebKit is failing to register a service worker if script fetch is not fetched when document is being reloaded
<a href="https://rdar.apple.com/152398237">rdar://152398237</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=294391">https://bugs.webkit.org/show_bug.cgi?id=294391</a>

Reviewed by Chris Dumez.

Some websites will test whether a page is controlled by a service worker or not.
If not, they will start registering a service worker and will reload until the page is controlled.

Reloading is expected to stop all loads, including the load to get the service worker script.
If the load is not finished by the time the reload cancels all loads, the service worker registration will fail.
This can make the website enter in a reload loop.

To prevent this, we add a quirk that delays reloading to happen until the service worker registration job has finished, if any.

* LayoutTests/http/wpt/service-workers/register-then-reload-expected.txt: Added.
* LayoutTests/http/wpt/service-workers/register-then-reload.html: Added.
* LayoutTests/http/wpt/service-workers/resources/lengthy-worker.py: Added.
(main):
* LayoutTests/http/wpt/service-workers/resources/register-then-reload-iframe.html: Added.
* Source/WebCore/page/Location.cpp:
(WebCore::Location::reload):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldDelayReloadWhenRegisteringServiceWorker const):
(WebCore::handleCapitalGroupQuirks):
(WebCore::Quirks::determineRelevantQuirks):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:
* Source/WebCore/workers/service/ServiceWorkerContainer.cpp:
(WebCore::ServiceWorkerContainer::jobFailedWithException):
(WebCore::ServiceWorkerContainer::jobResolvedWithRegistration):
(WebCore::ServiceWorkerContainer::jobFinishedLoadingScript):
(WebCore::ServiceWorkerContainer::jobFailedLoadingScript):
(WebCore::ServiceWorkerContainer::hasServiceWorkerScriptFetch const):
(WebCore::ServiceWorkerContainer::whenScriptFetchJobFinished):
* Source/WebCore/workers/service/ServiceWorkerContainer.h:
* Source/WebCore/workers/service/ServiceWorkerJob.cpp:
(WebCore::ServiceWorkerJob::fetchScriptWithContext):
(WebCore::ServiceWorkerJob::mayLoadScript const):
* Source/WebCore/workers/service/ServiceWorkerJob.h:

Canonical link: <a href="https://commits.webkit.org/296970@main">https://commits.webkit.org/296970@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d708dcdb5e0ade9e713d50ac6dd56a828e3d7ec9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110103 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29762 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20194 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116125 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60351 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112066 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30440 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38349 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83711 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113051 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24277 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99155 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64155 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23643 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17290 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59921 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93652 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17347 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118916 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37143 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27533 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92682 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37515 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95423 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92507 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23580 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37496 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15233 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33026 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37037 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42508 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36699 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40039 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38408 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->