### PR TITLE
Unreviewed, reverting 296189@main (278f3a4e1280)

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -7,7 +7,6 @@ API/tests/testapi.cpp
 BytecodeStructs.h
 bytecode/InlineCacheCompiler.h
 bytecode/SharedJITStubSet.h
-bytecode/StructureStubClearingWatchpoint.h
 bytecompiler/BytecodeGenerator.h
 bytecompiler/Label.h
 debugger/Debugger.cpp

--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -27,7 +27,6 @@ bytecode/DirectEvalCodeCache.h
 bytecode/GetByStatus.cpp
 bytecode/InByStatus.cpp
 bytecode/InlineCacheCompiler.cpp
-bytecode/ObjectPropertyConditionSet.cpp
 bytecode/PolyProtoAccessChain.cpp
 bytecode/PropertyCondition.cpp
 bytecode/PutByStatus.cpp

--- a/Source/JavaScriptCore/parser/ModuleAnalyzer.h
+++ b/Source/JavaScriptCore/parser/ModuleAnalyzer.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "ErrorType.h"
-#include "JSModuleRecord.h"
 #include "Nodes.h"
 
 namespace JSC {

--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
@@ -225,7 +225,7 @@ void CanvasCaptureMediaStreamTrack::Source::captureCanvas()
 
     RefPtr videoFrame = [&]() -> RefPtr<VideoFrame> {
 #if ENABLE(WEBGL)
-        if (RefPtr gl = dynamicDowncast<WebGLRenderingContextBase>(canvas->renderingContext()))
+        if (auto* gl = dynamicDowncast<WebGLRenderingContextBase>(canvas->renderingContext()))
             return gl->surfaceBufferToVideoFrame(CanvasRenderingContext::SurfaceBuffer::DisplayBuffer);
 #endif
         return canvas->toVideoFrame();

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -366,7 +366,7 @@ static AtomString effectiveViewTransitionName(RenderLayerModelObject& renderer, 
 
     Ref element = *renderer.element();
     if (transitionName.isAuto() && scope == &Style::Scope::forNode(element) && element->hasID())
-        return makeAtomString("-ua-id-"_s, renderer.protectedElement()->getIdAttribute());
+        return makeAtomString("-ua-id-"_s, renderer.element()->getIdAttribute());
 
     if (isCrossDocument)
         return nullAtom();

--- a/Source/WebCore/html/FormAssociatedElement.h
+++ b/Source/WebCore/html/FormAssociatedElement.h
@@ -33,7 +33,6 @@ public:
     virtual ~FormAssociatedElement() { RELEASE_ASSERT(!m_form); }
     virtual HTMLElement& asHTMLElement() = 0;
     virtual const HTMLElement& asHTMLElement() const = 0;
-    Ref<const HTMLElement> asProtectedHTMLElement() const { return asHTMLElement(); }
     virtual bool isFormListedElement() const = 0;
 
     virtual void formWillBeDestroyed() { m_form = nullptr; }

--- a/Source/WebCore/html/FormController.cpp
+++ b/Source/WebCore/html/FormController.cpp
@@ -43,7 +43,7 @@ HTMLFormElement* FormController::ownerForm(const FormListedElement& control)
     // Assume controls with form attribute have no owners because we restore
     // state during parsing and form owners of such controls might be
     // indeterminate.
-    return control.asProtectedHTMLElement()->hasAttributeWithoutSynchronization(HTMLNames::formAttr) ? nullptr : control.form();
+    return control.asHTMLElement().hasAttributeWithoutSynchronization(HTMLNames::formAttr) ? nullptr : control.form();
 }
 
 struct AtomStringVectorReader {

--- a/Source/WebCore/html/FormListedElement.cpp
+++ b/Source/WebCore/html/FormListedElement.cpp
@@ -281,7 +281,7 @@ void FormListedElement::setCustomValidity(const String& error)
 void FormListedElement::resetFormAttributeTargetObserver()
 {
     ASSERT_WITH_SECURITY_IMPLICATION(asHTMLElement().isConnected());
-    m_formAttributeTargetObserver = makeUnique<FormAttributeTargetObserver>(asProtectedHTMLElement()->attributeWithoutSynchronization(formAttr), *this);
+    m_formAttributeTargetObserver = makeUnique<FormAttributeTargetObserver>(asHTMLElement().attributeWithoutSynchronization(formAttr), *this);
 }
 
 void FormListedElement::formAttributeTargetChanged()
@@ -291,7 +291,7 @@ void FormListedElement::formAttributeTargetChanged()
 
 const AtomString& FormListedElement::name() const
 {
-    const AtomString& name = asProtectedHTMLElement()->getNameAttribute();
+    const AtomString& name = asHTMLElement().getNameAttribute();
     return name.isNull() ? emptyAtom() : name;
 }
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2531,7 +2531,7 @@ bool Page::shouldUpdateAccessibilityRegions() const
         if (RefPtr localMainFrame = this->localMainFrame())
             protectedMainDocument = localMainFrame ? localMainFrame->document() : nullptr;
         else if (RefPtr remoteFrame = dynamicDowncast<RemoteFrame>(mainFrame())) {
-            if (RefPtr owner = remoteFrame->ownerElement())
+            if (auto* owner = remoteFrame->ownerElement())
                 protectedMainDocument = owner->document();
         }
 

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
@@ -184,7 +184,7 @@ enum class FeatureToAnimate {
 
     ASSERT_UNUSED(scrollerImp, scrollerImp == _scroller->scrollerImp());
 
-    return CheckedPtr { _scroller }->lastKnownMousePositionInScrollbar();
+    return _scroller->lastKnownMousePositionInScrollbar();
 }
 
 - (NSRect)convertRectToLayer:(NSRect)rect
@@ -237,7 +237,7 @@ enum class FeatureToAnimate {
         return;
 
     ASSERT_UNUSED(scrollerImp, scrollerImp == _scroller->scrollerImp());
-    CheckedPtr { _scroller }->visibilityChanged(newKnobAlpha > 0);
+    _scroller->visibilityChanged(newKnobAlpha > 0);
     [self setUpAlphaAnimation:_knobAlphaAnimation featureToAnimate:FeatureToAnimate::KnobAlpha animateAlphaTo:newKnobAlpha duration:duration];
 }
 

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
@@ -92,11 +92,7 @@ public:
 
     // Only for use by WebScrollerImpPairDelegateMac. Do not use elsewhere!
     ScrollerMac& verticalScroller() { return m_verticalScroller; }
-    CheckedRef<ScrollerMac> checkedVerticalScroller()  { return m_verticalScroller; }
-    CheckedRef<const ScrollerMac> checkedVerticalScroller() const { return m_verticalScroller; }
     ScrollerMac& horizontalScroller() { return m_horizontalScroller; }
-    CheckedRef<ScrollerMac> checkedHorizontalScroller() { return m_horizontalScroller; }
-    CheckedRef<const ScrollerMac> checkedHorizontalScroller() const { return m_horizontalScroller; }
 
     String scrollbarStateForOrientation(ScrollbarOrientation) const;
 

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
@@ -60,31 +60,28 @@ void ScrollingTreeScrollingNodeDelegateMac::nodeWillBeDestroyed()
 
 void ScrollingTreeScrollingNodeDelegateMac::updateFromStateNode(const ScrollingStateScrollingNode& scrollingStateNode)
 {
-    CheckedRef horizontalScroller = m_scrollerPair->horizontalScroller();
-    CheckedRef verticalScroller = m_scrollerPair->verticalScroller();
-
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::PainterForScrollbar)) {
         auto horizontalScrollbar = scrollingStateNode.horizontalScrollerImp();
         auto verticalScrollbar = scrollingStateNode.verticalScrollerImp();
         if (horizontalScrollbar || verticalScrollbar) {
             m_scrollerPair->releaseReferencesToScrollerImpsOnTheMainThread();
-            horizontalScroller->setScrollerImp(horizontalScrollbar);
-            verticalScroller->setScrollerImp(verticalScrollbar);
+            m_scrollerPair->horizontalScroller().setScrollerImp(horizontalScrollbar);
+            m_scrollerPair->verticalScroller().setScrollerImp(verticalScrollbar);
         }
     }
-
+    
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollbarHoverState))
         m_scrollerPair->mouseIsInScrollbar(scrollingStateNode.scrollbarHoverState());
