### PR TITLE
Fix some PDF tests after 296104@main

### DIFF
--- a/Tools/TestWebKitAPI/TestPDFDocument.swift
+++ b/Tools/TestWebKitAPI/TestPDFDocument.swift
@@ -120,7 +120,7 @@ typealias CocoaColor = NSColor
 
         CGContextDrawPDFPageWithAnnotations(context, cgPage, nil)
 
-        let pixels = UnsafeMutableRawBufferPointer(start: context.data, count: context.width * context.height)
+        let pixels = UnsafeMutableRawBufferPointer(start: context.data, count: context.width * context.height * 4)
 
         let x = Int(point.x)
         let y = Int(point.y)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DrawingToPDF.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DrawingToPDF.mm
@@ -25,13 +25,13 @@
 
 #import "config.h"
 
-#if USE(PDFKIT_FOR_TESTING)
+#if HAVE(PDFKIT)
 
 #import "PlatformUtilities.h"
 #import "Test.h"
+#import "TestCocoaImageAndCocoaColor.h"
 #import "TestPDFDocument.h"
 #import "TestWKWebView.h"
-#import <WebCore/ColorCocoa.h>
 #import <WebKit/WKPDFConfiguration.h>
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/_WKFeature.h>
@@ -56,7 +56,7 @@ TEST(DrawingToPDF, GradientIntoPDF)
         RetainPtr page = [document pageAtIndex:0];
         EXPECT_NE(page.get(), nil);
 
-        EXPECT_TRUE([[page colorAtPoint:CGPointMake(50, 50)] isEqual:[CocoaColor blueColor]]);
+        EXPECT_TRUE(Util::compareColors([page colorAtPoint:CGPointMake(50, 50)], [CocoaColor blueColor]));
 
         didTakeSnapshot = true;
     }];
@@ -85,9 +85,9 @@ TEST(DrawingToPDF, BackgroundClipText)
         RetainPtr page = [document pageAtIndex:0];
         EXPECT_NE(page.get(), nil);
 
-        EXPECT_TRUE([[page colorAtPoint:NSMakePoint(2, 2)] isEqual:[CocoaColor whiteColor]]);
+        EXPECT_TRUE(Util::compareColors([page colorAtPoint:CGPointMake(2, 2)], [CocoaColor whiteColor]));
         // We can't test for blue because the colors are affected by colorspace conversions.
-        EXPECT_TRUE([[page colorAtPoint:NSMakePoint(25, 25)] isEqual:[CocoaColor whiteColor]]);
+        EXPECT_TRUE(!Util::compareColors([page colorAtPoint:CGPointMake(25, 25)], [CocoaColor whiteColor]));
 
         didTakeSnapshot = true;
     }];
@@ -129,7 +129,7 @@ TEST(DrawingToPDF, SiteIsolationFormControl)
         EXPECT_EQ([[page text] characterAtIndex:7], 'x');
 
         // The entire page should be green. Pick a point in the middle to check.
-        EXPECT_TRUE([[page colorAtPoint:NSMakePoint(400, 300)] isEqual:[CocoaColor greenColor]]);
+        EXPECT_TRUE(Util::compareColors([page colorAtPoint:CGPointMake(400, 300)], [CocoaColor greenColor]));
 
         didTakeSnapshot = true;
     }];
@@ -139,4 +139,4 @@ TEST(DrawingToPDF, SiteIsolationFormControl)
 
 } // namespace TestWebKitAPI
 
-#endif // USE(PDFKIT_FOR_TESTING)
+#endif // HAVE(PDFKIT)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PDFSnapshot.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PDFSnapshot.mm
@@ -25,13 +25,13 @@
 
 #import "config.h"
 
-#if USE(PDFKIT_FOR_TESTING)
+#if HAVE(PDFKIT)
 
 #import "PlatformUtilities.h"
 #import "Test.h"
+#import "TestCocoaImageAndCocoaColor.h"
 #import "TestPDFDocument.h"
 #import "TestWKWebView.h"
