### PR TITLE
Add new static position path for simple inline positioning.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5253,9 +5253,7 @@ imported/w3c/web-platform-tests/html/canvas/element/compositing/2d.composite.gri
 imported/w3c/web-platform-tests/html/canvas/element/compositing/2d.composite.grid.no_filter.shadow.fillRect.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/canvas/element/compositing/2d.composite.grid.no_filter.shadow.pattern.html [ ImageOnlyFailure ]
 
-webkit.org/b/209460 imported/w3c/web-platform-tests/css/css-grid/abspos/descendant-static-position-001.html [ ImageOnlyFailure ]
 webkit.org/b/209460 imported/w3c/web-platform-tests/css/css-grid/abspos/descendant-static-position-002.html [ ImageOnlyFailure ]
-webkit.org/b/209460 imported/w3c/web-platform-tests/css/css-grid/abspos/descendant-static-position-003.html [ ImageOnlyFailure ]
 webkit.org/b/212246 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-baseline-align-cycles-001.html [ ImageOnlyFailure ]
 webkit.org/b/231021 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-inline-baseline.html [ ImageOnlyFailure ]
 webkit.org/b/212246 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-item-content-baseline-001.html [ ImageOnlyFailure ]

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
@@ -393,6 +393,51 @@ bool PositionedLayoutConstraints::alignmentAppliesStretch(ItemPosition normalAli
 
 // MARK: - Static Position Computation
 
+
+bool PositionedLayoutConstraints::supportsNewStaticPositionPath(const RenderBox& renderer, LogicalBoxAxis selfAxis) const
+{
+    auto rendererWritingMode = renderer.writingMode();
+    if (!rendererWritingMode.isLogicalLeftInlineStart())
+        return false;
+
+    if (!rendererWritingMode.isHorizontal())
+        return false;
+
+    if (!m_containingWritingMode.isLogicalLeftInlineStart())
+        return false;
+
+    if (!m_containingWritingMode.isHorizontal())
+        return false;
+
+    // The parent sets the renderers static position so we need to set requirements based
+    // off that as well.
+    auto parentWritingMode = renderer.parent()->writingMode();
+    if (!parentWritingMode.isLogicalLeftInlineStart())
+        return false;
+
+    if (!parentWritingMode.isHorizontal())
+        return false;
+
+    if (selfAxis == LogicalBoxAxis::Block)
+        return false;
+    return true;
+}
+
+LayoutUnit PositionedLayoutConstraints::newComputeInlineStaticPosition(const RenderBox& renderer) const
+{
+    auto* parent = renderer.parent();
+    auto staticPosition = renderer.layer()->staticInlinePosition();
+    for (auto* current = parent; current && current != m_container.get(); current = current->container()) {
+        CheckedPtr renderBox = dynamicDowncast<RenderBox>(*current);
+        if (!renderBox)
+            continue;
+        staticPosition += renderBox->logicalLeft();
+        if (renderBox->isInFlowPositioned())
+            staticPosition += renderBox->isHorizontalWritingMode() ? renderBox->offsetForInFlowPosition().width() : renderBox->offsetForInFlowPosition().height();
+    }
+    return staticPosition;
+}
+
 void PositionedLayoutConstraints::computeStaticPosition(const RenderBox& renderer, LogicalBoxAxis selfAxis)
 {
     ASSERT(m_useStaticPosition);
@@ -426,17 +471,25 @@ void PositionedLayoutConstraints::computeStaticPosition(const RenderBox& rendere
             return;
         }
         // Rewind grid-area adjustments and fall through to the existing static position code.
-        m_containingRange.moveTo(m_originalContainingRange.min());
+        if (selfAxis != LogicalBoxAxis::Inline || !supportsNewStaticPositionPath(renderer, selfAxis))
+            m_containingRange.moveTo(m_originalContainingRange.min());
     }
 
-    if (selfAxis == LogicalBoxAxis::Inline)
-        computeInlineStaticDistance(renderer);
+    if (selfAxis == LogicalBoxAxis::Inline) {
+        if (supportsNewStaticPositionPath(renderer, LogicalBoxAxis::Inline)) {
+            auto staticPosition = newComputeInlineStaticPosition(renderer);
+            m_insetBefore = Style::InsetEdge::Fixed { staticPosition - m_containingRange.min() };
+        } else
+            computeInlineStaticDistance(renderer);
+    }
     else
         computeBlockStaticDistance(renderer);
 }
 
 void PositionedLayoutConstraints::computeInlineStaticDistance(const RenderBox& renderer)
 {
+    ASSERT(!supportsNewStaticPositionPath(renderer, LogicalBoxAxis::Inline), "Should have taken modern static position path.");
+
     auto* parent = renderer.parent();
     auto parentWritingMode = parent->writingMode();
 

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.h
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.h
@@ -82,6 +82,9 @@ private:
     void captureAnchorGeometry(const RenderBox&);
     LayoutRange adjustForPositionArea(const LayoutRange rangeToAdjust, const LayoutRange anchorArea, const BoxAxis containerAxis);
 
+    bool supportsNewStaticPositionPath(const RenderBox&, LogicalBoxAxis selfAxis) const;
+    LayoutUnit newComputeInlineStaticPosition(const RenderBox&) const;
+
     void computeStaticPosition(const RenderBox&, LogicalBoxAxis selfAxis);
     void computeInlineStaticDistance(const RenderBox&);
     void computeBlockStaticDistance(const RenderBox&);


### PR DESCRIPTION
#### a689a2c0e8f7de07b233ae83cd045ebdac7c77b9
<pre>
Add new static position path for simple inline positioning.

Initial code for new static position codepath. We determine whether or
not to take the new path before hand. Currently only works for the
inline axis and should only support very simple content.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a689a2c0e8f7de07b233ae83cd045ebdac7c77b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109531 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29189 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19618 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114744 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59734 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111494 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29867 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37777 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83260 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112479 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23799 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98658 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63720 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23178 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16801 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59350 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93171 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16841 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117846 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36570 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27081 "Too many flaky failures: fast/selectors/nth-last-child-of-register-requirement.html, fast/text/word-break-run-rounding.html, fast/webgpu/nocrash/fuzz-285311.html, http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-filtered-link-decoration-after-long-deletion.html, http/tests/security/contentSecurityPolicy/strict-dynamic-module-script.html, http/tests/security/cross-origin-cached-scripts-parallel.html, http/tests/site-isolation/edge-sampling-viewport-constrained-object.html, http/tests/websocket/tests/hybi/multiple-connections.html, http/tests/workers/service/interception-from-dedicated-worker-on-reload.html, http/tests/xmlhttprequest/access-control-basic-allow-preflight-cache.html, http/wpt/cache-storage/quota-third-party.https.html, http/wpt/cross-origin-opener-policy/non-secure-to-secure-context-navigation.https.html, http/wpt/crypto/pbkdf2-crash.any.html, http/wpt/fetch/disable-speculative-for-reload.html, http/wpt/html/cross-origin-embedder-policy/require-corp.https.html, http/wpt/html/interaction/focus/no-cross-origin-element-focus.html, http/wpt/html/semantics/scripting-1/the-script-element/module/module-fails-decoding-then-load-as-classic-script.html, http/wpt/html/semantics/text-level-semantics/the-a-element/a-download-click-404.html, imported/w3c/web-platform-tests/css/css-backgrounds/animations/background-position-interpolation.html, imported/w3c/web-platform-tests/css/mediaqueries/aspect-ratio-004.html, imported/w3c/web-platform-tests/service-workers/service-worker/ServiceWorkerGlobalScope/unregister.https.html, imported/w3c/web-platform-tests/service-workers/service-worker/resource-timing-fetch-variants.https.html, imported/w3c/web-platform-tests/service-workers/service-worker/skip-waiting-installed.https.html, imported/w3c/web-platform-tests/webstorage/event_case_sensitive.html, media/video-display-aspect-ratio.html, scrollingcoordinator/mac/latching/horizontal-overflow-back-swipe.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92261 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36943 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94918 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92078 "Found 3 new API test failures: /WebKitGTK/TestResources:/webkit/WebKitWebResource/get-data-error, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37017 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14765 "Too many flaky failures: compositing/backing/backing-store-attachment-empty-keyframe.html, css3/blending/background-blend-mode-crossfade-image.html, css3/filters/backdrop/backdrop-filter-uneven-corner-radii.html, fast/mediastream/captureInGPUProcess.html, fast/mediastream/video-background-with-canvas.html, http/tests/webrtc/audioSessionInFrames.html, imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-animation-with-will-change-transform-001.html, imported/w3c/web-platform-tests/css/css-writing-modes/abs-pos-non-replaced-vrl-184.xht, imported/w3c/web-platform-tests/payment-request/PaymentRequestUpdateEvent/constructor.http.html, intersection-observer/intersection-observer-should-not-leak-observed-nodes.html, webgl/2.0.y/conformance2/sync/sync-webgl-specific.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32363 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36464 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41935 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36123 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39467 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37834 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->