### PR TITLE
Use TextIndicator instead of TextIndicatorData in createDragImageForLink.

### DIFF
--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -1190,14 +1190,14 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
 
         client().willPerformDragSourceAction(DragSourceAction::Link, dragOrigin, dataTransfer);
         if (!dragImage) {
-            TextIndicatorData textIndicator;
-            dragImage = DragImage { createDragImageForLink(element, linkURL, textContentWithSimplifiedWhiteSpace, textIndicator, m_page->deviceScaleFactor()) };
+            auto [dragImageRef, textIndicator] = createDragImageForLink(element, linkURL, textContentWithSimplifiedWhiteSpace, m_page->deviceScaleFactor());
+            dragImage = DragImage { dragImageRef };
             if (dragImage) {
                 m_dragOffset = dragOffsetForLinkDragImage(dragImage.get());
                 dragLoc = IntPoint(dragOrigin.x() + m_dragOffset.x(), dragOrigin.y() + m_dragOffset.y());
                 dragImage = DragImage { platformAdjustDragImageForDeviceScaleFactor(dragImage.get(), m_page->deviceScaleFactor()) };
-                if (textIndicator.contentImage)
-                    dragImage.setTextIndicator(TextIndicator::create(textIndicator));
+                if (textIndicator && textIndicator->contentImage())
+                    dragImage.setTextIndicator(textIndicator);
             }
         }
 

--- a/Source/WebCore/platform/DragImage.cpp
+++ b/Source/WebCore/platform/DragImage.cpp
@@ -317,10 +317,10 @@ DragImageRef createDragImageIconForCachedImageFilename(const String&)
     return nullptr;
 }
 
-DragImageRef createDragImageForLink(Element&, URL&, const String&, TextIndicatorData&, float)
+DragImageData createDragImageForLink(Element&, URL&, const String&, float)
 {
     notImplemented();
-    return nullptr;
+    return  { nullptr, nullptr };
 }
 
 #endif

--- a/Source/WebCore/platform/DragImage.h
+++ b/Source/WebCore/platform/DragImage.h
@@ -96,7 +96,13 @@ WEBCORE_EXPORT DragImageRef createDragImageForSelection(LocalFrame&, TextIndicat
 WEBCORE_EXPORT DragImageRef createDragImageForRange(LocalFrame&, const SimpleRange&, bool forceBlackText = false);
 DragImageRef createDragImageForColor(const Color&, const FloatRect&, float, Path&);
 DragImageRef createDragImageForImage(LocalFrame&, Node&, IntRect& imageRect, IntRect& elementRect);
-DragImageRef createDragImageForLink(Element&, URL&, const String& label, TextIndicatorData&, float deviceScaleFactor);
+
+struct DragImageData {
+    DragImageRef dragImageRef;
+    RefPtr<TextIndicator> textIndicator;
+};
+
+DragImageData createDragImageForLink(Element&, URL&, const String& label, float deviceScaleFactor);
 void deleteDragImage(DragImageRef);
 
 IntPoint dragOffsetForLinkDragImage(DragImageRef);

--- a/Source/WebCore/platform/cairo/DragImageCairo.cpp
+++ b/Source/WebCore/platform/cairo/DragImageCairo.cpp
@@ -90,9 +90,9 @@ DragImageRef createDragImageIconForCachedImageFilename(const String&)
     return nullptr;
 }
 
-DragImageRef createDragImageForLink(Element&, URL&, const String&, TextIndicatorData&, float)
+DragImageData createDragImageForLink(Element&, URL&, const String&, float)
 {
-    return nullptr;
+    return { nullptr, nullptr };
 }
 
 DragImageRef createDragImageForColor(const Color&, const FloatRect&, float, Path&)

--- a/Source/WebCore/platform/cocoa/DragImageCocoa.mm
+++ b/Source/WebCore/platform/cocoa/DragImageCocoa.mm
@@ -287,7 +287,7 @@ LinkImageLayout::LinkImageLayout(URL& url, const String& titleString)
     boundingRect.setHeight((static_cast<int>(boundingRect.height() / 2) * 2));
 }
 
