### PR TITLE
[GTK][WPE] Make Damage iterable

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapperDamageVisualizer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperDamageVisualizer.cpp
@@ -52,9 +52,8 @@ void TextureMapperDamageVisualizer::paintDamage(TextureMapper& textureMapper, co
         return;
 
     const auto color = Color::red.colorWithAlphaByte(200);
-    damage->forEachNonEmptyRect([&](const auto& rect) {
+    for (const auto& rect : *damage)
         textureMapper.drawSolidColor(rect + m_margin, { }, color, true);
-    });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -511,15 +511,13 @@ void TextureMapperLayer::collectDamageSelf(TextureMapperPaintOptions& options, D
     // layer-level operations such as resizes, transformations, etc.
     const auto& clipBounds = options.textureMapper.clipBounds();
     if (m_damageInGlobalCoordinateSpace) {
-        m_damageInGlobalCoordinateSpace->forEachNonEmptyRect([&](const auto& rect) {
+        for (const auto& rect : *m_damageInGlobalCoordinateSpace)
             damage.add(intersection(rect, clipBounds));
-        });
     }
 
     if (m_damageInLayerCoordinateSpace) {
-        m_damageInLayerCoordinateSpace->forEachNonEmptyRect([&](const auto& rect) {
+        for (const auto& rect : *m_damageInLayerCoordinateSpace)
             damage.add(intersection(transformRectFromLayerToGlobalCoordinateSpace(rect, transform, options), clipBounds));
-        });
     }
 }
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -553,7 +553,7 @@ void CoordinatedPlatformLayer::setContentsTilePhase(const FloatSize& contentsTil
 void CoordinatedPlatformLayer::setDirtyRegion(Damage&& damage)
 {
     ASSERT(m_lock.isHeld());
-    auto dirtyRegion = damage.nonEmptyRects();
+    auto dirtyRegion = damage.rects();
     if (m_dirtyRegion != dirtyRegion) {
         m_dirtyRegion = WTFMove(dirtyRegion);
         notifyCompositionRequired();

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
@@ -681,7 +681,7 @@ void AcceleratedSurfaceDMABuf::didRenderFrame()
 #if ENABLE(DAMAGE_TRACKING)
     m_target->setDamage(WebCore::Damage(m_size));
     if (m_frameDamage) {
-        damageRects = m_frameDamage->nonEmptyRects();
+        damageRects = m_frameDamage->rects();
         m_frameDamage = std::nullopt;
     }
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp
@@ -48,11 +48,9 @@ TEST(Damage, Mode)
     EXPECT_TRUE(rectsDamage.add(IntRect { 300, 300, 200, 200 }));
     EXPECT_FALSE(rectsDamage.isEmpty());
     EXPECT_EQ(rectsDamage.size(), 2);
-    EXPECT_EQ(rectsDamage.bounds().x(), 100);
-    EXPECT_EQ(rectsDamage.bounds().y(), 100);
-    EXPECT_EQ(rectsDamage.bounds().width(), 400);
-    EXPECT_EQ(rectsDamage.bounds().height(), 400);
-    EXPECT_EQ(rectsDamage.nonEmptyRects().size(), 2);
+    EXPECT_EQ(rectsDamage[0], IntRect(100, 100, 200, 200));
+    EXPECT_EQ(rectsDamage[1], IntRect(300, 300, 200, 200));
+    EXPECT_EQ(rectsDamage.bounds(), IntRect(100, 100, 400, 400));
 
     // BoundingBox always unite damage in bounds.
     Damage bboxDamage(IntSize { 1024, 768 }, Damage::Mode::BoundingBox);
@@ -61,12 +59,8 @@ TEST(Damage, Mode)
     EXPECT_TRUE(bboxDamage.add(IntRect { 300, 300, 200, 200 }));
     EXPECT_FALSE(bboxDamage.isEmpty());
     EXPECT_EQ(bboxDamage.size(), 1);
-    EXPECT_EQ(bboxDamage.rects()[0], bboxDamage.bounds());
-    EXPECT_EQ(bboxDamage.bounds().x(), 100);
-    EXPECT_EQ(bboxDamage.bounds().y(), 100);
-    EXPECT_EQ(bboxDamage.bounds().width(), 400);
-    EXPECT_EQ(bboxDamage.bounds().height(), 400);
-    EXPECT_EQ(bboxDamage.nonEmptyRects().size(), 1);
+    EXPECT_EQ(bboxDamage[0], IntRect(100, 100, 400, 400));
+    EXPECT_EQ(bboxDamage[0], bboxDamage.bounds());
 
     // Full ignores any adds and always reports the whole area.
     Damage fullDamage(IntSize { 1024, 768 }, Damage::Mode::Full);
@@ -75,12 +69,8 @@ TEST(Damage, Mode)
     EXPECT_FALSE(fullDamage.add(IntRect { 300, 300, 200, 200 }));
     EXPECT_FALSE(fullDamage.isEmpty());
     EXPECT_EQ(fullDamage.size(), 1);
-    EXPECT_EQ(fullDamage.rects()[0], fullDamage.bounds());
-    EXPECT_EQ(fullDamage.bounds().x(), 0);
-    EXPECT_EQ(fullDamage.bounds().y(), 0);
-    EXPECT_EQ(fullDamage.bounds().width(), 1024);
-    EXPECT_EQ(fullDamage.bounds().height(), 768);
-    EXPECT_EQ(fullDamage.nonEmptyRects().size(), 1);
+    EXPECT_EQ(fullDamage[0], IntRect(0, 0, 1024, 768));
+    EXPECT_EQ(fullDamage[0], fullDamage.bounds());
 
     // We can make a Damage full.
     fullDamage = rectsDamage;
@@ -89,11 +79,8 @@ TEST(Damage, Mode)
     EXPECT_TRUE(fullDamage.mode() == Damage::Mode::Full);
     EXPECT_FALSE(fullDamage.isEmpty());
     EXPECT_EQ(fullDamage.size(), 1);
-    EXPECT_EQ(fullDamage.rects()[0], fullDamage.bounds());
-    EXPECT_EQ(fullDamage.bounds().x(), 0);
-    EXPECT_EQ(fullDamage.bounds().y(), 0);
-    EXPECT_EQ(fullDamage.bounds().width(), 1024);
-    EXPECT_EQ(fullDamage.bounds().height(), 768);
+    EXPECT_EQ(fullDamage[0], IntRect(0, 0, 1024, 768));
+    EXPECT_EQ(fullDamage[0], fullDamage.bounds());
 
     // Adding a rectangle with the size of the Damage rect makes it full.
     fullDamage = rectsDamage;
@@ -102,10 +89,7 @@ TEST(Damage, Mode)
     EXPECT_TRUE(fullDamage.mode() == Damage::Mode::Full);
     EXPECT_FALSE(fullDamage.isEmpty());
     EXPECT_EQ(fullDamage.size(), 1);
-    EXPECT_EQ(fullDamage.bounds().x(), 0);
-    EXPECT_EQ(fullDamage.bounds().y(), 0);
-    EXPECT_EQ(fullDamage.bounds().width(), 1024);
-    EXPECT_EQ(fullDamage.bounds().height(), 768);
+    EXPECT_EQ(fullDamage.bounds(), IntRect(0, 0, 1024, 768));
 
     // Adding a rectangle containing the Damage rect makes it full.
     fullDamage = rectsDamage;
@@ -114,10 +98,7 @@ TEST(Damage, Mode)
     EXPECT_TRUE(fullDamage.mode() == Damage::Mode::Full);
     EXPECT_FALSE(fullDamage.isEmpty());
     EXPECT_EQ(fullDamage.size(), 1);
-    EXPECT_EQ(fullDamage.bounds().x(), 0);
-    EXPECT_EQ(fullDamage.bounds().y(), 0);
-    EXPECT_EQ(fullDamage.bounds().width(), 1024);
-    EXPECT_EQ(fullDamage.bounds().height(), 768);
+    EXPECT_EQ(fullDamage.bounds(), IntRect(0, 0, 1024, 768));
 
     // Adding vector of rects with any value containing the Damage rect makes it full.
     fullDamage = rectsDamage;
@@ -130,10 +111,7 @@ TEST(Damage, Mode)
     EXPECT_TRUE(fullDamage.mode() == Damage::Mode::Full);
     EXPECT_FALSE(fullDamage.isEmpty());
     EXPECT_EQ(fullDamage.size(), 1);
-    EXPECT_EQ(fullDamage.bounds().x(), 0);
-    EXPECT_EQ(fullDamage.bounds().y(), 0);
-    EXPECT_EQ(fullDamage.bounds().width(), 1024);
-    EXPECT_EQ(fullDamage.bounds().height(), 768);
+    EXPECT_EQ(fullDamage.bounds(), IntRect(0, 0, 1024, 768));
 
     // It should be the same if the vector is long enough to unite.
     fullDamage = Damage(IntSize { 512, 512 });
@@ -149,10 +127,7 @@ TEST(Damage, Mode)
     EXPECT_TRUE(fullDamage.mode() == Damage::Mode::Full);
     EXPECT_FALSE(fullDamage.isEmpty());
     EXPECT_EQ(fullDamage.size(), 1);
-    EXPECT_EQ(fullDamage.bounds().x(), 0);
-    EXPECT_EQ(fullDamage.bounds().y(), 0);
-    EXPECT_EQ(fullDamage.bounds().width(), 512);
-    EXPECT_EQ(fullDamage.bounds().height(), 512);
+    EXPECT_EQ(fullDamage.bounds(), IntRect(0, 0, 512, 512));
 
     // Adding a full Damage to another with the same rect makes it full.
     fullDamage = rectsDamage;
@@ -162,10 +137,7 @@ TEST(Damage, Mode)
     EXPECT_TRUE(fullDamage.mode() == Damage::Mode::Full);
     EXPECT_FALSE(fullDamage.isEmpty());
     EXPECT_EQ(fullDamage.size(), 1);
-    EXPECT_EQ(fullDamage.bounds().x(), 0);
-    EXPECT_EQ(fullDamage.bounds().y(), 0);
-    EXPECT_EQ(fullDamage.bounds().width(), 1024);
-    EXPECT_EQ(fullDamage.bounds().height(), 768);
+    EXPECT_EQ(fullDamage.bounds(), IntRect(0, 0, 1024, 768));
 }
 
 TEST(Damage, Move)
@@ -175,24 +147,15 @@ TEST(Damage, Move)
     EXPECT_TRUE(damage.add(IntRect { 300, 300, 200, 200 }));
     EXPECT_FALSE(damage.isEmpty());
     EXPECT_EQ(damage.size(), 2);
-    EXPECT_EQ(damage.bounds().x(), 100);
-    EXPECT_EQ(damage.bounds().y(), 100);
-    EXPECT_EQ(damage.bounds().width(), 400);
-    EXPECT_EQ(damage.bounds().height(), 400);
+    EXPECT_EQ(damage.bounds(), IntRect(100, 100, 400, 400));
 
     Damage other = WTFMove(damage);
     EXPECT_FALSE(other.isEmpty());
     EXPECT_EQ(other.size(), 2);
-    EXPECT_EQ(other.bounds().x(), 100);
-    EXPECT_EQ(other.bounds().y(), 100);
-    EXPECT_EQ(other.bounds().width(), 400);
-    EXPECT_EQ(other.bounds().height(), 400);
+    EXPECT_EQ(other.bounds(), IntRect(100, 100, 400, 400));
     EXPECT_TRUE(damage.isEmpty());
     EXPECT_EQ(damage.size(), 0);
-    EXPECT_EQ(damage.bounds().x(), 100);
-    EXPECT_EQ(damage.bounds().y(), 100);
-    EXPECT_EQ(damage.bounds().width(), 400);
-    EXPECT_EQ(damage.bounds().height(), 400);
+    EXPECT_EQ(damage.bounds(), IntRect(100, 100, 400, 400));
 }
 
 TEST(Damage, AddRect)
@@ -200,51 +163,49 @@ TEST(Damage, AddRect)
     Damage damage(IntSize { 2048, 1024 });
     EXPECT_TRUE(damage.add(IntRect { 100, 100, 200, 200 }));
     EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage[0], IntRect(100, 100, 200, 200));
 
     // When there's only one rect, that should be the bounds.
-    EXPECT_EQ(damage.bounds().x(), 100);
-    EXPECT_EQ(damage.bounds().y(), 100);
-    EXPECT_EQ(damage.bounds().width(), 200);
-    EXPECT_EQ(damage.bounds().height(), 200);
+    EXPECT_EQ(damage.bounds(), IntRect(100, 100, 200, 200));
+    EXPECT_EQ(damage[0], damage.bounds());
 
     // When there's only one rect, adding a rect already contained
     // by the bounding box does nothing.
     EXPECT_FALSE(damage.add(IntRect { 150, 150, 100, 100 }));
     EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage[0], IntRect(100, 100, 200, 200));
