### PR TITLE
RenderGrid should use OrderIterator shouldSkipChild instead of querying renderer type directly

### DIFF
--- a/Source/WebCore/rendering/Grid.h
+++ b/Source/WebCore/rendering/Grid.h
@@ -82,6 +82,7 @@ public:
     OrderedTrackIndexSet* autoRepeatEmptyTracks(GridTrackSizingDirection) const;
 
     OrderIterator& orderIterator() { return m_orderIterator; }
+    const OrderIterator& orderIterator() const { return m_orderIterator; }
 
     void setNeedsItemsPlacement(bool);
     bool needsItemsPlacement() const { return m_needsItemsPlacement; };

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -274,7 +274,7 @@ static void cacheBaselineAlignedGridItems(const RenderGrid& grid, GridTrackSizin
     ASSERT_IMPLIES(cachingRowSubgridsForRootGrid, !algorithm.renderGrid()->isSubgridRows() && (algorithm.renderGrid() == &grid || grid.isSubgridOf(GridLayoutFunctions::flowAwareDirectionForGridItem(*algorithm.renderGrid(), grid, GridTrackSizingDirection::ForRows), *algorithm.renderGrid())));
 
     for (auto& gridItem : childrenOfType<RenderBox>(grid)) {
-        if (gridItem.isOutOfFlowPositioned() || gridItem.isLegend())
+        if (grid.currentGrid().orderIterator().shouldSkipChild(gridItem))
             continue;
 
         callback(const_cast<RenderBox*>(&gridItem));
@@ -377,7 +377,7 @@ static void clearGridItemOverridingSizesBeforeLayout(RenderGrid& renderGrid)
     // clear any override set previously, so it doesn't interfere in current layout
     // execution.
     for (auto& gridItem : childrenOfType<RenderBox>(renderGrid)) {
-        if (gridItem.isOutOfFlowPositioned() || gridItem.isLegend())
+        if (renderGrid.currentGrid().orderIterator().shouldSkipChild(gridItem))
             continue;
         gridItem.clearOverridingSize();
     }
@@ -417,8 +417,6 @@ void RenderGrid::layoutGrid(RelayoutChildren relayoutChildren)
 
         LayoutSize previousSize = size();
 
-        auto aspectRatioBlockSizeDependentGridItems = computeAspectRatioDependentAndBaselineItems(gridLayoutState);
-
         resetLogicalHeightBeforeLayoutIfNeeded();
 
         updateLogicalWidth();
@@ -427,6 +425,8 @@ void RenderGrid::layoutGrid(RelayoutChildren relayoutChildren)
         // The legend then gets skipped during normal layout. The same is true for ruby text.
         // It doesn't get included in the normal layout process but is instead skipped.
         layoutExcludedChildren(relayoutChildren);
+
+        auto aspectRatioBlockSizeDependentGridItems = computeAspectRatioDependentAndBaselineItems(gridLayoutState);
 
         LayoutUnit availableSpaceForColumns = contentBoxLogicalWidth();
         placeItemsOnGrid(availableSpaceForColumns);


### PR DESCRIPTION
#### 5042277fb2b310d0058acf94a1b6830d049b461c
<pre>
RenderGrid should use OrderIterator shouldSkipChild instead of querying renderer type directly
<a href="https://bugs.webkit.org/show_bug.cgi?id=294637">https://bugs.webkit.org/show_bug.cgi?id=294637</a>
<a href="https://rdar.apple.com/problem/153679479">rdar://problem/153679479</a>

Reviewed by NOBODY (OOPS!).

In 246990@main, we added some logic to deal with a crash when a
RenderGrid was also a fieldset by skipping over the fieldset&apos;s legend at
different parts in grid layout as they do not seem to be part of the
formatting context&apos;s in flow layout.

Other renderers (e.g. RenderFlexibleBox) have this same type of logic
but instead use the OrderIterator&apos;s shouldSkipChild API. For at least
the sake of consistency, we should probably try to use the same function
instead of checking for isLegend() directly. Unfortunately, we cannot
simply just adopt them at the exact spot the isLegend() checks occur
during execution because the isExcludedFromNormalLayout bit only gets
set on renderers during the layoutExcludedChildren phase. So we first
need to move the computeAspectRatioDependentAndBaselineItems call to
under layoutExcludedChildren and then start using the function.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5042277fb2b310d0058acf94a1b6830d049b461c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108278 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18361 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113487 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58722 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28629 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36488 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82207 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111226 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22691 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97532 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62643 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22105 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15670 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58220 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92057 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15726 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116609 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35333 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26016 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91233 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35705 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93809 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91034 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35924 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13691 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31093 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35234 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40775 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34955 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38309 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36632 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->