### PR TITLE
AX: Add tests for RTL/LTR bidi text

### DIFF
--- a/LayoutTests/accessibility/text-marker/text-marker-bidi-element-arabic-expected.txt
+++ b/LayoutTests/accessibility/text-marker/text-marker-bidi-element-arabic-expected.txt
@@ -1,0 +1,36 @@
+This test verifies that a combination of Arabic and English is read correctly by Accessibility, when using CSS unicode-bidi property.
+
+PASS: rangeLength === 28
+PASS: ltrCount === 22
+PASS: rtlCount === 7
+PASS: staticText.stringForTextMarkerRange(staticTextTextMarkerRange).trim() === 'Anyone can try لغة برمجة C++'
+PASS: rangeLength === 28
+PASS: ltrCount === 22
+PASS: rtlCount === 7
+PASS: staticText.stringForTextMarkerRange(staticTextTextMarkerRange).trim() === 'Anyone can try لغة برمجة C++'
+PASS: rangeLength === 28
+PASS: ltrCount === 22
+PASS: rtlCount === 7
+PASS: staticText.stringForTextMarkerRange(staticTextTextMarkerRange).trim() === 'Anyone can try لغة برمجة C++'
+PASS: rangeLength === 28
+PASS: ltrCount === 22
+PASS: rtlCount === 7
+PASS: staticText.stringForTextMarkerRange(staticTextTextMarkerRange).trim() === 'Anyone can try لغة برمجة C++'
+PASS: rangeLength === 28
+PASS: ltrCount === 28
+PASS: rtlCount === 0
+PASS: staticText.stringForTextMarkerRange(staticTextTextMarkerRange).trim() === 'Anyone can try لغة برمجة C++'
+PASS: rangeLength === 28
+PASS: ltrCount === 28
+PASS: rtlCount === 0
+PASS: staticText.stringForTextMarkerRange(staticTextTextMarkerRange).trim() === 'Anyone can try لغة برمجة C++'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Anyone can try لغة برمجة C++
+Anyone can try لغة برمجة C++
+Anyone can try لغة برمجة C++
+Anyone can try لغة برمجة C++
+Anyone can try لغة برمجة C++
+Anyone can try لغة برمجة C++

