### PR TITLE
[JSC] Ensure PolymorphicCallNode is unlinked when it is detached from CallLinkInfo

### DIFF
--- a/Source/JavaScriptCore/bytecode/CallLinkInfo.cpp
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfo.cpp
@@ -88,7 +88,7 @@ void CallLinkInfo::clearStub()
     if (!stub())
         return;
 
-    m_stub->clearCallNodesFor(this);
+    m_stub->unlinkForcefully();
     m_stub = nullptr;
 }
 

--- a/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.cpp
+++ b/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.cpp
@@ -55,9 +55,11 @@ void PolymorphicCallNode::unlinkOrUpgradeImpl(VM& vm, CodeBlock* oldCodeBlock, C
     }
 }
 
-void PolymorphicCallNode::clear()
+void PolymorphicCallNode::unlinkForcefully()
 {
     m_cleared = true;
+    if (isOnList())
+        remove();
 }
 
 PolymorphicCallStubRoutine* PolymorphicCallNode::owner()
@@ -150,10 +152,10 @@ CallEdgeList PolymorphicCallStubRoutine::edges() const
     return result;
 }
 
-void PolymorphicCallStubRoutine::clearCallNodesFor(CallLinkInfo*)
+void PolymorphicCallStubRoutine::unlinkForcefully()
 {
     for (auto& callNode : leadingSpan())
-        callNode.clear();
+        callNode.unlinkForcefully();
 }
 
 bool PolymorphicCallStubRoutine::visitWeakImpl(VM& vm)

--- a/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.h
+++ b/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.h
@@ -55,7 +55,7 @@ public:
 
     void unlinkOrUpgradeImpl(VM&, CodeBlock*, CodeBlock*);
 
-    void clear();
+    void unlinkForcefully();
 
     PolymorphicCallStubRoutine* owner();
 
@@ -94,7 +94,7 @@ public:
     bool hasEdges() const;
     CallEdgeList edges() const;
 
-    void clearCallNodesFor(CallLinkInfo*);
+    void unlinkForcefully();
 
     template<typename Functor>
     void forEachDependentCell(const Functor& functor) const


### PR DESCRIPTION
#### b51df8f033c8728c1c3053ce55f0677f2bc8b552
<pre>
[JSC] Ensure PolymorphicCallNode is unlinked when it is detached from CallLinkInfo
<a href="https://bugs.webkit.org/show_bug.cgi?id=294469">https://bugs.webkit.org/show_bug.cgi?id=294469</a>
<a href="https://rdar.apple.com/153330169">rdar://153330169</a>

Reviewed by Yijia Huang and Keith Miller.

Let&apos;s ensure that PolymorphicCallNode is unlinked when it is detached
from owner CallLinkInfo eagerly before it gets destroyed.

* Source/JavaScriptCore/bytecode/CallLinkInfo.cpp:
(JSC::CallLinkInfo::clearStub):
* Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.cpp:
(JSC::PolymorphicCallNode::unlinkForcefully):
(JSC::PolymorphicCallStubRoutine::unlinkForcefully):
(JSC::PolymorphicCallNode::clear): Deleted.
(JSC::PolymorphicCallStubRoutine::clearCallNodesFor): Deleted.
* Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.h:

Canonical link: <a href="https://commits.webkit.org/296216@main">https://commits.webkit.org/296216@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9726568e16ae8d99cd34e0e286728d90baa5ef39

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107745 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17833 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112954 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58280 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28112 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35955 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81807 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110679 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22281 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97098 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62207 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21702 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15242 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57716 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/100327 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91651 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15278 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116075 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/106284 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34820 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25654 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90841 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35197 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93353 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90610 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35516 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13280 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30575 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17427 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34725 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40281 "Found 4 new failures in Platform/spi/Cocoa/NearFieldSPI.h, API/tests/testapi.mm") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/130599 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34470 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35496 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37832 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36133 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->