### PR TITLE
[JSC] Run testapi with Malloc=1 in addition to default heap

### DIFF
--- a/Tools/Scripts/run-javascriptcore-tests
+++ b/Tools/Scripts/run-javascriptcore-tests
@@ -653,7 +653,7 @@ sub testPath {
 }
 
 sub runTest {
-    my ($testName, $jsonTestStatusName) = @_;
+    my ($testName, $jsonTestStatusName, $extraEnvVars) = @_;
 
     chdirWebKit();
     chdir($productDir) or die "Failed to switch directory to '$productDir'\n";
@@ -667,8 +667,13 @@ sub runTest {
     unshift @command, ("/usr/bin/arch", "-$archs") if $archs ne nativeArchitecture($remotes);
     unshift @command, wrapperPrefixIfNeeded() if isGtk() or isWPE();
 
-    if ($envVars ne "") {
-        foreach my $var (split(/\s+/, $envVars)) {
+    my $combinedEnv = $envVars;
+    $combinedEnv .= " $extraEnvVars" if defined $extraEnvVars && $extraEnvVars ne "";
+
+    local %ENV = %ENV; # Save and localize the environment for this test only
+
+    if ($combinedEnv ne "") {
+        foreach my $var (split(/\s+/, $combinedEnv)) {
             if ($var =~ /([^=]*)=(.*)/) {
                 $ENV{$1} = $2;
             }
@@ -762,8 +767,10 @@ if ($runTestMasm) { runTest("testmasm", "allMasmTestsPassed") }
 if ($runTestAir) { runTest("testair", "allAirTestsPassed") }
 if ($runTestB3) { runTest("testb3", "allB3TestsPassed") }
 if ($runTestDFG) { runTest("testdfg", "allDFGTestsPassed") }
-if ($runTestAPI) { runTest("testapi", "allApiTestsPassed") }
-
+if ($runTestAPI) {
+    runTest("testapi", "allApiTestsPassed");
+    runTest("testapi", "allApiTestsPassedWithSystemMalloc", "Malloc=1");
+}
 
 # Find JavaScriptCore directory
 chdirWebKit();


### PR DESCRIPTION
#### 7e487db29367e4c2eccf9f32d746c0d78d200e1c
<pre>
[JSC] Run testapi with Malloc=1 in addition to default heap
<a href="https://bugs.webkit.org/show_bug.cgi?id=294470">https://bugs.webkit.org/show_bug.cgi?id=294470</a>
<a href="https://rdar.apple.com/150362319">rdar://150362319</a>

Reviewed by Keith Miller.

Update run-javascriptcore-tests to run `testapi` twice: once with the default
allocator and once with the debug heap by setting `Malloc=1`.

This helps ensure that code paths used by daemons and other system processes
that rely on the debug heap are also tested.

* Tools/Scripts/run-javascriptcore-tests:
(runTest):

Canonical link: <a href="https://commits.webkit.org/296317@main">https://commits.webkit.org/296317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b91e63d06db014596b87b6352f1e99465feca353

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108063 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27728 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18147 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113273 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58575 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110026 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28422 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36277 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82039 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111011 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22526 "Found 1 new test failure: fast/filter-image/clipped-filter.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97359 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62471 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21938 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15494 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; 9 flakes 3 failures; Uploaded test results; 12 flakes 3 failures; Compiled WebKit (warnings); 2 failures; Found 1 new test failure: intersection-observer/intersection-observer-should-not-leak-observed-nodes.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58019 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/100665 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91879 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15558 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116398 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/106625 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35132 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25869 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91067 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35508 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93637 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90861 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35764 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13524 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17468 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35032 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/130914 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34771 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35543 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38129 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36434 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->