### PR TITLE
Stop using UncheckedKey containers in WebCore/svg

### DIFF
--- a/Source/WebCore/svg/SVGFontElement.h
+++ b/Source/WebCore/svg/SVGFontElement.h
@@ -31,12 +31,12 @@ namespace WebCore {
 // Describe an SVG <hkern>/<vkern> element
 struct SVGKerningPair {
     UnicodeRanges unicodeRange1;
-    UncheckedKeyHashSet<String> unicodeName1;
-    UncheckedKeyHashSet<String> glyphName1;
+    HashSet<String> unicodeName1;
+    HashSet<String> glyphName1;
 
     UnicodeRanges unicodeRange2;
-    UncheckedKeyHashSet<String> unicodeName2;
-    UncheckedKeyHashSet<String> glyphName2;
+    HashSet<String> unicodeName2;
+    HashSet<String> glyphName2;
     float kerning { 0 };
 };
 

--- a/Source/WebCore/svg/SVGLinearGradientElement.cpp
+++ b/Source/WebCore/svg/SVGLinearGradientElement.cpp
@@ -143,7 +143,7 @@ bool SVGLinearGradientElement::collectGradientAttributes(LinearGradientAttribute
     if (!renderer())
         return false;
 
-    UncheckedKeyHashSet<Ref<SVGGradientElement>> processedGradients;
+    HashSet<Ref<SVGGradientElement>> processedGradients;
     Ref<SVGGradientElement> current { *this };
 
     setGradientAttributes(current.get(), attributes);

--- a/Source/WebCore/svg/SVGParserUtilities.cpp
+++ b/Source/WebCore/svg/SVGParserUtilities.cpp
@@ -269,14 +269,14 @@ std::optional<FloatRect> parseRect(StringView string)
     });
 }
 