-#import <WebCore/ColorCocoa.h>
 #import <WebKit/WKPDFConfiguration.h>
 
 namespace TestWebKitAPI {
@@ -57,7 +57,7 @@ TEST(PDFSnapshot, FullContent)
         EXPECT_EQ([[page text] characterAtIndex:4], 'o');
 
         // The entire page should be green. Pick a point in the middle to check.
-        EXPECT_TRUE([[page colorAtPoint:NSMakePoint(400, 300)] isEqual:[CocoaColor greenColor]]);
+        EXPECT_TRUE(Util::compareColors([page colorAtPoint:CGPointMake(400, 300)], [CocoaColor greenColor]));
 
         didTakeSnapshot = true;
     }];
@@ -88,7 +88,7 @@ TEST(PDFSnapshot, Subregions)
         EXPECT_EQ([page characterCount], 0);
 
         // The entire page should be green. Pick a point in the middle to check.
-        EXPECT_TRUE([[page colorAtPoint:NSMakePoint(200, 150)] isEqual:[CocoaColor greenColor]]);
+        EXPECT_TRUE(Util::compareColors([page colorAtPoint:CGPointMake(200, 150)], [CocoaColor greenColor]));
 
         didTakeSnapshot = true;
     }];
@@ -108,10 +108,10 @@ TEST(PDFSnapshot, Subregions)
         EXPECT_TRUE(CGRectEqualToRect([page bounds], CGRectMake(0, 0, 1200, 1200)));
 
         // A pixel that was in the view should be green. Pick a point in the middle to check.
-        EXPECT_TRUE([[page colorAtPoint:NSMakePoint(200, 150)] isEqual:[CocoaColor greenColor]]);
+        EXPECT_TRUE(Util::compareColors([page colorAtPoint:CGPointMake(200, 150)], [CocoaColor greenColor]));
 
         // A pixel that was outside the view should also be green (we extend background color out). Pick a point in the middle to check.
-        EXPECT_TRUE([[page colorAtPoint:NSMakePoint(900, 700)] isEqual:[CocoaColor greenColor]]);
+        EXPECT_TRUE(Util::compareColors([page colorAtPoint:CGPointMake(900, 700)], [CocoaColor greenColor]));
 
         didTakeSnapshot = true;
     }];
@@ -136,19 +136,19 @@ TEST(PDFSnapshot, Over200Inches)
         RetainPtr page = [document pageAtIndex:0];
         EXPECT_NE(page.get(), nil);
         EXPECT_TRUE(CGRectEqualToRect([page bounds], CGRectMake(0, 0, 800, 14400)));
-        EXPECT_TRUE([[page colorAtPoint:NSMakePoint(400, 300)] isEqual:[CocoaColor greenColor]]);
+        EXPECT_TRUE(Util::compareColors([page colorAtPoint:CGPointMake(400, 300)], [CocoaColor greenColor]));
         EXPECT_EQ([page characterCount], 5);
 
         page = [document pageAtIndex:1];
         EXPECT_NE(page.get(), nil);
         EXPECT_TRUE(CGRectEqualToRect([page bounds], CGRectMake(0, 0, 800, 14400)));
-        EXPECT_TRUE([[page colorAtPoint:NSMakePoint(400, 300)] isEqual:[CocoaColor greenColor]]);
+        EXPECT_TRUE(Util::compareColors([page colorAtPoint:CGPointMake(400, 300)], [CocoaColor greenColor]));
         EXPECT_EQ([page characterCount], 0);
 
         page = [document pageAtIndex:2];
         EXPECT_NE(page.get(), nil);
         EXPECT_TRUE(CGRectEqualToRect([page bounds], CGRectMake(0, 0, 800, 600)));
-        EXPECT_TRUE([[page colorAtPoint:NSMakePoint(400, 300)] isEqual:[CocoaColor greenColor]]);
+        EXPECT_TRUE(Util::compareColors([page colorAtPoint:CGPointMake(400, 300)], [CocoaColor greenColor]));
         EXPECT_EQ([page characterCount], 0);
 
         didTakeSnapshot = true;
@@ -173,7 +173,7 @@ TEST(PDFSnapshot, Links)
         EXPECT_NE(page.get(), nil);
 
         EXPECT_TRUE(CGRectEqualToRect([page bounds], CGRectMake(0, 0, 800, 14400)));
