### PR TITLE
[macOS] Device Management password field in System Settings is not autofocused

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -904,11 +904,13 @@ static void addBrowsingContextControllerMethodStubsIfNeeded()
 {
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKWebView.class, self))
         return;
+
 #if ENABLE(SCREEN_TIME)
     [self _uninstallScreenTimeWebpageController];
 #endif
 
 #if PLATFORM(MAC)
+    [self _resetSecureInputState];
     [_textFinderClient willDestroyView:self];
 #endif
 

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.h
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.h
@@ -39,6 +39,8 @@ std::optional<WebCore::ScrollbarOverlayStyle> toCoreScrollbarStyle(_WKOverlayScr
 - (void)_takeFindStringFromSelectionInternal:(id)sender;
 - (void)insertText:(id)string replacementRange:(NSRange)replacementRange;
 
+- (void)_resetSecureInputState;
+
 @end
 
 #endif // PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1385,6 +1385,12 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _impl->insertText(string, replacementRange);
 }
 
+- (void)_resetSecureInputState
+{
+    if (_impl)
+        _impl->resetSecureInputState();
+}
+
 - (void)_setContentOffsetX:(NSNumber *)x y:(NSNumber *)y animated:(BOOL)animated
 {
     std::optional<int> optionalX = std::nullopt;


### PR DESCRIPTION
#### be6ccb595147fa29f475bb2009a968c7a36975ec
<pre>
[macOS] Device Management password field in System Settings is not autofocused
<a href="https://bugs.webkit.org/show_bug.cgi?id=294655">https://bugs.webkit.org/show_bug.cgi?id=294655</a>
<a href="https://rdar.apple.com/147434540">rdar://147434540</a>

Reviewed by Abrar Rahman Protyasha and Tim Horton.

When signing into a Managed Apple Account using the Device Management pane
in System Settings, users may be taken to a browser (Safari) for an
initial round of authentication.

When the user focuses the password field on the presented page, WebKit takes a
secure input assertion using `EnableSecureEventInput`. If the user then submits
the form using the enter key, the window is closed and the user is taken back to
System Settings to finally sign into their Managed Apple Account.

In this flow, the `WKWebView` is simply destroyed, and WebKit never releases the
input assertion. Since WebKit is holding onto an assertion, System Settings is
denied the right to be in front, and the native password field is not autofocused.

Fix by releasing the assertion when the web view is deallocated.

The issue does not occur when users click to submit the form in the browser, as
that removes focus from the password field, resulting in WebKit releasing the
assertion due to an editor state update.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView dealloc]):
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _resetSecureInputState]):

`WebViewImpl::resetSecureInputState` checks that an assertion is held, and only
calls `DisableSecureEventInput` if necessary.

Canonical link: <a href="https://commits.webkit.org/296384@main">https://commits.webkit.org/296384@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc1963ae2e0c29697cf0d9285e1954d13f6188c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108304 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27965 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113513 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58740 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28654 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36514 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82231 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111252 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22712 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97556 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62667 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22127 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58245 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92080 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15750 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116635 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35358 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26035 "Found 7 new test failures: http/tests/media/hls/hls-audio-tracks-language.html http/tests/media/hls/hls-webvtt-default.html http/tests/media/hls/hls-webvtt-style.html http/tests/media/hls/range-request-cross-origin.html http/tests/media/hls/track-in-band-multiple-cues.html http/tests/media/hls/track-webvtt-multitracks.html platform/mac/media/encrypted-media/fps-generateRequest.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91260 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35731 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93833 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91061 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35945 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13715 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31112 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17501 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35260 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40798 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34977 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38331 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36658 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->