### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in the Signals.cpp

### DIFF
--- a/Source/WTF/wtf/threads/Signals.cpp
+++ b/Source/WTF/wtf/threads/Signals.cpp
@@ -220,7 +220,7 @@ static Signal fromMachException(exception_type_t type)
 }
 
 #if CPU(ARM64E) && OS(DARWIN)
-inline ptrauth_generic_signature_t hashThreadState(const thread_state_t source)
+inline ptrauth_generic_signature_t hashThreadState(std::span<const natural_t> source)
 {
     constexpr size_t threadStatePCPointerIndex = (offsetof(arm_unified_thread_state, ts_64) + offsetof(arm_thread_state64_t, __opaque_pc)) / sizeof(uintptr_t);
     constexpr size_t threadStateSizeInPointers = sizeof(arm_unified_thread_state) / sizeof(uintptr_t);
@@ -229,15 +229,15 @@ inline ptrauth_generic_signature_t hashThreadState(const thread_state_t source)
 
     hash = ptrauth_sign_generic_data(hash, mach_thread_self());
 
-    auto srcPtr = unsafeMakeSpan(reinterpret_cast<const uintptr_t*>(source), threadStateSizeInPointers);
+    auto srcSpan = spanReinterpretCast<const uintptr_t>(source).first(threadStateSizeInPointers);
 
     // Exclude the __opaque_flags field which is reserved for OS use.
     // __opaque_flags is at the end of the payload.
     for (size_t i = 0; i < threadStateSizeInPointers - 1; ++i) {
         if (i != threadStatePCPointerIndex)
-            hash = ptrauth_sign_generic_data(srcPtr[i], hash);
+            hash = ptrauth_sign_generic_data(srcSpan[i], hash);
     }
-    const uint32_t* cpsrPtr = reinterpret_cast<const uint32_t*>(&srcPtr[threadStateSizeInPointers - 1]);
+    const uint32_t* cpsrPtr = reinterpret_cast<const uint32_t*>(&srcSpan[threadStateSizeInPointers - 1]);
     hash = ptrauth_sign_generic_data(static_cast<uint64_t>(*cpsrPtr), hash);
     
     return hash;
@@ -262,9 +262,10 @@ kern_return_t catch_mach_exception_raise_state_identity(mach_port_t, mach_port_t
     return KERN_FAILURE;
 }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-static kern_return_t runSignalHandlers(Signal signal, PlatformRegisters& registers, mach_msg_type_number_t dataCount, mach_exception_data_t exceptionData)
+static kern_return_t runSignalHandlers(Signal signal, PlatformRegisters& registers, mach_msg_type_number_t dataCount, mach_exception_data_t rawExceptionData)
 {
+    auto exceptionData = unsafeMakeSpan(rawExceptionData, dataCount);
+
     SigInfo info;
     SignalHandlers& handlers = g_wtfConfig.signalHandlers;
     if (signal == Signal::AccessFault) {
@@ -287,7 +288,6 @@ static kern_return_t runSignalHandlers(Signal signal, PlatformRegisters& registe
     });
     return didHandle ? KERN_SUCCESS : KERN_FAILURE;
 }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #if defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
 
@@ -318,11 +318,13 @@ kern_return_t catch_mach_exception_raise_state(
     const mach_exception_data_t exceptionData,
     mach_msg_type_number_t dataCount,
     int* stateFlavor,
-    const thread_state_t inState,
+    const thread_state_t rawInState,
     mach_msg_type_number_t inStateCount,
-    thread_state_t outState,
+    thread_state_t rawOutState,
     mach_msg_type_number_t* outStateCount)
 {
+    auto inState = unsafeMakeSpan(rawInState, inStateCount);
+    auto outState = unsafeMakeSpan(rawOutState, inStateCount);
     ASSERT(g_wtfConfig.isPermanentlyFrozen || g_wtfConfig.disabledFreezingForTesting);
     SignalHandlers& handlers = g_wtfConfig.signalHandlers;
     RELEASE_ASSERT(port == handlers.exceptionPort);
@@ -342,22 +344,20 @@ kern_return_t catch_mach_exception_raise_state(
     ptrauth_generic_signature_t inStateHash = hashThreadState(inState);
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    memcpy(outState, inState, inStateCount * sizeof(inState[0]));
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    memcpySpan(outState, inState);
 
 #if CPU(X86_64)
     RELEASE_ASSERT(*stateFlavor == x86_THREAD_STATE);
-    PlatformRegisters& registers = reinterpret_cast<x86_thread_state_t*>(outState)->uts.ts64;
+    PlatformRegisters& registers = reinterpretCastSpanStartTo<x86_thread_state_t>(outState).uts.ts64;
 #elif CPU(X86)
     RELEASE_ASSERT(*stateFlavor == x86_THREAD_STATE);
-    PlatformRegisters& registers = reinterpret_cast<x86_thread_state_t*>(outState)->uts.ts32;
+    PlatformRegisters& registers = reinterpretCastSpanStartTo<x86_thread_state_t>(outState).uts.ts32;
 #elif CPU(ARM64)
     RELEASE_ASSERT(*stateFlavor == ARM_THREAD_STATE);
-    PlatformRegisters& registers = reinterpret_cast<arm_unified_thread_state*>(outState)->ts_64;
+    PlatformRegisters& registers = reinterpretCastSpanStartTo<arm_unified_thread_state>(outState).ts_64;
 #elif CPU(ARM)
     RELEASE_ASSERT(*stateFlavor == ARM_THREAD_STATE);
-    PlatformRegisters& registers = reinterpret_cast<arm_unified_thread_state*>(outState)->ts_32;
+    PlatformRegisters& registers = reinterpretCastSpanStartTo<arm_unified_thread_state*>(outState).ts_32;
 #endif
 
     kern_return_t kr = runSignalHandlers(signal, registers, dataCount, exceptionData);
@@ -541,7 +541,7 @@ static void jscSignalHandler(int sig, siginfo_t* info, void* ucontext)
     }
 
     unsigned oldActionIndex = static_cast<size_t>(signal) + (sig == SIGBUS);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GTK/WPE port
     struct sigaction& oldAction = handlers.oldActions[static_cast<size_t>(oldActionIndex)];
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     if (signal == Signal::Usr) {
@@ -606,7 +606,7 @@ void SignalHandlers::finalize()
             RELEASE_ASSERT(!result);
             action.sa_flags = SA_SIGINFO;
             auto systemSignals = toSystemSignal(signal);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GTK/WPE port
             result = sigaction(std::get<0>(systemSignals), &action, &handlers.oldActions[offsetForSystemSignal(std::get<0>(systemSignals))]);
             if (std::get<1>(systemSignals))
                 result |= sigaction(*std::get<1>(systemSignals), &action, &handlers.oldActions[offsetForSystemSignal(*std::get<1>(systemSignals))]);


### PR DESCRIPTION
#### a7e8d05fd4b5e6c3f110a37c3530e8dd2693326b
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in the Signals.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=294476">https://bugs.webkit.org/show_bug.cgi?id=294476</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/threads/Signals.cpp:
(WTF::hashThreadState):
(WTF::jscSignalHandler):
(WTF::SignalHandlers::finalize):

Canonical link: <a href="https://commits.webkit.org/296220@main">https://commits.webkit.org/296220@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e71a488fcb3af53f05b6e6f5ee922d16f9f583fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107773 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17860 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112982 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58303 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28139 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35985 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81811 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110707 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22294 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97110 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62212 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21708 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15251 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57743 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/100351 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91661 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15293 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116102 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/106313 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34847 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25665 "Found 1 new test failure: fast/webgpu/nocrash/fuzz-291180.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90844 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35224 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93369 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90615 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23102 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35522 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13289 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30598 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34752 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40304 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/130626 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34493 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35500 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37855 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36156 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->