### PR TITLE
GoogleTest assertions should support CG/NSSize

### DIFF
--- a/Tools/TestWebKitAPI/cocoa/TestCocoa.h
+++ b/Tools/TestWebKitAPI/cocoa/TestCocoa.h
@@ -53,6 +53,8 @@ void instantiateUIApplicationIfNeeded(Class customApplicationClass = nil);
 
 std::ostream& operator<<(std::ostream&, const CGPoint&);
 bool operator==(const CGPoint&, const CGPoint&);
+std::ostream& operator<<(std::ostream&, const CGSize&);
+bool operator==(const CGSize&, const CGSize&);
 std::ostream& operator<<(std::ostream&, const CGRect&);
 bool operator==(const CGRect&, const CGRect&);
 
@@ -65,6 +67,8 @@ constexpr CGFloat blueColorComponents[4] = { 0, 0, 1, 1 };
 
 std::ostream& operator<<(std::ostream&, const NSPoint&);
 bool operator==(const NSPoint&, const NSPoint&);
+std::ostream& operator<<(std::ostream&, const NSSize&);
+bool operator==(const NSSize&, const NSSize&);
 std::ostream& operator<<(std::ostream&, const NSRect&);
 bool operator==(const NSRect&, const NSRect&);
 

--- a/Tools/TestWebKitAPI/cocoa/TestCocoa.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestCocoa.mm
@@ -33,13 +33,19 @@
 template<typename T>
 static inline std::ostream& ostreamRectCommon(std::ostream& os, const T& rect)
 {
-    return os << "(origin = " << rect.origin << ", size = (width = " << rect.size.width << ", height = " << rect.size.height << "))";
+    return os << "(origin = " << rect.origin << ", size = " << rect.size << ")";
 }
 
 template<typename T>
 static inline std::ostream& ostreamPointCommon(std::ostream& os, const T& point)
 {
     return os << "(x = " << point.x << ", y = " << point.y << ")";
+}
+
+template<typename T>
+static inline std::ostream& ostreamSizeCommon(std::ostream& os, const T& size)
+{
+    return os << "(width = " << size.width << ", height = " << size.height << ")";
 }
 
 #if USE(CG)
@@ -52,6 +58,16 @@ std::ostream& operator<<(std::ostream& os, const CGPoint& point)
 bool operator==(const CGPoint& a, const CGPoint& b)
 {
     return CGPointEqualToPoint(a, b);
+}
+
+std::ostream& operator<<(std::ostream& os, const CGSize& size)
+{
+    return ostreamSizeCommon(os, size);
+}
+
+bool operator==(const CGSize& a, const CGSize& b)
+{
+    return CGSizeEqualToSize(a, b);
 }
 
 std::ostream& operator<<(std::ostream& os, const CGRect& rect)
@@ -76,6 +92,16 @@ std::ostream& operator<<(std::ostream& os, const NSPoint& point)
 bool operator==(const NSPoint& a, const NSPoint& b)
 {
     return NSEqualPoints(a, b);
+}
+
+std::ostream& operator<<(std::ostream& os, const NSSize& size)
+{
+    return ostreamSizeCommon(os, size);
+}
+
+bool operator==(const NSSize& a, const NSSize& b)
+{
+    return NSEqualSizes(a, b);
 }
 
 std::ostream& operator<<(std::ostream& os, const NSRect& rect)


### PR DESCRIPTION
#### 4b2d3c32fb1a7163b0fa359c7580624ebefb3e3a
<pre>
GoogleTest assertions should support CG/NSSize
<a href="https://bugs.webkit.org/show_bug.cgi?id=294657">https://bugs.webkit.org/show_bug.cgi?id=294657</a>
<a href="https://rdar.apple.com/153708044">rdar://153708044</a>

Reviewed by Abrar Rahman Protyasha.

Add operator== and operator&lt;&lt; overloads for `CGSize` and `NSSize` in order
to allow for the use of these types with EXPECT_EQ() and other GoogleTest
assertions.

The benefits are reduced repetition, and more useful failure output which
prints out the values of both sizes.

* Tools/TestWebKitAPI/cocoa/TestCocoa.h:
* Tools/TestWebKitAPI/cocoa/TestCocoa.mm:
(ostreamRectCommon):
(ostreamSizeCommon):
(operator&lt;&lt;):
(operator==):

Canonical link: <a href="https://commits.webkit.org/296385@main">https://commits.webkit.org/296385@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/296a47ec728b7bc1e629680c8edfa408be245760

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108306 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27967 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18390 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113515 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58741 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110269 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28656 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36516 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82237 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111254 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22713 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97558 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62673 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22128 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15695 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58247 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92081 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15751 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116637 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35360 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26036 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91264 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35733 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93834 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91065 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35947 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13716 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31113 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17502 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35262 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34979 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38333 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36660 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->