### PR TITLE
[JSC] Tweak NumericStrings double-to-string hashing

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -998,6 +998,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/DisposableStackConstructor.h
     runtime/DisposableStackPrototype.h
     runtime/DisposableStackPrototypeInlines.h
+    runtime/DoubleToStringCache.h
     runtime/DumpContext.h
     runtime/ECMAMode.h
     runtime/EnsureStillAliveHere.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2083,6 +2083,7 @@
 		E3C8ED4323A1DBCB00131958 /* IsoInlinedHeapCellType.h in Headers */ = {isa = PBXBuildFile; fileRef = E3C8ED4223A1DBC500131958 /* IsoInlinedHeapCellType.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3CA3A4E2527AB2F004802BF /* JITOperationList.h in Headers */ = {isa = PBXBuildFile; fileRef = E3CA3A4C2527AB2F004802BF /* JITOperationList.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3CDCFAF28DD065A00215350 /* ImportMap.h in Headers */ = {isa = PBXBuildFile; fileRef = E3CDCFAE28DD065A00215350 /* ImportMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E3CE33872DFFB4FD00E763AB /* DoubleToStringCache.h in Headers */ = {isa = PBXBuildFile; fileRef = E3CE33842DFFB4ED00E763AB /* DoubleToStringCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3D239C91B829C1C00BBEF67 /* JSModuleEnvironment.h in Headers */ = {isa = PBXBuildFile; fileRef = E3D239C71B829C1C00BBEF67 /* JSModuleEnvironment.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3D3515F241B89D7008DC16E /* MarkedJSValueRefArray.h in Headers */ = {isa = PBXBuildFile; fileRef = E3D3515D241B89CE008DC16E /* MarkedJSValueRefArray.h */; };
 		E3D4FFE22AF21D96004ED359 /* InlineAttribute.h in Headers */ = {isa = PBXBuildFile; fileRef = E3D4FFE12AF21D96004ED359 /* InlineAttribute.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5841,6 +5842,8 @@
 		E3CA3A4B2527AB2E004802BF /* JITOperationList.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JITOperationList.cpp; sourceTree = "<group>"; };
 		E3CA3A4C2527AB2F004802BF /* JITOperationList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JITOperationList.h; sourceTree = "<group>"; };
 		E3CDCFAE28DD065A00215350 /* ImportMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ImportMap.h; sourceTree = "<group>"; };
+		E3CE33842DFFB4ED00E763AB /* DoubleToStringCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DoubleToStringCache.h; sourceTree = "<group>"; };
+		E3CE33852DFFB4ED00E763AB /* DoubleToStringCache.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DoubleToStringCache.cpp; sourceTree = "<group>"; };
 		E3D239C61B829C1C00BBEF67 /* JSModuleEnvironment.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSModuleEnvironment.cpp; sourceTree = "<group>"; };
 		E3D239C71B829C1C00BBEF67 /* JSModuleEnvironment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSModuleEnvironment.h; sourceTree = "<group>"; };
 		E3D264261D38C042000BE174 /* BytecodeGeneratorification.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BytecodeGeneratorification.cpp; sourceTree = "<group>"; };
@@ -8180,6 +8183,8 @@
 				278D26042A70CF20007F5BC3 /* DOMAttributeGetterSetterInlines.h */,
 				E3FC25102256ECF400583518 /* DoublePredictionFuzzerAgent.cpp */,
 				E3FC25112256ECF400583518 /* DoublePredictionFuzzerAgent.h */,
+				E3CE33852DFFB4ED00E763AB /* DoubleToStringCache.cpp */,
+				E3CE33842DFFB4ED00E763AB /* DoubleToStringCache.h */,
 				A70447EB17A0BD7000F5898E /* DumpContext.cpp */,
 				A70447EC17A0BD7000F5898E /* DumpContext.h */,
 				145FF2C6243BB99A00569E71 /* ECMAMode.cpp */,
@@ -10891,6 +10896,7 @@
 				E3FF75331D9CEA1800C7E16D /* DOMJITGetterSetter.h in Headers */,
 				E35CA1541DBC3A5C00F83516 /* DOMJITHeapRange.h in Headers */,
 				E350708A1DC49BBF0089BCD6 /* DOMJITSignature.h in Headers */,
+				E3CE33872DFFB4FD00E763AB /* DoubleToStringCache.h in Headers */,
 				A70447EE17A0BD7000F5898E /* DumpContext.h in Headers */,
 				145FF2C8243BB9D600569E71 /* ECMAMode.h in Headers */,
 				2A83638618D7D0EE0000EBCC /* EdenGCActivityCallback.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -795,6 +795,7 @@ runtime/DirectEvalExecutable.cpp
 runtime/DisposableStackConstructor.cpp
 runtime/DisposableStackPrototype.cpp
 runtime/DoublePredictionFuzzerAgent.cpp
+runtime/DoubleToStringCache.cpp
 runtime/DumpContext.cpp
 runtime/ECMAMode.cpp
 runtime/Error.cpp

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -1709,6 +1709,7 @@ NEVER_INLINE bool Heap::runEndPhase(GCConductor conn)
         sweepArrayBuffers();
         snapshotUnswept();
         finalizeUnconditionalFinalizers(); // We rely on these unconditional finalizers running before clearCurrentlyExecuting since CodeBlock's finalizer relies on querying currently executing.
+        vm().numericStrings.finalizeUnconditionally(vm());
         removeDeadCompilerWorklistEntries();
     }
 
@@ -2266,7 +2267,7 @@ void Heap::finalize()
 
     if (m_lastCollectionScope && m_lastCollectionScope.value() == CollectionScope::Full) {
         vm().jsonAtomStringCache.clear();
-        vm().numericStrings.clearOnGarbageCollection();
+        vm().numericStrings.clearOnGarbageCollection(vm());
         vm().stringReplaceCache.clear();
     }
     vm().keyAtomStringCache.clear();

--- a/Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h
@@ -294,7 +294,7 @@ inline bool canUseFastArrayJoin(const JSObject* thisObject)
 }
 
 // This is intentionally supporting non-JSArray as well.
-inline JSString* fastArrayJoin(JSGlobalObject* globalObject, JSObject* thisObject, StringView separator, unsigned length, bool& sawHoles, bool& genericCase)
+ALWAYS_INLINE JSString* fastArrayJoin(JSGlobalObject* globalObject, JSObject* thisObject, StringView separator, unsigned length, bool& sawHoles, bool& genericCase)
 {
     VM& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);

--- a/Source/JavaScriptCore/runtime/DoubleToStringCache.cpp
+++ b/Source/JavaScriptCore/runtime/DoubleToStringCache.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DoubleToStringCache.h"
+
+#include "JSCInlines.h"
+#include <wtf/Assertions.h>
+#include <wtf/TZoneMallocInlines.h>
+#include <wtf/dragonbox/dragonbox_to_chars.h>
+#include <wtf/dtoa.h>
+#include <wtf/dtoa/double-conversion.h>
+#include <wtf/text/MakeString.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DoubleToStringCache);
+
+const String& DoubleToStringCache::add(VM& vm, double d)
+{
+    uint64_t bits = std::bit_cast<uint64_t>(d);
+    if (!bits)
+        return vm.numericStrings.add(0);
+
+    auto& entry = acquire(bits);
+    if (bits == entry.key)
+        return entry.value;
+    entry.key = bits;
+    entry.value = String::number(d);
+    entry.jsString = nullptr;
+    return entry.value;
+}
+
+JSString* DoubleToStringCache::addJSString(VM& vm, double value)
+{
+    uint64_t bits = std::bit_cast<uint64_t>(value);
+    if (!bits)
+        return vm.numericStrings.addJSString(vm, 0);
+
+    auto& entry = acquire(bits);
+    if (value != entry.key) {
+        entry.key = bits;
+        entry.value = String::number(value);
+    } else {
+        if (entry.jsString)
+            return entry.jsString;
+    }
+    entry.jsString = jsNontrivialString(vm, entry.value);
+    return entry.jsString;
+}
+
+ALWAYS_INLINE unsigned DoubleToStringCache::primaryHash(uint64_t bits)
+{
+    return static_cast<uint32_t>(bits) ^ static_cast<uint32_t>(bits >> 32);
+}
+
+ALWAYS_INLINE unsigned DoubleToStringCache::secondaryHash(uint64_t bits)
+{
+    return WTF::IntHash<uint64_t>::hash(bits);
+}
+
+ALWAYS_INLINE DoubleToStringCache::CacheEntryWithJSString<uint64_t>& DoubleToStringCache::acquire(uint64_t bits)
+{
+    auto& entry0 = m_primaryCache[primaryHash(bits) & (m_primaryCache.size() - 1)];
+    if (entry0.key == bits)
+        return entry0;
+
+    auto& entry1 = m_secondaryCache[secondaryHash(bits) & (m_secondaryCache.size() - 1)];
+    if (entry1.key == bits)
+        return entry1;
+
+    if (entry0.key)
+        m_secondaryCache[secondaryHash(entry0.key) & (m_secondaryCache.size() - 1)] = std::exchange(entry0, { });
+    return entry0;
+}
+
+template<typename Visitor>
+void DoubleToStringCache::visitAggregateImpl(Visitor& visitor)
+{
+    if (!(visitor.heap()->collectionScope() == CollectionScope::Full)) {
+        for (auto& entry : m_primaryCache)
+            visitor.appendUnbarriered(entry.jsString);
+        for (auto& entry : m_secondaryCache)
+            visitor.appendUnbarriered(entry.jsString);
+    }
+}
+
+DEFINE_VISIT_AGGREGATE(DoubleToStringCache);
+
+void DoubleToStringCache::finalizeUnconditionally(VM& vm)
+{
+    for (auto& entry : m_primaryCache) {
+        if (entry.jsString && !vm.heap.isMarked(entry.jsString))
+            entry.jsString = nullptr;
+    }
+    for (auto& entry : m_secondaryCache)
+        if (entry.jsString && !vm.heap.isMarked(entry.jsString))
+            entry.jsString = nullptr;
+}
+
+} // namespace JSC
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/runtime/DoubleToStringCache.h
+++ b/Source/JavaScriptCore/runtime/DoubleToStringCache.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "SlotVisitorMacros.h"
+#include <array>
+#include <wtf/HashFunctions.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/text/WTFString.h>
+
+namespace JSC {
+
+class JSString;
+class VM;
+
+class DoubleToStringCache {
+    WTF_MAKE_TZONE_ALLOCATED(DoubleToStringCache);
+public:
+    static const size_t primaryCacheSize = 2048;
+    static const size_t secondaryCacheSize = 1024;
+
+    template<typename T>
+    struct CacheEntryWithJSString {
+        T key { };
+        String value { };
+        JSString* jsString { nullptr };
+    };
+
+    const String& add(VM&, double);
+    JSString* addJSString(VM&, double);
+
+    DoubleToStringCache() = default;
+
+    DECLARE_VISIT_AGGREGATE;
+    void finalizeUnconditionally(VM&);
+
+private:
+    CacheEntryWithJSString<uint64_t>& acquire(uint64_t);
+
+    static unsigned primaryHash(uint64_t);
+    static unsigned secondaryHash(uint64_t);
+
+    std::array<CacheEntryWithJSString<uint64_t>, primaryCacheSize> m_primaryCache { };
+    std::array<CacheEntryWithJSString<uint64_t>, secondaryCacheSize> m_secondaryCache { };
+};
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/Identifier.cpp
+++ b/Source/JavaScriptCore/runtime/Identifier.cpp
@@ -52,7 +52,7 @@ Identifier Identifier::from(VM& vm, int value)
 
 Identifier Identifier::from(VM& vm, double value)
 {
-    return Identifier(vm, vm.numericStrings.add(value));
+    return Identifier(vm, vm.numericStrings.add(vm, value));
 }
 
 void Identifier::dump(PrintStream& out) const

--- a/Source/JavaScriptCore/runtime/JSCJSValue.cpp
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.cpp
@@ -413,7 +413,7 @@ String JSValue::toWTFStringSlowCase(JSGlobalObject* globalObject) const
     if (isInt32())
         return vm.numericStrings.add(asInt32());
     if (isDouble())
-        return vm.numericStrings.add(asDouble());
+        return vm.numericStrings.add(vm, asDouble());
     if (isTrue())
         return vm.propertyNames->trueKeyword.string();
     if (isFalse())

--- a/Source/JavaScriptCore/runtime/JSStringJoiner.h
+++ b/Source/JavaScriptCore/runtime/JSStringJoiner.h
@@ -218,7 +218,7 @@ ALWAYS_INLINE void JSStringJoiner::appendNumber(VM& vm, double value)
     if (canBeStrictInt32(value))
         appendNumber(vm, static_cast<int32_t>(value));
     else
-        append8Bit(vm.numericStrings.add(value));
+        append8Bit(vm.numericStrings.add(vm, value));
 }
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

--- a/Source/JavaScriptCore/runtime/NumberPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/NumberPrototype.cpp
@@ -486,6 +486,13 @@ JSC_DEFINE_HOST_FUNCTION(numberProtoFuncToPrecision, (JSGlobalObject* globalObje
     return JSValue::encode(jsString(vm, String::numberToStringFixedPrecision(x, significantFigures, TrailingZerosPolicy::Keep)));
 }
 
+void NumericStrings::doubleToStringCacheSlow()
+{
+    auto cache = makeUnique<DoubleToStringCache>();
+    WTF::storeStoreFence();
+    m_doubleCache = WTFMove(cache);
+}
+
 JSString* NumericStrings::addJSString(VM& vm, int i)
 {
     if (static_cast<unsigned>(i) < cacheSize) {
@@ -509,16 +516,7 @@ JSString* NumericStrings::addJSString(VM& vm, int i)
 
 JSString* NumericStrings::addJSString(VM& vm, double value)
 {
-    auto& entry = lookup(value);
-    if (value != entry.key || entry.value.isNull()) {
-        entry.key = value;
-        entry.value = String::number(value);
-    } else {
-        if (entry.jsString)
-            return entry.jsString;
-    }
-    entry.jsString = jsNontrivialString(vm, entry.value);
-    return entry.jsString;
+    return doubleToStringCache().addJSString(vm, value);
 }
 
 void NumericStrings::initializeSmallIntCache(VM& vm)
@@ -587,7 +585,7 @@ JSString* int52ToString(VM& vm, int64_t value, int32_t radix)
         return int32ToString(vm, static_cast<int32_t>(value), radix);
 
     if (radix == 10)
-        return jsNontrivialString(vm, vm.numericStrings.add(static_cast<double>(value)));
+        return jsNontrivialString(vm, vm.numericStrings.add(vm, static_cast<double>(value)));
 
     // Position the decimal point at the center of the string, set
     // the startOfResultString pointer to point at the decimal point.

--- a/Source/JavaScriptCore/runtime/NumericStrings.h
+++ b/Source/JavaScriptCore/runtime/NumericStrings.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "DoubleToStringCache.h"
 #include <array>
 #include <wtf/HashFunctions.h>
 #include <wtf/text/WTFString.h>
@@ -40,13 +41,13 @@ public:
 
     template<typename T>
     struct CacheEntry {
-        T key;
+        T key { };
         String value;
     };
 
     template<typename T>
     struct CacheEntryWithJSString {
-        T key;
+        T key { };
         String value;
         JSString* jsString { nullptr };
     };
@@ -58,23 +59,18 @@ public:
         static constexpr ptrdiff_t offsetOfJSString() { return OBJECT_OFFSETOF(StringWithJSString, jsString); }
     };
 
-    ALWAYS_INLINE const String& add(double d)
+    ALWAYS_INLINE const String& add(VM& vm, double d)
     {
-        auto& entry = lookup(d);
-        if (d == entry.key && !entry.value.isNull())
-            return entry.value;
-        entry.key = d;
-        entry.value = String::number(d);
-        entry.jsString = nullptr;
-        return entry.value;
+        return doubleToStringCache().add(vm, d);
     }
 
     ALWAYS_INLINE const String& add(int i)
     {
         if (static_cast<unsigned>(i) < cacheSize)
             return lookupSmallString(static_cast<unsigned>(i)).value;
+        ASSERT(i);
         auto& entry = lookup(i);
-        if (i == entry.key && !entry.value.isNull())
+        if (i == entry.key)
             return entry.value;
         entry.key = i;
         entry.value = String::number(i);
@@ -86,8 +82,9 @@ public:
     {
         if (i < cacheSize)
             return lookupSmallString(static_cast<unsigned>(i)).value;
+        ASSERT(i);
         auto& entry = lookup(i);
-        if (i == entry.key && !entry.value.isNull())
+        if (i == entry.key)
             return entry.value;
         entry.key = i;
         entry.value = String::number(i);
@@ -97,15 +94,19 @@ public:
     JSString* addJSString(VM&, int);
     JSString* addJSString(VM&, double);
 
-    void clearOnGarbageCollection()
+    void clearOnGarbageCollection(VM&)
     {
         for (auto& entry : m_intCache)
-            entry.jsString = nullptr;
-        for (auto& entry : m_doubleCache)
             entry.jsString = nullptr;
         // 0-9 are managed by SmallStrings. They never die.
         for (unsigned i = 10; i < m_smallIntCache.size(); ++i)
             m_smallIntCache[i].jsString = nullptr;
+    }
+
+    void finalizeUnconditionally(VM& vm)
+    {
+        if (m_doubleCache)
+            m_doubleCache->finalizeUnconditionally(vm);
     }
 
     template<typename Visitor>
@@ -113,19 +114,25 @@ public:
     {
         for (auto& entry : m_intCache)
             visitor.appendUnbarriered(entry.jsString);
-        for (auto& entry : m_doubleCache)
-            visitor.appendUnbarriered(entry.jsString);
         // 0-9 are managed by SmallStrings. They never die.
         for (unsigned i = 10; i < m_smallIntCache.size(); ++i)
             visitor.appendUnbarriered(m_smallIntCache[i].jsString);
+        if (m_doubleCache)
+            m_doubleCache->visitAggregate(visitor);
     }
 
     const StringWithJSString* smallIntCache() { return m_smallIntCache.data(); }
 
     void initializeSmallIntCache(VM&);
 
+    ALWAYS_INLINE DoubleToStringCache& doubleToStringCache()
+    {
+        if (!m_doubleCache) [[unlikely]]
+            doubleToStringCacheSlow();
+        return *m_doubleCache;
+    }
+
 private:
-    CacheEntryWithJSString<double>& lookup(double d) { return m_doubleCache[WTF::FloatHash<double>::hash(d) & (cacheSize - 1)]; }
     CacheEntryWithJSString<int>& lookup(int i) { return m_intCache[WTF::IntHash<int>::hash(i) & (cacheSize - 1)]; }
     CacheEntry<unsigned>& lookup(unsigned i) { return m_unsignedCache[WTF::IntHash<unsigned>::hash(i) & (cacheSize - 1)]; }
     ALWAYS_INLINE StringWithJSString& lookupSmallString(unsigned i)
@@ -136,10 +143,12 @@ private:
         return m_smallIntCache[i];
     }
 
+    void doubleToStringCacheSlow();
+
     std::array<StringWithJSString, cacheSize> m_smallIntCache { };
     std::array<CacheEntryWithJSString<int>, cacheSize> m_intCache { };
-    std::array<CacheEntryWithJSString<double>, cacheSize> m_doubleCache { };
     std::array<CacheEntry<unsigned>, cacheSize> m_unsignedCache { };
+    std::unique_ptr<DoubleToStringCache> m_doubleCache;
 };
 
 } // namespace JSC


### PR DESCRIPTION
#### b63d01762112727b69a41b7e133838ec34b73ff3
<pre>
[JSC] Tweak NumericStrings double-to-string hashing
<a href="https://bugs.webkit.org/show_bug.cgi?id=294484">https://bugs.webkit.org/show_bug.cgi?id=294484</a>
<a href="https://rdar.apple.com/problem/153349138">rdar://problem/153349138</a>

Reviewed by NOBODY (OOPS!).

This patch extends double-to-string cache. V8 is using 4096 so we also
use this same number. Also introducing two-level cache mechanism so that
we avoid pathological hash conflicting cases.

* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::runEndPhase):
(JSC::Heap::finalize):
* Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h:
(JSC::fastArrayJoin):
* Source/JavaScriptCore/runtime/DoubleToStringCache.cpp: Added.
(JSC::DoubleToStringCache::add):
(JSC::DoubleToStringCache::addJSString):
(JSC::DoubleToStringCache::primaryHash):
(JSC::DoubleToStringCache::secondaryHash):
(JSC::DoubleToStringCache::acquire):
(JSC::DoubleToStringCache::visitAggregateImpl):
(JSC::DoubleToStringCache::finalizeUnconditionally):
* Source/JavaScriptCore/runtime/DoubleToStringCache.h: Added.
* Source/JavaScriptCore/runtime/Identifier.cpp:
(JSC::Identifier::from):
* Source/JavaScriptCore/runtime/JSCJSValue.cpp:
(JSC::JSValue::toWTFStringSlowCase const):
* Source/JavaScriptCore/runtime/JSStringJoiner.h:
(JSC::JSStringJoiner::appendNumber):
* Source/JavaScriptCore/runtime/NumberPrototype.cpp:
(JSC::NumericStrings::doubleToStringCacheSlow):
(JSC::NumericStrings::addJSString):
(JSC::int52ToString):
* Source/JavaScriptCore/runtime/NumericStrings.h:
(JSC::NumericStrings::add):
(JSC::NumericStrings::clearOnGarbageCollection):
(JSC::NumericStrings::finalizeUnconditionally):
(JSC::NumericStrings::visitAggregate):
(JSC::NumericStrings::doubleToStringCache):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b63d01762112727b69a41b7e133838ec34b73ff3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108231 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27893 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18314 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113441 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58696 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28591 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36444 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82184 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111179 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22658 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97495 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62616 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22071 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15630 "Found 1 new test failure: http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/proper-nested-upgrades.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58174 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/100812 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92024 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15686 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116565 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/106791 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35294 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25984 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91208 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35667 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93770 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91004 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35892 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13655 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31065 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35194 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40741 "Found 1 new failure in runtime/DoubleToStringCache.h and found 1 fixed file: runtime/NumericStrings.h") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/131077 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34924 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35582 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38279 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36592 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->