+    EXPECT_EQ(damage[0], damage.bounds());
 
     // Adding an empty rect does nothing.
     EXPECT_FALSE(damage.add(IntRect { }));
     EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage[0], IntRect(100, 100, 200, 200));
+    EXPECT_EQ(damage[0], damage.bounds());
 
     // Adding a new rect not contained by previous one adds it to the list.
     EXPECT_TRUE(damage.add(IntRect { 300, 300, 200, 200 }));
     EXPECT_EQ(damage.size(), 2);
-
+    EXPECT_EQ(damage[0], IntRect(100, 100, 200, 200));
+    EXPECT_EQ(damage[1], IntRect(300, 300, 200, 200));
     // Now the bounding box contains the two rectangles.
-    EXPECT_EQ(damage.bounds().x(), 100);
-    EXPECT_EQ(damage.bounds().y(), 100);
-    EXPECT_EQ(damage.bounds().width(), 400);
-    EXPECT_EQ(damage.bounds().height(), 400);
+    EXPECT_EQ(damage.bounds(), IntRect(100, 100, 400, 400));
 
     // Adding a rect containing the bounds makes it the only rect.
     EXPECT_TRUE(damage.add(IntRect { 50, 50, 500, 500 }));
     EXPECT_EQ(damage.size(), 1);
