### PR TITLE
[css-pseudo] Reflect in computed style that text-indent doesn't apply in ::marker

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/marker-default-styles-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/marker-default-styles-expected.txt
@@ -2,35 +2,35 @@
 PASS Computed value of 'unicode-bidi' for outside symbol
 PASS Computed value of 'font-variant-numeric' for outside symbol
 PASS Computed value of 'text-transform' for outside symbol
-FAIL Computed value of 'text-indent' for outside symbol assert_equals: expected "0px" but got "1px"
+PASS Computed value of 'text-indent' for outside symbol
 PASS Computed value of 'unicode-bidi' for outside decimal
 PASS Computed value of 'font-variant-numeric' for outside decimal
 PASS Computed value of 'text-transform' for outside decimal
-FAIL Computed value of 'text-indent' for outside decimal assert_equals: expected "0px" but got "1px"
+PASS Computed value of 'text-indent' for outside decimal
 PASS Computed value of 'unicode-bidi' for outside string
 PASS Computed value of 'font-variant-numeric' for outside string
 PASS Computed value of 'text-transform' for outside string
-FAIL Computed value of 'text-indent' for outside string assert_equals: expected "0px" but got "1px"
+PASS Computed value of 'text-indent' for outside string
 PASS Computed value of 'unicode-bidi' for outside marker
 PASS Computed value of 'font-variant-numeric' for outside marker
 PASS Computed value of 'text-transform' for outside marker
-FAIL Computed value of 'text-indent' for outside marker assert_equals: expected "0px" but got "1px"
+PASS Computed value of 'text-indent' for outside marker
 PASS Computed value of 'unicode-bidi' for inside symbol
 PASS Computed value of 'font-variant-numeric' for inside symbol
 PASS Computed value of 'text-transform' for inside symbol
-FAIL Computed value of 'text-indent' for inside symbol assert_equals: expected "0px" but got "1px"
+PASS Computed value of 'text-indent' for inside symbol
 PASS Computed value of 'unicode-bidi' for inside decimal
 PASS Computed value of 'font-variant-numeric' for inside decimal
 PASS Computed value of 'text-transform' for inside decimal
-FAIL Computed value of 'text-indent' for inside decimal assert_equals: expected "0px" but got "1px"
+PASS Computed value of 'text-indent' for inside decimal
 PASS Computed value of 'unicode-bidi' for inside string
 PASS Computed value of 'font-variant-numeric' for inside string
 PASS Computed value of 'text-transform' for inside string
-FAIL Computed value of 'text-indent' for inside string assert_equals: expected "0px" but got "1px"
+PASS Computed value of 'text-indent' for inside string
 PASS Computed value of 'unicode-bidi' for inside marker
 PASS Computed value of 'font-variant-numeric' for inside marker
 PASS Computed value of 'text-transform' for inside marker
-FAIL Computed value of 'text-indent' for inside marker assert_equals: expected "0px" but got "1px"
+PASS Computed value of 'text-indent' for inside marker
 outside symbol
 outside decimal
 outside string

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -366,6 +366,7 @@ dt {
     font-variant-numeric: tabular-nums;
     white-space: pre;
     text-transform: none;
+    text-indent: 0px !important;
 }
 
 /* form elements */

--- a/Source/WebCore/style/PropertyAllowlist.cpp
+++ b/Source/WebCore/style/PropertyAllowlist.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -82,6 +82,7 @@ bool isValidMarkerStyleProperty(CSSPropertyID id)
     case CSSPropertyTextEmphasisColor:
     case CSSPropertyTextEmphasisPosition:
     case CSSPropertyTextEmphasisStyle:
+    case CSSPropertyTextIndent:
     case CSSPropertyTextShadow:
     case CSSPropertyTextTransform:
     case CSSPropertyTextWrapMode:


### PR DESCRIPTION
#### 6df95a07177b83708160af79c215ab09cc673480
<pre>
[css-pseudo] Reflect in computed style that text-indent doesn&apos;t apply in ::marker

<a href="https://bugs.webkit.org/show_bug.cgi?id=294522">https://bugs.webkit.org/show_bug.cgi?id=294522</a>

Reviewed by Tim Nguyen.

This patch aligns WebKit with Blink / Chromium.

Inspired by: <a href="https://chromium.googlesource.com/chromium/src.git/+/da2ab72e3cb6d747044f9035d1d8968acd45ca20">https://chromium.googlesource.com/chromium/src.git/+/da2ab72e3cb6d747044f9035d1d8968acd45ca20</a>

The CSSWG resolved in <a href="https://github.com/w3c/csswg-drafts/issues/4568">https://github.com/w3c/csswg-drafts/issues/4568</a> that properties like
&apos;text-indent&apos;, which do not apply to ::marker, must not affect the marker
via inheritance from ancestors.

WebKit already ignored &apos;text-indent&apos; on ::marker in practice, so this change
is a no-op in terms of actual rendering behavior. However, this patch ensures
that the computed style accurately reflects that &apos;text-indent&apos; does not apply
to ::marker.

To do this, the patch sets &apos;text-indent: 0px !important&apos; in the UA stylesheet for
::marker. Additionally, because WebKit filters UA styles through a property allowlist,
&apos;text-indent&apos; had to be added to that list to take effect.

This aligns WebKit&apos;s computed style behavior with the spec and other engines.

* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/marker-default-styles-expected.txt:
* Source/WebCore/css/html.css:
(::marker):
* Source/WebCore/style/PropertyAllowlist.cpp:
(WebCore::Style::isValidMarkerStyleProperty):

Canonical link: <a href="https://commits.webkit.org/296253@main">https://commits.webkit.org/296253@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe9624167fd24f8f4d93dcf98d723d3d5e89e5ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107992 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113203 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58515 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109955 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28352 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36206 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81974 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110940 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22467 "Found 1 new test failure: http/tests/geolocation/geolocation-get-current-position-does-not-leak.https.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97294 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62405 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21879 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15427 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57950 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91820 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15493 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116330 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35064 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25808 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91005 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35440 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93572 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90799 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23131 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35705 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13459 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34962 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40516 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34706 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38065 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36366 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->