### PR TITLE
[JSC] Implement `Array.prototype.flat` in C++

### DIFF
--- a/JSTests/microbenchmarks/array-prototype-flat-depth-1-double.js
+++ b/JSTests/microbenchmarks/array-prototype-flat-depth-1-double.js
@@ -1,0 +1,15 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const array = new Array(1024);
+array.fill(99.99);
+array[512] = [1.1, 2.2, 3.3, 4.4, 5.5];
+
+let r;
+for (let i = 0; i < 1e5; i++) {
+    r = array.flat();
+}
+
+shouldBe(r.length, 1023 + 5);

--- a/JSTests/microbenchmarks/array-prototype-flat-depth-1-int32.js
+++ b/JSTests/microbenchmarks/array-prototype-flat-depth-1-int32.js
@@ -1,0 +1,15 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const array = new Array(1024);
+array.fill(99);
+array[512] = [1, 2, 3, 4, 5];
+
+let r;
+for (let i = 0; i < 1e5; i++) {
+    r = array.flat();
+}
+
+shouldBe(r.length, 1023 + 5);

--- a/JSTests/microbenchmarks/array-prototype-flat-depth-1-mixed.js
+++ b/JSTests/microbenchmarks/array-prototype-flat-depth-1-mixed.js
@@ -1,0 +1,21 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const array = new Array(1024);
+for (let i = 0; i < array.length; i++) {
+    if (i % 3 === 0) array[i] = i;
+    else if (i % 3 === 1) array[i] = `str${i}`;
+    else array[i] = i * 1.1;
+}
+array[256] = [true, false, null, undefined, {}];
+array[512] = [42, "hello", 3.14, BigInt(100), Symbol.for("test")];
+array[768] = [[], {a: 1}, new Date(), /regex/, function() {}];
+
+let r;
+for (let i = 0; i < 1e5; i++) {
+    r = array.flat();
+}
+
+shouldBe(r.length, 1021 + 5 + 5 + 5);

--- a/JSTests/microbenchmarks/array-prototype-flat-depth-1-string.js
+++ b/JSTests/microbenchmarks/array-prototype-flat-depth-1-string.js
@@ -1,0 +1,15 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const array = new Array(1024);
+array.fill("test");
+array[512] = ["hello", "world", "from", "webkit", "test"];
+
+let r;
+for (let i = 0; i < 1e5; i++) {
+    r = array.flat();
+}
+
+shouldBe(r.length, 1023 + 5);

--- a/JSTests/microbenchmarks/array-prototype-flat-depth-2.js
+++ b/JSTests/microbenchmarks/array-prototype-flat-depth-2.js
@@ -1,0 +1,17 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const array = new Array(1024);
+array.fill(99);
+array[256] = [[1, 2], [3, 4], [5, 6]];
+array[512] = [[7, 8, 9], [10, 11, 12]];
+array[768] = [[13], [14, 15], [16, 17, 18]];
+
+let r;
+for (let i = 0; i < 1e5; i++) {
+    r = array.flat(2);
+}
+
+shouldBe(r.length, 1021 + 6 + 6 + 6);

--- a/JSTests/microbenchmarks/array-prototype-flat-depth-3.js
+++ b/JSTests/microbenchmarks/array-prototype-flat-depth-3.js
@@ -1,0 +1,17 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const array = new Array(1024);
+array.fill(99);
+array[256] = [[[1, 2]], [[3], [4, 5]], [[[6]]]];
+array[512] = [[[7, 8, 9]], [[[10]], [[11, 12]]]];
+array[768] = [[[[13]]], [[[14, 15]], [[16]]], [[[17], [18]]]];
+
+let r;
+for (let i = 0; i < 1e5; i++) {
+    r = array.flat(3);
+}
+
+shouldBe(r.length, 1037);

--- a/JSTests/microbenchmarks/array-prototype-flat-depth-infinity.js
+++ b/JSTests/microbenchmarks/array-prototype-flat-depth-infinity.js
@@ -1,0 +1,17 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const array = new Array(1024);
+array.fill(99);
+array[256] = [[[[[1, 2]]]], [[[3], [4, 5]]], [[[[[[6]]]]]]];
+array[512] = [[[[[[7, 8, 9]]]]], [[[[[10]]], [[[11, 12]]]]]];
+array[768] = [[[[[[[13]]]]]], [[[[[[14, 15]]]], [[[16]]]], [[[[17], [18]]]]]];
+
+let r;
+for (let i = 0; i < 1e5; i++) {
+    r = array.flat(Infinity);
+}
+
+shouldBe(r.length, 1021 + 6 + 6 + 6);

--- a/JSTests/microbenchmarks/array-prototype-flat-huge-arrays.js
+++ b/JSTests/microbenchmarks/array-prototype-flat-huge-arrays.js
@@ -1,0 +1,17 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const array = new Array(100000);
+array.fill(42);
+for (let i = 0; i < 1000; i++) {
+    array[i * 100] = [1, 2, 3, 4, 5];
+}
+
+let r;
+for (let i = 0; i < 1e2; i++) {
+    r = array.flat();
+}
+
+shouldBe(r.length, 99000 + 1000 * 5);

