### PR TITLE
[SwiftUI] Conform WebPage to Transferable

### DIFF
--- a/Source/WebKit/UIProcess/API/Swift/WebPage+Transferable.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+Transferable.swift
@@ -1,0 +1,260 @@
+// Copyright (C) 2025 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE_SWIFTUI && compiler(>=6.0)
+
+public import CoreTransferable
+import Foundation
+import UniformTypeIdentifiers
+@_weakLinked internal import SwiftUI
+internal import WebKit_Private
+internal import WebKit_Private.WKSnapshotConfigurationPrivate
+
+@available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
+extension WebPage: Transferable {
+    /// A specialized configuration of a specific exportable type that can have specific properties unique to the content type.
+    public nonisolated struct ExportedContentConfiguration: Sendable {
+        /// Represents a specific semantic region of a webpage.
+        public struct Region: Sendable {
+            private enum Storage {
+                case contents
+                case rect(CGRect)
+            }
+
+            /// A region that corresponds to a rectangle in the page's coordinate system.
+            ///
+            /// - Parameter rect: The rectangle to use for the region.
+            /// - Returns: A ``Region`` that uses the specified rectangle.
+            public static func rect(_ rect: CGRect) -> Self {
+                .init(storage: .rect(rect))
+            }
+
+            /// The entire region of the webpage.
+            public static var contents: Self {
+                .init(storage: .contents)
+            }
+
+            private let storage: Storage
+
+            private init(storage: Storage) {
+                self.storage = storage
+            }
+
+            fileprivate var rect: CGRect? {
+                switch storage {
+                case .contents: nil
+                case .rect(let value): value
+                }
+            }
+
+            fileprivate var usesContentsRect: Bool {
+                switch storage {
+                case .contents: true
+                case .rect(_): false
+                }
+            }
+        }
+
+        fileprivate enum Storage {
+            case pdf(Region, allowTransparentBackground: Bool)
+            case image(Region, allowTransparentBackground: Bool, snapshotWidth: CGFloat?, afterScreenUpdates: Bool)
+        }
+
+        /// A configuration of a webpage for a representation as PDF data.
+        ///
+        /// - Parameters:
+        ///   - region: The region of the page used to generate the PDF.
+        ///   - allowTransparentBackground: Indicates whether the PDF may have a transparent background.
+        /// - Returns: The PDF configuration of this page that will be used when producing its representation.
+        public static func pdf(region: Region = .contents, allowTransparentBackground: Bool = false) -> Self {
+            .init(storage: .pdf(region, allowTransparentBackground: allowTransparentBackground))
+        }
+
+        /// A configuration of a webpage for a representation as image data.
+        ///
+        /// - Parameters:
+        ///   - region: The region of the page used to generate the image.
+        ///   - allowTransparentBackground: Indicates whether the image may have a transparent background.
+        ///   - snapshotWidth: The width of the captured image, in points.
+        ///
+        ///     Use this property to scale the generated image to the specified width. The webpage maintains the aspect ratio of the captured content, but scales it to match the width you specify.
+        ///
+        ///     The default value of this parameter is `nil`, which returns an image whose size matches the original size of the captured region.
+        ///
+        ///   - afterScreenUpdates: Indicates whether to take the snapshot after incorporating any pending screen updates.
+        ///
+        /// - Returns: The image configuration of this page that will be used when producing its representation.
+        public static func image(
+            region: Region = .contents,
+            allowTransparentBackground: Bool = false,
+            snapshotWidth: CGFloat? = nil,
+            afterScreenUpdates: Bool = true
+        ) -> Self {
+            .init(
+                storage: .image(
+                    region,
+                    allowTransparentBackground: allowTransparentBackground,
+                    snapshotWidth: snapshotWidth,
+                    afterScreenUpdates: afterScreenUpdates
+                )
+            )
+        }
+
+        fileprivate let storage: Storage
+
+        private init(storage: Storage) {
+            self.storage = storage
+        }
+    }
+
+    // Protocol requirement; no documentation needed.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public nonisolated static var transferRepresentation: some TransferRepresentation {
+        // FIXME: Add more exportable types, like .html, .plainText, .richText, .linkPresentationMetadata, etc.
+        // FIXME: Ideally, each of these would be conditionalized on content being loaded on the page.
+
+        // The preferred types are roughly in order of descending losslessness.
+
+        DataRepresentation(exportedContentType: .webArchive) {
+            try await $0.webArchiveRepresentation()
+        }
+
+        DataRepresentation(exportedContentType: .pdf) {
+            try await $0.exported(as: .pdf())
+        }
+
+        // FIXME: Support all the types that NSImage/UIImage support (this can't use ProxyRepresentation since it needs to be async).
+        // FIXME: This is slightly inefficient since it will be converting data to an image and then back to data.
+        DataRepresentation(exportedContentType: .image) {
+            try await $0.exported(as: .image())
+        }
+
+        // FIXME: See if this can somehow be made synchronous, so then it can use `ProxyRepresentation` with `exportingCondition`.
+        DataRepresentation(exportedContentType: .url) {
+            try await $0.urlRepresentation()
+        }
+    }
+
+    /// Using the type's `Transferable` conformance implementation, exports a value as binary data,
+    /// optionally with a specified configuration for that type of data.
+    ///
+    /// For example, you can export a 100 pt by 100 pt region of a webpage as a PDF, and allow it to have a transparent background:
+    ///
+    ///     let page = WebPage()
+    ///     // Load web content and wait for navigation to complete.
+    ///
+    ///     let square = CGRect(x: 0, y: 0, width: 100, height: 100)
+    ///     let pdf = try await page.exported(as: .pdf(region: .rect(square), allowTransparentBackground: true))
+    ///
+    /// If no configuration is needed, use the ``Transferable`` conformance of ``WebPage`` directly:
+    ///
+    ///     let page = WebPage()
+    ///     // Load web content and wait for navigation to complete.
+    ///
+    ///     let pdf = try await page.exported(as: .pdf)
+    ///
+    /// - Parameter representation: A conifguration for a representation for a specific type of data with optional customizable properties.
+    /// - Returns: The data with the specified representation type.
+    /// - Throws: An error if the specified representation cannot be created from the page.
+    public nonisolated func exported(as representation: ExportedContentConfiguration) async throws -> Data {
+        switch representation.storage {
+        case .pdf(let region, let allowTransparentBackground):
+            try await pdfRepresentation(region: region, allowTransparentBackground: allowTransparentBackground)
+        case .image(let region, let allowTransparentBackground, let snapshotWidth, let afterScreenUpdates):
+            try await imageRepresentation(
+                region: region,
+                allowTransparentBackground: allowTransparentBackground,
+                snapshotWidth: snapshotWidth,
+                afterScreenUpdates: afterScreenUpdates
+            )
+        }
+    }
+}
+
+// MARK: Private helper functions
+
+extension WebPage {
+    private func webArchiveRepresentation() async throws -> Data {
+        try await withCheckedThrowingContinuation { continuation in
+            backingWebView.createWebArchiveData {
+                continuation.resume(with: $0)
+            }
+        }
+    }
+
+    private func pdfRepresentation(
+        region: ExportedContentConfiguration.Region,
+        allowTransparentBackground: Bool
+    ) async throws -> Data {
+        let configuration = WKPDFConfiguration()
+        configuration.rect = region.rect
+        configuration.allowTransparentBackground = allowTransparentBackground
+
+        return try await backingWebView.pdf(configuration: configuration)
+    }
+
+    private func imageRepresentation(
+        region: ExportedContentConfiguration.Region,
+        allowTransparentBackground: Bool,
+        snapshotWidth: CGFloat?,
+        afterScreenUpdates: Bool
+    ) async throws -> Data {
+        let configuration = WKSnapshotConfiguration()
+        configuration.rect = region.rect ?? .null
+
+        #if os(macOS)
+        // FIXME: This should not be limited to macOS.
+        configuration._usesContentsRect = region.usesContentsRect
+        #endif
+
+        configuration._usesTransparentBackground = allowTransparentBackground
+        configuration.snapshotWidth = snapshotWidth.map {
+            NSNumber(value: $0)
+        }
+        configuration.afterScreenUpdates = afterScreenUpdates
+
+        let snapshot = try await backingWebView.takeSnapshot(configuration: configuration)
+
+        #if os(macOS)
+        return try await snapshot.exported(as: .image)
+        #else
+        guard #_hasSymbol(Image.self) else {
+            throw WKError(.unknown)
+        }
+        let image = Image(uiImage: snapshot)
+        return try await image.exported(as: .image)
+        #endif
+    }
+
+    private func urlRepresentation() async throws -> Data {
+        guard let url else {
+            throw WKError(.unknown)
+        }
+
+        return try await url.exported(as: .url)
+    }
+}
+
+#endif // ENABLE_SWIFTUI && compiler(>=6.0)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -141,6 +141,7 @@
 		029D6BB42C407AA30068CF99 /* JSWebExtensionAPISidePanel.h in Headers */ = {isa = PBXBuildFile; fileRef = 029D6BAF2C407AA30068CF99 /* JSWebExtensionAPISidePanel.h */; };
 		0701789E23BE9CFC005F0FAA /* RemoteMediaPlayerMIMETypeCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0701789B23BAE261005F0FAA /* RemoteMediaPlayerMIMETypeCache.cpp */; };
 		0712654928EE06F800AE69D7 /* WebChromeClientCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0712654728EE06F800AE69D7 /* WebChromeClientCocoa.mm */; };
