### PR TITLE
Introduce RemotePageVideoPresentationManagerProxy

### DIFF
--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -414,6 +414,7 @@ UIProcess/ProvisionalPageProxy.cpp
 UIProcess/RemotePageDrawingAreaProxy.cpp
 UIProcess/RemotePageFullscreenManagerProxy.cpp
 UIProcess/RemotePageProxy.cpp
+UIProcess/RemotePageVideoPresentationManagerProxy.cpp
 UIProcess/ResponsivenessTimer.cpp
 UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp
 UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp

--- a/Source/WebKit/UIProcess/API/APINavigationResponse.cpp
+++ b/Source/WebKit/UIProcess/API/APINavigationResponse.cpp
@@ -28,6 +28,7 @@
 
 #include "APIFrameInfo.h"
 #include "APINavigation.h"
+#include "FrameInfoData.h"
 #include "WebFrameProxy.h"
 
 namespace API {

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -199,6 +199,7 @@ public:
     RefPtr<WebCore::PlatformVideoPresentationInterface> bestVideoForElementFullscreen();
 
 private:
+    friend class RemotePageVideoPresentationManagerProxy;
     friend class VideoPresentationModelContext;
 
     explicit VideoPresentationManagerProxy(WebPageProxy&, PlaybackSessionManagerProxy&);

--- a/Source/WebKit/UIProcess/Gamepad/wpe/GamepadProviderWPE.h
+++ b/Source/WebKit/UIProcess/Gamepad/wpe/GamepadProviderWPE.h
@@ -65,7 +65,7 @@ private:
     void startMonitoringGamepads(WebCore::GamepadProviderClient&) final;
     void stopMonitoringGamepads(WebCore::GamepadProviderClient&) final;
     const Vector<WeakPtr<WebCore::PlatformGamepad>>& platformGamepads() final { return m_gamepadVector; }
-    void playEffect(unsigned, const String&, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
+    void playEffect(unsigned, const String&, WebCore::GamepadHapticEffectType, const WebCore::GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
     void stopEffects(unsigned, const String&, CompletionHandler<void()>&&) final;
 
     void inputNotificationTimerFired();

--- a/Source/WebKit/UIProcess/Gamepad/wpe/PlatformGamepadWPE.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/wpe/PlatformGamepadWPE.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "PlatformGamepadWPE.h"
 
+#include "GamepadProviderWPE.h"
+
 #if ENABLE(GAMEPAD) && ENABLE(WPE_PLATFORM)
 #include <wpe/wpe-platform.h>
 

--- a/Source/WebKit/UIProcess/RemotePageFullscreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageFullscreenManagerProxy.h
@@ -48,7 +48,6 @@ private:
     RemotePageFullscreenManagerProxy(WebCore::PageIdentifier, WebFullScreenManagerProxy*, WebProcessProxy&);
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
 
     const WebCore::PageIdentifier m_identifier;
     const WeakPtr<WebFullScreenManagerProxy> m_manager;

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -55,6 +55,10 @@
 #include "WebFullScreenManagerProxy.h"
 #endif
 
+#if ENABLE(VIDEO_PRESENTATION_MODE)
+#include "RemotePageVideoPresentationManagerProxy.h"
+#endif
+
 namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemotePageProxy);
@@ -95,6 +99,9 @@ void RemotePageProxy::injectPageIntoNewProcess()
     m_drawingArea = RemotePageDrawingAreaProxy::create(drawingArea.get(), m_process);
 #if ENABLE(FULLSCREEN_API)
     m_fullscreenManager = RemotePageFullscreenManagerProxy::create(pageID(), page->protectedFullScreenManager().get(), m_process);
+#endif
+#if ENABLE(VIDEO_PRESENTATION_MODE)
+    m_videoPresentationManager = RemotePageVideoPresentationManagerProxy::create(pageID(), m_process, page->protectedVideoPresentationManager().get());
 #endif
     m_visitedLinkStoreRegistration = makeUnique<RemotePageVisitedLinkStoreRegistration>(*page, m_process);
 

--- a/Source/WebKit/UIProcess/RemotePageProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageProxy.h
@@ -63,6 +63,7 @@ class DrawingAreaProxy;
 class NativeWebMouseEvent;
 class RemotePageDrawingAreaProxy;
 class RemotePageFullscreenManagerProxy;
+class RemotePageVideoPresentationManagerProxy;
 class RemotePageVisitedLinkStoreRegistration;
 class UserData;
 class WebFrameProxy;
@@ -118,6 +119,9 @@ private:
     RefPtr<RemotePageDrawingAreaProxy> m_drawingArea;
 #if ENABLE(FULLSCREEN_API)
     RefPtr<RemotePageFullscreenManagerProxy> m_fullscreenManager;
+#endif
+#if ENABLE(VIDEO_PRESENTATION_MODE)
+    RefPtr<RemotePageVideoPresentationManagerProxy> m_videoPresentationManager;
 #endif
     std::unique_ptr<RemotePageVisitedLinkStoreRegistration> m_visitedLinkStoreRegistration;
     WebPageProxyMessageReceiverRegistration m_messageReceiverRegistration;

--- a/Source/WebKit/UIProcess/RemotePageVideoPresentationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageVideoPresentationManagerProxy.cpp
@@ -24,35 +24,36 @@
  */
 
 #include "config.h"
-#include "RemotePageFullscreenManagerProxy.h"
+#include "RemotePageVideoPresentationManagerProxy.h"
 
-#if ENABLE(FULLSCREEN_API)
+#if ENABLE(VIDEO_PRESENTATION_MODE)
 
-#include "WebFullScreenManagerProxy.h"
-#include "WebFullScreenManagerProxyMessages.h"
+#include "VideoPresentationManagerProxy.h"
+#include "VideoPresentationManagerProxyMessages.h"
+#include "WebPageProxy.h"
 #include "WebProcessProxy.h"
 
 namespace WebKit {
 
-Ref<RemotePageFullscreenManagerProxy> RemotePageFullscreenManagerProxy::create(WebCore::PageIdentifier identifier, WebFullScreenManagerProxy* manager, WebProcessProxy& process)
+Ref<RemotePageVideoPresentationManagerProxy> RemotePageVideoPresentationManagerProxy::create(WebCore::PageIdentifier pageID, WebProcessProxy& process, VideoPresentationManagerProxy* manager)
 {
-    return adoptRef(*new RemotePageFullscreenManagerProxy(identifier, manager, process));
+    return adoptRef(*new RemotePageVideoPresentationManagerProxy(pageID, process, manager));
 }
 
-RemotePageFullscreenManagerProxy::RemotePageFullscreenManagerProxy(WebCore::PageIdentifier identifier, WebFullScreenManagerProxy* manager, WebProcessProxy& process)
-    : m_identifier(identifier)
+RemotePageVideoPresentationManagerProxy::RemotePageVideoPresentationManagerProxy(WebCore::PageIdentifier pageID, WebProcessProxy& process, VideoPresentationManagerProxy* manager)
+    : m_identifier(pageID)
     , m_manager(manager)
     , m_process(process)
 {
-    process.addMessageReceiver(Messages::WebFullScreenManagerProxy::messageReceiverName(), m_identifier, *this);
+    process.addMessageReceiver(Messages::VideoPresentationManagerProxy::messageReceiverName(), m_identifier, *this);
 }
 
-RemotePageFullscreenManagerProxy::~RemotePageFullscreenManagerProxy()
+RemotePageVideoPresentationManagerProxy::~RemotePageVideoPresentationManagerProxy()
 {
-    m_process->removeMessageReceiver(Messages::WebFullScreenManagerProxy::messageReceiverName(), m_identifier);
+    m_process->removeMessageReceiver(Messages::VideoPresentationManagerProxy::messageReceiverName(), m_identifier);
 }
 
-void RemotePageFullscreenManagerProxy::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void RemotePageVideoPresentationManagerProxy::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     if (RefPtr manager = m_manager.get())
         manager->didReceiveMessage(connection, decoder);

--- a/Source/WebKit/UIProcess/RemotePageVideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageVideoPresentationManagerProxy.h
@@ -23,40 +23,36 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "RemotePageFullscreenManagerProxy.h"
+#pragma once
 
-#if ENABLE(FULLSCREEN_API)
+#if ENABLE(VIDEO_PRESENTATION_MODE)
 
-#include "WebFullScreenManagerProxy.h"
-#include "WebFullScreenManagerProxyMessages.h"
-#include "WebProcessProxy.h"
+#include "MessageReceiver.h"
+#include <WebCore/PageIdentifier.h>
 
 namespace WebKit {
 
-Ref<RemotePageFullscreenManagerProxy> RemotePageFullscreenManagerProxy::create(WebCore::PageIdentifier identifier, WebFullScreenManagerProxy* manager, WebProcessProxy& process)
-{
-    return adoptRef(*new RemotePageFullscreenManagerProxy(identifier, manager, process));
-}
+class VideoPresentationManagerProxy;
+class WebProcessProxy;
 
-RemotePageFullscreenManagerProxy::RemotePageFullscreenManagerProxy(WebCore::PageIdentifier identifier, WebFullScreenManagerProxy* manager, WebProcessProxy& process)
-    : m_identifier(identifier)
-    , m_manager(manager)
-    , m_process(process)
-{
-    process.addMessageReceiver(Messages::WebFullScreenManagerProxy::messageReceiverName(), m_identifier, *this);
-}
+class RemotePageVideoPresentationManagerProxy : public IPC::MessageReceiver, public RefCounted<RemotePageVideoPresentationManagerProxy> {
+public:
+    static Ref<RemotePageVideoPresentationManagerProxy> create(WebCore::PageIdentifier, WebProcessProxy&, VideoPresentationManagerProxy*);
 
-RemotePageFullscreenManagerProxy::~RemotePageFullscreenManagerProxy()
-{
-    m_process->removeMessageReceiver(Messages::WebFullScreenManagerProxy::messageReceiverName(), m_identifier);
-}
+    ~RemotePageVideoPresentationManagerProxy();
 
-void RemotePageFullscreenManagerProxy::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
-{
-    if (RefPtr manager = m_manager.get())
-        manager->didReceiveMessage(connection, decoder);
-}
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
+private:
+    RemotePageVideoPresentationManagerProxy(WebCore::PageIdentifier, WebProcessProxy&, VideoPresentationManagerProxy*);
+
+    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+
+    const WebCore::PageIdentifier m_identifier;
+    const WeakPtr<VideoPresentationManagerProxy> m_manager;
+    const Ref<WebProcessProxy> m_process;
+};
 
 }
 #endif

--- a/Source/WebKit/UIProcess/UserMediaProcessManager.cpp
+++ b/Source/WebKit/UIProcess/UserMediaProcessManager.cpp
@@ -210,8 +210,8 @@ void UserMediaProcessManager::revokeSandboxExtensionsIfNeeded(WebProcessProxy& p
 
     for (auto& weakRemotePage : process.remotePages()) {
         if (RefPtr remotePage = weakRemotePage.get()) {
-            hasAudioCapture |= remotePage->mediaState().containsAny(MediaProducer::IsCapturingAudioMask);
-            hasVideoCapture |= remotePage->mediaState().containsAny(MediaProducer::IsCapturingVideoMask);
+            hasAudioCapture |= remotePage->mediaState().containsAny(WebCore::MediaProducer::IsCapturingAudioMask);
+            hasVideoCapture |= remotePage->mediaState().containsAny(WebCore::MediaProducer::IsCapturingVideoMask);
         }
     }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9733,6 +9733,11 @@ VideoPresentationManagerProxy* WebPageProxy::videoPresentationManager()
     return m_videoPresentationManager.get();
 }
 
+RefPtr<VideoPresentationManagerProxy> WebPageProxy::protectedVideoPresentationManager()
+{
+    return m_videoPresentationManager.get();
+}
+
 void WebPageProxy::setMockVideoPresentationModeEnabled(bool enabled)
 {
     m_mockVideoPresentationModeEnabled = enabled;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -786,6 +786,7 @@ public:
     PlaybackSessionManagerProxy* playbackSessionManager();
     RefPtr<PlaybackSessionManagerProxy> protectedPlaybackSessionManager();
     VideoPresentationManagerProxy* videoPresentationManager();
+    RefPtr<VideoPresentationManagerProxy> protectedVideoPresentationManager();
     void setMockVideoPresentationModeEnabled(bool);
 #endif
 

--- a/Source/WebKit/UIProcess/WebProcessActivityState.cpp
+++ b/Source/WebKit/UIProcess/WebProcessActivityState.cpp
@@ -29,6 +29,7 @@
 #include "APIPageConfiguration.h"
 #include "RemotePageProxy.h"
 #include "WebPageProxy.h"
+#include "WebProcessPool.h"
 #include "WebProcessProxy.h"
 
 namespace WebKit {

--- a/Source/WebKit/UIProcess/WebProcessActivityState.h
+++ b/Source/WebKit/UIProcess/WebProcessActivityState.h
@@ -31,6 +31,7 @@ namespace WebKit {
 
 class ProcessAssertion;
 class ProcessThrottlerActivity;
+class ProcessThrottlerTimedActivity;
 class RemotePageProxy;
 class WebPageProxy;
 class WebProcessProxy;

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -8607,6 +8607,8 @@
 		FA07D69E2CFFBBC800915660 /* NetworkTransportStreamCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NetworkTransportStreamCocoa.mm; sourceTree = "<group>"; };
 		FA13529B2C7E70140049C1BC /* NetworkTransportSessionCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NetworkTransportSessionCocoa.mm; sourceTree = "<group>"; };
 		FA1473272B06EE6200765CC1 /* SandboxExtension.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = SandboxExtension.serialization.in; sourceTree = "<group>"; };
+		FA1A7DE42E012DB3005E394B /* RemotePageVideoPresentationManagerProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemotePageVideoPresentationManagerProxy.h; sourceTree = "<group>"; };
+		FA1A7DE52E012DB3005E394B /* RemotePageVideoPresentationManagerProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemotePageVideoPresentationManagerProxy.cpp; sourceTree = "<group>"; };
 		FA1ED3F32B76B90700C90F3B /* CoreIPCCFType.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCCFType.mm; sourceTree = "<group>"; };
 		FA39AE4B2B2269C4008F93CD /* APIDictionary.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = APIDictionary.serialization.in; sourceTree = "<group>"; };
 		FA39AE4C2B229187008F93CD /* WebImage.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebImage.serialization.in; sourceTree = "<group>"; };
@@ -14825,6 +14827,8 @@
 				FABBBC7F2D35AC6800820017 /* RemotePageFullscreenManagerProxy.h */,
 				5C907E9A294D507100B3402D /* RemotePageProxy.cpp */,
 				5C907E99294D507100B3402D /* RemotePageProxy.h */,
+				FA1A7DE52E012DB3005E394B /* RemotePageVideoPresentationManagerProxy.cpp */,
+				FA1A7DE42E012DB3005E394B /* RemotePageVideoPresentationManagerProxy.h */,
 				5CEB40A22A534EE100563C91 /* RemotePageVisitedLinkStoreRegistration.h */,
 				BC111B08112F5E3C00337BAB /* ResponsivenessTimer.cpp */,
 				1A30066C1110F4F70031937C /* ResponsivenessTimer.h */,


### PR DESCRIPTION
#### 00cc4c323554cca244ca76efbd304449f34f6ac6
<pre>
Introduce RemotePageVideoPresentationManagerProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=294593">https://bugs.webkit.org/show_bug.cgi?id=294593</a>
<a href="https://rdar.apple.com/153605306">rdar://153605306</a>

Reviewed by Eric Carlson.

This is a small, simple object to receive and forward messages to the VideoPresentationManagerProxy
from processes other than the main frame process, similar to RemotePageFullscreenManagerProxy
which already exists and does not need to receive synchronous messages any more.
This is the first step towards fixing <a href="https://rdar.apple.com/147956565">rdar://147956565</a>

* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h:
* Source/WebKit/UIProcess/RemotePageFullscreenManagerProxy.cpp:
(WebKit::RemotePageFullscreenManagerProxy::didReceiveSyncMessage): Deleted.
* Source/WebKit/UIProcess/RemotePageFullscreenManagerProxy.h:
* Source/WebKit/UIProcess/RemotePageProxy.cpp:
(WebKit::RemotePageProxy::injectPageIntoNewProcess):
* Source/WebKit/UIProcess/RemotePageProxy.h:
* Source/WebKit/UIProcess/RemotePageVideoPresentationManagerProxy.cpp: Copied from Source/WebKit/UIProcess/RemotePageFullscreenManagerProxy.cpp.
(WebKit::RemotePageVideoPresentationManagerProxy::create):
(WebKit::RemotePageVideoPresentationManagerProxy::RemotePageVideoPresentationManagerProxy):
(WebKit::RemotePageVideoPresentationManagerProxy::~RemotePageVideoPresentationManagerProxy):
(WebKit::RemotePageVideoPresentationManagerProxy::didReceiveMessage):
* Source/WebKit/UIProcess/RemotePageVideoPresentationManagerProxy.h: Copied from Source/WebKit/UIProcess/RemotePageFullscreenManagerProxy.h.
* Source/WebKit/UIProcess/UserMediaProcessManager.cpp:
(WebKit::UserMediaProcessManager::revokeSandboxExtensionsIfNeeded):
* Source/WebKit/UIProcess/WebProcessActivityState.cpp:
* Source/WebKit/UIProcess/WebProcessActivityState.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/296318@main">https://commits.webkit.org/296318@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e3947f7d8f7d4f7b1dd0639f6d2ea7a1955baf6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108179 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27842 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18262 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113390 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58662 "Hash 4e3947f7 for PR 46834 does not build (failure)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28542 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36392 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82138 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/58662 "Hash 4e3947f7 for PR 46834 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111127 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22615 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97449 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62569 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22029 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58127 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91981 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15641 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116516 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35245 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25951 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91164 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35619 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93725 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90959 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35850 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13611 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17469 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35144 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40700 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34878 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38236 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36545 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->