### PR TITLE
Clean up and extend the Widget coordinate conversion functions

### DIFF
--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -191,16 +191,59 @@ bool FrameView::formControlRefreshEnabled() const
 }
 #endif
 
+// MARK: -
+
+IntPoint FrameView::convertFromRendererToContainingView(const RenderElement* renderer, IntPoint rendererPoint) const
+{
+    auto point = roundedIntPoint(renderer->localToAbsolute(rendererPoint, UseTransforms));
+    return contentsToView(point);
+}
+
+FloatPoint FrameView::convertFromRendererToContainingView(const RenderElement* renderer, FloatPoint rendererPoint) const
+{
+    auto point = renderer->localToAbsolute(rendererPoint, UseTransforms);
+    return contentsToView(point);
+}
+
 IntRect FrameView::convertFromRendererToContainingView(const RenderElement* renderer, const IntRect& rendererRect) const
 {
-    IntRect rect = snappedIntRect(enclosingLayoutRect(renderer->localToAbsoluteQuad(FloatRect(rendererRect)).boundingBox()));
-
+    auto rect = snappedIntRect(enclosingLayoutRect(renderer->localToAbsoluteQuad(FloatRect(rendererRect)).boundingBox()));
     return contentsToView(rect);
+}
+
+FloatRect FrameView::convertFromRendererToContainingView(const RenderElement* renderer, const FloatRect& rendererRect) const
+{
+    auto rect = renderer->localToAbsoluteQuad(FloatRect(rendererRect)).boundingBox();
+    return contentsToView(rect);
+}
+
+// MARK: -
+
+IntPoint FrameView::convertFromContainingViewToRenderer(const RenderElement* renderer, IntPoint viewPoint) const
+{
+    auto point = viewPoint;
+
+    // Convert from FrameView coords into page ("absolute") coordinates.
+    if (!delegatesScrollingToNativeView())
+        point = viewToContents(point);
+
+    return roundedIntPoint(renderer->absoluteToLocal(point, UseTransforms));
+}
+
+FloatPoint FrameView::convertFromContainingViewToRenderer(const RenderElement* renderer, FloatPoint viewPoint) const
+{
+    auto point = viewPoint;
+
+    // Convert from FrameView coords into page ("absolute") coordinates.
+    if (!delegatesScrollingToNativeView())
+        point = viewToContents(point);
+
+    return renderer->absoluteToLocal(point, UseTransforms);
 }
 
 IntRect FrameView::convertFromContainingViewToRenderer(const RenderElement* renderer, const IntRect& viewRect) const
 {
-    IntRect rect = viewToContents(viewRect);
+    auto rect = viewToContents(viewRect);
 
     // FIXME: we don't have a way to map an absolute rect down to a local quad, so just
     // move the rect for now.
@@ -210,32 +253,47 @@ IntRect FrameView::convertFromContainingViewToRenderer(const RenderElement* rend
 
 FloatRect FrameView::convertFromContainingViewToRenderer(const RenderElement* renderer, const FloatRect& viewRect) const
 {
-    FloatRect rect = viewToContents(viewRect);
+    auto rect = viewToContents(viewRect);
 
-    return (renderer->absoluteToLocalQuad(rect)).boundingBox();
+    return renderer->absoluteToLocalQuad(rect).boundingBox();
 }
 
-IntPoint FrameView::convertFromRendererToContainingView(const RenderElement* renderer, const IntPoint& rendererPoint) const
-{
-    IntPoint point = roundedIntPoint(renderer->localToAbsolute(rendererPoint, UseTransforms));
+// MARK: -
 
-    return contentsToView(point);
+IntPoint FrameView::convertToContainingView(IntPoint localPoint) const
+{
+    if (auto* parentScrollView = parent()) {
+        if (auto* parentView = dynamicDowncast<FrameView>(*parentScrollView)) {
+            // Get our renderer in the parent view
+            RenderWidget* renderer = frame().ownerRenderer();
+            if (!renderer)
+                return localPoint;
+
+            auto point = localPoint;
+            point.moveBy(roundedIntPoint(renderer->contentBoxLocation()));
+            return parentView->convertFromRendererToContainingView(renderer, point);
+        }
+        return Widget::convertToContainingView(localPoint);
+    }
+    return localPoint;
 }
 
-FloatPoint FrameView::convertFromRendererToContainingView(const RenderElement* renderer, const FloatPoint& rendererPoint) const
+FloatPoint FrameView::convertToContainingView(FloatPoint localPoint) const
 {
-    return contentsToView(renderer->localToAbsolute(rendererPoint, UseTransforms));
-}
+    if (auto* parentScrollView = parent()) {
+        if (auto* parentView = dynamicDowncast<FrameView>(*parentScrollView)) {
+            // Get our renderer in the parent view
+            RenderWidget* renderer = frame().ownerRenderer();
+            if (!renderer)
+                return localPoint;
 
-IntPoint FrameView::convertFromContainingViewToRenderer(const RenderElement* renderer, const IntPoint& viewPoint) const
-{
-    IntPoint point = viewPoint;
-
-    // Convert from FrameView coords into page ("absolute") coordinates.
-    if (!delegatesScrollingToNativeView())
-        point = viewToContents(point);
-
-    return roundedIntPoint(renderer->absoluteToLocal(point, UseTransforms));
+            auto point = localPoint;
+            point.moveBy(renderer->contentBoxLocation());
+            return parentView->convertFromRendererToContainingView(renderer, point);
+        }
+        return Widget::convertToContainingView(localPoint);
+    }
+    return localPoint;
 }
 
 IntRect FrameView::convertToContainingView(const IntRect& localRect) const
@@ -254,6 +312,62 @@ IntRect FrameView::convertToContainingView(const IntRect& localRect) const
         return Widget::convertToContainingView(localRect);
     }
     return localRect;
+}
+
+FloatRect FrameView::convertToContainingView(const FloatRect& localRect) const
+{
+    if (auto* parentScrollView = parent()) {
+        if (auto* parentView = dynamicDowncast<FrameView>(*parentScrollView)) {
+            // Get our renderer in the parent view
+            RenderWidget* renderer = frame().ownerRenderer();
+            if (!renderer)
+                return localRect;
+
+            auto rect = localRect;
+            rect.moveBy(renderer->contentBoxLocation());
+            return parentView->convertFromRendererToContainingView(renderer, rect);
+        }
+        return Widget::convertToContainingView(localRect);
+    }
+    return localRect;
+}
+
+// MARK: -
+
+IntPoint FrameView::convertFromContainingView(IntPoint parentPoint) const
+{
+    if (auto* parentScrollView = parent()) {
+        if (auto* parentView = dynamicDowncast<FrameView>(*parentScrollView)) {
+            // Get our renderer in the parent view
+            RenderWidget* renderer = frame().ownerRenderer();
+            if (!renderer)
+                return parentPoint;
+
+            auto point = parentView->convertFromContainingViewToRenderer(renderer, parentPoint);
+            point.moveBy(-roundedIntPoint(renderer->contentBoxLocation()));
+            return point;
+        }
+        return Widget::convertFromContainingView(parentPoint);
+    }
+    return parentPoint;
+}
+
+FloatPoint FrameView::convertFromContainingView(FloatPoint parentPoint) const
+{
+    if (auto* parentScrollView = parent()) {
+        if (auto* parentView = dynamicDowncast<FrameView>(*parentScrollView)) {
+            // Get our renderer in the parent view
+            RenderWidget* renderer = frame().ownerRenderer();
+            if (!renderer)
+                return parentPoint;
+
+            auto point = parentView->convertFromContainingViewToRenderer(renderer, parentPoint);
+            point.moveBy(-renderer->contentBoxLocation());
+            return point;
+        }
+        return Widget::convertFromContainingView(parentPoint);
+    }
+    return parentPoint;
 }
 
 IntRect FrameView::convertFromContainingView(const IntRect& parentRect) const
@@ -290,60 +404,6 @@ FloatRect FrameView::convertFromContainingView(const FloatRect& parentRect) cons
         return Widget::convertFromContainingView(parentRect);
     }
     return parentRect;
