### PR TITLE
[JSC] IPInt exception handlers should be tagged correctly

### DIFF
--- a/Source/JavaScriptCore/assembler/JITOperationList.cpp
+++ b/Source/JavaScriptCore/assembler/JITOperationList.cpp
@@ -130,6 +130,12 @@ LLINT_DECLARE_ROUTINE_VALIDATE(ipint_trampoline);
 LLINT_DECLARE_ROUTINE_VALIDATE(ipint_entry);
 LLINT_DECLARE_ROUTINE_VALIDATE(ipint_function_prologue_simd_trampoline);
 LLINT_DECLARE_ROUTINE_VALIDATE(ipint_function_prologue_simd);
+LLINT_DECLARE_ROUTINE_VALIDATE(ipint_catch_entry);
+LLINT_DECLARE_ROUTINE_VALIDATE(ipint_catch_all_entry);
+LLINT_DECLARE_ROUTINE_VALIDATE(ipint_table_catch_entry);
+LLINT_DECLARE_ROUTINE_VALIDATE(ipint_table_catch_ref_entry);
+LLINT_DECLARE_ROUTINE_VALIDATE(ipint_table_catch_all_entry);
+LLINT_DECLARE_ROUTINE_VALIDATE(ipint_table_catch_allref_entry);
 
 #if ENABLE(JIT_OPERATION_VALIDATION)
 #define LLINT_OP_EXTRAS(validateLabel) reinterpret_cast<void*>(validateLabel)
@@ -193,6 +199,12 @@ static LLIntOperations llintOperations()
             LLINT_ROUTINE(ipint_entry)
             LLINT_ROUTINE(ipint_function_prologue_simd_trampoline)
             LLINT_ROUTINE(ipint_function_prologue_simd)
+            LLINT_ROUTINE(ipint_catch_entry)
+            LLINT_ROUTINE(ipint_catch_all_entry)
+            LLINT_ROUTINE(ipint_table_catch_entry)
+            LLINT_ROUTINE(ipint_table_catch_ref_entry)
+            LLINT_ROUTINE(ipint_table_catch_all_entry)
+            LLINT_ROUTINE(ipint_table_catch_allref_entry)
 
             LLINT_OP(op_catch)
             LLINT_OP(wasm_catch)

--- a/Source/JavaScriptCore/bytecode/BytecodeList.rb
+++ b/Source/JavaScriptCore/bytecode/BytecodeList.rb
@@ -1499,6 +1499,12 @@ op :ipint_trampoline
 op :ipint_entry
 op :ipint_function_prologue_simd_trampoline
 op :ipint_function_prologue_simd
+op :ipint_catch_entry
+op :ipint_catch_all_entry
+op :ipint_table_catch_entry
+op :ipint_table_catch_ref_entry
+op :ipint_table_catch_all_entry
+op :ipint_table_catch_allref_entry
 
 op :js_trampoline_op_call
 op :js_trampoline_op_call_ignore_result

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -602,8 +602,7 @@ if X86_64
 end
 end
 
-global _ipint_catch_entry
-_ipint_catch_entry:
+op(ipint_catch_entry, macro()
 if WEBASSEMBLY and (ARM64 or ARM64E or X86_64)
     ipintCatchCommon()
 
@@ -618,9 +617,9 @@ if WEBASSEMBLY and (ARM64 or ARM64E or X86_64)
 else
     break
 end
+end)
 
-global _ipint_catch_all_entry
-_ipint_catch_all_entry:
+op(ipint_catch_all_entry, macro()
 if WEBASSEMBLY and (ARM64 or ARM64E or X86_64)
     ipintCatchCommon()
 
@@ -635,9 +634,9 @@ if WEBASSEMBLY and (ARM64 or ARM64E or X86_64)
 else
     break
 end
+end)
 
-global _ipint_table_catch_entry
-_ipint_table_catch_entry:
+op(ipint_table_catch_entry, macro()
 if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     ipintCatchCommon()
 
@@ -654,9 +653,9 @@ if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
 else
     break
 end
+end)
 
-global _ipint_table_catch_ref_entry
-_ipint_table_catch_ref_entry:
+op(ipint_table_catch_ref_entry, macro()
 if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     ipintCatchCommon()
 
@@ -673,9 +672,9 @@ if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
 else
     break
 end
+end)
 
