### PR TITLE
[WTF] Add overloads of WTF::arePointingToEqualData for non-nullable pointer-like types

### DIFF
--- a/Source/WTF/wtf/Ref.h
+++ b/Source/WTF/wtf/Ref.h
@@ -327,8 +327,15 @@ inline RefPtr<match_constness_t<Source, Target>> dynamicDowncast(Ref<Source, Ptr
     return static_reference_cast<match_constness_t<Source, Target>>(WTFMove(source));
 }
 
+template<typename T, typename PtrTraits, typename RefDerefTraits>
+inline bool arePointingToEqualData(const Ref<T, PtrTraits, RefDerefTraits>& a, const Ref<T, PtrTraits, RefDerefTraits>& b)
+{
+    return a.ptr() == b.ptr() || a.get() == b.get();
+}
+
 } // namespace WTF
 
 using WTF::Ref;
 using WTF::adoptRef;
+using WTF::arePointingToEqualData;
 using WTF::static_reference_cast;

--- a/Source/WTF/wtf/UniqueRef.h
+++ b/Source/WTF/wtf/UniqueRef.h
@@ -105,14 +105,14 @@ private:
     std::unique_ptr<T> m_ref;
 };
 
-template <typename T>
+template<typename T>
 struct GetPtrHelper<UniqueRef<T>> {
     using PtrType = T*;
     using UnderlyingType = T;
     static T* getPtr(const UniqueRef<T>& p) { return const_cast<T*>(p.ptr()); }
 };
 
-template <typename T>
+template<typename T>
 struct IsSmartPtr<UniqueRef<T>> {
     static constexpr bool value = true;
     static constexpr bool isNullable = false;
@@ -130,9 +130,16 @@ inline bool is(const UniqueRef<ArgType>& source)
     return is<ExpectedType>(source.get());
 }
 
+template<typename T>
+inline bool arePointingToEqualData(const UniqueRef<T>& a, const UniqueRef<T>& b)
+{
+    return a.ptr() == b.ptr() || a.get() == b.get();
+}
+
 } // namespace WTF
 
 using WTF::UniqueRef;
+using WTF::arePointingToEqualData;
 using WTF::makeUniqueRef;
 using WTF::makeUniqueRefWithoutFastMallocCheck;
 using WTF::makeUniqueRefWithoutRefCountedCheck;