+		071467782DFE84E500F77867 /* WebPage+Transferable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 071467772DFE84E500F77867 /* WebPage+Transferable.swift */; };
 		071BC59023CE1EAA00680D7C /* RemoteMediaPlayerProxyMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 071BC58D23CE1EAA00680D7C /* RemoteMediaPlayerProxyMessages.h */; };
 		07275C612D00CD24002315A5 /* CrossImportOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07275C602D00CD24002315A5 /* CrossImportOverlay.swift */; };
 		07275C632D00D32D002315A5 /* WebPage+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07275C622D00D32D002315A5 /* WebPage+SwiftUI.swift */; };
@@ -3242,6 +3243,7 @@
 		0701789C23BAE262005F0FAA /* RemoteMediaPlayerMIMETypeCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteMediaPlayerMIMETypeCache.h; sourceTree = "<group>"; };
 		070259BE2522841C00153405 /* UserMediaPermissionRequestManagerProxy.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = UserMediaPermissionRequestManagerProxy.mm; sourceTree = "<group>"; };
 		0712654728EE06F800AE69D7 /* WebChromeClientCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebChromeClientCocoa.mm; sourceTree = "<group>"; };
+		071467772DFE84E500F77867 /* WebPage+Transferable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebPage+Transferable.swift"; sourceTree = "<group>"; };
 		071BC57723C93BB700680D7C /* AudioTrackPrivateRemote.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AudioTrackPrivateRemote.h; sourceTree = "<group>"; };
 		071BC57923C93BB900680D7C /* AudioTrackPrivateRemote.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = AudioTrackPrivateRemote.cpp; sourceTree = "<group>"; };
 		071BC57B23CA532400680D7C /* TrackPrivateRemoteConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TrackPrivateRemoteConfiguration.h; sourceTree = "<group>"; };
@@ -9245,6 +9247,7 @@
 				07FAA74A2CE947AA00128360 /* WebPage+Navigation.swift */,
 				074E87E02CF8EA3D0059E469 /* WebPage+NavigationDeciding.swift */,
 				078B049F2CF18EAB00B453A6 /* WebPage+NavigationPreferences.swift */,
