### PR TITLE
AX: expose DOM identifiers via accessibilityIdentifier

### DIFF
--- a/LayoutTests/platform/ios/imported/blink/accessibility/link-inside-label-expected.txt
+++ b/LayoutTests/platform/ios/imported/blink/accessibility/link-inside-label-expected.txt
@@ -2,4 +2,4 @@ Row 1  More info Do something
 This tests that a link element present inside a label element is accessible when label has more than one child.
 
 
-Role was:WebCoreLink
+Role was:Link

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -2282,6 +2282,17 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 
+- (NSString *)accessibilityIdentifier
+{
+    RetainPtr userDefaults = adoptNS([[NSUserDefaults alloc] initWithSuiteName:@"com.apple.Accessibility"]);
+    if ([userDefaults boolForKey:@"AXEnableWebKitDOMIdentifier"]) {
+        auto* backingObject = self.updateObjectBackingStore;
+        return backingObject ? backingObject->identifierAttribute().createNSString().autorelease() : nil;
+    }
+
+    return nil;
+}
+
 - (void)accessibilityPerformPressAction
 {
     // In case anything we do by performing the press action causes an alert or other modal


### PR DESCRIPTION
#### 69e740927c3c026e18d65c4f8334d3347abdf9ba
<pre>
AX: expose DOM identifiers via accessibilityIdentifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=294462">https://bugs.webkit.org/show_bug.cgi?id=294462</a>
<a href="https://rdar.apple.com/153311467">rdar://153311467</a>

Reviewed by NOBODY (OOPS!).

When the `AXEnableWebKitDOMIdentifier` Accessibility user default is set to YES, allow
DOM identifiers to be returned via the accessibilityIdentifier method in the mac wrapper.

* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilityIdentifier]):
</pre>
----------------------------------------------------------------------
#### 9918acd7749a5ba3beb41596e4f8e0cee09d887d
<pre>
REGRESSION(295356@main): [ iOS ] imported/blink/accessibility/link-inside-label.html is a constant failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=294215">https://bugs.webkit.org/show_bug.cgi?id=294215</a>
<a href="https://rdar.apple.com/152857898">rdar://152857898</a>

Reviewed by NOBODY (OOPS!).

Removes last remaining WebCoreLink reference.

* LayoutTests/platform/ios/imported/blink/accessibility/link-inside-label-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69e740927c3c026e18d65c4f8334d3347abdf9ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107725 "Failed to checkout and rebase branch from PR 46722") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27399 "Failed to checkout and rebase branch from PR 46722") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17814 "Failed to checkout and rebase branch from PR 46722") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112935 "Failed to checkout and rebase branch from PR 46722") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/58261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109680 "Failed to checkout and rebase branch from PR 46722") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28092 "Failed to checkout and rebase branch from PR 46722") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35935 "Failed to checkout and rebase branch from PR 46722") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/112935 "Failed to checkout and rebase branch from PR 46722") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/58261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110659 "Failed to checkout and rebase branch from PR 46722") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/28092 "Failed to checkout and rebase branch from PR 46722") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/17814 "Failed to checkout and rebase branch from PR 46722") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/112935 "Failed to checkout and rebase branch from PR 46722") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/28092 "Failed to checkout and rebase branch from PR 46722") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/17814 "Failed to checkout and rebase branch from PR 46722") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/57697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/28092 "Failed to checkout and rebase branch from PR 46722") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/17814 "Failed to checkout and rebase branch from PR 46722") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116056 "Failed to checkout and rebase branch from PR 46722") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34801 "Failed to checkout and rebase branch from PR 46722") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/35935 "Failed to checkout and rebase branch from PR 46722") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/116056 "Failed to checkout and rebase branch from PR 46722") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/35178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/17814 "Failed to checkout and rebase branch from PR 46722") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/116056 "Failed to checkout and rebase branch from PR 46722") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/17814 "Failed to checkout and rebase branch from PR 46722") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34706 "Failed to checkout and rebase branch from PR 46722") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/40261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/34451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/37813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/36114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->