### PR TITLE
Make more m_queue's const to improve code readability

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -102,7 +102,7 @@ public:
 
     void stopListeningForIPC();
 
-    Ref<RemoteQueue> queue();
+    RemoteQueue& queue() { return m_queue; }
 
 private:
     friend class WebGPU::ObjectHeap;
@@ -115,8 +115,6 @@ private:
     RemoteDevice& operator=(RemoteDevice&&) = delete;
 
     WebCore::WebGPU::Device& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::Device> protectedBacking();
-    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
     Ref<WebGPU::ObjectHeap> protectedObjectHeap() const;
     Ref<RemoteGPU> protectedGPU() const { return m_gpu.get(); }
 
@@ -161,13 +159,13 @@ private:
     void setSharedVideoFrameMemory(WebCore::SharedMemoryHandle&&);
     void pauseAllErrorReporting(bool pauseErrorReporting);
 
-    Ref<WebCore::WebGPU::Device> m_backing;
+    const Ref<WebCore::WebGPU::Device> m_backing;
     WeakRef<WebGPU::ObjectHeap> m_objectHeap;
-    Ref<IPC::StreamServerConnection> m_streamConnection;
+    const Ref<IPC::StreamServerConnection> m_streamConnection;
     WebGPUIdentifier m_identifier;
-    Ref<RemoteQueue> m_queue;
+    const Ref<RemoteQueue> m_queue;
 #if ENABLE(VIDEO)
-    Ref<RemoteVideoFrameObjectHeap> m_videoFrameObjectHeap;
+    const Ref<RemoteVideoFrameObjectHeap> m_videoFrameObjectHeap;
 #if PLATFORM(COCOA)
     SharedVideoFrameReader m_sharedVideoFrameReader;
 #endif

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -85,7 +85,6 @@ private:
     void initializeCacheSize(CacheStorageCache&);
     void finishInitializingSize();
     void requestSpaceAfterInitializingSize(uint64_t size, CompletionHandler<void(bool)>&&);
-    Ref<CacheStorageRegistry> protectedRegistry();
 
     bool m_isInitialized { false };
     uint64_t m_updateCounter;
@@ -93,13 +92,13 @@ private:
     std::pair<uint64_t, HashSet<WebCore::DOMCacheIdentifier>> m_pendingSize;
     String m_path;
     FileSystem::Salt m_salt;
-    Ref<CacheStorageRegistry> m_registry;
+    const Ref<CacheStorageRegistry> m_registry;
     QuotaCheckFunction m_quotaCheckFunction;
     Vector<Ref<CacheStorageCache>> m_caches;
     HashMap<WebCore::DOMCacheIdentifier, Ref<CacheStorageCache>> m_removedCaches;
     HashMap<WebCore::DOMCacheIdentifier, Vector<IPC::Connection::UniqueID>> m_cacheRefConnections;
     HashSet<IPC::Connection::UniqueID> m_activeConnections;
-    Ref<WorkQueue> m_queue;
+    const Ref<WorkQueue> m_queue;
     Deque<std::pair<uint64_t, CompletionHandler<void(bool)>>> m_pendingSpaceRequests;
 };
 

--- a/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.cpp
@@ -38,14 +38,9 @@ RTCDataChannelRemoteManagerProxy::RTCDataChannelRemoteManagerProxy()
 {
 }
 
