### PR TITLE
Drag snapshot doesn't start in the right mouse location

### DIFF
--- a/Source/WebCore/dom/DataTransferMac.mm
+++ b/Source/WebCore/dom/DataTransferMac.mm
@@ -49,10 +49,8 @@ DragImageRef DataTransfer::createDragImage(const Document*, IntPoint& location) 
             IntRect imageRect;
             IntRect elementRect;
             result = createDragImageForImage(*frame, dragImageElement().releaseNonNull(), imageRect, elementRect);
-            // Client specifies point relative to element, not the whole image, which may include child
-            // layers spread out all over the place.
-            location.setX(elementRect.x() - imageRect.x() + m_dragLocation.x());
-            location.setY(imageRect.height() - (elementRect.y() - imageRect.y() + m_dragLocation.y()));
+            location.setX(m_dragLocation.x() - elementRect.x());
+            location.setY(m_dragLocation.y() - elementRect.y());
         }
     } else if (m_dragImage) {
         result = m_dragImage->protectedImage()->adapter().snapshotNSImage();


### PR DESCRIPTION
#### 7408ff150079
<pre>
Drag snapshot doesn&apos;t start in the right mouse location

<a href="https://bugs.webkit.org/show_bug.cgi?id=294651">https://bugs.webkit.org/show_bug.cgi?id=294651</a>
<a href="https://rdar.apple.com/153702781">rdar://153702781</a>

Reviewed by NOBODY (OOPS!).

Drag image should simply be the mouse position
relative to the element&apos;s visual position.

* Source/WebCore/dom/DataTransferMac.mm:
(WebCore::DataTransfer::createDragImage const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7408ff15007936999a87ca51ae031617c0c68317

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108298 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18381 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113507 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58736 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110261 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28648 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36508 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82226 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111246 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22706 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97552 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62662 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22121 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15690 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58239 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92074 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15746 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116629 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35352 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26031 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91253 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35725 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93829 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91054 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35940 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13711 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31108 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35254 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40792 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34971 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38325 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36652 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->