### PR TITLE
[Safe CPP] Address Warnings in Element.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -426,7 +426,6 @@ dom/DOMImplementation.cpp
 dom/DataTransfer.cpp
 dom/DataTransferItemList.cpp
 dom/Document.cpp
-dom/Element.cpp
 dom/ElementData.cpp
 dom/ElementInlines.h
 dom/ElementInternals.cpp

--- a/Source/WebCore/dom/CustomElementRegistry.h
+++ b/Source/WebCore/dom/CustomElementRegistry.h
@@ -76,6 +76,11 @@ public:
         return element.treeScope().customElementRegistry();
     }
 
+    static RefPtr<CustomElementRegistry> protectedRegistryForElement(const Element& element)
+    {
+        return registryForElement(element);
+    }
+
     static CustomElementRegistry* registryForNodeOrTreeScope(const Node& node, const TreeScope& treeScope)
     {
         if (node.usesNullCustomElementRegistry()) {
@@ -85,6 +90,11 @@ public:
         if (auto* element = dynamicDowncast<Element>(node); element && element->usesScopedCustomElementRegistryMap()) [[unlikely]]
             return scopedCustomElementRegistryMap().get(*element);
         return treeScope.customElementRegistry();
+    }
+
+    static RefPtr<CustomElementRegistry> protectedRegistryForNodeOrTreeScope(const Node& node, const TreeScope& treeScope)
+    {
+        return registryForNodeOrTreeScope(node, treeScope);
     }
 
     static void addToScopedCustomElementRegistryMap(Element&, CustomElementRegistry&);

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -400,6 +400,7 @@ public:
     const ElementData* elementData() const { return m_elementData.get(); }
     static constexpr ptrdiff_t elementDataMemoryOffset() { return OBJECT_OFFSETOF(Element, m_elementData); }
     inline UniqueElementData& ensureUniqueElementData();
+    inline Ref<UniqueElementData> protectedEnsureUniqueElementData();
 
     void synchronizeAllAttributes() const;
 
@@ -775,6 +776,7 @@ public:
 #endif
 
     Style::Resolver& styleResolver();
+    Ref<Style::Resolver> protectedStyleResolver();
     Style::UnadjustedStyle resolveStyle(const Style::ResolutionContext&);
 
     // Invalidates the style of a single element. Style is resolved lazily.

--- a/Source/WebCore/dom/ElementInlines.h
+++ b/Source/WebCore/dom/ElementInlines.h
@@ -184,6 +184,11 @@ inline UniqueElementData& Element::ensureUniqueElementData()
     return static_cast<UniqueElementData&>(*m_elementData);
 }
 
+inline Ref<UniqueElementData> Element::protectedEnsureUniqueElementData()
+{
+    return ensureUniqueElementData();
+}
+
 inline bool shouldIgnoreAttributeCase(const Element& element)
 {
     return element.isHTMLElement() && element.document().isHTMLDocument();

--- a/Source/WebCore/dom/ElementRareData.h
+++ b/Source/WebCore/dom/ElementRareData.h
@@ -72,6 +72,8 @@ public:
 
     PseudoElement* beforePseudoElement() const { return m_beforePseudoElement.get(); }
     PseudoElement* afterPseudoElement() const { return m_afterPseudoElement.get(); }
+    RefPtr<PseudoElement> protectedAfterPseudoElement() const { return afterPseudoElement(); }
+    RefPtr<PseudoElement> protectedBeforePseudoElement() const { return beforePseudoElement(); }
 
     void resetComputedStyle();
 

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -555,6 +555,11 @@ Element* Node::nextElementSibling() const
     return ElementTraversal::nextSibling(*this);
 }
 
+RefPtr<Element> Node::protectedNextElementSibling() const
+{
+    return nextElementSibling();
+}
+
 ExceptionOr<void> Node::insertBefore(Node& newChild, RefPtr<Node>&& refChild)
 {
     if (auto* containerNode = dynamicDowncast<ContainerNode>(*this))
@@ -1413,6 +1418,11 @@ Element* Node::parentElementInComposedTree() const
             return element;
     }
     return nullptr;
+}
+
+RefPtr<Element> Node::protectedParentElementInComposedTree() const
+{
+    return parentElementInComposedTree();
 }
 
 TreeScope& Node::treeScopeForSVGReferences() const

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -36,6 +36,7 @@
 #include <wtf/MainThread.h>
 #include <wtf/OptionSet.h>
 #include <wtf/RefCounted.h>
+#include <wtf/RefPtr.h>
 #include <wtf/RobinHoodHashSet.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/URLHash.h>
@@ -217,6 +218,8 @@ public:
     WEBCORE_EXPORT Element* previousElementSibling() const;
     WEBCORE_EXPORT Element* nextElementSibling() const;
 
