### PR TITLE
AX: accessibility/mac/element-focus.html is flakey after 295998@main

### DIFF
--- a/LayoutTests/accessibility/mac/editable-page-lazy-spellchecking.html
+++ b/LayoutTests/accessibility/mac/editable-page-lazy-spellchecking.html
@@ -1,4 +1,5 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ runSingly=true ] -->
+<!-- runSingly because this test sets Page-wide state, which can impact the behavior of other tests that are run simulatenously. -->
 <html>
 <head>
 <script src="../../resources/accessibility-helper.js"></script>
@@ -20,6 +21,7 @@ if (window.accessibilityController && window.textInputController) {
     var contenteditable = accessibilityController.accessibleElementById("contenteditable");
     var range = contenteditable.textMarkerRangeForElement(contenteditable);
     output += `Attributed string with range: ${contenteditable.attributedStringForTextMarkerRangeWithDidSpellCheck(range)}\n`;
+    textInputController.setPageEditable(false);
     debug(output);
 }
 </script>


### PR DESCRIPTION
#### 5456e6ced7d56bead6df230a7554a506fea53134
<pre>
AX: accessibility/mac/element-focus.html is flakey after 295998@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=294634">https://bugs.webkit.org/show_bug.cgi?id=294634</a>
<a href="https://rdar.apple.com/153674716">rdar://153674716</a>

Reviewed by Joshua Hoffman.

<a href="http://commits.webkit.org/295998@main">http://commits.webkit.org/295998@main</a> added a new test that set Page-wide edibility state. This can affect other tests
running simultaneously in the same web content process, using the same Page. accessibility/mac/element-focus.html is one
such example — the focusability of HTML anchor elements can depend on Page-wide editability state.

Fix this by adding the runSingly=true webkit-test-runner flag, which forces the test to run in its own isolated web
process and Page (at the cost of a tiny bit slower test runs).

* LayoutTests/accessibility/mac/editable-page-lazy-spellchecking.html:

Canonical link: <a href="https://commits.webkit.org/296354@main">https://commits.webkit.org/296354@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8862e53529e471d77be63e45b0a8bf8653a7010

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108240 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27902 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18323 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113450 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58702 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36453 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82186 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111188 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22669 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97505 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62618 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22082 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15641 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58183 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92035 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15697 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116574 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35303 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25992 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91215 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35676 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93780 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91011 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23199 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35902 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13665 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31071 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Compiled WebKit (cancelled)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35203 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34932 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38286 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36601 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->