-        EXPECT_TRUE([[page colorAtPoint:NSMakePoint(400, 300)] isEqual:[CocoaColor whiteColor]]);
+        EXPECT_TRUE(Util::compareColors([page colorAtPoint:CGPointMake(400, 300)], [CocoaColor whiteColor]));
 
         EXPECT_EQ([page characterCount], 8);
         EXPECT_EQ([[page text] characterAtIndex:0], 'C');
@@ -242,7 +242,7 @@ TEST(PDFSnapshot, AllowTransparentBackground)
         RetainPtr page = [document pageAtIndex:0];
         EXPECT_NE(page.get(), nil);
 
-        EXPECT_TRUE([[page colorAtPoint:NSMakePoint(1, 1)] isEqual:[CocoaColor colorWithWhite:0 alpha:0]]);
+        EXPECT_TRUE(Util::compareColors([page colorAtPoint:CGPointMake(1, 1)], [CocoaColor colorWithWhite:0 alpha:0]));
 
         didTakeSnapshot = true;
     }];
@@ -252,4 +252,4 @@ TEST(PDFSnapshot, AllowTransparentBackground)
 
 }
 
-#endif // USE(PDFKIT_FOR_TESTING)
+#endif // HAVE(PDFKIT)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewPrintFormatter.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewPrintFormatter.mm
@@ -29,10 +29,10 @@
 
 #import "PlatformUtilities.h"
 #import "Test.h"
+#import "TestCocoaImageAndCocoaColor.h"
 #import "TestNavigationDelegate.h"
 #import "TestPDFDocument.h"
 #import "TestWKWebView.h"
-#import "WebCore/ColorCocoa.h"
 #import <WebKit/WebKit.h>
 #import <WebKit/WebKitPrivate.h>
 #import <WebKit/_WKWebViewPrintFormatter.h>
@@ -132,7 +132,7 @@ TEST(WKWebView, PrintToPDFUsingPrintPageRenderer)
     EXPECT_NE([pdfData length], 0UL);
 }
 
-#if USE(PDFKIT_FOR_TESTING)
+#if HAVE(PDFKIT)
 TEST(WKWebView, PrintToPDFShouldPrintBackgrounds)
 {
     auto config = adoptNS([[WKWebViewConfiguration alloc] init]);
@@ -166,9 +166,9 @@ TEST(WKWebView, PrintToPDFShouldPrintBackgrounds)
         RetainPtr page = [pdf pageAtIndex:0];
 
         if (shouldPrintBackgrounds)
-            EXPECT_EQ([page colorAtPoint:NSMakePoint(99, 99)], [CocoaColor redColor]);
+            EXPECT_TRUE(TestWebKitAPI::Util::compareColors([page colorAtPoint:NSMakePoint(99, 99)], [CocoaColor redColor]));
         else
-            EXPECT_NE([page colorAtPoint:NSMakePoint(99, 99)], [CocoaColor redColor]);
+            EXPECT_FALSE(TestWebKitAPI::Util::compareColors([page colorAtPoint:NSMakePoint(99, 99)], [CocoaColor redColor]));
     };
     
     runTest(NO);
@@ -177,7 +177,7 @@ TEST(WKWebView, PrintToPDFShouldPrintBackgrounds)
     
     runTest(YES);
 }
-#endif // USE(PDFKIT_FOR_TESTING)
+#endif // HAVE(PDFKIT)
 
 TEST(WKWebView, PrintToPDFUsingPrintInteractionController)
 {

--- a/Tools/TestWebKitAPI/Tests/ios/ApplicationStateTracking.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/ApplicationStateTracking.mm
@@ -65,7 +65,7 @@ TEST(ApplicationStateTracking, WindowDeallocDoesNotPermanentlyFreezeLayerTree)
     [webView waitForNextPresentationUpdate];
 }
 
-#if USE(PDFKIT_FOR_TESTING)
+#if HAVE(PDFKIT)
 
 TEST(ApplicationStateTracking, NavigatingFromPDFDoesNotLeaveWebViewInactive)
 {
@@ -93,7 +93,7 @@ TEST(ApplicationStateTracking, NavigatingFromPDFDoesNotLeaveWebViewInactive)
     EXPECT_TRUE([[webView objectByEvaluatingJavaScript:@"internals.isPageActive()"] boolValue]);
 }
 
