### PR TITLE
[Liquid Glass] solidcore.com: top sampled color changes when scrolling against the top of the page

### DIFF
--- a/LayoutTests/fast/page-color-sampling/color-sampling-while-rubber-banding.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-while-rubber-banding.html
@@ -32,6 +32,11 @@
     jsTestIsAsync = true;
 
     addEventListener("load", async () => {
+        const header = document.querySelector("header");
+        addEventListener("scroll", () => {
+            header.style.background = pageYOffset >= 0 ? "rgb(250, 60, 0)" : "black";
+        });
+
         await UIHelper.setObscuredInsets(100, 0, 0, 0);
         await UIHelper.ensurePresentationUpdate();
         colorsBeforeScrolling = await UIHelper.fixedContainerEdgeColors();

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -913,7 +913,6 @@ public:
     WEBCORE_EXPORT Color sampledPageTopColor() const;
 
     WEBCORE_EXPORT void updateFixedContainerEdges(OptionSet<BoxSideFlag>);
-    Color lastTopFixedContainerColor() const;
     const FixedContainerEdges& fixedContainerEdges() const { return m_fixedContainerEdgesAndElements.first; }
 
 #if ENABLE(WEB_PAGE_SPATIAL_BACKDROP)


### PR DESCRIPTION
#### d068bfd5c61df539931b97b2193dc8adedf2b5e9
<pre>
[Liquid Glass] solidcore.com: top sampled color changes when scrolling against the top of the page
<a href="https://bugs.webkit.org/show_bug.cgi?id=294621">https://bugs.webkit.org/show_bug.cgi?id=294621</a>
<a href="https://rdar.apple.com/153151667">rdar://153151667</a>

Reviewed by Abrar Rahman Protyasha.

Adjust the heuristics for determining sampled colors along viewport edges, to maintain stability in
a couple more scenarios:

1.  When rubber-banding against viewport edges, keep the sampled top color stable by falling back to
    the last color (as long as the hit-tested element is still in the render tree).

2.  In the case where the fixed viewport edge loses its predominant color but the previously
    sampled element is still in the render tree, fall back to the last sampled color.

* LayoutTests/fast/page-color-sampling/color-sampling-while-rubber-banding.html:

Augment an existing test to cover this case, by changing the color of the header while rubber-
banding.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fixedContainerEdges const):

Remove unnecessary code to expand the hit-test region while rubber-banding, now that we just fall
back to the last color.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateFixedContainerEdges):
(WebCore::Page::lastTopFixedContainerColor const): Deleted.

Remove this helper method, which is no longer needed.

* Source/WebCore/page/Page.h:

Canonical link: <a href="https://commits.webkit.org/296334@main">https://commits.webkit.org/296334@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18b5112ab9972e5283a74bcd3fc281dd3cf57988

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108207 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27869 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18290 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113417 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/58686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110170 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28568 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36420 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82162 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/58686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111155 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22638 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97473 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62593 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22054 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15609 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58152 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/92004 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15665 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116543 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35271 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25971 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/91193 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35645 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93749 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90989 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/23184 "The change is no longer eligible for processing.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35872 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13635 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31052 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17477 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35170 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40725 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34904 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38260 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36571 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->