+				071467772DFE84E500F77867 /* WebPage+Transferable.swift */,
 				07CB79952CE9435700199C49 /* WebPage.swift */,
 			);
 			path = Swift;
@@ -21053,6 +21056,7 @@
 				07FAA74B2CE947AA00128360 /* WebPage+Navigation.swift in Sources */,
 				074E87E12CF8EA3D0059E469 /* WebPage+NavigationDeciding.swift in Sources */,
 				078B04A02CF18EAB00B453A6 /* WebPage+NavigationPreferences.swift in Sources */,
+				071467782DFE84E500F77867 /* WebPage+Transferable.swift in Sources */,
 				07CB79962CE9435700199C49 /* WebPage.swift in Sources */,
 				7CE9CE101FA0767A000177DE /* WebPageUpdatePreferences.cpp in Sources */,
 				079A4DA12D72CC0D00CA387F /* WebPageWebView.swift in Sources */,

--- a/Source/WebKit/_WebKit_SwiftUI/API/WebPage+SwiftUI.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/WebPage+SwiftUI.swift
@@ -40,22 +40,4 @@ extension WebPage {
             #endif
         }
     }
-
-    /// Generates an image from the web view’s contents.
-    ///
-    /// - Parameter configuration: The object that specifies the portion of the web page to capture, and other capture-related behaviors.
-    /// - Returns: An image that contains the specified portion of the webpage.
-    /// - Throws: An error if a problem occurred when generating the snapshot.
-    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
-    @available(watchOS, unavailable)
-    @available(tvOS, unavailable)
-    public func snapshot(_ configuration: WKSnapshotConfiguration = .init()) async throws -> Image? {
-        let cocoaImage = try await backingWebView.takeSnapshot(configuration: configuration)
-
-        #if canImport(UIKit)
-        return Image(uiImage: cocoaImage)
-        #else
-        return Image(nsImage: cocoaImage)
-        #endif
-    }
 }