-    EXPECT_EQ(damage.bounds().x(), 50);
-    EXPECT_EQ(damage.bounds().y(), 50);
-    EXPECT_EQ(damage.bounds().width(), 500);
-    EXPECT_EQ(damage.bounds().height(), 500);
+    EXPECT_EQ(damage[0], IntRect(50, 50, 500, 500));
+    EXPECT_EQ(damage[0], damage.bounds());
 
     // Adding FloatRect takes the enclosingIntRect
     EXPECT_TRUE(damage.add(FloatRect { 1024.50, 1024.25, 50.32, 25.75 }));
     EXPECT_EQ(damage.size(), 2);
-    EXPECT_EQ(damage.rects().last().x(), 1024);
-    EXPECT_EQ(damage.rects().last().y(), 1024);
-    EXPECT_EQ(damage.rects().last().width(), 51);
-    EXPECT_EQ(damage.rects().last().height(), 26);
+    EXPECT_EQ(damage[1], IntRect(1024, 1024, 51, 26));
 
     // Adding an empty FloatRect does nothing.
     EXPECT_FALSE(damage.add(FloatRect { 1024.50, 1024.25, 0, 0 }));
     EXPECT_EQ(damage.size(), 2);
+    EXPECT_EQ(damage[0], IntRect(50, 50, 500, 500));
+    EXPECT_EQ(damage[1], IntRect(1024, 1024, 51, 26));
 }
 
 TEST(Damage, AddRects)
@@ -252,15 +213,18 @@ TEST(Damage, AddRects)
     Damage damage(IntSize { 2048, 1024 });
     EXPECT_TRUE(damage.add(Vector<IntRect, 1> { { 100, 100, 200, 200 } }));
     EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage[0], IntRect(100, 100, 200, 200));
     EXPECT_EQ(damage.bounds(), IntRect(100, 100, 200, 200));
 
     // Adding an empty Vector does nothing.
     EXPECT_FALSE(damage.add(Vector<IntRect, 1> { }));
     EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage[0], IntRect(100, 100, 200, 200));
 
     // Adding a Vector with empty rets does nothing.
     EXPECT_FALSE(damage.add(Vector<IntRect, 1> { { }, { } }));
     EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage[0], IntRect(100, 100, 200, 200));
 
     // Adding more than 4 rectangles will unite.
     damage = Damage(IntSize { 512, 512 });
@@ -271,32 +235,41 @@ TEST(Damage, AddRects)
         { 200, 200, 4, 4 },
         { 128, 128, 4, 4 }
     }));
-    EXPECT_EQ(damage.size(), 4);
-    EXPECT_EQ(damage.rects()[0], damage.bounds());
+    EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage[0], damage.bounds());
+    EXPECT_EQ(damage.rectsForTesting().size(), 4);
+    EXPECT_EQ(damage.rectsForTesting()[0], damage.bounds());
 
     // Adding more than 4 rectangles to a non empty damage should unite too.
     damage = Damage(IntSize { 512, 512 });
     EXPECT_TRUE(damage.add(IntRect { 300, 0, 4, 4 }));
+    EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage[0], damage.bounds());
     EXPECT_TRUE(damage.add(Vector<IntRect, 1> {
         { 500, 0, 4, 4 },
         { 300, 200, 4, 4 },
         { 500, 200, 4, 4 },
         { 384, 128, 4, 4 }
     }));
-    EXPECT_EQ(damage.size(), 4);
-    EXPECT_EQ(damage.rects()[1], damage.bounds());
+    EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage[0], damage.bounds());
+    EXPECT_EQ(damage.rectsForTesting().size(), 4);
+    EXPECT_EQ(damage.rectsForTesting()[1], damage.bounds());
 
     // Adding more than 4 empty rectangles does nothing.
     damage = Damage(IntSize { 512, 512 });
     EXPECT_FALSE(damage.add(Vector<IntRect, 1> { { }, { }, { }, { }, { } }));
     EXPECT_EQ(damage.size(), 0);
+    EXPECT_EQ(damage.rectsForTesting().size(), 0);
 
     // Adding more than 4 empty rectangles to a non empty damage does nothing too.
     damage = Damage(IntSize { 512, 512 });
     EXPECT_TRUE(damage.add(IntRect { 300, 0, 4, 4 }));
     EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage.rectsForTesting().size(), 1);
     EXPECT_FALSE(damage.add(Vector<IntRect, 1> { { }, { }, { }, { }, { } }));
     EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage.rectsForTesting().size(), 1);
 
     // Adding a Vector to damage in BoundingBox mode always unite damage in bounds.
     damage = Damage(IntSize { 1024, 768 }, Damage::Mode::BoundingBox);
