### PR TITLE
HDR images don't get constrained when Safari goes to background

### DIFF
--- a/LayoutTests/fast/webgpu/regression/edr-triangle-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/edr-triangle-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: Pass
+

--- a/LayoutTests/fast/webgpu/regression/edr-triangle.html
+++ b/LayoutTests/fast/webgpu/regression/edr-triangle.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=600">
+<meta http-equiv="Content-type" content="text/html; charset=utf-8">
+<title>WebGPU Hello Triangle</title>
+<link rel="stylesheet" href="css/style.css">
+<style>
+body {
+    text-align: center;
+}
+canvas {
+    margin: 0 auto;
+}
+</style>
+</head>
+<body>
+<canvas></canvas>
+<script>
+    globalThis.testRunner?.waitUntilDone();
+    const log = console.debug;
+
+    async function helloTriangle() {
+        if (!navigator.gpu || GPUBufferUsage.COPY_SRC === undefined) {
+            document.body.className = 'error';
+            return;
+        }
+
+        const adapter = await navigator.gpu.requestAdapter();
+        const device = await adapter.requestDevice();
+        
+        /*** Vertex Buffer Setup ***/
+        
+        /* Vertex Data */
+        const vertexStride = 8 * 4;
+        const vertexDataSize = vertexStride * 3;
+        
+        /* GPUBufferDescriptor */
+        const vertexDataBufferDescriptor = {
+            size: vertexDataSize,
+            usage: GPUBufferUsage.VERTEX
+        };
+
+        /* GPUBuffer */
+        const vertexBuffer = device.createBuffer(vertexDataBufferDescriptor);
+        
+        /*** Shader Setup ***/
+        const wgslSource = `
+                         struct Vertex {
+                             @builtin(position) Position: vec4<f32>,
+                             @location(0) color: vec4<f32>,
+                             @location(1) multiplier: f32,
+                         }
+
+                         @vertex fn vsmain(@builtin(vertex_index) VertexIndex: u32) -> Vertex
+                         {
+                             var pos: array<vec2<f32>, 3> = array<vec2<f32>, 3>(
+                                 vec2<f32>( 0.0,  0.5),
+                                 vec2<f32>(-0.5, -0.5),
+                                 vec2<f32>( 0.5, -0.5)
+                             );
+                             var vertex_out : Vertex;
+                             vertex_out.Position = vec4<f32>(pos[VertexIndex] * 1.5, 0.0, 1.0);
+                             vertex_out.color = vec4<f32>(1.0, 1.0, 1.0, 1.0) - vec4<f32>(pos[VertexIndex] + vec2<f32>(0.5, 0.5), 0.0, 0.0);
+                             vertex_out.multiplier = f32(VertexIndex * 50);
+                             return vertex_out;
+                         }
+
+                         @fragment fn fsmain(in: Vertex) -> @location(0) vec4<f32>
+                         {
+                             return in.color * in.multiplier;
+                         }
+        `;
+        const shaderModule = device.createShaderModule({ code: wgslSource });
+        
+        /* GPUPipelineStageDescriptors */
+        const vertexStageDescriptor = { module: shaderModule, entryPoint: "vsmain" };
+
+        const fragmentStageDescriptor = { module: shaderModule, entryPoint: "fsmain", targets: [ {format: "rgba16float" }, ],  };
+        
+        /* GPURenderPipelineDescriptor */
+
+        const renderPipelineDescriptor = {
+            layout: 'auto',
+            vertex: vertexStageDescriptor,
+            fragment: fragmentStageDescriptor,
+            primitive: {topology: "triangle-list" },
+        };
+        /* GPURenderPipeline */
+        const renderPipeline = device.createRenderPipeline(renderPipelineDescriptor);
+        
+        /*** Swap Chain Setup ***/
+        
+        const canvas = document.querySelector("canvas");
+        canvas.width = 600;
+        canvas.height = 600;
+
+        const gpuContext = canvas.getContext("webgpu");
+        
+        /* GPUCanvasConfiguration */
+        const canvasConfiguration = { device: device, format: "rgba16float", toneMapping: { mode: 'extended' } };
+        gpuContext.configure(canvasConfiguration);
+        /* GPUTexture */
+        const currentTexture = gpuContext.getCurrentTexture();
+        
+        /*** Render Pass Setup ***/
+        
+        /* Acquire Texture To Render To */
+        
+        /* GPUTextureView */
+        const renderAttachment = currentTexture.createView();
+        
+        /* GPUColor */
+        const darkBlue = { r: 1, g: 1, b: 1, a: 1 };
+        
+        /* GPURenderPassColorATtachmentDescriptor */
+        const colorAttachmentDescriptor = {
+            view: renderAttachment,
+            loadOp: "clear",
+            storeOp: "store",
+            clearValue: darkBlue
+        };
+        
+        /* GPURenderPassDescriptor */
+        const renderPassDescriptor = { colorAttachments: [colorAttachmentDescriptor] };
+        
+        /*** Rendering ***/
+        
+        /* GPUCommandEncoder */
+        const commandEncoder = device.createCommandEncoder();
+        /* GPURenderPassEncoder */
+        const renderPassEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
+        
+        renderPassEncoder.setPipeline(renderPipeline);
+        const vertexBufferSlot = 0;
+        renderPassEncoder.setVertexBuffer(vertexBufferSlot, vertexBuffer, 0);
+        renderPassEncoder.draw(3, 1, 0, 0); // 3 vertices, 1 instance, 0th vertex, 0th instance.
+        renderPassEncoder.end();
+        
+        /* GPUComamndBuffer */
+        const commandBuffer = commandEncoder.finish();
+        
+        /* GPUQueue */
+        const queue = device.queue;
+        queue.submit([commandBuffer]);
+        await queue.onSubmittedWorkDone();
+
+        log('Pass');
+        globalThis.testRunner?.dumpAsText();
+        globalThis.testRunner?.notifyDone();
+    }
+
+    window.addEventListener("DOMContentLoaded", helloTriangle);
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.cpp
@@ -45,4 +45,9 @@ void GPUCompositorIntegration::paintCompositedResultsToCanvas(WebCore::ImageBuff
     m_backing->paintCompositedResultsToCanvas(imageBuffer, bufferIndex);
 }
 
