### PR TITLE
Fix color flicker on edges of liquid glass on macOS Tahoe with site isolation enabled

### DIFF
--- a/LayoutTests/http/tests/site-isolation/edge-sampling-commit-root-frame-load-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/edge-sampling-commit-root-frame-load-expected.txt
@@ -1,0 +1,3 @@
+ALERT: PASS
+
+

--- a/LayoutTests/http/tests/site-isolation/edge-sampling-commit-root-frame-load.html
+++ b/LayoutTests/http/tests/site-isolation/edge-sampling-commit-root-frame-load.html
@@ -1,0 +1,50 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true pageTopColorSamplingEnabled=true ContentInsetBackgroundFillEnabled=true ] -->
+<head>
+    <script src="/js-test-resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner) { testRunner.waitUntilDone(); testRunner.dumpAsText() }
+        async function runTest() {
+            if (window.UIHelper) {
+                await UIHelper.setObscuredInsets(100, 0, 100, 0);
+                await UIHelper.ensurePresentationUpdate();
+                color = await UIHelper.fixedContainerEdgeColors();
+                alert(color.top == "rgb(255, 0, 0)" ? "PASS" : ("FAIL " + color.top));
+                if (window.testRunner) { testRunner.notifyDone() }
+            }
+        }
+        onload = runTest;
+    </script>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        body, html {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+            font-family: system-ui;
+        }
+
+        .top {
+            position: fixed;
+            top: 0;
+            height: 60px;
+            left: 0;
+            right: 0;
+        }
+
+        .content {
+            width: 100%;
+            height: 100%;
+        }
+
+        .top > .content {
+            background: red;
+        }
+
+        iframe { margin: 0px; padding: 0px; border: 0px; top: 0; left: 0; right: 0; position: fixed; width: 100% }
+    </style>
+</head>
+<body bgcolor=blue>
+<iframe src="http://localhost:8000/site-isolation/resources/update-background.html"></iframe>
+<div class="top"><div class="content"></div></div>
+</body>

--- a/LayoutTests/http/tests/site-isolation/edge-sampling-viewport-constrained-object-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/edge-sampling-viewport-constrained-object-expected.txt
@@ -1,0 +1,3 @@
+ALERT: PASS
+
+

--- a/LayoutTests/http/tests/site-isolation/edge-sampling-viewport-constrained-object.html
+++ b/LayoutTests/http/tests/site-isolation/edge-sampling-viewport-constrained-object.html
@@ -1,0 +1,64 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true pageTopColorSamplingEnabled=true ContentInsetBackgroundFillEnabled=true ] -->
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="/js-test-resources/ui-helper.js"></script>
+    <style>
+        body, html {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+            font-family: system-ui;
+        }
+
+        .top {
+            position: fixed;
+            top: 0;
+            height: 60px;
+            left: 0;
+            right: 0;
+        }
+
+        .content {
+            width: 100%;
+            height: 100%;
+        }
+
+        .top > .content {
+            background: red;
+        }
+
+        iframe { margin: 0px; padding: 0px; border: 0px; top: 0; left: 0; right: 0; position: fixed; width: 100% }
+    </style>
+</head>
+
+<script>
+    function addAndRemove() {
+        d.parentNode.removeChild(d);
+        setTimeout(()=>{
+            document.body.appendChild(d);
+            setTimeout(addAndRemove, 100);
+        }, 100)
+    }
+
+    if (window.testRunner) { testRunner.waitUntilDone(); testRunner.dumpAsText() }
+    async function runTest() {
+        d = secondtopdiv;
+        addAndRemove();
+
+        if (window.UIHelper) {
+            await UIHelper.setObscuredInsets(100, 0, 100, 0);
+            await UIHelper.ensurePresentationUpdate();
+            color = await UIHelper.fixedContainerEdgeColors();
+            alert(color.top == "rgb(255, 0, 0)" ? "PASS" : ("FAIL " + color.top));
+            if (window.testRunner) { testRunner.notifyDone() }
+        }
+    }
+    onload = runTest;
+</script>
+
+<body bgcolor=blue>
+<iframe src="http://localhost:8000/site-isolation/resources/add-and-remove-viewport-constrained-object.html"></iframe>
+<div class="top"><div class="content"></div></div>
+<div class="top" id='secondtopdiv'><div class="content"></div></div>
+</body>

--- a/LayoutTests/http/tests/site-isolation/resources/add-and-remove-viewport-constrained-object.html
+++ b/LayoutTests/http/tests/site-isolation/resources/add-and-remove-viewport-constrained-object.html
@@ -1,0 +1,51 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        body, html {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+            font-family: system-ui;
+        }
+
+        .top {
+            position: fixed;
+            top: 0;
+            height: 60px;
+            left: 0;
+            right: 0;
+        }
+
+        .content {
+            width: 100%;
+            height: 100%;
+        }
+
+        .top > .content {
+            background: purple;
+        }
+
+        iframe { margin: 0px; padding: 0px; border: 0px; top: 0; left: 0; right: 0; position: fixed; width: 100% }
+    </style>
+</head>
+
+<script>
+    function addAndRemove() {
+        d.parentNode.removeChild(d);
+        setTimeout(()=>{
+            document.body.appendChild(d);
+            setTimeout(addAndRemove, 100);
+        }, 100)
+    }
+    
+    onload = ()=>{
+        d = topdiv;
+        addAndRemove();
+    }
+</script>
+
+<body bgcolor=blue>
+<div class="top" id='topdiv'><div class="content"></div></div>
+</body>