-
+    
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::HorizontalScrollbarLayer))
-        horizontalScroller->setHostLayer(static_cast<CALayer*>(scrollingStateNode.horizontalScrollbarLayer()));
-
+        m_scrollerPair->horizontalScroller().setHostLayer(static_cast<CALayer*>(scrollingStateNode.horizontalScrollbarLayer()));
+    
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::VerticalScrollbarLayer))
-        verticalScroller->setHostLayer(static_cast<CALayer*>(scrollingStateNode.verticalScrollbarLayer()));
+        m_scrollerPair->verticalScroller().setHostLayer(static_cast<CALayer*>(scrollingStateNode.verticalScrollbarLayer()));
 
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollableAreaParams)) {
-        horizontalScroller->setHiddenByStyle(scrollingStateNode.scrollableAreaParameters().horizontalNativeScrollbarVisibility);
-        verticalScroller->setHiddenByStyle(scrollingStateNode.scrollableAreaParameters().verticalNativeScrollbarVisibility);
+        m_scrollerPair->horizontalScroller().setHiddenByStyle(scrollingStateNode.scrollableAreaParameters().horizontalNativeScrollbarVisibility);
+        m_scrollerPair->verticalScroller().setHiddenByStyle(scrollingStateNode.scrollableAreaParameters().verticalNativeScrollbarVisibility);
     }
 
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollbarEnabledState)) {
@@ -95,8 +92,8 @@ void ScrollingTreeScrollingNodeDelegateMac::updateFromStateNode(const ScrollingS
 
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollbarLayoutDirection)) {
         auto scrollbarLayoutDirection = scrollingStateNode.scrollbarLayoutDirection();
-        horizontalScroller->setScrollbarLayoutDirection(scrollbarLayoutDirection);
-        verticalScroller->setScrollbarLayoutDirection(scrollbarLayoutDirection);
+        m_scrollerPair->horizontalScroller().setScrollbarLayoutDirection(scrollbarLayoutDirection);
+        m_scrollerPair->verticalScroller().setScrollbarLayoutDirection(scrollbarLayoutDirection);
     }
 
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollbarWidth)) {

--- a/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
@@ -64,7 +64,7 @@ void RenderSVGResourceContainer::styleDidChange(StyleDifference diff, const Rend
 void RenderSVGResourceContainer::idChanged()
 {
     // Remove old id, that is guaranteed to be present in cache.
-    m_id = protectedElement()->getIdAttribute();
+    m_id = element().getIdAttribute();
 
     registerResource();
 }

--- a/Source/WebCore/style/values/color/StyleLightDarkColor.cpp
+++ b/Source/WebCore/style/values/color/StyleLightDarkColor.cpp
@@ -40,7 +40,7 @@ Color toStyleColor(const CSS::LightDarkColor& unresolved, ColorResolutionState& 
     ColorResolutionStateNester nester { state };
 
     Ref<const Document> document = state.document;
-    if (document->useDarkAppearance(CheckedRef { state.style }.ptr()))
+    if (document->useDarkAppearance(&state.style))
         return toStyleColor(unresolved.darkColor, state);
     return toStyleColor(unresolved.lightColor, state);
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm
@@ -39,7 +39,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKNavigationResponse.class, self))
         return;
 
-    RefPtr { _navigationResponse.get() }->~NavigationResponse();
+    _navigationResponse->~NavigationResponse();
 
     [super dealloc];
 }