--- a/JSTests/microbenchmarks/array-prototype-flat-large-nested.js
+++ b/JSTests/microbenchmarks/array-prototype-flat-large-nested.js
@@ -1,0 +1,28 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function createLargeNestedArray(depth, width) {
+    if (depth === 0) {
+        return Array(width).fill(1);
+    }
+    const arr = [];
+    for (let i = 0; i < width; i++) {
+        arr.push(createLargeNestedArray(depth - 1, width));
+    }
+    return arr;
+}
+
+const array = new Array(512);
+array.fill(99);
+array[100] = createLargeNestedArray(3, 10);
+array[200] = createLargeNestedArray(2, 20);
+array[300] = createLargeNestedArray(4, 5);
+
+let r;
+for (let i = 0; i < 1e3; i++) {
+    r = array.flat(Infinity);
+}
+
+shouldBe(r.length, 21634);

--- a/JSTests/microbenchmarks/array-prototype-flat-small-arrays.js
+++ b/JSTests/microbenchmarks/array-prototype-flat-small-arrays.js
@@ -1,0 +1,13 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const array = [1, [2, 3], 4, [5], 6, [7, 8, 9], 10];
+
+let r;
+for (let i = 0; i < 1e5; i++) {
+    r = array.flat();
+}
+
+shouldBe(r.length, 10);

--- a/JSTests/microbenchmarks/array-prototype-flat-sparse-array.js
+++ b/JSTests/microbenchmarks/array-prototype-flat-sparse-array.js
@@ -1,0 +1,22 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const array = new Array(2048);
+array[100] = 1;
+array[500] = [2, 3, 4];
+array[1000] = 5;
+array[1500] = [6, 7, 8, 9];
+array[2000] = [[10, 11], [12, 13]];
+
+let r;
+for (let i = 0; i < 1e5; i++) {
+    r = array.flat();
+}
+
+let count = 0;
+for (let i = 0; i < r.length; i++) {
+    if (r[i] !== undefined) count++;
+}
+shouldBe(count, 11);

--- a/JSTests/stress/array-prototype-flat-hole.js
+++ b/JSTests/stress/array-prototype-flat-hole.js
@@ -1,0 +1,14 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+Array.prototype[2] = 222;
+const arr = [0, 1, , 3];
+const f = arr.flat(0);
+
+shouldBe(f.length, 4);
+shouldBe(f[0], 0);
+shouldBe(f[1], 1);
+shouldBe(f[2], 222);
+shouldBe(f[3], 3);

--- a/JSTests/stress/array-prototype-flat-nested-proxy-array.js
+++ b/JSTests/stress/array-prototype-flat-nested-proxy-array.js
@@ -1,0 +1,25 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const handler = {
+  get : function (t, p, r) { return Reflect.get(t, p, r); },
+  has : function (t, p, r) { return Reflect.has(t, p, r); }
+};
+
+const proxyArray = new Proxy([5, 6], handler);
+
+const array = [1, 2, 3, 4, proxyArray, 7, 8];
+shouldBe(array.length, 7);
+
+const flattened = array.flat();
+shouldBe(flattened.length, 8);
+shouldBe(flattened[0], 1);
+shouldBe(flattened[1], 2);
+shouldBe(flattened[2], 3);
+shouldBe(flattened[3], 4);
+shouldBe(flattened[4], 5);
+shouldBe(flattened[5], 6);
+shouldBe(flattened[6], 7);
+shouldBe(flattened[7], 8);

--- a/Source/JavaScriptCore/builtins/ArrayPrototype.js
+++ b/Source/JavaScriptCore/builtins/ArrayPrototype.js
@@ -294,24 +294,6 @@ function flatIntoArray(target, source, sourceLength, targetIndex, depth)
     return targetIndex;
 }
 
