### PR TITLE
[JSC] Change the default remote URL of `test262-import` from SSH to HTTPS

### DIFF
--- a/Tools/Scripts/test262/Import.pm
+++ b/Tools/Scripts/test262/Import.pm
@@ -83,7 +83,7 @@ sub processCLI {
             pod2usage(-exitstatus => 4, -verbose => 1);
         }
     } else {
-        $remoteUrl ||= 'git@github.com:tc39/test262.git';
+        $remoteUrl ||= 'https://github.com/tc39/test262.git';
         $branch ||= 'main';
     }
 
@@ -265,7 +265,7 @@ Specify the folder for Test262's repository.
 
 =item B<--remote, -r>
 
-Specify a remote Test262's repository. Defaults to 'git@github.com:tc39/test262.git'.
+Specify a remote Test262's repository. Defaults to 'https://github.com/tc39/test262.git'.
 
 =item B<--branch, -b>
 


### PR DESCRIPTION
#### 835b19efe32560c6cd56972e75a4328ea5f67033
<pre>
[JSC] Change the default remote URL of `test262-import` from SSH to HTTPS
<a href="https://bugs.webkit.org/show_bug.cgi?id=294644">https://bugs.webkit.org/show_bug.cgi?id=294644</a>

Reviewed by Yusuke Suzuki.

The test262-import script only updates from the public tc39/test262
repository. I believe we don&apos;t need authentication for this operation,
and it would be convenient to run this script without registering an
SSH key.

Therefore, this patch changes the default remote URL of `test262-import`
from SSH to HTTPS.

Canonical link: <a href="https://commits.webkit.org/296437@main">https://commits.webkit.org/296437@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2ed8fdcbeedc2819dd125d8a088ebb3d3b7f890

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108281 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27942 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113490 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58724 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110244 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28632 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36491 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82211 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111229 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22694 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97537 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62647 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22108 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15675 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58223 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92067 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15731 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116612 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35336 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26018 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91239 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35708 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93814 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91040 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23248 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35927 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13696 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31095 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35237 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34957 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38311 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36635 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->