-#endif // USE(PDFKIT_FOR_TESTING)
+#endif // HAVE(PDFKIT)
 
 } // namespace TestWebKitAPI
 

--- a/Tools/TestWebKitAPI/ios/TestPDFHostViewController.h
+++ b/Tools/TestWebKitAPI/ios/TestPDFHostViewController.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if USE(PDFKIT_FOR_TESTING) && PLATFORM(IOS_FAMILY)
+#if HAVE(PDFKIT) && PLATFORM(IOS_FAMILY)
 
 class ClassMethodSwizzler;
 
@@ -35,4 +35,4 @@ std::unique_ptr<ClassMethodSwizzler> createPDFHostViewControllerSwizzler();
 
 } // namespace TestWebKitAPI
 
-#endif // USE(PDFKIT_FOR_TESTING) && PLATFORM(IOS_FAMILY)
+#endif // HAVE(PDFKIT) && PLATFORM(IOS_FAMILY)

--- a/Tools/TestWebKitAPI/ios/TestPDFHostViewController.mm
+++ b/Tools/TestWebKitAPI/ios/TestPDFHostViewController.mm
@@ -26,7 +26,7 @@
 #import "config.h"
 #import "TestPDFHostViewController.h"
 
-#if USE(PDFKIT_FOR_TESTING) && PLATFORM(IOS_FAMILY)
+#if HAVE(PDFKIT) && PLATFORM(IOS_FAMILY)
 
 #import "ClassMethodSwizzler.h"
 #import "PDFKitSPI.h"
@@ -131,4 +131,4 @@ std::unique_ptr<ClassMethodSwizzler> createPDFHostViewControllerSwizzler()
 
 } // namespace TestWebKitAPI
 
-#endif // USE(PDFKIT_FOR_TESTING) && PLATFORM(IOS_FAMILY)
+#endif // HAVE(PDFKIT) && PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### ce9a4fafb44ecf70b9c84a30a544748cd90eb1c5
<pre>
Fix some PDF tests after 296104@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=294482">https://bugs.webkit.org/show_bug.cgi?id=294482</a>
<a href="https://rdar.apple.com/153344673">rdar://153344673</a>

Reviewed by Abrar Rahman Protyasha.

296104@main accidentally broke some PDF tests, but it also conveniently also accidentally
disabled those same tests because it didn&apos;t replace the PDFKIT_FOR_TESTING flag everywhere.

Fix that, and then fix some minor issues in the test implementation; specifically:

- The pixel buffer was too small
- Colors were being compared incorrectly due to color space differences; fix this by using the Util::compareColors
function instead.

* Tools/TestWebKitAPI/TestPDFDocument.swift:
(TestPDFPage.color(at:)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DrawingToPDF.mm:
(TestWebKitAPI::TEST(DrawingToPDF, GradientIntoPDF)):
(TestWebKitAPI::TEST(DrawingToPDF, BackgroundClipText)):
(TestWebKitAPI::TEST(DrawingToPDF, SiteIsolationFormControl)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PDFSnapshot.mm:
(TestWebKitAPI::TEST(PDFSnapshot, FullContent)):
(TestWebKitAPI::TEST(PDFSnapshot, Subregions)):
(TestWebKitAPI::TEST(PDFSnapshot, Over200Inches)):
(TestWebKitAPI::TEST(PDFSnapshot, Links)):
(TestWebKitAPI::TEST(PDFSnapshot, AllowTransparentBackground)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewPrintFormatter.mm:
* Tools/TestWebKitAPI/Tests/ios/ApplicationStateTracking.mm:
* Tools/TestWebKitAPI/ios/TestPDFHostViewController.h:
* Tools/TestWebKitAPI/ios/TestPDFHostViewController.mm:

Canonical link: <a href="https://commits.webkit.org/296229@main">https://commits.webkit.org/296229@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1ca82038ef2a429c04357628aa624e16c27da9b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107886 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27552 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113098 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58409 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109850 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28247 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36100 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81884 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110834 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22377 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97197 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62313 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21792 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15330 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57851 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91728 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15396 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116224 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34958 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25716 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90916 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35334 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93475 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90709 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23109 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35613 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13364 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30709 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34857 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34599 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37960 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36261 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->