### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in FTPDirectoryParser.cpp

### DIFF
--- a/Source/WebCore/loader/FTPDirectoryParser.cpp
+++ b/Source/WebCore/loader/FTPDirectoryParser.cpp
@@ -145,10 +145,7 @@ FTPEntryType parseOneFTPLine(std::span<LChar> line, ListState& state, ListResult
                             while (pos < linelen && isASCIIDigit(line[pos]))
                                 pos++;
                             if (pos < linelen && line[pos] == ',') {
-                                unsigned long long seconds = 0;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-                                sscanf(byteCast<char>(p.subspan(1)).data(), "%llu", &seconds);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+                                uint64_t seconds = parseIntegerAllowingTrailingJunk<uint64_t>(StringView { p.subspan(1) }).value_or(0);
                                 time_t t = static_cast<time_t>(seconds);
 
                                 // FIXME: This code has the year 2038 bug
@@ -425,9 +422,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
                              * So its rounded up to the next block, so what, its better
                              * than not showing the size at all.
                              */
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-                            uint64_t size = strtoull(byteCast<char>(tokens[1]).data(), 0, 10) * 512;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+                            uint64_t size = parseIntegerAllowingTrailingJunk<uint64_t>(StringView { tokens[1] }).value_or(0) * 512;
                             result.fileSize = String::number(size);
                         }
 


### PR DESCRIPTION
#### bbb83e2395e4f2508e0c9b3ac9123145709196f9
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in FTPDirectoryParser.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=294439">https://bugs.webkit.org/show_bug.cgi?id=294439</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/loader/FTPDirectoryParser.cpp:
(WebCore::parseOneFTPLine):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bbb83e2395e4f2508e0c9b3ac9123145709196f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107717 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17806 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112927 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/58253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109672 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28084 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35920 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/81786 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/58253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110651 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/22261 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97078 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62174 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21686 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15222 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57689 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91633 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15255 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116048 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34793 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25637 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/90823 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35170 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93330 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90582 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23095 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35494 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13261 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34698 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/40253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34443 "Built successfully") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37805 "Failed to checkout and rebase branch from PR 46709") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36106 "Failed to checkout and rebase branch from PR 46709") | | | 
<!--EWS-Status-Bubble-End-->