### PR TITLE
Drag snapshot does not paint transformed content

### DIFF
--- a/LayoutTests/fast/snapshot/transformed-expected.html
+++ b/LayoutTests/fast/snapshot/transformed-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+#box {
+    width: 100px;
+    height: 100px;
+    background-color: blue;
+    color: black;
+}
+</style>
+</head>
+<body>
+    <div id="box">
+        Is this included?
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/snapshot/transformed.html
+++ b/LayoutTests/fast/snapshot/transformed.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+#box {
+    width: 100px;
+    height: 100px;
+    background-color: blue;
+    color: black;
+}
+</style>
+</head>
+<body>
+    <div id="box" style="transform: translate(0, 30px)">Is this included?</div>
+    <canvas id="canvas"></canvas>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+}
+
+async function main() {
+    const box = document.getElementById('box');
+    const canvas = document.getElementById('canvas');
+
+    if (!window.internals) {
+        console.log('FAIL: window.internals is not available');
+        return;
+    }
+
+    const imageData = internals.snapshotNode(box);
+
+    if (!imageData) {
+        console.log('FAIL: snapshotNode returned null');
+        return;
+    }
+
+    canvas.width = imageData.width;
+    canvas.height = imageData.height;
+    
+    const ctx = canvas.getContext('2d');
+    ctx.putImageData(imageData, 0, 0);
+
+    box.remove();
+
+    if (window.testRunner) {
+        testRunner.notifyDone();
+    }
+}
+
+window.addEventListener('load', () => {
+    setTimeout(main, 200);
+}, false)
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7916,5 +7916,4 @@ webkit.org/b/294274 [ Debug ] platform/ios/mediastream/audio-muted-in-background
  webgl/1.0.x/conformance/textures/misc/gl-teximage.html [ Failure ]
  webgl/2.0.y/conformance/textures/misc/gl-teximage.html [ Failure ]
 
-fast/snapshot/nested-stacking-context.html [ Skip ]
-fast/snapshot/positioned-abs-relative-body.html [ Skip ]
+fast/snapshot [ Skip ]

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -911,7 +911,7 @@ void RenderObject::addAbsoluteRectForLayer(LayoutRect& result)
 // FIXME: change this to use the subtreePaint terminology
 LayoutRect RenderObject::paintingRootRect(LayoutRect& topLevelRect)
 {
-    LayoutRect result = absoluteBoundingBoxRectIgnoringTransforms();
+    LayoutRect result = absoluteBoundingBoxRect();
     topLevelRect = result;
     if (auto* renderElement = dynamicDowncast<RenderElement>(*this)) {
         for (CheckedRef child : childrenOfType<RenderObject>(*renderElement))

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -2124,9 +2124,8 @@ ExceptionOr<RefPtr<ImageData>> Internals::snapshotNode(Node& node)
     if (!imageBuffer)
         return Exception { ExceptionCode::InvalidStateError, "Failed to create snapshot"_s };
 
-    auto size = imageBuffer->logicalSize();
-    IntRect sourceRect(IntPoint(), imageBuffer->calculateBackendSize(size,
-        document->frame()->page()->deviceScaleFactor()));
+    auto logicalSize = imageBuffer->logicalSize();
+    IntRect sourceRect((IntPoint()), IntSize(logicalSize));
 
     PixelBufferFormat destinationFormat {
         AlphaPremultiplication::Unpremultiplied,


### PR DESCRIPTION
#### 860e78e7dd0ab13332da3636b1bf3f2e499344f7
<pre>
Drag snapshot does not paint transformed content
<a href="https://bugs.webkit.org/show_bug.cgi?id=267811">https://bugs.webkit.org/show_bug.cgi?id=267811</a>
<a href="https://rdar.apple.com/121382647">rdar://121382647</a>

Reviewed by Simon Fraser.

Previously, when taking a snapshot of a node,
any applied transforms were ignored. This caused
transformed elements to be missing in the snapshot image.

This fix ensures that node snapshots now correctly
account for transforms.

* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::snapshotNode):

Use logical size as ImageData understands
logical size, not backend size.

Canonical link: <a href="https://commits.webkit.org/296395@main">https://commits.webkit.org/296395@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23d43f0dd97573a5ff994f46df5d6d7daf78c901

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108352 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18436 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113561 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58781 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110315 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28702 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36563 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82278 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111300 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22758 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97600 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62713 "Found 1 new API test failure: /WPE/TestDownloads:/webkit/Downloads/mime-type (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22175 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15737 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58288 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92126 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15793 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116682 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35406 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26080 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91301 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35779 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93876 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91102 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23216 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35988 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13758 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31162 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35308 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40846 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35023 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38376 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36703 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->