### PR TITLE
[tvOS] Media controls close button should have a circular background

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.css
@@ -95,3 +95,19 @@
 .media-controls.fullscreen.tvos > .controls-bar.bottom > .time-control {
     margin-bottom: var(--tvos-time-control-bottom-margin);
 }
+
+.media-controls.fullscreen.tvos button.center {
+    width: 40px !important;
+    height: 40px !important;
+}
+
+.media-controls.fullscreen.tvos .background-tint > .blur {
+    display: none;
+}
+
+.media-controls.fullscreen.tvos .background-tint > .tint {
+    background-color: unset;
+    color-scheme: dark;
+    mix-blend-mode: unset;
+    -apple-visual-effect: -apple-system-glass-material-media-controls;
+}

--- a/Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.js
@@ -42,6 +42,7 @@ class TVOSMediaControls extends MediaControls
         this.element.classList.add("tvos");
 
         this.closeButton = new CloseButton(this);
+        this.closeButton.circular = true;
 
         this.timeControl.scrubber.allowsRelativeScrubbing = true;
         this.timeControl.scrubber.knobStyle = Slider.KnobStyle.None;
@@ -98,6 +99,8 @@ class TVOSMediaControls extends MediaControls
         this.skipForwardButton.scaleFactor = TVOSMediaControls.backForwardButtonScaleFactor;
         this.skipBackButton.scaleFactor = TVOSMediaControls.backForwardButtonScaleFactor;
         this.overflowButton.scaleFactor = TVOSMediaControls.overflowButtonScaleFactor;
+
+        this.closeButton.style = Button.Styles.Center;
 
         this._topLeftControlsBarContainer.children = this._topLeftContainerButtons();
         this._topLeftControlsBarContainer.layout();


### PR DESCRIPTION
#### 020427ba0badad372eefb84891715c8ff3d088e9
<pre>
[tvOS] Media controls close button should have a circular background
<a href="https://bugs.webkit.org/show_bug.cgi?id=294483">https://bugs.webkit.org/show_bug.cgi?id=294483</a>
<a href="https://rdar.apple.com/150302619">rdar://150302619</a>

Reviewed by Aditya Keerthi.

Changed the close button in tvos-media-controls to have a 40pt-diameter circular platter behind it
using `-apple-visual-effect: -apple-system-glass-material-media-controls` as the background
material.

* Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.css:
(.media-controls.fullscreen.tvos button.center):
(.media-controls.fullscreen.tvos .background-tint &gt; .blur):
(.media-controls.fullscreen.tvos .background-tint &gt; .tint):
* Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.js:
(TVOSMediaControls.prototype.layout):

Canonical link: <a href="https://commits.webkit.org/296299@main">https://commits.webkit.org/296299@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f46b1286a4625be10ba3b35d76736cec1b2dd034

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107810 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17896 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113024 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58334 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109776 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28173 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36020 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81833 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110755 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22324 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97146 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62248 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21724 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15286 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57777 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91680 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15340 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116145 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34879 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90869 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35255 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93416 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90653 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23162 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35544 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13322 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30629 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34783 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40335 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34524 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37886 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36187 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->