+void GPUCompositorIntegration::updateContentsHeadroom(float headroom)
+{
+    m_backing->updateContentsHeadroom(headroom);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.h
+++ b/Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.h
@@ -59,6 +59,7 @@ public:
     const WebGPU::CompositorIntegration& backing() const { return m_backing; }
 
     void paintCompositedResultsToCanvas(WebCore::ImageBuffer&, uint32_t);
+    void updateContentsHeadroom(float);
 
 private:
     GPUCompositorIntegration(Ref<WebGPU::CompositorIntegration>&& backing)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.cpp
@@ -59,6 +59,16 @@ void CompositorIntegrationImpl::prepareForDisplay(uint32_t frameIndex, Completio
     m_onSubmittedWorkScheduledCallback(WTFMove(completionHandler));
 }
 
+void CompositorIntegrationImpl::updateContentsHeadroom(float headroom)
+{
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    for (auto& ioSurface : m_renderBuffers)
+        ioSurface->setContentEDRHeadroom(headroom);
+#else
+    UNUSED_PARAM(headroom);
+#endif
+}
+
 #if PLATFORM(COCOA)
 Vector<MachSendRight> CompositorIntegrationImpl::recreateRenderBuffers(int width, int height, WebCore::DestinationColorSpace&& colorSpace, WebCore::AlphaPremultiplication alphaMode, TextureFormat textureFormat, Device& device)
 {

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.h
@@ -90,6 +90,7 @@ private:
     CompositorIntegrationImpl& operator=(CompositorIntegrationImpl&&) = delete;
 
     void prepareForDisplay(uint32_t frameIndex, CompletionHandler<void()>&&) override;
+    void updateContentsHeadroom(float) override;
 
 #if PLATFORM(COCOA)
     Vector<MachSendRight> recreateRenderBuffers(int width, int height, WebCore::DestinationColorSpace&&, WebCore::AlphaPremultiplication, WebCore::WebGPU::TextureFormat, Device&) override;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCompositorIntegration.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCompositorIntegration.h
@@ -63,6 +63,7 @@ public:
     virtual void prepareForDisplay(uint32_t frameIndex, CompletionHandler<void()>&&) = 0;
     virtual void withDisplayBufferAsNativeImage(uint32_t bufferIndex, Function<void(WebCore::NativeImage*)>) = 0;
     virtual void paintCompositedResultsToCanvas(WebCore::ImageBuffer&, uint32_t bufferIndex) = 0;
+    virtual void updateContentsHeadroom(float) = 0;
 
 protected:
     CompositorIntegration() = default;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8600,6 +8600,14 @@ void Document::windowScreenDidChange(PlatformDisplayID displayID)
     }
 }
 
