### PR TITLE
[Materials] Rename "hosted blur" materials to reference "glass"

### DIFF
--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -2011,13 +2011,13 @@ constexpr CSSValueID toCSSValueID(AppleVisualEffect effect)
     case AppleVisualEffect::BlurChromeMaterial:
         return CSSValueAppleSystemBlurMaterialChrome;
 #if HAVE(MATERIAL_HOSTING)
-    case AppleVisualEffect::HostedBlurMaterial:
+    case AppleVisualEffect::GlassMaterial:
         return CSSValueAppleSystemGlassMaterial;
-    case AppleVisualEffect::HostedThinBlurMaterial:
+    case AppleVisualEffect::GlassSubduedMaterial:
         return CSSValueAppleSystemGlassMaterialSubdued;
-    case AppleVisualEffect::HostedMediaControlsMaterial:
+    case AppleVisualEffect::GlassMediaControlsMaterial:
         return CSSValueAppleSystemGlassMaterialMediaControls;
-    case AppleVisualEffect::HostedThinMediaControlsMaterial:
+    case AppleVisualEffect::GlassSubduedMediaControlsMaterial:
         return CSSValueAppleSystemGlassMaterialMediaControlsSubdued;
 #endif
     case AppleVisualEffect::VibrancyLabel:
@@ -2058,13 +2058,13 @@ template<> constexpr AppleVisualEffect fromCSSValueID(CSSValueID valueID)
         return AppleVisualEffect::BlurChromeMaterial;
 #if HAVE(MATERIAL_HOSTING)
     case CSSValueAppleSystemGlassMaterial:
-        return AppleVisualEffect::HostedBlurMaterial;
+        return AppleVisualEffect::GlassMaterial;
     case CSSValueAppleSystemGlassMaterialSubdued:
-        return AppleVisualEffect::HostedThinBlurMaterial;
+        return AppleVisualEffect::GlassSubduedMaterial;
     case CSSValueAppleSystemGlassMaterialMediaControls:
-        return AppleVisualEffect::HostedMediaControlsMaterial;
+        return AppleVisualEffect::GlassMediaControlsMaterial;
     case CSSValueAppleSystemGlassMaterialMediaControlsSubdued:
-        return AppleVisualEffect::HostedThinMediaControlsMaterial;
+        return AppleVisualEffect::GlassSubduedMediaControlsMaterial;
 #endif
     case CSSValueAppleSystemVibrancyLabel:
         return AppleVisualEffect::VibrancyLabel;

--- a/Source/WebCore/platform/cocoa/AppleVisualEffect.cpp
+++ b/Source/WebCore/platform/cocoa/AppleVisualEffect.cpp
@@ -43,10 +43,10 @@ bool appleVisualEffectNeedsBackdrop(AppleVisualEffect effect)
         return true;
     case AppleVisualEffect::None:
 #if HAVE(MATERIAL_HOSTING)
-    case AppleVisualEffect::HostedBlurMaterial:
-    case AppleVisualEffect::HostedThinBlurMaterial:
-    case AppleVisualEffect::HostedMediaControlsMaterial:
-    case AppleVisualEffect::HostedThinMediaControlsMaterial:
+    case AppleVisualEffect::GlassMaterial:
+    case AppleVisualEffect::GlassSubduedMaterial:
+    case AppleVisualEffect::GlassMediaControlsMaterial:
+    case AppleVisualEffect::GlassSubduedMediaControlsMaterial:
 #endif
     case AppleVisualEffect::VibrancyLabel:
     case AppleVisualEffect::VibrancySecondaryLabel:
@@ -73,10 +73,10 @@ bool appleVisualEffectAppliesFilter(AppleVisualEffect effect)
     case AppleVisualEffect::BlurThickMaterial:
     case AppleVisualEffect::BlurChromeMaterial:
 #if HAVE(MATERIAL_HOSTING)
