### PR TITLE
Make subpixel-positioned iframes paint and hit-test correctly

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7829,9 +7829,10 @@ media/webkit-media-controls-not-visible-after-exiting-fullscreen.html [ Skip ]
 
 webkit.org/b/279297 fast/block/float/float-avoider-with-negative-margin.html [ ImageOnlyFailure ]
 
-# webkit.org/b/280685 imported/w3c/web-platform-tests/css/selectors/featureless-004/5.html are failures.
-imported/w3c/web-platform-tests/css/selectors/featureless-004.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/selectors/featureless-005.html [ ImageOnlyFailure ]
+# imported/w3c/web-platform-tests/css/selectors/featureless-004/5.html are failures.
+webkit.org/b/280685 imported/w3c/web-platform-tests/css/selectors/featureless-004.html [ ImageOnlyFailure ]
+webkit.org/b/280685 imported/w3c/web-platform-tests/css/selectors/featureless-005.html [ ImageOnlyFailure ]
+webkit.org/b/294638 imported/w3c/web-platform-tests/css/selectors/focus-visible-018-2.html [ Skip ]
 
 # Skip large regular expression tests on Debug to avoid timeout.
 [ Debug ] fast/regex/slow.html [ Skip ]

--- a/LayoutTests/compositing/iframes/hidpi-iframe-subpixel-compositing-expected.html
+++ b/LayoutTests/compositing/iframes/hidpi-iframe-subpixel-compositing-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        div {
+            width: 300px;
+            height: 150px;
+            margin: 20.33px;
+            border: 2px solid black;
+            background-color: green;
+        }
+    </style>
+</head>
+<body>
+    <p>There should be no gap between the black border and the green fill. The border should be a consistent width on all sides.</p>
+    <div></div>
+</body>
+</html>

--- a/LayoutTests/compositing/iframes/hidpi-iframe-subpixel-compositing.html
+++ b/LayoutTests/compositing/iframes/hidpi-iframe-subpixel-compositing.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        iframe {
+            display: block;
+            width: 300px;
+            height: 150px;
+            margin: 20.33px;
+            border: 2px solid black;
+        }
+    </style>
+</head>
+<body>
+    <p>There should be no gap between the black border and the green fill. The border should be a consistent width on all sides.</p>
+    <iframe srcdoc="
+    <style>
+        html, body {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+            background-color: green;
+        }
+        
+        div {
+            width: 10px;
+            height: 10px;
+            will-change: transform;
+        }
+    </style>
+    <body>
+        <div></div>
+    </body>
+    "></iframe>
+</body>
+</html>