@@ -83,7 +83,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (WKFrameInfo *)_navigationInitiatingFrame
 {
-    return wrapper(RefPtr { _navigationResponse.get() }->navigationInitiatingFrame());
+    return wrapper(_navigationResponse->navigationInitiatingFrame());
 }
 
 - (WKNavigation *)_navigation

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKThumbnailView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKThumbnailView.mm
@@ -220,7 +220,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [self _requestSnapshotIfNeeded];
 
     if (!_exclusivelyUsesSnapshot) {
-        auto obscuredContentInsets = RefPtr { _webPageProxy.get() }->obscuredContentInsets();
+        auto obscuredContentInsets = _webPageProxy->obscuredContentInsets();
         self._sublayerTranslation = CGPointMake(-obscuredContentInsets.left(), -obscuredContentInsets.top());
         if (_wkView) {
             [_wkView _setThumbnailView:self];

--- a/Source/WebKit/UIProcess/mac/WKTextAnimationManager.mm
+++ b/Source/WebKit/UIProcess/mac/WKTextAnimationManager.mm
@@ -234,7 +234,7 @@
             return;
         }
 
-        RefPtr snapshot = textIndicator->contentImage();
+        auto snapshot = textIndicator->contentImage();
         if (!snapshot) {
             completionHandler(nil);
             return;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebCryptoClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebCryptoClient.cpp
@@ -29,7 +29,6 @@
 #include "WebPageProxyMessages.h"
 #include "WebProcess.h"
 #include "WebProcessProxyMessages.h"
-#include <WebCore/CryptoKeyData.h>
 #include <WebCore/SerializedCryptoKeyWrap.h>
 #include <WebCore/WrappedCryptoKey.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebKitLegacy/mac/WebCoreSupport/TextIndicatorWindow.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/TextIndicatorWindow.mm
@@ -127,7 +127,7 @@ void TextIndicatorWindow::setTextIndicator(Ref<WebCore::TextIndicator> textIndic
     [m_textIndicatorView setWantsLayer:YES];
     [m_textIndicatorWindow setContentView:m_textIndicatorView.get()];
 
-    [[m_targetView.get() window] addChildWindow:m_textIndicatorWindow.get() ordered:NSWindowAbove];
+    [[m_targetView window] addChildWindow:m_textIndicatorWindow.get() ordered:NSWindowAbove];
     [m_textIndicatorWindow setReleasedWhenClosed:NO];
 
     if (m_textIndicator->presentationTransition() != WebCore::TextIndicatorPresentationTransition::None)


### PR DESCRIPTION
#### a955385f172aa5e3f0e0422ff28f543100f1c2d5
<pre>
Unreviewed, reverting 296189@main (278f3a4e1280)
<a href="https://bugs.webkit.org/show_bug.cgi?id=294452">https://bugs.webkit.org/show_bug.cgi?id=294452</a>
<a href="https://rdar.apple.com/153318679">rdar://153318679</a>

REGRESSION (296189@main): [macOS Debug] multiple fast/ tests are crashing

Reverted change:

    Fix recent Safer CPP bot regressions
    <a href="https://bugs.webkit.org/show_bug.cgi?id=294238">https://bugs.webkit.org/show_bug.cgi?id=294238</a>
    296189@main (278f3a4e1280)

Canonical link: <a href="https://commits.webkit.org/296205@main">https://commits.webkit.org/296205@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3c4316020f75017710e062e26f5dc701291b72e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107715 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17804 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/112925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/58251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109670 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28082 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35918 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/81783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/58251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110649 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/22260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/97076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/62171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/21685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/15220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/57687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/100298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/91631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/15253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/116046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/106255 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/34791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/116046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/35168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/93328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/116046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/13259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/17415 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/34696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/40251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/130570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/34441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/35490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/37803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/36104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->