### PR TITLE
Adopt more smart pointers for local variables in Source/WebKit

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -20,7 +20,6 @@ UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
 UIProcess/ViewGestureController.cpp
 UIProcess/WebPageProxy.cpp
 UIProcess/mac/WKTextAnimationManager.mm
-UIProcess/mac/WebViewImpl.mm
 WebProcess/FullScreen/WebFullScreenManager.cpp
 WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
 WebProcess/InjectedBundle/API/c/WKBundlePage.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -1,10 +1,7 @@
 UIProcess/Cocoa/VideoPresentationManagerProxy.mm
 UIProcess/ViewGestureController.cpp
-UIProcess/WebPageProxy.cpp
-UIProcess/mac/WebViewImpl.mm
 WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
 WebProcess/FullScreen/WebFullScreenManager.cpp
-WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.cpp
 WebProcess/InjectedBundle/API/c/WKBundle.cpp
 WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
 WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -15,16 +12,8 @@ WebProcess/InjectedBundle/InjectedBundlePageContextMenuClient.cpp
 WebProcess/InjectedBundle/InjectedBundlePageEditorClient.cpp
 WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
 WebProcess/InjectedBundle/mac/InjectedBundleMac.mm
-WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.mm
-WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
-WebProcess/WebCoreSupport/SessionStateConversion.cpp
 WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp
-WebProcess/WebCoreSupport/WebChromeClient.cpp
-WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
-WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
-WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
 WebProcess/WebPage/ViewUpdateDispatcher.cpp
 WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
 WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
 WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
-WebProcess/cocoa/TextTrackRepresentationCocoa.mm

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -5085,7 +5085,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     if (!_page || !_perProcessState.committedFindLayerID)
         return nil;
 