-}
-
-IntPoint FrameView::convertToContainingView(const IntPoint& localPoint) const
-{
-    if (auto* parentScrollView = parent()) {
-        if (auto* parentView = dynamicDowncast<FrameView>(*parentScrollView)) {
-            // Get our renderer in the parent view
-            RenderWidget* renderer = frame().ownerRenderer();
-            if (!renderer)
-                return localPoint;
-
-            auto point = localPoint;
-            point.moveBy(roundedIntPoint(renderer->contentBoxLocation()));
-            return parentView->convertFromRendererToContainingView(renderer, point);
-        }
-        return Widget::convertToContainingView(localPoint);
-    }
-    return localPoint;
-}
-
-FloatPoint FrameView::convertToContainingView(const FloatPoint& localPoint) const
-{
-    if (auto* parentScrollView = parent()) {
-        if (auto* parentView = dynamicDowncast<FrameView>(*parentScrollView)) {
-            // Get our renderer in the parent view
-            RenderWidget* renderer = frame().ownerRenderer();
-            if (!renderer)
-                return localPoint;
-
-            auto point = localPoint;
-            point.moveBy(renderer->contentBoxLocation());
-            return parentView->convertFromRendererToContainingView(renderer, point);
-        }
-        return Widget::convertToContainingView(localPoint);
-    }
-    return localPoint;
-}
-
-IntPoint FrameView::convertFromContainingView(const IntPoint& parentPoint) const
-{
-    if (auto* parentScrollView = parent()) {
-        if (auto* parentView = dynamicDowncast<FrameView>(*parentScrollView)) {
-            // Get our renderer in the parent view
-            RenderWidget* renderer = frame().ownerRenderer();
-            if (!renderer)
-                return parentPoint;
-
-            auto point = parentView->convertFromContainingViewToRenderer(renderer, parentPoint);
-            point.moveBy(-roundedIntPoint(renderer->contentBoxLocation()));
-            return point;
-        }
-        return Widget::convertFromContainingView(parentPoint);
-    }
-    return parentPoint;
 }
 
 }

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -86,20 +86,26 @@ public:
     //
 
     // Methods to convert points and rects between the coordinate space of the renderer, and this view.
+    WEBCORE_EXPORT IntPoint convertFromRendererToContainingView(const RenderElement*, IntPoint) const;
+    WEBCORE_EXPORT FloatPoint convertFromRendererToContainingView(const RenderElement*, FloatPoint) const;
     WEBCORE_EXPORT IntRect convertFromRendererToContainingView(const RenderElement*, const IntRect&) const;
+    WEBCORE_EXPORT FloatRect convertFromRendererToContainingView(const RenderElement*, const FloatRect&) const;
+
+    WEBCORE_EXPORT IntPoint convertFromContainingViewToRenderer(const RenderElement*, IntPoint) const;
+    WEBCORE_EXPORT FloatPoint convertFromContainingViewToRenderer(const RenderElement*, FloatPoint) const;
     WEBCORE_EXPORT IntRect convertFromContainingViewToRenderer(const RenderElement*, const IntRect&) const;
     WEBCORE_EXPORT FloatRect convertFromContainingViewToRenderer(const RenderElement*, const FloatRect&) const;
-    WEBCORE_EXPORT IntPoint convertFromRendererToContainingView(const RenderElement*, const IntPoint&) const;
-    WEBCORE_EXPORT FloatPoint convertFromRendererToContainingView(const RenderElement*, const FloatPoint&) const;
-    WEBCORE_EXPORT IntPoint convertFromContainingViewToRenderer(const RenderElement*, const IntPoint&) const;
 
     // Override ScrollView methods to do point conversion via renderers, in order to take transforms into account.
+    IntPoint convertToContainingView(IntPoint) const final;
+    FloatPoint convertToContainingView(FloatPoint) const final;
     IntRect convertToContainingView(const IntRect&) const final;
+    FloatRect convertToContainingView(const FloatRect&) const final;
+
+    IntPoint convertFromContainingView(IntPoint) const final;
+    FloatPoint convertFromContainingView(FloatPoint) const final;
     IntRect convertFromContainingView(const IntRect&) const final;
     FloatRect convertFromContainingView(const FloatRect&) const final;
-    IntPoint convertToContainingView(const IntPoint&) const final;
-    FloatPoint convertToContainingView(const FloatPoint&) const final;
-    IntPoint convertFromContainingView(const IntPoint&) const final;
 
 private:
     ScrollableArea* enclosingScrollableArea() const final;