-DragImageRef createDragImageForLink(Element& element, URL& url, const String& title, TextIndicatorData&, float deviceScaleFactor)
+DragImageData createDragImageForLink(Element& element, URL& url, const String& title, float deviceScaleFactor)
 {
     LinkImageLayout layout(url, title);
 
@@ -309,7 +309,7 @@ DragImageRef createDragImageForLink(Element& element, URL& url, const String& ti
 
     [dragImage unlockFocus];
 
-    return dragImage;
+    return  { dragImage, nullptr };
 }
 
 DragImageRef createDragImageForColor(const Color& color, const FloatRect&, float, Path&)

--- a/Source/WebCore/platform/ios/DragImageIOS.mm
+++ b/Source/WebCore/platform/ios/DragImageIOS.mm
@@ -123,7 +123,7 @@ static RetainPtr<CGImageRef> cgImageFromTextIndicator(const TextIndicator& textI
     return nativeImage->platformImage();
 }
 
-DragImageRef createDragImageForLink(Element& linkElement, URL&, const String&, TextIndicatorData& indicatorData, float)
+DragImageData createDragImageForLink(Element& linkElement, URL&, const String&, float)
 {
     constexpr OptionSet<TextIndicatorOption> defaultLinkIndicatorOptions {
         TextIndicatorOption::TightlyFitContent,
@@ -133,12 +133,11 @@ DragImageRef createDragImageForLink(Element& linkElement, URL&, const String&, T
         TextIndicatorOption::ComputeEstimatedBackgroundColor
     };
 
-    auto textIndicator = TextIndicator::createWithRange(makeRangeSelectingNodeContents(linkElement), defaultLinkIndicatorOptions, TextIndicatorPresentationTransition::None, { });
+    RefPtr textIndicator = TextIndicator::createWithRange(makeRangeSelectingNodeContents(linkElement), defaultLinkIndicatorOptions, TextIndicatorPresentationTransition::None, { });
     if (!textIndicator)
-        return nullptr;
+        return  { nullptr, nullptr };
 
-    indicatorData = textIndicator->data();
-    return cgImageFromTextIndicator(*textIndicator).autorelease();
+    return  { cgImageFromTextIndicator(*textIndicator).autorelease(), textIndicator };
 }
 
 DragImageRef createDragImageIconForCachedImageFilename(const String&)

--- a/Source/WebCore/platform/skia/DragImageSkia.cpp
+++ b/Source/WebCore/platform/skia/DragImageSkia.cpp
@@ -104,9 +104,9 @@ DragImageRef createDragImageIconForCachedImageFilename(const String&)
     return nullptr;
 }
 
-DragImageRef createDragImageForLink(Element&, URL&, const String&, TextIndicatorData&, float)
+DragImageData createDragImageForLink(Element&, URL&, const String&, float)
 {
-    return nullptr;
+    return { nullptr, nullptr };
 }
 
 DragImageRef createDragImageForColor(const Color&, const FloatRect&, float, Path&)

--- a/Source/WebCore/platform/win/cairo/DragImageWinCairo.cpp
+++ b/Source/WebCore/platform/win/cairo/DragImageWinCairo.cpp
@@ -249,7 +249,7 @@ static FontCascade dragLabelFont(int size, bool bold)
     return result;
 }
 
-DragImageRef createDragImageForLink(Element&, URL& url, const String& inLabel, TextIndicatorData&, float)
+DragImageData createDragImageForLink(Element&, URL& url, const String& inLabel, float)
 {
     static const FontCascade labelFont = dragLabelFont(DragLinkLabelFontsize, true);
     static const FontCascade urlFont = dragLabelFont(DragLinkURLFontSize, false);
@@ -327,7 +327,7 @@ DragImageRef createDragImageForLink(Element&, URL& url, const String& inLabel, T
     WebCoreDrawDoubledTextAtPoint(context, label, textPos, labelFont, topColor, bottomColor);
 
     deallocContext(contextRef);
-    return image.leak();
+    return { image.leak(), nullptr };
 }
 
 DragImageRef createDragImageForColor(const Color&, const FloatRect&, float, Path&)


### PR DESCRIPTION
#### cac26de4a923efa653f577fed297ed3e2bed8430
<pre>
Use TextIndicator instead of TextIndicatorData in createDragImageForLink.
<a href="https://bugs.webkit.org/show_bug.cgi?id=294473">https://bugs.webkit.org/show_bug.cgi?id=294473</a>
<a href="https://rdar.apple.com/problem/153335624">rdar://problem/153335624</a>

Reviewed by Abrar Rahman Protyasha.

Continuing to move off of TextIndicatorData.
Also, refactoring this code to return everything
instead of using out variables.

* Source/WebCore/page/DragController.cpp:
(WebCore::DragController::startDrag):
* Source/WebCore/platform/DragImage.cpp:
(WebCore::createDragImageForLink):
* Source/WebCore/platform/DragImage.h:
* Source/WebCore/platform/cocoa/DragImageCocoa.mm:
(WebCore::createDragImageForLink):
* Source/WebCore/platform/ios/DragImageIOS.mm:
(WebCore::createDragImageForLink):

Canonical link: <a href="https://commits.webkit.org/296242@main">https://commits.webkit.org/296242@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e118d43f17e809e0217fe72795901ce7945d729

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107926 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27591 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18010 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113137 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58448 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109889 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28286 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36140 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81917 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22412 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97236 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62348 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21824 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15369 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57890 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91763 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15435 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 11 flakes 3 failures; Uploaded test results; 10 flakes 3 failures; Running compile-webkit-without-change") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116264 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34998 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25753 "Found 1 new test failure: fast/webgpu/nocrash/fuzz-291180.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90950 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35374 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93514 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90744 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23116 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35647 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13401 "Passed tests") | [⏳ 🛠 playstation ](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34896 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40448 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Checked out pull request; Found 74135 issues") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34639 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37999 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36300 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->