@@ -305,8 +278,8 @@ TEST(Damage, AddRects)
         { 300, 300, 200, 200 }
     }));
     EXPECT_EQ(damage.size(), 1);
-    EXPECT_EQ(damage.rects()[0], damage.bounds());
-    EXPECT_EQ(damage.bounds(), IntRect(100, 100, 400, 400));
+    EXPECT_EQ(damage[0], IntRect(100, 100, 400, 400));
+    EXPECT_EQ(damage[0], damage.bounds());
 
     // Adding a Vector to damage in Full mode does nothing.
     damage = Damage(IntSize { 1024, 768 }, Damage::Mode::Full);
@@ -315,8 +288,8 @@ TEST(Damage, AddRects)
         { 300, 300, 200, 200 }
     }));
     EXPECT_EQ(damage.size(), 1);
-    EXPECT_EQ(damage.rects()[0], damage.bounds());
-    EXPECT_EQ(damage.bounds(), IntRect(0, 0, 1024, 768));
+    EXPECT_EQ(damage[0], IntRect(0, 0, 1024, 768));
+    EXPECT_EQ(damage[0], damage.bounds());
 }
 
 TEST(Damage, AddDamage)
@@ -324,21 +297,22 @@ TEST(Damage, AddDamage)
     Damage damage(IntSize { 2048, 1024 });
     EXPECT_TRUE(damage.add(IntRect { 100, 100, 200, 200 }));
     EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage[0], IntRect(100, 100, 200, 200));
 
     // Adding empty Damage does nothing.
     Damage other(IntSize { 2048, 1024 });
     EXPECT_FALSE(damage.add(other));
     EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage[0], IntRect(100, 100, 200, 200));
 
     // Adding a valid Damage adds its rectangles.
     EXPECT_TRUE(other.add(IntRect { 300, 300, 200, 200 }));
     EXPECT_EQ(other.size(), 1);
     EXPECT_TRUE(damage.add(other));
     EXPECT_EQ(damage.size(), 2);
-    EXPECT_EQ(damage.bounds().x(), 100);
-    EXPECT_EQ(damage.bounds().y(), 100);
-    EXPECT_EQ(damage.bounds().width(), 400);
-    EXPECT_EQ(damage.bounds().height(), 400);
+    EXPECT_EQ(damage[0], IntRect(100, 100, 200, 200));
+    EXPECT_EQ(damage[1], IntRect(300, 300, 200, 200));
+    EXPECT_EQ(damage.bounds(), IntRect(100, 100, 400, 400));
 
     // It's possible to add one Damage to another with different rectangle.
     damage = Damage(IntSize { 1024, 768 });
@@ -349,8 +323,8 @@ TEST(Damage, AddDamage)
     EXPECT_EQ(other.size(), 1);
     EXPECT_TRUE(damage.add(other));
     EXPECT_EQ(damage.size(), 2);
-    EXPECT_EQ(damage.rects()[0], IntRect(100, 100, 200, 200));
-    EXPECT_EQ(damage.rects()[1], IntRect(300, 300, 200, 200));
+    EXPECT_EQ(damage[0], IntRect(100, 100, 200, 200));
+    EXPECT_EQ(damage[1], IntRect(300, 300, 200, 200));
 
     // Adding a Damage already united with the same rectangle, just unites every rectangle in the grid.
     damage = Damage(IntSize { 512, 512 });
@@ -362,10 +336,10 @@ TEST(Damage, AddDamage)
         { 128, 128, 4, 4 }
     }));
     EXPECT_EQ(damage.size(), 4);
-    EXPECT_EQ(damage.rects()[0], IntRect(0, 0, 132, 132));
-    EXPECT_EQ(damage.rects()[1], IntRect(300, 0, 4, 4));
-    EXPECT_EQ(damage.rects()[2], IntRect(0, 300, 4, 4));
-    EXPECT_EQ(damage.rects()[3], IntRect(300, 300, 4, 4));
+    EXPECT_EQ(damage[0], IntRect(0, 0, 132, 132));
+    EXPECT_EQ(damage[1], IntRect(300, 0, 4, 4));
+    EXPECT_EQ(damage[2], IntRect(0, 300, 4, 4));
+    EXPECT_EQ(damage[3], IntRect(300, 300, 4, 4));
     other = Damage(IntSize { 512, 512 });
     EXPECT_TRUE(other.add(Vector<IntRect, 1> {
         { 10, 10, 4, 4 },
@@ -375,16 +349,16 @@ TEST(Damage, AddDamage)
         { 384, 384, 4, 4 }
     }));
     EXPECT_EQ(other.size(), 4);
-    EXPECT_EQ(other.rects()[0], IntRect(10, 10, 4, 4));
-    EXPECT_EQ(other.rects()[1], IntRect(310, 10, 4, 4));
-    EXPECT_EQ(other.rects()[2], IntRect(10, 310, 4, 4));
-    EXPECT_EQ(other.rects()[3], IntRect(310, 310, 78, 78));
+    EXPECT_EQ(other[0], IntRect(10, 10, 4, 4));
+    EXPECT_EQ(other[1], IntRect(310, 10, 4, 4));
+    EXPECT_EQ(other[2], IntRect(10, 310, 4, 4));
+    EXPECT_EQ(other[3], IntRect(310, 310, 78, 78));
     EXPECT_TRUE(damage.add(other));
     EXPECT_EQ(damage.size(), 4);
-    EXPECT_EQ(damage.rects()[0], IntRect(0, 0, 132, 132));
-    EXPECT_EQ(damage.rects()[1], IntRect(300, 0, 14, 14));
-    EXPECT_EQ(damage.rects()[2], IntRect(0, 300, 14, 14));
-    EXPECT_EQ(damage.rects()[3], IntRect(300, 300, 88, 88));
+    EXPECT_EQ(damage[0], IntRect(0, 0, 132, 132));
+    EXPECT_EQ(damage[1], IntRect(300, 0, 14, 14));
+    EXPECT_EQ(damage[2], IntRect(0, 300, 14, 14));
+    EXPECT_EQ(damage[3], IntRect(300, 300, 88, 88));
 }
 
 TEST(Damage, Unite)
