### PR TITLE
Add Bookmarks API to the browser namespace

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -571,6 +571,7 @@ $(PROJECT_DIR)/WebProcess/Extensions/Bindings/Scripts/GenerateImports.pl
 $(PROJECT_DIR)/WebProcess/Extensions/Bindings/Scripts/IDLAttributes.json
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIAction.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIAlarms.idl
+$(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIBookmarks.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPICommands.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPICookies.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIDOM.idl

--- a/Source/WebKit/DerivedSources-output.xcfilelist
+++ b/Source/WebKit/DerivedSources-output.xcfilelist
@@ -58,6 +58,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIAction.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIAction.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIAlarms.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIAlarms.mm
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIBookmarks.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIBookmarks.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPICommands.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPICommands.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPICookies.h

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -972,6 +972,7 @@ BINDINGS_SCRIPTS = \
 EXTENSION_INTERFACES = \
     WebExtensionAPIAction \
     WebExtensionAPIAlarms \
+    WebExtensionAPIBookmarks \
     WebExtensionAPICommands \
     WebExtensionAPICookies \
     WebExtensionAPIDeclarativeNetRequest \

--- a/Source/WebKit/Shared/Extensions/WebExtensionPermission.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionPermission.cpp
@@ -40,6 +40,13 @@ String WebExtensionPermission::alarms()
     return "alarms"_s;
 }
 
+#if ENABLE(WK_WEB_EXTENSIONS_BOOKMARKS)
+String WebExtensionPermission::bookmarks()
+{
+    return "bookmarks"_s;
+}
+#endif
+
 String WebExtensionPermission::clipboardWrite()
 {
     return "clipboardWrite"_s;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPermission.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPermission.mm
@@ -32,6 +32,7 @@
 
 WKWebExtensionPermission const WKWebExtensionPermissionActiveTab = @"activeTab";
 WKWebExtensionPermission const WKWebExtensionPermissionAlarms = @"alarms";
+WKWebExtensionPermission const WKWebExtensionPermissionBookmarks = @"bookmarks";
 WKWebExtensionPermission const WKWebExtensionPermissionClipboardWrite = @"clipboardWrite";
 WKWebExtensionPermission const WKWebExtensionPermissionContextMenus = @"contextMenus";
 WKWebExtensionPermission const WKWebExtensionPermissionCookies = @"cookies";

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPermissionPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPermissionPrivate.h
@@ -25,6 +25,10 @@
 
 #import <WebKit/WKWebExtensionPermission.h>
 
+/*! @abstract The `bookmarks` permission requests access to the `browser.bookmarks` APIs. */
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionBookmarks NS_SWIFT_NONISOLATED;
+
 /*! @abstract The `notifications` permission requests access to the `browser.notifications` APIs. */
 WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4))
 WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionNotifications NS_SWIFT_NONISOLATED;

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
@@ -1595,6 +1595,9 @@ const WebExtension::PermissionsSet& WebExtension::supportedPermissions()
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
         WebExtensionPermission::sidePanel(),
 #endif
+#if ENABLE(WK_WEB_EXTENSIONS_BOOKMARKS)
+        WebExtensionPermission::bookmarks(),
+#endif
     };
     return permissions;
 }

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1857,6 +1857,8 @@
 		9565083A26D87A2B00E15CB7 /* AppleMediaServicesUISPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 9565083826D87A2B00E15CB7 /* AppleMediaServicesUISPI.h */; };
 		9593675F252E5E3100D3F0A0 /* WKStylusDeviceObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 9593675D252E5E3000D3F0A0 /* WKStylusDeviceObserver.h */; };
 		95C943912523C0D00054F3D5 /* BaseBoardSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 95C943902523C0D00054F3D5 /* BaseBoardSPI.h */; };
+		96418A5E2DFA4B8100C19CDC /* JSWebExtensionAPIBookmarks.h in Headers */ = {isa = PBXBuildFile; fileRef = 96418A5D2DFA4B8100C19CDC /* JSWebExtensionAPIBookmarks.h */; };
+		96EE6CE82DFA4980000F90BD /* WebExtensionAPIBookmarks.h in Headers */ = {isa = PBXBuildFile; fileRef = 96EE6CE72DFA4975000F90BD /* WebExtensionAPIBookmarks.h */; };
 		99036AE223A949CF0000B06A /* _WKInspectorDebuggableInfoInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 99036AE123A949CE0000B06A /* _WKInspectorDebuggableInfoInternal.h */; };
 		99036AE523A958750000B06A /* APIDebuggableInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 99036AE323A958740000B06A /* APIDebuggableInfo.h */; };
 		99036AE923A970870000B06A /* DebuggableInfoData.h in Headers */ = {isa = PBXBuildFile; fileRef = 99036AE723A970870000B06A /* DebuggableInfoData.h */; };
