### PR TITLE
[Style] Support variadic rest parameters for more style and css type interfaces

### DIFF
--- a/Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp
@@ -397,7 +397,7 @@ void serializeMathFunctionArguments(StringBuilder& builder, const IndirectNode<R
         },
         [&](const Random::SharingFixed& fixed) {
             builder.append(nameLiteralForSerialization(CSSValueFixed), ' ');
-            serializationForCSS(builder, state.serializationContext, fixed.value);
+            CSS::serializationForCSS(builder, state.serializationContext, fixed.value);
             builder.append(", "_s);
         }
     );

--- a/Source/WebCore/css/scripts/process-css-properties.py
+++ b/Source/WebCore/css/scripts/process-css-properties.py
@@ -4367,7 +4367,7 @@ class GenerateStyleExtractorGenerated:
     def _generate_color_property_value_serialization_getter(self, to, property):
         to.write(f"if (extractorState.allowVisitedStyle) {{")
         with to.indent():
-            to.write(f"builder.append(serializationForCSS(extractorState.style.visitedDependentColor({property.id})));")
+            to.write(f"builder.append(WebCore::serializationForCSS(extractorState.style.visitedDependentColor({property.id})));")
             to.write(f"return;")
         to.write(f"}}")
         self._generate_property_value_serialization_getter(to, property)
