### PR TITLE
Add a lock to TreeScope mutations

### DIFF
--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -755,7 +755,7 @@ protected:
     NodeRareData& ensureRareData();
     void clearRareData();
 
-    void setTreeScope(TreeScope& scope) { m_treeScope = &scope; }
+    void setTreeScope(TreeScope&);
 
     void invalidateStyle(Style::Validity, Style::InvalidationMode = Style::InvalidationMode::Normal);
     void updateAncestorsForStyleRecalc();

--- a/Source/WebCore/dom/TreeScope.h
+++ b/Source/WebCore/dom/TreeScope.h
@@ -157,16 +157,16 @@ public:
     void markPendingSVGResourcesForRemoval(const AtomString&);
     RefPtr<SVGElement> takeElementFromPendingSVGResourcesForRemovalMap(const AtomString&);
 
+    // FIXME: Add a ThreadSafetyAnalysis annotated Lock subclass that allows for asserted reads from the mutator
+    static ALWAYS_INLINE Lock& treeScopeMutationLock();
+
 protected:
     TreeScope(ShadowRoot&, Document&, RefPtr<CustomElementRegistry>&&);
     explicit TreeScope(Document&);
     ~TreeScope();
 
     void destroyTreeScopeData();
-    void setDocumentScope(Document& document)
-    {
-        m_documentScope = document;
-    }
+    inline void setDocumentScope(Document&);
 
     RefPtr<Node> nodeFromPoint(const LayoutPoint& clientPoint, LayoutPoint* localPoint, HitTestSource);
 

--- a/Source/WebCore/dom/TreeScopeInlines.h
+++ b/Source/WebCore/dom/TreeScopeInlines.h
@@ -27,6 +27,8 @@
 
 #include "ContainerNode.h"
 #include "TreeScopeOrderedMap.h"
+#include <wtf/Lock.h>
+#include <wtf/Locker.h>
 
 namespace WebCore {
 
@@ -65,6 +67,18 @@ inline bool TreeScope::hasElementWithName(const AtomString& id) const
 inline bool TreeScope::containsMultipleElementsWithName(const AtomString& name) const
 {
     return m_elementsByName && !name.isEmpty() && m_elementsByName->containsMultiple(name);
+}
+
+inline void TreeScope::setDocumentScope(Document& document)
+{
+    Locker locker { treeScopeMutationLock() };
+    m_documentScope = document;
+}
+
+ALWAYS_INLINE Lock& TreeScope::treeScopeMutationLock()
+{
+    static Lock s_treeScopeMutationLock;
+    return s_treeScopeMutationLock;
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 400c1cd4ec872f4a11b9eb74084e16ee522806f6
<pre>
Add a lock to TreeScope mutations
<a href="https://bugs.webkit.org/show_bug.cgi?id=294603">https://bugs.webkit.org/show_bug.cgi?id=294603</a>
<a href="https://rdar.apple.com/153113627">rdar://153113627</a>

Reviewed by Chris Dumez.

Use a lock when updating the tree scope of a Node or the document scope of a TreeScope.

* Source/WebCore/dom/Node.h:
(WebCore::Node::setTreeScope): Moved to NodeInlines.h.
* Source/WebCore/dom/NodeInlines.h:
(WebCore::Node::opaqueRoot const):
(WebCore::Node::setTreeScope):
* Source/WebCore/dom/TreeScope.h:
(WebCore::TreeScope::setDocumentScope): Moved to TreeScopeInlines.h.
* Source/WebCore/dom/TreeScopeInlines.h:
(WebCore::TreeScope::setDocumentScope):
(WebCore::TreeScope::treeScopeMutationLock):

Canonical link: <a href="https://commits.webkit.org/296347@main">https://commits.webkit.org/296347@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94373ff278b3e68a3d189ce787c0037482a70db3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108213 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27875 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113423 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58689 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110176 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28574 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36426 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82173 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111161 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22643 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97478 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62605 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22059 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15614 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58158 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92009 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15670 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116548 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35277 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25975 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91196 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35650 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93754 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90992 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35878 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13640 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31060 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Failed to compile WebKit; Compiled WebKit (cancelled)") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17484 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35177 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40729 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34909 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38264 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36577 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->