@@ -7172,7 +7174,11 @@
 		9593675D252E5E3000D3F0A0 /* WKStylusDeviceObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WKStylusDeviceObserver.h; path = ios/WKStylusDeviceObserver.h; sourceTree = "<group>"; };
 		9593675E252E5E3100D3F0A0 /* WKStylusDeviceObserver.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WKStylusDeviceObserver.mm; path = ios/WKStylusDeviceObserver.mm; sourceTree = "<group>"; };
 		95C943902523C0D00054F3D5 /* BaseBoardSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BaseBoardSPI.h; sourceTree = "<group>"; };
+		96418A5D2DFA4B8100C19CDC /* JSWebExtensionAPIBookmarks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIBookmarks.h; sourceTree = "<group>"; };
+		96418A5F2DFA4BA900C19CDC /* JSWebExtensionAPIBookmarks.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIBookmarks.mm; sourceTree = "<group>"; };
 		966F42B3BF3CA9AFEE64F9BF /* RemoteSerializedImageBufferIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoteSerializedImageBufferIdentifier.h; sourceTree = "<group>"; };
+		96E05A002DF7B58700285827 /* WebExtensionAPIBookmarks.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPIBookmarks.idl; sourceTree = "<group>"; };
+		96EE6CE72DFA4975000F90BD /* WebExtensionAPIBookmarks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPIBookmarks.h; sourceTree = "<group>"; };
 		99036AE123A949CE0000B06A /* _WKInspectorDebuggableInfoInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKInspectorDebuggableInfoInternal.h; sourceTree = "<group>"; };
 		99036AE323A958740000B06A /* APIDebuggableInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APIDebuggableInfo.h; sourceTree = "<group>"; };
 		99036AE423A958740000B06A /* APIDebuggableInfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = APIDebuggableInfo.cpp; sourceTree = "<group>"; };
@@ -10370,6 +10376,7 @@
 				1C5DC4502908A9D00061EC62 /* Cocoa */,
 				1CC94E552AC92F960045F269 /* WebExtensionAPIAction.h */,
 				1C2B4D452A8199CC00C528A1 /* WebExtensionAPIAlarms.h */,
+				96EE6CE72DFA4975000F90BD /* WebExtensionAPIBookmarks.h */,
 				1C8ECFE32AFC79E9007BAA62 /* WebExtensionAPICommands.h */,
 				1C4005262B2B937E00F2D9EE /* WebExtensionAPICookies.h */,
 				3311023A2B17B49E00B21C8C /* WebExtensionAPIDeclarativeNetRequest.h */,
