### PR TITLE
[WebGPU] Remove warning banner from webkit.org

### DIFF
--- a/Websites/webkit.org/demos/webgpu/index.html
+++ b/Websites/webkit.org/demos/webgpu/index.html
@@ -171,19 +171,10 @@ section p a {
             examples can be found at <a href="https://webgpu.github.io/webgpu-samples/samples/helloTriangle">webgpu.github.io</a>. They should work in the latest <a
             href="https://webkit.org/build-archives/">WebKit</a> builds and
             <a href="https://developer.apple.com/safari/technology-preview/">Safari
-             Technology Preview</a> release. The full <a href="https://gpuweb.github.io/gpuweb/">specification</a> is a work-in-progress on <a
-            href="https://github.com/gpuweb/gpuweb
-            ">GitHub</a>, and the implementation may differ from the current API.
+             Technology Preview</a> release. The full <a href="https://www.w3.org/TR/webgpu/">specification</a> is currently a W3C Candidate Recommendation and WebKit's implementation is aligned with it.
         </p>
         <p class="howto">
-            Make sure you are on a system with WebGPU enabled. In Safari, first
-            make sure the Feature Flags Menu is visible (Preferences > Advanced > Show features for web developers),
-            then ensure Preferences > Feature Flags > WebGPU is checked.
-        </p>
-        <p class="warning">
-            WebGPU is an experimental technology, and you should not browse the entire
-            Web with it enabled for now. It doesn't do much validation of content, and
-            thus may cause some issues with your computer.
+            Make sure you are on a system with WebGPU enabled. WebGPU is enabled in Safari Technology Preview and Safari 26.0 beta.
         </p>
         <div class="example">
             <a href="https://webgpu.github.io/webgpu-samples/samples/helloTriangle">


### PR DESCRIPTION
#### 65d0a5ff8eaa933ab7cbaac190402138643a7385
<pre>
[WebGPU] Remove warning banner from webkit.org
<a href="https://bugs.webkit.org/show_bug.cgi?id=294544">https://bugs.webkit.org/show_bug.cgi?id=294544</a>
<a href="https://rdar.apple.com/153504567">rdar://153504567</a>

Reviewed by Anne van Kesteren.

With Safari 26.0 beta officially supporting WebGPU, we should
update this page.

* Websites/webkit.org/demos/webgpu/index.html:

Canonical link: <a href="https://commits.webkit.org/296290@main">https://commits.webkit.org/296290@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de50c742e7507de0dc3ab8f8640d0d3159fa8248

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108065 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27730 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18149 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113275 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/58576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28424 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36279 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/82040 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/58576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111013 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/22529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97357 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62472 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/21941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58021 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91884 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/15556 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116400 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35134 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/91068 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35509 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93635 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90863 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23152 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35766 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13522 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35034 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34772 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38130 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36435 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->