+    WEBCORE_EXPORT RefPtr<Element> protectedNextElementSibling() const;
+
     // From the ChildNode - https://dom.spec.whatwg.org/#childnode
     ExceptionOr<void> before(FixedVector<NodeOrString>&&);
     ExceptionOr<void> after(FixedVector<NodeOrString>&&);
@@ -315,6 +318,8 @@ public:
     inline RefPtr<ContainerNode> protectedParentOrShadowHostNode() const; // Defined in ShadowRoot.h
     ContainerNode* parentInComposedTree() const;
     WEBCORE_EXPORT Element* parentElementInComposedTree() const;
+    WEBCORE_EXPORT RefPtr<Element> protectedParentElementInComposedTree() const;
+
     Element* parentOrShadowHostElement() const;
     inline void setParentNode(ContainerNode*);
     inline Node& rootNode() const;

--- a/Source/WebCore/dom/PopoverData.h
+++ b/Source/WebCore/dom/PopoverData.h
@@ -54,6 +54,7 @@ public:
     Ref<ToggleEventTask> ensureToggleEventTask(Element&);
 
     HTMLElement* invoker() const { return m_invoker.get(); }
+    RefPtr<HTMLElement> protectedInvoker() const { return invoker(); }
     void setInvoker(const HTMLElement* element) { m_invoker = element; }
 
     class ScopedStartShowingOrHiding {


### PR DESCRIPTION
#### 21412c2db0e7c3d9c4b225baf099959b49fe0075
<pre>
[Safe CPP] Address Warnings in Element.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=294517">https://bugs.webkit.org/show_bug.cgi?id=294517</a>
<a href="https://rdar.apple.com/problem/153435711">rdar://problem/153435711</a>

Reviewed by NOBODY (OOPS!).

Address safe cpp warnings in Element.cpp.

 * Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
 * Source/WebCore/dom/CustomElementRegistry.h:
 (WebCore::CustomElementRegistry::protectedRegistryForElement):
 (WebCore::CustomElementRegistry::protectedRegistryForNodeOrTreeScope):
 * Source/WebCore/dom/Element.cpp:
 (WebCore::shouldAutofocus):
 (WebCore::Element::dispatchMouseEvent):
 (WebCore::Element::dispatchWheelEvent):
 (WebCore::Element::dispatchKeyEvent):
 (WebCore::Element::cloneShadowTreeIfPossible):
 (WebCore::Element::removeAttribute):
 (WebCore::Element::hasAttribute const):
 (WebCore::Element::hasFocusableStyle const):
 (WebCore::Element::setFocus):
 (WebCore::Element::setHovered):
 (WebCore::Element::offsetParentForBindings):
 (WebCore::Element::clientWidth):
 (WebCore::Element::clientHeight):
 (WebCore::Element::scrollLeft):
 (WebCore::Element::scrollTop):
 (WebCore::Element::setScrollLeft):
 (WebCore::Element::setScrollTop):
 (WebCore::Element::scrollWidth):
 (WebCore::Element::scrollHeight):
 (WebCore::Element::boundingBoxInRootViewCoordinates const):
 (WebCore::layoutOverflowRectContainsAllDescendants):
 (WebCore::Element::absoluteEventBounds):
 (WebCore::Element::getClientRects):
 (WebCore::Element::boundingClientRect):
 (WebCore::Element::screenRect const):
 (WebCore::trustedTypesCompliantAttributeValue):
 (WebCore::Element::validateAttributeIndex const):
 (WebCore::Element::toggleAttribute):
 (WebCore::Element::setAttribute):
 (WebCore::Element::setAttributeWithoutOverwriting):
 (WebCore::Element::setAttributeWithoutSynchronization):
 (WebCore::Element::setAttributeInternal):
 (WebCore::Element::notifyAttributeChanged):
 (WebCore::getElementByIdIncludingDisconnected):
 (WebCore::Element::elementForAttributeInternal const):
 (WebCore::Element::setElementAttribute):
 (WebCore::Element::setElementsArrayAttribute):
 (WebCore::Element::classAttributeChanged):
 (WebCore::Element::absoluteLinkURL const):
 (WebCore::Element::styleResolver):
 (WebCore::Element::protectedStyleResolver):
 (WebCore::Element::resolveStyle):
 (WebCore::invalidateSiblingsIfNeeded):
 (WebCore::Element::updateEffectiveLangState):
 (WebCore::Element::hasEquivalentAttributes const):
 (WebCore::Element::insertedIntoAncestor):
 (WebCore::Element::removedFromAncestor):
 (WebCore::Element::addShadowRoot):
 (WebCore::Element::removeShadowRootSlow):
 (WebCore::Element::retargetReferenceTargetForBindings const):
 (WebCore::Element::createUserAgentShadowRoot):
 (WebCore::Element::clearReactionQueueFromFailedCustomElement):
 (WebCore::Element::customElementDefaultARIA):
 (WebCore::Element::finishParsingChildren):
 (WebCore::Element::setAttributeNode):
 (WebCore::Element::setAttributeNodeNS):
 (WebCore::Element::removeAttributeNode):
 (WebCore::Element::setAttributeNS):
 (WebCore::Element::addAttributeInternal):
 (WebCore::Element::getAttributeNode):
 (WebCore::Element::getAttributeNodeNS):
 (WebCore::Element::hasAttributeNS const):
 (WebCore::isProgramaticallyFocusable):
 (WebCore::Element::focus):
 (WebCore::Element::updateFocusAppearance):
 (WebCore::Element::blur):
 (WebCore::Element::dispatchFocusEvent):
 (WebCore::Element::dispatchBlurEvent):
 (WebCore::Element::dispatchMouseForceWillBegin):
 (WebCore::Element::enqueueSecurityPolicyViolationEvent):
 (WebCore::Element::replaceChildrenWithMarkup):
 (WebCore::Element::setHTMLUnsafe):
 (WebCore::Element::setOuterHTML):
 (WebCore::Element::setInnerHTML):
 (WebCore::Element::innerText):
 (WebCore::forEachRenderLayer):
 (WebCore::Element::removeFromTopLayer):
 (WebCore::Element::renderOrDisplayContentsStyle const):
 (WebCore::Element::resolveComputedStyle):
 (WebCore::Element::resolvePseudoElementStyle):
 (WebCore::Element::computedStyle):
 (WebCore::Element::needsStyleInvalidation const):
 (WebCore::Element::effectiveLang const):
 (WebCore::Element::clearBeforePseudoElementSlow):
 (WebCore::Element::clearAfterPseudoElementSlow):
 (WebCore::Element::matches):
 (WebCore::Element::mayCauseRepaintInsideViewport const):
 (WebCore::Element::getURLAttribute const):
 (WebCore::Element::getNonEmptyURLAttribute const):
 (WebCore::Element::requestFullscreen):
 (WebCore::Element::disconnectFromIntersectionObserversSlow):
 (WebCore::Element::isSpellCheckingEnabled const):
 (WebCore::Element::updateName):
 (WebCore::Element::updateId):
 (WebCore::Element::willModifyAttribute):
 (WebCore::Element::ensureAttr):
 (WebCore::Element::cloneAttributesFromElement):
 (WebCore::Element::resolveURLStringIfNeeded const):
 (WebCore::contextElementForInsertion):
 (WebCore::Element::insertAdjacentHTML):
 (WebCore::Element::insertAdjacentText):
 (WebCore::Element::checkVisibility):
 (WebCore::Element::isInVisibilityAdjustmentSubtree const):
 (WebCore::Element::topmostPopoverAncestor):
 * Source/WebCore/dom/Element.h:
 * Source/WebCore/dom/ElementInlines.h:
 (WebCore::Element::protectedEnsureUniqueElementData):
 * Source/WebCore/dom/ElementRareData.h:
 (WebCore::ElementRareData::protectedAfterPseudoElement const):
 (WebCore::ElementRareData::protectedBeforePseudoElement const):
 * Source/WebCore/dom/Node.cpp:
 (WebCore::Node::protectedNextElementSibling const):
 (WebCore::Node::protectedParentElementInComposedTree const):
 * Source/WebCore/dom/Node.h:
 * Source/WebCore/dom/PopoverData.h:
 (WebCore::PopoverData::protectedInvoker const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21412c2db0e7c3d9c4b225baf099959b49fe0075

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107982 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27647 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18066 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113193 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58505 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109945 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28342 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36196 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81966 "Found 13 new test failures: fast/text/text-autospace-crash-on-partial-layout.html fast/transforms/flatten_disconnected_parent_crash.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/backdrop-invalidation.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-005.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-006.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/crashtests/top-layer-crash.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/crashtests/top-layer-nested-crash.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-003.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-006.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-008.html ... (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110930 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22460 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97285 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62397 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21872 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15418 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57940 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91813 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15484 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116320 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35054 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25841 "Found 13 new test failures: fast/text/text-autospace-crash-on-partial-layout.html fast/transforms/flatten_disconnected_parent_crash.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/backdrop-invalidation.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-005.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-006.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/crashtests/top-layer-crash.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/crashtests/top-layer-nested-crash.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-003.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-006.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-008.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90998 "Found 13 new test failures: fast/text/text-autospace-crash-on-partial-layout.html fast/transforms/flatten_disconnected_parent_crash.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/backdrop-invalidation.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-005.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-006.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/crashtests/top-layer-crash.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/crashtests/top-layer-nested-crash.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-003.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-006.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-008.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35430 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93563 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90792 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35696 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13450 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30955 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34952 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40506 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34696 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38055 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36356 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->