### PR TITLE
REGRESSION(296169@main): [macOS Debug] fast/webgpu/nocrash/fuzz-291180.html is a 100% crash in Debug

### DIFF
--- a/Source/WebGPU/WebGPU/RenderBundle.mm
+++ b/Source/WebGPU/WebGPU/RenderBundle.mm
@@ -63,7 +63,7 @@ RenderBundle::RenderBundle(NSArray<RenderBundleICBWithResources*> *resources, Ve
 {
     m_descriptor.colorFormats = m_descriptorColorFormats.size() ? &m_descriptorColorFormats[0] : nullptr;
 
-    ASSERT(m_renderBundleEncoder || m_renderBundlesResources.count);
+    ASSERT(m_renderBundleEncoder || m_renderBundlesResources);
 }
 
 RenderBundle::RenderBundle(Device& device, NSString* errorString)
@@ -76,7 +76,7 @@ RenderBundle::~RenderBundle() = default;
 
 bool RenderBundle::isValid() const
 {
-    return m_renderBundleEncoder || m_renderBundlesResources.count;
+    return m_renderBundleEncoder || m_renderBundlesResources;
 }
 
 void RenderBundle::setLabel(String&& label)


### PR DESCRIPTION
#### 5e4050693c3cff35b7cb1c0ce89456b14ee9a223
<pre>
REGRESSION(296169@main): [macOS Debug] fast/webgpu/nocrash/fuzz-291180.html is a 100% crash in Debug
<a href="https://bugs.webkit.org/show_bug.cgi?id=294622">https://bugs.webkit.org/show_bug.cgi?id=294622</a>
<a href="https://rdar.apple.com/153659060">rdar://153659060</a>

Reviewed by Tadeu Zagallo.

A render bundle with zero draw commands was treated as invalid, even
though the specification says it is valid.

Note, a render bundle with zero draw commands is a no-op.

Test: fuzz-291180.html was 100% crash under debug, now passes.

* Source/WebGPU/WebGPU/RenderBundle.mm:
(WebGPU::RenderBundle::RenderBundle):
(WebGPU::RenderBundle::isValid const):

Canonical link: <a href="https://commits.webkit.org/296344@main">https://commits.webkit.org/296344@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86947ac394d14c20bf2135fbe527d7a6815e5b06

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108226 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27888 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18309 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113436 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58693 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36439 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82177 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111174 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97488 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62609 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22068 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58170 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92021 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15680 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116560 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35289 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25979 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91202 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35662 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93764 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90998 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23192 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35885 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13649 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31062 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35189 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40738 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34919 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38274 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36589 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->