### PR TITLE
Change default UA style sheet to use `:focus-visble`

### DIFF
--- a/LayoutTests/fast/events/click-focus-anchor-has-no-ring-expected.html
+++ b/LayoutTests/fast/events/click-focus-anchor-has-no-ring-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+a { color: blue; }
+</style>
+</head>
+<body>
+<p>This test ensures that the focus ring is not drawn for anchors with a tabindex that received the focus by mouse.</p>
+<p><a id="anchor" tabindex="0" href="#">Anchor with tabindex</a></p>
+</body>
+</html>

--- a/LayoutTests/fast/events/click-focus-anchor-has-no-ring.html
+++ b/LayoutTests/fast/events/click-focus-anchor-has-no-ring.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+a { color: blue; }
+</style>
+</head>
+<body>
+<p>This test ensures that the focus ring is not drawn for anchors with a tabindex that received the focus by mouse.</p>
+<p><a id="anchor" tabindex="0" href="#">Anchor with tabindex</a></p>
+
+<script src="resources/focus-anchor-by-mouse.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/events/resources/focus-anchor-by-mouse.js
+++ b/LayoutTests/fast/events/resources/focus-anchor-by-mouse.js
@@ -1,0 +1,8 @@
+window.onload = function() {
+    if (window.eventSender) {
+        var aElement = document.getElementById('anchor');
+        var aRect = aElement.getBoundingClientRect();
+        eventSender.mouseMoveTo(aRect.left + 2, aRect.top + 2);
+        eventSender.mouseDown();
+    }
+};

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1258,18 +1258,18 @@ nobr {
 }
 
 /* Read-only text fields do not show a focus ring but do still receive focus */
-html:focus, body:focus, input[readonly]:focus, embed:focus, iframe:focus, object:focus {
+html:focus-visible, body:focus-visible, input[readonly]:focus, embed:focus-visible, iframe:focus-visible, object:focus-visible {
     outline: none;
 }
 
 #if !defined(WTF_PLATFORM_IOS_FAMILY) || !WTF_PLATFORM_IOS_FAMILY
-input:focus, textarea:focus, select:focus {
+input:focus-visible, textarea:focus-visible, select:focus-visible {
     outline-offset: -2px;
 }
 #endif
 
-input:is([type="button"], [type="checkbox"], [type="file"], [type="hidden"], [type="image"], [type="radio"], [type="reset"], [type="search"], [type="submit"]):focus,
-input[type="file"]:focus::file-selector-button {
+input:is([type="button"], [type="checkbox"], [type="file"], [type="hidden"], [type="image"], [type="radio"], [type="reset"], [type="search"], [type="submit"]):focus-visible,
+input[type="file"]:focus-visible::file-selector-button {
     outline-offset: 0;
 }
 


### PR DESCRIPTION
#### 70f3146b713f4f5768c0c5be4694094441f02a3c
<pre>
Change default UA style sheet to use `:focus-visble`
<a href="https://bugs.webkit.org/show_bug.cgi?id=269138">https://bugs.webkit.org/show_bug.cgi?id=269138</a>
<a href="https://rdar.apple.com/123155364">rdar://123155364</a>

Reviewed by Antti Koivisto.

Merge: <a href="https://source.chromium.org/chromium/chromium/src/+/c3102c24006870f7f08444133209998b5b74aa54">https://source.chromium.org/chromium/chromium/src/+/c3102c24006870f7f08444133209998b5b74aa54</a>

This patch changes from :focus to :focus-visible in the UA style sheet
when :focus was used to set outline properties. This aligns with [1]:

[1] <a href="https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo">https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo</a>

&quot;User agents should also use :focus-visible to specify the default focus style,
so that authors using :focus-visible will not also need to disable the default
:focus style.&quot;

The relevant performance optimizations are already landed in 303633@main.

Test: fast/events/click-focus-anchor-has-no-ring.html
* LayoutTests/fast/events/click-focus-anchor-has-no-ring.html: Added.
* LayoutTests/fast/events/click-focus-anchor-has-no-ring-expected.html: Added.
* LayoutTests/fast/events/resources/focus-anchor-by-mouse.js: Added.
(window.onload):
* Source/WebCore/css/html.css:
(html:focus-visible, body:focus-visible, input[readonly]:focus, embed:focus-visible, iframe:focus-visible, object:focus-visible):
(#if !defined(WTF_PLATFORM_IOS_FAMILY) || !WTF_PLATFORM_IOS_FAMILY):
(#endif):
(html:focus, body:focus, input[readonly]:focus, embed:focus, iframe:focus, object:focus): Deleted.

Canonical link: <a href="https://commits.webkit.org/303643@main">https://commits.webkit.org/303643@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/732c574c383401ece475599ae399474d39d1fd77

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133127 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5628 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44247 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140676 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85166 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/10353c89-5a75-417f-ae3d-22fe582742d5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134997 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5491 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101813 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69194 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7a71a19c-e1ae-4880-abfe-64bace389230) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136074 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4327 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119314 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82610 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c38e8023-6c39-4abb-be80-784ac596dc12) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4211 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1793 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113287 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37430 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143319 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5298 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38009 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110190 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5380 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4548 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110370 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27972 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4091 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115571 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58972 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5353 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33925 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5196 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68805 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5442 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5309 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->