+void Document::screenPropertiesDidChange(PlatformDisplayID displayID)
+{
+    for (auto& observer : copyToVector(m_screenPropertiesChangedObservers)) {
+        if (observer)
+            (*observer)(displayID);
+    }
+}
+
 String Document::displayStringModifiedByEncoding(const String& string) const
 {
     if (!m_decoder)
@@ -8751,6 +8759,12 @@ void Document::addDisplayChangedObserver(const DisplayChangedObserver& observer)
 {
     ASSERT(!m_displayChangedObservers.contains(observer));
     m_displayChangedObservers.add(observer);
+}
+
+void Document::addScreenPropertiesChangedObserver(const ScreenPropertiesChangedObserver& observer)
+{
+    ASSERT(!m_screenPropertiesChangedObservers.contains(observer));
+    m_screenPropertiesChangedObservers.add(observer);
 }
 
 #if HAVE(SPATIAL_TRACKING_LABEL)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1305,6 +1305,7 @@ public:
     void serviceCaretAnimation();
 
     void windowScreenDidChange(PlatformDisplayID);
+    void screenPropertiesDidChange(PlatformDisplayID);
 
     void finishedParsing();
 
@@ -1407,6 +1408,9 @@ public:
 
     using DisplayChangedObserver = WTF::Observer<void(PlatformDisplayID)>;
     void addDisplayChangedObserver(const DisplayChangedObserver&);
+
+    using ScreenPropertiesChangedObserver = WTF::Observer<void(PlatformDisplayID)>;
+    void addScreenPropertiesChangedObserver(const ScreenPropertiesChangedObserver&);
 
 #if HAVE(SPATIAL_TRACKING_LABEL)
     const String& defaultSpatialTrackingLabel() const;
@@ -2338,6 +2342,7 @@ private:
 
     WeakHashSet<MediaCanStartListener> m_mediaCanStartListeners;
     WeakHashSet<DisplayChangedObserver> m_displayChangedObservers;
+    WeakHashSet<ScreenPropertiesChangedObserver> m_screenPropertiesChangedObservers;
 
 #if HAVE(SPATIAL_TRACKING_LABEL)
     WeakHashSet<DefaultSpatialTrackingLabelChangedObserver> m_defaultSpatialTrackingLabelChangedObservers;

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -536,7 +536,8 @@ GPUCanvasContext* HTMLCanvasElement::createContextWebGPU(const String& type, GPU
     if (!document().settings().webGPUEnabled() || !gpu)
         return nullptr;
 
-    m_context = GPUCanvasContext::create(*this, *gpu);
+    Ref document = this->document();
+    m_context = GPUCanvasContext::create(*this, *gpu, document.ptr());
 
     if (m_context) {
         // Need to make sure a RenderLayer and compositing layer get created for the Canvas.

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -232,11 +232,11 @@ ExceptionOr<std::optional<OffscreenRenderingContext>> OffscreenCanvas::getContex
             Ref scriptExecutionContext = *this->scriptExecutionContext();
             if (RefPtr globalScope = dynamicDowncast<WorkerGlobalScope>(scriptExecutionContext)) {
                 if (auto* gpu = globalScope->protectedNavigator()->gpu())
-                    m_context = GPUCanvasContext::create(*this, *gpu);
+                    m_context = GPUCanvasContext::create(*this, *gpu, nullptr);
             } else if (RefPtr document = dynamicDowncast<Document>(scriptExecutionContext)) {
                 if (RefPtr window = document->window()) {
                     if (auto* gpu = window->protectedNavigator()->gpu())
-                        m_context = GPUCanvasContext::create(*this, *gpu);
+                        m_context = GPUCanvasContext::create(*this, *gpu, document.get());
                 }
             }
         }

--- a/Source/WebCore/html/canvas/GPUCanvasContext.cpp
+++ b/Source/WebCore/html/canvas/GPUCanvasContext.cpp
@@ -33,7 +33,7 @@ namespace WebCore {
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(GPUCanvasContext);
 
 #if !PLATFORM(COCOA)
-std::unique_ptr<GPUCanvasContext> GPUCanvasContext::create(CanvasBase&, GPU&)
+std::unique_ptr<GPUCanvasContext> GPUCanvasContext::create(CanvasBase&, GPU&, Document*)
 {
     return nullptr;
 }

--- a/Source/WebCore/html/canvas/GPUCanvasContext.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContext.h
@@ -38,6 +38,7 @@
 namespace WebCore {
 
 class CanvasBase;
+class Document;
 class GPU;
 class GPUTexture;
 class ImageBitmap;
@@ -53,7 +54,7 @@ public:
     using CanvasType = Variant<RefPtr<HTMLCanvasElement>>;
 #endif
 
-    static std::unique_ptr<GPUCanvasContext> create(CanvasBase&, GPU&);
+    static std::unique_ptr<GPUCanvasContext> create(CanvasBase&, GPU&, Document*);
 
     virtual CanvasType canvas() = 0;
     virtual ExceptionOr<void> configure(GPUCanvasConfiguration&&) = 0;

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -43,6 +43,7 @@
 
 namespace WebCore {
 
+class Document;
 class GPUDisplayBufferDisplayDelegate;
 
 class GPUCanvasContextCocoa final : public GPUCanvasContext {
@@ -54,7 +55,7 @@ public:
     using CanvasType = Variant<RefPtr<HTMLCanvasElement>>;
 #endif
 
-    static std::unique_ptr<GPUCanvasContextCocoa> create(CanvasBase&, GPU&);
+    static std::unique_ptr<GPUCanvasContextCocoa> create(CanvasBase&, GPU&, Document*);
 
     DestinationColorSpace colorSpace() const override;
     bool compositingResultsNeedUpdating() const override { return m_compositingResultsNeedsUpdating; }
@@ -75,7 +76,7 @@ public:
     RefPtr<ImageBuffer> transferToImageBuffer() override;
 
 private:
-    explicit GPUCanvasContextCocoa(CanvasBase&, Ref<GPUCompositorIntegration>&&, Ref<GPUPresentationContext>&&);
+    explicit GPUCanvasContextCocoa(CanvasBase&, Ref<GPUCompositorIntegration>&&, Ref<GPUPresentationContext>&&, Document*);
 
     void markContextChangedAndNotifyCanvasObservers();
 
@@ -87,6 +88,7 @@ private:
     CanvasType htmlOrOffscreenCanvas() const;
     ExceptionOr<void> configure(GPUCanvasConfiguration&&, bool);
     void present(uint32_t frameIndex);
+    void updateContentsHeadroom(float);
 
     struct Configuration {
         Ref<GPUDevice> device;
@@ -108,6 +110,9 @@ private:
 
     GPUIntegerCoordinate m_width { 0 };
     GPUIntegerCoordinate m_height { 0 };
+    float m_contentsHeadroom { 0.f };
+    using ScreenPropertiesChangedObserver = Observer<void(PlatformDisplayID)>;
+    std::optional<ScreenPropertiesChangedObserver> m_screenPropertiesChangedObserver;
     bool m_compositingResultsNeedsUpdating { false };
 };
 

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -35,7 +35,9 @@
 #include "GraphicsLayerContentsDisplayDelegate.h"
 #include "ImageBitmap.h"
 #include "PlatformCALayerDelegatedContents.h"
+#include "PlatformScreen.h"
 #include "RenderBox.h"
+#include "ScreenProperties.h"
 #include "Settings.h"
 #include <wtf/TZoneMallocInlines.h>
 
@@ -102,9 +104,9 @@ private:
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(GPUCanvasContextCocoa);
 
-std::unique_ptr<GPUCanvasContext> GPUCanvasContext::create(CanvasBase& canvas, GPU& gpu)
+std::unique_ptr<GPUCanvasContext> GPUCanvasContext::create(CanvasBase& canvas, GPU& gpu, Document* document)
 {
-    auto context = GPUCanvasContextCocoa::create(canvas, gpu);
+    auto context = GPUCanvasContextCocoa::create(canvas, gpu, document);
     if (context)
         context->suspendIfNeeded();
     return context;
@@ -117,7 +119,7 @@ static GPUPresentationContextDescriptor presentationContextDescriptor(GPUComposi
     };
 }
 
-std::unique_ptr<GPUCanvasContextCocoa> GPUCanvasContextCocoa::create(CanvasBase& canvas, GPU& gpu)
+std::unique_ptr<GPUCanvasContextCocoa> GPUCanvasContextCocoa::create(CanvasBase& canvas, GPU& gpu, Document* document)
 {
     RefPtr compositorIntegration = gpu.createCompositorIntegration();
     if (!compositorIntegration)
@@ -125,7 +127,7 @@ std::unique_ptr<GPUCanvasContextCocoa> GPUCanvasContextCocoa::create(CanvasBase&
     RefPtr presentationContext = gpu.createPresentationContext(presentationContextDescriptor(*compositorIntegration));
     if (!presentationContext)
         return nullptr;
-    return std::unique_ptr<GPUCanvasContextCocoa>(new GPUCanvasContextCocoa(canvas, compositorIntegration.releaseNonNull(), presentationContext.releaseNonNull()));
+    return std::unique_ptr<GPUCanvasContextCocoa>(new GPUCanvasContextCocoa(canvas, compositorIntegration.releaseNonNull(), presentationContext.releaseNonNull(), document));
 }
 
 static GPUIntegerCoordinate getCanvasWidth(const GPUCanvasContext::CanvasType& canvas)
@@ -161,14 +163,40 @@ GPUCanvasContextCocoa::CanvasType GPUCanvasContextCocoa::htmlOrOffscreenCanvas()
     return &downcast<OffscreenCanvas>(canvasBase());
 }
 
-GPUCanvasContextCocoa::GPUCanvasContextCocoa(CanvasBase& canvas, Ref<GPUCompositorIntegration>&& compositorIntegration, Ref<GPUPresentationContext>&& presentationContext)
+GPUCanvasContextCocoa::GPUCanvasContextCocoa(CanvasBase& canvas, Ref<GPUCompositorIntegration>&& compositorIntegration, Ref<GPUPresentationContext>&& presentationContext, Document* document)
     : GPUCanvasContext(canvas)
     , m_layerContentsDisplayDelegate(GPUDisplayBufferDisplayDelegate::create())
     , m_compositorIntegration(WTFMove(compositorIntegration))
     , m_presentationContext(WTFMove(presentationContext))
     , m_width(getCanvasWidth(htmlOrOffscreenCanvas()))
     , m_height(getCanvasHeight(htmlOrOffscreenCanvas()))
+    , m_screenPropertiesChangedObserver([this](auto displayID) {
+#if HAVE(SUPPORT_HDR_DISPLAY)
+        if (auto* screenData = WebCore::screenData(displayID))
+            updateContentsHeadroom(screenData->currentEDRHeadroom);
+#else
+        UNUSED_PARAM(displayID);
+        UNUSED_PARAM(this);
+#endif
+    })
 {
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    if (document)
+        document->addScreenPropertiesChangedObserver(*m_screenPropertiesChangedObserver);
+    else
+        m_screenPropertiesChangedObserver = std::nullopt;
+#else
+    UNUSED_PARAM(document);
+#endif
+}
+
+void GPUCanvasContextCocoa::updateContentsHeadroom(float headroom)
+{
+    if (m_contentsHeadroom == headroom)
+        return;
+
+    m_contentsHeadroom = headroom;
+    m_compositorIntegration->updateContentsHeadroom(headroom);
 }
 
 void GPUCanvasContextCocoa::reshape()
@@ -203,6 +231,16 @@ RefPtr<ImageBuffer> GPUCanvasContextCocoa::surfaceBufferToImageBuffer(SurfaceBuf
     // FIXME(https://bugs.webkit.org/show_bug.cgi?id=263957): WebGPU should support obtaining drawing buffer for Web Inspector.
     if (!m_configuration)
         return canvasBase().buffer();
+
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=294654 - OffscreenCanvas may not reflect the display the OffscreenCanvas is displayed on during background / resume
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    if (!m_screenPropertiesChangedObserver) {
+        float maxHeadroom = 1.f;
+        for (auto& screenData : WebCore::getScreenProperties().screenDataMap.values())
+            maxHeadroom = std::max(maxHeadroom, screenData.maxEDRHeadroom);
+        updateContentsHeadroom(maxHeadroom);
+    }
+#endif
 
     auto frameCount = m_configuration->frameCount;
     m_compositorIntegration->prepareForDisplay(frameCount, [weakThis = WeakPtr { *this }, frameCount] {
@@ -311,6 +349,7 @@ ExceptionOr<void> GPUCanvasContextCocoa::configure(GPUCanvasConfiguration&& conf
     m_layerContentsDisplayDelegate->setContentsFormat(textureFormat != WebGPU::TextureFormat::Rgba16float ? ContentsFormat::RGBA8 : ContentsFormat::RGBA16F);
 #endif
 
+    m_contentsHeadroom = 0.f;
     auto renderBuffers = m_compositorIntegration->recreateRenderBuffers(m_width, m_height, toWebCoreColorSpace(configuration.colorSpace, configuration.toneMapping), configuration.alphaMode == GPUCanvasAlphaMode::Premultiplied ? WebCore::AlphaPremultiplication::Premultiplied : WebCore::AlphaPremultiplication::Unpremultiplied, textureFormat, configuration.device->backing());
     // FIXME: This ASSERT() is wrong. It's totally possible for the IPC to the GPU process to timeout if the GPUP is busy, and return nothing here.
     ASSERT(!renderBuffers.isEmpty());

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1726,9 +1726,14 @@ void Page::screenPropertiesDidChange()
 #endif
 #if HAVE(SUPPORT_HDR_DISPLAY)
     updateDisplayEDRHeadroom();
+    updateDisplayEDRSuppression();
 #endif
 
     setNeedsRecalcStyleInAllFrames();
+
+    forEachRenderableDocument([this] (Document& document) {
+        document.screenPropertiesDidChange(m_displayID);
+    });
 }
 
 void Page::windowScreenDidChange(PlatformDisplayID displayID, std::optional<FramesPerSecond> nominalFramesPerSecond)
@@ -5807,6 +5812,18 @@ void Page::updateDisplayEDRHeadroom()
         if (RefPtr view = document.view())
             view->setDescendantsNeedUpdateBackingAndHierarchyTraversal();
     });
+}
+
+void Page::updateDisplayEDRSuppression()
+{
+    bool suppressEDR = suppressEDRForDisplay(m_displayID);
+    if (suppressEDR == m_suppressEDR)
+        return;
+
+    LOG_WITH_STREAM(HDR, stream << "Page " << this << " updateDisplayEDRSuppression " << m_suppressEDR << " to " << suppressEDR);
+    m_suppressEDR = suppressEDR;
+
+    forceRepaintAllFrames();
 }
 #endif
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1347,6 +1347,7 @@ public:
 #if HAVE(SUPPORT_HDR_DISPLAY)
     Headroom displayEDRHeadroom() const { return m_displayEDRHeadroom; }
     void updateDisplayEDRHeadroom();
+    void updateDisplayEDRSuppression();
 #endif
 
 private:
@@ -1780,6 +1781,7 @@ private:
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
     Headroom m_displayEDRHeadroom { Headroom::None };
+    bool m_suppressEDR { false };
 #endif
 
     UncheckedKeyHashSet<std::pair<URL, ScriptTelemetryCategory>> m_reportedScriptsWithTelemetry;

--- a/Source/WebCore/platform/PlatformScreen.h
+++ b/Source/WebCore/platform/PlatformScreen.h
@@ -118,6 +118,7 @@ OptionSet<ContentsFormat> screenContentsFormatsForTesting();
 
 WEBCORE_EXPORT float currentEDRHeadroomForDisplay(PlatformDisplayID);
 WEBCORE_EXPORT float maxEDRHeadroomForDisplay(PlatformDisplayID);
+WEBCORE_EXPORT bool suppressEDRForDisplay(PlatformDisplayID);
 #endif
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/platform/ScreenProperties.h
+++ b/Source/WebCore/platform/ScreenProperties.h
@@ -44,6 +44,7 @@ struct ScreenData {
     bool screenHasInvertedColors { false };
     bool screenSupportsHighDynamicRange { false };
 #if HAVE(SUPPORT_HDR_DISPLAY)
+    bool suppressEDR { false };
     float currentEDRHeadroom { 1 };
     float maxEDRHeadroom { 1 };
 #endif

--- a/Source/WebCore/platform/ios/PlatformScreenIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformScreenIOS.mm
@@ -136,6 +136,14 @@ float maxEDRHeadroomForDisplay(PlatformDisplayID)
 
     return [[PAL::getUIScreenClass() mainScreen] potentialEDRHeadroom];
 }
+
+bool suppressEDRForDisplay(PlatformDisplayID)
+{
+    if (auto data = screenData(primaryScreenDisplayID()))
+        return data->suppressEDR;
+
+    return false;
+}
 #endif
 
 DestinationColorSpace screenColorSpace(Widget* widget)

--- a/Source/WebCore/platform/mac/PlatformScreenMac.mm
+++ b/Source/WebCore/platform/mac/PlatformScreenMac.mm
@@ -343,6 +343,14 @@ float maxEDRHeadroomForDisplay(PlatformDisplayID displayID)
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
     return screen(displayID).maximumPotentialExtendedDynamicRangeColorComponentValue;
 }
+
+bool suppressEDRForDisplay(PlatformDisplayID displayID)
+{
+    if (auto data = screenData(displayID))
+        return data->suppressEDR;
+
+    return false;
+}
 #endif
 
 FloatRect screenRect(Widget* widget)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp
@@ -109,6 +109,11 @@ Ref<IPC::StreamServerConnection> RemoteCompositorIntegration::protectedStreamCon
     return m_streamConnection;
 }
 
+void RemoteCompositorIntegration::updateContentsHeadroom(float headroom)
+{
+    protectedBacking()->updateContentsHeadroom(headroom);
+}
+
 } // namespace WebKit
 
 #undef MESSAGE_CHECK

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h
@@ -108,6 +108,7 @@ private:
 #endif
 
     void prepareForDisplay(uint32_t frameIndex, CompletionHandler<void(bool)>&&);
+    void updateContentsHeadroom(float);
 
     Ref<WebCore::WebGPU::CompositorIntegration> m_backing;
     WeakRef<WebGPU::ObjectHeap> m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.messages.in
@@ -35,6 +35,7 @@ messages -> RemoteCompositorIntegration Stream {
     void PrepareForDisplay(uint32_t frameIndex) -> (bool dummy) Synchronous NotStreamEncodableReply // Because CanvasRenderingContext::prepareForDisplay() requires the layer contents synchronously, this needs to be Synchronous.
     void PaintCompositedResultsToCanvas(WebCore::RenderingResourceIdentifier imageBuffer, uint32_t bufferIndex) -> () Synchronous
     void Destruct()
+    void UpdateContentsHeadroom(float headroom)
 }
 
 #endif

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2493,6 +2493,7 @@ header: <WebCore/ScreenProperties.h>
     bool screenHasInvertedColors;
     bool screenSupportsHighDynamicRange;
 #if HAVE(SUPPORT_HDR_DISPLAY)
+    bool suppressEDR;
     float currentEDRHeadroom;
     float maxEDRHeadroom;
 #endif

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -1030,6 +1030,7 @@ private:
 #endif
 
     bool m_hasReceivedAXRequestInUIProcess { false };
+    bool m_suppressEDR { false };
 };
 
 template<typename T>

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -1266,34 +1266,6 @@ static NSTrackingAreaOptions flagsChangedEventMonitorTrackingAreaOptions()
 static RetainPtr<_WKWebViewTextInputNotifications> subscribeToTextInputNotifications(WebViewImpl*);
 #endif
 
-#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
-static void setDynamicRangeLimitRecursive(CALayer* layer, LayerDynamicRangeLimitSetter layerDynamicRangeLimitSetter)
-{
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    if ([layer wantsExtendedDynamicRangeContent]) {
-    ALLOW_DEPRECATED_DECLARATIONS_END
-        layerDynamicRangeLimitSetter(layer);
-    }
-    for (CALayer* sublayer in [layer sublayers])
-        setDynamicRangeLimitRecursive(sublayer, layerDynamicRangeLimitSetter);
-}
-#endif
-
-static void setDynamicRangeLimit(CALayer* layer, PlatformDynamicRangeLimit platformDynamicRangeLimit, bool animate)
-{
-#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
-    if (animate)
-        [CATransaction begin];
-    setDynamicRangeLimitRecursive(layer, layerDynamicRangeLimitSetter(platformDynamicRangeLimit));
-    if (animate)
-        [CATransaction commit];
-#else
-    UNUSED_PARAM(layer);
-    UNUSED_PARAM(platformDynamicRangeLimit);
-    UNUSED_PARAM(animate);
-#endif
-}
-
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebViewImpl);
 
 WebViewImpl::WebViewImpl(WKWebView *view, WebProcessPool& processPool, Ref<API::PageConfiguration>&& configuration)
@@ -2194,8 +2166,6 @@ void WebViewImpl::screenDidChangeColorSpace()
 void WebViewImpl::applicationShouldSuppressHDR(bool suppress)
 {
     m_page->setShouldSuppressHDR(suppress);
-    if (m_page->protectedPreferences()->acceleratedDrawingEnabled())
-        setDynamicRangeLimit(m_rootLayer.get(), suppress ? PlatformDynamicRangeLimit::defaultWhenSuppressingHDR() : PlatformDynamicRangeLimit::noLimit(), true);
 }
 
 bool WebViewImpl::mightBeginDragWhileInactive()

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
@@ -87,6 +87,12 @@ void RemoteCompositorIntegrationProxy::withDisplayBufferAsNativeImage(uint32_t, 
     RELEASE_ASSERT_NOT_REACHED();
 }
 
+void RemoteCompositorIntegrationProxy::updateContentsHeadroom(float headroom)
+{
+    auto result = send(Messages::RemoteCompositorIntegration::UpdateContentsHeadroom(headroom));
+    UNUSED_VARIABLE(result);
+}
+
 } // namespace WebKit::WebGPU
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h
@@ -95,6 +95,7 @@ private:
 #endif
 
     void prepareForDisplay(uint32_t frameIndex, CompletionHandler<void()>&&) override;
