### PR TITLE
Remove some more code for macOS 13 Ventura and earlier

### DIFF
--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -595,11 +595,6 @@
 #define HAVE_GCCONTROLLER_HID_DEVICE_CHECK 1
 #endif
 
-// Newer versions no longer square continuous haptics (rdar://110338126).
-#if (PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED < 140000)
-#define HAVE_GCCONTROLLER_REQUIRING_HAPTICS_SQUARING 1
-#endif
-
 #if PLATFORM(COCOA)
 #define HAVE_INCREMENTAL_PDF_APIS 1
 #endif
@@ -815,10 +810,6 @@
 #if PLATFORM(IOS) || PLATFORM(MACCATALYST) || PLATFORM(MAC) || PLATFORM(VISION) \
     || (PLATFORM(APPLETV) && __TV_OS_VERSION_MIN_REQUIRED >= 170000)
 #define HAVE_AVCAPTUREDEVICE 1
-#endif
-
-#if (PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED < 140000)
-#define HAVE_REQUIRE_MICROPHONE_CAPTURE_IN_UIPROCESS 1
 #endif
 
 #if PLATFORM(MAC) && defined __has_include && __has_include(<CoreFoundation/CFPriv.h>)

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -46,13 +46,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(GameControllerHapticEffect);
 
 static double magnitudeToIntensity(double magnitude)
 {
-    auto intensity = std::clamp<double>(magnitude, 0, 1);
-#if HAVE(GCCONTROLLER_REQUIRING_HAPTICS_SQUARING)
-    // Older versions of GameController didn't use the intensity as-is and required the values to
-    // be squared. Without this, values below 0.1 would end up not triggering any gamepad vibration.
-    intensity = std::sqrt(intensity);
-#endif
-    return intensity;
+    return std::clamp<double>(magnitude, 0, 1);
 }
 
 RefPtr<GameControllerHapticEffect> GameControllerHapticEffect::create(GameControllerHapticEngines& engines, GamepadHapticEffectType type, const GamepadEffectParameters& parameters)

--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -1,4 +1,4 @@
-; Copyright (C) 2010-2024 Apple Inc. All rights reserved.
+; Copyright (C) 2010-2025 Apple Inc. All rights reserved.
 ;
 ; Redistribution and use in source and binary forms, with or without
 ; modification, are permitted provided that the following conditions
@@ -1048,11 +1048,11 @@
     (global-name "com.apple.coremedia.endpointremotecontrolsession.xpc")
     (global-name "com.apple.coremedia.routediscoverer.xpc")
     (global-name "com.apple.coremedia.samplebufferconsumer.xpc")
-#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 130000
+#if PLATFORM(MAC)
     (global-name "com.apple.coremedia.shaphelper.xpc")
 #endif
     (global-name "com.apple.coremedia.volumecontroller.xpc")
-#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 130000
+#if PLATFORM(MAC)
     (global-name "com.apple.timesync.expositor")
     (global-name "com.apple.timesync.manager")
     (global-name "com.apple.timesync.ptp.manager")

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -116,12 +116,6 @@ bool defaultAppleMailPaginationQuirkEnabled()
 
 bool defaultCaptureAudioInGPUProcessEnabled()
 {
-#if HAVE(REQUIRE_MICROPHONE_CAPTURE_IN_UIPROCESS)
-    // Newer versions can capture microphone in GPUProcess.
-    if (!WTF::MacApplication::isSafari())
-        return false;
-#endif
-
 #if ENABLE(GPU_PROCESS_BY_DEFAULT)
     return true;
 #else

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -168,11 +168,7 @@
         (deny (with message "IOAccelerator")
             iokit-async-external-method
             iokit-external-method)
-        (allow iokit-async-external-method
-#if __MAC_OS_X_VERSION_MIN_REQUIRED < 130000
-            (iokit-method-number 0 47 48)
-#endif
-        )
+        (allow iokit-async-external-method)
         (allow iokit-external-method)
         (allow iokit-external-trap)
     ))
@@ -182,16 +178,8 @@
         (deny (with message "IOSurfaceRootUserClient")
             iokit-async-external-method
             iokit-external-method)
-        (allow iokit-async-external-method
-#if __MAC_OS_X_VERSION_MIN_REQUIRED < 130000
-            (iokit-method-number 17 40)
-#endif
-        )
-        (allow iokit-external-method
-#if __MAC_OS_X_VERSION_MIN_REQUIRED < 130000
-            (iokit-method-number 0 1 2 3 9 10 11 12 13 14 15 20 23 27 31 32 34 35 36 38 39 43 44)
-#endif
-        )
+        (allow iokit-async-external-method)
+        (allow iokit-external-method)
         (allow iokit-external-trap)
     ))
 
@@ -2022,13 +2010,13 @@
 
 (deny file-read* (with no-report)
     (home-literal "/Library/Preferences/com.apple.CFNetwork.plist")
-#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 130000
+#if PLATFORM(MAC)
     (home-literal "/Library/Preferences/com.apple.networkd.plist")
     (literal "/Library/Preferences/com.apple.networkd.plist")
 #endif
 )
 
-#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 140000
+#if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 140000
 (with-filter (webcontent-process-launched)
     (deny mach-task-special-port-get (with telemetry))
     (deny mach-task-special-port-set (with telemetry)))


### PR DESCRIPTION
#### 6fd6379fdedebc911a7a2a546afa79b010a81a1a
<pre>
Remove some more code for macOS 13 Ventura and earlier
<a href="https://bugs.webkit.org/show_bug.cgi?id=294560">https://bugs.webkit.org/show_bug.cgi?id=294560</a>

Reviewed by Per Arne Vollan.

A follow-up to 296269@main to tackle a couple more ambiguous cases and
some that were simply missed.

Canonical link: <a href="https://commits.webkit.org/296298@main">https://commits.webkit.org/296298@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e6288c0a146a2be3c49daad27396079f5c449ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108040 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27705 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18124 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113250 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58557 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110003 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28400 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36255 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82021 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110988 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22512 "Found 2 new test failures: fast/filter-image/clipped-filter.html media/video-unmuted-after-play-holds-sleep-assertion.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97338 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62453 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21924 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15477 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57996 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/100643 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91864 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15537 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116377 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/106602 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35111 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25855 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91053 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35487 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93616 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90847 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35747 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13503 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17459 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35010 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40565 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/130891 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34753 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35538 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38111 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36414 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->