@@ -4667,6 +4667,7 @@ class GenerateStyleExtractorGenerated:
                 headers=[
                     "CSSPrimitiveValueMappings.h",
                     "CSSProperty.h",
+                    "ColorSerialization.h",
                     "RenderStyle.h",
                     "StyleExtractorConverter.h",
                     "StyleExtractorCustom.h",

--- a/Source/WebCore/css/values/CSSValueTypes.cpp
+++ b/Source/WebCore/css/values/CSSValueTypes.cpp
@@ -35,19 +35,19 @@
 namespace WebCore {
 namespace CSS {
 
-void Serialize<CustomIdentifier>::operator()(StringBuilder& builder, const SerializationContext&, const CustomIdentifier& value)
+void serializationForCSSCustomIdentifier(StringBuilder& builder, const SerializationContext&, const CustomIdentifier& value)
 {
-    serializeIdentifier(value.value, builder);
+    WebCore::serializeIdentifier(value.value, builder);
 }
 
-void Serialize<WTF::AtomString>::operator()(StringBuilder& builder, const SerializationContext&, const WTF::AtomString& value)
+void serializationForCSSString(StringBuilder& builder, const SerializationContext&, const WTF::AtomString& value)
 {
-    serializeString(value, builder);
+    WebCore::serializeString(value, builder);
 }
 
-void Serialize<WTF::String>::operator()(StringBuilder& builder, const SerializationContext&, const WTF::String& value)
+void serializationForCSSString(StringBuilder& builder, const SerializationContext&, const WTF::String& value)
 {
-    serializeString(value, builder);
+    WebCore::serializeString(value, builder);
 }
 
 Ref<CSSValue> makePrimitiveCSSValue(CSSValueID value)

--- a/Source/WebCore/css/values/CSSValueTypes.h
+++ b/Source/WebCore/css/values/CSSValueTypes.h
@@ -48,27 +48,33 @@ struct SerializationContext;
 
 template<typename CSSType> struct Serialize;
 
-// Serialization Invokers
-template<typename CSSType> void serializationForCSS(StringBuilder& builder, const SerializationContext& context, const CSSType& value)
-{
-    Serialize<CSSType>{}(builder, context, value);
-}
+struct SerializeInvoker {
+   template<typename CSSType, typename... Rest> void operator()(StringBuilder& builder, const SerializationContext& context, const CSSType& value, Rest&&... rest) const
+   {
+        Serialize<CSSType>{}(builder, context, value, std::forward<Rest>(rest)...);
+   }
 
-template<typename CSSType> [[nodiscard]] String serializationForCSS(const SerializationContext& context, const CSSType& value)
-{
-    StringBuilder builder;
-    serializationForCSS(builder, context, value);
-    return builder.toString();
-}
+    template<typename CSSType, typename... Rest> [[nodiscard]] String operator()(const SerializationContext& context, const CSSType& value, Rest&&... rest) const
+    {
+        StringBuilder builder;
+        this->operator()(builder, context, value, std::forward<Rest>(rest)...);
+        return builder.toString();
+    }
+};
+inline constexpr SerializeInvoker serializationForCSS{};
 
-template<typename CSSType> void serializationForCSSOnOptionalLike(StringBuilder& builder, const SerializationContext& context, const CSSType& value)
+void serializationForCSSCustomIdentifier(StringBuilder&, const SerializationContext&, const CustomIdentifier&);
+void serializationForCSSString(StringBuilder&, const SerializationContext&, const WTF::AtomString&);
+void serializationForCSSString(StringBuilder&, const SerializationContext&, const WTF::String&);
+
+template<typename CSSType, typename... Rest> void serializationForCSSOnOptionalLike(StringBuilder& builder, const SerializationContext& context, const CSSType& value, Rest&&... rest)
 {
     if (!value)
         return;
-    serializationForCSS(builder, context, *value);
+    serializationForCSS(builder, context, *value, std::forward<Rest>(rest)...);
 }
 
-template<typename CSSType> void serializationForCSSOnTupleLike(StringBuilder& builder, const SerializationContext& context, const CSSType& value, ASCIILiteral separator)
+template<typename CSSType, typename... Rest> void serializationForCSSOnTupleLike(StringBuilder& builder, const SerializationContext& context, const CSSType& value, ASCIILiteral separator, Rest&&... rest)
 {
     auto swappedSeparator = ""_s;
     auto caller = WTF::makeVisitor(
@@ -76,79 +82,79 @@ template<typename CSSType> void serializationForCSSOnTupleLike(StringBuilder& bu
             if (!element)
                 return;
             builder.append(std::exchange(swappedSeparator, separator));
-            serializationForCSS(builder, context, *element);
+            serializationForCSS(builder, context, *element, rest...);
         },
         [&]<typename T>(const Markable<T>& element) {
             if (!element)
                 return;
             builder.append(std::exchange(swappedSeparator, separator));
-            serializationForCSS(builder, context, *element);
+            serializationForCSS(builder, context, *element, rest...);
         },
         [&](const auto& element) {
             builder.append(std::exchange(swappedSeparator, separator));
-            serializationForCSS(builder, context, element);
+            serializationForCSS(builder, context, element, rest...);
         }
     );
 
     WTF::apply([&](const auto& ...x) { (..., caller(x)); }, value);
 }
 
-template<typename CSSType> void serializationForCSSOnRangeLike(StringBuilder& builder, const SerializationContext& context, const CSSType& value, ASCIILiteral separator)
+template<typename CSSType, typename... Rest> void serializationForCSSOnRangeLike(StringBuilder& builder, const SerializationContext& context, const CSSType& value, ASCIILiteral separator, Rest&&... rest)
 {
     auto swappedSeparator = ""_s;
     for (const auto& element : value) {
         builder.append(std::exchange(swappedSeparator, separator));
-        serializationForCSS(builder, context, element);
+        serializationForCSS(builder, context, element, rest...);
     }
 }
 
-template<typename CSSType> void serializationForCSSOnVariantLike(StringBuilder& builder, const SerializationContext& context, const CSSType& value)
+template<typename CSSType, typename... Rest> void serializationForCSSOnVariantLike(StringBuilder& builder, const SerializationContext& context, const CSSType& value, Rest&&... rest)
 {
-    WTF::switchOn(value, [&](const auto& alternative) { serializationForCSS(builder, context, alternative); });
+    WTF::switchOn(value, [&](const auto& alternative) { serializationForCSS(builder, context, alternative, std::forward<Rest>(rest)...); });
 }
 
 // Constrained for `TreatAsEmptyLike`.
 template<EmptyLike CSSType> struct Serialize<CSSType> {
-    void operator()(StringBuilder&, const SerializationContext&, const CSSType&)
+    template<typename... Rest> void operator()(StringBuilder&, const SerializationContext&, const CSSType&, Rest&&...)
     {
     }
 };
 
 // Constrained for `TreatAsOptionalLike`.
 template<OptionalLike CSSType> struct Serialize<CSSType> {
-    void operator()(StringBuilder& builder, const SerializationContext& context, const CSSType& value)
+    template<typename... Rest> void operator()(StringBuilder& builder, const SerializationContext& context, const CSSType& value, Rest&&... rest)
     {
-        serializationForCSSOnOptionalLike(builder, context, value);
+        serializationForCSSOnOptionalLike(builder, context, value, std::forward<Rest>(rest)...);
     }
 };
 
 // Constrained for `TreatAsTupleLike`.
 template<TupleLike CSSType> struct Serialize<CSSType> {
-    void operator()(StringBuilder& builder, const SerializationContext& context, const CSSType& value)
+    template<typename... Rest> void operator()(StringBuilder& builder, const SerializationContext& context, const CSSType& value, Rest&&... rest)
     {
-        serializationForCSSOnTupleLike(builder, context, value, SerializationSeparatorString<CSSType>);
+        serializationForCSSOnTupleLike(builder, context, value, SerializationSeparatorString<CSSType>, std::forward<Rest>(rest)...);
     }
 };
 
 // Constrained for `TreatAsRangeLike`.
 template<RangeLike CSSType> struct Serialize<CSSType> {
-    void operator()(StringBuilder& builder, const SerializationContext& context, const CSSType& value)
+    template<typename... Rest> void operator()(StringBuilder& builder, const SerializationContext& context, const CSSType& value, Rest&&... rest)
     {
-        serializationForCSSOnRangeLike(builder, context, value, SerializationSeparatorString<CSSType>);
+        serializationForCSSOnRangeLike(builder, context, value, SerializationSeparatorString<CSSType>, std::forward<Rest>(rest)...);
     }
 };
 
 // Constrained for `TreatAsVariantLike`.
 template<VariantLike CSSType> struct Serialize<CSSType> {
-    void operator()(StringBuilder& builder, const SerializationContext& context, const CSSType& value)
+    template<typename... Rest> void operator()(StringBuilder& builder, const SerializationContext& context, const CSSType& value, Rest&&... rest)
     {
-        serializationForCSSOnVariantLike(builder, context, value);
+        serializationForCSSOnVariantLike(builder, context, value, std::forward<Rest>(rest)...);
     }
 };
 
 // Specialization for `Constant`.
 template<CSSValueID C> struct Serialize<Constant<C>> {
-    void operator()(StringBuilder& builder, const SerializationContext&, const Constant<C>& value)
+    template<typename... Rest> void operator()(StringBuilder& builder, const SerializationContext&, const Constant<C>& value, Rest&&...)
     {
         builder.append(nameLiteralForSerialization(value.value));
     }
@@ -156,62 +162,71 @@ template<CSSValueID C> struct Serialize<Constant<C>> {
 
 // Specialization for `CustomIdentifier`.
 template<> struct Serialize<CustomIdentifier> {
-    void operator()(StringBuilder&, const SerializationContext&, const CustomIdentifier&);
+    template<typename... Rest> void operator()(StringBuilder& builder, const SerializationContext& context, const CustomIdentifier& value, Rest&&...)
+    {
+        serializationForCSSCustomIdentifier(builder, context, value);
+    }
 };
 
 // Specialization for `WTF::AtomString`.
 template<> struct Serialize<WTF::AtomString> {
-    void operator()(StringBuilder&, const SerializationContext&, const WTF::AtomString&);
+    template<typename... Rest> void operator()(StringBuilder& builder, const SerializationContext& context, const WTF::AtomString& value, Rest&&...)
+    {
+        serializationForCSSString(builder, context, value);
+    }
 };
 
 // Specialization for `WTF::String`.
 template<> struct Serialize<WTF::String> {
-    void operator()(StringBuilder&, const SerializationContext&, const WTF::String&);
+    template<typename... Rest> void operator()(StringBuilder& builder, const SerializationContext& context, const WTF::String& value, Rest&&...)
+    {
+        serializationForCSSString(builder, context, value);
+    }
 };
 
 // Specialization for `FunctionNotation`.
 template<CSSValueID Name, typename CSSType> struct Serialize<FunctionNotation<Name, CSSType>> {
-    void operator()(StringBuilder& builder, const SerializationContext& context, const FunctionNotation<Name, CSSType>& value)
+    template<typename... Rest> void operator()(StringBuilder& builder, const SerializationContext& context, const FunctionNotation<Name, CSSType>& value, Rest&&... rest)
     {
         builder.append(nameLiteralForSerialization(value.name), '(');
-        serializationForCSS(builder, context, value.parameters);
+        serializationForCSS(builder, context, value.parameters, std::forward<Rest>(rest)...);
         builder.append(')');
     }
 };
 
 // Specialization for `MinimallySerializingSpaceSeparatedSize`.
 template<typename CSSType> struct Serialize<MinimallySerializingSpaceSeparatedSize<CSSType>> {
-    void operator()(StringBuilder& builder, const SerializationContext& context, const MinimallySerializingSpaceSeparatedSize<CSSType>& value)
+    template<typename... Rest> void operator()(StringBuilder& builder, const SerializationContext& context, const MinimallySerializingSpaceSeparatedSize<CSSType>& value, Rest&&... rest)
     {
         constexpr auto separator = SerializationSeparatorString<MinimallySerializingSpaceSeparatedSize<CSSType>>;
 
         if (get<0>(value) != get<1>(value)) {
-            serializationForCSSOnTupleLike(builder, context, std::tuple { get<0>(value), get<1>(value) }, separator);
+            serializationForCSSOnTupleLike(builder, context, std::tuple { get<0>(value), get<1>(value) }, separator, std::forward<Rest>(rest)...);
             return;
         }
-        serializationForCSS(builder, context, get<0>(value));
+        serializationForCSS(builder, context, get<0>(value), std::forward<Rest>(rest)...);
     }
 };
 
 // Specialization for `MinimallySerializingSpaceSeparatedRectEdges`.
 template<typename CSSType> struct Serialize<MinimallySerializingSpaceSeparatedRectEdges<CSSType>> {
-    void operator()(StringBuilder& builder, const SerializationContext& context, const MinimallySerializingSpaceSeparatedRectEdges<CSSType>& value)
+    template<typename... Rest> void operator()(StringBuilder& builder, const SerializationContext& context, const MinimallySerializingSpaceSeparatedRectEdges<CSSType>& value, Rest&&... rest)
     {
         constexpr auto separator = SerializationSeparatorString<MinimallySerializingSpaceSeparatedRectEdges<CSSType>>;
 
         if (value.left() != value.right()) {
-            serializationForCSSOnTupleLike(builder, context, std::tuple { value.top(), value.right(), value.bottom(), value.left() }, separator);
+            serializationForCSSOnTupleLike(builder, context, std::tuple { value.top(), value.right(), value.bottom(), value.left() }, separator, std::forward<Rest>(rest)...);
             return;
         }
         if (value.bottom() != value.top()) {
-            serializationForCSSOnTupleLike(builder, context, std::tuple { value.top(), value.right(), value.bottom() }, separator);
+            serializationForCSSOnTupleLike(builder, context, std::tuple { value.top(), value.right(), value.bottom() }, separator, std::forward<Rest>(rest)...);
             return;
         }
         if (value.right() != value.top()) {
-            serializationForCSSOnTupleLike(builder, context, std::tuple { value.top(), value.right() }, separator);
+            serializationForCSSOnTupleLike(builder, context, std::tuple { value.top(), value.right() }, separator, std::forward<Rest>(rest)...);
             return;
         }
-        serializationForCSS(builder, context, value.top());
+        serializationForCSS(builder, context, value.top(), std::forward<Rest>(rest)...);
     }
 };
 
@@ -227,18 +242,21 @@ template<typename CSSType> struct Serialize<MinimallySerializingSpaceSeparatedRe
 
 template<typename CSSType> struct ComputedStyleDependenciesCollector;
 
-// ComputedStyleDependencies Invoker
-template<typename CSSType> void collectComputedStyleDependencies(ComputedStyleDependencies& dependencies, const CSSType& value)
-{
-    ComputedStyleDependenciesCollector<CSSType>{}(dependencies, value);
-}
+struct ComputedStyleDependenciesCollectorInvoker {
+    // ComputedStyleDependencies Invoker
+    template<typename CSSType> void operator()(ComputedStyleDependencies& dependencies, const CSSType& value) const
+    {
+        ComputedStyleDependenciesCollector<CSSType>{}(dependencies, value);
+    }
 
-template<typename CSSType> [[nodiscard]] ComputedStyleDependencies collectComputedStyleDependencies(const CSSType& value)
-{
-    ComputedStyleDependencies dependencies;
-    collectComputedStyleDependencies(dependencies, value);
-    return dependencies;
-}
+    template<typename CSSType> [[nodiscard]] ComputedStyleDependencies operator()(const CSSType& value) const
+    {
+        ComputedStyleDependencies dependencies;
+        this->operator()(dependencies, value);
+        return dependencies;
+    }
+};
+inline constexpr ComputedStyleDependenciesCollectorInvoker collectComputedStyleDependencies{};
 
 template<typename CSSType> auto collectComputedStyleDependenciesOnOptionalLike(ComputedStyleDependencies& dependencies, const CSSType& value)
 {
@@ -352,11 +370,13 @@ template<> struct ComputedStyleDependenciesCollector<WTF::URL> {
 
 template<typename CSSType> struct CSSValueChildrenVisitor;
 
-// CSSValueVisitor Invoker
-template<typename CSSType> IterationStatus visitCSSValueChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>& func, const CSSType& value)
-{
-    return CSSValueChildrenVisitor<CSSType>{}(func, value);
-}
+struct CSSValueChildrenVisitorInvoker {
+    template<typename CSSType> IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>& func, const CSSType& value) const
+    {
+        return CSSValueChildrenVisitor<CSSType>{}(func, value);
+    }
+};
+inline constexpr CSSValueChildrenVisitorInvoker visitCSSValueChildren{};
 
 template<typename CSSType> IterationStatus visitCSSValueChildrenOnOptionalLike(NOESCAPE const Function<IterationStatus(CSSValue&)>& func, const CSSType& value)
 {
@@ -477,10 +497,13 @@ template<> struct CSSValueChildrenVisitor<WTF::URL> {
 
 template<typename CSSType> struct CSSValueCreation;
 
-template<typename CSSType> Ref<CSSValue> createCSSValue(CSSValuePool& pool, const CSSType& value)
-{
-    return CSSValueCreation<CSSType>{}(pool, value);
-}
+struct CSSValueCreationInvoker {
+    template<typename CSSType, typename... Rest> Ref<CSSValue> operator()(CSSValuePool& pool, const CSSType& value, Rest&&... rest) const
+    {
+        return CSSValueCreation<CSSType>{}(pool, value, std::forward<Rest>(rest)...);
+    }
+};
+inline constexpr CSSValueCreationInvoker createCSSValue{};
 
 Ref<CSSValue> makePrimitiveCSSValue(CSSValueID);
 Ref<CSSValue> makePrimitiveCSSValue(const CustomIdentifier&);
@@ -495,18 +518,18 @@ template<> Ref<CSSValue> makeListCSSValue<SerializationSeparatorType::Slash>(CSS
 
 // Constrained for `TreatAsVariantLike`.
 template<VariantLike CSSType> struct CSSValueCreation<CSSType> {
-    Ref<CSSValue> operator()(CSSValuePool& pool, const CSSType& value)
+    template<typename... Rest> Ref<CSSValue> operator()(CSSValuePool& pool, const CSSType& value, Rest&&... rest)
     {
-        return WTF::switchOn(value, [&](const auto& alternative) { return createCSSValue(pool, alternative); });
+        return WTF::switchOn(value, [&](const auto& alternative) { return createCSSValue(pool, alternative, std::forward<Rest>(rest)...); });
     }
 };
 
 // Constrained for `TreatAsTupleLike`
 template<TupleLike CSSType> struct CSSValueCreation<CSSType> {
-    Ref<CSSValue> operator()(CSSValuePool& pool, const CSSType& value)
+    template<typename... Rest> Ref<CSSValue> operator()(CSSValuePool& pool, const CSSType& value, Rest&&... rest)
     {
         if constexpr (std::tuple_size_v<CSSType> == 1 && SerializationSeparator<CSSType> == SerializationSeparatorType::None) {
-            return createCSSValue(pool, get<0>(value));
+            return createCSSValue(pool, get<0>(value), std::forward<Rest>(rest)...);
         } else {
             CSSValueListBuilder list;
 
@@ -514,15 +537,15 @@ template<TupleLike CSSType> struct CSSValueCreation<CSSType> {
                 [&]<typename T>(const std::optional<T>& element) {
                     if (!element)
                         return;
-                    list.append(createCSSValue(pool, *element));
+                    list.append(createCSSValue(pool, *element, rest...));
                 },
                 [&]<typename T>(const Markable<T>& element) {
                     if (!element)
                         return;
-                    list.append(createCSSValue(pool, *element));
+                    list.append(createCSSValue(pool, *element, rest...));
                 },
                 [&](const auto& element) {
-                    list.append(createCSSValue(pool, element));
+                    list.append(createCSSValue(pool, element, rest...));
                 }
             );
             WTF::apply([&](const auto& ...x) { (..., caller(x)); }, value);
@@ -534,11 +557,11 @@ template<TupleLike CSSType> struct CSSValueCreation<CSSType> {
 
 // Constrained for `TreatAsRangeLike`
 template<RangeLike CSSType> struct CSSValueCreation<CSSType> {
-    Ref<CSSValue> operator()(CSSValuePool& pool, const CSSType& value)
+    template<typename... Rest> Ref<CSSValue> operator()(CSSValuePool& pool, const CSSType& value, Rest&&... rest)
     {
         CSSValueListBuilder list;
         for (const auto& element : value)
-            list.append(createCSSValue(pool, element));
+            list.append(createCSSValue(pool, element, rest...));
 
         return makeListCSSValue<SerializationSeparator<CSSType>>(WTFMove(list));
     }
@@ -546,7 +569,7 @@ template<RangeLike CSSType> struct CSSValueCreation<CSSType> {
 
 // Specialization for `Constant`.
 template<CSSValueID Id> struct CSSValueCreation<Constant<Id>> {
-    Ref<CSSValue> operator()(CSSValuePool&, const Constant<Id>&)
+    template<typename... Rest> Ref<CSSValue> operator()(CSSValuePool&, const Constant<Id>&, Rest&&...)
     {
         return makePrimitiveCSSValue(Id);
     }
@@ -554,7 +577,7 @@ template<CSSValueID Id> struct CSSValueCreation<Constant<Id>> {
 
 // Specialization for `CustomIdentifier`.
 template<> struct CSSValueCreation<CustomIdentifier> {
-    Ref<CSSValue> operator()(CSSValuePool&, const CustomIdentifier& customIdentifier)
+    template<typename... Rest> Ref<CSSValue> operator()(CSSValuePool&, const CustomIdentifier& customIdentifier, Rest&&...)
     {
         return makePrimitiveCSSValue(customIdentifier);
     }
@@ -562,7 +585,7 @@ template<> struct CSSValueCreation<CustomIdentifier> {
 
 // Specialization for `WTF::AtomString`.
 template<> struct CSSValueCreation<WTF::AtomString> {
-    Ref<CSSValue> operator()(CSSValuePool&, const WTF::AtomString& string)
+    template<typename... Rest> Ref<CSSValue> operator()(CSSValuePool&, const WTF::AtomString& string, Rest&&...)
     {
         return makePrimitiveCSSValue(string);
     }
@@ -570,7 +593,7 @@ template<> struct CSSValueCreation<WTF::AtomString> {
 
 // Specialization for `WTF::String`.
 template<> struct CSSValueCreation<WTF::String> {
-    Ref<CSSValue> operator()(CSSValuePool&, const WTF::String& string)
+    template<typename... Rest> Ref<CSSValue> operator()(CSSValuePool&, const WTF::String& string, Rest&&...)
     {
         return makePrimitiveCSSValue(string);
     }
@@ -578,17 +601,17 @@ template<> struct CSSValueCreation<WTF::String> {
 
 // Specialization for `FunctionNotation`.
 template<CSSValueID Name, typename CSSType> struct CSSValueCreation<FunctionNotation<Name, CSSType>> {
-    Ref<CSSValue> operator()(CSSValuePool& pool, const FunctionNotation<Name, CSSType>& value)
+    template<typename... Rest> Ref<CSSValue> operator()(CSSValuePool& pool, const FunctionNotation<Name, CSSType>& value, Rest&&... rest)
     {
-        return makeFunctionCSSValue(value.name, createCSSValue(pool, value.parameters));
+        return makeFunctionCSSValue(value.name, createCSSValue(pool, value.parameters, std::forward<Rest>(rest)...));
     }
 };
 
 // Specialization for `MinimallySerializingSpaceSeparatedSize`.
 template<typename CSSType> struct CSSValueCreation<MinimallySerializingSpaceSeparatedSize<CSSType>> {
-    Ref<CSSValue> operator()(CSSValuePool& pool, const MinimallySerializingSpaceSeparatedSize<CSSType>& value)
+    template<typename... Rest> Ref<CSSValue> operator()(CSSValuePool& pool, const MinimallySerializingSpaceSeparatedSize<CSSType>& value, Rest&&... rest)
     {
-        return makeSpaceSeparatedCoalescingPairCSSValue(createCSSValue(pool, get<0>(value)), createCSSValue(pool, get<1>(value)));
+        return makeSpaceSeparatedCoalescingPairCSSValue(createCSSValue(pool, get<0>(value), rest...), createCSSValue(pool, get<1>(value), rest...));
     }
 };
 

--- a/Source/WebCore/css/values/color/CSSColorMix.cpp
+++ b/Source/WebCore/css/values/color/CSSColorMix.cpp
@@ -153,7 +153,7 @@ static void serializationForColorMixPercentage2(StringBuilder& builder, const CS
 void Serialize<ColorMix>::operator()(StringBuilder& builder, const SerializationContext& context, const ColorMix& value)
 {
     builder.append("color-mix(in "_s);
-    serializationForCSS(builder, value.colorInterpolationMethod);
+    WebCore::serializationForCSS(builder, value.colorInterpolationMethod);
     builder.append(", "_s);
     serializationForCSS(builder, context, value.mixComponents1.color);
     ColorMixSerializationDetails::serializationForColorMixPercentage1(builder, context, value);

--- a/Source/WebCore/css/values/color/CSSHexColor.cpp
+++ b/Source/WebCore/css/values/color/CSSHexColor.cpp
@@ -35,7 +35,7 @@ namespace CSS {
 
 void Serialize<HexColor>::operator()(StringBuilder& builder, const SerializationContext&, const HexColor& value)
 {
-    builder.append(serializationForCSS(WebCore::Color { value.value }));
+    builder.append(WebCore::serializationForCSS(WebCore::Color { value.value }));
 }
 
 } // namespace CSS

--- a/Source/WebCore/css/values/images/CSSGradient.cpp
+++ b/Source/WebCore/css/values/images/CSSGradient.cpp
@@ -138,9 +138,9 @@ static bool appendColorInterpolationMethod(StringBuilder& builder, CSS::Gradient
             return false;
         },
         [&]<typename MethodColorSpace>(const MethodColorSpace& methodColorSpace) {
-            builder.append(needsLeadingSpace ? " "_s : ""_s, "in "_s, serializationForCSS(methodColorSpace.interpolationColorSpace));
+            builder.append(needsLeadingSpace ? " "_s : ""_s, "in "_s, WebCore::serializationForCSS(methodColorSpace.interpolationColorSpace));
             if constexpr (hasHueInterpolationMethod<MethodColorSpace>)
-                serializationForCSS(builder, methodColorSpace.hueInterpolationMethod);
+                WebCore::serializationForCSS(builder, methodColorSpace.hueInterpolationMethod);
             return true;
         }
     );

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -129,7 +129,7 @@ namespace Style {
 
 class BuilderConverter {
 public:
-    template<typename T> static T convertStyleType(BuilderState&, const CSSValue&);
+    template<typename T, typename... Rest> static T convertStyleType(BuilderState&, const CSSValue&, Rest&&...);
 
     static WebCore::Length convertLength(BuilderState&, const CSSValue&);
     static WebCore::Length convertLengthOrAuto(BuilderState&, const CSSValue&);
@@ -375,9 +375,9 @@ inline auto BuilderConverter::requiredFunctionDowncast(BuilderState& builderStat
     return function;
 }
 
-template<typename T> inline T BuilderConverter::convertStyleType(BuilderState& builderState, const CSSValue& value)
+template<typename T, typename... Rest> inline T BuilderConverter::convertStyleType(BuilderState& builderState, const CSSValue& value, Rest&&... rest)
 {
-    return toStyleFromCSSValue<T>(builderState, value);
+    return toStyleFromCSSValue<T>(builderState, value, std::forward<Rest>(rest)...);
 }
 
 inline WebCore::Length BuilderConverter::convertLength(BuilderState& builderState, const CSSValue& value)

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -138,7 +138,7 @@ class ExtractorConverter {
 public:
     // MARK: Strong value conversions
 
-    template<typename T> static Ref<CSSValue> convertStyleType(ExtractorState&, const T&);
+    template<typename T, typename... Rest> static Ref<CSSValue> convertStyleType(ExtractorState&, const T&, Rest&&...);
 
     // MARK: Primitive conversions
 
@@ -334,9 +334,9 @@ public:
 
 // MARK: - Strong value conversions
 
-template<typename T> Ref<CSSValue> ExtractorConverter::convertStyleType(ExtractorState& state, const T& value)
+template<typename T, typename... Rest> Ref<CSSValue> ExtractorConverter::convertStyleType(ExtractorState& state, const T& value, Rest&&... rest)
 {
-    return createCSSValue(state.pool, state.style, value);
+    return createCSSValue(state.pool, state.style, value, std::forward<Rest>(rest)...);
 }
 
 // MARK: - Primitive conversions

--- a/Source/WebCore/style/StyleExtractorSerializer.h
+++ b/Source/WebCore/style/StyleExtractorSerializer.h
@@ -48,7 +48,7 @@ class ExtractorSerializer {
 public:
     // MARK: Strong value conversions
 
-    template<typename T> static void serializeStyleType(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const T&);
+    template<typename T, typename... Rest> static void serializeStyleType(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const T&, Rest&&...);
 
     // MARK: Primitive serializations
 
@@ -243,9 +243,9 @@ public:
 
 // MARK: - Strong value serializations
 
-template<typename T> void ExtractorSerializer::serializeStyleType(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const T& value)
+template<typename T, typename... Rest> void ExtractorSerializer::serializeStyleType(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const T& value, Rest&&... rest)
 {
-    serializationForCSS(builder, context, state.style, value);
+    serializationForCSS(builder, context, state.style, value, std::forward<Rest>(rest)...);
 }
 
 // MARK: - Primitive serializations

--- a/Source/WebCore/style/StyleInterpolationFunctions.h
+++ b/Source/WebCore/style/StyleInterpolationFunctions.h
@@ -73,12 +73,12 @@ namespace WebCore::Style::Interpolation {
 
 inline int blendFunc(int from, int to, const Context& context)
 {
-    return blend(from, to, context);
+    return WebCore::blend(from, to, context);
 }
 
 inline double blendFunc(double from, double to, const Context& context)
 {
-    return blend(from, to, context);
+    return WebCore::blend(from, to, context);
 }
 
 inline float blendFunc(float from, float to, const Context& context)
@@ -96,19 +96,19 @@ inline float blendFunc(float from, float to, const Context& context)
 
 inline WebCore::Color blendFunc(const WebCore::Color& from, const WebCore::Color& to, const Context& context)
 {
-    return blend(from, to, context);
+    return WebCore::blend(from, to, context);
 }
 
 inline WebCore::Length blendFunc(const WebCore::Length& from, const WebCore::Length& to, const Context& context, ValueRange valueRange = ValueRange::All)
 {
-    return blend(from, to, context, valueRange);
+    return WebCore::blend(from, to, context, valueRange);
 }
 
 inline GapLength blendFunc(const GapLength& from, const GapLength& to, const Context& context)
 {
     if (from.isNormal() || to.isNormal())
         return context.progress < 0.5 ? from : to;
-    return blend(from.length(), to.length(), context, ValueRange::NonNegative);
+    return WebCore::blend(from.length(), to.length(), context, ValueRange::NonNegative);
 }
 
 inline bool canInterpolateLengthVariants(const GapLength& from, const GapLength& to)
@@ -126,13 +126,13 @@ inline bool lengthVariantRequiresInterpolationForAccumulativeIteration(const Gap
 
 inline TabSize blendFunc(const TabSize& from, const TabSize& to, const Context& context)
 {
-    auto blendedValue = blend(from.value(), to.value(), context);
+    auto blendedValue = WebCore::blend(from.value(), to.value(), context);
     return { blendedValue < 0 ? 0 : blendedValue, from.isSpaces() ? SpaceValueType : LengthValueType };
 }
 
 inline LengthSize blendFunc(const LengthSize& from, const LengthSize& to, const Context& context)
 {
-    return blend(from, to, context, ValueRange::NonNegative);
+    return WebCore::blend(from, to, context, ValueRange::NonNegative);
 }
 
 inline bool canInterpolateLengthVariants(const LengthSize& from, const LengthSize& to)
@@ -150,7 +150,7 @@ inline bool lengthVariantRequiresInterpolationForAccumulativeIteration(const Len
 
 inline LengthPoint blendFunc(const LengthPoint& from, const LengthPoint& to, const Context& context)
 {
-    return blend(from, to, context);
+    return WebCore::blend(from, to, context);
 }
 
 inline TransformOperations blendFunc(const TransformOperations& from, const TransformOperations& to, const Context& context)
@@ -473,7 +473,7 @@ inline GridLength blendFunc(const GridLength& from, const GridLength& to, const 
         return context.progress < 0.5 ? from : to;
 
     if (from.isFlex())
-        return GridLength(blend(from.flex(), to.flex(), context));
+        return GridLength(WebCore::blend(from.flex(), to.flex(), context));
 
     return GridLength(blendFunc(from.length(), to.length(), context));
 }

--- a/Source/WebCore/style/values/StyleValueTypes.h
+++ b/Source/WebCore/style/values/StyleValueTypes.h
@@ -96,11 +96,13 @@ template<> inline constexpr bool TreatAsNonConverting<WTF::URL> = true;
 
 // MARK: - Conversion from "Style to "CSS"
 
-// Conversion Invoker
-template<typename StyleType, typename... Rest> decltype(auto) toCSS(const StyleType& styleType, const RenderStyle& style, Rest&&... rest)
-{
-    return ToCSS<StyleType>{}(styleType, style, std::forward<Rest>(rest)...);
-}
+struct ToCSSInvoker {
+    template<typename StyleType, typename... Rest> decltype(auto) operator()(const StyleType& styleType, const RenderStyle& style, Rest&&... rest) const
+    {
+        return ToCSS<StyleType>{}(styleType, style, std::forward<Rest>(rest)...);
+    }
+};
+inline constexpr ToCSSInvoker toCSS{};
 
 // Conversion Utility Types
 template<typename StyleType> using CSSType = std::decay_t<decltype(toCSS(std::declval<const StyleType&>(), std::declval<const RenderStyle&>()))>;
@@ -141,7 +143,7 @@ template<typename... Ts> struct ToCSSMapping<Variant<Ts...>> {
 
 // Constrained for `TreatAsNonConverting`.
 template<NonConverting StyleType> struct ToCSS<StyleType> {
-    constexpr StyleType operator()(const StyleType& value, const RenderStyle&)
+    template<typename... Rest> constexpr StyleType operator()(const StyleType& value, const RenderStyle&, Rest&&...)
     {
         return value;
     }
@@ -151,10 +153,10 @@ template<NonConverting StyleType> struct ToCSS<StyleType> {
 template<OptionalLike StyleType> struct ToCSS<StyleType> {
     using Result = typename ToCSSMapping<StyleType>::type;
 
-    Result operator()(const StyleType& value, const RenderStyle& style)
+    template<typename... Rest> Result operator()(const StyleType& value, const RenderStyle& style, Rest&&... rest)
     {
         if (value)
-            return toCSS(*value, style);
+            return toCSS(*value, style, std::forward<Rest>(rest)...);
         return std::nullopt;
     }
 };
@@ -163,9 +165,9 @@ template<OptionalLike StyleType> struct ToCSS<StyleType> {
 template<TupleLike StyleType> struct ToCSS<StyleType> {
     using Result = typename ToCSSMapping<StyleType>::type;
 
-    Result operator()(const StyleType& value, const RenderStyle& style)
+    template<typename... Rest> Result operator()(const StyleType& value, const RenderStyle& style, Rest&&... rest)
     {
-        return toCSSOnTupleLike<Result>(value, style);
+        return toCSSOnTupleLike<Result>(value, style, std::forward<Rest>(rest)...);
     }
 };
 
@@ -173,9 +175,9 @@ template<TupleLike StyleType> struct ToCSS<StyleType> {
 template<VariantLike StyleType> struct ToCSS<StyleType> {
     using Result = typename ToCSSMapping<StyleType>::type;
 
-    Result operator()(const StyleType& value, const RenderStyle& style)
+    template<typename... Rest> Result operator()(const StyleType& value, const RenderStyle& style, Rest&&... rest)
     {
-        return WTF::switchOn(value, [&](const auto& alternative) { return Result { toCSS(alternative, style) }; });
+        return WTF::switchOn(value, [&](const auto& alternative) { return Result { toCSS(alternative, style, std::forward<Rest>(rest)...) }; });
     }
 };
 
@@ -183,9 +185,9 @@ template<VariantLike StyleType> struct ToCSS<StyleType> {
 template<typename StyleType, size_t inlineCapacity> struct ToCSS<SpaceSeparatedVector<StyleType, inlineCapacity>> {
     using Result = SpaceSeparatedVector<CSSType<StyleType>, inlineCapacity>;
 
-    Result operator()(const SpaceSeparatedVector<StyleType, inlineCapacity>& value, const RenderStyle& style)
+    template<typename... Rest> Result operator()(const SpaceSeparatedVector<StyleType, inlineCapacity>& value, const RenderStyle& style, Rest&&... rest)
     {
-        return Result { value.value.template map<typename Result::Vector>([&](const auto& x) { return toCSS(x, style); }) };
+        return Result { value.value.template map<typename Result::Vector>([&](const auto& x) { return toCSS(x, style, rest...); }) };
     }
 };
 
@@ -193,36 +195,42 @@ template<typename StyleType, size_t inlineCapacity> struct ToCSS<SpaceSeparatedV
 template<typename StyleType, size_t inlineCapacity> struct ToCSS<CommaSeparatedVector<StyleType, inlineCapacity>> {
     using Result = CommaSeparatedVector<CSSType<StyleType>, inlineCapacity>;
 
-    Result operator()(const CommaSeparatedVector<StyleType, inlineCapacity>& value, const RenderStyle& style)
+    template<typename... Rest> Result operator()(const CommaSeparatedVector<StyleType, inlineCapacity>& value, const RenderStyle& style, Rest&&... rest)
     {
-        return Result { value.value.template map<typename Result::Vector>([&](const auto& x) { return toCSS(x, style); }) };
+        return Result { value.value.template map<typename Result::Vector>([&](const auto& x) { return toCSS(x, style, rest...); }) };
     }
 };
 
 // MARK: - Conversion from "CSS" to "Style"
 
-// Conversion Invokers
-template<typename CSSType, typename... Rest> decltype(auto) toStyle(const CSSType& cssType, const CSSToLengthConversionData& conversionData, Rest&&... rest)
-{
-    return ToStyle<CSSType>{}(cssType, conversionData, std::forward<Rest>(rest)...);
-}
+struct ToStyleInvoker {
+    template<typename CSSType, typename... Rest> decltype(auto) operator()(const CSSType& cssType, const CSSToLengthConversionData& conversionData, Rest&&... rest) const
+    {
+        return ToStyle<CSSType>{}(cssType, conversionData, std::forward<Rest>(rest)...);
+    }
 
-template<typename CSSType, typename... Rest> decltype(auto) toStyle(const CSSType& cssType, const BuilderState& builderState, Rest&&... rest)
-{
-    return ToStyle<CSSType>{}(cssType, builderState, std::forward<Rest>(rest)...);
-}
+    template<typename CSSType, typename... Rest> decltype(auto) operator()(const CSSType& cssType, const BuilderState& builderState, Rest&&... rest) const
+    {
+        return ToStyle<CSSType>{}(cssType, builderState, std::forward<Rest>(rest)...);
+    }
 
-template<typename CSSType, typename... Rest> decltype(auto) toStyle(const CSSType& cssType, NoConversionDataRequiredToken token, Rest&&... rest)
-{
-    return ToStyle<CSSType>{}(cssType, token, std::forward<Rest>(rest)...);
-}
+    template<typename CSSType, typename... Rest> decltype(auto) operator()(const CSSType& cssType, NoConversionDataRequiredToken token, Rest&&... rest) const
+    {
+        return ToStyle<CSSType>{}(cssType, token, std::forward<Rest>(rest)...);
+    }
+};
+inline constexpr ToStyleInvoker toStyle{};
 
 // Convenience invoker that adds a `NoConversionDataRequiredToken` argument.
-template<typename CSSType, typename... Rest> decltype(auto) toStyleNoConversionDataRequired(const CSSType& cssType, Rest&&... rest)
-{
-    return toStyle(cssType, NoConversionDataRequiredToken { }, std::forward<Rest>(rest)...);
-}
+struct ToStyleNoConversionDataRequiredInvoker {
+    template<typename CSSType, typename... Rest> decltype(auto) operator()(const CSSType& cssType, Rest&&... rest) const
+    {
+        return WebCore::Style::toStyle(cssType, NoConversionDataRequiredToken { }, std::forward<Rest>(rest)...);
+    }
+};
+inline constexpr ToStyleNoConversionDataRequiredInvoker toStyleNoConversionDataRequired{};
 
+// Conversion Utilities
 template<typename To, typename From, typename... Rest> auto toStyleOnTupleLike(const From& tupleLike, Rest&&... rest) -> To
 {
     return WTF::apply([&](const auto& ...x) { return To { toStyle(x, rest...)... }; }, tupleLike);
@@ -233,7 +241,6 @@ template<typename To, typename From, typename... Rest> auto toStyleNoConversionD
     return WTF::apply([&](const auto& ...x) { return To { toStyleNoConversionDataRequired(x, rest...)... }; }, tupleLike);
 }
 
-// Conversion Utility Types
 template<typename CSSType> using StyleType = std::decay_t<decltype(toStyle(std::declval<const CSSType&>(), std::declval<const BuilderState&>()))>;
 
 // Standard NonConverting type mappings (identity mappings):
@@ -335,26 +342,28 @@ template<typename CSSType, size_t inlineCapacity> struct ToStyle<CommaSeparatedV
 
 template<typename StyleType> struct CSSValueCreation;
 
-// Conversion Invoker
-template<typename StyleType> Ref<CSSValue> createCSSValue(CSSValuePool& pool, const RenderStyle& style, const StyleType& value)
-{
-    return CSSValueCreation<StyleType>{}(pool, style, value);
-}
+struct CSSValueCreationInvoker {
+    template<typename StyleType, typename... Rest> Ref<CSSValue> operator()(CSSValuePool& pool, const RenderStyle& style, const StyleType& value, Rest&&... rest) const
+    {
+        return CSSValueCreation<StyleType>{}(pool, style, value, std::forward<Rest>(rest)...);
+    }
+};
+inline constexpr CSSValueCreationInvoker createCSSValue{};
 
 // Constrained for `TreatAsVariantLike`.
 template<VariantLike StyleType> struct CSSValueCreation<StyleType> {
-    Ref<CSSValue> operator()(CSSValuePool& pool, const RenderStyle& style, const StyleType& value)
+    template<typename... Rest> Ref<CSSValue> operator()(CSSValuePool& pool, const RenderStyle& style, const StyleType& value, Rest&&... rest)
     {
-        return WTF::switchOn(value, [&](const auto& alternative) -> Ref<CSSValue> { return createCSSValue(pool, style, alternative); });
+        return WTF::switchOn(value, [&](const auto& alternative) -> Ref<CSSValue> { return createCSSValue(pool, style, alternative, std::forward<Rest>(rest)...); });
     }
 };
 
 // Constrained for `TreatAsTupleLike`
 template<TupleLike StyleType> struct CSSValueCreation<StyleType> {
-    Ref<CSSValue> operator()(CSSValuePool& pool, const RenderStyle& style, const StyleType& value)
+    template<typename... Rest> Ref<CSSValue> operator()(CSSValuePool& pool, const RenderStyle& style, const StyleType& value, Rest&&... rest)
     {
         if constexpr (std::tuple_size_v<StyleType> == 1 && SerializationSeparator<StyleType> == SerializationSeparatorType::None) {
-            return createCSSValue(pool, style, get<0>(value));
+            return createCSSValue(pool, style, get<0>(value), std::forward<Rest>(rest)...);
         } else {
             CSSValueListBuilder list;
 
@@ -362,15 +371,15 @@ template<TupleLike StyleType> struct CSSValueCreation<StyleType> {
                 [&]<typename T>(const std::optional<T>& element) {
                     if (!element)
                         return;
-                    list.append(createCSSValue(pool, style, *element));
+                    list.append(createCSSValue(pool, style, *element, rest...));
                 },
                 [&]<typename T>(const Markable<T>& element) {
                     if (!element)
                         return;
-                    list.append(createCSSValue(pool, style, *element));
+                    list.append(createCSSValue(pool, style, *element, rest...));
                 },
                 [&](const auto& element) {
-                    list.append(createCSSValue(pool, style, element));
+                    list.append(createCSSValue(pool, style, element, rest...));
                 }
             );
             WTF::apply([&](const auto& ...x) { (..., caller(x)); }, value);
@@ -382,11 +391,11 @@ template<TupleLike StyleType> struct CSSValueCreation<StyleType> {
 
 // Constrained for `TreatAsRangeLike`
 template<RangeLike StyleType> struct CSSValueCreation<StyleType> {
-    Ref<CSSValue> operator()(CSSValuePool& pool, const RenderStyle& style, const StyleType& value)
+    template<typename... Rest> Ref<CSSValue> operator()(CSSValuePool& pool, const RenderStyle& style, const StyleType& value, Rest&&... rest)
     {
         CSSValueListBuilder list;
         for (const auto& element : value)
-            list.append(createCSSValue(pool, style, element));
+            list.append(createCSSValue(pool, style, element, rest...));
 
         return CSS::makeListCSSValue<SerializationSeparator<StyleType>>(WTFMove(list));
     }
@@ -394,25 +403,25 @@ template<RangeLike StyleType> struct CSSValueCreation<StyleType> {
 
 // Constrained for `TreatAsNonConverting`.
 template<NonConverting StyleType> struct CSSValueCreation<StyleType> {
-    Ref<CSSValue> operator()(CSSValuePool& pool, const RenderStyle&, const StyleType& value)
+    template<typename... Rest> Ref<CSSValue> operator()(CSSValuePool& pool, const RenderStyle&, const StyleType& value, Rest&&... rest)
     {
-        return CSS::createCSSValue(pool, value);
+        return CSS::createCSSValue(pool, value, std::forward<Rest>(rest)...);
     }
 };
 
 // Specialization for `FunctionNotation`.
 template<CSSValueID Name, typename StyleType> struct CSSValueCreation<FunctionNotation<Name, StyleType>> {
-    Ref<CSSValue> operator()(CSSValuePool& pool, const RenderStyle& style, const FunctionNotation<Name, StyleType>& value)
+    template<typename... Rest> Ref<CSSValue> operator()(CSSValuePool& pool, const RenderStyle& style, const FunctionNotation<Name, StyleType>& value, Rest&&... rest)
     {
-        return CSS::makeFunctionCSSValue(value.name, createCSSValue(pool, style, value.parameters));
+        return CSS::makeFunctionCSSValue(value.name, createCSSValue(pool, style, value.parameters, std::forward<Rest>(rest)...));
     }
 };
 
 // Specialization for `MinimallySerializingSpaceSeparatedSize`.
 template<typename CSSType> struct CSSValueCreation<MinimallySerializingSpaceSeparatedSize<CSSType>> {
-    Ref<CSSValue> operator()(CSSValuePool& pool, const RenderStyle& style, const MinimallySerializingSpaceSeparatedSize<CSSType>& value)
+    template<typename... Rest> Ref<CSSValue> operator()(CSSValuePool& pool, const RenderStyle& style, const MinimallySerializingSpaceSeparatedSize<CSSType>& value, Rest&&... rest)
     {
-        return CSS::makeSpaceSeparatedCoalescingPairCSSValue(createCSSValue(pool, style, get<0>(value)), createCSSValue(pool, style, get<1>(value)));
+        return CSS::makeSpaceSeparatedCoalescingPairCSSValue(createCSSValue(pool, style, get<0>(value), rest...), createCSSValue(pool, style, get<1>(value), rest...));
     }
 };
 
@@ -426,19 +435,13 @@ template<typename CSSType> struct CSSValueCreation<MinimallySerializingSpaceSepa
 
 template<typename StyleType> struct CSSValueConversion;
 
-// Conversion Invoker
-template<typename StyleType> StyleType toStyleFromCSSValue(BuilderState& builderState, const CSSValue& value)
-{
-    return CSSValueConversion<StyleType>{}(builderState, value);
-}
-
-// Constrained for `TreatAsVariantLike`.
-template<VariantLike StyleType> struct CSSValueConversion<StyleType> {
-    StyleType operator()(BuilderState& builderState, const CSSValue& value)
+template<typename StyleType> struct CSSValueConversionInvoker {
+    template<typename... Rest> StyleType operator()(BuilderState& builderState, const CSSValue& value, Rest&&... rest) const
     {
-        return WTF::switchOn(value, [&](const auto& alternative) -> StyleType { return toStyleFromCSSValue(builderState, alternative); });
+        return CSSValueConversion<StyleType>{}(builderState, value, std::forward<Rest>(rest)...);
     }
 };
+template<typename StyleType> inline constexpr CSSValueConversionInvoker<StyleType> toStyleFromCSSValue{};
 
 // MARK: - Conversion directly from "Style" to "Platform"
 
@@ -450,11 +453,13 @@ template<VariantLike StyleType> struct CSSValueConversion<StyleType> {
 
 template<typename StyleType> struct ToPlatform;
 
-// Conversion Invoker
-template<typename StyleType> decltype(auto) toPlatform(const StyleType& value)
-{
-    return ToPlatform<StyleType>{}(value);
-}
+struct ToPlatformInvoker {
+    template<typename StyleType, typename... Rest> decltype(auto) operator()(const StyleType& value, Rest&&... rest) const
+    {
+        return ToPlatform<StyleType>{}(value, std::forward<Rest>(rest)...);
+    }
+};
+inline constexpr ToPlatformInvoker toPlatform{};
 
 // MARK: - Serialization
 
@@ -466,27 +471,29 @@ template<typename StyleType> decltype(auto) toPlatform(const StyleType& value)
 
 template<typename StyleType> struct Serialize;
 
-// Serialization Invokers
-template<typename StyleType> void serializationForCSS(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const StyleType& value)
-{
-    Serialize<StyleType>{}(builder, context, style, value);
-}
+struct SerializeInvoker {
+    template<typename StyleType, typename... Rest> void operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const StyleType& value, Rest&&... rest) const
+    {
+        Serialize<StyleType>{}(builder, context, style, value, std::forward<Rest>(rest)...);
+    }
 
-template<typename StyleType> [[nodiscard]] String serializationForCSS(const CSS::SerializationContext& context, const RenderStyle& style, const StyleType& value)
-{
-    StringBuilder builder;
-    serializationForCSS(builder, context, style, value);
-    return builder.toString();
-}
+    template<typename StyleType, typename... Rest> [[nodiscard]] String operator()(const CSS::SerializationContext& context, const RenderStyle& style, const StyleType& value, Rest&&... rest) const
+    {
+        StringBuilder builder;
+        this->operator()(builder, context, style, value, std::forward<Rest>(rest)...);
+        return builder.toString();
+    }
+};
+inline constexpr SerializeInvoker serializationForCSS{};
 
-template<typename StyleType> void serializationForCSSOnOptionalLike(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const StyleType& value)
+template<typename StyleType, typename... Rest> void serializationForCSSOnOptionalLike(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const StyleType& value, Rest&&... rest)
 {
     if (!value)
         return;
-    serializationForCSS(builder, context, style, *value);
+    serializationForCSS(builder, context, style, *value, std::forward<Rest>(rest)...);
 }
 
-template<typename StyleType> void serializationForCSSOnTupleLike(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const StyleType& value, ASCIILiteral separator)
+template<typename StyleType, typename... Rest> void serializationForCSSOnTupleLike(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const StyleType& value, ASCIILiteral separator, Rest&&... rest)
 {
     auto swappedSeparator = ""_s;
     auto caller = WTF::makeVisitor(
@@ -494,127 +501,127 @@ template<typename StyleType> void serializationForCSSOnTupleLike(StringBuilder& 
             if (!element)
                 return;
             builder.append(std::exchange(swappedSeparator, separator));
-            serializationForCSS(builder, context, style, *element);
+            serializationForCSS(builder, context, style, *element, rest...);
         },
         [&]<typename T>(const Markable<T>& element) {
             if (!element)
                 return;
             builder.append(std::exchange(swappedSeparator, separator));
-            serializationForCSS(builder, context, style, *element);
+            serializationForCSS(builder, context, style, *element, rest...);
         },
         [&](const auto& element) {
             builder.append(std::exchange(swappedSeparator, separator));
-            serializationForCSS(builder, context, style, element);
+            serializationForCSS(builder, context, style, element, rest...);
         }
     );
 
     WTF::apply([&](const auto& ...x) { (..., caller(x)); }, value);
 }
 
-template<typename StyleType> void serializationForCSSOnRangeLike(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const StyleType& value, ASCIILiteral separator)
+template<typename StyleType, typename... Rest> void serializationForCSSOnRangeLike(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const StyleType& value, ASCIILiteral separator, Rest&&... rest)
 {
     auto swappedSeparator = ""_s;
     for (const auto& element : value) {
         builder.append(std::exchange(swappedSeparator, separator));
-        serializationForCSS(builder, context, style, element);
+        serializationForCSS(builder, context, style, element, rest...);
     }
 }
 
-template<typename StyleType> void serializationForCSSOnVariantLike(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const StyleType& value)
+template<typename StyleType, typename... Rest> void serializationForCSSOnVariantLike(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const StyleType& value, Rest&&... rest)
 {
-    WTF::switchOn(value, [&](const auto& alternative) { serializationForCSS(builder, context, style, alternative); });
+    WTF::switchOn(value, [&](const auto& alternative) { serializationForCSS(builder, context, style, alternative, std::forward<Rest>(rest)...); });
 }
 
 // Constrained for `TreatAsEmptyLike`.
 template<EmptyLike StyleType> struct Serialize<StyleType> {
-    void operator()(StringBuilder&, const CSS::SerializationContext&, const RenderStyle&, const StyleType&)
+    template<typename... Rest> void operator()(StringBuilder&, const CSS::SerializationContext&, const RenderStyle&, const StyleType&, Rest&&...)
     {
     }
 };
 
 // Constrained for `TreatAsOptionalLike`.
 template<OptionalLike StyleType> struct Serialize<StyleType> {
-    void operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const StyleType& value)
+    template<typename... Rest> void operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const StyleType& value, Rest&&... rest)
     {
-        serializationForCSSOnOptionalLike(builder, context, style, value);
+        serializationForCSSOnOptionalLike(builder, context, style, value, std::forward<Rest>(rest)...);
     }
 };
 
 // Constrained for `TreatAsTupleLike`.
 template<TupleLike StyleType> struct Serialize<StyleType> {
-    void operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const StyleType& value)
+    template<typename... Rest> void operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const StyleType& value, Rest&&... rest)
     {
-        serializationForCSSOnTupleLike(builder, context, style, value, SerializationSeparatorString<StyleType>);
+        serializationForCSSOnTupleLike(builder, context, style, value, SerializationSeparatorString<StyleType>, std::forward<Rest>(rest)...);
     }
 };
 
 // Constrained for `TreatAsRangeLike`.
 template<RangeLike StyleType> struct Serialize<StyleType> {
-    void operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const StyleType& value)
+    template<typename... Rest> void operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const StyleType& value, Rest&&... rest)
     {
-        serializationForCSSOnRangeLike(builder, context, style, value, SerializationSeparatorString<StyleType>);
+        serializationForCSSOnRangeLike(builder, context, style, value, SerializationSeparatorString<StyleType>, std::forward<Rest>(rest)...);
     }
 };
 
 // Constrained for `TreatAsVariantLike`.
 template<VariantLike StyleType> struct Serialize<StyleType> {
-    void operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const StyleType& value)
+    template<typename... Rest> void operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const StyleType& value, Rest&&... rest)
     {
-        serializationForCSSOnVariantLike(builder, context, style, value);
+        serializationForCSSOnVariantLike(builder, context, style, value, std::forward<Rest>(rest)...);
     }
 };
 
 // Constrained for `TreatAsNonConverting`.
 template<NonConverting StyleType> struct Serialize<StyleType> {
-    void operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle&, const StyleType& value)
+    template<typename... Rest> void operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle&, const StyleType& value, Rest&&... rest)
     {
-        CSS::serializationForCSS(builder, context, value);
+        CSS::serializationForCSS(builder, context, value, std::forward<Rest>(rest)...);
     }
 };
 
 // Specialization for `FunctionNotation`.
 template<CSSValueID Name, typename StyleType> struct Serialize<FunctionNotation<Name, StyleType>> {
-    void operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const FunctionNotation<Name, StyleType>& value)
+    template<typename... Rest> void operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const FunctionNotation<Name, StyleType>& value, Rest&&... rest)
     {
         builder.append(nameLiteralForSerialization(value.name), '(');
-        serializationForCSS(builder, context, style, value.parameters);
+        serializationForCSS(builder, context, style, value.parameters, std::forward<Rest>(rest)...);
         builder.append(')');
     }
 };
 
 // Specialization for `MinimallySerializingSpaceSeparatedSize`.
 template<typename CSSType> struct Serialize<MinimallySerializingSpaceSeparatedSize<CSSType>> {
-    void operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const MinimallySerializingSpaceSeparatedSize<CSSType>& value)
+    template<typename... Rest> void operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const MinimallySerializingSpaceSeparatedSize<CSSType>& value, Rest&&... rest)
     {
         constexpr auto separator = SerializationSeparatorString<MinimallySerializingSpaceSeparatedSize<CSSType>>;
 
         if (get<0>(value) != get<1>(value)) {
-            serializationForCSSOnTupleLike(builder, context, style, std::tuple { get<0>(value), get<1>(value) }, separator);
+            serializationForCSSOnTupleLike(builder, context, style, std::tuple { get<0>(value), get<1>(value) }, separator, std::forward<Rest>(rest)...);
             return;
         }
-        serializationForCSS(builder, context, style, get<0>(value));
+        serializationForCSS(builder, context, style, get<0>(value), std::forward<Rest>(rest)...);
     }
 };
 
 // Specialization for `MinimallySerializingSpaceSeparatedRectEdges`.
 template<typename StyleType> struct Serialize<MinimallySerializingSpaceSeparatedRectEdges<StyleType>> {
-    void operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const MinimallySerializingSpaceSeparatedRectEdges<StyleType>& value)
+    template<typename... Rest> void operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const MinimallySerializingSpaceSeparatedRectEdges<StyleType>& value, Rest&&... rest)
     {
         constexpr auto separator = SerializationSeparatorString<MinimallySerializingSpaceSeparatedRectEdges<StyleType>>;
 
         if (value.left() != value.right()) {
-            serializationForCSSOnTupleLike(builder, context, style, std::tuple { value.top(), value.right(), value.bottom(), value.left() }, separator);
+            serializationForCSSOnTupleLike(builder, context, style, std::tuple { value.top(), value.right(), value.bottom(), value.left() }, separator, std::forward<Rest>(rest)...);
             return;
         }
         if (value.bottom() != value.top()) {
-            serializationForCSSOnTupleLike(builder, context, style, std::tuple { value.top(), value.right(), value.bottom() }, separator);
+            serializationForCSSOnTupleLike(builder, context, style, std::tuple { value.top(), value.right(), value.bottom() }, separator, std::forward<Rest>(rest)...);
             return;
         }
         if (value.right() != value.top()) {
-            serializationForCSSOnTupleLike(builder, context, style, std::tuple { value.top(), value.right() }, separator);
+            serializationForCSSOnTupleLike(builder, context, style, std::tuple { value.top(), value.right() }, separator, std::forward<Rest>(rest)...);
             return;
         }
-        serializationForCSS(builder, context, style, value.top());
+        serializationForCSS(builder, context, style, value.top(), std::forward<Rest>(rest)...);
     }
 };
 
@@ -694,53 +701,59 @@ template<typename StyleType> concept HasBlendWithRenderStyle = requires {
     { Blending<StyleType>{}.blend(std::declval<const StyleType&>(), std::declval<const StyleType&>(), std::declval<const RenderStyle&>(), std::declval<const RenderStyle&>(), std::declval<const BlendingContext&>()) } -> std::same_as<StyleType>;
 };
 
-// `CanBlend` Invoker
-template<typename StyleType> auto canBlend(const StyleType& a, const StyleType& b) -> bool
-{
-    if constexpr (HasCanBlendWithoutRenderStyle<StyleType>)
-        return Blending<StyleType>{}.canBlend(a, b);
-    else
-        return true;
-}
+struct CanBlendInvoker {
+    template<typename StyleType> auto operator()(const StyleType& a, const StyleType& b) const -> bool
+    {
+        if constexpr (HasCanBlendWithoutRenderStyle<StyleType>)
+            return Blending<StyleType>{}.canBlend(a, b);
+        else
+            return true;
+    }
 
-template<typename StyleType> auto canBlend(const StyleType& a, const StyleType& b, const RenderStyle& aStyle, const RenderStyle& bStyle) -> bool
-{
-    if constexpr (HasCanBlendWithRenderStyle<StyleType>)
-        return Blending<StyleType>{}.canBlend(a, b, aStyle, bStyle);
-    else
-        return WebCore::Style::canBlend(a, b);
-}
+    template<typename StyleType> auto operator()(const StyleType& a, const StyleType& b, const RenderStyle& aStyle, const RenderStyle& bStyle) const -> bool
+    {
+        if constexpr (HasCanBlendWithRenderStyle<StyleType>)
+            return Blending<StyleType>{}.canBlend(a, b, aStyle, bStyle);
+        else
+            return this->operator()(a, b);
+    }
+};
+inline constexpr CanBlendInvoker canBlend{};
 
-// `RequiresInterpolationForAccumulativeIteration` Invoker
-template<typename StyleType> auto requiresInterpolationForAccumulativeIteration(const StyleType& a, const StyleType& b) -> bool
-{
-    if constexpr (HasRequiresInterpolationForAccumulativeIterationWithoutRenderStyle<StyleType>)
-        return Blending<StyleType>{}.requiresInterpolationForAccumulativeIteration(a, b);
-    else
-        return false;
-}
+struct RequiresInterpolationForAccumulativeIterationInvoker {
+    template<typename StyleType> auto operator()(const StyleType& a, const StyleType& b) const -> bool
+    {
+        if constexpr (HasRequiresInterpolationForAccumulativeIterationWithoutRenderStyle<StyleType>)
+            return Blending<StyleType>{}.requiresInterpolationForAccumulativeIteration(a, b);
+        else
+            return false;
+    }
 
-template<typename StyleType> auto requiresInterpolationForAccumulativeIteration(const StyleType& a, const StyleType& b, const RenderStyle& aStyle, const RenderStyle& bStyle) -> bool
-{
-    if constexpr (HasRequiresInterpolationForAccumulativeIterationWithRenderStyle<StyleType>)
-        return Blending<StyleType>{}.requiresInterpolationForAccumulativeIteration(a, b, aStyle, bStyle);
-    else
-        return WebCore::Style::requiresInterpolationForAccumulativeIteration(a, b);
-}
+    template<typename StyleType> auto operator()(const StyleType& a, const StyleType& b, const RenderStyle& aStyle, const RenderStyle& bStyle) const -> bool
+    {
+        if constexpr (HasRequiresInterpolationForAccumulativeIterationWithRenderStyle<StyleType>)
+            return Blending<StyleType>{}.requiresInterpolationForAccumulativeIteration(a, b, aStyle, bStyle);
+        else
+            return this->operator()(a, b);
+    }
+};
+inline constexpr RequiresInterpolationForAccumulativeIterationInvoker requiresInterpolationForAccumulativeIteration{};
 
-// `Blend` Invoker
-template<typename StyleType> auto blend(const StyleType& a, const StyleType& b, const BlendingContext& context) -> StyleType
-{
-    return Blending<StyleType>{}.blend(a, b, context);
-}
+struct BlendInvoker {
+    template<typename StyleType> auto operator()(const StyleType& a, const StyleType& b, const BlendingContext& context) const -> StyleType
+    {
+        return Blending<StyleType>{}.blend(a, b, context);
+    }
 
-template<typename StyleType> auto blend(const StyleType& a, const StyleType& b, const RenderStyle& aStyle, const RenderStyle& bStyle, const BlendingContext& context) -> StyleType
-{
-    if constexpr (HasBlendWithRenderStyle<StyleType>)
-        return Blending<StyleType>{}.blend(a, b, aStyle, bStyle, context);
-    else
-        return WebCore::Style::blend(a, b, context);
-}
+    template<typename StyleType> auto operator()(const StyleType& a, const StyleType& b, const RenderStyle& aStyle, const RenderStyle& bStyle, const BlendingContext& context) const -> StyleType
+    {
+        if constexpr (HasBlendWithRenderStyle<StyleType>)
+            return Blending<StyleType>{}.blend(a, b, aStyle, bStyle, context);
+        else
+            return this->operator()(a, b, context);
+    }
+};
+inline constexpr BlendInvoker blend{};
 
 // Utilities for blending
 
@@ -1104,14 +1117,16 @@ template<typename StyleType, size_t inlineCapacity> struct Blending<CommaSeparat
 
 template<typename> struct IsZero;
 
-// IsZero Invoker
-template<typename T> bool isZero(const T& value)
-{
-    if constexpr (HasIsZero<T>)
-        return value.isZero();
-    else
-        return IsZero<T>{}(value);
-}
+struct IsZeroInvoker {
+    template<typename T> bool operator()(const T& value) const
+    {
+        if constexpr (HasIsZero<T>)
+            return value.isZero();
+        else
+            return IsZero<T>{}(value);
+    }
+};
+inline constexpr IsZeroInvoker isZero{};
 
 // Constrained for `TreatAsTupleLike`.
 template<TupleLike T> struct IsZero<T> {
@@ -1143,14 +1158,16 @@ template<VariantLike T> struct IsZero<T> {
 
 template<typename> struct IsEmpty;
 
-// IsEmpty Invoker
-template<typename T> bool isEmpty(const T& value)
-{
-    if constexpr (HasIsEmpty<T>)
-        return value.isEmpty();
-    else
-        return IsEmpty<T>{}(value);
-}
+struct IsEmptyInvoker {
+    template<typename T> bool operator()(const T& value) const
+    {
+        if constexpr (HasIsEmpty<T>)
+            return value.isEmpty();
+        else
+            return IsEmpty<T>{}(value);
+    }
+};
+inline constexpr IsEmptyInvoker isEmpty{};
 
 // Specialization for `SpaceSeparatedSize`.
 template<typename T> struct IsEmpty<SpaceSeparatedSize<T>> {

--- a/Source/WebCore/style/values/color/StyleColor.cpp
+++ b/Source/WebCore/style/values/color/StyleColor.cpp
@@ -306,7 +306,7 @@ bool containsCurrentColor(const Color& value)
 void Serialize<Color>::operator()(StringBuilder& builder, const CSS::SerializationContext&, const RenderStyle& style, const Color& value)
 {
     // NOTE: The specialization of Style::Serialize is used for computed value serialization, so the resolved "used" value is used.
-    builder.append(serializationForCSS(style.colorResolvingCurrentColor(value)));
+    builder.append(WebCore::serializationForCSS(style.colorResolvingCurrentColor(value)));
 }
 
 // MARK: - TextStream.

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Blending.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Blending.h
@@ -87,14 +87,14 @@ template<auto R, typename V> struct Blending<LengthPercentage<R, V>> {
 
             if (!WTF::holdsAlternative<Calc>(to) && !WTF::holdsAlternative<Percentage>(from) && (context.progress == 1 || fromIsZero)) {
                 if (WTF::holdsAlternative<Length>(to))
-                    return WebCore::Style::blend<Length>(0_css_px, get<Length>(to), context);
-                return WebCore::Style::blend<Percentage>(0_css_percentage, get<Percentage>(to), context);
+                    return WebCore::Style::blend(Length(0_css_px), get<Length>(to), context);
+                return WebCore::Style::blend(Percentage(0_css_percentage), get<Percentage>(to), context);
             }
 
             if (!WTF::holdsAlternative<Calc>(from) && !WTF::holdsAlternative<Percentage>(to) && (!context.progress || toIsZero)) {
                 if (WTF::holdsAlternative<Length>(from))
-                    return WebCore::Style::blend<Length>(get<Length>(from), 0_css_px, context);
-                return WebCore::Style::blend<Percentage>(get<Percentage>(from), 0_css_percentage, context);
+                    return WebCore::Style::blend(get<Length>(from), Length(0_css_px), context);
+                return WebCore::Style::blend(get<Percentage>(from), Percentage(0_css_percentage), context);
             }
 
             return Calc { Calculation::blend(copyCalculation(from), copyCalculation(to), context.progress) };


### PR DESCRIPTION
#### 9c2edfbd60bf4a38bc9e2abecea12ad8f4c51ae3
<pre>
[Style] Support variadic rest parameters for more style and css type interfaces
<a href="https://bugs.webkit.org/show_bug.cgi?id=294586">https://bugs.webkit.org/show_bug.cgi?id=294586</a>

Reviewed by Darin Adler.

A few of the style interfaces (ToStyle and ToCSS specifically) already support
a client defined variadic &quot;Rest...&quot; parameter. This expands the set of interfaces
to include Serialize, CSSValueCreation, CSSValueConversion, and ToPlatform.

Doing this introduces a bit of ambiguity due to ADL. To fix this, we convert
the interface invokers to use &quot;customization point objects&quot; to avoid ADL.
See <a href="https://stackoverflow.com/questions/53495848/what-are-customization-point-objects-and-how-to-use-them">https://stackoverflow.com/questions/53495848/what-are-customization-point-objects-and-how-to-use-them</a> for more.

* Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp:
* Source/WebCore/css/scripts/process-css-properties.py:
* Source/WebCore/css/values/CSSValueTypes.cpp:
* Source/WebCore/css/values/CSSValueTypes.h:
* Source/WebCore/css/values/color/CSSColorMix.cpp:
* Source/WebCore/css/values/color/CSSHexColor.cpp:
* Source/WebCore/css/values/images/CSSGradient.cpp:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleExtractorConverter.h:
* Source/WebCore/style/StyleExtractorSerializer.h:
* Source/WebCore/style/StyleInterpolationFunctions.h:
* Source/WebCore/style/values/StyleValueTypes.h:
* Source/WebCore/style/values/color/StyleColor.cpp:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Blending.h:

Canonical link: <a href="https://commits.webkit.org/296375@main">https://commits.webkit.org/296375@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d26e5a784c50d12171f25f40ef8426278605c06

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108295 "76 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27956 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113504 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58733 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110258 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28645 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36505 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82224 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111243 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22704 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97550 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62660 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22120 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15688 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58236 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92072 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15744 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116626 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35349 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26028 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91252 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35722 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93827 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91053 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23211 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35936 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13709 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31105 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35251 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40789 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34968 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38322 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36649 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->