--- a/LayoutTests/fast/frames/hidpi-iframe-subpixel-hit-test-expected.txt
+++ b/LayoutTests/fast/frames/hidpi-iframe-subpixel-hit-test-expected.txt
@@ -1,0 +1,23 @@
+
+Tests that hit-testing takes subpixel iframe offsets into account
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+top
+PASS hitElement.tagName is "IFRAME"
+FAIL hitElement.tagName should be BODY. Was IFRAME.
+bottom
+PASS hitElement.tagName is "IFRAME"
+PASS hitElement.tagName is "BODY"
+left
+PASS hitElement.tagName is "IFRAME"
+FAIL hitElement.tagName should be BODY. Was IFRAME.
+right
+PASS hitElement.tagName is "IFRAME"
+PASS hitElement.tagName is "BODY"
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/frames/hidpi-iframe-subpixel-hit-test.html
+++ b/LayoutTests/fast/frames/hidpi-iframe-subpixel-hit-test.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            margin: 0;
+        }
+
+        iframe {
+            width: 300px;
+            height: 150px;
+            margin: 20.33px;
+            border: none;
+            outline: 4px solid black;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script>
+        
+        let hitElement;
+        window.addEventListener('load', () => {
+            description('Tests that hit-testing takes subpixel iframe offsets into account');
+
+            const iframe = document.getElementsByTagName('iframe')[0];
+            const bounds = iframe.getBoundingClientRect();
+            
+            debug('top');
+            hitElement = document.elementFromPoint(bounds.x + 10, bounds.y + 0.1);
+            shouldBe('hitElement.tagName', '"IFRAME"');
+
+            // The 0.6 is because some browsers use a pixel-sized area hit-test.
+            hitElement = document.elementFromPoint(bounds.x + 10, bounds.y - 0.6);
+            shouldBe('hitElement.tagName', '"BODY"');
+
+            debug('bottom');
+            hitElement = document.elementFromPoint(bounds.x + 10, bounds.bottom - 0.1);
+            shouldBe('hitElement.tagName', '"IFRAME"');
+
+            hitElement = document.elementFromPoint(bounds.x + 10, bounds.bottom + 0.1);
+            shouldBe('hitElement.tagName', '"BODY"');
+
+            debug('left');
+            hitElement = document.elementFromPoint(bounds.x + 0.1, bounds.y + 10);
+            shouldBe('hitElement.tagName', '"IFRAME"');
+
+            // The 0.6 is because some browsers use a pixel-sized area hit-test.
+            hitElement = document.elementFromPoint(bounds.x - 0.6, bounds.y + 10);
+            shouldBe('hitElement.tagName', '"BODY"');
+
+            debug('right');
+            hitElement = document.elementFromPoint(bounds.right - 0.1, bounds.y + 10);
+            shouldBe('hitElement.tagName', '"IFRAME"');
+
+            hitElement = document.elementFromPoint(bounds.right + 0.1, bounds.y + 10);
+            shouldBe('hitElement.tagName', '"BODY"');
+        }, false);
+    </script>
+</head>
+<body>
+    <iframe srcdoc="
+    <style>
+        html, body {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+        }
+        div {
+            width: 100%;
+            height: 100%;
+            background-color: green;
+        }
+    </style>
+    <body>
+        <div></div>
+    </body>
+    "></iframe>
+<div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/fast/frames/hidpi-iframe-subpixel-painting-expected.html
+++ b/LayoutTests/fast/frames/hidpi-iframe-subpixel-painting-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        div {
+            width: 300px;
+            height: 150px;
+            margin: 20.33px;
+            border: 4px solid black;
+            background-color: green;
+        }
+    </style>
+</head>
+<body>
+    <p>There should be no gap between the black border and the green fill</p>
+    <div></div>
+</body>
+</html>

--- a/LayoutTests/fast/frames/hidpi-iframe-subpixel-painting.html
+++ b/LayoutTests/fast/frames/hidpi-iframe-subpixel-painting.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        iframe {
+            display: block;
+            width: 300px;
+            height: 150px;
+            margin: 20.33px;
+            border: 4px solid black;
+        }
+    </style>
+</head>
+<body>
+    <p>There should be no gap between the black border and the green fill</p>
+    <iframe srcdoc="
+    <style>
+        html, body {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+        }
+        div {
+            width: 100%;
+            height: 100%;
+            background-color: green;
+        }
+    </style>
+    <body>
+        <div></div>
+    </body>
+    "></iframe>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/elementFromPoint-subpixel-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/elementFromPoint-subpixel-expected.txt
@@ -1,8 +1,6 @@
 
-FAIL Hit test top left corner of box assert_equals: expected Element node <div class="box" id="box">
-      <div class="child"></div... but got Element node <div class="map"></div>
+PASS Hit test top left corner of box
 PASS Hit test top right corner of box
-FAIL Hit test bottom left corner of box assert_equals: expected Element node <div class="box" id="box">
-      <div class="child"></div... but got Element node <div class="map"></div>
+PASS Hit test bottom left corner of box
 PASS Hit test lower left corner of box
 

--- a/LayoutTests/transforms/3d/hit-testing/rotated-hit-test-2-expected.txt
+++ b/LayoutTests/transforms/3d/hit-testing/rotated-hit-test-2-expected.txt
@@ -1,4 +1,4 @@
-Element at 56, 100 has id "container": PASS
+Element at 55, 100 has id "container": PASS
 Element at 57, 100 has id "target": PASS
 Element at 100, 100 has id "target": PASS
 Element at 195, 100 has id "target": PASS

--- a/LayoutTests/transforms/3d/hit-testing/rotated-hit-test-2.html
+++ b/LayoutTests/transforms/3d/hit-testing/rotated-hit-test-2.html
@@ -9,7 +9,7 @@
       height: 200px;
       margin: 50px;
       border: 1px solid black;
-      -webkit-perspective: 500px;
+      perspective: 500px;
     }
 
     .box {
@@ -21,8 +21,8 @@
     }
 
     #target {
