### PR TITLE
[iOS] [SelectionHonorsOverflowScrolling] youtube.com: selection doesn’t show up in search field

### DIFF
--- a/LayoutTests/editing/selection/ios/select-text-in-container-with-backdrop-filter-expected.txt
+++ b/LayoutTests/editing/selection/ios/select-text-in-container-with-backdrop-filter-expected.txt
@@ -1,0 +1,10 @@
+This test verifies that the native text selection renders correctly in containers with a CSS backdrop filter.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS viewWithSelection is not viewWithoutSelection
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Select this text.

--- a/LayoutTests/editing/selection/ios/select-text-in-container-with-backdrop-filter.html
+++ b/LayoutTests/editing/selection/ios/select-text-in-container-with-backdrop-filter.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true SelectionHonorsOverflowScrolling=true ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <script src="../../../resources/ui-helper.js"></script>
+    <script src="../../../resources/js-test.js"></script>
+    <style>
+    html, body {
+        font-family: system-ui;
+        font-size: 16px;
+    }
+
+    section {
+        width: 100%;
+        height: 100px;
+        text-align: center;
+        backdrop-filter: blur(24px);
+        background-color: rgba(200, 200, 200, 0.1);
+        border-bottom: 1px solid gray;
+        line-height: 100px;
+        position: absolute;
+        top: 0;
+    }
+
+    #target {
+        border: 1px solid tomato;
+        border-radius: 4px;
+        padding: 4px;
+        font-size: 24px;
+    }
+    </style>
+    <script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        description("This test verifies that the native text selection renders correctly in containers with a CSS backdrop filter.");
+
+        const target = document.getElementById("target");
+
+        await UIHelper.longPressElement(target);
+        await UIHelper.waitForSelectionToAppear();
+
+        const {x, y} = UIHelper.midPointOfRect(await UIHelper.selectionBounds());
+        viewWithSelection = await UIHelper.frontmostViewAtPoint(x, y);
+
+        getSelection().removeAllRanges();
+        await UIHelper.ensurePresentationUpdate();
+        viewWithoutSelection = await UIHelper.frontmostViewAtPoint(x, y);
+
+        shouldNotBe("viewWithSelection", "viewWithoutSelection");
+        finishJSTest();
+    });
+    </script>
+</head>
+<body>
+    <section>Select <span id="target">this</span> text.</section>
+</body>
+</html>

--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -1570,7 +1570,7 @@ EnclosingLayerInfomation computeEnclosingLayer(const SimpleRange& range)
         if (!graphicsLayer)
             continue;
 
-        auto identifier = graphicsLayer->primaryLayerID();
+        auto identifier = graphicsLayer->layerIDIgnoringStructuralLayer();
         if (!identifier)
             continue;
 

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -312,6 +312,7 @@ public:
     virtual void initialize(Type) { }
 
     virtual std::optional<PlatformLayerIdentifier> primaryLayerID() const { return std::nullopt; }
+    virtual std::optional<PlatformLayerIdentifier> layerIDIgnoringStructuralLayer() const { return primaryLayerID(); }
 
     GraphicsLayerClient& client() const { return *m_client; }
 

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -502,6 +502,11 @@ std::optional<PlatformLayerIdentifier> GraphicsLayerCA::primaryLayerID() const
     return primaryLayer()->layerID();
 }
 
+std::optional<PlatformLayerIdentifier> GraphicsLayerCA::layerIDIgnoringStructuralLayer() const
+{
+    return protectedLayer()->layerID();
+}
+
 PlatformLayer* GraphicsLayerCA::platformLayer() const
 {
     return primaryLayer()->platformLayer();

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -68,6 +68,7 @@ public:
     WEBCORE_EXPORT String debugName() const override;
 
     WEBCORE_EXPORT std::optional<PlatformLayerIdentifier> primaryLayerID() const override;
+    WEBCORE_EXPORT std::optional<PlatformLayerIdentifier> layerIDIgnoringStructuralLayer() const final;
 
     WEBCORE_EXPORT PlatformLayer* platformLayer() const override;
     PlatformCALayer* platformCALayer() const { return primaryLayer(); }


### PR DESCRIPTION
#### 1bbc9d4d1dba7ff67be8c337fe0bde218c887024
<pre>
[iOS] [SelectionHonorsOverflowScrolling] youtube.com: selection doesn’t show up in search field
<a href="https://bugs.webkit.org/show_bug.cgi?id=294486">https://bugs.webkit.org/show_bug.cgi?id=294486</a>
<a href="https://rdar.apple.com/153309873">rdar://153309873</a>

Reviewed by Abrar Rahman Protyasha.

When selecting text inside of an element with a backdrop filter on iOS 26, native selection views
are currently inserted *behind* the selected web content rather than above it, causing the actual
selection UI to be partly (or fully) obscured.

This happens because the corresponding `RenderLayerBacking` (corresponding to an element with a
backdrop filter) requires an additional structural graphics layer as the ancestor of the underlying
layer that draws the content (and contains any composited children). We currently use
`primaryLayerID` to compute the identifier of the layer where the selection views will be inserted,
but this ends up being the identifier for this structural layer rather than the `m_layer`.

As a result, selection views are inserted under the structural layer in the back-most position (with
the intention of being obscured by any composited children). This causes the layer contents to cover
the selection views entirely.

To fix this, we switch from using `primaryLayerID` to a new `layerIDIgnoringStructuralLayer`, which
(on Cocoa platforms) skips this structural layer and returns the inner content layer, allowing the
selection views to be parented above the layer&apos;s contents (but behind any composited children that
may cover it).

* LayoutTests/editing/selection/ios/select-text-in-container-with-backdrop-filter-expected.txt: Added.
* LayoutTests/editing/selection/ios/select-text-in-container-with-backdrop-filter.html: Added.

Add a new layout test to verify the bug fix. This test selects text inside of a container with a
backdrop filter, and verifies that the native selection view is frontmost (relative to the
compositing view).

* Source/WebCore/editing/Editing.cpp:
(WebCore::computeEnclosingLayer):

Use `layerIDIgnoringStructuralLayer` here instead of `primaryLayerID`; see above for more details.

* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::layerIDIgnoringStructuralLayer const):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::layerIDIgnoringStructuralLayer const):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:

Canonical link: <a href="https://commits.webkit.org/296221@main">https://commits.webkit.org/296221@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3420e86af62b47b0564815c3aeab020ed2deb95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107818 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27486 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17904 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113032 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58342 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109784 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36028 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81845 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110763 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22328 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97142 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62264 "Passed tests") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21748 "An unexpected error occured. Recent messages:OS: Sequoia (15.5), Xcode: 16.4") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15283 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57785 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/100401 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91682 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15334 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116153 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34887 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90873 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35263 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93410 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90657 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23103 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35554 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13320 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30637 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34791 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40343 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34532 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37894 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36195 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->