-    case AppleVisualEffect::HostedBlurMaterial:
-    case AppleVisualEffect::HostedThinBlurMaterial:
-    case AppleVisualEffect::HostedMediaControlsMaterial:
-    case AppleVisualEffect::HostedThinMediaControlsMaterial:
+    case AppleVisualEffect::GlassMaterial:
+    case AppleVisualEffect::GlassSubduedMaterial:
+    case AppleVisualEffect::GlassMediaControlsMaterial:
+    case AppleVisualEffect::GlassSubduedMediaControlsMaterial:
 #endif
         return false;
     case AppleVisualEffect::VibrancyLabel:
@@ -98,10 +98,10 @@ bool appleVisualEffectAppliesFilter(AppleVisualEffect effect)
 bool appleVisualEffectIsHostedMaterial(AppleVisualEffect effect)
 {
     switch (effect) {
-    case AppleVisualEffect::HostedBlurMaterial:
-    case AppleVisualEffect::HostedThinBlurMaterial:
-    case AppleVisualEffect::HostedMediaControlsMaterial:
-    case AppleVisualEffect::HostedThinMediaControlsMaterial:
+    case AppleVisualEffect::GlassMaterial:
+    case AppleVisualEffect::GlassSubduedMaterial:
+    case AppleVisualEffect::GlassMediaControlsMaterial:
+    case AppleVisualEffect::GlassSubduedMediaControlsMaterial:
         return true;
     case AppleVisualEffect::None:
     case AppleVisualEffect::BlurUltraThinMaterial:
@@ -147,17 +147,17 @@ TextStream& operator<<(TextStream& ts, AppleVisualEffect effect)
         ts << "blur-material-chrome"_s;
         break;
 #if HAVE(MATERIAL_HOSTING)
-    case AppleVisualEffect::HostedBlurMaterial:
-        ts << "hosted-blur-material"_s;
+    case AppleVisualEffect::GlassMaterial:
+        ts << "glass-material"_s;
         break;
-    case AppleVisualEffect::HostedThinBlurMaterial:
-        ts << "hosted-thin-blur-material"_s;
+    case AppleVisualEffect::GlassSubduedMaterial:
+        ts << "glass-material-subdued"_s;
         break;
-    case AppleVisualEffect::HostedMediaControlsMaterial:
-        ts << "hosted-media-controls-material";
+    case AppleVisualEffect::GlassMediaControlsMaterial:
+        ts << "glass-material-media-controls";
         break;
-    case AppleVisualEffect::HostedThinMediaControlsMaterial:
-        ts << "hosted-thin-media-controls-material";
+    case AppleVisualEffect::GlassSubduedMediaControlsMaterial:
+        ts << "glass-material-media-controls-subdued";
         break;
 #endif
     case AppleVisualEffect::VibrancyLabel:

--- a/Source/WebCore/platform/cocoa/AppleVisualEffect.h
+++ b/Source/WebCore/platform/cocoa/AppleVisualEffect.h
@@ -43,10 +43,10 @@ enum class AppleVisualEffect : uint8_t {
     BlurThickMaterial,
     BlurChromeMaterial,
 #if HAVE(MATERIAL_HOSTING)
-    HostedBlurMaterial,
-    HostedThinBlurMaterial,
-    HostedMediaControlsMaterial,
-    HostedThinMediaControlsMaterial,
+    GlassMaterial,
+    GlassSubduedMaterial,
+    GlassMediaControlsMaterial,
+    GlassSubduedMediaControlsMaterial,
 #endif
     VibrancyLabel,
     VibrancySecondaryLabel,

--- a/Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.h
+++ b/Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.h
@@ -38,10 +38,10 @@
 
 typedef NS_ENUM(NSInteger, WKHostedMaterialEffectType) {
     WKHostedMaterialEffectTypeNone,
-    WKHostedMaterialEffectTypeBlur,
-    WKHostedMaterialEffectTypeThinBlur,
-    WKHostedMaterialEffectTypeMediaControls,
-    WKHostedMaterialEffectTypeThinMediaControls,
+    WKHostedMaterialEffectTypeGlass,
+    WKHostedMaterialEffectTypeSubduedGlass,
+    WKHostedMaterialEffectTypeMediaControlsGlass,
+    WKHostedMaterialEffectTypeSubduedMediaControlsGlass,
 };
 
 typedef NS_ENUM(NSInteger, WKHostedMaterialColorScheme) {

--- a/Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.swift
+++ b/Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.swift
@@ -83,18 +83,18 @@ private struct MaterialHostingView<P: MaterialHostingProvider>: View {
         switch type {
         case .none:
             return nil
-        case .blur:
-            return Material._glass(.regular)
-        case .thinBlur:
-            return Material._glass(.regular.forceSubdued())
-        case .mediaControls:
+        case .glass:
+            return ._glass(.regular)
+        case .subduedGlass:
+            return ._glass(.regular.forceSubdued())
+        case .mediaControlsGlass:
 #if canImport(SwiftUI, _version: 7.0.60)
-            return Material._glass(.regular.adaptive(false))
+            return ._glass(.regular.adaptive(false))
 #else
-            return Material._glass(.regular)
+            return ._glass(.regular)
 #endif
-        case .thinMediaControls:
-            return Material._glass(.avplayer.forceSubdued())
+        case .subduedMediaControlsGlass:
+            return ._glass(.avplayer.forceSubdued())
         @unknown default:
             return nil
         }

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -168,10 +168,10 @@ static MTCoreMaterialRecipe materialRecipeForAppleVisualEffect(AppleVisualEffect
     case AppleVisualEffect::None:
         return PAL::get_CoreMaterial_MTCoreMaterialRecipeNone();
 #if HAVE(MATERIAL_HOSTING)
-    case AppleVisualEffect::HostedBlurMaterial:
-    case AppleVisualEffect::HostedThinBlurMaterial:
-    case AppleVisualEffect::HostedMediaControlsMaterial:
-    case AppleVisualEffect::HostedThinMediaControlsMaterial:
+    case AppleVisualEffect::GlassMaterial:
+    case AppleVisualEffect::GlassSubduedMaterial:
+    case AppleVisualEffect::GlassMediaControlsMaterial:
+    case AppleVisualEffect::GlassSubduedMediaControlsMaterial:
 #endif
     case AppleVisualEffect::VibrancyLabel:
     case AppleVisualEffect::VibrancySecondaryLabel:
@@ -209,10 +209,10 @@ static MTCoreMaterialVisualStyle materialVisualStyleForAppleVisualEffect(AppleVi
     case AppleVisualEffect::BlurThickMaterial:
     case AppleVisualEffect::BlurChromeMaterial:
 #if HAVE(MATERIAL_HOSTING)
-    case AppleVisualEffect::HostedBlurMaterial:
-    case AppleVisualEffect::HostedThinBlurMaterial:
-    case AppleVisualEffect::HostedMediaControlsMaterial:
-    case AppleVisualEffect::HostedThinMediaControlsMaterial:
+    case AppleVisualEffect::GlassMaterial:
+    case AppleVisualEffect::GlassSubduedMaterial:
+    case AppleVisualEffect::GlassMediaControlsMaterial:
+    case AppleVisualEffect::GlassSubduedMediaControlsMaterial:
 #endif
         ASSERT_NOT_REACHED();
         return nil;
@@ -239,10 +239,10 @@ static MTCoreMaterialVisualStyleCategory materialVisualStyleCategoryForAppleVisu
     case AppleVisualEffect::BlurThickMaterial:
     case AppleVisualEffect::BlurChromeMaterial:
 #if HAVE(MATERIAL_HOSTING)
-    case AppleVisualEffect::HostedBlurMaterial:
-    case AppleVisualEffect::HostedThinBlurMaterial:
-    case AppleVisualEffect::HostedMediaControlsMaterial:
-    case AppleVisualEffect::HostedThinMediaControlsMaterial:
+    case AppleVisualEffect::GlassMaterial:
+    case AppleVisualEffect::GlassSubduedMaterial:
+    case AppleVisualEffect::GlassMediaControlsMaterial:
+    case AppleVisualEffect::GlassSubduedMediaControlsMaterial:
 #endif
         ASSERT_NOT_REACHED();
         return nil;
@@ -254,14 +254,14 @@ static MTCoreMaterialVisualStyleCategory materialVisualStyleCategoryForAppleVisu
 static WKHostedMaterialEffectType hostedMaterialEffectTypeForAppleVisualEffect(AppleVisualEffect effect)
 {
     switch (effect) {
-    case AppleVisualEffect::HostedBlurMaterial:
-        return WKHostedMaterialEffectTypeBlur;
-    case AppleVisualEffect::HostedThinBlurMaterial:
-        return WKHostedMaterialEffectTypeThinBlur;
-    case AppleVisualEffect::HostedMediaControlsMaterial:
-        return WKHostedMaterialEffectTypeMediaControls;
-    case AppleVisualEffect::HostedThinMediaControlsMaterial:
-        return WKHostedMaterialEffectTypeThinMediaControls;
+    case AppleVisualEffect::GlassMaterial:
+        return WKHostedMaterialEffectTypeGlass;
+    case AppleVisualEffect::GlassSubduedMaterial:
+        return WKHostedMaterialEffectTypeSubduedGlass;
+    case AppleVisualEffect::GlassMediaControlsMaterial:
+        return WKHostedMaterialEffectTypeMediaControlsGlass;
+    case AppleVisualEffect::GlassSubduedMediaControlsMaterial:
+        return WKHostedMaterialEffectTypeSubduedMediaControlsGlass;
     case AppleVisualEffect::None:
     case AppleVisualEffect::BlurUltraThinMaterial:
     case AppleVisualEffect::BlurThinMaterial:

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8141,10 +8141,10 @@ enum class WebCore::AppleVisualEffect : uint8_t {
     BlurThickMaterial,
     BlurChromeMaterial,
 #if HAVE(MATERIAL_HOSTING)
-    HostedBlurMaterial,
-    HostedThinBlurMaterial,
-    HostedMediaControlsMaterial,
-    HostedThinMediaControlsMaterial,
+    GlassMaterial,
+    GlassSubduedMaterial,
+    GlassMediaControlsMaterial,
+    GlassSubduedMediaControlsMaterial,
 #endif
     VibrancyLabel,
     VibrancySecondaryLabel,


### PR DESCRIPTION
#### 6775399e6f337820368f459e1486eac83b784aec
<pre>
[Materials] Rename &quot;hosted blur&quot; materials to reference &quot;glass&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=294495">https://bugs.webkit.org/show_bug.cgi?id=294495</a>
<a href="https://rdar.apple.com/153366580">rdar://153366580</a>

Reviewed by Anne van Kesteren.

* Source/WebCore/css/CSSPrimitiveValueMappings.h:
(WebCore::toCSSValueID):
(WebCore::fromCSSValueID):
* Source/WebCore/platform/cocoa/AppleVisualEffect.cpp:
(WebCore::appleVisualEffectNeedsBackdrop):
(WebCore::appleVisualEffectAppliesFilter):
(WebCore::appleVisualEffectIsHostedMaterial):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/cocoa/AppleVisualEffect.h:
* Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.h:
* Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.swift:
(MaterialHostingView.resolvedMaterialEffect(for:)):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::materialRecipeForAppleVisualEffect):
(WebKit::materialVisualStyleForAppleVisualEffect):
(WebKit::materialVisualStyleCategoryForAppleVisualEffect):
(WebKit::hostedMaterialEffectTypeForAppleVisualEffect):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/296228@main">https://commits.webkit.org/296228@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecc7d6a8a53feb212b36bbcfa88a26e8123650f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107869 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27537 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17955 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113083 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58393 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109835 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28232 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36080 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81872 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110814 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22363 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97183 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62305 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21778 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15317 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57836 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91712 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15382 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116204 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34938 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25701 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90900 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35314 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93461 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90692 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35593 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13351 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30688 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17432 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34842 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40394 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34584 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37945 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36246 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->