-global _ipint_table_catch_all_entry
-_ipint_table_catch_all_entry:
+op(ipint_table_catch_all_entry, macro()
 if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     ipintCatchCommon()
 
@@ -692,9 +691,9 @@ if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
 else
     break
 end
+end)
 
-global _ipint_table_catch_allref_entry
-_ipint_table_catch_allref_entry:
+op(ipint_table_catch_allref_entry, macro()
 if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     ipintCatchCommon()
 
@@ -711,6 +710,7 @@ if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
 else
     break
 end
+end)
 
 # Trampoline entrypoints
 

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.h
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.h
@@ -31,13 +31,6 @@
 
 extern "C" void SYSV_ABI ipint_entry();
 extern "C" void SYSV_ABI ipint_entry_simd();
-extern "C" void SYSV_ABI ipint_catch_entry();
-extern "C" void SYSV_ABI ipint_catch_all_entry();
-
-extern "C" void SYSV_ABI ipint_table_catch_entry();
-extern "C" void SYSV_ABI ipint_table_catch_ref_entry();
-extern "C" void SYSV_ABI ipint_table_catch_all_entry();
-extern "C" void SYSV_ABI ipint_table_catch_allref_entry();
 
 #define IPINT_VALIDATE_DEFINE_FUNCTION(opcode, name) \
     extern "C" void SYSV_ABI ipint_ ## name ## _validate() REFERENCED_FROM_ASM WTF_INTERNAL NO_REORDER;

--- a/Source/JavaScriptCore/llint/LLIntThunks.h
+++ b/Source/JavaScriptCore/llint/LLIntThunks.h
@@ -132,6 +132,12 @@ MacroAssemblerCodeRef<JITThunkPtrTag> wasmFunctionEntryThunk();
 MacroAssemblerCodeRef<JITThunkPtrTag> wasmFunctionEntryThunkSIMD();
 MacroAssemblerCodeRef<JITThunkPtrTag> inPlaceInterpreterEntryThunk();
 MacroAssemblerCodeRef<JITThunkPtrTag> inPlaceInterpreterSIMDEntryThunk();
+MacroAssemblerCodeRef<JITThunkPtrTag> inPlaceInterpreterCatchEntryThunk();
+MacroAssemblerCodeRef<JITThunkPtrTag> inPlaceInterpreterCatchAllEntryThunk();
+MacroAssemblerCodeRef<JITThunkPtrTag> inPlaceInterpreterTableCatchEntryThunk();
+MacroAssemblerCodeRef<JITThunkPtrTag> inPlaceInterpreterTableCatchRefEntryThunk();
+MacroAssemblerCodeRef<JITThunkPtrTag> inPlaceInterpreterTableCatchAllEntryThunk();
+MacroAssemblerCodeRef<JITThunkPtrTag> inPlaceInterpreterTableCatchAllrefEntryThunk();
 #endif // ENABLE(WEBASSEMBLY)
 
 } } // namespace JSC::LLInt

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -2926,6 +2926,30 @@ op(ipint_function_prologue_simd, macro ()
     crash()
 end)
 