-    if (auto* drawingArea = _page->drawingArea())
+    if (RefPtr drawingArea = _page->drawingArea())
         return downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(*drawingArea).remoteLayerTreeHost().layerForID(*_perProcessState.committedFindLayerID);
 
     return nil;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -117,7 +117,7 @@ void RemoteScrollingCoordinatorProxyMac::hasNodeWithAnimatedScrollChanged(bool h
 #if ENABLE(SCROLLING_THREAD)
     m_eventDispatcher->hasNodeWithAnimatedScrollChanged(hasAnimatedScrolls);
 #else
-    auto* drawingArea = dynamicDowncast<RemoteLayerTreeDrawingAreaProxy>(webPageProxy().drawingArea());
+    RefPtr drawingArea = dynamicDowncast<RemoteLayerTreeDrawingAreaProxy>(webPageProxy().drawingArea());
     if (!drawingArea)
         return;
 

--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -780,7 +780,7 @@ void ViewGestureController::applyMagnification()
     if (m_frameHandlesMagnificationGesture) {
         if (RefPtr page = m_webPageProxy.get())
             page->scalePage(m_magnification, roundedIntPoint(m_magnificationOrigin), [] { });
-    } else if (auto* drawingArea = m_webPageProxy ? m_webPageProxy->drawingArea() : nullptr)
+    } else if (RefPtr drawingArea = m_webPageProxy ? m_webPageProxy->drawingArea() : nullptr)
         drawingArea->adjustTransientZoom(m_magnification, scaledMagnificationOrigin(m_magnificationOrigin, m_magnification), m_magnificationOrigin);
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7607,7 +7607,7 @@ void WebPageProxy::viewIsBecomingVisible()
 {
     WEBPAGEPROXY_RELEASE_LOG(ViewState, "viewIsBecomingVisible:");
     protectedLegacyMainFrameProcess()->markProcessAsRecentlyUsed();
-    if (auto* drawingAreaProxy = drawingArea())
+    if (RefPtr drawingAreaProxy = drawingArea())
         drawingAreaProxy->viewIsBecomingVisible();
 #if ENABLE(MEDIA_STREAM)
     if (RefPtr userMediaPermissionRequestManager = m_userMediaPermissionRequestManager)
@@ -7622,7 +7622,7 @@ void WebPageProxy::viewIsBecomingInvisible()
 {
     WEBPAGEPROXY_RELEASE_LOG(ViewState, "viewIsBecomingInvisible:");
     protectedLegacyMainFrameProcess()->pageIsBecomingInvisible(m_webPageID);
-    if (auto* drawingAreaProxy = drawingArea())
+    if (RefPtr drawingAreaProxy = drawingArea())
         drawingAreaProxy->viewIsBecomingInvisible();
 
     RefPtr protectedPageClient { pageClient() };

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -672,7 +672,7 @@ static WebCore::FloatBoxExtent floatBoxExtent(UIEdgeInsets insets)
     enclosedInScrollableAncestorView:(BOOL)enclosedInScrollableAncestorView
     sendEvenIfUnchanged:(BOOL)sendEvenIfUnchanged
 {
-    auto drawingArea = _page->drawingArea();
+    RefPtr drawingArea = _page->drawingArea();
     if (!drawingArea)
         return;
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2369,7 +2369,7 @@ void WebViewImpl::viewDidChangeBackingProperties()
         return;
 
     m_colorSpace = nullptr;
-    if (DrawingAreaProxy *drawingArea = m_page->drawingArea())
+    if (RefPtr drawingArea = m_page->drawingArea())
         drawingArea->colorSpaceDidChange();
 }
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -46,7 +46,7 @@ SampleBufferDisplayLayerManager::SampleBufferDisplayLayerManager(GPUProcessConne
 void SampleBufferDisplayLayerManager::didReceiveLayerMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     if (ObjectIdentifier<SampleBufferDisplayLayerIdentifierType>::isValidIdentifier(decoder.destinationID())) {
-        if (auto* layer = m_layers.get(ObjectIdentifier<SampleBufferDisplayLayerIdentifierType>(decoder.destinationID())).get())
+        if (RefPtr layer = m_layers.get(ObjectIdentifier<SampleBufferDisplayLayerIdentifierType>(decoder.destinationID())).get())
             layer->didReceiveMessage(connection, decoder);
     }
 }

--- a/Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.mm
+++ b/Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.mm
@@ -256,7 +256,7 @@ void ARKitInlinePreviewModelPlayerMac::sizeDidChange(WebCore::LayoutSize size)
         if (!strongSelf)
             return;
 
-        auto* drawingArea = page->drawingArea();
+        RefPtr drawingArea = page->drawingArea();
         if (!drawingArea)
             return;
 

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
@@ -52,7 +52,7 @@ RefPtr<LibWebRTCNetworkManager> LibWebRTCNetworkManager::getOrCreate(WebCore::Sc
     if (!document)
         return nullptr;
 
-    auto* networkManager = downcast<LibWebRTCNetworkManager>(document->rtcNetworkManager());
+    RefPtr networkManager = downcast<LibWebRTCNetworkManager>(document->rtcNetworkManager());
     if (!networkManager) {
         auto newNetworkManager = adoptRef(*new LibWebRTCNetworkManager(identifier));
         networkManager = newNetworkManager.ptr();
@@ -111,14 +111,14 @@ void LibWebRTCNetworkManager::StartUpdating()
         if (!protectedThis)
             return;
 
-        auto& monitor = WebProcess::singleton().libWebRTCNetwork().monitor();
+        Ref monitor = WebProcess::singleton().libWebRTCNetwork().monitor();
         if (protectedThis->m_receivedNetworkList) {
             WebCore::LibWebRTCProvider::callOnWebRTCNetworkThread([protectedThis] {
                 protectedThis->SignalNetworksChanged();
             });
-        } else if (monitor.didReceiveNetworkList())
-            protectedThis->networksChanged(monitor.networkList() , monitor.ipv4(), monitor.ipv6());
-        monitor.startUpdating();
+        } else if (monitor->didReceiveNetworkList())
+            protectedThis->networksChanged(monitor->networkList() , monitor->ipv4(), monitor->ipv6());
+        monitor->startUpdating();
     });
 }
 
@@ -208,9 +208,9 @@ void LibWebRTCNetworkManager::signalUsedInterface(String&& name)
     if (!m_allowedInterfaces.add(WTFMove(name)).isNewEntry || m_useMDNSCandidates || !m_enableEnumeratingVisibleNetworkInterfaces)
         return;
 
