### PR TITLE
Stop using UncheckedKey containers in WebCore/css

### DIFF
--- a/Source/WebCore/css/CSSCounterStyleRegistry.cpp
+++ b/Source/WebCore/css/CSSCounterStyleRegistry.cpp
@@ -64,11 +64,11 @@ void CSSCounterStyleRegistry::resolveReferencesIfNeeded()
 
 void CSSCounterStyleRegistry::resolveExtendsReference(CSSCounterStyle& counterStyle, CounterStyleMap* map)
 {
-    UncheckedKeyHashSet<CSSCounterStyle*> countersInChain;
+    HashSet<CSSCounterStyle*> countersInChain;
     resolveExtendsReference(counterStyle, countersInChain, map);
 }
 
-void CSSCounterStyleRegistry::resolveExtendsReference(CSSCounterStyle& counter, UncheckedKeyHashSet<CSSCounterStyle*>& countersInChain, CounterStyleMap* map)
+void CSSCounterStyleRegistry::resolveExtendsReference(CSSCounterStyle& counter, HashSet<CSSCounterStyle*>& countersInChain, CounterStyleMap* map)
 {
     ASSERT(counter.isExtendsSystem() && counter.isExtendsUnresolved());
     if (!(counter.isExtendsSystem() && counter.isExtendsUnresolved()))

--- a/Source/WebCore/css/CSSCounterStyleRegistry.h
+++ b/Source/WebCore/css/CSSCounterStyleRegistry.h
@@ -36,7 +36,7 @@ struct ListStyleType;
 class StyleRuleCounterStyle;
 enum CSSValueID : uint16_t;
 
-using CounterStyleMap = UncheckedKeyHashMap<AtomString, RefPtr<CSSCounterStyle>>;
+using CounterStyleMap = HashMap<AtomString, RefPtr<CSSCounterStyle>>;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSCounterStyleRegistry);
 class CSSCounterStyleRegistry {
@@ -58,7 +58,7 @@ private:
     // If no map is passed on, user-agent counter styles map will be used
     static void resolveFallbackReference(CSSCounterStyle&, CounterStyleMap* = nullptr);
     static void resolveExtendsReference(CSSCounterStyle&, CounterStyleMap* = nullptr);
-    static void resolveExtendsReference(CSSCounterStyle&, UncheckedKeyHashSet<CSSCounterStyle*>&, CounterStyleMap* = nullptr);
+    static void resolveExtendsReference(CSSCounterStyle&, HashSet<CSSCounterStyle*>&, CounterStyleMap* = nullptr);
     static RefPtr<CSSCounterStyle> counterStyle(const AtomString&, CounterStyleMap* = nullptr);
     void invalidate();
 

--- a/Source/WebCore/css/CSSFontFaceSet.cpp
+++ b/Source/WebCore/css/CSSFontFaceSet.cpp
@@ -381,7 +381,7 @@ static FontSelectionRequest computeFontSelectionRequest(CSSPropertyParserHelpers
     return { weightSelectionValue, widthSelectionValue, styleSelectionValue };
 }
 
-using CodePointsMap = UncheckedKeyHashSet<uint32_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
+using CodePointsMap = HashSet<uint32_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
 static CodePointsMap codePointsFromString(StringView stringView)
 {
     CodePointsMap result;
@@ -406,7 +406,7 @@ ExceptionOr<Vector<std::reference_wrapper<CSSFontFace>>> CSSFontFaceSet::matchin
     if (!font)
         return Exception { ExceptionCode::SyntaxError };
 
-    UncheckedKeyHashSet<AtomString> uniqueFamilies;
+    HashSet<AtomString> uniqueFamilies;
     Vector<AtomString> familyOrder;
     for (auto& familyRaw : font->family) {
         auto familyAtom = WTF::switchOn(familyRaw,
@@ -424,7 +424,7 @@ ExceptionOr<Vector<std::reference_wrapper<CSSFontFace>>> CSSFontFaceSet::matchin
             familyOrder.append(familyAtom);
     }
 
-    UncheckedKeyHashSet<CSSFontFace*> resultConstituents;
+    HashSet<CSSFontFace*> resultConstituents;
     auto request = computeFontSelectionRequest(*font);
     for (auto codePoint : codePointsFromString(string)) {
         bool found = false;

--- a/Source/WebCore/css/CSSFontFaceSet.h
+++ b/Source/WebCore/css/CSSFontFaceSet.h
@@ -122,14 +122,14 @@ private:
         static void constructDeletedValue(FontSelectionKey& slot) { slot = std::nullopt; }
         static bool isDeletedValue(const FontSelectionKey& value) { return !value; }
     };
-    using FontSelectionHashMap = UncheckedKeyHashMap<FontSelectionKey, RefPtr<CSSSegmentedFontFace>, FontSelectionKeyHash, FontSelectionKeyHashTraits>;
+    using FontSelectionHashMap = HashMap<FontSelectionKey, RefPtr<CSSSegmentedFontFace>, FontSelectionKeyHash, FontSelectionKeyHashTraits>;
 
     // m_faces should hold all the same fonts as the ones inside inside m_facesLookupTable.
     Vector<Ref<CSSFontFace>> m_faces; // We should investigate moving m_faces to FontFaceSet and making it reference FontFaces. This may clean up the font loading design.
-    UncheckedKeyHashMap<String, Vector<Ref<CSSFontFace>>, ASCIICaseInsensitiveHash> m_facesLookupTable;
-    UncheckedKeyHashMap<String, Vector<Ref<CSSFontFace>>, ASCIICaseInsensitiveHash> m_locallyInstalledFacesLookupTable;
-    UncheckedKeyHashMap<String, FontSelectionHashMap, ASCIICaseInsensitiveHash> m_cache;
-    UncheckedKeyHashMap<StyleRuleFontFace*, CSSFontFace*> m_constituentCSSConnections;
+    HashMap<String, Vector<Ref<CSSFontFace>>, ASCIICaseInsensitiveHash> m_facesLookupTable;
+    HashMap<String, Vector<Ref<CSSFontFace>>, ASCIICaseInsensitiveHash> m_locallyInstalledFacesLookupTable;
+    HashMap<String, FontSelectionHashMap, ASCIICaseInsensitiveHash> m_cache;
+    HashMap<StyleRuleFontFace*, CSSFontFace*> m_constituentCSSConnections;
     size_t m_facesPartitionIndex { 0 }; // All entries in m_faces before this index are CSS-connected.
     Status m_status { Status::Loaded };
     WeakHashSet<FontModifiedObserver> m_fontModifiedObservers;

--- a/Source/WebCore/css/CSSFontSelector.h
+++ b/Source/WebCore/css/CSSFontSelector.h
@@ -132,7 +132,7 @@ private:
     WeakPtr<ScriptExecutionContext> m_context;
     RefPtr<FontFaceSet> m_fontFaceSet;
     const Ref<CSSFontFaceSet> m_cssFontFaceSet;
-    UncheckedKeyHashSet<FontSelectorClient*> m_clients;
+    HashSet<FontSelectorClient*> m_clients;
 
     struct PaletteMapHash : DefaultHash<std::pair<AtomString, AtomString>> {
         static unsigned hash(const std::pair<AtomString, AtomString>& key)
@@ -145,11 +145,11 @@ private:
             return ASCIICaseInsensitiveHash::equal(a.first, b.first) && DefaultHash<AtomString>::equal(a.second, b.second);
         }
     };
-    UncheckedKeyHashMap<std::pair<AtomString, AtomString>, FontPaletteValues, PaletteMapHash> m_paletteMap;
-    UncheckedKeyHashMap<String, Ref<FontFeatureValues>> m_featureValues;
+    HashMap<std::pair<AtomString, AtomString>, FontPaletteValues, PaletteMapHash> m_paletteMap;
+    HashMap<String, Ref<FontFeatureValues>> m_featureValues;
 
-    UncheckedKeyHashSet<RefPtr<CSSFontFace>> m_cssConnectionsPossiblyToRemove;
-    UncheckedKeyHashSet<RefPtr<StyleRuleFontFace>> m_cssConnectionsEncounteredDuringBuild;
+    HashSet<RefPtr<CSSFontFace>> m_cssConnectionsPossiblyToRemove;
+    HashSet<RefPtr<StyleRuleFontFace>> m_cssConnectionsEncounteredDuringBuild;
 
     CSSFontFaceSet::FontModifiedObserver m_fontModifiedObserver;
 

--- a/Source/WebCore/css/CSSGridTemplateAreasValue.cpp
+++ b/Source/WebCore/css/CSSGridTemplateAreasValue.cpp
@@ -57,7 +57,7 @@ Ref<CSSGridTemplateAreasValue> CSSGridTemplateAreasValue::create(NamedGridAreaMa
 
 static String stringForPosition(const NamedGridAreaMap& gridAreaMap, size_t row, size_t column)
 {
-    UncheckedKeyHashSet<String> candidates;
+    HashSet<String> candidates;
     for (auto& it : gridAreaMap.map) {
         auto& area = it.value;
         if (row >= area.rows.startLine() && row < area.rows.endLine())

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -235,9 +235,9 @@ static inline bool isStringType(CSSUnitType type)
 
 #endif // ASSERT_ENABLED
 
-static UncheckedKeyHashMap<const CSSPrimitiveValue*, String>& serializedPrimitiveValues()
+static HashMap<const CSSPrimitiveValue*, String>& serializedPrimitiveValues()
 {
-    static NeverDestroyed<UncheckedKeyHashMap<const CSSPrimitiveValue*, String>> map;
+    static NeverDestroyed<HashMap<const CSSPrimitiveValue*, String>> map;
     return map;
 }
 

--- a/Source/WebCore/css/CSSSegmentedFontFace.h
+++ b/Source/WebCore/css/CSSSegmentedFontFace.h
@@ -63,7 +63,7 @@ private:
     void fontLoaded(CSSFontFace&) final;
 
     // FIXME: Add support for font-feature-values in the key for this cache.
-    UncheckedKeyHashMap<std::tuple<FontDescriptionKey, FontPaletteValues>, FontRanges> m_cache;
+    HashMap<std::tuple<FontDescriptionKey, FontPaletteValues>, FontRanges> m_cache;
     Vector<Ref<CSSFontFace>, 1> m_fontFaces;
 };
 

--- a/Source/WebCore/css/CSSStyleProperties.cpp
+++ b/Source/WebCore/css/CSSStyleProperties.cpp
@@ -121,7 +121,7 @@ static inline void writeEpubPrefix(std::span<char>& buffer)
 
 static CSSPropertyID parseJavaScriptCSSPropertyName(const AtomString& propertyName)
 {
-    using CSSPropertyIDMap = UncheckedKeyHashMap<AtomString, CSSPropertyID>;
+    using CSSPropertyIDMap = HashMap<AtomString, CSSPropertyID>;
     static NeverDestroyed<CSSPropertyIDMap> propertyIDCache;
 
     auto* propertyNameString = propertyName.impl();
@@ -204,7 +204,7 @@ enum class CSSPropertyLookupMode { ConvertUsingDashPrefix, ConvertUsingNoDashPre
 
 template<CSSPropertyLookupMode mode> static CSSPropertyID lookupCSSPropertyFromIDLAttribute(const AtomString& attribute)
 {
-    static NeverDestroyed<UncheckedKeyHashMap<AtomString, CSSPropertyID>> cache;
+    static NeverDestroyed<HashMap<AtomString, CSSPropertyID>> cache;
 
     if (auto id = cache.get().get(attribute))
         return id;

--- a/Source/WebCore/css/CSSStyleProperties.h
+++ b/Source/WebCore/css/CSSStyleProperties.h
@@ -96,7 +96,7 @@ protected:
     virtual OptionalOrReference<CSSParserContext> cssParserContext() const;
 
     MutableStyleProperties* m_propertySet;
-    UncheckedKeyHashMap<CSSValue*, WeakPtr<DeprecatedCSSOMValue>> m_cssomValueWrappers;
+    HashMap<CSSValue*, WeakPtr<DeprecatedCSSOMValue>> m_cssomValueWrappers;
 
 private:
     CSSRule* parentRule() const override { return nullptr; }

--- a/Source/WebCore/css/CSSStyleRule.cpp
+++ b/Source/WebCore/css/CSSStyleRule.cpp
@@ -41,7 +41,7 @@
 
 namespace WebCore {
 
-typedef UncheckedKeyHashMap<const CSSStyleRule*, String> SelectorTextCache;
+typedef HashMap<const CSSStyleRule*, String> SelectorTextCache;
 static SelectorTextCache& selectorTextCache()
 {
     static NeverDestroyed<SelectorTextCache> cache;

--- a/Source/WebCore/css/CSSValuePool.h
+++ b/Source/WebCore/css/CSSValuePool.h
@@ -78,9 +78,9 @@ public:
     Ref<CSSPrimitiveValue> createFontFamilyValue(const AtomString&);
 
 private:
-    UncheckedKeyHashMap<WebCore::Color, Ref<CSSColorValue>> m_colorValueCache;
-    UncheckedKeyHashMap<AtomString, RefPtr<CSSValueList>> m_fontFaceValueCache;
-    UncheckedKeyHashMap<AtomString, Ref<CSSPrimitiveValue>> m_fontFamilyValueCache;
+    HashMap<WebCore::Color, Ref<CSSColorValue>> m_colorValueCache;
+    HashMap<AtomString, RefPtr<CSSValueList>> m_fontFaceValueCache;
+    HashMap<AtomString, Ref<CSSPrimitiveValue>> m_fontFamilyValueCache;
 };
 
 inline CSSPrimitiveValue& CSSPrimitiveValue::implicitInitialValue()

--- a/Source/WebCore/css/FontFaceSet.h
+++ b/Source/WebCore/css/FontFaceSet.h
@@ -114,7 +114,7 @@ private:
     FontFaceSet& readyPromiseResolve();
 
     const Ref<CSSFontFaceSet> m_backing;
-    UncheckedKeyHashMap<RefPtr<FontFace>, Vector<Ref<PendingPromise>>> m_pendingPromises;
+    HashMap<RefPtr<FontFace>, Vector<Ref<PendingPromise>>> m_pendingPromises;
     const UniqueRef<ReadyPromise> m_readyPromise;
 
     bool m_isDocumentLoaded { true };

--- a/Source/WebCore/css/ImmutableStyleProperties.cpp
+++ b/Source/WebCore/css/ImmutableStyleProperties.cpp
@@ -68,7 +68,7 @@ Ref<ImmutableStyleProperties> ImmutableStyleProperties::create(std::span<const C
 
 static auto& deduplicationMap()
 {
-    static NeverDestroyed<UncheckedKeyHashMap<unsigned, Ref<ImmutableStyleProperties>, AlreadyHashed>> map;
+    static NeverDestroyed<HashMap<unsigned, Ref<ImmutableStyleProperties>, AlreadyHashed>> map;
     return map.get();
 }
 

--- a/Source/WebCore/css/MutableStyleProperties.cpp
+++ b/Source/WebCore/css/MutableStyleProperties.cpp
@@ -290,7 +290,7 @@ bool MutableStyleProperties::removeProperties(std::span<const CSSPropertyID> pro
         return false;
 
     // FIXME: This is always used with static sets and in that case constructing the hash repeatedly is pretty pointless.
-    UncheckedKeyHashSet<CSSPropertyID> toRemove;
+    HashSet<CSSPropertyID> toRemove;
     toRemove.add(properties.begin(), properties.end());
 
     return m_propertyVector.removeAllMatching([&toRemove](const CSSProperty& property) {

--- a/Source/WebCore/css/PropertySetCSSDescriptors.h
+++ b/Source/WebCore/css/PropertySetCSSDescriptors.h
@@ -84,7 +84,7 @@ protected:
     Ref<MutableStyleProperties> protectedPropertySet() const;
 
     WeakPtr<CSSRule> m_parentRule;
-    UncheckedKeyHashMap<CSSValue*, WeakPtr<DeprecatedCSSOMValue>> m_cssomValueWrappers;
+    HashMap<CSSValue*, WeakPtr<DeprecatedCSSOMValue>> m_cssomValueWrappers;
 
     // FIXME: Replaced this with a more descriptor specific property map that doesn't have all the complexity of the Style one.
     Ref<MutableStyleProperties> m_propertySet;

--- a/Source/WebCore/css/StyleSheetContents.h
+++ b/Source/WebCore/css/StyleSheetContents.h
@@ -180,7 +180,7 @@ private:
     Vector<Ref<StyleRuleImport>> m_importRules;
     Vector<Ref<StyleRuleNamespace>> m_namespaceRules;
     Vector<Ref<StyleRuleBase>> m_childRules;
-    typedef UncheckedKeyHashMap<AtomString, AtomString> PrefixNamespaceURIMap;
+    typedef HashMap<AtomString, AtomString> PrefixNamespaceURIMap;
     PrefixNamespaceURIMap m_namespaces;
     AtomString m_defaultNamespace;
 

--- a/Source/WebCore/css/calc/CSSCalcSymbolTable.h
+++ b/Source/WebCore/css/calc/CSSCalcSymbolTable.h
@@ -47,7 +47,7 @@ public:
     bool contains(CSSValueID) const;
 
 private:
-    UncheckedKeyHashMap<CSSValueID, std::pair<CSSUnitType, double>> m_table;
+    HashMap<CSSValueID, std::pair<CSSUnitType, double>> m_table;
 };
 
 }

--- a/Source/WebCore/css/calc/CSSCalcSymbolsAllowed.h
+++ b/Source/WebCore/css/calc/CSSCalcSymbolsAllowed.h
@@ -47,7 +47,7 @@ public:
     bool contains(CSSValueID) const;
 
 private:
-    // FIXME: A UncheckedKeyHashMap here is not ideal, as these tables are always constant expressions
+    // FIXME: A HashMap here is not ideal, as these tables are always constant expressions
     // and always quite small (currently always 4, but in the future will include one that
     // is 5 elements, hard coding a size of 4 would be unfortunate. A more ideal solution
     // would be to have this be a SortedArrayMap, but it currently has the restriction that
@@ -55,7 +55,7 @@ private:
     // use the size only at construction and store store a std::span instead (or a variant
     // version could be made).
 
-    UncheckedKeyHashMap<CSSValueID, CSSUnitType> m_table;
+    HashMap<CSSValueID, CSSUnitType> m_table;
 };
 
 }

--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -135,7 +135,7 @@ auto CSSParser::parseCustomPropertyValue(MutableStyleProperties& declaration, co
     return declaration.addParsedProperties(parser.topContext().m_parsedProperties) ? ParseResult::Changed : ParseResult::Unchanged;
 }
 
-static inline void filterProperties(IsImportant important, const ParsedPropertyVector& input, ParsedPropertyVector& output, size_t& unusedEntries, std::bitset<numCSSProperties>& seenProperties, UncheckedKeyHashSet<AtomString>& seenCustomProperties)
+static inline void filterProperties(IsImportant important, const ParsedPropertyVector& input, ParsedPropertyVector& output, size_t& unusedEntries, std::bitset<numCSSProperties>& seenProperties, HashSet<AtomString>& seenCustomProperties)
 {
     // Add properties in reverse order so that highest priority definitions are reached first. Duplicate definitions can then be ignored when found.
     for (size_t i = input.size(); i--;) {
@@ -166,7 +166,7 @@ static Ref<ImmutableStyleProperties> createStyleProperties(ParsedPropertyVector&
     std::bitset<numCSSProperties> seenProperties;
     size_t unusedEntries = parsedProperties.size();
     ParsedPropertyVector results(unusedEntries);
-    UncheckedKeyHashSet<AtomString> seenCustomProperties;
+    HashSet<AtomString> seenCustomProperties;
 
     filterProperties(IsImportant::Yes, parsedProperties, results, unusedEntries, seenProperties, seenCustomProperties);
     filterProperties(IsImportant::No, parsedProperties, results, unusedEntries, seenProperties, seenCustomProperties);
@@ -197,7 +197,7 @@ bool CSSParser::parseDeclarationList(MutableStyleProperties& declaration, const 
     std::bitset<numCSSProperties> seenProperties;
     size_t unusedEntries = parser.topContext().m_parsedProperties.size();
     ParsedPropertyVector results(unusedEntries);
-    UncheckedKeyHashSet<AtomString> seenCustomProperties;
+    HashSet<AtomString> seenCustomProperties;
     filterProperties(IsImportant::Yes, parser.topContext().m_parsedProperties, results, unusedEntries, seenProperties, seenCustomProperties);
     filterProperties(IsImportant::No, parser.topContext().m_parsedProperties, results, unusedEntries, seenProperties, seenCustomProperties);
     if (unusedEntries)

--- a/Source/WebCore/css/typedom/CSSNumericValue.h
+++ b/Source/WebCore/css/typedom/CSSNumericValue.h
@@ -68,7 +68,7 @@ public:
     static Ref<CSSNumericValue> rectifyNumberish(CSSNumberish&&);
 
     // https://drafts.css-houdini.org/css-typed-om/#sum-value-value
-    using UnitMap = UncheckedKeyHashMap<CSSUnitType, int, WTF::IntHash<CSSUnitType>, WTF::StrongEnumHashTraits<CSSUnitType>>;
+    using UnitMap = HashMap<CSSUnitType, int, WTF::IntHash<CSSUnitType>, WTF::StrongEnumHashTraits<CSSUnitType>>;
     struct Addend {
         double value;
         UnitMap units;

--- a/Source/WebCore/css/typedom/HashMapStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/HashMapStylePropertyMapReadOnly.cpp
@@ -30,12 +30,12 @@
 
 namespace WebCore {
 
-Ref<HashMapStylePropertyMapReadOnly> HashMapStylePropertyMapReadOnly::create(UncheckedKeyHashMap<AtomString, RefPtr<CSSValue>>&& map)
+Ref<HashMapStylePropertyMapReadOnly> HashMapStylePropertyMapReadOnly::create(HashMap<AtomString, RefPtr<CSSValue>>&& map)
 {
     return adoptRef(*new HashMapStylePropertyMapReadOnly(WTFMove(map)));
 }
 
-HashMapStylePropertyMapReadOnly::HashMapStylePropertyMapReadOnly(UncheckedKeyHashMap<AtomString, RefPtr<CSSValue>>&& map)
+HashMapStylePropertyMapReadOnly::HashMapStylePropertyMapReadOnly(HashMap<AtomString, RefPtr<CSSValue>>&& map)
     : m_map(WTFMove(map))
 {
 }

--- a/Source/WebCore/css/typedom/HashMapStylePropertyMapReadOnly.h
+++ b/Source/WebCore/css/typedom/HashMapStylePropertyMapReadOnly.h
@@ -33,10 +33,10 @@ namespace WebCore {
 
 class HashMapStylePropertyMapReadOnly final : public MainThreadStylePropertyMapReadOnly {
 public:
-    static Ref<HashMapStylePropertyMapReadOnly> create(UncheckedKeyHashMap<AtomString, RefPtr<CSSValue>>&&);
+    static Ref<HashMapStylePropertyMapReadOnly> create(HashMap<AtomString, RefPtr<CSSValue>>&&);
     ~HashMapStylePropertyMapReadOnly();
 
-    Type type() const final { return Type::UncheckedKeyHashMap; }
+    Type type() const final { return Type::HashMap; }
     RefPtr<CSSValue> propertyValue(CSSPropertyID) const final;
     String shorthandPropertySerialization(CSSPropertyID) const final;
     RefPtr<CSSValue> customPropertyValue(const AtomString& property) const final;
@@ -44,11 +44,11 @@ public:
     Vector<StylePropertyMapEntry> entries(ScriptExecutionContext*) const final;
 
 private:
-    HashMapStylePropertyMapReadOnly(UncheckedKeyHashMap<AtomString, RefPtr<CSSValue>>&&);
+    HashMapStylePropertyMapReadOnly(HashMap<AtomString, RefPtr<CSSValue>>&&);
 
-    UncheckedKeyHashMap<AtomString, RefPtr<CSSValue>> m_map;
+    HashMap<AtomString, RefPtr<CSSValue>> m_map;
 };
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_CSSOM_STYLE_PROPERTY_MAP(HashMapStylePropertyMapReadOnly, WebCore::StylePropertyMapReadOnly::Type::UncheckedKeyHashMap);
+SPECIALIZE_TYPE_TRAITS_CSSOM_STYLE_PROPERTY_MAP(HashMapStylePropertyMapReadOnly, WebCore::StylePropertyMapReadOnly::Type::HashMap);

--- a/Source/WebCore/css/typedom/StylePropertyMapReadOnly.h
+++ b/Source/WebCore/css/typedom/StylePropertyMapReadOnly.h
@@ -45,7 +45,7 @@ public:
     enum class Type {
         Computed,
         Declared,
-        UncheckedKeyHashMap,
+        HashMap,
         Inline,
     };
 

--- a/Source/WebCore/html/CustomPaintImage.cpp
+++ b/Source/WebCore/html/CustomPaintImage.cpp
@@ -96,7 +96,7 @@ ImageDrawResult CustomPaintImage::doCustomPaint(GraphicsContext& destContext, co
     Ref canvas = CustomPaintCanvas::create(*scriptExecutionContext, destSize.width(), destSize.height());
     RefPtr context = canvas->getContext();
 
-    UncheckedKeyHashMap<AtomString, RefPtr<CSSValue>> propertyValues;
+    HashMap<AtomString, RefPtr<CSSValue>> propertyValues;
 
     if (RefPtr element = renderElement->element()) {
         for (auto& name : m_inputProperties)


### PR DESCRIPTION
#### ac9b068983e0b70ebf6f97ebe49c5e24f7782a8e
<pre>
Stop using UncheckedKey containers in WebCore/css
<a href="https://bugs.webkit.org/show_bug.cgi?id=294538">https://bugs.webkit.org/show_bug.cgi?id=294538</a>

Reviewed by Darin Adler.

Stop using UncheckedKey containers in WebCore/css, for extra safety.
This tested as performance neutral on Speedometer and MotionMark.

* Source/WebCore/css/CSSCounterStyleRegistry.cpp:
(WebCore::CSSCounterStyleRegistry::resolveExtendsReference):
* Source/WebCore/css/CSSCounterStyleRegistry.h:
* Source/WebCore/css/CSSFontFaceSet.cpp:
(WebCore::CSSFontFaceSet::matchingFacesExcludingPreinstalledFonts):
* Source/WebCore/css/CSSFontFaceSet.h:
* Source/WebCore/css/CSSFontSelector.h:
* Source/WebCore/css/CSSGridTemplateAreasValue.cpp:
(WebCore::stringForPosition):
* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::serializedPrimitiveValues):
* Source/WebCore/css/CSSSegmentedFontFace.h:
* Source/WebCore/css/CSSStyleProperties.cpp:
(WebCore::lookupCSSPropertyFromIDLAttribute):
* Source/WebCore/css/CSSStyleProperties.h:
* Source/WebCore/css/CSSStyleRule.cpp:
* Source/WebCore/css/CSSValuePool.h:
* Source/WebCore/css/FontFaceSet.h:
* Source/WebCore/css/ImmutableStyleProperties.cpp:
(WebCore::deduplicationMap):
* Source/WebCore/css/MutableStyleProperties.cpp:
(WebCore::MutableStyleProperties::removeProperties):
* Source/WebCore/css/PropertySetCSSDescriptors.h:
* Source/WebCore/css/StyleSheetContents.h:
* Source/WebCore/css/calc/CSSCalcSymbolTable.h:
* Source/WebCore/css/calc/CSSCalcSymbolsAllowed.h:
* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::filterProperties):
(WebCore::createStyleProperties):
(WebCore::CSSParser::parseDeclarationList):
* Source/WebCore/css/typedom/CSSNumericValue.h:
* Source/WebCore/css/typedom/HashMapStylePropertyMapReadOnly.cpp:
(WebCore::HashMapStylePropertyMapReadOnly::create):
(WebCore::HashMapStylePropertyMapReadOnly::HashMapStylePropertyMapReadOnly):
* Source/WebCore/css/typedom/HashMapStylePropertyMapReadOnly.h:
* Source/WebCore/css/typedom/StylePropertyMapReadOnly.h:
* Source/WebCore/html/CustomPaintImage.cpp:
(WebCore::CustomPaintImage::doCustomPaint):

Canonical link: <a href="https://commits.webkit.org/296252@main">https://commits.webkit.org/296252@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e6c3ac887f6c38f7d2cef31de947ecd9cfcec2e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107989 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27654 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18073 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113200 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58512 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109952 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28349 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36203 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81971 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110937 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22463 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97290 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62402 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21875 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15423 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57947 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91816 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15489 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116327 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35061 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25805 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91008 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35437 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93568 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90802 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23130 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35700 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13455 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34959 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40513 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34703 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38062 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36363 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->