### PR TITLE
[Liquid Glass] [macOS] Favorites bar in Safari sometimes fails to adapt to changing luminance

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3061,6 +3061,7 @@ static WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::Fixe
 
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
     [self _updateFixedColorExtensionViews];
+    [self _updateHiddenScrollPocketEdges];
 #endif
 
 #if PLATFORM(MAC) && ENABLE(CONTENT_INSET_BACKGROUND_FILL)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2401,7 +2401,6 @@ void WebViewImpl::pageDidScroll(const IntPoint& scrollPosition)
 
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
     updateScrollPocketVisibilityWhenScrolledToTop();
-    updateTopScrollPocketCaptureColor();
 #endif
 
     [m_view didChangeValueForKey:@"hasScrolledContentsUnderTitlebar"];
@@ -2421,8 +2420,11 @@ void WebViewImpl::updateScrollPocketVisibilityWhenScrolledToTop()
 void WebViewImpl::updateTopScrollPocketCaptureColor()
 {
     RetainPtr view = m_view.get();
+    if ([view _usesAutomaticContentInsetBackgroundFill])
+        return;
+
     RetainPtr captureColor = [view _sampledTopFixedPositionContentColor];
-    if (!captureColor && (m_pageIsScrolledToTop || [view _hasVisibleColorExtensionView:BoxSide::Top])) {
+    if (!captureColor) {
         if (auto backgroundColor = m_page->underPageBackgroundColorIgnoringPlatformColor(); backgroundColor.isValid())
             captureColor = cocoaColor(backgroundColor);
         else


### PR DESCRIPTION
#### 6166dacefda3453223389520e49ade48a8299c17
<pre>
[Liquid Glass] [macOS] Favorites bar in Safari sometimes fails to adapt to changing luminance
<a href="https://bugs.webkit.org/show_bug.cgi?id=294531">https://bugs.webkit.org/show_bug.cgi?id=294531</a>
<a href="https://rdar.apple.com/151338155">rdar://151338155</a>

Reviewed by Richard Robinson.

Make a couple of adjustments to ensure that the favorites bar in Safari remains legible, even as the
top fixed-position header or page background change when Liquid Glass is enabled.

1.  Always call `-[NSScrollPocket setCaptureColor:]` when using a hard pocket style, to force UI
    above the scroll edge effect region to either be in light mode or dark mode depending on the
    color of the pocket.

2.  Remove code that currently *avoids* setting the scroll pocket&apos;s capture color when scrolled past
    the top in the case where there is no fixed element. We need to set the capture color here to
    ensure that the favorites bar always appears legible, even when scrolling over the dark portion
    of a website with a light background or vice versa.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _updateFixedContainerEdges:]):

Drive-by fix: add a missing call to `-_updateHiddenScrollPocketEdges` here to ensure that scroll
pockets are suppressed on iOS when there&apos;s a fixed-position container at that edge.

* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::pageDidScroll):

There&apos;s no more need to `updateTopScrollPocketCaptureColor` in response to the web view being
scrolled, since it no longer depends on `m_pageIsScrolledToTop`.

(WebKit::WebViewImpl::updateTopScrollPocketCaptureColor):

Always set the `-captureColor` of the pocket. We also only set the capture color in the case where a
hard scroll edge effect is used (as opposed to soft scroll edge effect), since — when using a soft
pocket — the luminance should always come from the sampled content underneath. This is important to
avoid a white-on-white favorites bar in Reader mode in Safari, on <a href="https://daringfireball.net.">https://daringfireball.net.</a>

Canonical link: <a href="https://commits.webkit.org/296288@main">https://commits.webkit.org/296288@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/554af24eab30c0b1f57738056d64e330165571c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108039 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27704 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18123 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113249 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58556 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28399 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36254 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82020 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110987 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22508 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97339 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62452 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21919 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57995 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91860 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15538 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116376 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35110 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25854 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91052 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35486 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93617 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90846 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23154 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35746 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13504 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35009 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40564 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34752 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38110 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36413 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->