-std::optional<UncheckedKeyHashSet<String>> parseGlyphName(StringView string)
+std::optional<HashSet<String>> parseGlyphName(StringView string)
 {
     // FIXME: Parsing error detection is missing.
 
     return readCharactersForParsing(string, [](auto buffer) {
         skipOptionalSVGSpaces(buffer);
 
-        UncheckedKeyHashSet<String> values;
+        HashSet<String> values;
 
         while (buffer.hasCharactersRemaining()) {
             // Leading and trailing white space, and white space before and after separators, will be ignored.
@@ -372,13 +372,13 @@ template<typename CharacterType> static std::optional<UnicodeRange> parseUnicode
     return range;
 }
 
-std::optional<std::pair<UnicodeRanges, UncheckedKeyHashSet<String>>> parseKerningUnicodeString(StringView string)
+std::optional<std::pair<UnicodeRanges, HashSet<String>>> parseKerningUnicodeString(StringView string)
 {
     // FIXME: Parsing error detection is missing.
 
-    return readCharactersForParsing(string, [](auto buffer) -> std::pair<UnicodeRanges, UncheckedKeyHashSet<String>> {
+    return readCharactersForParsing(string, [](auto buffer) -> std::pair<UnicodeRanges, HashSet<String>> {
         UnicodeRanges rangeList;
-        UncheckedKeyHashSet<String> stringList;
+        HashSet<String> stringList;
 
         while (1) {
             auto inputStart = buffer.position();

--- a/Source/WebCore/svg/SVGParserUtilities.h
+++ b/Source/WebCore/svg/SVGParserUtilities.h
@@ -52,8 +52,8 @@ std::optional<FloatRect> parseRect(StringView);
 std::optional<FloatPoint> parseFloatPoint(StringParsingBuffer<LChar>&);
 std::optional<FloatPoint> parseFloatPoint(StringParsingBuffer<UChar>&);
 
-std::optional<std::pair<UnicodeRanges, UncheckedKeyHashSet<String>>> parseKerningUnicodeString(StringView);
-std::optional<UncheckedKeyHashSet<String>> parseGlyphName(StringView);
+std::optional<std::pair<UnicodeRanges, HashSet<String>>> parseKerningUnicodeString(StringView);
+std::optional<HashSet<String>> parseGlyphName(StringView);
 
 template<typename CharacterType> constexpr bool isSVGSpaceOrComma(CharacterType c)
 {

--- a/Source/WebCore/svg/SVGPathElement.cpp
+++ b/Source/WebCore/svg/SVGPathElement.cpp
@@ -54,7 +54,7 @@ private:
     friend class NeverDestroyed<PathSegListCache, MainThreadAccessTraits>;
     PathSegListCache() = default;
 
-    UncheckedKeyHashMap<AtomString, DataRef<SVGPathByteStream::Data>> m_cache;
+    HashMap<AtomString, DataRef<SVGPathByteStream::Data>> m_cache;
     uint64_t m_sizeInBytes { 0 };
     static constexpr uint64_t maxItemSizeInBytes = 5 * 1024; // 5 Kb.
     static constexpr uint64_t maxCacheSizeInBytes = 150 * 1024; // 150 Kb.

--- a/Source/WebCore/svg/SVGRadialGradientElement.cpp
+++ b/Source/WebCore/svg/SVGRadialGradientElement.cpp
@@ -157,7 +157,7 @@ bool SVGRadialGradientElement::collectGradientAttributes(RadialGradientAttribute
     if (!renderer())
         return false;
 
-    UncheckedKeyHashSet<RefPtr<SVGGradientElement>> processedGradients;
+    HashSet<RefPtr<SVGGradientElement>> processedGradients;
     RefPtr<SVGGradientElement> current = this;
 
     setGradientAttributes(*current, attributes);

--- a/Source/WebCore/svg/SVGToOTFFontConversion.cpp
+++ b/Source/WebCore/svg/SVGToOTFFontConversion.cpp
@@ -233,9 +233,9 @@ private:
 
     Vector<char> transcodeGlyphPaths(float width, const SVGElement& glyphOrMissingGlyphElement, std::optional<FloatRect>& boundingBox) const;
 
-    void addCodepointRanges(const UnicodeRanges&, UncheckedKeyHashSet<Glyph>& glyphSet) const;
-    void addCodepoints(const UncheckedKeyHashSet<String>& codepoints, UncheckedKeyHashSet<Glyph>& glyphSet) const;
-    void addGlyphNames(const UncheckedKeyHashSet<String>& glyphNames, UncheckedKeyHashSet<Glyph>& glyphSet) const;
+    void addCodepointRanges(const UnicodeRanges&, HashSet<Glyph>& glyphSet) const;
+    void addCodepoints(const HashSet<String>& codepoints, HashSet<Glyph>& glyphSet) const;
+    void addGlyphNames(const HashSet<String>& glyphNames, HashSet<Glyph>& glyphSet) const;
     void addKerningPair(Vector<KerningData>&, SVGKerningPair&&) const;
     template<typename T> size_t appendKERNSubtable(std::optional<SVGKerningPair> (T::*buildKerningPair)() const, uint16_t coverage);
     size_t finishAppendingKERNSubtable(Vector<KerningData>, uint16_t coverage);
@@ -254,8 +254,8 @@ private:
     Ref<const SVGFontElement> protectedFontElement() const { return m_fontElement.get(); }
 
     Vector<GlyphData> m_glyphs;
-    UncheckedKeyHashMap<String, Glyph> m_glyphNameToIndexMap; // SVG 1.1: "It is recommended that glyph names be unique within a font."
-    UncheckedKeyHashMap<String, Vector<Glyph, 1>> m_codepointsToIndicesMap;
+    HashMap<String, Glyph> m_glyphNameToIndexMap; // SVG 1.1: "It is recommended that glyph names be unique within a font."
+    HashMap<String, Vector<Glyph, 1>> m_codepointsToIndicesMap;
     Vector<uint8_t> m_result;
     Vector<char, 17> m_emptyGlyphCharString;
     FloatRect m_boundingBox;
@@ -1019,7 +1019,7 @@ Vector<Glyph, 1> SVGToOTFFontConverter::glyphsForCodepoint(char32_t codepoint) c
     return m_codepointsToIndicesMap.get(codepointToString(codepoint));
 }
 
-void SVGToOTFFontConverter::addCodepointRanges(const UnicodeRanges& unicodeRanges, UncheckedKeyHashSet<Glyph>& glyphSet) const
+void SVGToOTFFontConverter::addCodepointRanges(const UnicodeRanges& unicodeRanges, HashSet<Glyph>& glyphSet) const
 {
     for (auto& unicodeRange : unicodeRanges) {
         for (auto codepoint = unicodeRange.first; codepoint <= unicodeRange.second; ++codepoint) {
@@ -1029,7 +1029,7 @@ void SVGToOTFFontConverter::addCodepointRanges(const UnicodeRanges& unicodeRange
     }
 }
 
-void SVGToOTFFontConverter::addCodepoints(const UncheckedKeyHashSet<String>& codepoints, UncheckedKeyHashSet<Glyph>& glyphSet) const
+void SVGToOTFFontConverter::addCodepoints(const HashSet<String>& codepoints, HashSet<Glyph>& glyphSet) const
 {
     for (auto& codepointString : codepoints) {
         for (auto index : m_codepointsToIndicesMap.get(codepointString))
@@ -1037,7 +1037,7 @@ void SVGToOTFFontConverter::addCodepoints(const UncheckedKeyHashSet<String>& cod
     }
 }
 
-void SVGToOTFFontConverter::addGlyphNames(const UncheckedKeyHashSet<String>& glyphNames, UncheckedKeyHashSet<Glyph>& glyphSet) const
+void SVGToOTFFontConverter::addGlyphNames(const HashSet<String>& glyphNames, HashSet<Glyph>& glyphSet) const
 {
     for (auto& glyphName : glyphNames) {
         if (Glyph glyph = m_glyphNameToIndexMap.get(glyphName))
@@ -1047,8 +1047,8 @@ void SVGToOTFFontConverter::addGlyphNames(const UncheckedKeyHashSet<String>& gly
 
 void SVGToOTFFontConverter::addKerningPair(Vector<KerningData>& data, SVGKerningPair&& kerningPair) const
 {
-    UncheckedKeyHashSet<Glyph> glyphSet1;
-    UncheckedKeyHashSet<Glyph> glyphSet2;
+    HashSet<Glyph> glyphSet1;
+    HashSet<Glyph> glyphSet2;
 
     addCodepointRanges(kerningPair.unicodeRange1, glyphSet1);
     addCodepointRanges(kerningPair.unicodeRange2, glyphSet2);
@@ -1308,8 +1308,8 @@ void SVGToOTFFontConverter::processGlyphElement(const SVGElement& glyphOrMissing
 
 void SVGToOTFFontConverter::appendLigatureGlyphs()
 {
-    UncheckedKeyHashSet<uint32_t> ligatureCodepoints;
-    UncheckedKeyHashSet<uint32_t> nonLigatureCodepoints;
+    HashSet<uint32_t> ligatureCodepoints;
+    HashSet<uint32_t> nonLigatureCodepoints;
     for (auto& glyph : m_glyphs) {
         auto codePoints = StringView(glyph.codepoints).codePoints();
         auto codePointsIterator = codePoints.begin();

--- a/Source/WebCore/svg/animation/SMILTimeContainer.h
+++ b/Source/WebCore/svg/animation/SMILTimeContainer.h
@@ -75,7 +75,7 @@ private:
 
     using ElementAttributePair = std::pair<SVGElement*, QualifiedName>;
     using AnimationsVector = Vector<SVGSMILElement*>;
-    using GroupedAnimationsMap = UncheckedKeyHashMap<ElementAttributePair, AnimationsVector>;
+    using GroupedAnimationsMap = HashMap<ElementAttributePair, AnimationsVector>;
 
     void processScheduledAnimations(NOESCAPE const Function<void(SVGSMILElement&)>&);
     void updateDocumentOrderIndexes();

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -454,7 +454,7 @@ void SVGSMILElement::parseBeginOrEnd(StringView parseString, BeginOrEnd beginOrE
     Vector<SMILTimeWithOrigin>& timeList = beginOrEnd == Begin ? m_beginTimes : m_endTimes;
     if (beginOrEnd == End)
         m_hasEndEventConditions = false;
-    UncheckedKeyHashSet<double> existing;
+    HashSet<double> existing;
     for (auto& time : timeList)
         existing.add(time.time().value());
     for (auto string : parseString.split(';')) {

--- a/Source/WebCore/svg/graphics/SVGImageCache.h
+++ b/Source/WebCore/svg/graphics/SVGImageCache.h
@@ -52,7 +52,7 @@ private:
     Image* findImageForRenderer(const RenderObject*) const;
     RefPtr<SVGImage> protectedSVGImage() const;
 
-    typedef UncheckedKeyHashMap<const CachedImageClient*, RefPtr<SVGImageForContainer>> ImageForContainerMap;
+    typedef HashMap<const CachedImageClient*, RefPtr<SVGImageForContainer>> ImageForContainerMap;
 
     WeakPtr<SVGImage> m_svgImage;
     ImageForContainerMap m_imageForContainerMap;

--- a/Source/WebCore/svg/graphics/filters/SVGFilterEffectGraph.h
+++ b/Source/WebCore/svg/graphics/filters/SVGFilterEffectGraph.h
@@ -85,7 +85,7 @@ private:
         return sourceGraphic();
     }
 
-    UncheckedKeyHashMap<AtomString, Ref<FilterEffect>> m_sourceNodes;
+    HashMap<AtomString, Ref<FilterEffect>> m_sourceNodes;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/graphics/filters/SVGFilterGraph.h
+++ b/Source/WebCore/svg/graphics/filters/SVGFilterGraph.h
@@ -118,8 +118,8 @@ protected:
         return true;
     }
 
-    UncheckedKeyHashMap<AtomString, Ref<NodeType>> m_namedNodes;
-    UncheckedKeyHashMap<Ref<NodeType>, NodeVector> m_nodeInputs;
+    HashMap<AtomString, Ref<NodeType>> m_namedNodes;
+    HashMap<Ref<NodeType>, NodeVector> m_nodeInputs;
     RefPtr<NodeType> m_lastNode;
 };
 

--- a/Source/WebCore/svg/properties/SVGPropertyAnimatorFactory.h
+++ b/Source/WebCore/svg/properties/SVGPropertyAnimatorFactory.h
@@ -69,10 +69,10 @@ public:
     }
 
 private:
-    // This UncheckedKeyHashMap maps an attribute name to a pair of static methods. The first one creates a shared
+    // This HashMap maps an attribute name to a pair of static methods. The first one creates a shared
     // Ref<SVGProperty> for the value type of this attribute. The second creates the animator given the
     // attribute name and the shared Ref<SVGProperty>.
-    using AttributeAnimatorCreator = UncheckedKeyHashMap<
+    using AttributeAnimatorCreator = HashMap<
         QualifiedName::QualifiedNameImpl*,
         std::pair<
             Function<Ref<SVGProperty>()>,
@@ -169,7 +169,7 @@ private:
         return map;
     }
 
-    using AttributeProperty = UncheckedKeyHashMap<QualifiedName, Ref<SVGProperty>>;
+    using AttributeProperty = HashMap<QualifiedName, Ref<SVGProperty>>;
     AttributeProperty m_attributeProperty;
 };
     

--- a/Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h
+++ b/Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h
@@ -285,9 +285,9 @@ public:
 
     // Enumerate recursively the SVGMemberAccessors of the OwnerType and all its BaseTypes.
     // Collect all the pairs <AttributeName, String> only for the dirty properties.
-    UncheckedKeyHashMap<QualifiedName, String> synchronizeAllAttributes() const override
+    HashMap<QualifiedName, String> synchronizeAllAttributes() const override
     {
-        UncheckedKeyHashMap<QualifiedName, String> map;
+        HashMap<QualifiedName, String> map;
         enumerateRecursively([&](const auto& entry) -> bool {
             if (auto string = entry.value->synchronize(m_owner))
                 map.add(entry.key, *string);
@@ -310,7 +310,7 @@ public:
 
     bool isAnimatedStylePropertyAttribute(const QualifiedName& attributeName) const override
     {
-        static NeverDestroyed<UncheckedKeyHashSet<QualifiedName::QualifiedNameImpl*>> animatedStyleAttributes = std::initializer_list<QualifiedName::QualifiedNameImpl*> {
+        static NeverDestroyed<HashSet<QualifiedName::QualifiedNameImpl*>> animatedStyleAttributes = std::initializer_list<QualifiedName::QualifiedNameImpl*> {
             SVGNames::cxAttr->impl(),
             SVGNames::cyAttr->impl(),
             SVGNames::rAttr->impl(),
@@ -342,7 +342,7 @@ public:
 
 private:
     // Singleton map for every OwnerType.
-    using QualifiedNameAccessorHashMap = UncheckedKeyHashMap<QualifiedName, const SVGMemberAccessor<OwnerType>*, SVGAttributeHashTranslator>;
+    using QualifiedNameAccessorHashMap = HashMap<QualifiedName, const SVGMemberAccessor<OwnerType>*, SVGAttributeHashTranslator>;
 
     static QualifiedNameAccessorHashMap& attributeNameToAccessorMap()
     {

--- a/Source/WebCore/svg/properties/SVGPropertyRegistry.h
+++ b/Source/WebCore/svg/properties/SVGPropertyRegistry.h
@@ -40,7 +40,7 @@ public:
     virtual QualifiedName animatedPropertyAttributeName(const SVGAnimatedProperty&) const = 0;
     virtual void setAnimatedPropertyDirty(const QualifiedName&, SVGAnimatedProperty&) const = 0;
     virtual std::optional<String> synchronize(const QualifiedName&) const = 0;
-    virtual UncheckedKeyHashMap<QualifiedName, String> synchronizeAllAttributes() const = 0;
+    virtual HashMap<QualifiedName, String> synchronizeAllAttributes() const = 0;
 
     virtual bool isAnimatedPropertyAttribute(const QualifiedName&) const = 0;
     virtual bool isAnimatedStylePropertyAttribute(const QualifiedName&) const = 0;


### PR DESCRIPTION
#### 6b128f751ce33ec0cbc7f35e8d5e202151a8ea52
<pre>
Stop using UncheckedKey containers in WebCore/svg
<a href="https://bugs.webkit.org/show_bug.cgi?id=294539">https://bugs.webkit.org/show_bug.cgi?id=294539</a>

Reviewed by Darin Adler.

Stop using UncheckedKey containers in WebCore/svg, for extra safety.
This tested as performance neutral on Speedometer and MotionMark.

* Source/WebCore/rendering/svg/RenderSVGResourceMasker.h:
* Source/WebCore/rendering/svg/RenderSVGResourcePattern.h:
* Source/WebCore/rendering/svg/SVGTextChunk.h:
* Source/WebCore/rendering/svg/SVGTextChunkBuilder.cpp:
(WebCore::SVGTextChunkBuilder::buildTextChunks):
(WebCore::SVGTextChunkBuilder::layoutTextChunks):
* Source/WebCore/rendering/svg/SVGTextChunkBuilder.h:
* Source/WebCore/rendering/svg/SVGTextLayoutAttributes.h:
* Source/WebCore/rendering/svg/SVGTextLayoutEngine.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.h:
* Source/WebCore/rendering/svg/legacy/SVGResourcesCache.h:
* Source/WebCore/svg/SVGFontElement.h:
* Source/WebCore/svg/SVGLinearGradientElement.cpp:
(WebCore::SVGLinearGradientElement::collectGradientAttributes):
* Source/WebCore/svg/SVGParserUtilities.cpp:
(WebCore::parseGlyphName):
(WebCore::parseKerningUnicodeString):
* Source/WebCore/svg/SVGParserUtilities.h:
* Source/WebCore/svg/SVGPathElement.cpp:
* Source/WebCore/svg/SVGRadialGradientElement.cpp:
(WebCore::SVGRadialGradientElement::collectGradientAttributes):
* Source/WebCore/svg/SVGToOTFFontConversion.cpp:
(WebCore::SVGToOTFFontConverter::addCodepointRanges const):
(WebCore::SVGToOTFFontConverter::addCodepoints const):
(WebCore::SVGToOTFFontConverter::addGlyphNames const):
(WebCore::SVGToOTFFontConverter::addKerningPair const):
(WebCore::SVGToOTFFontConverter::appendLigatureGlyphs):
* Source/WebCore/svg/animation/SMILTimeContainer.h:
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::parseBeginOrEnd):
* Source/WebCore/svg/graphics/SVGImageCache.h:
* Source/WebCore/svg/graphics/filters/SVGFilterEffectGraph.h:
* Source/WebCore/svg/graphics/filters/SVGFilterGraph.h:
* Source/WebCore/svg/properties/SVGPropertyAnimatorFactory.h:
* Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h:
* Source/WebCore/svg/properties/SVGPropertyRegistry.h:

Canonical link: <a href="https://commits.webkit.org/296254@main">https://commits.webkit.org/296254@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66f0855e723856e4ab151f619acd5f30e8254713

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107990 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27655 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18074 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113201 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58513 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109953 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28350 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36204 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81973 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110938 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22468 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97293 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62404 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21880 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15426 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57948 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91821 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15492 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116328 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35062 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25806 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91003 "Found 1 new test failure: fast/events/domactivate-sets-underlying-click-event-as-handled.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35438 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93571 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90797 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23129 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35703 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13458 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34960 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40514 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34704 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38063 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36364 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->