### PR TITLE
[CSS-Flexbox] Fallback to 'safe center' for 'align-content'

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-content-wrap-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-content-wrap-003-expected.txt
@@ -10,22 +10,8 @@ PASS .flexbox 8
 PASS .flexbox 9
 PASS .flexbox 10
 PASS .flexbox 11
-FAIL .flexbox 12 assert_equals:
-<div data-expected-height="30" class="flexbox horizontal" style="align-content: space-around; height: 30px">
-  <div data-offset-x="0" data-offset-y="0" data-expected-height="20"></div>
-  <div data-offset-x="100" data-offset-y="0" data-expected-height="20"></div>
-  <div data-offset-x="0" data-offset-y="20" data-expected-height="20"></div>
-  <div data-offset-x="0" data-offset-y="40" data-expected-height="20"></div>
-</div>
-offsetTop expected 0 but got -15
-FAIL .flexbox 13 assert_equals:
-<div data-expected-height="30" class="flexbox horizontal" style="align-content: space-evenly; height: 30px">
-  <div data-offset-x="0" data-offset-y="0" data-expected-height="20"></div>
-  <div data-offset-x="100" data-offset-y="0" data-expected-height="20"></div>
-  <div data-offset-x="0" data-offset-y="20" data-expected-height="20"></div>
-  <div data-offset-x="0" data-offset-y="40" data-expected-height="20"></div>
-</div>
-offsetTop expected 0 but got -15
+PASS .flexbox 12
+PASS .flexbox 13
 PASS .flexbox 14
 PASS .flexbox 15
 PASS .flexbox 16
@@ -46,22 +32,8 @@ PASS .flexbox 30
 PASS .flexbox 31
 PASS .flexbox 32
 PASS .flexbox 33
-FAIL .flexbox 34 assert_equals:
-<div data-expected-width="30" class="flexbox vertical-rl" style="align-content: space-around; width: 30px;">
-  <div data-offset-x="10" data-offset-y="0" data-expected-width="20"></div>
-  <div data-offset-x="10" data-offset-y="10" data-expected-width="20"></div>
-  <div data-offset-x="-10" data-offset-y="0" data-expected-width="20"></div>
-  <div data-offset-x="-30" data-offset-y="0" data-expected-width="20"></div>
-</div>
-offsetLeft expected 10 but got 25
-FAIL .flexbox 35 assert_equals:
-<div data-expected-width="30" class="flexbox vertical-rl" style="align-content: space-evenly; width: 30px;">
-  <div data-offset-x="10" data-offset-y="0" data-expected-width="20"></div>
-  <div data-offset-x="10" data-offset-y="10" data-expected-width="20"></div>
-  <div data-offset-x="-10" data-offset-y="0" data-expected-width="20"></div>
-  <div data-offset-x="-30" data-offset-y="0" data-expected-width="20"></div>
-</div>
-offsetLeft expected 10 but got 25
+PASS .flexbox 34
+PASS .flexbox 35
 PASS .flexbox 36
 PASS .flexbox 37
 PASS .flexbox 38

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -2477,13 +2477,13 @@ static LayoutUnit initialAlignContentOffset(LayoutUnit availableFreeSpace, Conte
         if (availableFreeSpace > 0 && numberOfLines)
             return availableFreeSpace / (2 * numberOfLines);
         if (availableFreeSpace < 0)
-            return availableFreeSpace / 2;
+            return std::max(0_lu, availableFreeSpace / 2);
     }
     if (alignContentDistribution == ContentDistribution::SpaceEvenly) {
         if (availableFreeSpace > 0)
             return availableFreeSpace / (numberOfLines + 1);
-        // Fallback to 'center'
-        return availableFreeSpace / 2;
+        // Fallback to 'safe center'
+        return std::max(0_lu, availableFreeSpace / 2);
     }
     return 0_lu;
 }


### PR DESCRIPTION
#### 95238f7747df0bff6dbac4535b957e2a5b7b9228
<pre>
[CSS-Flexbox] Fallback to &apos;safe center&apos; for &apos;align-content&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=294506">https://bugs.webkit.org/show_bug.cgi?id=294506</a>
<a href="https://rdar.apple.com/153403381">rdar://153403381</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit with Web Specification [1] &amp; [2]:

[1] <a href="https://www.w3.org/TR/css-align-3/#valdef-align-content-space-around">https://www.w3.org/TR/css-align-3/#valdef-align-content-space-around</a>
[2] <a href="https://www.w3.org/TR/css-align-3/#valdef-align-content-space-evenly">https://www.w3.org/TR/css-align-3/#valdef-align-content-space-evenly</a>

For both &apos;space-around&apos; and &apos;space-evenly&apos;, the default fallback alignment
is &apos;space center&apos;.

This patch clamps the value to &apos;non-negative&apos; by using `std::max`.

* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::initialAlignContentOffset):
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-content-wrap-003-expected.txt: Progression

Canonical link: <a href="https://commits.webkit.org/296239@main">https://commits.webkit.org/296239@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5df82f2c846a5ff0a6088f9d54002464c5202ece

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107941 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27606 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18025 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113152 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58463 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109904 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28301 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36155 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81930 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110889 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22423 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97249 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62361 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21835 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15382 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57905 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91774 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15448 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116279 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35013 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25764 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90961 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35389 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93527 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90755 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23115 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35659 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13414 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30769 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34911 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40465 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34655 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38014 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36315 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->