--- a/Source/WebCore/platform/ScrollView.cpp
+++ b/Source/WebCore/platform/ScrollView.cpp
@@ -902,7 +902,7 @@ FloatPoint ScrollView::viewToContents(const FloatPoint& point) const
     if (delegatesScrollingToNativeView())
         return point;
 
-    return viewToContents(IntPoint(point));
+    return point + toIntSize(documentScrollPositionRelativeToViewOrigin());
 }
 
 FloatPoint ScrollView::contentsToView(const FloatPoint& point) const
@@ -1043,14 +1043,16 @@ IntRect ScrollView::contentsToRootView(const IntRect& contentsRect) const
     return convertToRootView(contentsToView(contentsRect));
 }
 
-IntPoint ScrollView::windowToContents(const IntPoint& windowPoint) const
+// MARK: -
+
+IntPoint ScrollView::windowToContents(IntPoint windowPoint) const
 {
     return viewToContents(convertFromContainingWindow(windowPoint));
 }
 
-IntPoint ScrollView::contentsToWindow(const IntPoint& contentsPoint) const
+FloatPoint ScrollView::windowToContents(FloatPoint windowPoint) const
 {
-    return convertToContainingWindow(contentsToView(contentsPoint));
+    return viewToContents(convertFromContainingWindow(windowPoint));
 }
 
 IntRect ScrollView::windowToContents(const IntRect& windowRect) const
@@ -1058,10 +1060,34 @@ IntRect ScrollView::windowToContents(const IntRect& windowRect) const
     return viewToContents(convertFromContainingWindow(windowRect));
 }
 
+FloatRect ScrollView::windowToContents(const FloatRect& windowRect) const
+{
+    return viewToContents(convertFromContainingWindow(windowRect));
+}
+
+// MARK: -
+
+IntPoint ScrollView::contentsToWindow(IntPoint contentsPoint) const
+{
+    return convertToContainingWindow(contentsToView(contentsPoint));
+}
+
+FloatPoint ScrollView::contentsToWindow(FloatPoint contentsPoint) const
+{
+    return convertToContainingWindow(contentsToView(contentsPoint));
+}
+
 IntRect ScrollView::contentsToWindow(const IntRect& contentsRect) const
 {
     return convertToContainingWindow(contentsToView(contentsRect));
 }
+
+FloatRect ScrollView::contentsToWindow(const FloatRect& contentsRect) const
+{
+    return convertToContainingWindow(contentsToView(contentsRect));
+}
+
+// MARK: -
 
 IntRect ScrollView::contentsToScreen(const IntRect& rect) const
 {
@@ -1135,6 +1161,14 @@ FloatPoint ScrollView::convertChildToSelf(const Widget* child, FloatPoint point)
 }
 
 IntPoint ScrollView::convertSelfToChild(const Widget* child, IntPoint point) const
+{
+    if (!isScrollViewScrollbar(child))
+        point += toIntSize(documentScrollPositionRelativeToViewOrigin());
+    point.moveBy(-child->location());
+    return point;
+}
+
+FloatPoint ScrollView::convertSelfToChild(const Widget* child, FloatPoint point) const
 {
     if (!isScrollViewScrollbar(child))
         point += toIntSize(documentScrollPositionRelativeToViewOrigin());

--- a/Source/WebCore/platform/ScrollView.h
+++ b/Source/WebCore/platform/ScrollView.h
@@ -336,10 +336,15 @@ public:
     // Event coordinates are assumed to be in the coordinate space of a window that contains
     // the entire widget hierarchy. It is up to the platform to decide what the precise definition
     // of containing window is. (For example on Mac it is the containing NSWindow.)
-    WEBCORE_EXPORT IntPoint windowToContents(const IntPoint&) const;
-    WEBCORE_EXPORT IntPoint contentsToWindow(const IntPoint&) const;
+    WEBCORE_EXPORT IntPoint windowToContents(IntPoint) const;
+    FloatPoint windowToContents(FloatPoint) const;
     WEBCORE_EXPORT IntRect windowToContents(const IntRect&) const;
+    FloatRect windowToContents(const FloatRect&) const;
+
+    WEBCORE_EXPORT IntPoint contentsToWindow(IntPoint) const;
+    FloatPoint contentsToWindow(FloatPoint) const;
     WEBCORE_EXPORT IntRect contentsToWindow(const IntRect&) const;
+    FloatRect contentsToWindow(const FloatRect&) const;
 
     // Functions for converting to and from screen coordinates.
     WEBCORE_EXPORT IntRect contentsToScreen(const IntRect&) const;
@@ -363,7 +368,9 @@ public:
 
     IntPoint convertChildToSelf(const Widget*, IntPoint) const;
     FloatPoint convertChildToSelf(const Widget*, FloatPoint) const;
+
     IntPoint convertSelfToChild(const Widget*, IntPoint) const;
+    FloatPoint convertSelfToChild(const Widget*, FloatPoint) const;
 
     // Widget override. Handles painting of the contents of the view as well as the scrollbars.
     WEBCORE_EXPORT void paint(GraphicsContext&, const IntRect&, Widget::SecurityOriginPaintPolicy = SecurityOriginPaintPolicy::AnyOrigin, RegionContext* = nullptr) final;

--- a/Source/WebCore/platform/Scrollbar.cpp
+++ b/Source/WebCore/platform/Scrollbar.cpp
@@ -495,12 +495,12 @@ IntRect Scrollbar::convertFromContainingView(const IntRect& parentRect) const
     return m_scrollableArea.convertFromContainingViewToScrollbar(*this, parentRect);
 }
 
-IntPoint Scrollbar::convertToContainingView(const IntPoint& localPoint) const
+IntPoint Scrollbar::convertToContainingView(IntPoint localPoint) const
 {
     return m_scrollableArea.convertFromScrollbarToContainingView(*this, localPoint);
 }
 
-IntPoint Scrollbar::convertFromContainingView(const IntPoint& parentPoint) const
+IntPoint Scrollbar::convertFromContainingView(IntPoint parentPoint) const
 {
     return m_scrollableArea.convertFromContainingViewToScrollbar(*this, parentPoint);
 }

--- a/Source/WebCore/platform/Scrollbar.h
+++ b/Source/WebCore/platform/Scrollbar.h
@@ -126,8 +126,8 @@ public:
     IntRect convertToContainingView(const IntRect&) const override;
     IntRect convertFromContainingView(const IntRect&) const override;
 