--- a/Source/WebCore/css/CSSCustomPropertyValue.cpp
+++ b/Source/WebCore/css/CSSCustomPropertyValue.cpp
@@ -82,12 +82,10 @@ bool CSSCustomPropertyValue::equals(const CSSCustomPropertyValue& other) const
 
     return WTF::switchOn(m_value,
         [&](const Ref<CSSVariableReferenceValue>& value) {
-            auto& otherValue = std::get<Ref<CSSVariableReferenceValue>>(other.m_value);
-            return value.ptr() == otherValue.ptr() || value.get() == otherValue.get();
+            return arePointingToEqualData(value, std::get<Ref<CSSVariableReferenceValue>>(other.m_value));
         },
         [&](const Ref<CSSVariableData>& value) {
-            auto& otherValue = std::get<Ref<CSSVariableData>>(other.m_value);
-            return value.ptr() == otherValue.ptr() || value.get() == otherValue.get();
+            return arePointingToEqualData(value, std::get<Ref<CSSVariableData>>(other.m_value));
         },
         [&](const CSSWideKeyword& keyword) {
             return keyword == std::get<CSSWideKeyword>(other.m_value);

--- a/Source/WebCore/css/CSSFontStyleRangeValue.cpp
+++ b/Source/WebCore/css/CSSFontStyleRangeValue.cpp
@@ -44,10 +44,8 @@ String CSSFontStyleRangeValue::customCSSText(const CSS::SerializationContext& co
 
 bool CSSFontStyleRangeValue::equals(const CSSFontStyleRangeValue& other) const
 {
-    if (!obliqueValues)
-        return fontStyleValue.get() == other.fontStyleValue.get();
-    return fontStyleValue.get() == other.fontStyleValue.get()
-        && *obliqueValues == *other.obliqueValues;
+    return arePointingToEqualData(fontStyleValue, other.fontStyleValue)
+        && arePointingToEqualData(obliqueValues, other.obliqueValues);
 }
 
-}
+} // namespace WebCore

--- a/Source/WebCore/css/CSSVariableReferenceValue.cpp
+++ b/Source/WebCore/css/CSSVariableReferenceValue.cpp
@@ -63,7 +63,7 @@ Ref<CSSVariableReferenceValue> CSSVariableReferenceValue::create(Ref<CSSVariable
 
 bool CSSVariableReferenceValue::equals(const CSSVariableReferenceValue& other) const
 {
-    return m_data.get() == other.m_data.get();
+    return arePointingToEqualData(m_data, other.m_data);
 }
 
 String CSSVariableReferenceValue::customCSSText(const CSS::SerializationContext&) const

--- a/Source/WebCore/css/calc/CSSCalcTree.h
+++ b/Source/WebCore/css/calc/CSSCalcTree.h
@@ -198,7 +198,7 @@ template<typename Op> struct IndirectNode {
     operator const Op&() const { return *op; }
     operator Op&() { return *op; }
 
-    bool operator==(const IndirectNode<Op>& other) const { return type == other.type && op.get() == other.op.get(); }
+    bool operator==(const IndirectNode<Op>& other) const { return type == other.type && arePointingToEqualData(op, other.op); }
 };
 
 using Node = Variant<

--- a/Source/WebCore/css/values/CSSValueAggregates.h
+++ b/Source/WebCore/css/values/CSSValueAggregates.h
@@ -175,7 +175,7 @@ template<CSSValueID C, typename T> struct FunctionNotation {
 
 template<CSSValueID C, typename T> bool operator==(const UniqueRef<FunctionNotation<C, T>>& a, const UniqueRef<FunctionNotation<C, T>>& b)
 {
-    return a.get() == b.get();
+    return arePointingToEqualData(a, b);
 }
 
 template<size_t, CSSValueID C, typename T> const auto& get(const FunctionNotation<C, T>& function)

--- a/Source/WebCore/css/values/color/CSSDynamicRangeLimitMix.h
+++ b/Source/WebCore/css/values/color/CSSDynamicRangeLimitMix.h
@@ -45,7 +45,7 @@ DEFINE_TYPE_WRAPPER(DynamicRangeLimitMixFunction, DynamicRangeLimitMixFunctionVa
 // FIXME: Replace use of direct UniqueRef with something like std::indirect from https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3019r12.pdf to get this for free.
 inline bool operator==(const UniqueRef<DynamicRangeLimitMixFunction>& a, const UniqueRef<DynamicRangeLimitMixFunction>& b)
 {
-    return a.get() == b.get();
+    return arePointingToEqualData(a, b);
 }
 
 } // namespace CSS

--- a/Source/WebCore/platform/graphics/FontCascadeDescription.h
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.h
@@ -170,7 +170,7 @@ private:
 inline bool FontCascadeDescription::operator==(const FontCascadeDescription& other) const
 {
     return static_cast<const FontDescription&>(*this) == static_cast<const FontDescription&>(other)
-        && m_families.get() == other.m_families.get()
+        && arePointingToEqualData(m_families, other.m_families)
         && m_specifiedSize == other.m_specifiedSize
         && m_isAbsoluteSize == other.m_isAbsoluteSize
         && m_kerning == other.m_kerning

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
@@ -386,14 +386,11 @@ void CDMSessionAVContentKeySession::addParser(AVStreamDataParser* parser)
 
 bool CDMSessionAVContentKeySession::isAnyKeyUsable(const Keys& keys) const
 {
-    Keys requestKeys = CDMPrivateFairPlayStreaming::keyIDsForRequest(contentKeyRequest().get());
+    auto requestKeys = CDMPrivateFairPlayStreaming::keyIDsForRequest(contentKeyRequest().get());
     for (auto& requestKey : requestKeys) {
-        if (keys.findIf([&] (auto& key) {
-            return key.get() == requestKey.get();
-        }) != notFound)
+        if (keys.containsIf([&](auto& key) { return arePointingToEqualData(key, requestKey); }))
             return true;
     }
-
     return false;
 }
 

--- a/Source/WebCore/platform/graphics/filters/FELighting.cpp
+++ b/Source/WebCore/platform/graphics/filters/FELighting.cpp
@@ -58,7 +58,7 @@ bool FELighting::operator==(const FELighting& other) const
         && m_specularExponent == other.m_specularExponent
         && m_kernelUnitLengthX == other.m_kernelUnitLengthX
         && m_kernelUnitLengthY == other.m_kernelUnitLengthY
-        && m_lightSource.get() == other.m_lightSource.get();
+        && arePointingToEqualData(m_lightSource, other.m_lightSource);
 }
 
 bool FELighting::setSurfaceScale(float surfaceScale)

--- a/Source/WebCore/platform/graphics/filters/FilterOperations.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterOperations.cpp
@@ -49,7 +49,7 @@ bool FilterOperations::operator==(const FilterOperations& other) const
 {
     static_assert(std::ranges::sized_range<decltype(m_operations)>);
 
-    return std::ranges::equal(m_operations, other.m_operations, [](auto& a, auto& b) { return a.get() == b.get(); });
+    return std::ranges::equal(m_operations, other.m_operations, [](auto& a, auto& b) { return arePointingToEqualData(a, b); });
 }
 
 bool FilterOperations::operationsMatch(const FilterOperations& other) const

--- a/Source/WebCore/platform/graphics/transforms/TransformOperations.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TransformOperations.cpp
@@ -47,7 +47,7 @@ bool TransformOperations::operator==(const TransformOperations& o) const
 {
     static_assert(std::ranges::sized_range<decltype(m_operations)>);
 
-    return std::ranges::equal(m_operations, o.m_operations, [](auto& a, auto& b) { return a.get() == b.get(); });
+    return std::ranges::equal(m_operations, o.m_operations, [](auto& a, auto& b) { return arePointingToEqualData(a, b); });
 }
 
 TransformOperations TransformOperations::clone() const

--- a/Source/WebCore/rendering/style/StyleCursorImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCursorImage.cpp
@@ -89,7 +89,7 @@ bool StyleCursorImage::equals(const StyleCursorImage& other) const
 
 bool StyleCursorImage::equalInputImages(const StyleCursorImage& other) const
 {
-    return m_image.get() == other.m_image.get();
+    return arePointingToEqualData(m_image, other.m_image);
 }
 
 Ref<CSSValue> StyleCursorImage::computedStyleValue(const RenderStyle& style) const

--- a/Source/WebCore/rendering/style/StyleMultiImage.cpp
+++ b/Source/WebCore/rendering/style/StyleMultiImage.cpp
@@ -57,7 +57,7 @@ StyleMultiImage::~StyleMultiImage() = default;
 
 bool StyleMultiImage::equals(const StyleMultiImage& other) const
 {
-    return (!m_isPending && !other.m_isPending && m_selectedImage.get() == other.m_selectedImage.get());
+    return !m_isPending && !other.m_isPending && arePointingToEqualData(m_selectedImage, other.m_selectedImage);
 }
 
 void StyleMultiImage::load(CachedResourceLoader& loader, const ResourceLoaderOptions& options)

--- a/Source/WebCore/style/StyleCustomProperty.cpp
+++ b/Source/WebCore/style/StyleCustomProperty.cpp
@@ -56,8 +56,7 @@ bool CustomProperty::operator==(const CustomProperty& other) const
             return true;
         },
         [&](const Ref<CSSVariableData>& value) {
-            auto& otherValue = std::get<Ref<CSSVariableData>>(other.m_value);
-            return value.ptr() == otherValue.ptr() || value.get() == otherValue.get();
+            return arePointingToEqualData(value, std::get<Ref<CSSVariableData>>(other.m_value));
         },
         [&](const Value& value) {
             return value == std::get<Value>(other.m_value);

--- a/Source/WebCore/style/StyleCustomProperty.h
+++ b/Source/WebCore/style/StyleCustomProperty.h
@@ -58,7 +58,7 @@ public:
 
     struct Transform {
         Ref<TransformOperation> operation;
-        bool operator==(const Transform& other) const { return operation.get() == other.operation.get(); }
+        bool operator==(const Transform& other) const { return arePointingToEqualData(operation, other.operation); }
     };
 
     using Value = Variant<

--- a/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
+++ b/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
@@ -291,7 +291,7 @@ void SVGFilter::mergeEffects(const FilterEffectVector& effects)
     ASSERT(m_effects.size() == effects.size());
 
     for (unsigned index = 0; index < m_effects.size(); ++index) {
-        if (m_effects[index].get() == effects[index].get())
+        if (arePointingToEqualData(m_effects[index], effects[index]))
             continue;
 
         clearEffectResult(m_effects[index]);


### PR DESCRIPTION
#### f7123211c62d1bfdaeb837b5f5c0b69827866e20
<pre>
[WTF] Add overloads of WTF::arePointingToEqualData for non-nullable pointer-like types
<a href="https://bugs.webkit.org/show_bug.cgi?id=294615">https://bugs.webkit.org/show_bug.cgi?id=294615</a>

Reviewed by Darin Adler.

Replaces the relatively common idiom of:

```
   foo.ptr() == bar.ptr() || foo.get() == bar.get();
```

used for Ref and UniqueRef that want value semantics, with
calls to an overload of WTF::arePointingToEqualData that
does the right thing.

* Source/WTF/wtf/Ref.h:
* Source/WTF/wtf/UniqueRef.h:
    - Adds overloads.

* Source/WebCore/css/CSSCustomPropertyValue.cpp:
* Source/WebCore/css/CSSFontStyleRangeValue.cpp:
* Source/WebCore/css/CSSVariableReferenceValue.cpp:
* Source/WebCore/css/calc/CSSCalcTree.h:
* Source/WebCore/css/values/CSSValueAggregates.h:
* Source/WebCore/css/values/color/CSSDynamicRangeLimitMix.h:
* Source/WebCore/platform/graphics/FontCascadeDescription.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm:
* Source/WebCore/platform/graphics/filters/FELighting.cpp:
* Source/WebCore/platform/graphics/filters/FilterOperations.cpp:
* Source/WebCore/platform/graphics/transforms/TransformOperations.cpp:
* Source/WebCore/rendering/style/StyleCursorImage.cpp:
* Source/WebCore/rendering/style/StyleMultiImage.cpp:
* Source/WebCore/style/StyleCustomProperty.cpp:
* Source/WebCore/style/StyleCustomProperty.h:
* Source/WebCore/svg/graphics/filters/SVGFilter.cpp:
    - Adopt new arePointingToEqualData overloads.

Canonical link: <a href="https://commits.webkit.org/296358@main">https://commits.webkit.org/296358@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e27be1d74ecbd6fec22f037ac72d273154c389e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108192 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27855 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18275 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113403 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58678 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110155 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28555 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36406 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82152 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111140 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22626 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97464 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62583 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22040 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15600 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58140 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/100781 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91992 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15656 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116529 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/106753 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35258 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25964 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91183 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35632 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93740 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90978 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23198 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35862 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13626 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31039 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35157 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40713 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/131041 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34891 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35570 "Found 2 new JSC stress test failures: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js.default, wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38249 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36558 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->