### PR TITLE
Use official HDR-suppression APIs

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
@@ -62,14 +62,6 @@ DECLARE_SYSTEM_HEADER
 
 #endif // __OBJC__
 
-#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
-typedef NSString * CADynamicRange;
-
-@interface CALayer (Staging_145326880)
-@property (assign) CADynamicRange preferredDynamicRange;
-@end
-#endif // HAVE(SUPPORT_HDR_DISPLAY_APIS)
-
 #else
 
 #ifdef __OBJC__

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformDynamicRangeLimitCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformDynamicRangeLimitCocoa.mm
@@ -26,7 +26,7 @@
 #import "config.h"
 #import "PlatformDynamicRangeLimitCocoa.h"
 
-#import <pal/spi/cocoa/QuartzCoreSPI.h>
+#import <QuartzCore/CALayer.h>
 
 namespace WebCore {
 
@@ -34,20 +34,15 @@ LayerDynamicRangeLimitSetter layerDynamicRangeLimitSetter(PlatformDynamicRangeLi
 {
 #if HAVE(SUPPORT_HDR_DISPLAY_APIS)
     if ([CALayer instancesRespondToSelector:@selector(setPreferredDynamicRange:)]) {
-        // FIXME: Unstage, see follow-up to rdar://145750574
-        static CADynamicRange const WebKitCADynamicRangeStandard = @"standard";
-        static CADynamicRange const WebKitCADynamicRangeConstrainedHigh = @"constrainedHigh";
-        static CADynamicRange const WebKitCADynamicRangeHigh = @"high";
-
         constexpr auto betweenStandardAndConstrained = (PlatformDynamicRangeLimit::standard().value() + PlatformDynamicRangeLimit::constrained().value()) / 2;
         if (platformDynamicRangeLimit.value() < betweenStandardAndConstrained)
-            return [](CALayer *layer) { [layer setPreferredDynamicRange:WebKitCADynamicRangeStandard]; };
+            return [](CALayer *layer) { [layer setPreferredDynamicRange:CADynamicRangeStandard]; };
 
         constexpr auto betweenConstrainedAndHigh = (PlatformDynamicRangeLimit::constrained().value() + PlatformDynamicRangeLimit::noLimit().value()) / 2;
         if (platformDynamicRangeLimit.value() < betweenConstrainedAndHigh)
-            return [](CALayer *layer) { [layer setPreferredDynamicRange:WebKitCADynamicRangeConstrainedHigh]; };
+            return [](CALayer *layer) { [layer setPreferredDynamicRange:CADynamicRangeConstrainedHigh]; };
 
-        return [](CALayer *layer) { [layer setPreferredDynamicRange:WebKitCADynamicRangeHigh]; };
+        return [](CALayer *layer) { [layer setPreferredDynamicRange:CADynamicRangeHigh]; };
     }
 #endif // HAVE(SUPPORT_HDR_DISPLAY_APIS)
     UNUSED_PARAM(platformDynamicRangeLimit);

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -366,8 +366,10 @@ static void* keyValueObservingContext = &keyValueObservingContext;
     [defaultNotificationCenter addObserver:self selector:@selector(_windowDidEnterOrExitFullScreen:) name:NSWindowDidExitFullScreenNotification object:window];
 
     [defaultNotificationCenter addObserver:self selector:@selector(_screenDidChangeColorSpace:) name:NSScreenColorSpaceDidChangeNotification object:nil];
-    [defaultNotificationCenter addObserver:self selector:@selector(_applicationShouldBeginSuppressingHDR:) name:@"NSApplicationShouldBeginSuppressingHighDynamicRangeContentNotification" object:NSApp];
-    [defaultNotificationCenter addObserver:self selector:@selector(_applicationShouldEndSuppressingHDR:) name:@"NSApplicationShouldEndSuppressingHighDynamicRangeContentNotification" object:NSApp];
+#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
+    [defaultNotificationCenter addObserver:self selector:@selector(_applicationShouldBeginSuppressingHDR:) name:NSApplicationShouldBeginSuppressingHighDynamicRangeContentNotification object:NSApp];
+    [defaultNotificationCenter addObserver:self selector:@selector(_applicationShouldEndSuppressingHDR:) name:NSApplicationShouldEndSuppressingHighDynamicRangeContentNotification object:NSApp];
+#endif // HAVE(SUPPORT_HDR_DISPLAY_APIS)
 
     if (_shouldObserveFontPanel) {
         ASSERT(!_isObservingFontPanel);
@@ -543,6 +545,7 @@ static void* keyValueObservingContext = &keyValueObservingContext;
         _impl->screenDidChangeColorSpace();
 }
 
+#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
 - (void)_applicationShouldBeginSuppressingHDR:(NSNotification *)notification
 {
     if (_impl)
@@ -554,6 +557,7 @@ static void* keyValueObservingContext = &keyValueObservingContext;
     if (_impl)
         _impl->applicationShouldSuppressHDR(false);
 }
+#endif // HAVE(SUPPORT_HDR_DISPLAY_APIS)
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {


### PR DESCRIPTION
#### f000f446e0f56e5a5dd6b1c396c6f4bb280ac7ac
<pre>
Use official HDR-suppression APIs
<a href="https://bugs.webkit.org/show_bug.cgi?id=294549">https://bugs.webkit.org/show_bug.cgi?id=294549</a>
<a href="https://rdar.apple.com/149022443">rdar://149022443</a>

Reviewed by Cameron McCormack.

* Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h:
No more need for the in-development names.

* Source/WebCore/platform/graphics/ca/cocoa/PlatformDynamicRangeLimitCocoa.mm:
(WebCore::layerDynamicRangeLimitSetter):
Use [CALayer setPreferredDynamicRange:] now in QuartzCore/CALayer.h.

* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(-[WKWindowVisibilityObserver startObserving:]):
Use NSApplication suppress-HDR notifications; guarded by SUPPORT_HDR_DISPLAY_APIS,
which will only be #defined for the OS versions that support them.

Canonical link: <a href="https://commits.webkit.org/296302@main">https://commits.webkit.org/296302@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b40b5aea20f806ea5252e5d9f055955889ed470

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108021 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27686 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18105 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113231 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58538 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109984 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28381 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36235 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82003 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110969 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22495 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97322 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62435 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21907 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15456 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57978 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91848 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116358 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35092 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25836 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91036 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35468 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93600 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90830 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23164 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35730 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13487 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34991 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40545 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34734 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38092 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36395 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->