### PR TITLE
Painted images don't get tone mapped down to the level supported by the display.

### DIFF
--- a/Source/WTF/wtf/spi/cocoa/IOSurfaceSPI.h
+++ b/Source/WTF/wtf/spi/cocoa/IOSurfaceSPI.h
@@ -67,6 +67,9 @@ extern const CFStringRef kIOSurfacePlaneBytesPerRow;
 extern const CFStringRef kIOSurfacePlaneOffset;
 extern const CFStringRef kIOSurfacePlaneSize;
 extern const CFStringRef kIOSurfacePlaneInfo;
+#if HAVE(SUPPORT_HDR_DISPLAY)
+extern const CFStringRef kIOSurfaceContentHeadroom;
+#endif
 
 size_t IOSurfaceAlignProperty(CFStringRef property, size_t value);
 IOSurfaceRef IOSurfaceCreate(CFDictionaryRef properties);

--- a/Source/WebCore/PAL/pal/cocoa/QuartzCoreSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/QuartzCoreSoftLink.h
@@ -33,3 +33,5 @@ SOFT_LINK_FRAMEWORK_FOR_HEADER(PAL, QuartzCore)
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(PAL, QuartzCore, CAIOSurfaceCreate, CAIOSurfaceRef, (IOSurfaceRef surface), (surface))
 #define CAIOSurfaceCreate PAL::softLink_QuartzCore_CAIOSurfaceCreate
 
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(PAL, QuartzCore, CAIOSurfaceReloadColorAttributes, void, (CAIOSurfaceRef surface), (surface))
+#define CAIOSurfaceReloadColorAttributes PAL::softLink_QuartzCore_CAIOSurfaceReloadColorAttributes

--- a/Source/WebCore/PAL/pal/cocoa/QuartzCoreSoftLink.mm
+++ b/Source/WebCore/PAL/pal/cocoa/QuartzCoreSoftLink.mm
@@ -31,4 +31,5 @@
 
 SOFT_LINK_FRAMEWORK_FOR_SOURCE_WITH_EXPORT(PAL, QuartzCore, PAL_EXPORT)
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(PAL, QuartzCore, CAIOSurfaceCreate, CAIOSurfaceRef, (IOSurfaceRef surface), (surface), PAL_EXPORT)
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(PAL, QuartzCore, CAIOSurfaceReloadColorAttributes, void, (CAIOSurfaceRef surface), (surface), PAL_EXPORT)
 

--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -369,6 +369,13 @@ bool CachedImage::hasHDRContent() const
     return m_image && m_image->hasHDRContent();
 }
 