-function flat()
-{
-    "use strict";
-
-    var array = @toObject(this, "Array.prototype.flat requires that |this| not be null or undefined");
-    var length = @toLength(array.length);
-
-    var depthNum = 1;
-    var depth = @argument(0);
-    if (depth !== @undefined)
-        depthNum = @toIntegerOrInfinity(depth);
-
-    var result = @newArrayWithSpecies(0, array);
-
-    @flatIntoArray(result, array, length, 0, depthNum);
-    return result;
-}
-
 @linkTimeConstant
 function flatIntoArrayWithCallback(target, source, sourceLength, targetIndex, callback, thisArg)
 {

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.h
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.h
@@ -329,6 +329,7 @@
     macro(AsyncDisposableStack) \
     macro(disposeAsync) \
     macro(keys) \
+    macro(flat) \
 
 #define JSC_COMMON_IDENTIFIERS_EACH_PRIVATE_FIELD(macro) \
     macro(constructor)

--- a/Source/JavaScriptCore/runtime/JSArray.h
+++ b/Source/JavaScriptCore/runtime/JSArray.h
@@ -133,6 +133,8 @@ public:
 
     JSString* fastToString(JSGlobalObject*);
 
+    JSArray* fastFlat(JSGlobalObject*, uint64_t depth, uint64_t length);
+
     ALWAYS_INLINE bool definitelyNegativeOneMiss() const;
 
     enum ShiftCountMode {


### PR DESCRIPTION
#### 7b9df2f4b1a9e2f12cf4feceb0870e44ab8efed6
<pre>
[JSC] Implement `Array.prototype.flat` in C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=294503">https://bugs.webkit.org/show_bug.cgi?id=294503</a>

Reviewed by Yusuke Suzuki.

This patch implements `Array.prototype.flat` in C++.

The new fast path for `Array#flat` first calculates the length
of the resulting array using O(n) `calculateFlattenedLength`,
then directly sets values into the butterfly buffer of the
resulting array using O(n) `fastFlatIntoBuffer`.

                                             TipOfTree                  Patched

array-prototype-flat-depth-1-string      395.8826+-4.5561     ^    147.9479+-3.7062        ^ definitely 2.6758x faster
array-prototype-flat-large-nested        111.9910+-4.9277     ^     30.5805+-0.2314        ^ definitely 3.6622x faster
array-prototype-flat-sparse-array        198.6802+-2.0652     ^    133.4569+-3.7686        ^ definitely 1.4887x faster
array-prototype-flat-small-arrays          9.0792+-0.4023     ^      4.8345+-0.1067        ^ definitely 1.8780x faster
array-prototype-flat-depth-1-double      600.7011+-40.1338    ^    105.1259+-1.4612        ^ definitely 5.7141x faster
array-prototype-flat-depth-1-int32       447.6045+-6.5491     ^    106.2142+-7.6386        ^ definitely 4.2142x faster
array-prototype-flat-depth-infinity      524.9275+-4.1636     ^    141.2842+-5.6371        ^ definitely 3.7154x faster
array-prototype-flat-depth-2             522.6723+-2.1402     ^    118.4029+-5.5013        ^ definitely 4.4144x faster
array-prototype-flat-huge-arrays          43.4337+-3.9484     ^     10.1096+-0.1294        ^ definitely 4.2963x faster
array-prototype-flat-depth-1-mixed       450.7441+-18.1260    ^    136.2629+-0.7525        ^ definitely 3.3079x faster
array-prototype-flat-depth-3             526.4249+-2.3837     ^    124.7195+-4.6807        ^ definitely 4.2209x faster

* JSTests/microbenchmarks/array-prototype-flat-depth-1-double.js: Added.
(shouldBe):
* JSTests/microbenchmarks/array-prototype-flat-depth-1-int32.js: Added.
(shouldBe):
* JSTests/microbenchmarks/array-prototype-flat-depth-1-mixed.js: Added.
(shouldBe):
* JSTests/microbenchmarks/array-prototype-flat-depth-1-string.js: Added.
(shouldBe):
* JSTests/microbenchmarks/array-prototype-flat-depth-2.js: Added.
(shouldBe):
* JSTests/microbenchmarks/array-prototype-flat-depth-3.js: Added.
(shouldBe):
* JSTests/microbenchmarks/array-prototype-flat-depth-infinity.js: Added.
(shouldBe):
* JSTests/microbenchmarks/array-prototype-flat-huge-arrays.js: Added.
(shouldBe):
* JSTests/microbenchmarks/array-prototype-flat-large-nested.js: Added.
(shouldBe):
(createLargeNestedArray):
* JSTests/microbenchmarks/array-prototype-flat-small-arrays.js: Added.
(shouldBe):
* JSTests/microbenchmarks/array-prototype-flat-sparse-array.js: Added.
(shouldBe):
* JSTests/stress/array-prototype-flat-hole.js: Added.
(shouldBe):
* JSTests/stress/array-prototype-flat-nested-proxy-array.js: Added.
(shouldBe):
(const.handler.has):
* Source/JavaScriptCore/builtins/ArrayPrototype.js:
(flat): Deleted.
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::ArrayPrototype::finishCreation):
(JSC::flatIntoArray):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/CommonIdentifiers.h:
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::calculateFlattenedLength):
(JSC::fastFlatIntoBuffer):
(JSC::JSArray::fastFlat):
* Source/JavaScriptCore/runtime/JSArray.h:

Canonical link: <a href="https://commits.webkit.org/298127@main">https://commits.webkit.org/298127@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2057d249afb9310b42173beeaa5c124157d7a23f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114347 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34092 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120519 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65065 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34723 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42653 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/86904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117295 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27652 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102694 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/67296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26833 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20819 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64201 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/106746 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97027 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20935 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123729 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/112910 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41361 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30847 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/95729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41738 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98894 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/95513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24338 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40655 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18491 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37403 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41241 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46749 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/137119 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40836 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36681 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44142 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42584 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->