-    IntPoint convertToContainingView(const IntPoint&) const override;
-    IntPoint convertFromContainingView(const IntPoint&) const override;
+    IntPoint convertToContainingView(IntPoint) const override;
+    IntPoint convertFromContainingView(IntPoint) const override;
 
     void moveThumb(int pos, bool draggingDocument = false);
 

--- a/Source/WebCore/platform/Widget.cpp
+++ b/Source/WebCore/platform/Widget.cpp
@@ -83,22 +83,24 @@ void Widget::setCursor(const Cursor& cursor)
         view->hostWindow()->setCursor(cursor);
 }
 
-IntRect Widget::convertFromRootView(const IntRect& rootRect) const
+// MARK: -
+
+IntPoint Widget::convertToRootView(IntPoint localPoint) const
 {
     if (const ScrollView* parentScrollView = parent()) {
-        IntRect parentRect = parentScrollView->convertFromRootView(rootRect);
-        return convertFromContainingView(parentRect);
+        auto parentPoint = convertToContainingView(localPoint);
+        return parentScrollView->convertToRootView(parentPoint);
     }
-    return rootRect;
+    return localPoint;
 }
 
-FloatRect Widget::convertFromRootView(const FloatRect& rootRect) const
+FloatPoint Widget::convertToRootView(FloatPoint localPoint) const
 {
     if (const ScrollView* parentScrollView = parent()) {
-        FloatRect parentRect = parentScrollView->convertFromRootView(rootRect);
-        return convertFromContainingView(parentRect);
+        auto parentPoint = convertToContainingView(localPoint);
+        return parentScrollView->convertToRootView(parentPoint);
     }
-    return rootRect;
+    return localPoint;
 }
 
 IntRect Widget::convertToRootView(const IntRect& localRect) const
@@ -119,7 +121,9 @@ FloatRect Widget::convertToRootView(const FloatRect& localRect) const
     return localRect;
 }
 
