### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in HTMLEntitySearch.cpp

### DIFF
--- a/Source/WebCore/html/parser/HTMLEntitySearch.cpp
+++ b/Source/WebCore/html/parser/HTMLEntitySearch.cpp
@@ -27,21 +27,13 @@
 #include "config.h"
 #include "HTMLEntitySearch.h"
 
-#include "HTMLEntityTable.h"
 #include <numeric>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 
-static const HTMLEntityTableEntry* midpoint(const HTMLEntityTableEntry* left, const HTMLEntityTableEntry* right)
-{
-    return std::midpoint(left, right);
-}
-
 HTMLEntitySearch::HTMLEntitySearch()
-    : m_first(HTMLEntityTable::firstEntry())
-    , m_last(HTMLEntityTable::lastEntry())
+    : m_entries(HTMLEntityTable::entries())
 {
 }
 
@@ -61,74 +53,71 @@ HTMLEntitySearch::CompareResult HTMLEntitySearch::compare(const HTMLEntityTableE
 
 const HTMLEntityTableEntry* HTMLEntitySearch::findFirst(UChar nextCharacter) const
 {
-    auto* left = m_first;
-    auto* right = m_last;
-    if (left == right)
-        return left;
-    CompareResult result = compare(left, nextCharacter);
+    auto span = m_entries;
+    if (span.size() == 1)
+        return &span.front();
+    CompareResult result = compare(&span.front(), nextCharacter);
     if (result == Prefix)
-        return left;
+        return &span.front();
     if (result == After)
-        return right;
-    while (left + 1 < right) {
-        auto* probe = midpoint(left, right);
+        return &span.back();
+    while (span.size() > 2) {
+        auto* probe = std::midpoint(&span.front(), &span.back());
         result = compare(probe, nextCharacter);
         if (result == Before)
-            left = probe;
+            span = span.subspan(probe - span.data());
         else {
             ASSERT(result == After || result == Prefix);
-            right = probe;
+            span = span.first(probe - span.data() + 1);
         }
     }
-    ASSERT(left + 1 == right);
-    return right;
+    ASSERT(span.size() == 2);
+    return &span.back();
 }
 
 const HTMLEntityTableEntry* HTMLEntitySearch::findLast(UChar nextCharacter) const
 {
-    auto* left = m_first;
-    auto* right = m_last;
-    if (left == right)
-        return right;
-    CompareResult result = compare(right, nextCharacter);
+    auto span = m_entries;
+    if (span.size() == 1)
+        return &span.back();
+    CompareResult result = compare(&span.back(), nextCharacter);
     if (result == Prefix)
-        return right;
+        return &span.back();
     if (result == Before)
-        return left;
-    while (left + 1 < right) {
-        auto* probe = midpoint(left, right);
+        return &span.front();
+    while (span.size() > 2) {
+        auto* probe = std::midpoint(&span.front(), &span.back());
         result = compare(probe, nextCharacter);
         if (result == After)
-            right = probe;
+            span = span.first(probe - span.data() + 1);
         else {
             ASSERT(result == Before || result == Prefix);
-            left = probe;
+            span = span.subspan(probe - span.data());
         }
     }
-    ASSERT(left + 1 == right);
-    return left;
+    ASSERT(span.size() == 2);
+    return &span.front();
 }
 
 void HTMLEntitySearch::advance(UChar nextCharacter)
 {
     ASSERT(isEntityPrefix());
     if (!m_currentLength) {
-        m_first = HTMLEntityTable::firstEntryStartingWith(nextCharacter);
-        m_last = HTMLEntityTable::lastEntryStartingWith(nextCharacter);
-        if (!m_first || !m_last)
-            return fail();
+        m_entries = HTMLEntityTable::entriesStartingWith(nextCharacter);
+        if (m_entries.empty())
+            return;
     } else {
-        m_first = findFirst(nextCharacter);
-        m_last = findLast(nextCharacter);
-        if (m_first == m_last && compare(m_first, nextCharacter) != Prefix)
+        auto* first = findFirst(nextCharacter);
+        m_entries = m_entries.subspan(first - m_entries.data());
+        auto* last = findLast(nextCharacter);
+        m_entries = m_entries.first(last - m_entries.data() + 1);
+        if (first == last && compare(first, nextCharacter) != Prefix)
             return fail();
     }
     ++m_currentLength;
-    if (m_first->nameLength() != m_currentLength)
+    if (m_entries[0].nameLength() != m_currentLength)
         return;
-    m_mostRecentMatch = m_first;
+    m_mostRecentMatch = &m_entries.front();
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/html/parser/HTMLEntitySearch.h
+++ b/Source/WebCore/html/parser/HTMLEntitySearch.h
@@ -25,11 +25,10 @@
 
 #pragma once
 
+#include "HTMLEntityTable.h"
 #include <unicode/umachine.h>
 
 namespace WebCore {
-
-struct HTMLEntityTableEntry;
 
 class HTMLEntitySearch {
 public:
@@ -37,7 +36,7 @@ public:
 
     void advance(UChar);
 
-    bool isEntityPrefix() const { return m_first; }
+    bool isEntityPrefix() const { return m_entries.data(); }
     unsigned currentLength() const { return m_currentLength; }
 
     const HTMLEntityTableEntry* match() const { return m_mostRecentMatch; }
@@ -48,16 +47,11 @@ private:
     const HTMLEntityTableEntry* findFirst(UChar) const;
     const HTMLEntityTableEntry* findLast(UChar) const;
 
-    void fail()
-    {
-        m_first = nullptr;
-        m_last = nullptr;
-    }
+    void fail() { m_entries = { }; }
 
     unsigned m_currentLength { 0 };
     const HTMLEntityTableEntry* m_mostRecentMatch { nullptr };
-    const HTMLEntityTableEntry* m_first { nullptr };
-    const HTMLEntityTableEntry* m_last { nullptr };
+    std::span<const HTMLEntityTableEntry> m_entries;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/parser/HTMLEntityTable.h
+++ b/Source/WebCore/html/parser/HTMLEntityTable.h
@@ -32,7 +32,7 @@ namespace WebCore {
 
 // Optimize packing since there are over 2000 of these.
 struct HTMLEntityTableEntry {
-    const char* nameCharacters() const;
+    std::span<const char> nameCharacters() const;
     unsigned nameLength() const { return nameLengthExcludingSemicolon + nameIncludesTrailingSemicolon; }
 
     unsigned firstCharacter : 21; // All Unicode characters fit in 21 bits.
@@ -44,11 +44,8 @@ struct HTMLEntityTableEntry {
 
 class HTMLEntityTable {
 public:
-    static const HTMLEntityTableEntry* firstEntry();
-    static const HTMLEntityTableEntry* lastEntry();
-
-    static const HTMLEntityTableEntry* firstEntryStartingWith(UChar);
-    static const HTMLEntityTableEntry* lastEntryStartingWith(UChar);
+    static std::span<const HTMLEntityTableEntry> entries();
+    static std::span<const HTMLEntityTableEntry> entriesStartingWith(UChar);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/parser/create-html-entity-table
+++ b/Source/WebCore/html/parser/create-html-entity-table
@@ -95,11 +95,12 @@ output_file.write("""/*
 #include "config.h"
 #include "HTMLEntityTable.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+#include <array>
+#include <wtf/text/ASCIILiteral.h>
 
 namespace WebCore {
 
-static constexpr char staticEntityStringStorage[] = """)
+static constexpr auto staticEntityStringStorage = """)
 
 assert len(entries) > 0, "Code assumes a non-empty entity array."
 def check_ascii(entity_string):
@@ -144,7 +145,7 @@ for entry in entries:
     assert len(entry) == 2, "We will use slot [2] in the list for the offset."
     entry.append(this_offset)
 
-output_file.write(";\n")
+output_file.write("_s;\n")
 
 index = {}
 for offset, entry in enumerate(entries):
@@ -153,7 +154,7 @@ for offset, entry in enumerate(entries):
         index[starting_letter] = offset
 
 output_file.write("""
-static constexpr HTMLEntityTableEntry staticEntityTable[%s] = {\n""" % entity_count)
+static constexpr std::array<HTMLEntityTableEntry, %s> staticEntityTable {\n""" % entity_count)
 
 for entry in entries:
     values = entry[VALUE].split(' ')
@@ -169,60 +170,48 @@ for entry in entries:
     assert second_character < (1 << 16)
     assert entry[OFFSET] < (1 << 14)
     assert name_length < (1 << 5)
-    output_file.write('    { %s, %s, %s, %s, %s }, // &%s\n' % (
+    output_file.write('    HTMLEntityTableEntry { %s, %s, %s, %s, %s }, // &%s\n' % (
         first_character, second_character, entry[OFFSET], name_length, name_includes_trailing_semicolon, entry[ENTITY]))
 
 output_file.write("""};
 
 """)
 
-output_file.write("static constexpr uint16_t uppercaseOffset[] = {\n")
+output_file.write("static constexpr auto uppercaseOffset = std::to_array<uint16_t>({\n")
 for letter in string.ascii_uppercase:
     output_file.write("%d,\n" % index[letter])
 output_file.write("%d\n" % index['a'])
-output_file.write("""};
+output_file.write("""});
 
-static constexpr uint16_t lowercaseOffset[] = {\n""")
+static constexpr auto lowercaseOffset = std::to_array<uint16_t>({\n""")
 for letter in string.ascii_lowercase:
     output_file.write("%d,\n" % index[letter])
 output_file.write("%d\n" % entity_count)
-output_file.write("""};
+output_file.write("""});
 
-const char* HTMLEntityTableEntry::nameCharacters() const
+std::span<const char> HTMLEntityTableEntry::nameCharacters() const
 {
-    return staticEntityStringStorage + nameCharactersOffset;
+    return staticEntityStringStorage.span().subspan(nameCharactersOffset);
 }
 
-const HTMLEntityTableEntry* HTMLEntityTable::firstEntryStartingWith(UChar c)
+std::span<const HTMLEntityTableEntry> HTMLEntityTable::entriesStartingWith(UChar c)
 {
-    if (c >= 'A' && c <= 'Z')
-        return &staticEntityTable[uppercaseOffset[c - 'A']];
-    if (c >= 'a' && c <= 'z')
-        return &staticEntityTable[lowercaseOffset[c - 'a']];
-    return nullptr;
+    if (c >= 'A' && c <= 'Z') {
+        auto* start = &staticEntityTable[uppercaseOffset[c - 'A']];
+        return unsafeMakeSpan(start, &staticEntityTable[uppercaseOffset[c - 'A' + 1] - 1] - start + 1);
+    }
+    if (c >= 'a' && c <= 'z') {
+        auto* start = &staticEntityTable[lowercaseOffset[c - 'a']];
+        return unsafeMakeSpan(start, &staticEntityTable[lowercaseOffset[c - 'a' + 1] - 1] - start + 1);
+    }
+    return { };
 }
 
-const HTMLEntityTableEntry* HTMLEntityTable::lastEntryStartingWith(UChar c)
+std::span<const HTMLEntityTableEntry> HTMLEntityTable::entries()
 {
-    if (c >= 'A' && c <= 'Z')
-        return &staticEntityTable[uppercaseOffset[c - 'A' + 1]] - 1;
-    if (c >= 'a' && c <= 'z')
-        return &staticEntityTable[lowercaseOffset[c - 'a' + 1]] - 1;
-    return nullptr;
-}
-
-const HTMLEntityTableEntry* HTMLEntityTable::firstEntry()
-{
-    return &staticEntityTable[0];
-}
-
-const HTMLEntityTableEntry* HTMLEntityTable::lastEntry()
-{
-    return &staticEntityTable[%s - 1];
+    return staticEntityTable;
 }
 
 }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-
-""" % entity_count)
+""")


### PR DESCRIPTION
#### ead49985ff234aa074dd9ba4f8d608fe96d7cf41
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in HTMLEntitySearch.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=294481">https://bugs.webkit.org/show_bug.cgi?id=294481</a>

Reviewed by Darin Adler.

* Source/WebCore/html/parser/HTMLEntitySearch.cpp:
(WebCore::HTMLEntitySearch::HTMLEntitySearch):
(WebCore::HTMLEntitySearch::findFirst const):
(WebCore::HTMLEntitySearch::findLast const):
(WebCore::HTMLEntitySearch::advance):
(WebCore::midpoint): Deleted.
* Source/WebCore/html/parser/HTMLEntitySearch.h:
(WebCore::HTMLEntitySearch::isEntityPrefix const):
(WebCore::HTMLEntitySearch::fail):
* Source/WebCore/html/parser/HTMLEntityTable.h:
* Source/WebCore/html/parser/create-html-entity-table:

Canonical link: <a href="https://commits.webkit.org/296248@main">https://commits.webkit.org/296248@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e651e89b92fac41a8786ca4c657dff66b53f9731

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107914 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17998 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113125 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58436 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109877 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36128 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81910 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110862 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22400 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97226 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62338 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21816 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15359 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57878 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91751 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15425 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116252 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34986 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25752 "Found 8 new test failures: fast/webgpu/nocrash/fuzz-291180.html http/tests/media/hls/hls-audio-tracks-language.html http/tests/media/hls/hls-webvtt-default.html http/tests/media/hls/hls-webvtt-style.html http/tests/media/hls/range-request-cross-origin.html http/tests/media/hls/track-in-band-multiple-cues.html http/tests/media/hls/track-webvtt-multitracks.html platform/mac/media/encrypted-media/fps-generateRequest.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90940 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35362 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93504 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90733 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23123 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35639 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13393 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30736 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Running compile-webkit") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34884 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40436 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34627 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37987 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36288 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->