### PR TITLE
[Safe CPP] Address Warnings in AudioNodeInput/Output

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioNodeInput.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioNodeInput.cpp
@@ -110,7 +110,7 @@ void AudioNodeInput::disable(AudioNodeOutput* output)
     }
 
     // Propagate disabled state to outputs.
-    node()->disableOutputsIfNecessary();
+    protectedNode()->disableOutputsIfNecessary();
 }
 
 void AudioNodeInput::enable(AudioNodeOutput* output)
@@ -134,12 +134,12 @@ void AudioNodeInput::enable(AudioNodeOutput* output)
     m_disabledOutputs.remove(output);
 
     // Propagate enabled state to outputs.
-    node()->enableOutputsIfNecessary();
+    protectedNode()->enableOutputsIfNecessary();
 }
 
 void AudioNodeInput::didUpdate()
 {
-    node()->checkNumberOfChannelsForInput(this);
+    protectedNode()->checkNumberOfChannelsForInput(this);
 }
 
 void AudioNodeInput::updateInternalBus()
@@ -210,7 +210,7 @@ void AudioNodeInput::sumAllConnections(AudioBus& summingBus, size_t framesToProc
         ASSERT(output);
 
         // Render audio from this output.
-        AudioBus& connectionBus = output->pull(nullptr, framesToProcess);
+        Ref connectionBus = output->pull(nullptr, framesToProcess);
 
         // Sum, with unity-gain.
         summingBus.sumFrom(connectionBus, interpretation);
@@ -232,7 +232,7 @@ AudioBus& AudioNodeInput::pull(AudioBus* inPlaceBus, size_t framesToProcess)
     if (!numberOfRenderingConnections()) {
         // At least, generate silence if we're not connected to anything.
         // FIXME: if we wanted to get fancy, we could propagate a 'silent hint' here to optimize the downstream graph processing.
-        m_internalSummingBus->zero();
+        protectedInternalSummingBus()->zero();
         return m_internalSummingBus;
     }
 

--- a/Source/WebCore/Modules/webaudio/AudioNodeInput.h
+++ b/Source/WebCore/Modules/webaudio/AudioNodeInput.h
@@ -52,6 +52,7 @@ public:
 
     // Can be called from any thread.
     AudioNode* node() const { return m_node.get(); }
+    RefPtr<AudioNode> protectedNode() const { return node(); }
 
     // Must be called with the context's graph lock.
     void connect(AudioNodeOutput*);
@@ -93,6 +94,7 @@ private:
     AudioBus& internalSummingBus();
     void sumAllConnections(AudioBus& summingBus, size_t framesToProcess);
 
+    Ref<AudioBus> protectedInternalSummingBus() { return m_internalSummingBus; }
     Ref<AudioBus> m_internalSummingBus;
 };
 

--- a/Source/WebCore/Modules/webaudio/AudioNodeOutput.h
+++ b/Source/WebCore/Modules/webaudio/AudioNodeOutput.h
@@ -49,7 +49,8 @@ public:
 
     // Can be called from any thread.
     AudioNode* node() const { return m_node.get(); }
-    BaseAudioContext& context() { return m_node->context(); }
+    RefPtr<AudioNode> protectedNode() const { return node(); }
+    BaseAudioContext& context() { return protectedNode()->context(); }
     
     // Causes our AudioNode to process if it hasn't already for this render quantum.
     // It returns the bus containing the processed audio for this output, returning inPlaceBus if in-place processing was possible.

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -128,9 +128,6 @@ Modules/webaudio/AudioContext.cpp
 Modules/webaudio/AudioDestinationNode.cpp
 Modules/webaudio/AudioListener.cpp
 Modules/webaudio/AudioNode.cpp
-Modules/webaudio/AudioNodeInput.cpp
-Modules/webaudio/AudioNodeOutput.cpp
-Modules/webaudio/AudioNodeOutput.h
 Modules/webaudio/AudioParam.cpp
 Modules/webaudio/AudioScheduledSourceNode.cpp
 Modules/webaudio/AudioSummingJunction.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -53,8 +53,6 @@ Modules/webaudio/AudioBuffer.cpp
 Modules/webaudio/AudioBufferSourceNode.cpp
 Modules/webaudio/AudioDestinationNode.cpp
 Modules/webaudio/AudioNode.cpp
