### PR TITLE
REGRESSION (STP): Web Inspector search result loses selection in Elements tab

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/TreeOutline.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TreeOutline.js
@@ -363,9 +363,9 @@ WI.TreeOutline = class TreeOutline extends WI.Object
 
     removeChildren(suppressOnDeselect)
     {
-        for (let child of this.children) {
-            child.deselect(suppressOnDeselect);
+        this.selectedTreeElement?.deselect(suppressOnDeselect);
 
+        for (let child of this.children) {
             let treeOutline = child.treeOutline;
 
             child._detach();
@@ -402,12 +402,14 @@ WI.TreeOutline = class TreeOutline extends WI.Object
 
     _forgetTreeElementAndDescendants(element)
     {
+        console.assert(!element.selected, element);
         element.treeOutline = null;
         this._knownTreeElements.delete(element.identifier, element);
 
         const skipUnrevealed = false;
         const dontPopulate = true;
         for (let current = element.children[0]; current; current = current.traverseNextTreeElement(skipUnrevealed, element, dontPopulate)) {
+            console.assert(!current.selected, current);
             current.treeOutline = null;
             this._knownTreeElements.delete(current.identifier, current);
         }


### PR DESCRIPTION
#### 7d8692809ce959568f746d44d08470975f7f9771
<pre>
REGRESSION (STP): Web Inspector search result loses selection in Elements tab
<a href="https://rdar.apple.com/153304495">rdar://153304495</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=294396">https://bugs.webkit.org/show_bug.cgi?id=294396</a>

Reviewed by Patrick Angle.

The bug can be simplified as, if you leave the Elements tab while
there&apos;s a node selected in the DOM tree, when you come back to the
Elements tab, that node appears unselected and can&apos;t be selected again
until you first select something else.

The regression point was <a href="https://github.com/WebKit/WebKit/pull/41834.">https://github.com/WebKit/WebKit/pull/41834.</a>
In that patch, we refactored and simplified the TreeOutline&apos;s logic for
forgetting an element and its descendants. During refactoring, we
removed the logic to ensure that those forgotten elements get
deselected. When the TreeOutline is set to visible the second time (when
you come back), the tree will try to reapply the selected element, but
it got skipped because its selectedTreeElement wasn&apos;t cleared. This
resulted in the selected style not being applied despite that element
is selected internally.

So, when all children of the TreeOutline get removed, we make sure to
clear the selectedTreeElement, restoring an equivalent behavior to the
code predating <a href="https://github.com/WebKit/WebKit/pull/41834.">https://github.com/WebKit/WebKit/pull/41834.</a> (Deselecting
all children by calling `deselect` still won&apos;t guarantee clearing
selectedTreeElement because the selected element could live deeper.)

Tested on macOS 26.0 and verified that the OpenResourceDialog still
works like normal.

* Source/WebInspectorUI/UserInterface/Views/TreeOutline.js:
(WI.TreeOutline.prototype._forgetTreeElementAndDescendants):

Canonical link: <a href="https://commits.webkit.org/296460@main">https://commits.webkit.org/296460@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7fb0779fa1a29d3635e24151007e834babe3b19c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108257 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27919 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18340 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113466 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58711 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28615 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36470 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82195 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111205 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22678 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97513 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62627 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22091 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15648 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58199 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92044 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15704 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116588 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35318 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26003 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91224 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35690 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93787 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91020 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23263 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35913 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13672 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31081 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35217 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40762 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34942 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38296 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36616 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->