-      -webkit-transform-origin: 10% 50%;
-      -webkit-transform: rotateY(45deg);
+      transform-origin: 10% 50%;
+      transform: rotateY(45deg);
     }
 
     .box:hover {
@@ -32,7 +32,7 @@
   <script src="resources/hit-test-utils.js"></script>
   <script>
       var hitTestData = [
-        { 'point': [56, 100], 'target' : 'container' },
+        { 'point': [55, 100], 'target' : 'container' },
         { 'point': [57, 100], 'target' : 'target' },
         { 'point': [100, 100], 'target' : 'target' },
         { 'point': [195, 100], 'target' : 'target' },

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -1860,10 +1860,15 @@ void EventHandler::autoHideCursorTimerFired()
 
 static LayoutPoint documentPointForWindowPoint(LocalFrame& frame, const IntPoint& windowPoint)
 {
-    auto* view = frame.view();
-    // FIXME: Is it really OK to use the wrong coordinates here when view is 0?
-    // Historically the code would just crash; this is clearly no worse than that.
-    return view ? view->windowToContents(windowPoint) : windowPoint;
+    RefPtr view = frame.view();
+    if (!view) {
+        // FIXME: Is it really OK to use the wrong coordinates here when view is 0?
+        // Historically the code would just crash; this is clearly no worse than that.
+        return windowPoint;
+    }
+
+    auto result = view->windowToContents(FloatPoint { windowPoint });
+    return LayoutPoint { result };
 }
 
 std::optional<RemoteUserInputEventData> EventHandler::userInputEventDataForRemoteFrame(const RemoteFrame* remoteFrame, const IntPoint& pointInFrame)

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
@@ -171,7 +171,8 @@ EventTrackingRegions ScrollingCoordinator::absoluteEventTrackingRegionsForFrame(
 
         EventTrackingRegions subframeRegion = absoluteEventTrackingRegionsForFrame(*localSubframe);
         // Map from the frame document to our document.
-        IntPoint offset = subframeView->contentsToContainingViewContents(IntPoint());
+        // Event regions are integral, and can't represent subpixel frame positions.
+        auto offset = subframeView->contentsToContainingViewContents(IntPoint());
 
         // FIXME: this translation ignores non-trival transforms on the frame.
         subframeRegion.translate(toIntSize(offset));

--- a/Source/WebCore/rendering/HitTestLocation.cpp
+++ b/Source/WebCore/rendering/HitTestLocation.cpp
@@ -28,7 +28,7 @@ HitTestLocation::HitTestLocation() = default;
 
 HitTestLocation::HitTestLocation(const LayoutPoint& point)
     : m_point(point)
-    , m_boundingBox(LayoutRect { flooredIntPoint(point), LayoutSize { 1, 1 } })
+    , m_boundingBox(LayoutRect { point, LayoutSize { 1, 1 } })
     , m_transformedPoint(point)
     , m_transformedRect(m_boundingBox)
 {
@@ -93,7 +93,7 @@ void HitTestLocation::move(const LayoutSize& offset)
     m_point.move(offset);
     m_transformedPoint.move(offset);
     m_transformedRect.move(offset);
-    m_boundingBox = enclosingIntRect(m_transformedRect.boundingBox());
+    m_boundingBox = LayoutRect { m_transformedRect.boundingBox() };
 }
 
 template<typename RectType>

--- a/Source/WebCore/rendering/HitTestingTransformState.cpp
+++ b/Source/WebCore/rendering/HitTestingTransformState.cpp
@@ -74,4 +74,13 @@ LayoutRect HitTestingTransformState::boundsOfMappedArea() const
     return identity.clampedBoundsOfProjectedQuad(m_lastPlanarArea);
 }
 
+LayoutRect HitTestingTransformState::boundsOfMappedQuad() const
+{
+    if (auto inverse = m_accumulatedTransform.inverse())
+        return inverse.value().clampedBoundsOfProjectedQuad(m_lastPlanarQuad);
+    TransformationMatrix identity;
+    return identity.clampedBoundsOfProjectedQuad(m_lastPlanarQuad);
+}
+
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/HitTestingTransformState.h
+++ b/Source/WebCore/rendering/HitTestingTransformState.h
@@ -57,6 +57,8 @@ public:
     FloatQuad mappedQuad() const;
     FloatQuad mappedArea() const;
     LayoutRect boundsOfMappedArea() const;
+    LayoutRect boundsOfMappedQuad() const;
+
     void flatten();
 
     FloatPoint m_lastPlanarPoint;

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -4988,14 +4988,16 @@ RenderLayer::HitLayer RenderLayer::hitTestLayerByApplyingTransform(RenderLayer* 
     //
     // We can't just map hitTestLocation and hitTestRect because they may have been flattened (losing z)
     // by our container.
-    FloatPoint localPoint = newTransformState->mappedPoint();
-    FloatQuad localPointQuad = newTransformState->mappedQuad();
-    LayoutRect localHitTestRect = newTransformState->boundsOfMappedArea();
+    auto localPoint = newTransformState->mappedPoint();
+    auto localHitTestRect = newTransformState->boundsOfMappedArea();
     HitTestLocation newHitTestLocation;
-    if (hitTestLocation.isRectBasedTest())
+    if (hitTestLocation.isRectBasedTest()) {
+        auto localPointQuad = newTransformState->mappedQuad();
         newHitTestLocation = HitTestLocation(localPoint, localPointQuad);
-    else
-        newHitTestLocation = HitTestLocation(flooredLayoutPoint(localPoint));
+    } else {
+        auto localPointQuad = newTransformState->boundsOfMappedQuad();
+        newHitTestLocation = HitTestLocation(localPoint, FloatRect { localPointQuad });
+    }
 
     // Now do a hit test with the root layer shifted to be us.
     return hitTestLayer(this, containerLayer, request, result, localHitTestRect, newHitTestLocation, true, newTransformState.ptr(), zOffset);

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1105,7 +1105,8 @@ void RenderLayerBacking::updateAfterWidgetResize()
 
     if (auto* innerCompositor = RenderLayerCompositor::frameContentsCompositor(*renderWidget)) {
         innerCompositor->frameViewDidChangeSize();
-        innerCompositor->frameViewDidChangeLocation(flooredIntPoint(contentsBox().location()));
+        auto snappedContentOrigin = roundPointToDevicePixels(contentsBox().location(), deviceScaleFactor());
+        innerCompositor->frameViewDidChangeLocation(snappedContentOrigin);
     }
 
     if (auto* contentsLayer = layerForContents())

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -2780,7 +2780,7 @@ bool RenderLayerCompositor::canAccelerateVideoRendering(RenderVideo& video) cons
 }
 #endif
 
-void RenderLayerCompositor::frameViewDidChangeLocation(const IntPoint& contentsOffset)
+void RenderLayerCompositor::frameViewDidChangeLocation(FloatPoint contentsOffset)
 {
     if (m_overflowControlsHostLayer)
         m_overflowControlsHostLayer->setPosition(contentsOffset);

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -332,7 +332,7 @@ public:
     void collectViewTransitionNewContentLayers(RenderLayer&, Vector<Ref<GraphicsLayer>>&);
 
     // Update the geometry of the layers used for clipping and scrolling in frames.
-    void frameViewDidChangeLocation(const IntPoint& contentsOffset);
+    void frameViewDidChangeLocation(FloatPoint contentsOffset);
     void frameViewDidChangeSize();
     void frameViewDidScroll();
     void frameViewDidAddOrRemoveScrollbars();

--- a/Source/WebCore/rendering/RenderWidget.cpp
+++ b/Source/WebCore/rendering/RenderWidget.cpp
@@ -252,7 +252,9 @@ void RenderWidget::paintContents(PaintInfo& paintInfo, const LayoutPoint& paintO
         }
     }
 
-    IntPoint contentPaintOffset = roundedIntPoint(paintOffset + location() + contentBoxRect().location());
+    auto contentPaintOffset = paintOffset + location() + contentBoxRect().location();
+    auto snappedPaintOffset = roundPointToDevicePixels(contentPaintOffset, document().deviceScaleFactor());
+
     // Tell the widget to paint now. This is the only time the widget is allowed
     // to paint itself. That way it will composite properly with z-indexed layers.
     LayoutRect paintRect = paintInfo.rect;
@@ -265,18 +267,18 @@ void RenderWidget::paintContents(PaintInfo& paintInfo, const LayoutPoint& paintO
         }
     }
 
-    IntPoint widgetLocation = m_widget->frameRect().location();
-    IntSize widgetPaintOffset = contentPaintOffset - widgetLocation;
+    auto widgetLocation = m_widget->frameRect().location();
+    auto widgetPaintOffset = snappedPaintOffset - widgetLocation;
     // When painting widgets into compositing layers, tx and ty are relative to the enclosing compositing layer,
     // not the root. In this case, shift the CTM and adjust the paintRect to be root-relative to fix plug-in drawing.
     if (!widgetPaintOffset.isZero()) {
         paintInfo.context().translate(widgetPaintOffset);
-        paintRect.move(-widgetPaintOffset);
+        paintRect.move(-widgetPaintOffset.width(), -widgetPaintOffset.height());
     }
 
     if (paintInfo.regionContext) {
         AffineTransform transform;
-        transform.translate(contentPaintOffset);
+        transform.translate(snappedPaintOffset);
         paintInfo.regionContext->pushTransform(transform);
     }
 


### PR DESCRIPTION
#### 79b2e213326cb5035fddf5ef403a0d50fe6b1dd5
<pre>
Make subpixel-positioned iframes paint and hit-test correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=294571">https://bugs.webkit.org/show_bug.cgi?id=294571</a>
<a href="https://rdar.apple.com/152114545">rdar://152114545</a>

Reviewed by Alan Baradlay.

IFrames are Widgets, and Widgets live in an integer-based hierarchy, so have historically
painted and hit-tested using integer coordinates. However, iframes are often positioned on
subpixel boundaries, which leads to pixel gaps. Some of these are very obvious, e.g. an
iframe inside a `position:fixed; bottom: 0` element that should align seamlessly with UI.

However, we can adjust iframes for painting and hit-testing to overcome the integral
Widget limitation. This PR does this in various places.

First, `RenderWidget::paintContents()` adjusts the CTM to account for a subpixel position,
which fixes painting gaps (tested by iframe-subpixel-painting.html).

Second, the compositing code needs to handle subpixel positioning of the iframe&apos;s layers,
fixed in `RenderLayerBacking::updateAfterWidgetResize()` and tested by
iframe-subpixel-compositing.html.

Finally, hit-testing needs to maintain fractional coordinates;
`documentPointForWindowPoint()` is fixed to use FloatPoint coordinate mapping, and
HitTestLocation no longer rounds the origin of m_boundingBox which is what&apos;s used by the
`nodeAtPoint()` code.

Removing the flooring of the point in the HitTestLocation constructor caused
`css/css-transforms/transform-scale-hittest.html` to fail; this hit-tests a pixel above an
element with a 100x scale. The existing code would map the 1x1px hit-test area through the
scale, resulting in a 100x100px hit-test area; fix to map through the inverse transform to
maintain the 1x1px hit-test area in screen space. This is a merge of
<a href="https://chromium.googlesource.com/chromium/src.git/+/c47a6f0b4a592c2383fb553b6169f89ab01d851d">https://chromium.googlesource.com/chromium/src.git/+/c47a6f0b4a592c2383fb553b6169f89ab01d851d</a>

* LayoutTests/TestExpectations: imported/w3c/web-platform-tests/css/selectors/focus-visible-018-2.html
fails; <a href="https://github.com/web-platform-tests/wpt/pull/53241">https://github.com/web-platform-tests/wpt/pull/53241</a> exists to fix this.
* LayoutTests/compositing/iframes/hidpi-iframe-subpixel-compositing-expected.html: Added.
* LayoutTests/compositing/iframes/hidpi-iframe-subpixel-compositing.html: Added.
* LayoutTests/fast/frames/hidpi-iframe-subpixel-hit-test-expected.txt: Added.
* LayoutTests/fast/frames/hidpi-iframe-subpixel-hit-test.html: Added.
* LayoutTests/fast/frames/hidpi-iframe-subpixel-painting-expected.html: Added.
* LayoutTests/fast/frames/hidpi-iframe-subpixel-painting.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/elementFromPoint-subpixel-expected.txt:
* LayoutTests/transforms/3d/hit-testing/rotated-hit-test-2-expected.txt:
* LayoutTests/transforms/3d/hit-testing/rotated-hit-test-2.html: Tweak the test; browsers
have different results.
* Source/WebCore/page/EventHandler.cpp:
(WebCore::documentPointForWindowPoint):
* Source/WebCore/page/scrolling/ScrollingCoordinator.cpp:
(WebCore::ScrollingCoordinator::absoluteEventTrackingRegionsForFrame const):
* Source/WebCore/rendering/HitTestLocation.cpp:
(WebCore::HitTestLocation::HitTestLocation): No longer floor the point.
(WebCore::HitTestLocation::move): No longer convert to IntRect.
* Source/WebCore/rendering/HitTestingTransformState.cpp:
(WebCore::HitTestingTransformState::boundsOfMappedQuad const):
* Source/WebCore/rendering/HitTestingTransformState.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::hitTestLayerByApplyingTransform):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateAfterWidgetResize):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::frameViewDidChangeLocation):
* Source/WebCore/rendering/RenderLayerCompositor.h:
* Source/WebCore/rendering/RenderWidget.cpp:
(WebCore::RenderWidget::paintContents):

Canonical link: <a href="https://commits.webkit.org/296407@main">https://commits.webkit.org/296407@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9974033a603c7206123021c222219d0a405cd9a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28048 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18472 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113596 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58808 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110350 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28737 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36598 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82304 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111335 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22791 "Found 1 new test failure: http/tests/security/cached-svg-image-with-css-cross-domain.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97633 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62739 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22208 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15770 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58323 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92160 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15825 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116717 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35441 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26108 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91331 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35814 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93908 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91132 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23228 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36020 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13790 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31188 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35344 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40882 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35057 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38410 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36738 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->