-Modules/webaudio/AudioNodeInput.cpp
-Modules/webaudio/AudioNodeOutput.cpp
 Modules/webaudio/AudioParam.cpp
 Modules/webaudio/AudioWorkletGlobalScope.cpp
 Modules/webaudio/AudioWorkletNode.cpp


### PR DESCRIPTION
#### c6bc88b0d7e07f84b1b11ff5dbe63a125ac985f4
<pre>
[Safe CPP] Address Warnings in AudioNodeInput/Output
<a href="https://bugs.webkit.org/show_bug.cgi?id=294555">https://bugs.webkit.org/show_bug.cgi?id=294555</a>
<a href="https://rdar.apple.com/problem/153530833">rdar://problem/153530833</a>

Reviewed by NOBODY (OOPS!).

Address Safe CPP warnings AudioNodeInput and AudioNodeOutput.

* Source/WebCore/Modules/webaudio/AudioNodeInput.cpp:
(WebCore::AudioNodeInput::disable):
(WebCore::AudioNodeInput::enable):
(WebCore::AudioNodeInput::didUpdate):
(WebCore::AudioNodeInput::sumAllConnections):
(WebCore::AudioNodeInput::pull):
* Source/WebCore/Modules/webaudio/AudioNodeInput.h:
* Source/WebCore/Modules/webaudio/AudioNodeOutput.cpp:
(WebCore::AudioNodeOutput::setNumberOfChannels):
(WebCore::AudioNodeOutput::propagateChannelCount):
(WebCore::AudioNodeOutput::pull):
(WebCore::AudioNodeOutput::disconnectAllParams):
* Source/WebCore/Modules/webaudio/AudioNodeOutput.h:
(WebCore::AudioNodeOutput::protectedNode const):
(WebCore::AudioNodeOutput::context):
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6bc88b0d7e07f84b1b11ff5dbe63a125ac985f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108191 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27854 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18274 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113402 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58677 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110154 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28554 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36405 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82147 "Failure limit exceed. At least found 325 new test failures: fast/history/page-cache-running-audiocontext.html fast/mediastream/audio-unit-reconfigure.html fast/mediastream/getUserMedia-webaudio.html fast/mediastream/media-devices-enumerate-devices.html fast/mediastream/mediastreamtrack-audio-clone.html fast/mediastream/mediastreamtrack-audio-mute.html http/wpt/mediarecorder/MediaRecorder-dataavailable.html http/wpt/mediarecorder/MediaRecorder-mock-dataavailable.html http/wpt/mediarecorder/MediaRecorder-onremovetrack.html http/wpt/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-postmessage-message-port.https.html ... (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111139 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22625 "Found 1 new test failure: fast/filter-image/clipped-filter.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97460 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62578 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22039 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15596 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58139 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91991 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15652 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116528 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35257 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25963 "Found 60 new test failures: accessibility/mac/element-focus.html fast/history/page-cache-closed-audiocontext.html fast/history/page-cache-subframes-with-provisional-load.html fast/mediastream/audio-session-category-capture-audio-context.html fast/mediastream/audio-unit-reconfigure.html fast/mediastream/getUserMedia-webaudio.html fast/mediastream/media-element-current-time.html fast/mediastream/mediastreamtrack-audio-clone.html fast/mediastream/mediastreamtrack-audio-mute.html fast/mediastream/mediastreamtrack-video-zoom.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91175 "Failure limit exceed. At least found 305 new test failures: fast/history/page-cache-closed-audiocontext.html fast/history/page-cache-running-audiocontext.html fast/mediastream/audio-unit-reconfigure.html fast/mediastream/getUserMedia-webaudio.html fast/mediastream/media-devices-enumerate-devices.html fast/mediastream/mediastreamtrack-audio-clone.html fast/mediastream/mediastreamtrack-audio-mute.html fast/mediastream/mock-media-source-webaudio.html http/tests/security/webaudio-render-remote-audio-allowed-crossorigin-redirect.html http/wpt/mediarecorder/MediaRecorder-mock-dataavailable.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35631 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93736 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90970 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35860 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13622 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31038 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35156 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40712 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34890 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38248 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36557 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->