-IntPoint Widget::convertFromRootView(const IntPoint& rootPoint) const
+// MARK: -
+
+IntPoint Widget::convertFromRootView(IntPoint rootPoint) const
 {
     if (const ScrollView* parentScrollView = parent()) {
         IntPoint parentPoint = parentScrollView->convertFromRootView(rootPoint);
@@ -128,16 +132,7 @@ IntPoint Widget::convertFromRootView(const IntPoint& rootPoint) const
     return rootPoint;
 }
 
-IntPoint Widget::convertToRootView(const IntPoint& localPoint) const
-{
-    if (const ScrollView* parentScrollView = parent()) {
-        IntPoint parentPoint = convertToContainingView(localPoint);
-        return parentScrollView->convertToRootView(parentPoint);
-    }
-    return localPoint;
-}
-
-FloatPoint Widget::convertFromRootView(const FloatPoint& rootPoint) const
+FloatPoint Widget::convertFromRootView(FloatPoint rootPoint) const
 {
     if (const ScrollView* parentScrollView = parent()) {
         FloatPoint parentPoint = parentScrollView->convertFromRootView(rootPoint);
@@ -146,59 +141,155 @@ FloatPoint Widget::convertFromRootView(const FloatPoint& rootPoint) const
     return rootPoint;
 }
 
-FloatPoint Widget::convertToRootView(const FloatPoint& localPoint) const
+IntRect Widget::convertFromRootView(const IntRect& rootRect) const
 {
     if (const ScrollView* parentScrollView = parent()) {
-        FloatPoint parentPoint = convertToContainingView(localPoint);
-        return parentScrollView->convertToRootView(parentPoint);
-    }
-    return localPoint;
-}
-
-IntRect Widget::convertFromContainingWindow(const IntRect& windowRect) const
-{
-    if (const ScrollView* parentScrollView = parent()) {
-        IntRect parentRect = parentScrollView->convertFromContainingWindow(windowRect);
+        IntRect parentRect = parentScrollView->convertFromRootView(rootRect);
         return convertFromContainingView(parentRect);
     }
-    return convertFromContainingWindowToRoot(this, windowRect);
+    return rootRect;
 }
 
-IntRect Widget::convertToContainingWindow(const IntRect& localRect) const
+FloatRect Widget::convertFromRootView(const FloatRect& rootRect) const
 {
     if (const ScrollView* parentScrollView = parent()) {
-        IntRect parentRect = convertToContainingView(localRect);
-        return parentScrollView->convertToContainingWindow(parentRect);
+        FloatRect parentRect = parentScrollView->convertFromRootView(rootRect);
+        return convertFromContainingView(parentRect);
     }
-    return convertFromRootToContainingWindow(this, localRect);
+    return rootRect;
 }
 
-IntPoint Widget::convertFromContainingWindow(const IntPoint& windowPoint) const
-{
-    if (const ScrollView* parentScrollView = parent()) {
-        IntPoint parentPoint = parentScrollView->convertFromContainingWindow(windowPoint);
-        return convertFromContainingView(parentPoint);
-    }
-    return convertFromContainingWindowToRoot(this, windowPoint);
-}
+// MARK: -
 
-IntPoint Widget::convertToContainingWindow(const IntPoint& localPoint) const
+IntPoint Widget::convertToContainingWindow(IntPoint localPoint) const
 {
     if (const ScrollView* parentScrollView = parent()) {
-        IntPoint parentPoint = convertToContainingView(localPoint);
+        auto parentPoint = convertToContainingView(localPoint);
         return parentScrollView->convertToContainingWindow(parentPoint);
     }
     return convertFromRootToContainingWindow(this, localPoint);
 }
 
+FloatPoint Widget::convertToContainingWindow(FloatPoint localPoint) const
+{
+    if (const ScrollView* parentScrollView = parent()) {
+        auto parentPoint = convertToContainingView(localPoint);
+        return parentScrollView->convertToContainingWindow(parentPoint);
+    }
+    return convertFromRootToContainingWindow(this, localPoint);
+}
+
+IntRect Widget::convertToContainingWindow(const IntRect& localRect) const
+{
+    if (const ScrollView* parentScrollView = parent()) {
+        auto parentRect = convertToContainingView(localRect);
+        return parentScrollView->convertToContainingWindow(parentRect);
+    }
+    return convertFromRootToContainingWindow(this, localRect);
+}
+
+FloatRect Widget::convertToContainingWindow(const FloatRect& localRect) const
+{
+    if (const ScrollView* parentScrollView = parent()) {
+        auto parentRect = convertToContainingView(localRect);
+        return parentScrollView->convertToContainingWindow(parentRect);
+    }
+    return convertFromRootToContainingWindow(this, localRect);
+}
+
+// MARK: -
+
+IntPoint Widget::convertFromContainingWindow(IntPoint windowPoint) const
+{
+    if (const ScrollView* parentScrollView = parent()) {
+        auto parentPoint = parentScrollView->convertFromContainingWindow(windowPoint);
+        return convertFromContainingView(parentPoint);
+    }
+    return convertFromContainingWindowToRoot(this, windowPoint);
+}
+
+FloatPoint Widget::convertFromContainingWindow(FloatPoint windowPoint) const
+{
+    if (const ScrollView* parentScrollView = parent()) {
+        auto parentPoint = parentScrollView->convertFromContainingWindow(windowPoint);
+        return convertFromContainingView(parentPoint);
+    }
+    return convertFromContainingWindowToRoot(this, windowPoint);
+}
+
+IntRect Widget::convertFromContainingWindow(const IntRect& windowRect) const
+{
+    if (const ScrollView* parentScrollView = parent()) {
+        auto parentRect = parentScrollView->convertFromContainingWindow(windowRect);
+        return convertFromContainingView(parentRect);
+    }
+    return convertFromContainingWindowToRoot(this, windowRect);
+}
+
+FloatRect Widget::convertFromContainingWindow(const FloatRect& windowRect) const
+{
+    if (const ScrollView* parentScrollView = parent()) {
+        auto parentRect = parentScrollView->convertFromContainingWindow(windowRect);
+        return convertFromContainingView(parentRect);
+    }
+    return convertFromContainingWindowToRoot(this, windowRect);
+}
+
+// MARK: -
+
+IntPoint Widget::convertToContainingView(IntPoint localPoint) const
+{
+    if (const auto* parentScrollView = parent())
+        return parentScrollView->convertChildToSelf(this, localPoint);
+
+    return localPoint;
+}
+
+FloatPoint Widget::convertToContainingView(FloatPoint localPoint) const
+{
+    if (const ScrollView* parentScrollView = parent())
+        return parentScrollView->convertChildToSelf(this, localPoint);
+
+    return localPoint;
+}
+
 IntRect Widget::convertToContainingView(const IntRect& localRect) const
 {
     if (const ScrollView* parentScrollView = parent()) {
-        IntRect parentRect(localRect);
+        auto parentRect = localRect;
         parentRect.setLocation(parentScrollView->convertChildToSelf(this, localRect.location()));
         return parentRect;
     }
     return localRect;
+}
+
+FloatRect Widget::convertToContainingView(const FloatRect& localRect) const
+{
+    if (const ScrollView* parentScrollView = parent()) {
+        auto parentRect = localRect;
+        parentRect.setLocation(parentScrollView->convertChildToSelf(this, localRect.location()));
+        return parentRect;
+    }
+    return localRect;
+}
+
+// MARK: -
+
+IntPoint Widget::convertFromContainingView(IntPoint parentPoint) const
+{
+    if (const auto* parentScrollView = parent())
+        return parentScrollView->convertSelfToChild(this, parentPoint);
+
+    return parentPoint;
+}
+
+
+FloatPoint Widget::convertFromContainingView(FloatPoint parentPoint) const
+{
+    if (const auto* parentScrollView = parent())
+        return parentScrollView->convertSelfToChild(this, parentPoint);
+
+    return parentPoint;
 }
 
 IntRect Widget::convertFromContainingView(const IntRect& parentRect) const
@@ -212,44 +303,17 @@ IntRect Widget::convertFromContainingView(const IntRect& parentRect) const
     return parentRect;
 }
 
-FloatRect Widget::convertToContainingView(const FloatRect& localRect) const
-{
-    return convertToContainingView(IntRect(localRect));
-}
-
 FloatRect Widget::convertFromContainingView(const FloatRect& parentRect) const
 {
-    return convertFromContainingView(IntRect(parentRect));
+    if (const auto* parentScrollView = parent()) {
+        auto localRect = parentRect;
+        localRect.setLocation(parentScrollView->convertSelfToChild(this, localRect.location()));
+        return localRect;
+    }
+    return parentRect;
 }
 
-IntPoint Widget::convertToContainingView(const IntPoint& localPoint) const
-{
-    if (const auto* parentScrollView = parent())
-        return parentScrollView->convertChildToSelf(this, localPoint);
-
-    return localPoint;
-}
-
-IntPoint Widget::convertFromContainingView(const IntPoint& parentPoint) const
-{
-    if (const auto* parentScrollView = parent())
-        return parentScrollView->convertSelfToChild(this, parentPoint);
-
-    return parentPoint;
-}
-
-FloatPoint Widget::convertToContainingView(const FloatPoint& localPoint) const
-{
-    if (const ScrollView* parentScrollView = parent())
-        return parentScrollView->convertChildToSelf(this, localPoint);
-
-    return localPoint;
-}
-
-FloatPoint Widget::convertFromContainingView(const FloatPoint& parentPoint) const
-{
-    return convertFromContainingView(IntPoint(parentPoint));
-}
+// MARK: -
 
 #if !PLATFORM(COCOA)
 
@@ -293,9 +357,38 @@ void Widget::paint(GraphicsContext&, const IntRect&, SecurityOriginPaintPolicy, 
 {
 }
 
+// MARK: -
+
+IntPoint Widget::convertFromRootToContainingWindow(const Widget*, IntPoint point)
+{
+    return point;
+}
+
+FloatPoint Widget::convertFromRootToContainingWindow(const Widget*, FloatPoint point)
+{
+    return point;
+}
+
 IntRect Widget::convertFromRootToContainingWindow(const Widget*, const IntRect& rect)
 {
     return rect;
+}
+
+FloatRect Widget::convertFromRootToContainingWindow(const Widget*, const FloatRect& rect)
+{
+    return rect;
+}
+
+// MARK: -
+
+IntPoint Widget::convertFromContainingWindowToRoot(const Widget*, IntPoint point)
+{
+    return point;
+}
+
+FloatPoint Widget::convertFromContainingWindowToRoot(const Widget*, FloatPoint point)
+{
+    return point;
 }
 
 IntRect Widget::convertFromContainingWindowToRoot(const Widget*, const IntRect& rect)
@@ -303,14 +396,9 @@ IntRect Widget::convertFromContainingWindowToRoot(const Widget*, const IntRect& 
     return rect;
 }
 
-IntPoint Widget::convertFromRootToContainingWindow(const Widget*, const IntPoint& point)
+FloatRect Widget::convertFromContainingWindowToRoot(const Widget*, const FloatRect& rect)
 {
-    return point;
-}
-
-IntPoint Widget::convertFromContainingWindowToRoot(const Widget*, const IntPoint& point)
-{
-    return point;
+    return rect;
 }
 
 #endif // !PLATFORM(COCOA)

--- a/Source/WebCore/platform/Widget.h
+++ b/Source/WebCore/platform/Widget.h
@@ -145,27 +145,29 @@ public:
 
     virtual void notifyWidget(WidgetNotification) { }
 
+    IntPoint convertToRootView(IntPoint) const;
+    FloatPoint convertToRootView(FloatPoint) const;
     WEBCORE_EXPORT IntRect convertToRootView(const IntRect&) const;
-    IntRect convertFromRootView(const IntRect&) const;
-
     FloatRect convertToRootView(const FloatRect&) const;
+
+    IntPoint convertFromRootView(IntPoint) const;
+    FloatPoint convertFromRootView(FloatPoint) const;
+    IntRect convertFromRootView(const IntRect&) const;
     FloatRect convertFromRootView(const FloatRect&) const;
-
-    IntPoint convertToRootView(const IntPoint&) const;
-    IntPoint convertFromRootView(const IntPoint&) const;
-
-    FloatPoint convertToRootView(const FloatPoint&) const;
-    FloatPoint convertFromRootView(const FloatPoint&) const;
 
     // It is important for cross-platform code to realize that Mac has flipped coordinates.  Therefore any code
     // that tries to convert the location of a rect using the point-based convertFromContainingWindow will end
     // up with an inaccurate rect.  Always make sure to use the rect-based convertFromContainingWindow method
     // when converting window rects.
+    WEBCORE_EXPORT IntPoint convertToContainingWindow(IntPoint) const;
+    FloatPoint convertToContainingWindow(FloatPoint) const;
     WEBCORE_EXPORT IntRect convertToContainingWindow(const IntRect&) const;
-    IntRect convertFromContainingWindow(const IntRect&) const;
+    FloatRect convertToContainingWindow(const FloatRect&) const;
 
-    WEBCORE_EXPORT IntPoint convertToContainingWindow(const IntPoint&) const;
-    IntPoint convertFromContainingWindow(const IntPoint&) const;
+    IntPoint convertFromContainingWindow(IntPoint) const;
+    FloatPoint convertFromContainingWindow(FloatPoint) const;
+    IntRect convertFromContainingWindow(const IntRect&) const;
+    FloatRect convertFromContainingWindow(const FloatRect&) const;
 
     virtual void frameRectsChanged() { }
 
@@ -190,14 +192,15 @@ public:
 #endif
 
     // Virtual methods to convert points to/from the containing ScrollView
+    WEBCORE_EXPORT virtual IntPoint convertToContainingView(IntPoint) const;
+    WEBCORE_EXPORT virtual FloatPoint convertToContainingView(FloatPoint) const;
     WEBCORE_EXPORT virtual IntRect convertToContainingView(const IntRect&) const;
-    WEBCORE_EXPORT virtual IntRect convertFromContainingView(const IntRect&) const;
     WEBCORE_EXPORT virtual FloatRect convertToContainingView(const FloatRect&) const;
+
+    WEBCORE_EXPORT virtual IntPoint convertFromContainingView(IntPoint) const;
+    WEBCORE_EXPORT virtual FloatPoint convertFromContainingView(FloatPoint) const;
+    WEBCORE_EXPORT virtual IntRect convertFromContainingView(const IntRect&) const;
     WEBCORE_EXPORT virtual FloatRect convertFromContainingView(const FloatRect&) const;
-    WEBCORE_EXPORT virtual IntPoint convertToContainingView(const IntPoint&) const;
-    WEBCORE_EXPORT virtual IntPoint convertFromContainingView(const IntPoint&) const;
-    WEBCORE_EXPORT virtual FloatPoint convertToContainingView(const FloatPoint&) const;
-    WEBCORE_EXPORT virtual FloatPoint convertFromContainingView(const FloatPoint&) const;
 
     virtual bool isPluginView() const { return false; }
 
@@ -206,11 +209,15 @@ private:
 
     // These methods are used to convert from the root widget to the containing window,
     // which has behavior that may differ between platforms (e.g. Mac uses flipped window coordinates).
+    static IntPoint convertFromRootToContainingWindow(const Widget* rootWidget, IntPoint);
+    static FloatPoint convertFromRootToContainingWindow(const Widget* rootWidget, FloatPoint);
     static IntRect convertFromRootToContainingWindow(const Widget* rootWidget, const IntRect&);
-    static IntRect convertFromContainingWindowToRoot(const Widget* rootWidget, const IntRect&);
+    static FloatRect convertFromRootToContainingWindow(const Widget* rootWidget, const FloatRect&);
 
-    static IntPoint convertFromRootToContainingWindow(const Widget* rootWidget, const IntPoint&);
-    static IntPoint convertFromContainingWindowToRoot(const Widget* rootWidget, const IntPoint&);
+    static IntPoint convertFromContainingWindowToRoot(const Widget* rootWidget, IntPoint);
+    static FloatPoint convertFromContainingWindowToRoot(const Widget* rootWidget, FloatPoint);
+    static IntRect convertFromContainingWindowToRoot(const Widget* rootWidget, const IntRect&);
+    static FloatRect convertFromContainingWindowToRoot(const Widget* rootWidget, const FloatRect&);
 
 private:
     bool m_selfVisible { false };

--- a/Source/WebCore/platform/ios/WidgetIOS.mm
+++ b/Source/WebCore/platform/ios/WidgetIOS.mm
@@ -189,6 +189,45 @@ void Widget::removeFromSuperview()
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
+// MARK: -
+
+IntPoint Widget::convertFromRootToContainingWindow(const Widget* rootWidget, IntPoint point)
+{
+    if (!rootWidget->platformWidget())
+        return point;
+
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+    WAKScrollView *view = checked_objc_cast<WAKScrollView>(rootWidget->platformWidget());
+    NSPoint convertedPoint;
+    if (WAKView *documentView = [view documentView])
+        convertedPoint = [documentView convertPoint:point toView:nil];
+    else
+        convertedPoint = [view convertPoint:point toView:nil];
+
+    return roundedIntPoint(FloatPoint { convertedPoint });
+    END_BLOCK_OBJC_EXCEPTIONS
+
+    return point;
+}
+
+FloatPoint Widget::convertFromRootToContainingWindow(const Widget* rootWidget, FloatPoint point)
+{
+    if (!rootWidget->platformWidget())
+        return point;
+
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+    WAKScrollView *view = checked_objc_cast<WAKScrollView>(rootWidget->platformWidget());
+    NSPoint convertedPoint;
+    if (WAKView *documentView = [view documentView])
+        convertedPoint = [documentView convertPoint:point toView:nil];
+    else
+        convertedPoint = [view convertPoint:point toView:nil];
+    return convertedPoint;
+    END_BLOCK_OBJC_EXCEPTIONS
+
+    return point;
+}
+
 IntRect Widget::convertFromRootToContainingWindow(const Widget* rootWidget, const IntRect& rect)
 {
     if (!rootWidget->platformWidget())
@@ -202,6 +241,59 @@ IntRect Widget::convertFromRootToContainingWindow(const Widget* rootWidget, cons
     END_BLOCK_OBJC_EXCEPTIONS
 
     return rect;
+}
+
+FloatRect Widget::convertFromRootToContainingWindow(const Widget* rootWidget, const FloatRect& rect)
+{
+    if (!rootWidget->platformWidget())
+        return rect;
+
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+    WAKScrollView *view = checked_objc_cast<WAKScrollView>(rootWidget->platformWidget());
+    if (WAKView *documentView = [view documentView])
+        return enclosingIntRect([documentView convertRect:rect toView:nil]);
+    return [view convertRect:rect toView:nil];
+    END_BLOCK_OBJC_EXCEPTIONS
+
+    return rect;
+}
+
+// MARK: -
+
+IntPoint Widget::convertFromContainingWindowToRoot(const Widget* rootWidget, IntPoint point)
+{
+    if (!rootWidget->platformWidget())
+        return point;
+
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+    WAKScrollView *view = checked_objc_cast<WAKScrollView>(rootWidget->platformWidget());
+    NSPoint convertedPoint;
+    if (WAKView *documentView = [view documentView])
+        convertedPoint = IntPoint([documentView convertPoint:point fromView:nil]);
+    else
+        convertedPoint = IntPoint([view convertPoint:point fromView:nil]);
+    return roundedIntPoint(FloatPoint { convertedPoint });
+    END_BLOCK_OBJC_EXCEPTIONS
+
+    return point;
+}
+
+FloatPoint Widget::convertFromContainingWindowToRoot(const Widget* rootWidget, FloatPoint point)
+{
+    if (!rootWidget->platformWidget())
+        return point;
+
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+    WAKScrollView *view = checked_objc_cast<WAKScrollView>(rootWidget->platformWidget());
+    NSPoint convertedPoint;
+    if (WAKView *documentView = [view documentView])
+        convertedPoint = IntPoint([documentView convertPoint:point fromView:nil]);
+    else
+        convertedPoint = IntPoint([view convertPoint:point fromView:nil]);
+    return convertedPoint;
+    END_BLOCK_OBJC_EXCEPTIONS
+
+    return point;
 }
 
 IntRect Widget::convertFromContainingWindowToRoot(const Widget* rootWidget, const IntRect& rect)
@@ -219,41 +311,22 @@ IntRect Widget::convertFromContainingWindowToRoot(const Widget* rootWidget, cons
     return rect;
 }
 
-IntPoint Widget::convertFromRootToContainingWindow(const Widget* rootWidget, const IntPoint& point)
+FloatRect Widget::convertFromContainingWindowToRoot(const Widget* rootWidget, const FloatRect& rect)
 {
     if (!rootWidget->platformWidget())
-        return point;
+        return rect;
 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
     WAKScrollView *view = checked_objc_cast<WAKScrollView>(rootWidget->platformWidget());
-    NSPoint convertedPoint;
     if (WAKView *documentView = [view documentView])
-        convertedPoint = [documentView convertPoint:point toView:nil];
-    else
-        convertedPoint = [view convertPoint:point toView:nil];
-    return IntPoint(roundf(convertedPoint.x), roundf(convertedPoint.y));
+        return enclosingIntRect([documentView convertRect:rect fromView:nil]);
+    return [view convertRect:rect fromView:nil];
     END_BLOCK_OBJC_EXCEPTIONS
 
-    return point;
+    return rect;
 }
 
-IntPoint Widget::convertFromContainingWindowToRoot(const Widget* rootWidget, const IntPoint& point)
-{
-    if (!rootWidget->platformWidget())
-        return point;
-
-    BEGIN_BLOCK_OBJC_EXCEPTIONS
-    WAKScrollView *view = checked_objc_cast<WAKScrollView>(rootWidget->platformWidget());
-    NSPoint convertedPoint;
-    if (WAKView *documentView = [view documentView])
-        convertedPoint = IntPoint([documentView convertPoint:point fromView:nil]);
-    else
-        convertedPoint = IntPoint([view convertPoint:point fromView:nil]);
-    return IntPoint(roundf(convertedPoint.x), roundf(convertedPoint.y));
-    END_BLOCK_OBJC_EXCEPTIONS
-
-    return point;
-}
+// MARK: -
 
 NSView *Widget::platformWidget() const
 {

--- a/Source/WebCore/platform/mac/WidgetMac.mm
+++ b/Source/WebCore/platform/mac/WidgetMac.mm
@@ -275,7 +275,32 @@ void Widget::removeFromSuperview()
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
+// MARK: -
+
 // These are here to deal with flipped coords on Mac.
+
+IntPoint Widget::convertFromRootToContainingWindow(const Widget* rootWidget, IntPoint point)
+{
+    if (!rootWidget->platformWidget())
+        return point;
+
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+    return IntPoint([rootWidget->platformWidget() convertPoint:point toView:nil]);
+    END_BLOCK_OBJC_EXCEPTIONS
+    return point;
+}
+
+FloatPoint Widget::convertFromRootToContainingWindow(const Widget* rootWidget, FloatPoint point)
+{
+    if (!rootWidget->platformWidget())
+        return point;
+
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+    return [rootWidget->platformWidget() convertPoint:point toView:nil];
+    END_BLOCK_OBJC_EXCEPTIONS
+    return point;
+}
+
 IntRect Widget::convertFromRootToContainingWindow(const Widget* rootWidget, const IntRect& rect)
 {
     if (!rootWidget->platformWidget())
@@ -286,6 +311,44 @@ IntRect Widget::convertFromRootToContainingWindow(const Widget* rootWidget, cons
     END_BLOCK_OBJC_EXCEPTIONS
 
     return rect;
+}
+
+FloatRect Widget::convertFromRootToContainingWindow(const Widget* rootWidget, const FloatRect& rect)
+{
+    if (!rootWidget->platformWidget())
+        return rect;
+
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+    return [rootWidget->platformWidget() convertRect:rect toView:nil];
+    END_BLOCK_OBJC_EXCEPTIONS
+
+    return rect;
+}
+
+// MARK: -
+
+IntPoint Widget::convertFromContainingWindowToRoot(const Widget* rootWidget, IntPoint point)
+{
+    if (!rootWidget->platformWidget())
+        return point;
+
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+    return IntPoint([rootWidget->platformWidget() convertPoint:point fromView:nil]);
+    END_BLOCK_OBJC_EXCEPTIONS
+
+    return point;
+}
+
+FloatPoint Widget::convertFromContainingWindowToRoot(const Widget* rootWidget, FloatPoint point)
+{
+    if (!rootWidget->platformWidget())
+        return point;
+
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+    return [rootWidget->platformWidget() convertPoint:point fromView:nil];
+    END_BLOCK_OBJC_EXCEPTIONS
+
+    return point;
 }
 
 IntRect Widget::convertFromContainingWindowToRoot(const Widget* rootWidget, const IntRect& rect)
@@ -300,28 +363,19 @@ IntRect Widget::convertFromContainingWindowToRoot(const Widget* rootWidget, cons
     return rect;
 }
 
-IntPoint Widget::convertFromRootToContainingWindow(const Widget* rootWidget, const IntPoint& point)
+FloatRect Widget::convertFromContainingWindowToRoot(const Widget* rootWidget, const FloatRect& rect)
 {
     if (!rootWidget->platformWidget())
-        return point;
+        return rect;
 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    return IntPoint([rootWidget->platformWidget() convertPoint:point toView:nil]);
-    END_BLOCK_OBJC_EXCEPTIONS
-    return point;
-}
-
-IntPoint Widget::convertFromContainingWindowToRoot(const Widget* rootWidget, const IntPoint& point)
-{
-    if (!rootWidget->platformWidget())
-        return point;
-
-    BEGIN_BLOCK_OBJC_EXCEPTIONS
-    return IntPoint([rootWidget->platformWidget() convertPoint:point fromView:nil]);
+    return [rootWidget->platformWidget() convertRect:rect fromView:nil];
     END_BLOCK_OBJC_EXCEPTIONS
 
-    return point;
+    return rect;
 }
+
+// MARK: -
 
 NSView *Widget::platformWidget() const
 {


### PR DESCRIPTION
#### e50c61a139e343cc6e6611510f6490e05b12e3c5
<pre>
Clean up and extend the Widget coordinate conversion functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=294530">https://bugs.webkit.org/show_bug.cgi?id=294530</a>
<a href="https://rdar.apple.com/153473471">rdar://153473471</a>

Reviewed by Alan Baradlay.

A future change will require `convertFromRootToContainingWindow()` and `convertFromContainingWindowToRoot()`
which support FloatPoint, so add `Widget::convert*` variants for FloatPoint/FloatRect.

Also clean up the declarations and the definitions; order consistently by function then type
(IntPoint, FloatPoint, IntRect, FloatRect).

Pass IntPoint and FloatPoint arguments by value.

* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::convertFromRendererToContainingView const):
(WebCore::FrameView::convertFromContainingViewToRenderer const):
(WebCore::FrameView::convertToContainingView const):
(WebCore::FrameView::convertFromContainingView const):
* Source/WebCore/page/FrameView.h:
* Source/WebCore/platform/ScrollView.cpp:
(WebCore::ScrollView::viewToContents const):
(WebCore::ScrollView::windowToContents const):
(WebCore::ScrollView::contentsToWindow const):
(WebCore::ScrollView::convertSelfToChild const):
* Source/WebCore/platform/ScrollView.h:
* Source/WebCore/platform/Scrollbar.cpp:
(WebCore::Scrollbar::convertToContainingView const):
(WebCore::Scrollbar::convertFromContainingView const):
* Source/WebCore/platform/Scrollbar.h:
* Source/WebCore/platform/Widget.cpp:
(WebCore::Widget::convertToRootView const):
(WebCore::Widget::convertFromRootView const):
(WebCore::Widget::convertToContainingWindow const):
(WebCore::Widget::convertFromContainingWindow const):
(WebCore::Widget::convertToContainingView const):
(WebCore::Widget::convertFromContainingView const):
(WebCore::Widget::convertFromRootToContainingWindow):
(WebCore::Widget::convertFromContainingWindowToRoot):
* Source/WebCore/platform/Widget.h:
* Source/WebCore/platform/ios/WidgetIOS.mm:
(WebCore::Widget::convertFromRootToContainingWindow):
(WebCore::Widget::convertFromContainingWindowToRoot):
* Source/WebCore/platform/mac/WidgetMac.mm:
(WebCore::Widget::convertFromRootToContainingWindow):
(WebCore::Widget::convertFromContainingWindowToRoot):

Canonical link: <a href="https://commits.webkit.org/296272@main">https://commits.webkit.org/296272@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89f0185da6690d305b6b2fa480fa949802de21a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108006 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27671 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18090 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113217 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58526 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109969 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36220 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81994 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110954 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22482 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97309 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62425 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21894 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15442 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57964 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91835 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15508 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116344 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35078 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25822 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91025 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35454 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93587 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90819 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23141 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35717 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13474 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34976 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40530 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34720 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38079 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36380 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->