--- a/LayoutTests/http/tests/site-isolation/resources/localhostiframe.html
+++ b/LayoutTests/http/tests/site-isolation/resources/localhostiframe.html
@@ -1,0 +1,1 @@
+<iframe src="http://localhost:8000/site-isolation/resources/green-background.html"></iframe>

--- a/LayoutTests/http/tests/site-isolation/resources/update-background.html
+++ b/LayoutTests/http/tests/site-isolation/resources/update-background.html
@@ -1,0 +1,35 @@
+<head>
+    <style>
+        .top {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            height: 80px;
+            background-color: rgb(0, 122, 255);
+            z-index: 100;
+        }
+    </style>
+</head>
+
+<body style='background-color:black'/>
+
+<script>
+    onload = () => {
+        document.body.style = 'background-color:white';
+        iframe = document.createElement('iframe');
+        iframe.src = 'http://127.0.0.1:8000/site-isolation/resources/localhostiframe.html';
+        iframe.onload = ()=> {
+            document.body.style = 'background-color:black';
+
+            // FIXME: Removing this setTimeout makes http/tests/site-isolation/edge-sampling-commit-root-frame-load.html
+            // never finish with site isolation off but not on.  Something seems broken
+            // related to WebPage::didFinishLoadInAnotherProcess.  Fix it and remove this setTimeout.
+            setTimeout(()=>{
+                iframe.parentNode.removeChild(iframe);
+                setTimeout(onload, 100)
+            }, 100);
+        }
+        document.body.appendChild(iframe);
+    }
+</script>

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4971,7 +4971,9 @@ void WebPage::willCommitLayerTree(RemoteLayerTreeTransaction& layerTransaction, 
     layerTransaction.setThemeColor(page->themeColor());
     layerTransaction.setPageExtendedBackgroundColor(page->pageExtendedBackgroundColor());
     layerTransaction.setSampledPageTopColor(page->sampledPageTopColor());
-    if (std::exchange(m_needsFixedContainerEdgesUpdate, false)) {
+
+    bool isMainFrameProcess = !!page->localMainFrame();
+    if (isMainFrameProcess && std::exchange(m_needsFixedContainerEdgesUpdate, false)) {
         page->updateFixedContainerEdges(sidesRequiringFixedContainerEdges());
         layerTransaction.setFixedContainerEdges(page->fixedContainerEdges());
     }


### PR DESCRIPTION
#### 7e720d823db10027f5a82acacdea67b2e485b0de
<pre>
Fix color flicker on edges of liquid glass on macOS Tahoe with site isolation enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=294493">https://bugs.webkit.org/show_bug.cgi?id=294493</a>
<a href="https://rdar.apple.com/153247645">rdar://153247645</a>

Reviewed by Wenson Hsieh and Abrar Rahman Protyasha.

283227@main fixed a similar color flicker from themeColor being updated by iframe processes.
288491@main fixed a similar color flicker from underPageBackgroundColor being updated by iframe processes.
This fixes a color flicker from _sampledTopFixedPositionContentColor being updated by iframe processes.
Page::updateFixedContainerEdges already kind of did the right thing, but if m_needsFixedContainerEdgesUpdate
was ever set to true, it would send a layer tree update with PredominantColorType::None interleaved between
what often was a non-PredominantColorType in a FixedContainerEdge.  I added tests that exhibited the flicker
when opened in Safari or MiniBrowser in two different ways: by committing the load of a root frame in
WebPage::didCommitLoad, and by adding and removing viewport constrained objects which caused
WebPage::didAddOrRemoveViewportConstrainedObjects to set m_needsFixedContainerEdgesUpdate to true.
In a process that doesn&apos;t have the main frame, we don&apos;t want to send any updates because it will just flicker.

* LayoutTests/http/tests/site-isolation/edge-sampling-commit-root-frame-load-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/edge-sampling-commit-root-frame-load.html: Added.
* LayoutTests/http/tests/site-isolation/edge-sampling-viewport-constrained-object-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/edge-sampling-viewport-constrained-object.html: Added.
* LayoutTests/http/tests/site-isolation/resources/add-and-remove-viewport-constrained-object.html: Added.
* LayoutTests/http/tests/site-isolation/resources/localhostiframe.html: Added.
* LayoutTests/http/tests/site-isolation/resources/update-background.html: Added.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::willCommitLayerTree):

Canonical link: <a href="https://commits.webkit.org/296235@main">https://commits.webkit.org/296235@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6ccafd5b10284d7d65db102fdde99fdbd8912be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107922 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27587 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18006 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113133 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/58444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28282 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36136 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81911 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/58444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110870 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22408 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97232 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62342 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21823 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15365 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57886 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91759 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15431 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116260 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34994 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25739 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90949 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35370 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93510 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90743 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35644 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13397 "Passed tests") | [⏳ 🛠 playstation ](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17435 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34892 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/40444 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34635 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37995 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36296 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->