+    void updateContentsHeadroom(float) override;
 
     WebGPUIdentifier m_backing;
     const Ref<ConvertToBackingContext> m_convertToBackingContext;


### PR DESCRIPTION
#### 10635ec82dfc5ca52f9f2ad3a6876ebcfb8e97f8
<pre>
HDR images don&apos;t get constrained when Safari goes to background
<a href="https://bugs.webkit.org/show_bug.cgi?id=294092">https://bugs.webkit.org/show_bug.cgi?id=294092</a>
<a href="https://rdar.apple.com/151892044">rdar://151892044</a>

Reviewed by Matt Woodrow.

Constrain the dynamic range on backgrounding and repaint so
all images are rendered with the correct headroom.

* Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.cpp:
(WebCore::GPUCompositorIntegration::updateContentsHeadroom):
Forward to backing.

* Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.h:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.cpp:
(WebCore::WebGPU::CompositorIntegrationImpl::updateContentsHeadroom):
Tell GPUP to update IOSurface headroom.

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCompositorIntegration.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::screenPropertiesDidChange):
(WebCore::Document::addScreenPropertiesChangedObserver):
Add a notification for client&apos;s to subscribe and respond to screen property changes.

* Source/WebCore/dom/Document.h:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::createContextWebGPU):
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::getContext):
Pass Document to the GPUCanvasContext.

