### PR TITLE
Add helper for computing the reflected control point for smooth segments

### DIFF
--- a/Source/WebCore/svg/SVGPathParser.cpp
+++ b/Source/WebCore/svg/SVGPathParser.cpp
@@ -167,6 +167,12 @@ bool SVGPathParser::parseCurveToCubicSegment()
     return true;
 }
 
+static FloatPoint reflectedPoint(const FloatPoint& center, const FloatPoint& point)
+{
+    // `center` is the middle point between `point` and `reflectedPoint`.
+    return { 2 * center.x() - point.x(), 2 * center.y() - point.y() };
+}
+
 bool SVGPathParser::parseCurveToCubicSmoothSegment()
 {
     auto result = m_source->parseCurveToCubicSmoothSegment(m_currentPoint);
@@ -180,9 +186,7 @@ bool SVGPathParser::parseCurveToCubicSmoothSegment()
         m_controlPoint = m_currentPoint;
 
     if (m_pathParsingMode == NormalizedParsing) {
-        FloatPoint point1 = m_currentPoint;
-        point1.scale(2);
-        point1.move(-m_controlPoint.x(), -m_controlPoint.y());
+        FloatPoint point1 = reflectedPoint(m_currentPoint, m_controlPoint);
         if (m_mode == RelativeCoordinates) {
             result->point2 += m_currentPoint;
             result->targetPoint += m_currentPoint;
@@ -240,9 +244,7 @@ bool SVGPathParser::parseCurveToQuadraticSmoothSegment()
         m_controlPoint = m_currentPoint;
 
     if (m_pathParsingMode == NormalizedParsing) {
-        FloatPoint cubicPoint = m_currentPoint;
-        cubicPoint.scale(2);
-        cubicPoint.move(-m_controlPoint.x(), -m_controlPoint.y());
+        FloatPoint cubicPoint = reflectedPoint(m_currentPoint, m_controlPoint);
         FloatPoint point1(m_currentPoint.x() + 2 * cubicPoint.x(), m_currentPoint.y() + 2 * cubicPoint.y());
         FloatPoint point2(result->targetPoint.x() + 2 * cubicPoint.x(), result->targetPoint.y() + 2 * cubicPoint.y());
         if (m_mode == RelativeCoordinates) {


### PR DESCRIPTION
#### 3d643c7076c54090350d8ac71db384eb7d7bba78
<pre>
Add helper for computing the reflected control point for smooth segments
<a href="https://bugs.webkit.org/show_bug.cgi?id=294591">https://bugs.webkit.org/show_bug.cgi?id=294591</a>

Reviewed by Said Abou-Hallawa.

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/dfe891bb1ac9bddc6c9cfbf2d3e0e3d423edc85a">https://chromium.googlesource.com/chromium/blink/+/dfe891bb1ac9bddc6c9cfbf2d3e0e3d423edc85a</a>

This patch introduces helper &apos;reflectedPoint&apos;, which enables us to clean-up
code in other two &apos;smooth segments&apos; functions. It is just clean-up.

* Source/WebCore/svg/SVGPathParser.cpp:
(WebCore::reflectedPoint):
(WebCore::SVGPathParser::parseCurveToCubicSmoothSegment):
(WebCore::SVGPathParser::parseCurveToQuadraticSmoothSegment):

Canonical link: <a href="https://commits.webkit.org/296366@main">https://commits.webkit.org/296366@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12769321326416a6b4b14e7863fa0fe3b4d950b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108285 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27946 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18368 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113494 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58726 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110248 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28636 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36495 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82212 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111233 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22697 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97540 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62648 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22111 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15678 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58227 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92063 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15734 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116616 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35340 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26021 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91240 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35712 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93817 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91041 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23206 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35928 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13699 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31097 "Hash 12769321 for PR 46832 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35241 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40781 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34960 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38314 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36639 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->