### PR TITLE
AX: Accessing AXIsolatedTree::{m_relations, m_selectedTextMarkerRange} requires m_changeLogLock, which can cause the AX thread to block on the main-thread or vice versa

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -3290,8 +3290,8 @@ void AXObjectCache::dirtyIsolatedTreeRelations()
     AXTRACE("AXObjectCache::dirtyIsolatedTreeRelations"_s);
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    if (auto tree = AXIsolatedTree::treeForPageID(m_pageID))
-        tree->relationsNeedUpdate(true);
+    if (RefPtr tree = AXIsolatedTree::treeForPageID(m_pageID))
+        tree->markRelationsDirty();
     startUpdateTreeSnapshotTimer();
 #endif
 }


### PR DESCRIPTION
#### 0d9a8c75467085fe703169321d43d78dad82fdfe
<pre>
AX: Accessing AXIsolatedTree::{m_relations, m_selectedTextMarkerRange} requires m_changeLogLock, which can cause the AX thread to block on the main-thread or vice versa
<a href="https://bugs.webkit.org/show_bug.cgi?id=294652">https://bugs.webkit.org/show_bug.cgi?id=294652</a>
<a href="https://rdar.apple.com/153703482">rdar://153703482</a>

Reviewed by Joshua Hoffman.

Ideally, the accessibility thread should only synchronize with the main-thread via AXIsolatedTree::m_changeLogLock
once: at the beginning of serving a request, via AXIsolatedTree::applyPendingChanges(). But prior to this commit,
we would take the lock any time we needed to access AXIsolatedTree::m_relations or AXIsolatedTree::m_selectedTextMarkerRange,
which could potentially be a lot. This can cause the AX thread to block on the main-thread at random times, and vice
versa, which can harm performance.

With this commit, we move caching the selected text marker range and relations map to a similar approach taken for other
synced data structures. We create an m_pendingFoo equivalent, guarded by a lock, and apply that in AXIsolatedTree::applyPendingChanges.
Then we can use the synced data structure safely without a lock off the main-thread.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::dirtyIsolatedTreeRelations):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::create):
(WebCore::AXIsolatedTree::updateRelations):
(WebCore::AXIsolatedTree::setSelectedTextMarkerRange):
(WebCore::AXIsolatedTree::relatedObjectIDsFor):
(WebCore::AXIsolatedTree::applyPendingChanges):
(WebCore::AXIsolatedTree::selectedTextMarkerRange): Deleted.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
(WebCore::AXIsolatedTree::markRelationsDirty):
(WebCore::AXIsolatedTree::selectedTextMarkerRange):
(WebCore::AXIsolatedTree::relationsNeedUpdate): Deleted.

Canonical link: <a href="https://commits.webkit.org/296378@main">https://commits.webkit.org/296378@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecb8642b5db01cbdbcffec7ad944d237f9cb0605

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108300 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27961 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18383 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113509 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58738 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110263 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28650 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36510 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82230 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111248 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22710 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97554 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62666 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22125 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15692 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58241 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92078 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15748 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116631 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35354 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26033 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91259 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35727 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93831 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91060 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23212 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35942 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13713 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31110 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35256 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40794 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34973 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38327 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36654 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->