### PR TITLE
[macOS] Unable to pause video playback in PiP mode

### DIFF
--- a/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
@@ -198,4 +198,20 @@ public:
 
 } // namespace WebCore
 
+namespace WTF {
+
+template <>
+struct LogArgument<OptionSet<WebCore::PlaybackSessionModel::PlaybackState>> {
+    static String toString(const OptionSet<WebCore::PlaybackSessionModel::PlaybackState> state)
+    {
+        if (!state.toRaw())
+            return "Paused"_s;
+        if (state.contains(WebCore::PlaybackSessionModel::PlaybackState::Stalled))
+            return "Stalled"_s;
+        return "Playing"_s;
+    }
+};
+
+}
+
 #endif // PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
@@ -146,6 +146,7 @@ private:
     void updateMediaSelectionOptions();
     void updateMediaSelectionIndices();
     void maybeUpdateVideoMetadata();
+    void updateRate();
 
     void videoTrackConfigurationChanged();
 

--- a/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
@@ -116,6 +116,8 @@ void PlaybackSessionInterfaceMac::currentTimeChanged(double currentTime, double 
 void PlaybackSessionInterfaceMac::rateChanged(OptionSet<PlaybackSessionModel::PlaybackState> playbackState, double playbackRate, double defaultPlaybackRate)
 {
 #if ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, "playbackState: ", playbackState, ", playbackRate: ", playbackRate);
+
     auto isPlaying = playbackState.contains(PlaybackSessionModel::PlaybackState::Playing);
     WebPlaybackControlsManager* controlsManager = playBackControlsManager();
     [controlsManager setDefaultPlaybackRate:defaultPlaybackRate fromJavaScript:YES];

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm
@@ -631,6 +631,7 @@ void VideoPresentationInterfaceMac::currentTimeChanged(double currentTime, doubl
 
 void VideoPresentationInterfaceMac::rateChanged(OptionSet<PlaybackSessionModel::PlaybackState> playbackState, double playbackRate, double /* defaultPlaybackRate */)
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, "playbackState: ", playbackState, ", playbackRate: ", playbackRate);
     AVPlayerTimeControlStatus timeControlStatus = AVPlayerTimeControlStatusPaused;
     if (playbackState.containsAll({ PlaybackSessionModel::PlaybackState::Stalled, PlaybackSessionModel::PlaybackState::Playing }))
         timeControlStatus = AVPlayerTimeControlStatusWaitingToPlayAtSpecifiedRate;


### PR DESCRIPTION
#### f3a0304bc66ce5f06298cab648e3adbe4ebd596f
<pre>
[macOS] Unable to pause video playback in PiP mode
<a href="https://rdar.apple.com/152192112">rdar://152192112</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=294449">https://bugs.webkit.org/show_bug.cgi?id=294449</a>

Reviewed by Eric Carlson.

From logging, it appears that the playback state of the WebContent process is becoming
out-of-sync with the cached playback state in the UIProcess. Without knowing exactly how
this synchronization failed, work around the issue by explicitly updating the cached
playback state whenever a play() or pause() command is issued by the UIProcess.

* Source/WebCore/platform/cocoa/PlaybackSessionModel.h:
(WTF::LogArgument&lt;OptionSet&lt;WebCore::PlaybackSessionModel::PlaybackState&gt;&gt;::toString):
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm:
(WebCore::PlaybackSessionModelMediaElement::updateForEventName):
(WebCore::PlaybackSessionModelMediaElement::play):
(WebCore::PlaybackSessionModelMediaElement::pause):
(WebCore::PlaybackSessionModelMediaElement::updateRate):
* Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm:
(WebCore::PlaybackSessionInterfaceMac::rateChanged):
* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm:
(WebCore::VideoPresentationInterfaceMac::rateChanged):

Canonical link: <a href="https://commits.webkit.org/296219@main">https://commits.webkit.org/296219@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/448627798d33d3c1de94a5a77f66ee05a02d247e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107711 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27385 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17800 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112921 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58247 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109666 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28078 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35993 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81781 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110645 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22256 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97071 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62168 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21683 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15214 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57683 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91627 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15247 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116042 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34787 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90819 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35164 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93323 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90578 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23101 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35490 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13255 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30542 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34692 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40247 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34437 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37799 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36100 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->