@@ -400,13 +374,13 @@ TEST(Damage, Unite)
     EXPECT_TRUE(damage.add(IntRect { 200, 200, 4, 4 }));
     EXPECT_EQ(damage.size(), 4);
     EXPECT_TRUE(damage.add(IntRect { 128, 128, 4, 4 }));
-    EXPECT_EQ(damage.size(), 4);
-    EXPECT_FALSE(damage.rects()[0].isEmpty());
-    EXPECT_TRUE(damage.rects()[1].isEmpty());
-    EXPECT_TRUE(damage.rects()[2].isEmpty());
-    EXPECT_TRUE(damage.rects()[3].isEmpty());
-    EXPECT_EQ(damage.nonEmptyRects().size(), 1);
-    EXPECT_EQ(damage.rects()[0], damage.bounds());
+    EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage.rectsForTesting().size(), 4);
+    EXPECT_FALSE(damage.rectsForTesting()[0].isEmpty());
+    EXPECT_TRUE(damage.rectsForTesting()[1].isEmpty());
+    EXPECT_TRUE(damage.rectsForTesting()[2].isEmpty());
+    EXPECT_TRUE(damage.rectsForTesting()[3].isEmpty());
+    EXPECT_EQ(damage[0], damage.bounds());
 
     // Add several rects to the second tile.
     damage = Damage(IntSize { 512, 512 });
@@ -419,16 +393,15 @@ TEST(Damage, Unite)
     EXPECT_TRUE(damage.add(IntRect { 500, 200, 4, 4 }));
     EXPECT_EQ(damage.size(), 4);
     EXPECT_TRUE(damage.add(IntRect { 384, 128, 4, 4 }));
-    EXPECT_EQ(damage.size(), 4);
-    EXPECT_TRUE(damage.rects()[0].isEmpty());
-    EXPECT_FALSE(damage.rects()[1].isEmpty());
-    EXPECT_TRUE(damage.rects()[2].isEmpty());
-    EXPECT_TRUE(damage.rects()[3].isEmpty());
-    EXPECT_EQ(damage.nonEmptyRects().size(), 1);
-    damage.forEachNonEmptyRect([&](const auto& rect) {
+    EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage.rectsForTesting().size(), 4);
+    EXPECT_TRUE(damage.rectsForTesting()[0].isEmpty());
+    EXPECT_FALSE(damage.rectsForTesting()[1].isEmpty());
+    EXPECT_TRUE(damage.rectsForTesting()[2].isEmpty());
+    EXPECT_TRUE(damage.rectsForTesting()[3].isEmpty());
+    for (const auto& rect : damage)
         EXPECT_EQ(rect, damage.bounds());
-    });
-    EXPECT_EQ(damage.rects()[1], damage.bounds());
+    EXPECT_EQ(damage[0], damage.bounds());
 
     // Add several rects to the third tile.
     damage = Damage(IntSize { 512, 512 });
@@ -441,13 +414,15 @@ TEST(Damage, Unite)
     EXPECT_TRUE(damage.add(IntRect { 200, 500, 4, 4 }));
     EXPECT_EQ(damage.size(), 4);
     EXPECT_TRUE(damage.add(IntRect { 128, 384, 4, 4 }));
-    EXPECT_EQ(damage.size(), 4);
-    EXPECT_TRUE(damage.rects()[0].isEmpty());
-    EXPECT_TRUE(damage.rects()[1].isEmpty());
-    EXPECT_FALSE(damage.rects()[2].isEmpty());
-    EXPECT_TRUE(damage.rects()[3].isEmpty());
-    EXPECT_EQ(damage.nonEmptyRects().size(), 1);
-    EXPECT_EQ(damage.rects()[2], damage.bounds());
+    EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage.rectsForTesting().size(), 4);
+    EXPECT_TRUE(damage.rectsForTesting()[0].isEmpty());
+    EXPECT_TRUE(damage.rectsForTesting()[1].isEmpty());
+    EXPECT_FALSE(damage.rectsForTesting()[2].isEmpty());
+    EXPECT_TRUE(damage.rectsForTesting()[3].isEmpty());
+    for (const auto& rect : damage)
+        EXPECT_EQ(rect, damage.bounds());
+    EXPECT_EQ(damage[0], damage.bounds());
 
     // Add several rects to the fourth tile.
     damage = Damage(IntSize { 512, 512 });
@@ -460,16 +435,15 @@ TEST(Damage, Unite)
     EXPECT_TRUE(damage.add(IntRect { 500, 500, 4, 4 }));
     EXPECT_EQ(damage.size(), 4);
     EXPECT_TRUE(damage.add(IntRect { 384, 384, 4, 4 }));
-    EXPECT_EQ(damage.size(), 4);
-    EXPECT_TRUE(damage.rects()[0].isEmpty());
-    EXPECT_TRUE(damage.rects()[1].isEmpty());
-    EXPECT_TRUE(damage.rects()[2].isEmpty());
-    EXPECT_FALSE(damage.rects()[3].isEmpty());
-    EXPECT_EQ(damage.nonEmptyRects().size(), 1);
-    damage.forEachNonEmptyRect([&](const auto& rect) {
+    EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage.rectsForTesting().size(), 4);
+    EXPECT_TRUE(damage.rectsForTesting()[0].isEmpty());
+    EXPECT_TRUE(damage.rectsForTesting()[1].isEmpty());
+    EXPECT_TRUE(damage.rectsForTesting()[2].isEmpty());
+    EXPECT_FALSE(damage.rectsForTesting()[3].isEmpty());
+    for (const auto& rect : damage)
         EXPECT_EQ(rect, damage.bounds());
-    });
-    EXPECT_EQ(damage.rects()[3], damage.bounds());
+    EXPECT_EQ(damage[0], damage.bounds());
 
     // Add one rect per tile.
     damage = Damage(IntSize { 512, 512 });
@@ -481,83 +455,101 @@ TEST(Damage, Unite)
     EXPECT_EQ(damage.size(), 3);
     EXPECT_TRUE(damage.add(IntRect { 300, 300, 4, 4 }));
     EXPECT_EQ(damage.size(), 4);
