### PR TITLE
REGRESSION (296041@main): Video elements fail to enter standby mode on iOS

### DIFF
--- a/Source/WebKit/UIProcess/API/APIUIClient.h
+++ b/Source/WebKit/UIProcess/API/APIUIClient.h
@@ -248,6 +248,11 @@ public:
     virtual void recentlyAccessedGamepadsForTesting(WebKit::WebPageProxy&) { }
     virtual void stoppedAccessingGamepadsForTesting(WebKit::WebPageProxy&) { }
 #endif
+
+#if PLATFORM(IOS_FAMILY)
+    virtual void didEnterStandby(WebKit::WebPageProxy&) { }
+    virtual void didExitStandby(WebKit::WebPageProxy&) { }
+#endif
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
@@ -302,6 +302,9 @@ struct UIEdgeInsets;
 
 - (void)_webView:(WKWebView *)webView startXRSessionWithFeatures:(_WKXRSessionFeatureFlags)features completionHandler:(void (^)(id, UIViewController *))completionHandler WK_API_AVAILABLE(ios(17.4), visionos(1.1));
 
+- (void)_webViewDidEnterStandbyForTesting:(WKWebView *)webView WK_API_AVAILABLE(ios(WK_IOS_TBA));
+- (void)_webViewDidExitStandbyForTesting:(WKWebView *)webView WK_API_AVAILABLE(ios(WK_IOS_TBA));
+
 #else // !TARGET_OS_IPHONE
 
 - (NSViewController *)_presentingViewControllerForWebView:(WKWebView *)webView WK_API_AVAILABLE(macos(13.0));

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
@@ -207,6 +207,11 @@ private:
         void stoppedAccessingGamepadsForTesting(WebPageProxy&) final;
 #endif
 
+#if PLATFORM(IOS_FAMILY)
+        void didEnterStandby(WebPageProxy&) final;
+        void didExitStandby(WebPageProxy&) final;
+#endif
+
         id<WKUIDelegatePrivate> uiDelegatePrivate();
 
         WeakPtr<UIDelegate> m_uiDelegate;
@@ -320,6 +325,11 @@ private:
 #if ENABLE(GAMEPAD)
         bool webViewRecentlyAccessedGamepadsForTesting : 1;
         bool webViewStoppedAccessingGamepadsForTesting : 1;
+#endif
+
+#if PLATFORM(IOS_FAMILY)
+        bool webViewDidEnterStandby : 1;
+        bool webViewDidExitStandby : 1;
 #endif
     } m_delegateMethods;
 };

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -256,6 +256,11 @@ void UIDelegate::setDelegate(id<WKUIDelegate> delegate)
     m_delegateMethods.webViewRecentlyAccessedGamepadsForTesting = [delegate respondsToSelector:@selector(_webViewRecentlyAccessedGamepadsForTesting:)];
     m_delegateMethods.webViewStoppedAccessingGamepadsForTesting = [delegate respondsToSelector:@selector(_webViewStoppedAccessingGamepadsForTesting:)];
 #endif
+
+#if PLATFORM(IOS_FAMILY)
+    m_delegateMethods.webViewDidEnterStandby = [delegate respondsToSelector:@selector(_webViewDidEnterStandbyForTesting:)];
+    m_delegateMethods.webViewDidExitStandby = [delegate respondsToSelector:@selector(_webViewDidExitStandbyForTesting:)];
+#endif
 }
 
 #if ENABLE(CONTEXT_MENUS)