@@ -10607,6 +10614,7 @@
 			children = (
 				1CC94E502AC92E9F0045F269 /* WebExtensionAPIAction.idl */,
 				1C2B4D472A819C4700C528A1 /* WebExtensionAPIAlarms.idl */,
+				96E05A002DF7B58700285827 /* WebExtensionAPIBookmarks.idl */,
 				1C8ECFE22AFC79BC007BAA62 /* WebExtensionAPICommands.idl */,
 				1C4005252B2B932800F2D9EE /* WebExtensionAPICookies.idl */,
 				331102392B17AFD800B21C8C /* WebExtensionAPIDeclarativeNetRequest.idl */,
@@ -15913,6 +15921,8 @@
 				1CC94E512AC92F190045F269 /* JSWebExtensionAPIAction.mm */,
 				1C2B4D482A819D0C00C528A1 /* JSWebExtensionAPIAlarms.h */,
 				1C2B4D492A819D0C00C528A1 /* JSWebExtensionAPIAlarms.mm */,
+				96418A5D2DFA4B8100C19CDC /* JSWebExtensionAPIBookmarks.h */,
+				96418A5F2DFA4BA900C19CDC /* JSWebExtensionAPIBookmarks.mm */,
 				1C8ECFE72AFC7DCB007BAA62 /* JSWebExtensionAPICommands.h */,
 				1C8ECFE82AFC7DCB007BAA62 /* JSWebExtensionAPICommands.mm */,
 				1C40052B2B2B953D00F2D9EE /* JSWebExtensionAPICookies.h */,
@@ -17322,6 +17332,7 @@
 				46DBC28D2AF96BA400E6B63A /* ITPThirdPartyDataForSpecificFirstParty.h in Headers */,
 				9B47908F253151CC00EC11AB /* JSIPCBinding.h in Headers */,
 				1CC94E542AC92F190045F269 /* JSWebExtensionAPIAction.h in Headers */,
+				96418A5E2DFA4B8100C19CDC /* JSWebExtensionAPIBookmarks.h in Headers */,
 				1C8ECFE92AFC7DCB007BAA62 /* JSWebExtensionAPICommands.h in Headers */,
 				1C40052D2B2B953D00F2D9EE /* JSWebExtensionAPICookies.h in Headers */,
 				331102412B17B99800B21C8C /* JSWebExtensionAPIDeclarativeNetRequest.h in Headers */,
@@ -17831,6 +17842,7 @@
 				1C2B4D422A817D7200C528A1 /* WebExtensionAlarmParameters.h in Headers */,
 				1CC94E562AC92F960045F269 /* WebExtensionAPIAction.h in Headers */,
 				1C2B4D462A8199CD00C528A1 /* WebExtensionAPIAlarms.h in Headers */,
+				96EE6CE82DFA4980000F90BD /* WebExtensionAPIBookmarks.h in Headers */,
 				1C8ECFE42AFC79E9007BAA62 /* WebExtensionAPICommands.h in Headers */,
 				1C4005272B2B937E00F2D9EE /* WebExtensionAPICookies.h in Headers */,
 				3311023B2B17B49E00B21C8C /* WebExtensionAPIDeclarativeNetRequest.h in Headers */,

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
@@ -36,8 +36,10 @@
 #import "WKWebExtensionPermission.h"
 #import "WebExtensionControllerProxy.h"
 
-#if ENABLE(INSPECTOR_EXTENSIONS) || ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+#if ENABLE(INSPECTOR_EXTENSIONS) || ENABLE(WK_WEB_EXTENSIONS_SIDEBAR) ||  ENABLE(WK_WEB_EXTENSIONS_BOOKMARKS)
 #import "WebPage.h"
+#import <WebCore/Page.h>
+#import <WebCore/Settings.h>
 #endif
 
 namespace WebKit {
@@ -49,6 +51,11 @@ bool WebExtensionAPINamespace::isPropertyAllowed(const ASCIILiteral& name, WebPa
 
     if (name == "action"_s)
         return extensionContext().supportsManifestVersion(3) && objectForKey<NSDictionary>(extensionContext().manifest(), @"action", false);
+
+#if ENABLE(WK_WEB_EXTENSIONS_BOOKMARKS)
+    if (name == "bookmarks"_s)
+        return page->corePage()->settings().webExtensionBookmarksEnabled() && extensionContext().hasPermission("bookmarks"_s);
+#endif
 
     if (name == "commands"_s)
         return objectForKey<NSDictionary>(extensionContext().manifest(), @"commands", false);
@@ -263,6 +270,18 @@ WebExtensionAPISidebarAction& WebExtensionAPINamespace::sidebarAction()
         m_sidebarAction = WebExtensionAPISidebarAction::create(*this);
 
     return *m_sidebarAction;
+}
+#endif
+
+#if ENABLE(WK_WEB_EXTENSIONS_BOOKMARKS)
+WebExtensionAPIBookmarks& WebExtensionAPINamespace::bookmarks()
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks
+
+    if (!m_bookmarks)
+        m_bookmarks = WebExtensionAPIBookmarks::create(*this);
+
+    return *m_bookmarks;
 }
 #endif
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIBookmarks.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIBookmarks.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Igalia S.L. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,40 +25,18 @@
 
 #pragma once
 
-#if ENABLE(WK_WEB_EXTENSIONS)
+#if ENABLE(WK_WEB_EXTENSIONS_BOOKMARKS)
 
-#include <wtf/text/WTFString.h>
+#include "JSWebExtensionAPIBookmarks.h"
+#include "WebExtensionAPIObject.h"
 
 namespace WebKit {
 
-/* Constants for specifying permission in a WebExtensionContext. */
-class WebExtensionPermission {
-public:
-    static String activeTab();
-    static String alarms();
-#if ENABLE(WK_WEB_EXTENSIONS_BOOKMARKS)
-    static String bookmarks();
-#endif
-    static String clipboardWrite();
-    static String contextMenus();
-    static String cookies();
-    static String declarativeNetRequest();
-    static String declarativeNetRequestFeedback();
-    static String declarativeNetRequestWithHostAccess();
-    static String menus();
-    static String nativeMessaging();
-    static String notifications();
-    static String scripting();
-#if ENABLE(WK_WEB_EXTENSION_SIDEBAR)
-    static String sidePanel();
-#endif // ENABLE(WK_WEB_EXTENSION_SIDEBAR)
-    static String storage();
-    static String tabs();
-    static String unlimitedStorage();
-    static String webNavigation();
-    static String webRequest();
+class WebExtensionAPIBookmarks : public WebExtensionAPIObject, public JSWebExtensionWrappable {
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIBookmarks, bookmarks, bookmarks);
+
 };
 
 } // namespace WebKit
 
-#endif // ENABLE(WK_WEB_EXTENSIONS)
+#endif

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h
@@ -30,6 +30,9 @@
 #include "JSWebExtensionAPINamespace.h"
 #include "WebExtensionAPIAction.h"
 #include "WebExtensionAPIAlarms.h"
+#if ENABLE(WK_WEB_EXTENSIONS_BOOKMARKS)
+#include "WebExtensionAPIBookmarks.h"
+#endif
 #include "WebExtensionAPICommands.h"
 #include "WebExtensionAPICookies.h"
 #include "WebExtensionAPIDOM.h"
@@ -87,6 +90,9 @@ public:
     WebExtensionAPISidePanel& sidePanel();
     WebExtensionAPISidebarAction& sidebarAction();
 #endif
+#if ENABLE(WK_WEB_EXTENSIONS_BOOKMARKS)
+    WebExtensionAPIBookmarks& bookmarks();
+#endif
     WebExtensionAPIStorage& storage();
     WebExtensionAPITabs& tabs();
     WebExtensionAPITest& test();
@@ -115,6 +121,9 @@ private:
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
     RefPtr<WebExtensionAPISidePanel> m_sidePanel;
     RefPtr<WebExtensionAPISidebarAction> m_sidebarAction;
+#endif
+#if ENABLE(WK_WEB_EXTENSIONS_BOOKMARKS)
+    RefPtr<WebExtensionAPIBookmarks> m_bookmarks;
 #endif
     RefPtr<WebExtensionAPIStorage> m_storage;
     RefPtr<WebExtensionAPITabs> m_tabs;

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIBookmarks.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIBookmarks.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Igalia S.L. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,42 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+[
+    Conditional=WK_WEB_EXTENSIONS_BOOKMARKS,
+    MainWorldOnly,
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPIBookmarks {
 
-#if ENABLE(WK_WEB_EXTENSIONS)
-
-#include <wtf/text/WTFString.h>
-
-namespace WebKit {
-
-/* Constants for specifying permission in a WebExtensionContext. */
-class WebExtensionPermission {
-public:
-    static String activeTab();
-    static String alarms();
-#if ENABLE(WK_WEB_EXTENSIONS_BOOKMARKS)
-    static String bookmarks();
-#endif
-    static String clipboardWrite();
-    static String contextMenus();
-    static String cookies();
-    static String declarativeNetRequest();
-    static String declarativeNetRequestFeedback();
-    static String declarativeNetRequestWithHostAccess();
-    static String menus();
-    static String nativeMessaging();
-    static String notifications();
-    static String scripting();
-#if ENABLE(WK_WEB_EXTENSION_SIDEBAR)
-    static String sidePanel();
-#endif // ENABLE(WK_WEB_EXTENSION_SIDEBAR)
-    static String storage();
-    static String tabs();
-    static String unlimitedStorage();
-    static String webNavigation();
-    static String webRequest();
 };
-
-} // namespace WebKit
-
-#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl
@@ -32,6 +32,8 @@
 
     [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIAlarms alarms;
 
+    [MainWorldOnly, Dynamic, Conditional=WK_WEB_EXTENSIONS_BOOKMARKS] readonly attribute WebExtensionAPIBookmarks bookmarks;
+
     [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIAction browserAction;
 
     [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPICookies cookies;

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -329,6 +329,7 @@ Tests/WebKitCocoa/WKURLSchemeHandler-leaks.mm
 Tests/WebKitCocoa/WKWebExtension.mm
 Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
 Tests/WebKitCocoa/WKWebExtensionAPIAlarms.mm
+Tests/WebKitCocoa/WKWebExtensionAPIBookmarks.mm
 Tests/WebKitCocoa/WKWebExtensionAPICommands.mm
 Tests/WebKitCocoa/WKWebExtensionAPICookies.mm
 Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -3340,6 +3340,7 @@
 		97DAA8C22DF096CE004B3040 /* TypeCheckingTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TypeCheckingTests.cpp; sourceTree = "<group>"; };
 		97DAA8CD2DF1F325004B3040 /* MetalCompilationTests.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; path = MetalCompilationTests.mm; sourceTree = "<group>"; };
 		97DAA8CF2DF70B91004B3040 /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
+		96E05A012DF7B66F00285827 /* WKWebExtensionAPIBookmarks.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPIBookmarks.mm; sourceTree = "<group>"; };
 		996EDCCA270E70AB006DF175 /* InspectorExtension-basic-page.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "InspectorExtension-basic-page.html"; sourceTree = "<group>"; };
 		9984FACA1CFFAEEE008D198C /* WKWebViewTextInput.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewTextInput.mm; sourceTree = "<group>"; };
 		9984FACD1CFFB038008D198C /* editable-body.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "editable-body.html"; sourceTree = "<group>"; };
@@ -4774,6 +4775,7 @@
 				1CFAA40828947999009F894D /* WKWebExtension.mm */,
 				1CC94E3D2AC75AB10045F269 /* WKWebExtensionAPIAction.mm */,
 				1C2B4D4C2A81F42800C528A1 /* WKWebExtensionAPIAlarms.mm */,
+				96E05A012DF7B66F00285827 /* WKWebExtensionAPIBookmarks.mm */,
 				1C8ECFF12AFD6F49007BAA62 /* WKWebExtensionAPICommands.mm */,
 				1C40052E2B2CEE8C00F2D9EE /* WKWebExtensionAPICookies.mm */,
 				33C39CFF2B07D4B9008FA14B /* WKWebExtensionAPIDeclarativeNetRequest.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIBookmarks.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIBookmarks.mm
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "HTTPServer.h"
+#import "WebExtensionUtilities.h"
+#import <WebKit/WKWebExtensionPermissionPrivate.h>
+
+#if ENABLE(WK_WEB_EXTENSIONS_BOOKMARKS)
+
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/_WKFeature.h>
+
+namespace TestWebKitAPI {
+
+#pragma mark - Constants
+
+static constexpr auto *bookmarkOffManifest = @{
+    @"manifest_version": @3,
+    @"name": @"bookmarkpermission off Test",
+    @"description": @"bookmarkpermission off Test",
+    @"version": @"1",
+
+    @"permissions": @[],
+    @"background": @{
+        @"scripts": @[ @"background.js", ],
+        @"type": @"module",
+        @"persistent": @NO,
+    },
+};
+
+static auto *bookmarkOnManifest = @{
+    @"manifest_version": @3,
+    @"name": @"bookmarkpermission on Test",
+    @"description": @"bookmarkpermission on Test",
+    @"version": @"1",
+
+    @"permissions": @[ @"bookmarks" ],
+    @"background": @{
+        @"scripts": @[ @"background.js", ],
+        @"type": @"module",
+        @"persistent": @NO,
+    },
+    @"action": @{
+        @"default_title": @"Test Action",
+        @"default_popup": @"popup.html",
+    },
+};
+
+#pragma mark - Test Fixture
+
+class WKWebExtensionAPIBookmarks : public testing::Test {
+protected:
+    WKWebExtensionAPIBookmarks()
+    {
+        bookmarkConfig = WKWebExtensionControllerConfiguration.nonPersistentConfiguration;
+        if (!bookmarkConfig.webViewConfiguration)
+            bookmarkConfig.webViewConfiguration = [[WKWebViewConfiguration alloc] init];
+
+        for (_WKFeature *feature in [WKPreferences _features]) {
+            if ([feature.key isEqualToString:@"WebExtensionBookmarksEnabled"])
+                [bookmarkConfig.webViewConfiguration.preferences _setEnabled:YES forFeature:feature];
+        }
+    }
+    RetainPtr<TestWebExtensionManager> getManagerFor(NSArray<NSString *> *script, NSDictionary<NSString *, id> *manifest)
+    {
+        return getManagerFor(@{ @"background.js" : Util::constructScript(script) }, manifest);
+    }
+
+    RetainPtr<TestWebExtensionManager> getManagerFor(NSDictionary<NSString *, id> *resources, NSDictionary<NSString *, id> *manifest)
+    {
+        return Util::parseExtension(manifest, resources, bookmarkConfig);
+    }
+
+    WKWebExtensionControllerConfiguration *bookmarkConfig;
+};
+
+#pragma mark - Common Tests
+
+TEST_F(WKWebExtensionAPIBookmarks, APISUnavailableWhenManifestDoesNotRequest)
+{
+    auto *script = @[
+        @"browser.test.assertDeepEq(browser.bookmarks, undefined)",
+        @"browser.test.notifyPass()",
+    ];
+
+    Util::loadAndRunExtension(bookmarkOffManifest, @{ @"background.js": Util::constructScript(script) }, bookmarkConfig);
+}
+
+#pragma mark - more Tests
+
+TEST_F(WKWebExtensionAPIBookmarks, APIAvailableWhenManifestRequests)
+{
+    auto *script = @[
+        @"browser.test.assertFalse(browser.bookmarks === undefined)",
+        @"browser.test.notifyPass()",
+    ];
+
+    Util::loadAndRunExtension(bookmarkOnManifest, @{ @"background.js": Util::constructScript(script) }, bookmarkConfig);
+}
+
+}
+
+#endif
+

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPISidebar.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPISidebar.mm
@@ -132,7 +132,7 @@ class WKWebExtensionAPISidebar : public testing::Test {
 protected:
     WKWebExtensionAPISidebar()
     {
-        sidebarConfig = WKWebExtensionControllerConfiguration.defaultConfiguration;
+        sidebarConfig = WKWebExtensionControllerConfiguration.nonPersistantConfiguration;
         if (!sidebarConfig.webViewConfiguration)
             sidebarConfig.webViewConfiguration = [[WKWebViewConfiguration alloc] init];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
@@ -28,6 +28,7 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #import "HTTPServer.h"
+#import "TestWKWebView.h"
 #import "WebExtensionUtilities.h"
 
 namespace TestWebKitAPI {


### PR DESCRIPTION
#### bbf50b748dba84f51f7002498e72f8db18bc1f6c
<pre>
Add Bookmarks API to the browser namespace
<a href="https://rdar.apple.com/152868076">rdar://152868076</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=294224">https://bugs.webkit.org/show_bug.cgi?id=294224</a>

Reviewed by Brian Weinstein and Timothy Hatcher.

Add Bookmarks API to the browser namespace. Files included to check for bookmark
permissions in the manifests and have test files.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources-output.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/Extensions/WebExtensionPermission.cpp:
(WebKit::WebExtensionPermission::bookmarks):
* Source/WebKit/Shared/Extensions/WebExtensionPermission.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPermission.mm: Gives access to
Bookmark API if bookmarks are enabled in the mm file
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPermissionPrivate.h:
* Source/WebKit/UIProcess/Extensions/WebExtension.cpp:
(WebKit::WebExtension::supportedPermissions):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm:
(WebKit::WebExtensionAPINamespace::isPropertyAllowed): Checks for bookmarks in the manifest
(WebKit::WebExtensionAPINamespace::bookmarks):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIBookmarks.h: Copied from Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPermissionPrivate.h.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIBookmarks.idl: Copied from Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPermissionPrivate.h.
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl:
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIBookmarks.mm: Added.
(TestWebKitAPI::WKWebExtensionAPIBookmarks::WKWebExtensionAPIBookmarks):
(TestWebKitAPI::WKWebExtensionAPIBookmarks::getManagerFor):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIBookmarks, APISUnavailableWhenManifestDoesNotRequest)):
Tests when the manifest does not includes the bookmarks permissions
(TestWebKitAPI::TEST_F(WKWebExtensionAPIBookmarks, APIAvailableWhenManifestRequests)): Tests when the manifest includes the bookmarks permissions
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPISidebar.mm:
(TestWebKitAPI::WKWebExtensionAPISidebar::WKWebExtensionAPISidebar):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm: Included import to fix building issues

Canonical link: <a href="https://commits.webkit.org/296338@main">https://commits.webkit.org/296338@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42492c91fb1cf56886cd322e9076da9d31d4dea7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27870 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18291 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113418 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/58687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110171 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28569 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36421 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82160 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/58687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111156 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22637 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97469 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62591 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22053 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15605 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58153 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92003 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15661 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116544 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35272 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25973 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91187 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35646 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93745 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90982 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/23183 "The change is no longer eligible for processing.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35873 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13631 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31054 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17480 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35171 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40726 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34907 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38261 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36572 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->