-    EXPECT_FALSE(damage.rects()[0].isEmpty());
-    EXPECT_EQ(damage.rects()[0].x(), 0);
-    EXPECT_EQ(damage.rects()[0].y(), 0);
-    EXPECT_EQ(damage.rects()[0].width(), 4);
-    EXPECT_EQ(damage.rects()[0].height(), 4);
-    EXPECT_FALSE(damage.rects()[1].isEmpty());
-    EXPECT_EQ(damage.rects()[1].x(), 300);
-    EXPECT_EQ(damage.rects()[1].y(), 0);
-    EXPECT_EQ(damage.rects()[1].width(), 4);
-    EXPECT_EQ(damage.rects()[1].height(), 4);
-    EXPECT_FALSE(damage.rects()[2].isEmpty());
-    EXPECT_EQ(damage.rects()[2].x(), 0);
-    EXPECT_EQ(damage.rects()[2].y(), 300);
-    EXPECT_EQ(damage.rects()[2].width(), 4);
-    EXPECT_EQ(damage.rects()[2].height(), 4);
-    EXPECT_FALSE(damage.rects()[3].isEmpty());
-    EXPECT_EQ(damage.rects()[3].x(), 300);
-    EXPECT_EQ(damage.rects()[3].y(), 300);
-    EXPECT_EQ(damage.rects()[3].width(), 4);
-    EXPECT_EQ(damage.rects()[3].height(), 4);
-    EXPECT_EQ(damage.nonEmptyRects().size(), 4);
+    EXPECT_EQ(damage[0], IntRect(0, 0, 4, 4));
+    EXPECT_EQ(damage[1], IntRect(300, 0, 4, 4));
+    EXPECT_EQ(damage[2], IntRect(0, 300, 4, 4));
+    EXPECT_EQ(damage[3], IntRect(300, 300, 4, 4));
+    EXPECT_EQ(damage.rectsForTesting().size(), 4);
+    EXPECT_EQ(damage.rectsForTesting()[0], damage[0]);
+    EXPECT_EQ(damage.rectsForTesting()[1], damage[1]);
+    EXPECT_EQ(damage.rectsForTesting()[2], damage[2]);
+    EXPECT_EQ(damage.rectsForTesting()[3], damage[3]);
+    size_t i = 0;
+    for (const auto& rect : damage)
+        EXPECT_EQ(damage[i++], rect);
+
+    // Add several rects to each tile.
+    damage = Damage(IntSize { 512, 512 });
+    EXPECT_TRUE(damage.add(IntRect { 0, 0, 4, 4 }));
+    EXPECT_EQ(damage.size(), 1);
+    EXPECT_TRUE(damage.add(IntRect { 300, 0, 4, 4 }));
+    EXPECT_EQ(damage.size(), 2);
+    EXPECT_TRUE(damage.add(IntRect { 0, 300, 4, 4 }));
+    EXPECT_EQ(damage.size(), 3);
+    EXPECT_TRUE(damage.add(IntRect { 300, 300, 4, 4 }));
+    EXPECT_EQ(damage.size(), 4);
+    EXPECT_TRUE(damage.add(IntRect { 200, 0, 4, 4 }));
+    EXPECT_EQ(damage.size(), 4);
+    EXPECT_TRUE(damage.add(IntRect { 500, 0, 4, 4 }));
+    EXPECT_EQ(damage.size(), 4);
+    EXPECT_TRUE(damage.add(IntRect { 200, 300, 4, 4 }));
+    EXPECT_EQ(damage.size(), 4);
+    EXPECT_TRUE(damage.add(IntRect { 500, 300, 4, 4 }));
+    EXPECT_EQ(damage.size(), 4);
+    EXPECT_EQ(damage[0], IntRect(0, 0, 204, 4));
+    EXPECT_EQ(damage[1], IntRect(300, 0, 204, 4));
+    EXPECT_EQ(damage[2], IntRect(0, 300, 204, 4));
+    EXPECT_EQ(damage[3], IntRect(300, 300, 204, 4));
+    EXPECT_EQ(damage.rectsForTesting().size(), 4);
+    EXPECT_EQ(damage.rectsForTesting()[0], damage[0]);
+    EXPECT_EQ(damage.rectsForTesting()[1], damage[1]);
+    EXPECT_EQ(damage.rectsForTesting()[2], damage[2]);
+    EXPECT_EQ(damage.rectsForTesting()[3], damage[3]);
+    i = 0;
+    for (const auto& rect : damage)
+        EXPECT_EQ(damage[i++], rect);
 
     // Add rects with points off the grid area.
     damage = Damage(IntSize { 512, 512 });
     EXPECT_TRUE(damage.add(IntRect { -2, 0, 4, 4 }));
     EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage.rectsForTesting().size(), 1);
     EXPECT_TRUE(damage.add(IntRect { 50, -2, 4, 4 }));
     EXPECT_EQ(damage.size(), 2);
+    EXPECT_EQ(damage.rectsForTesting().size(), 2);
     EXPECT_TRUE(damage.add(IntRect { 550, 0, 4, 4 }));
     EXPECT_EQ(damage.size(), 3);
+    EXPECT_EQ(damage.rectsForTesting().size(), 3);
     EXPECT_TRUE(damage.add(IntRect { 300, -2, 4, 4 }));
     EXPECT_EQ(damage.size(), 4);
+    EXPECT_EQ(damage.rectsForTesting().size(), 4);
     EXPECT_TRUE(damage.add(IntRect { -2, 300, 4, 4 }));
-    EXPECT_EQ(damage.size(), 4);
+    EXPECT_EQ(damage.size(), 3);
+    EXPECT_EQ(damage.rectsForTesting().size(), 4);
     EXPECT_TRUE(damage.add(IntRect { 50, 550, 4, 4 }));
-    EXPECT_EQ(damage.size(), 4);
+    EXPECT_EQ(damage.size(), 3);
+    EXPECT_EQ(damage.rectsForTesting().size(), 4);
     EXPECT_TRUE(damage.add(IntRect { 300, 550, 4, 4 }));
     EXPECT_EQ(damage.size(), 4);
