### PR TITLE
Sync `RequestAnimationFrameCallback` with WebIDL interface

### DIFF
--- a/Source/WebCore/dom/RequestAnimationFrameCallback.idl
+++ b/Source/WebCore/dom/RequestAnimationFrameCallback.idl
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010 Google Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -31,4 +32,8 @@
 // highResTime is passed as high resolution timestamp, see
 // http://www.w3.org/TR/hr-time/ for details.
 
-[ GenerateIsReachable=ImplScriptExecutionContext ] callback RequestAnimationFrameCallback = undefined (unrestricted double highResTime);
+// https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#animation-frames
+
+typedef double DOMHighResTimeStamp;
+
+[ GenerateIsReachable=ImplScriptExecutionContext ] callback RequestAnimationFrameCallback = undefined (DOMHighResTimeStamp highResTime);


### PR DESCRIPTION
#### cad743944a731aa27beceb43086cc06813065916
<pre>
Sync `RequestAnimationFrameCallback` with WebIDL interface
<a href="https://bugs.webkit.org/show_bug.cgi?id=283862">https://bugs.webkit.org/show_bug.cgi?id=283862</a>

Reviewed by Chris Dumez.

This patch aligns WebKit with Web Specification [1]:

[1] <a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#animation-frames">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#animation-frames</a>

It fixes where &apos;highResTime&apos; was &apos;unrestricted double&apos;, which is not same
as &apos;double&apos;, since earlier can allow values like non-finite, and special
&quot;not a number&quot; values (NaNs). This matches what specification says and
also other browser implementation as well.

* Source/WebCore/dom/RequestAnimationFrameCallback.idl:

Canonical link: <a href="https://commits.webkit.org/296745@main">https://commits.webkit.org/296745@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f4dad762364fda53baba69889c7a605d92f622f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107981 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27646 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18065 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113192 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58504 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109944 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28341 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36195 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81965 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110929 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22459 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97284 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62396 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21871 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15417 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57939 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91812 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15483 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116319 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35053 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25799 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90997 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35429 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93562 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90791 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23430 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35695 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13449 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30824 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34951 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40505 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34695 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38054 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36355 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->