### PR TITLE
Call owner document's checkCompleted in WebRemoteFrameClient::frameDetached

### DIFF
--- a/LayoutTests/http/tests/site-isolation/resources/update-background.html
+++ b/LayoutTests/http/tests/site-isolation/resources/update-background.html
@@ -21,14 +21,8 @@
         iframe.src = 'http://127.0.0.1:8000/site-isolation/resources/localhostiframe.html';
         iframe.onload = ()=> {
             document.body.style = 'background-color:black';
-
-            // FIXME: Removing this setTimeout makes http/tests/site-isolation/edge-sampling-commit-root-frame-load.html
-            // never finish with site isolation off but not on.  Something seems broken
-            // related to WebPage::didFinishLoadInAnotherProcess.  Fix it and remove this setTimeout.
-            setTimeout(()=>{
-                iframe.parentNode.removeChild(iframe);
-                setTimeout(onload, 100)
-            }, 100);
+            iframe.parentNode.removeChild(iframe);
+            setTimeout(onload, 100)
         }
         document.body.appendChild(iframe);
     }

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1439,7 +1439,7 @@ public:
     void incrementLoadEventDelayCount() { ++m_loadEventDelayCount; }
     void decrementLoadEventDelayCount();
     bool isDelayingLoadEvent() const { return m_loadEventDelayCount; }
-    void checkCompleted();
+    WEBCORE_EXPORT void checkCompleted();
 
 #if ENABLE(IOS_TOUCH_EVENTS)
 #include <WebKitAdditions/DocumentIOS.h>

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -31,6 +31,7 @@
 #include "WebPageProxyMessages.h"
 #include <WebCore/FrameLoadRequest.h>
 #include <WebCore/FrameTree.h>
+#include <WebCore/HTMLFrameOwnerElement.h>
 #include <WebCore/HitTestResult.h>
 #include <WebCore/PolicyChecker.h>
 #include <WebCore/RemoteFrame.h>
@@ -53,11 +54,16 @@ void WebRemoteFrameClient::frameDetached()
         return;
     }
 
+    RefPtr ownerElement = coreFrame->ownerElement();
+
     if (RefPtr parent = coreFrame->tree().parent()) {
         coreFrame->tree().detachFromParent();
         parent->tree().removeChild(*coreFrame);
     }
     m_frame->invalidate();
+
+    if (ownerElement)
+        ownerElement->protectedDocument()->checkCompleted();
 }
 
 void WebRemoteFrameClient::sizeDidChange(IntSize size)


### PR DESCRIPTION
#### d323b2fc4cd2686c828bd8976fae6ec2d2b6311c
<pre>
Call owner document&apos;s checkCompleted in WebRemoteFrameClient::frameDetached
<a href="https://bugs.webkit.org/show_bug.cgi?id=294569">https://bugs.webkit.org/show_bug.cgi?id=294569</a>

Reviewed by Charlie Wolfe.

If we remove a RemoteFrame from the tree before or during the load event, then by the time
WebPage::didFinishLoadInAnotherProcess is called there is no more frame to be found so we
do nothing and the load event of the parent is never called.  To fix this, when removing a
LocalFrame, call the parent document&apos;s checkCompleted function if it is in the same process.
Document::checkCompleted is intended to be able to be called multiple times, and if it is
not completed loading yet it does nothing.

* LayoutTests/http/tests/site-isolation/resources/update-background.html:
* Source/WebCore/dom/Document.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp:
(WebKit::WebRemoteFrameClient::frameDetached):

Canonical link: <a href="https://commits.webkit.org/296294@main">https://commits.webkit.org/296294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7faa3bb81928380fd68440e9255bddf8bc5e7f5c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108078 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27743 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18162 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113288 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58585 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110041 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28438 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36292 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/82062 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111026 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/22535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97368 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62494 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21950 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15503 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58034 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91892 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/15567 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116413 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35147 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25879 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91082 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35522 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93646 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90877 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35772 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13533 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17457 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35047 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40601 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34785 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38143 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36448 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->