* Source/WebCore/html/canvas/GPUCanvasContext.cpp:
(WebCore::GPUCanvasContext::create):
* Source/WebCore/html/canvas/GPUCanvasContext.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContext::create):
(WebCore::GPUCanvasContextCocoa::create):
(WebCore::GPUCanvasContextCocoa::GPUCanvasContextCocoa):
(WebCore::GPUCanvasContextCocoa::updateContentsHeadroom):
(WebCore::GPUCanvasContextCocoa::configure):
Subscribe to screen property changes and forward to the backing as needed.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::screenPropertiesDidChange):
* Source/WebCore/platform/graphics/cocoa/IOSurface.h:
* Source/WebCore/platform/graphics/cocoa/IOSurface.mm:
(WebCore::IOSurface::setContentHeadroom const):
Add member function for updating IOSurface headroom.

* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp:
(WebKit::RemoteCompositorIntegration::updateContentsHeadroom):
Forward to implementation.

* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.messages.in:
Add message to update IOSurface headroom.

* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::registerNotificationObservers):
(WebKit::WebProcessPool::screenPropertiesChanged):
Backgrounding results in screen properties being changed, effectively.

* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::applicationShouldSuppressHDR):
(WebKit::setDynamicRangeLimitRecursive): Deleted.
(WebKit::setDynamicRangeLimit): Deleted.
No longer needed.

* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp:
(WebKit::WebGPU::RemoteCompositorIntegrationProxy::updateContentsHeadroom):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h:
Forward message to GPUP.

* LayoutTests/fast/webgpu/regression/edr-triangle-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/edr-triangle.html: Added.
Add EDR triangle test.

Canonical link: <a href="https://commits.webkit.org/296453@main">https://commits.webkit.org/296453@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/778bb515ae079017fc9a8886dc4dcf69c1d91bc9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108588 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18673 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113796 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58979 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110551 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28938 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36803 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82479 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111536 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22971 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97809 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62916 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22387 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15948 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58510 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92340 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15999 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116917 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35642 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26276 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/91503 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36015 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94080 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91308 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23260 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36204 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13963 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35543 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41077 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35254 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38600 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36932 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->