--- a/LayoutTests/accessibility/text-marker/text-marker-bidi-element-arabic.html
+++ b/LayoutTests/accessibility/text-marker/text-marker-bidi-element-arabic.html
@@ -1,0 +1,115 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<style>
+.unicode-bidi-normal {
+    unicode-bidi: normal;
+}
+.unicode-bidi-embed {
+    unicode-bidi: embed;
+}
+.unicode-bidi-bidi-override {
+    unicode-bidi: bidi-override;
+}
+.unicode-bidi-plaintext {
+    unicode-bidi: plaintext;
+}
+.unicode-bidi-isolate {
+    unicode-bidi: isolate;
+}
+.unicode-bidi-isolate-override {
+    unicode-bidi: isolate-override;
+}
+</style>
+</head>
+
+<body>
+<div id="content-normal" class="unicode-bidi-normal">Anyone can try لغة برمجة C++</div>
+<div id="content-embed" class="unicode-bidi-embed">Anyone can try لغة برمجة C++</div>
+<div id="content-bidi-override" class="unicode-bidi-bidi-override">Anyone can try لغة برمجة C++</div>
+<div id="content-plaintext" class="unicode-bidi-plaintext">Anyone can try لغة برمجة C++</div>
+<div id="content-isolate" class="unicode-bidi-isolate">Anyone can try لغة برمجة C++</div>
+<div id="content-isolate-override" class="unicode-bidi-isolate-override">Anyone can try لغة برمجة C++</div>
+<script>
+
+// This is essentially expectRectWithVariance, but uses data from
+// boundsForRange directly, instead of building out a template
+// string for the expectedRect tuple (see accessibility-helper.js)
+function getRectWidthFromBoundsForRange(boundsForRangeData) {
+    const parsedResult = boundsForRangeData
+        .replaceAll(/{|}/g, '')
+        .split(/[ ,]+/)
+        .map(token => parseFloat(token))
+        .filter(float => !isNaN(float));
+    if (parsedResult.length !== 4) {
+        debug(`FAIL: Expression ${boundsForRangeData} didn't produce a string result with four numbers (was ${parsedResult}).\n`);
+    }
+    return parsedResult[2]
+}
+var output = "This test verifies that a combination of Arabic and English is read correctly by Accessibility, when using CSS unicode-bidi property.\n\n";
+
+if (window.accessibilityController) {
+    var testIDs = ["content-normal", "content-embed", "content-plaintext", "content-isolate"] 
+    var testOverrideIDs = ["content-bidi-override", "content-isolate-override"]
+    var staticText, staticTextTextMarkerRange, startMarker, endMarker, rangeLength, maxBounds, lastBounds, currentBounds;
+    var ltrCount = 0;
+    var rtlCount = 0;
+    testIDs.forEach(testID => {
+        ltrCount = 0;
+        rtlCount = 0;
+        staticText = accessibilityController.accessibleElementById(testID).childAtIndex(0);
+        staticTextTextMarkerRange = staticText.textMarkerRangeForElement(staticText);
+        rangeLength = staticText.textMarkerRangeLength(staticTextTextMarkerRange);
+        output += expect("rangeLength", "28");
+        maxBounds = getRectWidthFromBoundsForRange(staticText.boundsForRange(0, 28));
+
+        lastBounds = -1;
+        for (let i = 0; i <= rangeLength; i++) {
+            currentBounds = getRectWidthFromBoundsForRange(staticText.boundsForRange(0, i));
+            if (currentBounds > lastBounds) {
+                ltrCount++;
+            }
+            if (currentBounds < lastBounds) {
+                rtlCount++;
+            }
+            lastBounds = currentBounds;
+        }
+        output += expect("ltrCount", "22");
+        output += expect("rtlCount", "7");
+        output += expect("staticText.stringForTextMarkerRange(staticTextTextMarkerRange).trim()", "'Anyone can try لغة برمجة C++'")
+    });
+
+    testOverrideIDs.forEach(testOverrideID => {
+        ltrCount = 0;
+        rtlCount = 0;
+        staticText = accessibilityController.accessibleElementById(testOverrideID).childAtIndex(0);
+        staticTextTextMarkerRange = staticText.textMarkerRangeForElement(staticText);
+        rangeLength = staticText.textMarkerRangeLength(staticTextTextMarkerRange);
+        output += expect("rangeLength", "28");
+        maxBounds = getRectWidthFromBoundsForRange(staticText.boundsForRange(0, 28));
+
+        lastBounds = -1;
+        for (let i = 0; i < rangeLength; i++) {
+            currentBounds = getRectWidthFromBoundsForRange(staticText.boundsForRange(0, i));
+            if (currentBounds > lastBounds) {
+                ltrCount++;
+            }
+            if (currentBounds < lastBounds) {
+                rtlCount++;
+            }
+            lastBounds = currentBounds;
+        }
+        output += expect("ltrCount", "28");
+        output += expect("rtlCount", "0");
+
+        output += expect("staticText.stringForTextMarkerRange(staticTextTextMarkerRange).trim()", "'Anyone can try لغة برمجة C++'")
+    });
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/text-marker/text-marker-bidi-element-hebrew-expected.txt
+++ b/LayoutTests/accessibility/text-marker/text-marker-bidi-element-hebrew-expected.txt
@@ -1,0 +1,36 @@
+This test verifies that a combination of Hebrew and English is read correctly by Accessibility, when using CSS unicode-bidi property.
+
+PASS: rangeLength === 28
+PASS: ltrCount === 22
+PASS: rtlCount === 7
+PASS: staticText.stringForTextMarkerRange(staticTextTextMarkerRange).trim() === 'Anyone can try שפת תכנות C++'
+PASS: rangeLength === 28
+PASS: ltrCount === 22
+PASS: rtlCount === 7
+PASS: staticText.stringForTextMarkerRange(staticTextTextMarkerRange).trim() === 'Anyone can try שפת תכנות C++'
+PASS: rangeLength === 28
+PASS: ltrCount === 22
+PASS: rtlCount === 7
+PASS: staticText.stringForTextMarkerRange(staticTextTextMarkerRange).trim() === 'Anyone can try שפת תכנות C++'
+PASS: rangeLength === 28
+PASS: ltrCount === 22
+PASS: rtlCount === 7
+PASS: staticText.stringForTextMarkerRange(staticTextTextMarkerRange).trim() === 'Anyone can try שפת תכנות C++'
+PASS: rangeLength === 28
+PASS: ltrCount === 28
+PASS: rtlCount === 0
+PASS: staticText.stringForTextMarkerRange(staticTextTextMarkerRange).trim() === 'Anyone can try שפת תכנות C++'
+PASS: rangeLength === 28
+PASS: ltrCount === 28
+PASS: rtlCount === 0
+PASS: staticText.stringForTextMarkerRange(staticTextTextMarkerRange).trim() === 'Anyone can try שפת תכנות C++'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Anyone can try שפת תכנות C++
+Anyone can try שפת תכנות C++
+Anyone can try שפת תכנות C++
+Anyone can try שפת תכנות C++
+Anyone can try שפת תכנות C++
+Anyone can try שפת תכנות C++

--- a/LayoutTests/accessibility/text-marker/text-marker-bidi-element-hebrew.html
+++ b/LayoutTests/accessibility/text-marker/text-marker-bidi-element-hebrew.html
@@ -1,0 +1,117 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<style>
+.unicode-bidi-normal {
+    unicode-bidi: normal;
+}
+.unicode-bidi-embed {
+    unicode-bidi: embed;
+}
+.unicode-bidi-bidi-override {
+    unicode-bidi: bidi-override;
+}
+.unicode-bidi-plaintext {
+    unicode-bidi: plaintext;
+}
+.unicode-bidi-isolate {
+    unicode-bidi: isolate;
+}
+.unicode-bidi-isolate-override {
+    unicode-bidi: isolate-override;
+}
+</style>
+</head>
+
+<body>
+<div id="content-normal" class="unicode-bidi-normal">Anyone can try שפת תכנות C++</div>
+<div id="content-embed" class="unicode-bidi-embed">Anyone can try שפת תכנות C++</div>
+<div id="content-bidi-override" class="unicode-bidi-bidi-override">Anyone can try שפת תכנות C++</div>
+<div id="content-plaintext" class="unicode-bidi-plaintext">Anyone can try שפת תכנות C++</div>
+<div id="content-isolate" class="unicode-bidi-isolate">Anyone can try שפת תכנות C++</div>
+<div id="content-isolate-override" class="unicode-bidi-isolate-override">Anyone can try שפת תכנות C++</div>
+<script>
+
+// This is essentially expectRectWithVariance, but uses data from
+// boundsForRange directly, instead of building out a template
+// string for the expectedRect tuple (see accessibility-helper.js)
+function getRectWidthFromBoundsForRange(boundsForRangeData) {
+    const parsedResult = boundsForRangeData
+        .replaceAll(/{|}/g, '')
+        .split(/[ ,]+/)
+        .map(token => parseFloat(token))
+        .filter(float => !isNaN(float));
+    if (parsedResult.length !== 4) {
+        debug(`FAIL: Expression ${boundsForRangeData} didn't produce a string result with four numbers (was ${parsedResult}).\n`);
+    }
+    return parsedResult[2]
+}
+
+var output = "This test verifies that a combination of Hebrew and English is read correctly by Accessibility, when using CSS unicode-bidi property.\n\n";
+
+if (window.accessibilityController) {
+    var testIDs = ["content-normal", "content-embed", "content-plaintext", "content-isolate"] 
+    var testOverrideIDs = ["content-bidi-override", "content-isolate-override"]
+    var staticText, staticTextTextMarkerRange, startMarker, endMarker, rangeLength, maxBounds, lastBounds, currentBounds;
+    var ltrCount = 0;
+    var rtlCount = 0;
+    let maxBoundsExpected = 215;
+    testIDs.forEach(testID => {
+        ltrCount = 0;
+        rtlCount = 0;
+        staticText = accessibilityController.accessibleElementById(testID).childAtIndex(0);
+        staticTextTextMarkerRange = staticText.textMarkerRangeForElement(staticText);
+        rangeLength = staticText.textMarkerRangeLength(staticTextTextMarkerRange);
+        output += expect("rangeLength", "28");
+        maxBounds = getRectWidthFromBoundsForRange(staticText.boundsForRange(0, 28));
+
+        lastBounds = -1;
+        for (let i = 0; i <= rangeLength; i++) {
+            currentBounds = getRectWidthFromBoundsForRange(staticText.boundsForRange(0, i));
+            if (currentBounds > lastBounds) {
+                ltrCount++;
+            }
+            if (currentBounds < lastBounds) {
+                rtlCount++;
+            }
+            lastBounds = currentBounds;
+        }
+        output += expect("ltrCount", "22");
+        output += expect("rtlCount", "7");
+        output += expect("staticText.stringForTextMarkerRange(staticTextTextMarkerRange).trim()", "'Anyone can try שפת תכנות C++'")
+    });
+
+    testOverrideIDs.forEach(testOverrideID => {
+        ltrCount = 0;
+        rtlCount = 0;
+        staticText = accessibilityController.accessibleElementById(testOverrideID).childAtIndex(0);
+        staticTextTextMarkerRange = staticText.textMarkerRangeForElement(staticText);
+        rangeLength = staticText.textMarkerRangeLength(staticTextTextMarkerRange);
+        output += expect("rangeLength", "28");
+        maxBounds = getRectWidthFromBoundsForRange(staticText.boundsForRange(0, 28));
+
+        lastBounds = -1;
+        for (let i = 0; i < rangeLength; i++) {
+            currentBounds = getRectWidthFromBoundsForRange(staticText.boundsForRange(0, i));
+            if (currentBounds > lastBounds) {
+                ltrCount++;
+            }
+            if (currentBounds < lastBounds) {
+                rtlCount++;
+            }
+            lastBounds = currentBounds;
+        }
+        output += expect("ltrCount", "28");
+        output += expect("rtlCount", "0");
+
+        output += expect("staticText.stringForTextMarkerRange(staticTextTextMarkerRange).trim()", "'Anyone can try שפת תכנות C++'")
+    });
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -2429,6 +2429,11 @@ accessibility/attachment-element.html [ Pass ]
 
 # Enable Text marker tests for iOS
 webkit.org/b/153292 accessibility/text-marker [ Pass ]
+
+# textMarkerRangeForElement not implemented on iOS
+accessibility/text-marker/text-marker-bidi-element-arabic.html [ Skip ]
+accessibility/text-marker/text-marker-bidi-element-hebrew.html [ Skip ]
+
 # TextMarkerDebugDescription not implemented on iOS:
 accessibility/text-marker/text-marker-debug-description.html [ Skip ]
 


### PR DESCRIPTION
#### c275e7895a0215704795fd1cbe080265855ab24b
<pre>
AX: Add tests for RTL/LTR bidi text
<a href="https://bugs.webkit.org/show_bug.cgi?id=294460">https://bugs.webkit.org/show_bug.cgi?id=294460</a>
<a href="https://rdar.apple.com/153327595">rdar://153327595</a>

Reviewed by Tyler Wilcock.

Add tests for bidi text: English-Arabic and English-Hebrew. This test
counts the number of LTR and RTL positions within strings based on
textmarkers. There are six strings tested, each with a unique value
applied to its unicode-bidi css property.

* LayoutTests/accessibility/text-marker/text-marker-bidi-element-arabic-expected.txt: Added.
* LayoutTests/accessibility/text-marker/text-marker-bidi-element-arabic.html: Added.
* LayoutTests/accessibility/text-marker/text-marker-bidi-element-hebrew-expected.txt: Added.
* LayoutTests/accessibility/text-marker/text-marker-bidi-element-hebrew.html: Added.
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/296764@main">https://commits.webkit.org/296764@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/199a68d82054b252cd4d8b14690a34bbbea6cd27

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109504 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19591 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114708 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59718 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29841 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37750 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83231 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112452 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23772 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98635 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63691 "") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23151 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16777 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59324 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93143 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16818 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117822 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36545 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27057 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92240 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36916 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94895 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92057 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23445 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36996 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14742 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/32337 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36438 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36101 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39445 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37809 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->