### PR TITLE
[scroll-animations] https://scroll-driven-animations.style/demos/shrinking-header-shadow/css/ does not work

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animate-font-size-with-margin-override-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animate-font-size-with-margin-override-expected.html
@@ -1,0 +1,12 @@
+<style>
+h2 {
+    margin: 0;
+    background-color: lightblue;
+    font-size: 30px;
+}
+div { border: 2px solid green; }
+</style>
+
+<div>
+<h2>This should not have any margins.</h2>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animate-font-size-with-margin-override-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animate-font-size-with-margin-override-ref.html
@@ -1,0 +1,12 @@
+<style>
+h2 {
+    margin: 0;
+    background-color: lightblue;
+    font-size: 30px;
+}
+div { border: 2px solid green; }
+</style>
+
+<div>
+<h2>This should not have any margins.</h2>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animate-font-size-with-margin-override.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animate-font-size-with-margin-override.html
@@ -1,0 +1,16 @@
+<link rel="match" href="animate-font-size-with-margin-override-ref.html">
+<style>
+@keyframes anim {
+    from, to { font-size: 30px; }
+}
+h2 {
+    margin: 0;
+    background-color: lightblue;
+    animation: anim both;
+}
+div { border: 2px solid green; }
+</style>
+
+<div>
+<h2>This should not have any margins.</h2>
+</div>

--- a/Source/WebCore/style/PropertyCascade.h
+++ b/Source/WebCore/style/PropertyCascade.h
@@ -115,6 +115,7 @@ private:
     static void setPropertyInternal(Property&, CSSPropertyID, CSSValue&, const MatchedProperties&, CascadeLevel);
 
     bool hasProperty(CSSPropertyID, const CSSValue&);
+    bool mayOverrideExistingProperty(CSSPropertyID, const CSSValue&);
 
     unsigned logicalGroupPropertyIndex(CSSPropertyID) const;
     void setLogicalGroupPropertyIndex(CSSPropertyID, unsigned);


### PR DESCRIPTION
#### 3b8072782a834ba1f39f32ee9a55b40fb7adbf97
<pre>
[scroll-animations] <a href="https://scroll-driven-animations.style/demos/shrinking-header-shadow/css/">https://scroll-driven-animations.style/demos/shrinking-header-shadow/css/</a> does not work
<a href="https://bugs.webkit.org/show_bug.cgi?id=284527">https://bugs.webkit.org/show_bug.cgi?id=284527</a>
<a href="https://rdar.apple.com/141356000">rdar://141356000</a>

Reviewed by Antoine Quint.

After applyin animated properties we re-apply any propeties that might override them. In this case we re-apply
margin properties for &lt;h2&gt; because their UA stylesheet value uses em units which depend on the animated font-heighr
property. However author style overrides this value but that fails to happen because logical/physical property mismatch.

* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animate-font-size-with-margin-override-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animate-font-size-with-margin-override-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animate-font-size-with-margin-override.html: Added.
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::mayOverrideExistingProperty):

Factor into a separate function.
Move the test for logical property group here so it happens before the test for animated properties where we bail out.

(WebCore::Style::PropertyCascade::addMatch):
* Source/WebCore/style/PropertyCascade.h:

Canonical link: <a href="https://commits.webkit.org/296304@main">https://commits.webkit.org/296304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0453396c77048452e195204027f26b41f28f9db2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108038 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18122 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113248 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58555 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110001 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28398 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36253 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82019 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110986 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22511 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97337 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62451 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21923 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15471 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57994 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91863 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15536 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116375 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35109 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25852 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91049 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35485 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93615 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90843 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23166 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35745 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13502 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35008 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40563 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34751 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38109 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36412 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->