### PR TITLE
AnimatedPoints should be an alias for points

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/animatedPoints-non-animated-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/animatedPoints-non-animated-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL animatedPoints represents non-animated value assert_equals: expected 20 but got 170
+PASS animatedPoints represents non-animated value
 

--- a/Source/WebCore/svg/SVGPolyElement.h
+++ b/Source/WebCore/svg/SVGPolyElement.h
@@ -33,8 +33,13 @@ class SVGPolyElement : public SVGGeometryElement {
 public:
     const SVGPointList& points() const { return m_points->currentValue(); }
 
+    // per SVG 2 https://svgwg.org/svg2-draft/shapes.html#InterfaceSVGAnimatedPoints
+    // The points and animatedPoints IDL attributes represent the current
+    // non-animated value of the reflected attribute.
+    // On getting points or animatedPoints, an SVGPointList object is returned that
+    // reflects the base value of the reflected attribute.
     SVGPointList& points() { return m_points->baseVal(); }
-    SVGPointList& animatedPoints() { return *m_points->animVal(); }
+    SVGPointList& animatedPoints() { return m_points->baseVal(); }
 
     size_t approximateMemoryCost() const override;
 


### PR DESCRIPTION
#### 11e224445404575c13fb2df5747c3201ba1a215c
<pre>
AnimatedPoints should be an alias for points
<a href="https://bugs.webkit.org/show_bug.cgi?id=294554">https://bugs.webkit.org/show_bug.cgi?id=294554</a>
<a href="https://rdar.apple.com/problem/153535301">rdar://problem/153535301</a>

Reviewed by NOBODY (OOPS!).

This fixes a WPT failure.
<a href="http://wpt.live/svg/shapes/animatedPoints-non-animated.html">http://wpt.live/svg/shapes/animatedPoints-non-animated.html</a>
The specs says that animatedPoints &quot;is simply an alias for points.&quot;

* Source/WebCore/svg/SVGPolyElement.h:
(WebCore::SVGPolyElement::animatedPoints):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11e224445404575c13fb2df5747c3201ba1a215c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108032 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27697 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18116 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113242 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58549 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109995 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36247 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82014 "Found 4 new test failures: imported/w3c/web-platform-tests/svg/animations/additive-type-by-animation.html imported/w3c/web-platform-tests/svg/animations/animate-css-xml-attributeType.html imported/w3c/web-platform-tests/svg/animations/svgpointlist-animation-1.html imported/w3c/web-platform-tests/svg/animations/svgpointlist-animation-2.html (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110980 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22505 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97332 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62446 "Found 2 new API test failures: /WPE/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies, /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21917 "Found 4 new test failures: imported/w3c/web-platform-tests/svg/animations/additive-type-by-animation.html imported/w3c/web-platform-tests/svg/animations/animate-css-xml-attributeType.html imported/w3c/web-platform-tests/svg/animations/svgpointlist-animation-1.html imported/w3c/web-platform-tests/svg/animations/svgpointlist-animation-2.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15466 "Found 4 new test failures: imported/w3c/web-platform-tests/svg/animations/additive-type-by-animation.html imported/w3c/web-platform-tests/svg/animations/animate-css-xml-attributeType.html imported/w3c/web-platform-tests/svg/animations/svgpointlist-animation-1.html imported/w3c/web-platform-tests/svg/animations/svgpointlist-animation-2.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57988 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91858 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15531 "Found 4 new test failures: imported/w3c/web-platform-tests/svg/animations/additive-type-by-animation.html imported/w3c/web-platform-tests/svg/animations/animate-css-xml-attributeType.html imported/w3c/web-platform-tests/svg/animations/svgpointlist-animation-1.html imported/w3c/web-platform-tests/svg/animations/svgpointlist-animation-2.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116369 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35103 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25848 "Found 4 new test failures: imported/w3c/web-platform-tests/svg/animations/additive-type-by-animation.html imported/w3c/web-platform-tests/svg/animations/animate-css-xml-attributeType.html imported/w3c/web-platform-tests/svg/animations/svgpointlist-animation-1.html imported/w3c/web-platform-tests/svg/animations/svgpointlist-animation-2.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91046 "Found 4 new test failures: imported/w3c/web-platform-tests/svg/animations/additive-type-by-animation.html imported/w3c/web-platform-tests/svg/animations/animate-css-xml-attributeType.html imported/w3c/web-platform-tests/svg/animations/svgpointlist-animation-1.html imported/w3c/web-platform-tests/svg/animations/svgpointlist-animation-2.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35479 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93610 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90840 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35741 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13497 "Found 4 new test failures: imported/w3c/web-platform-tests/svg/animations/additive-type-by-animation.html imported/w3c/web-platform-tests/svg/animations/animate-css-xml-attributeType.html imported/w3c/web-platform-tests/svg/animations/svgpointlist-animation-1.html imported/w3c/web-platform-tests/svg/animations/svgpointlist-animation-2.html (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30954 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Compiled WebKit (cancelled)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35002 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40557 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34745 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38103 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36406 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->