+Headroom CachedImage::currentFrameHeadroom() const
+{
+    if (!m_image)
+        return Headroom::None;
+    return m_image->currentFrameHeadroom();
+}
+
 void CachedImage::notifyObservers(const IntRect* changeRect)
 {
     CachedResourceClientWalker<CachedImageClient> walker(*this);

--- a/Source/WebCore/loader/cache/CachedImage.h
+++ b/Source/WebCore/loader/cache/CachedImage.h
@@ -97,6 +97,7 @@ public:
     void computeIntrinsicDimensions(Length& intrinsicWidth, Length& intrinsicHeight, FloatSize& intrinsicRatio);
 
     bool hasHDRContent() const;
+    Headroom currentFrameHeadroom() const;
 
     bool isManuallyCached() const { return m_isManuallyCached; }
     RevalidationDecision makeRevalidationDecision(CachePolicy) const override;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -29,6 +29,7 @@
 #include "FindOptions.h"
 #include "FrameLoaderTypes.h"
 #include "HistoryItem.h"
+#include "ImageTypes.h"
 #include "IntRectHash.h"
 #include "LoadSchedulingMode.h"
 #include "MediaSessionGroupIdentifier.h"
@@ -1342,6 +1343,11 @@ public:
     bool requiresUserGestureForAudioPlayback() const;
     bool requiresUserGestureForVideoPlayback() const;
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    Headroom displayEDRHeadroom() const { return m_displayEDRHeadroom; }
+    void updateDisplayEDRHeadroom();
+#endif
+
 private:
     explicit Page(PageConfiguration&&);
 
@@ -1769,6 +1775,10 @@ private:
 
 #if ENABLE(WRITING_TOOLS)
     const UniqueRef<WritingToolsController> m_writingToolsController;
+#endif
+
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    Headroom m_displayEDRHeadroom { Headroom::None };
 #endif
 
     UncheckedKeyHashSet<std::pair<URL, ScriptTelemetryCategory>> m_reportedScriptsWithTelemetry;

--- a/Source/WebCore/platform/Logging.h
+++ b/Source/WebCore/platform/Logging.h
@@ -115,6 +115,7 @@ namespace WebCore {
     M(FTP) \
     M(Fullscreen) \
     M(Gamepad) \
+    M(HDR) \
     M(HID) \
     M(History) \
     M(IOSurface) \

--- a/Source/WebCore/platform/PlatformScreen.h
+++ b/Source/WebCore/platform/PlatformScreen.h
@@ -115,6 +115,9 @@ WEBCORE_EXPORT PlatformDisplayID primaryScreenDisplayID();
 #if HAVE(SUPPORT_HDR_DISPLAY)
 WEBCORE_EXPORT void setScreenContentsFormatsForTesting(OptionSet<ContentsFormat>);
 OptionSet<ContentsFormat> screenContentsFormatsForTesting();
+
+WEBCORE_EXPORT float currentEDRHeadroomForDisplay(PlatformDisplayID);
+WEBCORE_EXPORT float maxEDRHeadroomForDisplay(PlatformDisplayID);
 #endif
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/platform/ScreenProperties.h
+++ b/Source/WebCore/platform/ScreenProperties.h
@@ -43,6 +43,10 @@ struct ScreenData {
     bool screenSupportsExtendedColor { false };
     bool screenHasInvertedColors { false };
     bool screenSupportsHighDynamicRange { false };
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    float currentEDRHeadroom { 1 };
+    float maxEDRHeadroom { 1 };
+#endif
 #if PLATFORM(MAC)
     FloatSize screenSize; // In millimeters.
     bool screenIsMonochrome { false };

--- a/Source/WebCore/platform/graphics/BitmapImage.h
+++ b/Source/WebCore/platform/graphics/BitmapImage.h
@@ -60,7 +60,7 @@ public:
     unsigned currentFrameIndex() const { return m_source->currentFrameIndex(); }
     bool currentFrameHasAlpha() const { return m_source->currentImageFrame().hasAlpha(); }
     ImageOrientation currentFrameOrientation() const { return m_source->currentImageFrame().orientation(); }
-    Headroom currentFrameHeadroom() const { return m_source->currentImageFrame().headroom(); }
+    Headroom currentFrameHeadroom() const final { return m_source->currentImageFrame().headroom(); }
     DecodingOptions currentFrameDecodingOptions() const { return m_source->currentImageFrame().decodingOptions(); }
 
     // Primary & current NativeImage

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -239,6 +239,13 @@ public:
     virtual void setLineJoin(LineJoin) = 0;
     virtual void setMiterLimit(float) = 0;
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    virtual void setMaxEDRHeadroom(std::optional<float>) { }
+    virtual float maxPaintedEDRHeadroom() const { return 1; }
+    virtual bool hasPaintedClampedEDRHeadroom() const { return false; }
+    virtual void clearMaxPaintedEDRHeadroom() { }
+#endif
+
     // Images, Patterns, ControlParts, and Media
 
     IntSize compatibleImageBufferSize(const FloatSize&) const;

--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -453,6 +453,10 @@ void GraphicsLayer::setDrawsHDRContent(bool b)
     ASSERT(m_type != Type::Structural);
     m_drawsHDRContent = b;
 }
+
+void GraphicsLayer::setNeedsDisplayIfEDRHeadroomExceeds(float)
+{
+}
 #endif
 
 const TransformationMatrix& GraphicsLayer::transform() const

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -428,6 +428,8 @@ public:
 #if HAVE(SUPPORT_HDR_DISPLAY)
     bool drawsHDRContent() const { return m_drawsHDRContent; }
     WEBCORE_EXPORT virtual void setDrawsHDRContent(bool);
+
+    WEBCORE_EXPORT virtual void setNeedsDisplayIfEDRHeadroomExceeds(float);
 #endif
 
     bool contentsAreVisible() const { return m_contentsVisible; }

--- a/Source/WebCore/platform/graphics/GraphicsLayerClient.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayerClient.h
@@ -72,6 +72,9 @@ enum class PlatformLayerTreeAsTextFlags : uint8_t {
 enum class GraphicsLayerPaintBehavior : uint8_t {
     DefaultAsynchronousImageDecode = 1 << 0,
     ForceSynchronousImageDecode = 1 << 1,
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    TonemapHDRToDisplayHeadroom = 1 << 2,
+#endif
 };
     
 class GraphicsLayerClient {

--- a/Source/WebCore/platform/graphics/Image.h
+++ b/Source/WebCore/platform/graphics/Image.h
@@ -125,6 +125,7 @@ public:
 
     virtual DestinationColorSpace colorSpace();
     virtual bool hasHDRContent() const { return false; }
+    virtual Headroom currentFrameHeadroom() const { return Headroom::None; }
 
     // Animation begins whenever someone draws the image, so startAnimation() is not normally called.
     // It will automatically pause once all observers no longer want to render the image anywhere.

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -743,6 +743,14 @@ void GraphicsLayerCA::setDrawsHDRContent(bool drawsHDRContent)
     GraphicsLayer::setDrawsHDRContent(drawsHDRContent);
     noteLayerPropertyChanged(DrawsHDRContentChanged | DebugIndicatorsChanged);
 }
+
+void GraphicsLayerCA::setNeedsDisplayIfEDRHeadroomExceeds(float headroom)
+{
+    if (protectedLayer()->setNeedsDisplayIfEDRHeadroomExceeds(headroom)) {
+        if (!!m_uncommittedChanges)
+            client().notifyFlushRequired(this);
+    }
+}
 #endif
 
 void GraphicsLayerCA::setContentsVisible(bool contentsVisible)

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -103,6 +103,7 @@ public:
     WEBCORE_EXPORT void setDrawsContent(bool) override;
 #if HAVE(SUPPORT_HDR_DISPLAY)
     WEBCORE_EXPORT void setDrawsHDRContent(bool) override;
+    WEBCORE_EXPORT void setNeedsDisplayIfEDRHeadroomExceeds(float) override;
 #endif
     WEBCORE_EXPORT void setContentsVisible(bool) override;
     WEBCORE_EXPORT void setAcceleratesDrawing(bool) override;

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
@@ -300,6 +300,10 @@ public:
     virtual GraphicsLayer::CustomAppearance customAppearance() const = 0;
     virtual void updateCustomAppearance(GraphicsLayer::CustomAppearance) = 0;
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    virtual bool setNeedsDisplayIfEDRHeadroomExceeds(float);
+#endif
+
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
     virtual bool isSeparated() const = 0;
     virtual void setIsSeparated(bool) = 0;

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
@@ -253,6 +253,13 @@ void PlatformCALayer::setAcceleratedEffectsAndBaseValues(const AcceleratedEffect
 }
 #endif
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+bool PlatformCALayer::setNeedsDisplayIfEDRHeadroomExceeds(float)
+{
+    return false;
+}
+#endif
+
 void PlatformCALayer::dumpAdditionalProperties(TextStream&, OptionSet<PlatformLayerTreeAsTextFlags>)
 {
 }

--- a/Source/WebCore/platform/graphics/ca/TileController.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileController.cpp
@@ -235,6 +235,13 @@ void TileController::setAcceleratesDrawing(bool acceleratesDrawing)
     tileGrid().updateTileLayerProperties();
 }
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+bool TileController::setNeedsDisplayIfEDRHeadroomExceeds(float headroom)
+{
+    return tileGrid().setNeedsDisplayIfEDRHeadroomExceeds(headroom);
+}
+#endif
+
 void TileController::setContentsFormat(ContentsFormat contentsFormat)
 {
     if (m_contentsFormat == contentsFormat)

--- a/Source/WebCore/platform/graphics/ca/TileController.h
+++ b/Source/WebCore/platform/graphics/ca/TileController.h
@@ -80,6 +80,10 @@ public:
     WEBCORE_EXPORT void setContentsScale(float);
     WEBCORE_EXPORT float contentsScale() const;
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    WEBCORE_EXPORT bool setNeedsDisplayIfEDRHeadroomExceeds(float);
+#endif
+
     bool acceleratesDrawing() const { return m_acceleratesDrawing; }
     WEBCORE_EXPORT void setAcceleratesDrawing(bool);
 

--- a/Source/WebCore/platform/graphics/ca/TileGrid.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.cpp
@@ -110,6 +110,16 @@ void TileGrid::setScale(float scale)
     m_controller->willRepaintAllTiles(*this);
 }
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+bool TileGrid::setNeedsDisplayIfEDRHeadroomExceeds(float headroom)
+{
+    bool changed = false;
+    for (auto& entry : m_tiles)
+        changed |= entry.value.layer->setNeedsDisplayIfEDRHeadroomExceeds(headroom);
+    return changed;
+}
+#endif
+
 void TileGrid::setNeedsDisplay()
 {
     for (auto& entry : m_tiles) {

--- a/Source/WebCore/platform/graphics/ca/TileGrid.h
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.h
@@ -76,6 +76,10 @@ public:
     void setNeedsDisplayInRect(const IntRect&);
     void dropTilesInRect(const IntRect&);
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    bool setNeedsDisplayIfEDRHeadroomExceeds(float);
+#endif
+
     void updateTileLayerProperties();
 
     bool prepopulateRect(const FloatRect&);

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -402,8 +402,12 @@ void GraphicsContextCG::drawNativeImageInternal(NativeImage& nativeImage, const 
     if (headroom == Headroom::FromImage)
         headroom = nativeImage.headroom();
 
-    if (headroom > Headroom::None)
+    if (headroom > Headroom::None) {
+        if (m_maxEDRHeadroom)
+            headroom = std::min(headroom.headroom, *m_maxEDRHeadroom);
+        LOG_WITH_STREAM(HDR, stream << "GraphicsContextCG::drawNativeImageInternal setEDRTargetHeadroom " << headroom << " max(" << m_maxEDRHeadroom << ")");
         CGContextSetEDRTargetHeadroom(context, headroom);
+    }
 
     if (options.dynamicRangeLimit() == PlatformDynamicRangeLimit::standard())
         setCGDynamicRangeLimitForImage(context, subImage.get(), options.dynamicRangeLimit().value());
@@ -1542,6 +1546,14 @@ bool GraphicsContextCG::consumeHasDrawn()
     m_hasDrawn = false;
     return hasDrawn;
 }
+
+#if HAVE(SUPPORT_HDR_DISPLAY)
+void GraphicsContextCG::setMaxEDRHeadroom(std::optional<float> headroom)
+{
+    m_maxEDRHeadroom = headroom;
+}
+#endif
+
 
 }
 

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
@@ -145,6 +145,10 @@ public:
     // Returns true if there has been potential draws since last call.
     bool consumeHasDrawn();
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    void setMaxEDRHeadroom(std::optional<float>) final;
+#endif
+
 protected:
     void setCGShadow(const std::optional<GraphicsDropShadow>&, bool shadowsIgnoreTransforms);
     void setCGStyle(const std::optional<GraphicsStyle>&, bool shadowsIgnoreTransforms);
@@ -158,6 +162,9 @@ private:
 
     const RetainPtr<CGContextRef> m_cgContext;
     mutable std::optional<DestinationColorSpace> m_colorSpace;
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    std::optional<float> m_maxEDRHeadroom;
+#endif
     const RenderingMode m_renderingMode : 2; // NOLINT
     const bool m_isLayerCGContext : 1;
     mutable bool m_userToDeviceTransformKnownToBeIdentity : 1 { false };

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.h
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.h
@@ -195,6 +195,12 @@ public:
     IntSize size() const { return m_size; }
     size_t totalBytes() const { return m_totalBytes; }
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    WEBCORE_EXPORT void setContentEDRHeadroom(float);
+    WEBCORE_EXPORT std::optional<float> contentEDRHeadroom() const;
+    void loadContentEDRHeadroom();
+#endif
+
     WEBCORE_EXPORT DestinationColorSpace colorSpace();
     WEBCORE_EXPORT IOSurfaceID surfaceID() const;
     WEBCORE_EXPORT size_t bytesPerRow() const;
@@ -234,6 +240,9 @@ private:
     std::optional<DestinationColorSpace> m_colorSpace;
     IntSize m_size;
     size_t m_totalBytes;
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    std::optional<float> m_contentEDRHeadroom;
+#endif
 
     ProcessIdentity m_resourceOwner;
 

--- a/Source/WebCore/platform/ios/PlatformScreenIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformScreenIOS.mm
@@ -120,6 +120,24 @@ bool screenSupportsHighDynamicRange(Widget*)
     return false;
 }
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+float currentEDRHeadroomForDisplay(PlatformDisplayID)
+{
+    if (auto data = screenData(primaryScreenDisplayID()))
+        return data->currentEDRHeadroom;
+
+    return [[PAL::getUIScreenClass() mainScreen] currentEDRHeadroom];
+}
+
+float maxEDRHeadroomForDisplay(PlatformDisplayID)
+{
+    if (auto data = screenData(primaryScreenDisplayID()))
+        return data->maxEDRHeadroom;
+
+    return [[PAL::getUIScreenClass() mainScreen] potentialEDRHeadroom];
+}
+#endif
+
 DestinationColorSpace screenColorSpace(Widget* widget)
 {
     UNUSED_PARAM(widget);
@@ -251,6 +269,10 @@ ScreenProperties collectScreenProperties()
         screenData.screenHasInvertedColors = WebCore::screenHasInvertedColors();
         screenData.screenSupportsHighDynamicRange = WebCore::screenSupportsHighDynamicRange(nullptr);
         screenData.scaleFactor = WebCore::screenPPIFactor();
+#if HAVE(SUPPORT_HDR_DISPLAY)
+        screenData.maxEDRHeadroom = [screen potentialEDRHeadroom];
+        screenData.currentEDRHeadroom = [screen currentEDRHeadroom];
+#endif
 
         screenProperties.screenDataMap.set(++displayID, WTFMove(screenData));
 

--- a/Source/WebCore/platform/mac/PlatformScreenMac.mm
+++ b/Source/WebCore/platform/mac/PlatformScreenMac.mm
@@ -175,6 +175,10 @@ ScreenProperties collectScreenProperties()
         screenData.screenSize = FloatSize { CGDisplayScreenSize(displayID) };
         screenData.scaleFactor = screen.backingScaleFactor;
         screenData.screenSupportsHighDynamicRange = screenSupportsHighDynamicRange(displayID, screenData.preferredDynamicRangeMode);
+#if HAVE(SUPPORT_HDR_DISPLAY)
+        screenData.maxEDRHeadroom = [screen maximumPotentialExtendedDynamicRangeColorComponentValue];
+        screenData.currentEDRHeadroom = [screen maximumExtendedDynamicRangeColorComponentValue];
+#endif
 
         screenProperties.screenDataMap.set(displayID, WTFMove(screenData));
         if (!screenProperties.primaryDisplayID)
@@ -320,6 +324,26 @@ FloatRect screenRectForPrimaryScreen()
 {
     return screenRectForDisplay(primaryScreenDisplayID());
 }
+
+#if HAVE(SUPPORT_HDR_DISPLAY)
+float currentEDRHeadroomForDisplay(PlatformDisplayID displayID)
+{
+    if (auto data = screenData(displayID))
+        return data->currentEDRHeadroom;
+
+    ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
+    return screen(displayID).maximumExtendedDynamicRangeColorComponentValue;
+}
+
+float maxEDRHeadroomForDisplay(PlatformDisplayID displayID)
+{
+    if (auto data = screenData(displayID))
+        return data->maxEDRHeadroom;
+
+    ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
+    return screen(displayID).maximumPotentialExtendedDynamicRangeColorComponentValue;
+}
+#endif
 
 FloatRect screenRect(Widget* widget)
 {

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -134,6 +134,9 @@ inline RenderElement::RenderElement(Type type, ContainerNode& elementOrDocument,
     , m_hasPausedImageAnimations(false)
     , m_hasCounterNodeMap(false)
     , m_hasContinuationChainNode(false)
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    , m_hasHDRImages(false)
+#endif
     , m_isContinuation(false)
     , m_isFirstLetter(false)
     , m_renderBlockHasMarginBeforeQuirk(false)

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -241,6 +241,11 @@ public:
     bool hasPausedImageAnimations() const { return m_hasPausedImageAnimations; }
     void setHasPausedImageAnimations(bool b) { m_hasPausedImageAnimations = b; }
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    bool hasHDRImages() const { return m_hasHDRImages; }
+    void setHasHDRImages(bool b) { m_hasHDRImages = b; }
+#endif
+
     bool hasCounterNodeMap() const { return m_hasCounterNodeMap; }
     void setHasCounterNodeMap(bool f) { m_hasCounterNodeMap = f; }
 
@@ -441,6 +446,9 @@ private:
     unsigned m_hasPausedImageAnimations : 1;
     unsigned m_hasCounterNodeMap : 1;
     unsigned m_hasContinuationChainNode : 1;
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    unsigned m_hasHDRImages : 1;
+#endif
 
     unsigned m_isContinuation : 1;
     unsigned m_isFirstLetter : 1;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -117,6 +117,10 @@ public:
     void setNeedsDisplay(const WebCore::IntRect);
     void setNeedsDisplay();
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    bool setNeedsDisplayIfEDRHeadroomExceeds(float);
+#endif
+
     void setDelegatedContents(const PlatformCALayerRemoteDelegatedContents&);
 
     // Returns true if we need to encode the buffer.
@@ -208,6 +212,11 @@ protected:
     WebCore::RepaintRectList m_paintingRects;
 
     MonotonicTime m_lastDisplayTime;
+
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    float m_edrHeadroom { 1.0f };
+    bool m_hasPaintedClampedEDRHeadroom { false };
+#endif
 };
 
 // The subset of RemoteLayerBackingStore that gets serialized into the UI
@@ -254,6 +263,9 @@ private:
 
     bool m_isOpaque;
     RemoteLayerBackingStore::Type m_type;
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    float m_edrHeadroom;
+#endif
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, BackingStoreNeedsDisplayReason);

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -102,6 +102,9 @@ header: "RemoteLayerBackingStore.h"
 [CustomEncoder, CustomHeader, LegacyPopulateFromEmptyConstructor, Nested] class WebKit::RemoteLayerBackingStoreProperties {
     bool m_isOpaque;
     WebKit::RemoteLayerBackingStore::Type m_type;
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    float m_edrHeadroom;
+#endif
     std::optional<WebKit::ImageBufferBackendHandle> m_bufferHandle;
     std::optional<WebKit::RemoteImageBufferSetIdentifier> m_bufferSet;
     std::optional<WebKit::BufferAndBackendInfo> m_frontBufferInfo;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
@@ -170,6 +170,9 @@ void RemoteLayerWithRemoteRenderingBackingStore::dump(WTF::TextStream& ts) const
     ts.dumpProperty("buffer set"_s, m_bufferSet);
     ts.dumpProperty("cache identifiers"_s, m_bufferCacheIdentifiers);
     ts.dumpProperty("is opaque"_s, isOpaque());
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    ts.dumpProperty("headroom", m_edrHeadroom);
+#endif
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2492,6 +2492,10 @@ header: <WebCore/ScreenProperties.h>
     bool screenSupportsExtendedColor;
     bool screenHasInvertedColors;
     bool screenSupportsHighDynamicRange;
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    float currentEDRHeadroom;
+    float maxEDRHeadroom;
+#endif
 #if PLATFORM(MAC)
     WebCore::FloatSize screenSize;
     bool screenIsMonochrome;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
@@ -28,6 +28,7 @@
 #include "RemoteAcceleratedEffectStack.h"
 #include "RemoteLayerBackingStore.h"
 #include <WebCore/EventRegion.h>
+#include <WebCore/IOSurface.h>
 #include <WebCore/LayerHostingContextIdentifier.h>
 #include <WebCore/PlatformLayerIdentifier.h>
 #include <WebCore/RenderingResourceIdentifier.h>
@@ -127,6 +128,7 @@ public:
     struct CachedContentsBuffer {
         BufferAndBackendInfo imageBufferInfo;
         RetainPtr<id> buffer;
+        std::unique_ptr<WebCore::IOSurface> ioSurface;
     };
 
     Vector<CachedContentsBuffer> takeCachedContentsBuffers() { return std::exchange(m_cachedContentsBuffers, { }); }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
@@ -229,6 +229,9 @@ void RemoteLayerTreeDrawingAreaProxyIOS::setPreferredFramesPerSecond(IPC::Connec
 
 void RemoteLayerTreeDrawingAreaProxyIOS::didRefreshDisplay()
 {
+    if (RefPtr page = this->page())
+        page->didRefreshDisplay();
+
     if (m_needsDisplayRefreshCallbacksForDrawing)
         RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay();
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2713,6 +2713,8 @@ public:
 
 #if PLATFORM(IOS_FAMILY)
     void isPotentialTapInProgress(CompletionHandler<void(bool)>&&);
+
+    void didRefreshDisplay();
 #endif
 
 #if PLATFORM(COCOA) && ENABLE(ASYNC_SCROLLING)

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -635,6 +635,10 @@ public:
     void registerAdditionalFonts(NSArray *fontNames);
 #endif
 
+#if PLATFORM(IOS_FAMILY)
+    void didRefreshDisplay();
+#endif
+
 private:
     enum class NeedsGlobalStaticInitialization : bool { No, Yes };
     void platformInitialize(NeedsGlobalStaticInitialization);
@@ -841,9 +845,14 @@ private:
     RetainPtr<NSObject> m_accessibilityDisplayOptionsNotificationObserver;
     RetainPtr<NSObject> m_scrollerStyleNotificationObserver;
     RetainPtr<NSObject> m_deactivationObserver;
+    RetainPtr<NSObject> m_didChangeScreenParametersNotificationObserver;
     RetainPtr<WKWebInspectorPreferenceObserver> m_webInspectorPreferenceObserver;
 
     const UniqueRef<PerActivityStateCPUUsageSampler> m_perActivityStateCPUUsageSampler;
+#endif
+
+#if PLATFORM(IOS_FAMILY) && HAVE(SUPPORT_HDR_DISPLAY)
+    float m_currentEDRHeadroom { 1 };
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1799,6 +1799,11 @@ FloatSize WebPageProxy::viewLayoutSize() const
     return internals().viewportConfigurationViewLayoutSize;
 }
 
+void WebPageProxy::didRefreshDisplay()
+{
+    m_configuration->protectedProcessPool()->didRefreshDisplay();
+}
+
 #if ENABLE(PDF_PAGE_NUMBER_INDICATOR)
 
 void WebPageProxy::createPDFPageNumberIndicator(PDFPluginIdentifier identifier, const IntRect& rect, size_t pageCount)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
@@ -159,6 +159,13 @@ private:
     RefPtr<WebCore::ImageBuffer> createAlignedImageBuffer(const WebCore::FloatSize&, const WebCore::DestinationColorSpace&, std::optional<WebCore::RenderingMethod>) const final;
     RefPtr<WebCore::ImageBuffer> createAlignedImageBuffer(const WebCore::FloatRect&, const WebCore::DestinationColorSpace&, std::optional<WebCore::RenderingMethod>) const final;
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    void setMaxEDRHeadroom(std::optional<float> headroom) final { m_maxEDRHeadroom = headroom; }
+    float maxPaintedEDRHeadroom() const final { return m_maxPaintedEDRHeadroom; }
+    bool hasPaintedClampedEDRHeadroom() const final { return m_hasPaintedClampedEDRHeadroom; }
+    void clearMaxPaintedEDRHeadroom() final { m_maxPaintedEDRHeadroom = 1; m_hasPaintedClampedEDRHeadroom = false; }
+#endif
+
     const WebCore::RenderingMode m_renderingMode;
     const RemoteDisplayListRecorderIdentifier m_identifier;
     RefPtr<IPC::StreamClientConnection> m_connection;
@@ -168,6 +175,11 @@ private:
 #if PLATFORM(COCOA) && ENABLE(VIDEO)
     Lock m_sharedVideoFrameWriterLock;
     std::unique_ptr<SharedVideoFrameWriter> m_sharedVideoFrameWriter WTF_GUARDED_BY_LOCK(m_sharedVideoFrameWriterLock);
+#endif
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    std::optional<float> m_maxEDRHeadroom;
+    float m_maxPaintedEDRHeadroom { 1 };
+    bool m_hasPaintedClampedEDRHeadroom { false };
 #endif
     // Flag for pending draws. Start with true because we do not know what commands have been scheduled to the context.
     bool m_hasDrawn { true };

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
@@ -222,6 +222,10 @@ public:
     void setScrollingNodeID(std::optional<WebCore::ScrollingNodeID>) override;
 #endif
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    bool setNeedsDisplayIfEDRHeadroomExceeds(float) override;
+#endif
+
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
     bool isSeparated() const override;
     void setIsSeparated(bool) override;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -1079,6 +1079,15 @@ void PlatformCALayerRemote::setScrollingNodeID(std::optional<ScrollingNodeID> no
 }
 #endif
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+bool PlatformCALayerRemote::setNeedsDisplayIfEDRHeadroomExceeds(float headroom)
+{
+    if (m_properties.backingStoreOrProperties.store)
+        return m_properties.backingStoreOrProperties.store->setNeedsDisplayIfEDRHeadroomExceeds(headroom);
+    return false;
+}
+#endif
+
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
 bool PlatformCALayerRemote::isSeparated() const
 {

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteTiledBacking.cpp
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteTiledBacking.cpp
@@ -87,6 +87,14 @@ void PlatformCALayerRemoteTiledBacking::setAcceleratesDrawing(bool acceleratesDr
     m_tileController->setAcceleratesDrawing(acceleratesDrawing);
 }
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+bool PlatformCALayerRemoteTiledBacking::setNeedsDisplayIfEDRHeadroomExceeds(float headroom)
+{
+    return m_tileController->setNeedsDisplayIfEDRHeadroomExceeds(headroom);
+}
+#endif
+
+
 ContentsFormat PlatformCALayerRemoteTiledBacking::contentsFormat() const
 {
     return m_tileController->contentsFormat();

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteTiledBacking.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteTiledBacking.h
@@ -53,6 +53,10 @@ private:
     bool acceleratesDrawing() const override;
     void setAcceleratesDrawing(bool) override;
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    bool setNeedsDisplayIfEDRHeadroomExceeds(float) override;
+#endif
+
     WebCore::ContentsFormat contentsFormat() const override;
     void setContentsFormat(WebCore::ContentsFormat) override;
 


### PR DESCRIPTION
#### 75fb0f2929ea8df1f8984abb911e172a16eca764
<pre>
Painted images don&apos;t get tone mapped down to the level supported by the display.
<a href="https://bugs.webkit.org/show_bug.cgi?id=294419">https://bugs.webkit.org/show_bug.cgi?id=294419</a>
&lt;<a href="https://rdar.apple.com/152695267">rdar://152695267</a>&gt;

Reviewed by Mike Wyrzykowski.

Add support for getting the currently available EDR headroom to PlatformScreen,
and synchronize it to all processes. Use
NSApplicationDidChangeScreenParametersNotification to detect change on macos,
use a poll on every displaylink update on iOS.

When painting via RemoteDisplayListRecorderProxy, clamp image headroom to the
maximum currently available on the display, and keep track of what the highest
painted value was (and if it was clamped). Theses values get stored on the
RemoteLayerBackingStore.

When display headroom changes, trigger a compositing update for all layers. Adds
a new function &apos;setNeedsDisplayIfHeadroomExceeds&apos; to GraphicsLayer (and layers
below it) that conditionally mark repaint if the new display headroom would
apply different clamping to what is currently painted into the layer.

Some of this is a bit awkward since we don&apos;t really know what is painted into a
layer in advance, so using the recorded to track what HDR painting occurred and
keep it available for the next paint.

This approach lets us track headroom per-tile, and only repaint affected tiles
when the display headroom. The downside is that a content change to remove an
HDR image won&apos;t drop the max headroom for tiles that it was previouly drawn to,
so those will get repainted again if the display headroom changes (once, and
then the cached headroom will be correct).

We also serialize the resulting headroom of the layer to the UI process via
RemoteLayerBackingStoreProperties. We use CAIOSurface to cache a CoreAnimation
wrapper around an IOSurface, and we need to recreate these if the IOSurface
headroom metadata has changed.

* Source/WebCore/PAL/pal/cocoa/QuartzCoreSoftLink.h:
* Source/WebCore/PAL/pal/cocoa/QuartzCoreSoftLink.mm:
* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::currentFrameHeadroom const):
* Source/WebCore/loader/cache/CachedImage.h:
* Source/WebCore/page/Page.cpp:
(WebCore::m_presentingApplicationBundleIdentifier):
(WebCore::Page::screenPropertiesDidChange):
(WebCore::Page::updateDisplayEDRHeadroom):
* Source/WebCore/page/Page.h:
(WebCore::Page::displayEDRHeadroom const):
* Source/WebCore/platform/Logging.h:
* Source/WebCore/platform/PlatformScreen.h:
* Source/WebCore/platform/ScreenProperties.h:
* Source/WebCore/platform/graphics/BitmapImage.h:
* Source/WebCore/platform/graphics/GraphicsContext.h:
(WebCore::GraphicsContext::setMaxEDRHeadroom):
(WebCore::GraphicsContext::maxPaintedHeadroom const):
(WebCore::GraphicsContext::paintingClampedHeadroom const):
(WebCore::GraphicsContext::clearMaxPaintedHeadroom):
* Source/WebCore/platform/graphics/GraphicsLayer.cpp:
(WebCore::GraphicsLayer::setNeedsDisplayIfHeadroomExceeds):
* Source/WebCore/platform/graphics/GraphicsLayer.h:
* Source/WebCore/platform/graphics/GraphicsLayerClient.h:
* Source/WebCore/platform/graphics/Image.h:
(WebCore::Image::currentFrameHeadroom const):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::setNeedsDisplayIfHeadroomExceeds):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayer.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayer.mm:
(WebCore::PlatformCALayer::setNeedsDisplayIfHeadroomExceeds):
* Source/WebCore/platform/graphics/ca/TileController.cpp:
(WebCore::TileController::setNeedsDisplayIfHeadroomExceeds):
* Source/WebCore/platform/graphics/ca/TileController.h:
* Source/WebCore/platform/graphics/ca/TileGrid.cpp:
(WebCore::TileGrid::setNeedsDisplayIfHeadroomExceeds):
* Source/WebCore/platform/graphics/ca/TileGrid.h:
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::drawNativeImageInternal):
(WebCore::GraphicsContextCG::setMaxEDRHeadroom):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.h:
* Source/WebCore/platform/graphics/cocoa/IOSurface.h:
* Source/WebCore/platform/graphics/cocoa/IOSurface.mm:
(WebCore::IOSurface::asCAIOSurfaceLayerContents const):
(WebCore::IOSurface::setContentEDRHeadroom):
(WebCore::IOSurface::contentEDRHeadroom const):
* Source/WebCore/platform/ios/PlatformScreenIOS.mm:
(WebCore::currentEDRHeadroomForDisplay):
(WebCore::maxEDRHeadroomForDisplay):
(WebCore::collectScreenProperties):
* Source/WebCore/platform/mac/PlatformScreenMac.mm:
(WebCore::collectScreenProperties):
(WebCore::currentEDRHeadroomForDisplay):
(WebCore::maxEDRHeadroomForDisplay):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::RenderElement):
* Source/WebCore/rendering/RenderElement.h:
(WebCore::RenderElement::hasHDRImages const):
(WebCore::RenderElement::setHasHDRImages):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateDrawsContent):
(WebCore::RenderLayerBacking::paintContents):
* Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::encode const):
(WebKit::RemoteLayerBackingStoreProperties::dump const):
(WebKit::RemoteLayerBackingStore::setNeedsDisplay):
(WebKit::RemoteLayerBackingStore::setNeedsDisplayIfHeadroomExceeds):
(WebKit::RemoteLayerBackingStore::supportsPartialRepaint const):
(WebKit::RemoteLayerBackingStore::drawInContext):
(WebKit::RemoteLayerBackingStoreProperties::updateCachedBuffers):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm:
(WebKit::RemoteLayerWithRemoteRenderingBackingStore::dump const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::registerNotificationObservers):
(WebKit::WebProcessPool::unregisterNotificationObservers):
(WebKit::WebProcessPool::willRefreshDisplay):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::didRefreshDisplay):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::willRefreshDisplay):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::drawNativeImageInternal):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h:
(WebKit::RemoteDisplayListRecorderProxy::paintingClampedHeadroom const):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm:
(WebKit::PlatformCALayerRemote::setNeedsDisplayIfHeadroomExceeds):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteTiledBacking.cpp:
(WebKit::PlatformCALayerRemoteTiledBacking::setNeedsDisplayIfHeadroomExceeds):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteTiledBacking.h:

Canonical link: <a href="https://commits.webkit.org/296360@main">https://commits.webkit.org/296360@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c442922882acac16f8677af6c70278fdea401fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108296 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18379 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113505 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/58734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110259 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28646 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36506 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82223 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/58734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111244 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22703 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97549 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62659 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22116 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15687 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58237 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/100859 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92071 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15743 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116627 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/106855 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35350 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26029 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/91255 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35723 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93826 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91056 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23202 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35937 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13708 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35252 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40790 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/131141 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34969 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35595 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38323 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36650 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->