### PR TITLE
Update some getUserMedia layout tests to explicitly stop capture tracks

### DIFF
--- a/LayoutTests/http/tests/media/media-stream/resources/enumerate-devices-iframe.html
+++ b/LayoutTests/http/tests/media/media-stream/resources/enumerate-devices-iframe.html
@@ -14,15 +14,20 @@
 
     async function checkSpeakerSelection()
     {
+        let stream1, stream2;
         // Speakers are currently only exposed after getUserMedia.
         try {
-            await navigator.mediaDevices.getUserMedia({ audio : true });
+            stream1 = await navigator.mediaDevices.getUserMedia({ audio : true });
         } catch (e) {
         }
         try {
-            await navigator.mediaDevices.getUserMedia({ video : true });
+            stream2 = await navigator.mediaDevices.getUserMedia({ video : true });
         } catch (e) {
         }
+        if (stream1)
+            stream1.getTracks().forEach(t => t.stop());
+        if (stream2)
+            stream2.getTracks().forEach(t => t.stop());
         return checkDeviceKind('audiooutput');
     }
 

--- a/LayoutTests/http/tests/media/media-stream/resources/enumerate-devices-source-id-frame.html
+++ b/LayoutTests/http/tests/media/media-stream/resources/enumerate-devices-source-id-frame.html
@@ -12,12 +12,13 @@
 
             async function test(event)
             {
-                await navigator.mediaDevices.getUserMedia({video: true, audio: true });
+                const stream = await navigator.mediaDevices.getUserMedia({video: true, audio: true });
                 let devices = await navigator.mediaDevices.enumerateDevices();
                 let result = {
                     origin: self.origin, 
                     devices: devices.map(device => { return {deviceId: device.deviceId, kind: device.kind} }),
                 };
+                stream.getTracks().forEach(t => t.stop());
 
                 parent.postMessage(result, "*");
                 


### PR DESCRIPTION
#### ee3f2da0a0290feebbad60d1b50279119cf4c97d
<pre>
Update some getUserMedia layout tests to explicitly stop capture tracks
<a href="https://rdar.apple.com/153712082">rdar://153712082</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=294659">https://bugs.webkit.org/show_bug.cgi?id=294659</a>

Reviewed by Jean-Yves Avenard.

Stop tracks explictly when no longer needed to prevent the console warning to trigger flakinesses.

* LayoutTests/http/tests/media/media-stream/resources/enumerate-devices-iframe.html:
* LayoutTests/http/tests/media/media-stream/resources/enumerate-devices-source-id-frame.html:

Canonical link: <a href="https://commits.webkit.org/296368@main">https://commits.webkit.org/296368@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f076092543395fd7f868cd354e0e16464fe70df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108310 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27971 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18394 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113519 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58745 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28660 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36520 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82238 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111258 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22718 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97561 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62674 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22133 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15698 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58251 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92086 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15754 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116641 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35364 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26039 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91266 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35737 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93837 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91067 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23207 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35950 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13719 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31117 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35266 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34983 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38337 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36664 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->