### PR TITLE
[Unified PDF] Jetsams hit when quickly scrolling via Find-in-page results

### DIFF
--- a/Source/WebKit/Shared/WebFoundTextRange.cpp
+++ b/Source/WebKit/Shared/WebFoundTextRange.cpp
@@ -27,8 +27,14 @@
 #include "WebFoundTextRange.h"
 
 #include <wtf/StdLibExtras.h>
+#include <wtf/text/TextStream.h>
 
 namespace WebKit {
+
+unsigned WebFoundTextRange::PDFData::hash() const
+{
+    return pairIntHash(pairIntHash(pairIntHash(startPage, endPage), startOffset), endOffset);
+}
 
 unsigned WebFoundTextRange::hash() const
 {
@@ -37,7 +43,7 @@ unsigned WebFoundTextRange::hash() const
             return pairIntHash(domData.location, domData.length);
         },
         [] (const WebFoundTextRange::PDFData& pdfData) {
-            return pairIntHash(pairIntHash(pairIntHash(pdfData.startPage, pdfData.endPage), pdfData.startOffset), pdfData.endOffset);
+            return pdfData.hash();
         }
     );
 }
@@ -52,6 +58,12 @@ bool WebFoundTextRange::operator==(const WebFoundTextRange& other) const
     return data == other.data
         && frameIdentifier == other.frameIdentifier
         && order == other.order;
+}
+
+TextStream& operator<<(TextStream& ts, const WebFoundTextRange::PDFData& data)
+{
+    ts << "[start page: " << data.startPage << ", start offset: " << data.startOffset << ", end page: " << data.endPage << ", end offset: " << data.endOffset << "]";
+    return ts;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -442,7 +442,7 @@ private:
     void scrollToRevealTextMatch(const WebFoundTextRange::PDFData&) final;
 
     Vector<WebCore::FloatRect> visibleRectsForFindMatchRects(PDFPageCoverage) const;
-    PDFSelection *selectionFromWebFoundTextRangePDFData(const WebFoundTextRange::PDFData&) const;
+    PDFSelection *selectionFromWebFoundTextRangePDFData(const WebFoundTextRange::PDFData&);
 
     static WebCore::Color selectionTextIndicatorHighlightColor();
     RefPtr<WebCore::TextIndicator> textIndicatorForCurrentSelection(OptionSet<WebCore::TextIndicatorOption>, WebCore::TextIndicatorPresentationTransition) final;
@@ -730,6 +730,8 @@ private:
 #else
     static constexpr bool hasFullAnnotationSupport = false;
 #endif
+
+    HashMap<WebFoundTextRange::PDFData, RetainPtr<PDFSelection>> m_webFoundTextRangePDFDataSelectionMap;
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, RepaintRequirement);


### PR DESCRIPTION
#### 5c8e008844109a2b2cf1bdc1819f50f4b9a41a1a
<pre>
[Unified PDF] Jetsams hit when quickly scrolling via Find-in-page results
<a href="https://bugs.webkit.org/show_bug.cgi?id=294617">https://bugs.webkit.org/show_bug.cgi?id=294617</a>
<a href="https://rdar.apple.com/149223603">rdar://149223603</a>

Reviewed by Aditya Keerthi.

We notice the web content process often jetsams when we there is a large
number find-in-page results and we jump through them. This is explained
by unnecessary memory incurred in:

1. UnifiedPDFPlugin::visibleRectsForFindMatchRects(): Where we provide
   rects for _every_ find match, even if they are not within the
   unobscured content rect. Thus, WebFoundTextRangeController::drawRect
   paints many more paths than it needs to.
2. UnifiedPDFPlugin::selectionFromWebFoundTextRangePDFData(): Where we
   call into -[PDFDocument selectionFromPage:...] for every find-in-page
   result. This produces O(n) memory allocations under
   CGPDFSelectionCreateForRange.

Fixes are explained in line.

* Source/WebKit/Shared/WebFoundTextRange.cpp:
(WebKit::WebFoundTextRange::PDFData::hash const):
(WebKit::WebFoundTextRange::hash const):
(WebKit::operator&lt;&lt;):
    While the patch does not add new logging of PDFData, this is a useful
    utility to have.
* Source/WebKit/Shared/WebFoundTextRange.h:
(WTF::WebFoundTextRangePDFDataHash::hash):
(WTF::WebFoundTextRangePDFDataHash::equal):
(WTF::HashTraits&lt;WebKit::WebFoundTextRange::PDFData&gt;::emptyValue):
(WTF::HashTraits&lt;WebKit::WebFoundTextRange::PDFData&gt;::isEmptyValue):
(WTF::HashTraits&lt;WebKit::WebFoundTextRange::PDFData&gt;::constructDeletedValue):
(WTF::HashTraits&lt;WebKit::WebFoundTextRange::PDFData&gt;::isDeletedValue):
    Provide hash traits for PDFData, allowing it to be used as a map key.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::releaseMemory):
(WebKit::UnifiedPDFPlugin::findString):
     Remember to release the cache memory when appropriate, i.e. when a
     find session terminates or when we are generally releasing memory
     in the plugin.
(WebKit::UnifiedPDFPlugin::visibleRectsForFindMatchRects const):
    Only return rects for the find matches that currently intersect the
    unobscured content rect. This means we don&apos;t have an O(n) number of
    find match rects to paint.
(WebKit::UnifiedPDFPlugin::selectionFromWebFoundTextRangePDFData):

Canonical link: <a href="https://commits.webkit.org/296356@main">https://commits.webkit.org/296356@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/637fd71279086a91254030d669738c8223f95dbb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108265 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27926 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18348 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113474 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/58714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28620 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36477 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82202 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/58714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111213 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22682 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97526 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62635 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22099 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58207 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92048 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15718 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116596 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35324 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26006 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91226 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35696 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93801 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91023 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23200 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35915 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13685 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31085 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35224 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40766 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34946 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38300 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36622 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->