### PR TITLE
[JSC] Ensure all visitWeak is called from StructureStubInfo

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -1735,7 +1735,7 @@ void CodeBlock::finalizeJITInlineCaches()
 
     forEachStructureStubInfo([&](StructureStubInfo& stubInfo) {
         ConcurrentJSLockerBase locker(NoLockingNecessary);
-        stubInfo.visitWeakReferences(locker, this);
+        stubInfo.visitWeak(locker, this);
         return IterationStatus::Continue;
     });
 }

--- a/Source/JavaScriptCore/bytecode/StructureStubInfo.cpp
+++ b/Source/JavaScriptCore/bytecode/StructureStubInfo.cpp
@@ -416,7 +416,7 @@ void StructureStubInfo::visitAggregateImpl(Visitor& visitor)
 
 DEFINE_VISIT_AGGREGATE(StructureStubInfo);
 
-void StructureStubInfo::visitWeakReferences(const ConcurrentJSLockerBase& locker, CodeBlock* codeBlock)
+void StructureStubInfo::visitWeak(const ConcurrentJSLockerBase& locker, CodeBlock* codeBlock)
 {
     VM& vm = codeBlock->vm();
     {

--- a/Source/JavaScriptCore/bytecode/StructureStubInfo.h
+++ b/Source/JavaScriptCore/bytecode/StructureStubInfo.h
@@ -139,7 +139,7 @@ public:
 
     // Check if the stub has weak references that are dead. If it does, then it resets itself,
     // either entirely or just enough to ensure that those dead pointers don't get used anymore.
-    void visitWeakReferences(const ConcurrentJSLockerBase&, CodeBlock*);
+    void visitWeak(const ConcurrentJSLockerBase&, CodeBlock*);
     
     // This returns true if it has marked everything that it will ever mark.
     template<typename Visitor> void propagateTransitions(Visitor&);

--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp
@@ -163,6 +163,15 @@ void PolymorphicAccessJITStubRoutine::addedToSharedJITStubSet()
     m_isInSharedJITStubSet = true;
 }
 
+bool PolymorphicAccessJITStubRoutine::visitWeakImpl(VM& vm)
+{
+    bool isValid = true;
+    for (StructureID weakReference : m_weakStructures)
+        isValid &= vm.heap.isMarked(weakReference.decode());
+    isValid &= Base::visitWeakImpl(vm);
+    return isValid;
+}
+
 MarkingGCAwareJITStubRoutine::MarkingGCAwareJITStubRoutine(
     Type type, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& code, VM& vm, FixedVector<Ref<AccessCase>>&& cases, FixedVector<StructureID>&& weakStructures, JSCell* owner,
     const Vector<JSCell*>& cells, Vector<std::unique_ptr<OptimizingCallLinkInfo>, 16>&& callLinkInfos, bool isCodeImmutable)
@@ -196,7 +205,7 @@ bool MarkingGCAwareJITStubRoutine::visitWeakImpl(VM& vm)
         if (callLinkInfo)
             callLinkInfo->visitWeak(vm);
     }
-    return PolymorphicAccessJITStubRoutine::visitWeakImpl(vm);
+    return Base::visitWeakImpl(vm);
 }
 
 CallLinkInfo* MarkingGCAwareJITStubRoutine::callLinkInfoAtImpl(const ConcurrentJSLocker&, unsigned index)

--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
@@ -147,6 +147,8 @@ public:
             m_owners.remove(codeBlock);
     }
 
+    bool visitWeakImpl(VM&);
+
 protected:
     void observeZeroRefCountImpl();
     VM& vm() { return m_vm; }


### PR DESCRIPTION
#### e6bba582bc4ae7350ff27ca9c1bef656ac4bd31f
<pre>
[JSC] Ensure all visitWeak is called from StructureStubInfo
<a href="https://bugs.webkit.org/show_bug.cgi?id=294545">https://bugs.webkit.org/show_bug.cgi?id=294545</a>
<a href="https://rdar.apple.com/problem/153505034">rdar://problem/153505034</a>

Reviewed by Keith Miller.

Further safety related changes. Ensure that all children calls visitWeak
from StructureStubInfo to ensure everything is cleaned up before
StructureStubInfo and its stubRoutine gets destroyed eagerly.

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::finalizeJITInlineCaches):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::PolymorphicAccess::visitWeak):
(JSC::InlineCacheHandler::visitWeak):
* Source/JavaScriptCore/bytecode/StructureStubInfo.cpp:
(JSC::StructureStubInfo::visitWeak):
(JSC::StructureStubInfo::visitWeakReferences): Deleted.
* Source/JavaScriptCore/bytecode/StructureStubInfo.h:
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp:
(JSC::PolymorphicAccessJITStubRoutine::visitWeakImpl):
(JSC::MarkingGCAwareJITStubRoutine::visitWeakImpl):
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h:

Canonical link: <a href="https://commits.webkit.org/296286@main">https://commits.webkit.org/296286@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fe2b8a4ea123effad5d8feceb9921ac92313f5e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108037 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18121 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113247 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58554 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28397 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36252 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82017 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110985 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22510 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97336 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62449 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21922 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15470 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57993 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/100640 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91862 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15535 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116374 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/106599 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35108 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25853 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/91054 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35484 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93614 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90848 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35744 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13501 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17453 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35007 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40562 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/130888 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34750 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35537 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38108 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36411 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->