### PR TITLE
Move Loading of BUILDBOT_SERVER_HOST into Password Util

### DIFF
--- a/Tools/CISupport/ews-app/ews/config.py
+++ b/Tools/CISupport/ews-app/ews/config.py
@@ -34,7 +34,7 @@ PATCH_FOLDER = '/tmp/'
 if is_test_mode_enabled:
     BUILDBOT_SERVER_HOST = 'localhost'
 else:
-    BUILDBOT_SERVER_HOST = f'ews-build.webkit{custom_suffix}.org'
+    BUILDBOT_SERVER_HOST = util.load_passowrd('BUILDBOT_SERVER_HOST')
 
 BUILDBOT_TRY_HOST = util.load_password('BUILDBOT_TRY_HOST', default=BUILDBOT_SERVER_HOST)
 


### PR DESCRIPTION
#### 4ca95b5c09e6fa752b8c78888c31a1fe54e012be
<pre>
Move Loading of BUILDBOT_SERVER_HOST into Password Util
<a href="https://bugs.webkit.org/show_bug.cgi?id=294443">https://bugs.webkit.org/show_bug.cgi?id=294443</a>
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Move Loading of BUILDBOT_SERVER_HOST into Password Util

* Tools/CISupport/ews-app/ews/config.py:
</pre>