@@ -2233,5 +2238,39 @@ void UIDelegate::UIClient::endXRSession(WebPageProxy&, PlatformXRSessionEndReaso
 #endif // PLATFORM(IOS_FAMILY)
 
 #endif // ENABLE(WEBXR)
+
+#if PLATFORM(IOS_FAMILY)
+void UIDelegate::UIClient::didEnterStandby(WebPageProxy&)
+{
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
+        return;
+
+    if (!uiDelegate->m_delegateMethods.webViewDidEnterStandby)
+        return;
+
+    RetainPtr delegate = uiDelegatePrivate();
+    if (!delegate)
+        return;
+
+    [delegate _webViewDidEnterStandbyForTesting:uiDelegate->m_webView.get().get()];
+}
+
+void UIDelegate::UIClient::didExitStandby(WebPageProxy&)
+{
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
+        return;
+
+    if (!uiDelegate->m_delegateMethods.webViewDidExitStandby)
+        return;
+
+    RetainPtr delegate = uiDelegatePrivate();
+    if (!delegate)
+        return;
+
+    [delegate _webViewDidExitStandbyForTesting:uiDelegate->m_webView.get().get()];
+}
+#endif // PLATFORM(IOS_FAMILY)
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -1419,12 +1419,12 @@ void VideoPresentationManagerProxy::didExitFullscreen(PlaybackSessionContextIden
     sendToWebProcess(contextId, Messages::VideoPresentationManager::DidExitFullscreen(contextId.object()));
 
 #if PLATFORM(IOS_FAMILY)
-    if (ensureInterface(contextId)->changingStandbyOnly()) {
-        callCloseCompletionHandlers();
-        return;
-    }
+    if (ensureInterface(contextId)->changingStandbyOnly())
+        page->didExitStandby(contextId);
+    else
 #endif
     page->didExitFullscreen(contextId);
+
     callCloseCompletionHandlers();
 }
 
@@ -1442,7 +1442,8 @@ void VideoPresentationManagerProxy::didEnterFullscreen(PlaybackSessionContextIde
 
 #if PLATFORM(IOS_FAMILY)
     if (ensureInterface(contextId)->changingStandbyOnly())
-        return;
+        page->didEnterStandby(contextId);
+    else
 #endif
     page->didEnterFullscreen(contextId);
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8806,6 +8806,18 @@ void WebPageProxy::failedToEnterFullscreen(PlaybackSessionContextIdentifier iden
 {
 }
 
+#if PLATFORM(IOS_FAMILY)
+void WebPageProxy::didEnterStandby(PlaybackSessionContextIdentifier)
+{
+    m_uiClient->didEnterStandby(*this);
+}
+
+void WebPageProxy::didExitStandby(PlaybackSessionContextIdentifier)
+{
+    m_uiClient->didExitStandby(*this);
+}
+#endif
+
 #else
 
 void WebPageProxy::didEnterFullscreen()

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2333,6 +2333,10 @@ public:
     void didCleanupFullscreen(PlaybackSessionContextIdentifier);
     void didChangePlaybackRate(PlaybackSessionContextIdentifier);
     void didChangeCurrentTime(PlaybackSessionContextIdentifier);
+#if PLATFORM(IOS_FAMILY)
+    void didEnterStandby(PlaybackSessionContextIdentifier);
+    void didExitStandby(PlaybackSessionContextIdentifier);
+#endif
 #else
     void didEnterFullscreen();
     void didExitFullscreen();

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -279,6 +279,7 @@ void VideoPresentationManager::removeClientForContext(WebCore::MediaPlayerClient
 
 bool VideoPresentationManager::canEnterVideoFullscreen(HTMLVideoElement& videoElement, WebCore::HTMLMediaElementEnums::VideoFullscreenMode mode) const
 {
+    ASSERT(mode != HTMLMediaElementEnums::VideoFullscreenModeNone);
 #if PLATFORM(IOS) || PLATFORM(VISION)
     if (m_currentVideoFullscreenMode == mode)
         return videoElement.document().quirks().allowLayeredFullscreenVideos();
@@ -403,7 +404,7 @@ void VideoPresentationManager::enterVideoFullscreenForVideoElement(HTMLVideoElem
     ASSERT(standby || mode != HTMLMediaElementEnums::VideoFullscreenModeNone);
 
 #if PLATFORM(IOS) || PLATFORM(VISION)
-    if (m_currentVideoFullscreenMode == mode && !videoElement.document().quirks().allowLayeredFullscreenVideos()) {
+    if (!canEnterVideoFullscreen(videoElement, mode) && !standby) {
         ERROR_LOG(LOGIDENTIFIER, "already in fullscreen mode %d, aborting", mode);
         ASSERT_NOT_REACHED();
         return;


### PR DESCRIPTION
#### 749e2237fe35d634e010d496dd73dc5e60f20243
<pre>
REGRESSION (296041@main): Video elements fail to enter standby mode on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=294650">https://bugs.webkit.org/show_bug.cgi?id=294650</a>
<a href="https://rdar.apple.com/153578542">rdar://153578542</a>

Reviewed by Eric Carlson.

296041@main fixed a bug where VideoPresentationManager::enterVideoFullscreenForVideoElement would
incorrectly return early when returning from PiP to standard fullscreen by ensuring that it only
returns early when the new VideoFullscreenMode is the same as the current VideoFullscreenMode.
However, when entering standby mode for a video element, enterVideoFullscreenForVideoElement is
called with VideoFullscreenModeNone and the standby boolean set to true. Since
VideoFullscreenModeNone matches the current VideoFullscreenMode, this call would incorrectly return
early.

Resolved this by allowing VideoPresentationManager::enterVideoFullscreenForVideoElement to proceed
when the standby bit is set.

Added an API test.

* Source/WebKit/UIProcess/API/APIUIClient.h:
(API::UIClient::didEnterStandby):
(API::UIClient::didExitStandby):
* Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::setDelegate):
(WebKit::UIDelegate::UIClient::didEnterStandby):
(WebKit::UIDelegate::UIClient::didExitStandby):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::didExitFullscreen):
(WebKit::VideoPresentationManagerProxy::didEnterFullscreen):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didEnterStandby):
(WebKit::WebPageProxy::didExitStandby):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::VideoPresentationManager::canEnterVideoFullscreen const):
(WebKit::VideoPresentationManager::enterVideoFullscreenForVideoElement):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UI/VideoPresentationMode.mm:
(-[VideoPresentationModeUIDelegate waitForDidEnterFullscreen]):
(-[VideoPresentationModeUIDelegate waitForDidExitFullscreen]):
(-[VideoPresentationModeUIDelegate waitForDidEnterStandby]):
(-[VideoPresentationModeUIDelegate waitForDidExitStandby]):
(-[VideoPresentationModeUIDelegate _webViewDidEnterFullscreen:]):
(-[VideoPresentationModeUIDelegate _webViewDidExitFullscreen:]):
(-[VideoPresentationModeUIDelegate _webViewDidEnterStandbyForTesting:]):
(-[VideoPresentationModeUIDelegate _webViewDidExitStandbyForTesting:]):
(TEST(VideoPresentationMode, Fullscreen)):
(TEST(VideoPresentationMode, Inline)):
(TEST(VideoPresentationMode, Standby)):
(TEST(VideoPresentationMode, PictureInPicture)):

Canonical link: <a href="https://commits.webkit.org/296390@main">https://commits.webkit.org/296390@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b60cea2f6e4c67284d74e5bae8ca23db5f2762d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108297 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18380 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113506 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58735 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110260 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28647 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36507 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82227 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111245 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22707 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97551 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62663 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22122 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15689 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58238 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92075 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15745 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116628 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35351 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26030 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91254 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35724 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93828 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91055 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23214 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35939 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13710 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31107 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35253 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40791 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34970 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38324 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36651 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->