--- a/Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift
+++ b/Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift
@@ -153,7 +153,7 @@ final class BrowserViewModel {
 
     func exportAsPDF() {
         Task {
-            let data = try await page.pdf()
+            let data = try await page.exported(as: .pdf)
             exportedPDF = PDF(data: data, title: !page.title.isEmpty ? page.title : nil)
         }
     }

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 /* Begin PBXBuildFile section */
 		041A1E34216FFDBC00789E0A /* PublicSuffix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 041A1E33216FFDBC00789E0A /* PublicSuffix.cpp */; };
 		04DB2396235E43EC00328F17 /* BumpPointerAllocator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0451A5A6235E438E009DF945 /* BumpPointerAllocator.cpp */; };
+		0714677A2DFE8DEA00F77867 /* WebPageTransferableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 071467792DFE8DEA00F77867 /* WebPageTransferableTests.swift */; };
 		07275CBC2D01398C002315A5 /* _WebKit_SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 07275CBB2D01398C002315A5 /* _WebKit_SwiftUI.framework */; };
 		074E87E52CF920A20059E469 /* Bundle+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074E87E42CF920A20059E469 /* Bundle+Extras.swift */; };
 		075663822DF68BAB00E9A4E3 /* TestPDFDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B0CA82DF656BD00B3E569 /* TestPDFDocument.swift */; };
@@ -2244,6 +2245,7 @@
 		070721142CE2F5F6004D9EC8 /* WKWebViewSwiftOverlayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKWebViewSwiftOverlayTests.swift; sourceTree = "<group>"; };
 		0711DF51226A95FB003DD2F7 /* AVFoundationSoftLinkTest.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AVFoundationSoftLinkTest.mm; sourceTree = "<group>"; };
 		07137049265320E500CA2C9A /* AudioBufferSize.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AudioBufferSize.mm; sourceTree = "<group>"; };
+		071467792DFE8DEA00F77867 /* WebPageTransferableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPageTransferableTests.swift; sourceTree = "<group>"; };
 		0721D4582838295400A95853 /* start-offset.ts */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.typescript; path = "start-offset.ts"; sourceTree = "<group>"; };
 		07275CBB2D01398C002315A5 /* _WebKit_SwiftUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = _WebKit_SwiftUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		07338E042B7433A400F949EB /* WritingSuggestions.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WritingSuggestions.mm; sourceTree = "<group>"; };
@@ -4206,6 +4208,7 @@
 				070721102CE2F4B8004D9EC8 /* TestWebKitAPIBundle-Bridging-Header.h */,
 				078B04472CF118BD00B453A6 /* URLSchemeHandlerTests.swift */,
 				07FAA74C2CE95E3200128360 /* WebPageTests.swift */,
+				071467792DFE8DEA00F77867 /* WebPageTransferableTests.swift */,
 				070721142CE2F5F6004D9EC8 /* WKWebViewSwiftOverlayTests.swift */,
 			);
 			path = "WebKit Swift";
