### PR TITLE
[Liquid Glass] Add a way to hide the top fixed color extension view and override top scroll edge effect color

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3171,7 +3171,10 @@ static WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::Fixe
 
     auto insets = [self _obscuredInsetsForFixedColorExtension];
     auto updateExtensionView = [&](WebCore::BoxSide side) {
-        BOOL needsView = insets.at(side) > 0 && _fixedContainerEdges.hasFixedEdge(side);
+        BOOL needsView = insets.at(side) > 0
+            && _fixedContainerEdges.hasFixedEdge(side)
+            && (side != WebCore::BoxSide::Top || !_shouldSuppressTopColorExtensionView);
+
         RetainPtr extensionView = _fixedColorExtensionViews.at(side);
         if (!needsView) {
             [extensionView fadeOut];
@@ -6137,6 +6140,24 @@ static Vector<Ref<API::TargetedElementInfo>> elementsFromWKElements(NSArray<_WKT
 - (void)_scrollToEdge:(_WKRectEdge)edge animated:(BOOL)animated
 {
     self._protectedPage->scrollToEdge(toRectEdges(edge), animated ? WebCore::ScrollIsAnimated::Yes : WebCore::ScrollIsAnimated::No);
+}
+
+- (BOOL)_shouldSuppressTopColorExtensionView
+{
+    return _shouldSuppressTopColorExtensionView;
+}
+
+- (void)_setShouldSuppressTopColorExtensionView:(BOOL)value
+{
+    if (_shouldSuppressTopColorExtensionView == value)
+        return;
+
+    _shouldSuppressTopColorExtensionView = value;
+
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+    [self _updateFixedColorExtensionViews];
+    [self _updateTopScrollPocketCaptureColor];
+#endif
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -281,6 +281,10 @@ struct PerWebProcessState {
     _WKRenderingProgressEvents _observedRenderingProgressEvents;
     BOOL _usePlatformFindUI;
     BOOL _usesAutomaticContentInsetBackgroundFill;
+    BOOL _shouldSuppressTopColorExtensionView;
+#if PLATFORM(MAC)
+    RetainPtr<NSColor> _overrideTopScrollEdgeEffectColor;
+#endif
 
     CocoaEdgeInsets _minimumViewportInset;
     CocoaEdgeInsets _maximumViewportInset;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -615,6 +615,8 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 
 @property (nonatomic) audit_token_t presentingApplicationAuditToken WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
 
+@property (nonatomic, setter=_setShouldSuppressTopColorExtensionView:) BOOL _shouldSuppressTopColorExtensionView WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 @end
 
 #if TARGET_OS_IPHONE
@@ -880,6 +882,7 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 - (void)_setObscuredContentInsets:(NSEdgeInsets)insets immediate:(BOOL)immediate WK_API_AVAILABLE(macos(WK_MAC_TBA));
 @property (nonatomic, readonly) NSEdgeInsets _obscuredContentInsets WK_API_AVAILABLE(macos(WK_MAC_TBA));
 @property (nonatomic, setter=_setUsesAutomaticContentInsetBackgroundFill:) BOOL _usesAutomaticContentInsetBackgroundFill WK_API_AVAILABLE(macos(WK_MAC_TBA));
+@property (nonatomic, copy, setter=_setOverrideTopScrollEdgeEffectColor:) NSColor *_overrideTopScrollEdgeEffectColor WK_API_AVAILABLE(macos(WK_MAC_TBA));
 
 - (void)_showWritingTools WK_API_AVAILABLE(macos(15.2));
 

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1583,6 +1583,23 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     );
 }
 
+- (NSColor *)_overrideTopScrollEdgeEffectColor
+{
+    return _overrideTopScrollEdgeEffectColor.get();
+}
+
+- (void)_setOverrideTopScrollEdgeEffectColor:(NSColor *)color
+{
+    if (_overrideTopScrollEdgeEffectColor == color || [_overrideTopScrollEdgeEffectColor isEqual:color])
+        return;
+
+    _overrideTopScrollEdgeEffectColor = adoptNS(color.copy);
+
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+    [self _updateTopScrollPocketCaptureColor];
+#endif
+}
+
 - (void)_setUsesAutomaticContentInsetBackgroundFill:(BOOL)value
 {
     if (_usesAutomaticContentInsetBackgroundFill == value)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2423,7 +2423,10 @@ void WebViewImpl::updateTopScrollPocketCaptureColor()
     if ([view _usesAutomaticContentInsetBackgroundFill])
         return;
 
-    RetainPtr captureColor = [view _sampledTopFixedPositionContentColor];
+    RetainPtr captureColor = [view _overrideTopScrollEdgeEffectColor];
+    if (!captureColor && ![view _shouldSuppressTopColorExtensionView])
+        captureColor = [view _sampledTopFixedPositionContentColor];
+
     if (!captureColor) {
         if (auto backgroundColor = m_page->underPageBackgroundColorIgnoringPlatformColor(); backgroundColor.isValid())
             captureColor = cocoaColor(backgroundColor);


### PR DESCRIPTION
#### 383ba72d164097ef9f267981d102d19a5bb0b577
<pre>
[Liquid Glass] Add a way to hide the top fixed color extension view and override top scroll edge effect color
<a href="https://bugs.webkit.org/show_bug.cgi?id=294574">https://bugs.webkit.org/show_bug.cgi?id=294574</a>
<a href="https://rdar.apple.com/153564136">rdar://153564136</a>

Reviewed by Abrar Rahman Protyasha and Megan Gardner.

Add support for 2 new SPI methods (hopefully, soon-to-be APIs) on `WKWebView`:

•   `_shouldSuppressTopColorExtensionView`, used to prevent WebKit from automatically placing a
    color extension view when a fixed element near the top of the viewport is detected.

•   `_overrideTopScrollEdgeEffectColor`, used to override the capture color of the scroll edge
    effect view on macOS.

The combination of these two properties allows clients (i.e. Safari) to implement a mode where it
doesn&apos;t show website colors (i.e. background color, or top fixed element color) as the background of
the tab bar; instead, a hard pocket tinted with the default system background color is used.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _updateFixedColorExtensionViews]):
(-[WKWebView _shouldSuppressTopColorExtensionView]):
(-[WKWebView _setShouldSuppressTopColorExtensionView:]):

Add support for the new properties; see above for more details.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _overrideTopScrollEdgeEffectColor]):
(-[WKWebView _setOverrideTopScrollEdgeEffectColor:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::updateTopScrollPocketCaptureColor):

Also avoid tinting the top scroll pocket with the sampled fixed position color when the top color
extension view is suppressed. Setting `-captureColor` here only made sense in the case where there&apos;s
a color extension view beneath the pocket.

Canonical link: <a href="https://commits.webkit.org/296293@main">https://commits.webkit.org/296293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8658483c5bcae95f31f4a74aa00709918bc318d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108072 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18156 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113282 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58583 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28431 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36286 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82047 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111020 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/22533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97365 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62479 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21945 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58028 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91888 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15564 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116407 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35141 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25876 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91075 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35516 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93643 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90870 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23157 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35769 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13530 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35041 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40595 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34779 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38137 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36442 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->