-    auto& monitor = WebProcess::singleton().libWebRTCNetwork().monitor();
-    if (monitor.didReceiveNetworkList())
-        networksChanged(monitor.networkList() , monitor.ipv4(), monitor.ipv6(), false);
+    Ref monitor = WebProcess::singleton().libWebRTCNetwork().monitor();
+    if (monitor->didReceiveNetworkList())
+        networksChanged(monitor->networkList() , monitor->ipv4(), monitor->ipv6(), false);
 }
 
 void LibWebRTCNetworkManager::networkProcessCrashed()

--- a/Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -85,8 +85,8 @@ Ref<FrameState> toFrameState(const HistoryItem& historyItem)
     frameState->shouldRestoreScrollPosition = historyItem.shouldRestoreScrollPosition();
     frameState->pageScaleFactor = historyItem.pageScaleFactor();
 
-    if (FormData* formData = const_cast<HistoryItem&>(historyItem).formData()) {
-        HTTPBody httpBody = toHTTPBody(*formData);
+    if (RefPtr formData = const_cast<HistoryItem&>(historyItem).formData()) {
+        HTTPBody httpBody = toHTTPBody(formData.releaseNonNull());
         httpBody.contentType = historyItem.formContentType();
 
         frameState->httpBody = WTFMove(httpBody);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -598,7 +598,7 @@ void WebChromeClient::rootFrameAdded(const WebCore::LocalFrame& frame)
     if (!m_page)
         return;
 
-    if (auto* drawingArea = m_page->drawingArea())
+    if (RefPtr drawingArea = m_page->drawingArea())
         drawingArea->addRootFrame(frame.frameID());
 }
 
@@ -607,7 +607,7 @@ void WebChromeClient::rootFrameRemoved(const WebCore::LocalFrame& frame)
     if (!m_page)
         return;
 
-    if (auto* drawingArea = m_page->drawingArea())
+    if (RefPtr drawingArea = m_page->drawingArea())
         drawingArea->removeRootFrame(frame.frameID());
 }
 
@@ -1097,7 +1097,7 @@ GraphicsLayerFactory* WebChromeClient::graphicsLayerFactory() const
     RefPtr page = m_page.get();
     if (!page)
         return nullptr;
-    if (auto drawingArea = page->drawingArea())
+    if (RefPtr drawingArea = page->drawingArea())
         return drawingArea->graphicsLayerFactory();
     return nullptr;
 }
@@ -1280,7 +1280,7 @@ void WebChromeClient::attachViewOverlayGraphicsLayer(GraphicsLayer* graphicsLaye
     if (!page)
         return;
 
-    auto* drawingArea = page->drawingArea();
+    RefPtr drawingArea = page->drawingArea();
     if (!drawingArea)
         return;
 
@@ -1306,7 +1306,7 @@ void WebChromeClient::triggerRenderingUpdate()
     if (!page)
         return;
 
-    if (auto* drawingArea = page->drawingArea())
+    if (RefPtr drawingArea = page->drawingArea())
         drawingArea->triggerRenderingUpdate();
 }
 
@@ -1315,7 +1315,7 @@ bool WebChromeClient::scheduleRenderingUpdate()
     RefPtr page = m_page.get();
     if (!page)
         return false;
-    if (auto* drawingArea = page->drawingArea())
+    if (RefPtr drawingArea = page->drawingArea())
         return drawingArea->scheduleRenderingUpdate();
     return false;
 }
@@ -1326,7 +1326,7 @@ void WebChromeClient::renderingUpdateFramesPerSecondChanged()
     if (!page)
         return;
 
-    if (auto* drawingArea = page->drawingArea())
+    if (RefPtr drawingArea = page->drawingArea())
         drawingArea->renderingUpdateFramesPerSecondChanged();
 }
 
@@ -1356,7 +1356,7 @@ bool WebChromeClient::layerTreeStateIsFrozen() const
     if (!page)
         return false;
 
-    if (auto* drawingArea = page->drawingArea())
+    if (RefPtr drawingArea = page->drawingArea())
         return drawingArea->layerTreeStateIsFrozen();
 
     return false;
@@ -2367,7 +2367,7 @@ void WebChromeClient::resetDamageHistoryForTesting()
     if (!m_page)
         return;
 
