### PR TITLE
[JSC] Range Check for `canBeInt32` and `canBeStrictInt32` to Avoid Unexpected Results

### DIFF
--- a/Source/JavaScriptCore/runtime/MathCommon.h
+++ b/Source/JavaScriptCore/runtime/MathCommon.h
@@ -240,19 +240,137 @@ inline std::optional<double> safeReciprocalForDivByConst(double constant)
     return reciprocal;
 }
 
+// The difference from canBeInt32 is that canBeStrictInt32 returns false with -0.0
 ALWAYS_INLINE bool canBeStrictInt32(double value)
 {
-    if (std::isinf(value) || std::isnan(value))
+#if CPU(ARM64)
+    constexpr double int32Min = static_cast<double>(std::numeric_limits<int32_t>::min());
+    constexpr double int32Max = static_cast<double>(std::numeric_limits<int32_t>::max());
+
+    int valueAsInt32;
+    int cond;
+    double int32AsDouble;
+    bool isValidInt32;
+
+    asm (
+        // isValidInt32 = isfinite(value)
+        "fcmp %d[val], %d[val]" "\n"
+        "cset %w[isValidInt32], vc" "\n"
+
+        // cond = (value >= int32Min)
+        // isValidInt32 &= cond
+        "fcmp %d[val], %d[min]" "\n"
+        "cset %w[cond], ge" "\n"
+        "and %w[isValidInt32], %w[isValidInt32], %w[cond]" "\n"
+
+        // cond = (value <= int32Max)
+        // isValidInt32 &= cond
+        "fcmp %d[val], %d[max]" "\n"
+        "cset %w[cond], le" "\n"
+        "and %w[isValidInt32], %w[isValidInt32], %w[cond]" "\n"
+
+        // valueAsInt32 = int32_t(value)
+        // int32AsDouble = double(valueAsInt32)
+        "fcvtzs %w[valueAsInt32], %d[val]" "\n"
+        "scvtf %d[int32AsDouble], %w[valueAsInt32]" "\n"
+
+        // cond = (value == int32AsDouble)
+        // isValidInt32 &= cond
+        "fcmp %d[val], %d[int32AsDouble]" "\n"
+        "cset %w[cond], eq" "\n"
+        "and %w[isValidInt32], %w[isValidInt32], %w[cond]" "\n"
+
+        // cond = (valueAsInt32 == 0 && signbit(value))
+        // isValidInt32 &= !cond
+        "cmp %w[valueAsInt32], #0" "\n"
+        "cset %w[cond], eq" "\n"
+        "fmov x0, %d[val]" "\n"
+        "lsr x0, x0, #63" "\n"
+        "and %w[cond], %w[cond], w0" "\n"
+        "mvn %w[cond], %w[cond]" "\n"
+        "and %w[isValidInt32], %w[isValidInt32], %w[cond]" "\n"
+
+        : [isValidInt32] "=r"(isValidInt32),
+          [valueAsInt32] "=&r"(valueAsInt32),
+          [int32AsDouble] "=&w"(int32AsDouble),
+          [cond] "=&r"(cond)
+        : [val] "w"(value),
+          [min] "w"(int32Min),
+          [max] "w"(int32Max)
+        : "x0", "cc"
+    );
+    return isValidInt32;
+#else
+    if (!std::isfinite(value)
+        || value < static_cast<double>(std::numeric_limits<int32_t>::min())
+        || value > static_cast<double>(std::numeric_limits<int32_t>::max())
+    ) {
         return false;
+    }
     const int32_t asInt32 = static_cast<int32_t>(value);
-    return !(asInt32 != value || (!asInt32 && std::signbit(value))); // true for -0.0
+    return !(asInt32 != value || (!asInt32 && std::signbit(value)));
+#endif
 }
 
+// The difference from canBeStrictInt32 is that canBeInt32 returns true with -0.0
 ALWAYS_INLINE bool canBeInt32(double value)
 {
-    if (std::isinf(value) || std::isnan(value))
+#if CPU(ARM64)
+    constexpr double int32Min = static_cast<double>(std::numeric_limits<int32_t>::min());
+    constexpr double int32Max = static_cast<double>(std::numeric_limits<int32_t>::max());
+
+    double int32AsDouble;
+    int valueAsInt32;
+    int cond;
+    bool isValidInt32;
+
+    asm (
+        // isValidInt32 = isfinite(value)
+        "fcmp %d[val], %d[val]" "\n"
+        "cset %w[isValidInt32], vc" "\n"
+
+        // cond = (value >= int32Min)
+        // isValidInt32 &= cond
+        "fcmp %d[val], %d[min]" "\n"
+        "cset %w[cond], ge" "\n"
+        "and %w[isValidInt32], %w[isValidInt32], %w[cond]" "\n"
+
+        // cond = (value <= int32Max)
+        // isValidInt32 &= cond
+        "fcmp %d[val], %d[max]" "\n"
+        "cset %w[cond], le" "\n"
+        "and %w[isValidInt32], %w[isValidInt32], %w[cond]" "\n"
+
+        // valueAsInt32 = int32_t(value)
+        // int32AsDouble = double(valueAsInt32)
+        "fcvtzs %w[valueAsInt32], %d[val]" "\n"
+        "scvtf %d[int32AsDouble], %w[valueAsInt32]" "\n"
+
+        // cond = (value == int32AsDouble)
+        // isValidInt32 &= cond
+        "fcmp %d[val], %d[int32AsDouble]" "\n"
+        "cset %w[cond], eq" "\n"
+        "and %w[isValidInt32], %w[isValidInt32], %w[cond]" "\n"
+
+        : [isValidInt32] "=r"(isValidInt32),
+          [valueAsInt32] "=&r"(valueAsInt32),
+          [int32AsDouble] "=&w"(int32AsDouble),
+          [cond] "=&r"(cond)
+        : [val] "w"(value),
+          [min] "w"(int32Min),
+          [max] "w"(int32Max)
+        :
+    );
+    return isValidInt32;
+#else
+    if (!std::isfinite(value)
+        || value < static_cast<double>(std::numeric_limits<int32_t>::min())
+        || value > static_cast<double>(std::numeric_limits<int32_t>::max())
+    ) {
         return false;
+    }
     return static_cast<int32_t>(value) == value;
+#endif
 }
 
 extern "C" {


### PR DESCRIPTION
#### dcb8098f028e9537ccabe871eac92b793b53ff2b
<pre>
[JSC] Range Check for `canBeInt32` and `canBeStrictInt32` to Avoid Unexpected Results
<a href="https://bugs.webkit.org/show_bug.cgi?id=294529">https://bugs.webkit.org/show_bug.cgi?id=294529</a>

Reviewed by NOBODY (OOPS!).

This patch adds range checks for canBeInt32 and canBeStrictInt32
to prevent unexpected results.
For example, 2147483679.0 is outside the range of int32_t, and it was not
handled correctly.

* Source/JavaScriptCore/runtime/MathCommon.h:
(JSC::canBeStrictInt32):
(JSC::canBeInt32):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcb8098f028e9537ccabe871eac92b793b53ff2b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120860 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31210 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127268 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72936 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41252 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49131 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91795 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61041 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32939 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108340 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72491 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31968 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26443 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70862 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/112986 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102434 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26622 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130128 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/119376 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47781 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36291 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100413 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48149 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104514 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100316 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45707 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23754 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/44465 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47643 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53348 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/149514 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47114 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/149514 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50458 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48798 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->