### PR TITLE
Unreviewed, fixing non-JIT-enabled build with wasm

### DIFF
--- a/Source/JavaScriptCore/llint/LLIntThunks.cpp
+++ b/Source/JavaScriptCore/llint/LLIntThunks.cpp
@@ -231,45 +231,6 @@ ALWAYS_INLINE void* untaggedPtr(void* ptr)
     return CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>();
 }
 
-#if ENABLE(JIT)
-#define DEFINE_IPINT_THUNK(funcName, target) \
-    MacroAssemblerCodeRef<JITThunkPtrTag> funcName() \
-    { \
-        static LazyNeverDestroyed<MacroAssemblerCodeRef<JITThunkPtrTag>> codeRef; \
-        static std::once_flag onceKey; \
-        std::call_once(onceKey, [&] { \
-            if (Options::useJIT()) \
-                codeRef.construct(generateThunkWithJumpToPrologue<JITThunkPtrTag>(target, #target)); \
-            else \
-                codeRef.construct(getCodeRef<JITThunkPtrTag>(target)); \
-        }); \
-        return codeRef; \
-    }
-
-#else
-
-#define DEFINE_IPINT_THUNK(funcName, target) \
-    MacroAssemblerCodeRef<JITThunkPtrTag> funcName() \
-    { \
-        static LazyNeverDestroyed<MacroAssemblerCodeRef<JITThunkPtrTag>> codeRef; \
-        static std::once_flag onceKey; \
-        std::call_once(onceKey, [&] { \
-            codeRef.construct(getCodeRef<JITThunkPtrTag>(target)); \
-        }); \
-        return codeRef; \
-    }
-
-#endif
-
-DEFINE_IPINT_THUNK(inPlaceInterpreterEntryThunk, ipint_entry)
-DEFINE_IPINT_THUNK(inPlaceInterpreterSIMDEntryThunk, ipint_function_prologue_simd)
-DEFINE_IPINT_THUNK(inPlaceInterpreterCatchEntryThunk, ipint_catch_entry)
-DEFINE_IPINT_THUNK(inPlaceInterpreterCatchAllEntryThunk, ipint_catch_all_entry)
-DEFINE_IPINT_THUNK(inPlaceInterpreterTableCatchEntryThunk, ipint_table_catch_entry)
-DEFINE_IPINT_THUNK(inPlaceInterpreterTableCatchRefEntryThunk, ipint_table_catch_ref_entry)
-DEFINE_IPINT_THUNK(inPlaceInterpreterTableCatchAllEntryThunk, ipint_table_catch_all_entry)
-DEFINE_IPINT_THUNK(inPlaceInterpreterTableCatchAllrefEntryThunk, ipint_table_catch_allref_entry)
-
 #endif // ENABLE(WEBASSEMBLY)
 
 MacroAssemblerCodeRef<JSEntryPtrTag> defaultCallThunk()
@@ -1018,6 +979,52 @@ MacroAssemblerCodeRef<JITThunkPtrTag> wasmFunctionEntryThunkSIMD()
 } // namespace LLInt
 
 #endif // ENABLE(JIT)
+
+namespace LLInt {
+
+#if ENABLE(WEBASSEMBLY)
+#if ENABLE(JIT)
+#define DEFINE_IPINT_THUNK(funcName, target) \
+    MacroAssemblerCodeRef<JITThunkPtrTag> funcName() \
+    { \
+        static LazyNeverDestroyed<MacroAssemblerCodeRef<JITThunkPtrTag>> codeRef; \
+        static std::once_flag onceKey; \
+        std::call_once(onceKey, [&] { \
+            if (Options::useJIT()) \
+                codeRef.construct(generateThunkWithJumpToPrologue<JITThunkPtrTag>(target, #target)); \
+            else \
+                codeRef.construct(getCodeRef<JITThunkPtrTag>(target)); \
+        }); \
+        return codeRef; \
+    }
+
+#else
+
+#define DEFINE_IPINT_THUNK(funcName, target) \
+    MacroAssemblerCodeRef<JITThunkPtrTag> funcName() \
+    { \
+        static LazyNeverDestroyed<MacroAssemblerCodeRef<JITThunkPtrTag>> codeRef; \
+        static std::once_flag onceKey; \
+        std::call_once(onceKey, [&] { \
+            codeRef.construct(getCodeRef<JITThunkPtrTag>(target)); \
+        }); \
+        return codeRef; \
+    }
+
+#endif
+
+DEFINE_IPINT_THUNK(inPlaceInterpreterEntryThunk, ipint_entry)
+DEFINE_IPINT_THUNK(inPlaceInterpreterSIMDEntryThunk, ipint_function_prologue_simd)
+DEFINE_IPINT_THUNK(inPlaceInterpreterCatchEntryThunk, ipint_catch_entry)
+DEFINE_IPINT_THUNK(inPlaceInterpreterCatchAllEntryThunk, ipint_catch_all_entry)
+DEFINE_IPINT_THUNK(inPlaceInterpreterTableCatchEntryThunk, ipint_table_catch_entry)
+DEFINE_IPINT_THUNK(inPlaceInterpreterTableCatchRefEntryThunk, ipint_table_catch_ref_entry)
+DEFINE_IPINT_THUNK(inPlaceInterpreterTableCatchAllEntryThunk, ipint_table_catch_all_entry)
+DEFINE_IPINT_THUNK(inPlaceInterpreterTableCatchAllrefEntryThunk, ipint_table_catch_allref_entry)
+
+#endif
+
+} // namespace LLInt
 
 #if ENABLE(C_LOOP)
 // Non-JIT (i.e. C Loop LLINT) case:


### PR DESCRIPTION
#### 069c62b468f44771a8e81573c6f3dcc67a3697b6
<pre>
Unreviewed, fixing non-JIT-enabled build with wasm
<a href="https://bugs.webkit.org/show_bug.cgi?id=294624">https://bugs.webkit.org/show_bug.cgi?id=294624</a>
<a href="https://rdar.apple.com/153660918">rdar://153660918</a>

* Source/JavaScriptCore/llint/LLIntThunks.cpp:

Canonical link: <a href="https://commits.webkit.org/296333@main">https://commits.webkit.org/296333@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c21bcc31950a62e8073c91e812e0d6c041db47b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108216 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18299 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113426 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/58690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28576 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36429 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82167 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/58690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111164 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22641 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97479 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62599 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22057 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15615 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58161 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/100803 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92007 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15671 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116550 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/106776 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35279 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/91200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35652 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93755 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90986 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35879 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13641 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17476 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35179 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40731 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/131063 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34911 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35575 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38265 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36579 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->