+    EXPECT_EQ(damage.rectsForTesting().size(), 4);
     EXPECT_TRUE(damage.add(IntRect { 550, 300, 4, 4 }));
     EXPECT_EQ(damage.size(), 4);
-    EXPECT_FALSE(damage.rects()[0].isEmpty());
-    EXPECT_EQ(damage.rects()[0].x(), -2);
-    EXPECT_EQ(damage.rects()[0].y(), -2);
-    EXPECT_EQ(damage.rects()[0].width(), 56);
-    EXPECT_EQ(damage.rects()[0].height(), 6);
-    EXPECT_FALSE(damage.rects()[1].isEmpty());
-    EXPECT_EQ(damage.rects()[1].x(), 300);
-    EXPECT_EQ(damage.rects()[1].y(), -2);
-    EXPECT_EQ(damage.rects()[1].width(), 254);
-    EXPECT_EQ(damage.rects()[1].height(), 6);
-    EXPECT_FALSE(damage.rects()[2].isEmpty());
-    EXPECT_EQ(damage.rects()[2].x(), -2);
-    EXPECT_EQ(damage.rects()[2].y(), 300);
-    EXPECT_EQ(damage.rects()[2].width(), 56);
-    EXPECT_EQ(damage.rects()[2].height(), 254);
-    EXPECT_FALSE(damage.rects()[3].isEmpty());
-    EXPECT_EQ(damage.rects()[3].x(), 300);
-    EXPECT_EQ(damage.rects()[3].y(), 300);
-    EXPECT_EQ(damage.rects()[3].width(), 254);
-    EXPECT_EQ(damage.rects()[3].height(), 254);
-    EXPECT_EQ(damage.nonEmptyRects().size(), 4);
+    EXPECT_EQ(damage.rectsForTesting().size(), 4);
+    EXPECT_EQ(damage[0], IntRect(-2, -2, 56, 6));
+    EXPECT_EQ(damage[1], IntRect(300, -2, 254, 6));
+    EXPECT_EQ(damage[2], IntRect(-2, 300, 56, 254));
+    EXPECT_EQ(damage[3], IntRect(300, 300, 254, 254));
 
     // Add several rects and check that unite works for single tile grid.
     damage = Damage(IntSize { 128, 128 });
     EXPECT_TRUE(damage.add(IntRect { 10, 10, 4, 4 }));
     EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage[0], damage.bounds());
     EXPECT_TRUE(damage.add(IntRect { 60, 60, 4, 4 }));
     EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage[0], damage.bounds());
     EXPECT_TRUE(damage.add(IntRect { 70, 10, 4, 4 }));
     EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage[0], damage.bounds());
     EXPECT_TRUE(damage.add(IntRect { 120, 60, 4, 4 }));
     EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage[0], damage.bounds());
     EXPECT_TRUE(damage.add(IntRect { 10, 70, 4, 4 }));
     EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage[0], damage.bounds());
     EXPECT_TRUE(damage.add(IntRect { 120, 120, 4, 4 }));
     EXPECT_EQ(damage.size(), 1);
-    EXPECT_EQ(damage.nonEmptyRects().size(), 1);
+    EXPECT_EQ(damage[0], damage.bounds());
 
     // Grid size should be ceiled.
     damage = Damage(IntSize { 512, 333 });
@@ -566,14 +558,12 @@ TEST(Damage, Unite)
     EXPECT_TRUE(damage.add(IntRect { 2, 2, 1, 1 }));
     EXPECT_TRUE(damage.add(IntRect { 3, 3, 1, 1 }));
     EXPECT_EQ(damage.size(), 4);
-    EXPECT_EQ(damage.nonEmptyRects().size(), 4);
 
     // Grid size should be ceiled with high precision.
     damage = Damage(IntSize { 257, 50 });
     EXPECT_TRUE(damage.add(IntRect { 0, 0, 1, 1 }));
     EXPECT_TRUE(damage.add(IntRect { 1, 1, 1, 1 }));
     EXPECT_EQ(damage.size(), 2);
-    EXPECT_EQ(damage.nonEmptyRects().size(), 2);
 
     // Unification should work correctly when grid does not start and { 0, 0 }.
     damage = Damage(IntRect { 256, 256, 512, 512 });
@@ -584,27 +574,31 @@ TEST(Damage, Unite)
     EXPECT_EQ(damage.size(), 4);
     EXPECT_TRUE(damage.add(IntRect { 301, 301, 1, 1 }));
     EXPECT_EQ(damage.size(), 4);
-    EXPECT_EQ(damage.rects()[0], IntRect(300, 300, 2, 2));
-    EXPECT_EQ(damage.rects()[1], IntRect(600, 300, 1, 1));
-    EXPECT_EQ(damage.rects()[2], IntRect(300, 600, 1, 1));
-    EXPECT_EQ(damage.rects()[3], IntRect(600, 600, 1, 1));
-    EXPECT_EQ(damage.nonEmptyRects().size(), 4);
+    EXPECT_EQ(damage[0], IntRect(300, 300, 2, 2));
+    EXPECT_EQ(damage[1], IntRect(600, 300, 1, 1));
+    EXPECT_EQ(damage[2], IntRect(300, 600, 1, 1));
+    EXPECT_EQ(damage[3], IntRect(600, 600, 1, 1));
 
     // Adding a rect covering the current bounding box makes the Damage no longer unified.
     damage = Damage(IntSize { 512, 512 });
     EXPECT_TRUE(damage.add(IntRect { 300, 0, 4, 4 }));
     EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage.rectsForTesting().size(), 1);
     EXPECT_TRUE(damage.add(IntRect { 500, 0, 4, 4 }));
     EXPECT_EQ(damage.size(), 2);
+    EXPECT_EQ(damage.rectsForTesting().size(), 2);
     EXPECT_TRUE(damage.add(IntRect { 300, 200, 4, 4 }));
     EXPECT_EQ(damage.size(), 3);
+    EXPECT_EQ(damage.rectsForTesting().size(), 3);
     EXPECT_TRUE(damage.add(IntRect { 500, 200, 4, 4 }));
     EXPECT_EQ(damage.size(), 4);
+    EXPECT_EQ(damage.rectsForTesting().size(), 4);
     EXPECT_TRUE(damage.add(IntRect { 384, 128, 4, 4 }));