+op(ipint_catch_entry, macro()
+    crash()
+end)
+
+op(ipint_catch_all_entry, macro()
+    crash()
+end)
+
+op(ipint_table_catch_entry, macro()
+    crash()
+end)
+
+op(ipint_table_catch_ref_entry, macro()
+    crash()
+end)
+
+op(ipint_table_catch_all_entry, macro()
+    crash()
+end)
+
+op(ipint_table_catch_allref_entry, macro()
+    crash()
+end)
+
 _wasm_trampoline_wasm_call:
 _wasm_trampoline_wasm_call_indirect:
 _wasm_trampoline_wasm_call_ref:

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -254,41 +254,29 @@ IPIntCallee::IPIntCallee(FunctionIPIntMetadataGenerator& generator, FunctionSpac
         for (size_t i = 0; i < count; i++) {
             const UnlinkedHandlerInfo& unlinkedHandler = generator.m_exceptionHandlers[i];
             HandlerInfo& handler = m_exceptionHandlers[i];
-            void* ptr = nullptr;
+            CodeLocationLabel<ExceptionHandlerPtrTag> target;
             switch (unlinkedHandler.m_type) {
             case HandlerType::Catch:
-                ptr = reinterpret_cast<void*>(ipint_catch_entry);
+                target = CodeLocationLabel<ExceptionHandlerPtrTag>(LLInt::inPlaceInterpreterCatchEntryThunk().retaggedCode<ExceptionHandlerPtrTag>());
                 break;
             case HandlerType::CatchAll:
             case HandlerType::Delegate:
-                ptr = reinterpret_cast<void*>(ipint_catch_all_entry);
+                target = CodeLocationLabel<ExceptionHandlerPtrTag>(LLInt::inPlaceInterpreterCatchAllEntryThunk().retaggedCode<ExceptionHandlerPtrTag>());
                 break;
             case HandlerType::TryTableCatch:
-                ptr = reinterpret_cast<void*>(ipint_table_catch_entry);
+                target = CodeLocationLabel<ExceptionHandlerPtrTag>(LLInt::inPlaceInterpreterTableCatchEntryThunk().retaggedCode<ExceptionHandlerPtrTag>());
                 break;
             case HandlerType::TryTableCatchRef:
-                ptr = reinterpret_cast<void*>(ipint_table_catch_ref_entry);
+                target = CodeLocationLabel<ExceptionHandlerPtrTag>(LLInt::inPlaceInterpreterTableCatchRefEntryThunk().retaggedCode<ExceptionHandlerPtrTag>());
                 break;
             case HandlerType::TryTableCatchAll:
-                ptr = reinterpret_cast<void*>(ipint_table_catch_all_entry);
+                target = CodeLocationLabel<ExceptionHandlerPtrTag>(LLInt::inPlaceInterpreterTableCatchAllEntryThunk().retaggedCode<ExceptionHandlerPtrTag>());
                 break;
             case HandlerType::TryTableCatchAllRef:
-                ptr = reinterpret_cast<void*>(ipint_table_catch_allref_entry);
+                target = CodeLocationLabel<ExceptionHandlerPtrTag>(LLInt::inPlaceInterpreterTableCatchAllrefEntryThunk().retaggedCode<ExceptionHandlerPtrTag>());
                 break;
             }
-            void* untagged = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).untaggedPtr();
-            void* retagged = nullptr;
-#if ENABLE(JIT_CAGE)
-            if (Options::useJITCage())
-#else
-            if (false)
-#endif
-                retagged = tagCodePtr<ExceptionHandlerPtrTag>(untagged);
-            else
-                retagged = WTF::tagNativeCodePtrImpl<ExceptionHandlerPtrTag>(untagged);
-            assertIsTaggedWith<ExceptionHandlerPtrTag>(retagged);
 
-            CodeLocationLabel<ExceptionHandlerPtrTag> target(retagged);
             handler.initialize(unlinkedHandler, target);
         }
     }


### PR DESCRIPTION
#### 1f3b9d9bc9e4b8d4acb6e7a12a8e28e07411425a
<pre>
[JSC] IPInt exception handlers should be tagged correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=294580">https://bugs.webkit.org/show_bug.cgi?id=294580</a>
<a href="https://rdar.apple.com/149335739">rdar://149335739</a>

Reviewed by Keith Miller.

When JITCage is enabled, they must be JIT code. So,

1. When JIT is enabled, we just wrap these handlers with JIT code as the
   same way to the other trampolines as well.
2. When JIT is not enabled, then we just grab a code pointer to these
   ops.

* Source/JavaScriptCore/assembler/JITOperationList.cpp:
(JSC::llintOperations):
* Source/JavaScriptCore/bytecode/BytecodeList.rb:
* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/llint/InPlaceInterpreter.h:
* Source/JavaScriptCore/llint/LLIntThunks.cpp:
(JSC::LLInt::inPlaceInterpreterEntryThunk): Deleted.
(JSC::LLInt::inPlaceInterpreterSIMDEntryThunk): Deleted.
* Source/JavaScriptCore/llint/LLIntThunks.h:
* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::IPIntCallee::IPIntCallee):

Canonical link: <a href="https://commits.webkit.org/296295@main">https://commits.webkit.org/296295@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3463cc04d4917111cf7fa16dd84caaf04490e2e4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108079 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27744 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18163 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113289 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58586 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36293 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82057 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111027 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/22539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97370 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62489 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/21954 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15506 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58035 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/100680 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91896 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15569 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116414 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/106641 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35148 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25883 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/91089 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35523 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93648 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90884 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35775 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13535 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17458 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35048 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40602 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/130930 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34786 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35545 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38144 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36449 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->