### PR TITLE
IntersectionObserver: Node leak test is flaky after 296279@main

### DIFF
--- a/LayoutTests/intersection-observer/intersection-observer-should-not-leak-observed-nodes.html
+++ b/LayoutTests/intersection-observer/intersection-observer-should-not-leak-observed-nodes.html
@@ -24,12 +24,14 @@ function runTest()
     for (let i = 0; i < 100; ++i)
         intersectionObservers.push(createIntersectionObserver());
 
+    const smallTimeoutToAllowDeliveryOfQueuedNotifications = 10;
+
     requestAnimationFrame(() => {
         setTimeout(() => {
             gc();
             log.textContent += internals.referencingNodeCount(document) < initialNodeCount + intersectionObservers.length * 0.8 ? 'PASS' : 'FAIL - Less than 20% of nodes were collected.'
             testRunner.notifyDone();
-        }, 0);
+        }, smallTimeoutToAllowDeliveryOfQueuedNotifications);
     });
 }
 


### PR DESCRIPTION
#### d42738eb1727364302b444006a80a7d1c4948199
<pre>
IntersectionObserver: Node leak test is flaky after 296279@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=294628">https://bugs.webkit.org/show_bug.cgi?id=294628</a>

Reviewed by Simon Fraser.

296279@main made notification delivery asynchronous for JS intersection observers.
The test that would check for nodes being leaked by the observer was doing gc after an
rAF + zero delay timer. Since we keep pending notification targets alive until we deliver,
this effectively was causing a race between the EventLoop&apos;s task queue executing the notification
and the zero delay timer running. Sometimes we wouldn&apos;t deliver notifications before attempting a GC.

This change adds a small timeout between the rendering update where we run the requestAnimationFrame
callback and when we run gc to try to collect nodes so that the EventLoop&apos;s task queue has a chance to
execute.

* LayoutTests/intersection-observer/intersection-observer-should-not-leak-observed-nodes.html:

Canonical link: <a href="https://commits.webkit.org/296352@main">https://commits.webkit.org/296352@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/587753f4344296657c7ab6ef21432c2488dbecf1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108234 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27896 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113444 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58698 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28594 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36447 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82179 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111182 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22660 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97498 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62611 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22073 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15634 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58177 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92026 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15689 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116568 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35297 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25988 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91206 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35670 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93773 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91002 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23197 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35895 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13658 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31067 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35197 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34927 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38282 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36595 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->