@@ -7800,6 +7803,7 @@
 				078B0CA92DF656BD00B3E569 /* TestPDFDocument.swift in Sources */,
 				078B04482CF118BD00B453A6 /* URLSchemeHandlerTests.swift in Sources */,
 				07FAA74D2CE95E3200128360 /* WebPageTests.swift in Sources */,
+				0714677A2DFE8DEA00F77867 /* WebPageTransferableTests.swift in Sources */,
 				077489CC2CE4061A00133938 /* WKWebViewSwiftOverlayTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTransferableTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTransferableTests.swift
@@ -1,0 +1,150 @@
+// Copyright (C) 2025 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.0)
+
+import Testing
+@_spi(Testing) import WebKit
+import _WebKit_SwiftUI
+import UniformTypeIdentifiers
+import SwiftUI
+
+@MainActor
+struct WebPageTransferableTests {
+    @Test
+    func transferableContentTypes() async throws {
+        let exportedContentTypes = WebPage.exportedContentTypes()
+        #expect(exportedContentTypes == [.webArchive, .pdf, .image, .url])
+
+        let importedContentTypes = WebPage.importedContentTypes()
+        #expect(importedContentTypes.isEmpty)
+
+        let webPage = WebPage()
+
+        let instanceExportedContentTypes = webPage.exportedContentTypes()
+        #expect(instanceExportedContentTypes == [.webArchive, .pdf, .image, .url])
+
+        let instanceImportedContentTypes = webPage.importedContentTypes()
+        #expect(instanceImportedContentTypes.isEmpty)
+    }
+
+    @Test
+    func exportToPDFWithFullContent() async throws {
+        let webPage = WebPage()
+        webPage.load(
+            html: "<meta name='viewport' content='width=device-width'><body bgcolor=#00ff00>Hello</body>",
+            baseURL: .aboutBlank
+        )
+
+        // FIXME: Remove this when possible.
+        try await Task.sleep(for: .seconds(10))
+
+        let data = try await webPage.exported(as: .pdf)
+        let pdf = TestPDFDocument(from: data)
+        #expect(pdf.pageCount == 1)
+
+        let page = try #require(pdf.page(at: 0))
+
+        #expect(page.bounds == .init(x: 0, y: 0, width: 1024, height: 768))
+        #expect(page.text == "Hello")
+        #expect(page.color(at: .init(x: 400, y: 300)) == .green)
+    }
+
+    @Test
+    func exportToPDFWithSubRegion() async throws {
+        let webPage = WebPage()
+        webPage.load(
+            html: "<meta name='viewport' content='width=device-width'><body bgcolor=#00ff00>Hello</body>",
+            baseURL: .aboutBlank
+        )
+
+        // FIXME: Remove this when possible.
+        try await Task.sleep(for: .seconds(10))
+
+        let region = CGRect(x: 200, y: 150, width: 400, height: 300)
+        let data = try await webPage.exported(as: .pdf(region: .rect(region)))
+        let pdf = TestPDFDocument(from: data)
+        #expect(pdf.pageCount == 1)
+
+        let page = try #require(pdf.page(at: 0))
+
+        #expect(page.bounds == .init(x: 0, y: 0, width: 400, height: 300))
+        #expect(page.characterCount == 0)
+        #expect(page.color(at: .init(x: 200, y: 150)) == .green)
+    }
+
+    @Test
+    func exportToPDFWithoutLoadingAnyWebContentFails() async throws {
+        let webPage = WebPage()
+
+        // FIXME: This should be `TransferableError.self`, but that type is not API.
+        await #expect(throws: (any Error).self) {
+            let _ = try await webPage.exported(as: .pdf)
+        }
+    }
+
+    @Test
+    func exportToURL() async throws {
+        let webPage = WebPage()
+        webPage.load(
+            html: "<meta name='viewport' content='width=device-width'><body bgcolor=#00ff00>Hello</body>",
+            baseURL: .aboutBlank
+        )
+
+        // FIXME: Remove this when possible.
+        try await Task.sleep(for: .seconds(10))
+
+        let data = try await webPage.exported(as: .url)
+        let actualURL = try await URL(importing: data, contentType: .url)
+
+        #expect(actualURL == .aboutBlank)
+    }
+
+    @Test
+    func exportToImage() async throws {
+        let defaultFrame = CGRect(x: 0, y: 0, width: 1024, height: 768)
+        let scaleFactor: CGFloat = 2
+
+        let webPage = WebPage()
+        webPage.load(
+            html: "<body style='background-color: red;'></body>",
+            baseURL: .aboutBlank
+        )
+
+        // FIXME: Remove this when possible.
+        try await Task.sleep(for: .seconds(10))
+
+        let imageData = try await webPage.exported(as: .image)
+
+        #if os(macOS)
+        let image = try await NSImage(importing: imageData, contentType: .image)
+        #else
+        let image = try #require(UIImage(data: imageData))
+        #endif
+
+        #expect(image.size.width == defaultFrame.size.width * scaleFactor)
+        #expect(image.size.height == defaultFrame.size.height * scaleFactor)
+    }
+}
+
+#endif // ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.0)


### PR DESCRIPTION
#### 5bc842de99ab753aaca529954c45711dbbed7bbe
<pre>
[SwiftUI] Conform WebPage to Transferable
<a href="https://bugs.webkit.org/show_bug.cgi?id=294528">https://bugs.webkit.org/show_bug.cgi?id=294528</a>
<a href="https://rdar.apple.com/152695298">rdar://152695298</a>

Reviewed by Aditya Keerthi.

`WebPage` has several ad-hoc functions to produce web archives, PDFs, and images. Instead of these
functions, this PR conforms `WebPage` to `Transferable`, which offers several conveniences
and enhanced functionality, as well as being a substantially more modern API design.

This change involves three major parts:

1) Conform `WebPage` to the `Transferable` protocol. This provides a lot of conveniences to the developer;
in particular, it will now be possible to directly use a WebPage directly when performing operations that
are done on `Transferable` types such as drag and drop and copy and paste. Additionally, this makes it possible
for new exportable types to be added in WebKit without having to make any API modifications. Developers can also
directly use the conformance by using the `exported(as:)` function, providing uniformity both within WebKit itself
and amongst other types that conform to `Transferable`.

2) The current `WebPage`/`WKWebView` API provides several configuration options for generating PDFs and images.
If `WebPage` were to just conform to `Transferable`, these customization options would be lost. To maintain parity,
an overload of `exported(as:)` is provided by WebKit itself, with the parameter describing the exported type along
with its configuration. Data created using the normal `Transferable` conformance will use the default configurations.

3) Remove the existing functions from `WebPage`, since they will be obviated by the `Transferable` conformance.

As an implementation detail, `WebPage` can also add support for several other content types, such as URL, rich text,
and link presentation metadata, in addition to pdf, web archive, and image. This does not directly impact the API
surface but is good to note.

* Source/WebKit/UIProcess/API/Swift/WebPage+Transferable.swift: Added.

Conform WebPage to Transferable; to do so, WebPage implements the `transferRepresentaion` rquirement. This provides
different content types that a WebPage can be exported to; specifically, web archive data, pdf, image, and URL.

* Source/WebKit/UIProcess/API/Swift/WebPage.swift:

When a WebPage is used without a WebView, it needs to have some non-zero size so that representations such as PDF
and image can actually be created. If a WebPage is not bound to a WebView, it&apos;s frame is now set to a fixed size.

Also, remove the old PDF and web archive data functions.

* Source/WebKit/_WebKit_SwiftUI/API/WebPage+SwiftUI.swift:

Remove the old snapshot function.

* Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift:

Update the test app.

* Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTransferableTests.swift: Added.

Add several tests to test the Transferable functionality.

Canonical link: <a href="https://commits.webkit.org/296332@main">https://commits.webkit.org/296332@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/336ece80d4d00d963fbd77547a48aff48c9ba564

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108129 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27792 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18212 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113340 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58623 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110092 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28488 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36342 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82101 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22573 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97409 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62533 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21990 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15545 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58083 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91936 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15603 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116465 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35194 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25915 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91126 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35569 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93686 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90921 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23187 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35810 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13572 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31002 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35095 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40650 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34829 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38187 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36496 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->