-    EXPECT_EQ(damage.size(), 4);
+    EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage.rectsForTesting().size(), 4);
     EXPECT_TRUE(damage.add(IntRect { 250, 0, 254, 254 }));
     EXPECT_EQ(damage.size(), 1);
-    EXPECT_EQ(damage.nonEmptyRects().size(), 1);
+    EXPECT_EQ(damage.rectsForTesting().size(), 1);
 }
 
 TEST(Damage, MaxRectangles)
@@ -617,9 +611,8 @@ TEST(Damage, MaxRectangles)
         { 300, 300, 4, 4 }
     }));
     EXPECT_EQ(damage.size(), 2);
-    EXPECT_EQ(damage.rects()[0], IntRect(0, 0, 4, 304));
-    EXPECT_EQ(damage.rects()[1], IntRect(300, 0, 4, 304));
-    EXPECT_EQ(damage.nonEmptyRects().size(), 2);
+    EXPECT_EQ(damage[0], IntRect(0, 0, 4, 304));
+    EXPECT_EQ(damage[1], IntRect(300, 0, 4, 304));
 
     damage = Damage(IntSize { 2048, 1024 }, Damage::Mode::Rectangles, 3);
     EXPECT_TRUE(damage.add(Vector<IntRect, 1> {
@@ -629,10 +622,9 @@ TEST(Damage, MaxRectangles)
         { 1800, 800, 200, 200 }
     }));
     EXPECT_EQ(damage.size(), 3);
-    EXPECT_EQ(damage.rects()[0], IntRect(100, 100, 200, 200));
-    EXPECT_EQ(damage.rects()[1], IntRect(700, 500, 200, 200));
-    EXPECT_EQ(damage.rects()[2], IntRect(1400, 700, 600, 300));
-    EXPECT_EQ(damage.nonEmptyRects().size(), 3);
+    EXPECT_EQ(damage[0], IntRect(100, 100, 200, 200));
+    EXPECT_EQ(damage[1], IntRect(700, 500, 200, 200));
+    EXPECT_EQ(damage[2], IntRect(1400, 700, 600, 300));
 
     // Using MaxRectangles = 0 means no maximum so default fixed cell size is used
     damage = Damage(IntSize { 512, 512 }, Damage::Mode::Rectangles, 0);
@@ -644,11 +636,10 @@ TEST(Damage, MaxRectangles)
         { 384, 384, 4, 4 }
     }));
     EXPECT_EQ(damage.size(), 4);
-    EXPECT_EQ(damage.rects()[0], IntRect(0, 0, 4, 4));
-    EXPECT_EQ(damage.rects()[1], IntRect(300, 0, 4, 4));
-    EXPECT_EQ(damage.rects()[2], IntRect(0, 300, 4, 4));
-    EXPECT_EQ(damage.rects()[3], IntRect(300, 300, 88, 88));
-    EXPECT_EQ(damage.nonEmptyRects().size(), 4);
+    EXPECT_EQ(damage[0], IntRect(0, 0, 4, 4));
+    EXPECT_EQ(damage[1], IntRect(300, 0, 4, 4));
+    EXPECT_EQ(damage[2], IntRect(0, 300, 4, 4));
+    EXPECT_EQ(damage[3], IntRect(300, 300, 88, 88));
 
     // Passing MaxRectangles = 1 always unifies.
     damage = Damage(IntSize { 512, 512 }, Damage::Mode::Rectangles, 1);
@@ -660,9 +651,8 @@ TEST(Damage, MaxRectangles)
         { 384, 384, 4, 4 }
     }));
     EXPECT_EQ(damage.size(), 1);
-    EXPECT_EQ(damage.rects()[0], damage.bounds());
+    EXPECT_EQ(damage[0], damage.bounds());
     EXPECT_EQ(damage.bounds(), IntRect(0, 0, 388, 388));
-    EXPECT_EQ(damage.nonEmptyRects().size(), 1);
 
     // Passing MaxRectangles with BoundingBode mode ignores it.
     damage = Damage(IntSize { 1024, 768 }, Damage::Mode::BoundingBox, 2);
@@ -672,9 +662,8 @@ TEST(Damage, MaxRectangles)
         { 300, 300, 200, 200 }
     }));
     EXPECT_EQ(damage.size(), 1);
-    EXPECT_EQ(damage.rects()[0], damage.bounds());
+    EXPECT_EQ(damage[0], damage.bounds());
     EXPECT_EQ(damage.bounds(), IntRect(100, 100, 400, 400));
-    EXPECT_EQ(damage.nonEmptyRects().size(), 1);
 
     // Passing MaxRectangles with Full mode ignores it.
     damage = Damage(IntSize { 1024, 768 }, Damage::Mode::Full, 3);
@@ -683,9 +672,8 @@ TEST(Damage, MaxRectangles)
         { 300, 300, 200, 200 }
     }));
     EXPECT_EQ(damage.size(), 1);
-    EXPECT_EQ(damage.rects()[0], damage.bounds());
+    EXPECT_EQ(damage[0], damage.bounds());
     EXPECT_EQ(damage.bounds(), IntRect(0, 0, 1024, 768));
-    EXPECT_EQ(damage.nonEmptyRects().size(), 1);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 3de4a7eaf3f379b8147dd48ee98b4a24aa44684e
<pre>
[GTK][WPE] Make Damage iterable
<a href="https://bugs.webkit.org/show_bug.cgi?id=291358">https://bugs.webkit.org/show_bug.cgi?id=291358</a>

Reviewed by Nikolas Zimmermann.

Instead of exposing the internal vector we use for dirty rects, that can
contain empty rectangles after uniting, we can make Damage iterable and
always return the actual rectangles.

Canonical link: <a href="https://commits.webkit.org/296308@main">https://commits.webkit.org/296308@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a33d88f3136d3f58f79cf7a773e9781f3e01b2dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107656 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27332 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17746 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112868 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58196 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109613 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28024 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35926 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81741 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110589 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22216 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97030 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62121 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21650 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15169 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57630 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91588 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15203 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115986 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34732 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25639 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90780 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35109 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93280 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90526 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35444 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13217 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30489 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17463 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34638 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40194 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34384 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37745 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36047 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->