-Ref<WorkQueue> RTCDataChannelRemoteManagerProxy::protectedQueue()
-{
-    return m_queue;
-}
-
 void RTCDataChannelRemoteManagerProxy::registerConnectionToWebProcess(NetworkConnectionToWebProcess& connectionToWebProcess)
 {
-    protectedQueue()->dispatch([this, protectedThis = Ref { *this }, identifier = connectionToWebProcess.webProcessIdentifier(), connectionID = connectionToWebProcess.connection().uniqueID()]() mutable {
+    m_queue->dispatch([this, protectedThis = Ref { *this }, identifier = connectionToWebProcess.webProcessIdentifier(), connectionID = connectionToWebProcess.connection().uniqueID()]() mutable {
         ASSERT(!m_webProcessConnections.contains(identifier));
         m_webProcessConnections.add(identifier, connectionID);
     });
@@ -54,7 +49,7 @@ void RTCDataChannelRemoteManagerProxy::registerConnectionToWebProcess(NetworkCon
 
 void RTCDataChannelRemoteManagerProxy::unregisterConnectionToWebProcess(NetworkConnectionToWebProcess& connectionToWebProcess)
 {
-    protectedQueue()->dispatch([this, protectedThis = Ref { *this }, identifier = connectionToWebProcess.webProcessIdentifier()] {
+    m_queue->dispatch([this, protectedThis = Ref { *this }, identifier = connectionToWebProcess.webProcessIdentifier()] {
         ASSERT(m_webProcessConnections.contains(identifier));
         m_webProcessConnections.remove(identifier);
     });

--- a/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.h
+++ b/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -46,8 +46,6 @@ public:
 private:
     RTCDataChannelRemoteManagerProxy();
 
-    Ref<WorkQueue> protectedQueue();
-
     // IPC::WorkQueueMessageReceiver overrides.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
@@ -61,7 +59,7 @@ private:
     void detectError(WebCore::RTCDataChannelIdentifier, WebCore::RTCErrorDetailType, const String&);
     void bufferedAmountIsDecreasing(WebCore::RTCDataChannelIdentifier, size_t amount);
 
-    Ref<WorkQueue> m_queue;
+    const Ref<WorkQueue> m_queue;
     HashMap<WebCore::ProcessIdentifier, IPC::Connection::UniqueID> m_webProcessConnections;
 };
 

--- a/Source/WebKit/Platform/IPC/MessageReceiveQueues.h
+++ b/Source/WebKit/Platform/IPC/MessageReceiveQueues.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -66,13 +66,13 @@ public:
 
     void enqueueMessage(Connection& connection, UniqueRef<Decoder>&& message) final
     {
-        Ref { m_queue }->dispatch([connection = Ref { connection }, message = WTFMove(message), receiver = m_receiver]() mutable {
+        m_queue->dispatch([connection = Ref { connection }, message = WTFMove(message), receiver = m_receiver]() mutable {
             connection->dispatchMessageReceiverMessage(receiver.get(), WTFMove(message));
         });
     }
 private:
-    Ref<WorkQueue> m_queue;
-    Ref<WorkQueueMessageReceiverBase> m_receiver;
+    const Ref<WorkQueue> m_queue;
+    const Ref<WorkQueueMessageReceiverBase> m_receiver;
 };
 
 } // namespace IPC

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024 Igalia, S.L. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -53,7 +54,7 @@ WebExtensionSQLiteDatabase::WebExtensionSQLiteDatabase(const URL& url, Ref<WorkQ
 
 void WebExtensionSQLiteDatabase::assertQueue()
 {
-    assertIsCurrent(m_queue.get());
+    assertIsCurrent(queue());
 }
 
 int WebExtensionSQLiteDatabase::close()

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.h
@@ -88,7 +88,7 @@ public:
 
     sqlite3* sqlite3Handle() const { return m_db; };
     void assertQueue();
-    Ref<WorkQueue> queue() const { return m_queue; };
+    WorkQueue& queue() const { return m_queue; };
 
 private:
     RefPtr<API::Error> errorWithSQLiteErrorCode(int errorCode);
@@ -99,7 +99,7 @@ private:
 
     CString m_lastErrorMessage;
 
-    Ref<WorkQueue> m_queue;
+    const Ref<WorkQueue> m_queue;
 };
 
 }; // namespace WebKit

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteStatement.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteStatement.cpp
@@ -62,7 +62,7 @@ WebExtensionSQLiteStatement::~WebExtensionSQLiteStatement()
     if (!handle)
         return;
 
-    database()->queue()->dispatch([database = Ref { database() }, handle = WTFMove(handle)]() mutable {
+    database()->queue().dispatch([database = Ref { database() }, handle = WTFMove(handle)]() mutable {
         // The database might have closed already;
         if (!database->sqlite3Handle())
             return;

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteStore.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteStore.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024 Igalia, S.L. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,7 +57,7 @@ void WebExtensionSQLiteStore::close()
         return;
 
     if (isMainRunLoop()) {
-        queue()->dispatchSync([db = RefPtr { database() }] {
+        m_queue->dispatchSync([db = RefPtr { database() }] {
             db->close();
         });
 
@@ -69,7 +70,7 @@ void WebExtensionSQLiteStore::close()
 
 void WebExtensionSQLiteStore::deleteDatabase(CompletionHandler<void(const String& errorMessage)>&& completionHandler)
 {
-    queue()->dispatch([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)]() mutable {
+    m_queue->dispatch([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)]() mutable {
         auto deleteDatabaseErrorMessage = protectedThis->deleteDatabase();
         WorkQueue::protectedMain()->dispatch([deleteDatabaseErrorMessage = crossThreadCopy(deleteDatabaseErrorMessage), completionHandler = WTFMove(completionHandler)]() mutable {
             completionHandler(deleteDatabaseErrorMessage);
@@ -317,7 +318,7 @@ void WebExtensionSQLiteStore::createSavepoint(CompletionHandler<void(Markable<WT
 {
     UUID savepointIdentifier = UUID::createVersion4();
 
-    queue()->dispatch([protectedThis = Ref { *this }, savepointIdentifier = crossThreadCopy(savepointIdentifier), completionHandler = WTFMove(completionHandler)]() mutable {
+    m_queue->dispatch([protectedThis = Ref { *this }, savepointIdentifier = crossThreadCopy(savepointIdentifier), completionHandler = WTFMove(completionHandler)]() mutable {
         String errorMessage;
         if (protectedThis->openDatabaseIfNecessary(errorMessage, false)) {
             WorkQueue::protectedMain()->dispatch([errorMessage = crossThreadCopy(errorMessage), completionHandler = WTFMove(completionHandler)]() mutable {
@@ -344,7 +345,7 @@ void WebExtensionSQLiteStore::createSavepoint(CompletionHandler<void(Markable<WT
 
 void WebExtensionSQLiteStore::commitSavepoint(WTF::UUID& savepointIdentifier, CompletionHandler<void(const String& errorMessage)>&& completionHandler)
 {
-    queue()->dispatch([protectedThis = Ref { *this }, savepointIdentifier = crossThreadCopy(savepointIdentifier), completionHandler = WTFMove(completionHandler)]() mutable {
+    m_queue->dispatch([protectedThis = Ref { *this }, savepointIdentifier = crossThreadCopy(savepointIdentifier), completionHandler = WTFMove(completionHandler)]() mutable {
         String errorMessage;
         if (protectedThis->openDatabaseIfNecessary(errorMessage, false)) {
             WorkQueue::protectedMain()->dispatch([errorMessage = crossThreadCopy(errorMessage), completionHandler = WTFMove(completionHandler)]() mutable {
@@ -371,7 +372,7 @@ void WebExtensionSQLiteStore::commitSavepoint(WTF::UUID& savepointIdentifier, Co
 
 void WebExtensionSQLiteStore::rollbackToSavepoint(WTF::UUID& savepointIdentifier, CompletionHandler<void(const String& errorMessage)>&& completionHandler)
 {
-    queue()->dispatch([protectedThis = Ref { *this }, savepointIdentifier = crossThreadCopy(savepointIdentifier), completionHandler = WTFMove(completionHandler)]() mutable {
+    m_queue->dispatch([protectedThis = Ref { *this }, savepointIdentifier = crossThreadCopy(savepointIdentifier), completionHandler = WTFMove(completionHandler)]() mutable {
         String errorMessage;
         if (protectedThis->openDatabaseIfNecessary(errorMessage, false)) {
             WorkQueue::protectedMain()->dispatch([errorMessage = crossThreadCopy(errorMessage), completionHandler = WTFMove(completionHandler)]() mutable {

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteStore.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteStore.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024 Igalia, S.L. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,7 +73,7 @@ protected:
     DatabaseResult setDatabaseSchemaVersion(SchemaVersion newVersion);
     SchemaVersion migrateToCurrentSchemaVersionIfNeeded();
 
-    Ref<WorkQueue> queue() { return m_queue; };
+    WorkQueue& queue() { return m_queue; };
     RefPtr<WebExtensionSQLiteDatabase> database() { return m_database; };
     String uniqueIdentifier() { return m_uniqueIdentifier; };
     CString lastErrorMessage() { return m_database->m_lastErrorMessage; };
@@ -92,7 +93,7 @@ private:
     String m_uniqueIdentifier;
     URL m_directory;
     RefPtr<WebExtensionSQLiteDatabase> m_database;
-    Ref<WorkQueue> m_queue;
+    const Ref<WorkQueue> m_queue;
     bool m_useInMemoryDatabase;
 };
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionStorageSQLiteStore.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionStorageSQLiteStore.cpp
@@ -60,7 +60,7 @@ WebExtensionStorageSQLiteStore::WebExtensionStorageSQLiteStore(const String& uni
 
 void WebExtensionStorageSQLiteStore::getAllKeys(CompletionHandler<void(Vector<String> keys, const String& errorMessage)>&& completionHandler)
 {
-    queue()->dispatch([weakThis = ThreadSafeWeakPtr { *this }, uniqueIdentifier = crossThreadCopy(uniqueIdentifier()), completionHandler = WTFMove(completionHandler)]() mutable {
+    queue().dispatch([weakThis = ThreadSafeWeakPtr { *this }, uniqueIdentifier = crossThreadCopy(uniqueIdentifier()), completionHandler = WTFMove(completionHandler)]() mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis) {
             RELEASE_LOG_ERROR(Extensions, "Failed to retrieve all keys for extension %s.", uniqueIdentifier.utf8().data());
@@ -79,7 +79,7 @@ void WebExtensionStorageSQLiteStore::getAllKeys(CompletionHandler<void(Vector<St
 
 void WebExtensionStorageSQLiteStore::getValuesForKeys(Vector<String> keys, CompletionHandler<void(HashMap<String, String> results, const String& errorMessage)>&& completionHandler)
 {
-    queue()->dispatch([weakThis = ThreadSafeWeakPtr { *this }, uniqueIdentifier = crossThreadCopy(uniqueIdentifier()), keys = crossThreadCopy(keys), completionHandler = WTFMove(completionHandler)]() mutable {
+    queue().dispatch([weakThis = ThreadSafeWeakPtr { *this }, uniqueIdentifier = crossThreadCopy(uniqueIdentifier()), keys = crossThreadCopy(keys), completionHandler = WTFMove(completionHandler)]() mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis) {
             RELEASE_LOG_ERROR(Extensions, "Failed to retrieve values for keys: %s for extension %s.", rowFilterStringFromRowKeys(keys).utf8().data(), uniqueIdentifier.utf8().data());
@@ -111,7 +111,7 @@ static size_t storageSizeOf(HashMap<String, String> map)
 
 void WebExtensionStorageSQLiteStore::getStorageSizeForKeys(Vector<String> keys, CompletionHandler<void(size_t storageSize, const String& errorMessage)>&& completionHandler)
 {
-    queue()->dispatch([protectedThis = Ref { *this }, uniqueIdentifier = crossThreadCopy(uniqueIdentifier()), keys = crossThreadCopy(keys), completionHandler = WTFMove(completionHandler)]() mutable {
+    queue().dispatch([protectedThis = Ref { *this }, uniqueIdentifier = crossThreadCopy(uniqueIdentifier()), keys = crossThreadCopy(keys), completionHandler = WTFMove(completionHandler)]() mutable {
         String errorMessage;
         if (!keys.isEmpty()) {
             auto keysAndValues = protectedThis->getValuesForKeysWithErrorMessage(keys, errorMessage);
@@ -167,7 +167,7 @@ void WebExtensionStorageSQLiteStore::getStorageSizeForAllKeys(HashMap<String, St
             return;
         }
 
-        queue()->dispatch([weakThis = ThreadSafeWeakPtr { *this }, uniqueIdentifier = crossThreadCopy(uniqueIdentifier()), storageSize, additionalKeyedData = crossThreadCopy(additionalKeyedData), completionHandler = WTFMove(completionHandler)]() mutable {
+        queue().dispatch([weakThis = ThreadSafeWeakPtr { *this }, uniqueIdentifier = crossThreadCopy(uniqueIdentifier()), storageSize, additionalKeyedData = crossThreadCopy(additionalKeyedData), completionHandler = WTFMove(completionHandler)]() mutable {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis) {
                 RELEASE_LOG_ERROR(Extensions, "Failed to calculate storage size for extension %s.", uniqueIdentifier.utf8().data());
@@ -193,7 +193,7 @@ void WebExtensionStorageSQLiteStore::getStorageSizeForAllKeys(HashMap<String, St
 
 void WebExtensionStorageSQLiteStore::setKeyedData(HashMap<String, String> keyedData, CompletionHandler<void(Vector<String> keysSuccessfullySet, const String& errorMessage)>&& completionHandler)
 {
-    queue()->dispatch([weakThis = ThreadSafeWeakPtr { *this }, keyedData = crossThreadCopy(keyedData), completionHandler = WTFMove(completionHandler)]() mutable {
+    queue().dispatch([weakThis = ThreadSafeWeakPtr { *this }, keyedData = crossThreadCopy(keyedData), completionHandler = WTFMove(completionHandler)]() mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis) {
             completionHandler({ }, makeString("Failed to set keys: "_s, rowFilterStringFromRowKeys(toVector(keyedData, true))));
@@ -227,7 +227,7 @@ void WebExtensionStorageSQLiteStore::setKeyedData(HashMap<String, String> keyedD
 
 void WebExtensionStorageSQLiteStore::deleteValuesForKeys(Vector<String> keys, CompletionHandler<void(const String& errorMessage)>&& completionHandler)
 {
-    queue()->dispatch([weakThis = ThreadSafeWeakPtr { *this }, keys = crossThreadCopy(keys), completionHandler = WTFMove(completionHandler)]() mutable {
+    queue().dispatch([weakThis = ThreadSafeWeakPtr { *this }, keys = crossThreadCopy(keys), completionHandler = WTFMove(completionHandler)]() mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis) {
             completionHandler(makeString("Failed to delete keys: "_s, rowFilterStringFromRowKeys(keys)));


### PR DESCRIPTION
#### fddbb3398ca15e7e1ca9e80c5c73ab16154cafcf
<pre>
Make more m_queue&apos;s const to improve code readability
<a href="https://bugs.webkit.org/show_bug.cgi?id=294499">https://bugs.webkit.org/show_bug.cgi?id=294499</a>

Reviewed by Mike Wyrzykowski and Chris Dumez.

It appears some were left behind in previous iterations of making
things const. This also makes some members const that are not m_queue
and applies <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/296240@main">https://commits.webkit.org/296240@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccb948565cb8086be3352a3b8f903af8121d6d48

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107880 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27548 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17966 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113094 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58404 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28243 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36092 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81881 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110826 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22373 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97194 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62310 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21788 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57847 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91724 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15393 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116216 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34950 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25708 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90911 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35326 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93472 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90704 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35605 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13361 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30700 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17437 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34853 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40405 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34595 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37956 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36257 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->