-    if (auto* drawingArea = m_page->drawingArea())
+    if (RefPtr drawingArea = m_page->drawingArea())
         drawingArea->resetDamageHistoryForTesting();
 }
 
@@ -2376,7 +2376,7 @@ void WebChromeClient::foreachRegionInDamageHistoryForTesting(Function<void(const
     if (!m_page)
         return;
 
-    if (const auto* drawingArea = m_page->drawingArea())
+    if (const RefPtr drawingArea = m_page->drawingArea())
         drawingArea->foreachRegionInDamageHistoryForTesting(WTFMove(callback));
 }
 #endif

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2011 Nokia Corporation and/or its subsidiary(-ies).
  * Copyright (C) 2012 Company 100, Inc.
  * Copyright (C) 2014-2019 Igalia S.L.
@@ -217,7 +217,7 @@ void LayerTreeHost::flushLayers()
 #endif
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
-    if (auto* drawingArea = m_webPage.drawingArea())
+    if (RefPtr drawingArea = m_webPage.drawingArea())
         drawingArea->dispatchPendingCallbacksAfterEnsuringDrawing();
 #endif
 
@@ -487,13 +487,13 @@ void LayerTreeHost::handleDisplayRefreshMonitorUpdate(bool hasBeenRescheduled)
 
 void LayerTreeHost::willRenderFrame()
 {
-    if (auto* drawingArea = m_webPage.drawingArea())
+    if (RefPtr drawingArea = m_webPage.drawingArea())
         drawingArea->willStartRenderingUpdateDisplay();
 }
 
 void LayerTreeHost::didRenderFrame()
 {
-    if (auto* drawingArea = m_webPage.drawingArea())
+    if (RefPtr drawingArea = m_webPage.drawingArea())
         drawingArea->didCompleteRenderingUpdateDisplay();
     if (auto fps = m_compositor->fps()) {
         if (RefPtr document = m_webPage.corePage()->localTopDocument())

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -203,9 +203,9 @@ void PlatformCALayerRemote::recursiveMarkWillBeDisplayedWithRenderingSuppresion(
         m_properties.backingStoreOrProperties.store->layerWillBeDisplayedWithRenderingSuppression();
 
     for (size_t i = 0; i < m_children.size(); ++i) {
-        PlatformCALayerRemote& child = downcast<PlatformCALayerRemote>(*m_children[i]);
-        ASSERT(child.superlayer() == this);
-        child.recursiveMarkWillBeDisplayedWithRenderingSuppresion();
+        Ref child = downcast<PlatformCALayerRemote>(*m_children[i]);
+        ASSERT(child->superlayer() == this);
+        child->recursiveMarkWillBeDisplayedWithRenderingSuppresion();
     }
 }
 
@@ -251,9 +251,9 @@ void PlatformCALayerRemote::recursiveBuildTransaction(RemoteLayerTreeContext& co
     }
 
     for (size_t i = 0; i < m_children.size(); ++i) {
-        PlatformCALayerRemote& child = downcast<PlatformCALayerRemote>(*m_children[i]);
-        ASSERT(child.superlayer() == this);
-        child.recursiveBuildTransaction(context, transaction);
+        Ref child = downcast<PlatformCALayerRemote>(*m_children[i]);
+        ASSERT(child->superlayer() == this);
+        child->recursiveBuildTransaction(context, transaction);
     }
 
     if (m_maskLayer)
@@ -556,7 +556,7 @@ void PlatformCALayerRemote::setMaskLayer(RefPtr<WebCore::PlatformCALayer>&& laye
 
     PlatformCALayer::setMaskLayer(WTFMove(layer));
 
-    if (auto* layer = maskLayer())
+    if (RefPtr layer = maskLayer())
         m_properties.maskLayerID = layer->layerID();
     else
         m_properties.maskLayerID = { };

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -89,7 +89,7 @@ std::optional<DrawingAreaIdentifier> RemoteLayerTreeContext::drawingAreaIdentifi
 
 std::optional<WebCore::DestinationColorSpace> RemoteLayerTreeContext::displayColorSpace() const
 {
-    if (auto* drawingArea = m_webPage->drawingArea())
+    if (RefPtr drawingArea = m_webPage->drawingArea())
         return drawingArea->displayColorSpace();
     
     return { };
@@ -187,7 +187,7 @@ void RemoteLayerTreeContext::buildTransaction(RemoteLayerTreeTransaction& transa
 
     PlatformCALayerRemote& rootLayerRemote = downcast<PlatformCALayerRemote>(rootLayer);
     transaction.setRootLayerID(rootLayerRemote.layerID());
-    if (auto* rootFrame = WebProcess::singleton().webFrame(rootFrameID))
+    if (RefPtr rootFrame = WebProcess::singleton().webFrame(rootFrameID))
         transaction.setRemoteContextHostedIdentifier(rootFrame->layerHostingContextIdentifier());
 
     m_currentTransaction = &transaction;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -203,7 +203,7 @@ WheelEventHandlingResult RemoteScrollingCoordinator::handleWheelEventForScrollin
 
 void RemoteScrollingCoordinator::scrollingTreeNodeScrollbarVisibilityDidChange(ScrollingNodeID nodeID, ScrollbarOrientation orientation, bool isVisible)
 {
-    auto* frameView = frameViewForScrollingNode(nodeID);
+    RefPtr frameView = frameViewForScrollingNode(nodeID);
     if (!frameView)
         return;
 
@@ -213,7 +213,7 @@ void RemoteScrollingCoordinator::scrollingTreeNodeScrollbarVisibilityDidChange(S
 
 void RemoteScrollingCoordinator::scrollingTreeNodeScrollbarMinimumThumbLengthDidChange(ScrollingNodeID nodeID, ScrollbarOrientation orientation, int minimumThumbLength)
 {
-    auto* frameView = frameViewForScrollingNode(nodeID);
+    RefPtr frameView = frameViewForScrollingNode(nodeID);
     if (!frameView)
         return;
 

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -340,12 +340,12 @@ void TiledCoreAnimationDrawingArea::addCommitHandlers()
         return;
 
     [CATransaction addCommitHandler:[retainedPage = Ref { m_webPage.get() }] {
-        if (auto* drawingArea = dynamicDowncast<TiledCoreAnimationDrawingArea>(retainedPage->drawingArea()))
+        if (RefPtr drawingArea = dynamicDowncast<TiledCoreAnimationDrawingArea>(retainedPage->drawingArea()))
             drawingArea->willStartRenderingUpdateDisplay();
     } forPhase:kCATransactionPhasePreLayout];
 
     [CATransaction addCommitHandler:[retainedPage = Ref { m_webPage.get() }] {
-        if (auto* drawingArea = dynamicDowncast<TiledCoreAnimationDrawingArea>(retainedPage->drawingArea()))
+        if (RefPtr drawingArea = dynamicDowncast<TiledCoreAnimationDrawingArea>(retainedPage->drawingArea()))
             drawingArea->didCompleteRenderingUpdateDisplay();
     } forPhase:kCATransactionPhasePostCommit];
     

--- a/Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,9 +44,8 @@ WebTextTrackRepresentationCocoa::WebTextTrackRepresentationCocoa(WebCore::TextTr
     : WebCore::TextTrackRepresentationCocoa(client)
     , m_mediaElement(WeakPtr { mediaElement })
 {
-    auto* page = mediaElement.document().page();
-    if (page)
-        m_page = WeakPtr { WebPage::fromCorePage(*page) };
+    if (RefPtr page = mediaElement.document().page())
+        m_page = WeakPtr { WebPage::fromCorePage(page.releaseNonNull()) };
 }
 
 void WebTextTrackRepresentationCocoa::update()


### PR DESCRIPTION
#### 3eeb666b390ee047aeb53bf3a4e53a548ac28e0c
<pre>
Adopt more smart pointers for local variables in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=294551">https://bugs.webkit.org/show_bug.cgi?id=294551</a>

Reviewed by Ryosuke Niwa and Chris Dumez.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/296312@main">https://commits.webkit.org/296312@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae5119a5c085156725d15544bf51f14212daa0d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27840 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113388 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58660 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36390 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/82136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111125 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/22613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/97447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/62567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/22027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58125 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/91979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/15639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/116514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35243 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/116514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35617 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/93723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/116514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/35847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13609 "Build is in progress. Recent messages:") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17466 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35142 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/40698 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34876 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38234 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/36543 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->