### PR TITLE
Adopt more smart pointers in dom/Text

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -125,9 +125,6 @@ dom/ShadowRoot.cpp
 dom/SimpleRange.cpp
 dom/SlotAssignment.cpp
 dom/StaticRange.cpp
-dom/Text.cpp
-dom/TextNodeTraversal.cpp
-dom/TextNodeTraversal.h
 dom/TreeScope.cpp
 dom/TypedElementDescendantIteratorInlines.h
 dom/ViewTransition.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -214,9 +214,6 @@ dom/SpaceSplitString.cpp
 dom/StaticRange.cpp
 dom/StyledElement.cpp
 dom/Subscriber.cpp
-dom/Text.cpp
-dom/TextNodeTraversal.cpp
-dom/TextNodeTraversal.h
 dom/TreeScope.cpp
 dom/TrustedType.cpp
 dom/TypedElementDescendantIteratorInlines.h

--- a/Source/WebCore/dom/Text.cpp
+++ b/Source/WebCore/dom/Text.cpp
@@ -104,13 +104,13 @@ static const Text* latestLogicallyAdjacentTextNode(const Text* text)
 
 String Text::wholeText() const
 {
-    const Text* startText = earliestLogicallyAdjacentTextNode(this);
-    const Text* endText = latestLogicallyAdjacentTextNode(this);
+    RefPtr startText = earliestLogicallyAdjacentTextNode(this);
+    RefPtr endText = latestLogicallyAdjacentTextNode(this);
     ASSERT(endText);
-    const Node* onePastEndText = TextNodeTraversal::nextSibling(*endText);
+    RefPtr<const Node> onePastEndText = TextNodeTraversal::nextSibling(*endText);
 
     StringBuilder result;
-    for (const Text* text = startText; text != onePastEndText; text = TextNodeTraversal::nextSibling(*text))
+    for (RefPtr text = startText; text != onePastEndText; text = TextNodeTraversal::nextSibling(*text))
         result.append(text->data());
     return result.toString();
 }

--- a/Source/WebCore/dom/TextNodeTraversal.cpp
+++ b/Source/WebCore/dom/TextNodeTraversal.cpp
@@ -34,7 +34,7 @@ namespace TextNodeTraversal {
 
 void appendContents(const ContainerNode& root, StringBuilder& result)
 {
-    for (Text* text = TextNodeTraversal::firstWithin(root); text; text = TextNodeTraversal::next(*text, &root))
+    for (RefPtr text = TextNodeTraversal::firstWithin(root); text; text = TextNodeTraversal::next(*text, &root))
         result.append(text->data());
 }
 
@@ -57,7 +57,7 @@ String contentsAsString(const Node& root)
 String childTextContent(const ContainerNode& root)
 {
     StringBuilder result;
-    for (Text* text = TextNodeTraversal::firstChild(root); text; text = TextNodeTraversal::nextSibling(*text))
+    for (RefPtr text = TextNodeTraversal::firstChild(root); text; text = TextNodeTraversal::nextSibling(*text))
         result.append(text->data());
     return result.toString();
 }

--- a/Source/WebCore/dom/TextNodeTraversal.h
+++ b/Source/WebCore/dom/TextNodeTraversal.h
@@ -77,7 +77,7 @@ inline Text* firstChild(const ContainerNode& current) { return firstTextChildTem
 template <class NodeType>
 inline Text* firstTextWithinTemplate(NodeType& current)
 {
-    for (auto* node = current.firstChild(); node; node = NodeTraversal::next(*node, &current)) {
+    for (RefPtr node = current.firstChild(); node; node = NodeTraversal::next(*node, &current)) {
         if (auto* text = dynamicDowncast<Text>(*node))
             return text;
     }
@@ -89,7 +89,7 @@ inline Text* firstWithin(const ContainerNode& current) { return firstTextWithinT
 template <class NodeType>
 inline Text* traverseNextTextTemplate(NodeType& current)
 {
-    for (auto* node = NodeTraversal::next(current); node; node = NodeTraversal::next(*node)) {
+    for (RefPtr node = NodeTraversal::next(current); node; node = NodeTraversal::next(*node)) {
         if (auto* text = dynamicDowncast<Text>(*node))
             return text;
     }
@@ -101,7 +101,7 @@ inline Text* next(const Text& current) { return traverseNextTextTemplate(current
 template <class NodeType>
 inline Text* traverseNextTextTemplate(NodeType& current, const Node* stayWithin)
 {
-    for (auto* node = NodeTraversal::next(current, stayWithin); node; node = NodeTraversal::next(*node, stayWithin)) {
+    for (RefPtr node = NodeTraversal::next(current, stayWithin); node; node = NodeTraversal::next(*node, stayWithin)) {
         if (auto* text = dynamicDowncast<Text>(*node))
             return text;
     }


### PR DESCRIPTION
#### dcd17064b3b5f57c9b57b09f5a061c0560ac9e32
<pre>
Adopt more smart pointers in dom/Text
<a href="https://bugs.webkit.org/show_bug.cgi?id=294640">https://bugs.webkit.org/show_bug.cgi?id=294640</a>
<a href="https://rdar.apple.com/153684504">rdar://153684504</a> (Adopt more smart pointers in dom/Text (294640))

Reviewed by Ryosuke Niwa.

Smart pointer adoption as per the static analyzer.

* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/dom/Text.cpp:
(WebCore::Text::wholeText const):
* Source/WebCore/dom/TextNodeTraversal.cpp:
(WebCore::TextNodeTraversal::appendContents):
(WebCore::TextNodeTraversal::childTextContent):
* Source/WebCore/dom/TextNodeTraversal.h:
(WebCore::TextNodeTraversal::firstTextWithinTemplate):
(WebCore::TextNodeTraversal::traverseNextTextTemplate):

Canonical link: <a href="https://commits.webkit.org/296685@main">https://commits.webkit.org/296685@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20a3947b940c8130fbcb784b92b2f6feb8ee1d9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108990 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28650 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19075 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114200 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59317 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110953 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29333 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37217 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82825 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111938 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23324 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98171 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63267 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22738 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16309 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58895 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92695 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16356 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117319 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36039 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26637 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91841 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36410 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94435 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91642 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36552 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14307 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31900 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17631 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35936 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41454 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35635 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38975 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37322 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->