### PR TITLE
Remove Style::Builder backpointer from BuilderState

### DIFF
--- a/Source/WebCore/css/CSSPendingSubstitutionValue.cpp
+++ b/Source/WebCore/css/CSSPendingSubstitutionValue.cpp
@@ -31,7 +31,7 @@
 
 namespace WebCore {
 
-RefPtr<CSSValue> CSSPendingSubstitutionValue::resolveValue(Style::BuilderState& builderState, CSSPropertyID propertyID) const
+RefPtr<CSSValue> CSSPendingSubstitutionValue::resolveValue(Style::Builder& builder, CSSPropertyID propertyID) const
 {
     auto cacheValue = [&](auto data) {
         ParsedPropertyVector parsedProperties;
@@ -43,7 +43,7 @@ RefPtr<CSSValue> CSSPendingSubstitutionValue::resolveValue(Style::BuilderState& 
         m_cachedPropertyValues = parsedProperties;
     };
 
-    if (!m_shorthandValue->resolveAndCacheValue(builderState, cacheValue))
+    if (!m_shorthandValue->resolveAndCacheValue(builder, cacheValue))
         return nullptr;
 
     for (auto& property : m_cachedPropertyValues) {

--- a/Source/WebCore/css/CSSPendingSubstitutionValue.h
+++ b/Source/WebCore/css/CSSPendingSubstitutionValue.h
@@ -49,7 +49,7 @@ public:
     bool equals(const CSSPendingSubstitutionValue& other) const { return m_shorthandValue.ptr() == other.m_shorthandValue.ptr(); }
     static String customCSSText(const CSS::SerializationContext&) { return emptyString(); }
 
-    RefPtr<CSSValue> resolveValue(Style::BuilderState&, CSSPropertyID) const;
+    RefPtr<CSSValue> resolveValue(Style::Builder&, CSSPropertyID) const;
 
     IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>& func) const
     {

--- a/Source/WebCore/css/CSSVariableReferenceValue.cpp
+++ b/Source/WebCore/css/CSSVariableReferenceValue.cpp
@@ -78,7 +78,7 @@ const CSSParserContext& CSSVariableReferenceValue::context() const
     return m_data->context();
 }
 
-auto CSSVariableReferenceValue::resolveVariableFallback(const AtomString& variableName, CSSParserTokenRange range, CSSValueID functionId, Style::BuilderState& builderState) const -> std::pair<FallbackResult, Vector<CSSParserToken>>
+auto CSSVariableReferenceValue::resolveVariableFallback(const AtomString& variableName, CSSParserTokenRange range, CSSValueID functionId, Style::Builder& builder) const -> std::pair<FallbackResult, Vector<CSSParserToken>>
 {
     ASSERT(range.atEnd() || range.peek().type() == CommaToken);
 
@@ -87,10 +87,10 @@ auto CSSVariableReferenceValue::resolveVariableFallback(const AtomString& variab
 
     range.consumeIncludingWhitespace();
 
-    auto tokens = resolveTokenRange(range, builderState);
+    auto tokens = resolveTokenRange(range, builder);
 
     if (functionId == CSSValueVar) {
-        auto* registered = builderState.document().customPropertyRegistry().get(variableName);
+        auto* registered = builder.state().document().customPropertyRegistry().get(variableName);
         if (registered && !registered->syntax.isUniversal()) {
             // https://drafts.css-houdini.org/css-properties-values-api/#fallbacks-in-var-references
             // The fallback value must match the syntax definition of the custom property being referenced,
@@ -108,18 +108,18 @@ auto CSSVariableReferenceValue::resolveVariableFallback(const AtomString& variab
     return { FallbackResult::Valid, WTFMove(*tokens) };
 }
 
-static const Style::CustomProperty* propertyValueForVariableName(const AtomString& variableName, CSSValueID functionId, Style::BuilderState& builderState)
+static const Style::CustomProperty* propertyValueForVariableName(const AtomString& variableName, CSSValueID functionId, Style::Builder& builder)
 {
     if (functionId == CSSValueEnv)
-        return builderState.document().constantProperties().values().get(variableName);
+        return builder.state().document().constantProperties().values().get(variableName);
 
     // Apply this variable first, in case it is still unresolved
-    builderState.builder().applyCustomProperty(variableName);
+    builder.applyCustomProperty(variableName);
 
-    return builderState.style().customPropertyValue(variableName);
+    return builder.state().style().customPropertyValue(variableName);
 }
 
-bool CSSVariableReferenceValue::resolveVariableReference(CSSParserTokenRange range, CSSValueID functionId, Vector<CSSParserToken>& tokens, Style::BuilderState& builderState) const
+bool CSSVariableReferenceValue::resolveVariableReference(CSSParserTokenRange range, CSSValueID functionId, Vector<CSSParserToken>& tokens, Style::Builder& builder) const
 {
     ASSERT(functionId == CSSValueVar || functionId == CSSValueEnv);
 
@@ -128,11 +128,11 @@ bool CSSVariableReferenceValue::resolveVariableReference(CSSParserTokenRange ran
     auto variableName = range.consumeIncludingWhitespace().value().toAtomString();
 
     // Fallback has to be resolved even when not used to detect cycles and invalid syntax.
-    auto [fallbackResult, fallbackTokens] = resolveVariableFallback(variableName, range, functionId, builderState);
+    auto [fallbackResult, fallbackTokens] = resolveVariableFallback(variableName, range, functionId, builder);
     if (fallbackResult == FallbackResult::Invalid)
         return false;
 
-    auto* property = propertyValueForVariableName(variableName, functionId, builderState);
+    auto* property = propertyValueForVariableName(variableName, functionId, builder);
 
     if (!property || property->isGuaranteedInvalid()) {
         if (fallbackTokens.size() > maxSubstitutionTokens)
@@ -152,14 +152,14 @@ bool CSSVariableReferenceValue::resolveVariableReference(CSSParserTokenRange ran
     return true;
 }
 
-std::optional<Vector<CSSParserToken>> CSSVariableReferenceValue::resolveTokenRange(CSSParserTokenRange range, Style::BuilderState& builderState) const
+std::optional<Vector<CSSParserToken>> CSSVariableReferenceValue::resolveTokenRange(CSSParserTokenRange range, Style::Builder& builder) const
 {
     Vector<CSSParserToken> tokens;
     bool success = true;
     while (!range.atEnd()) {
         auto functionId = range.peek().functionId();
         if (functionId == CSSValueVar || functionId == CSSValueEnv) {
-            if (!resolveVariableReference(range.consumeBlock(), functionId, tokens, builderState))
+            if (!resolveVariableReference(range.consumeBlock(), functionId, tokens, builder))
                 success = false;
             continue;
         }
@@ -196,33 +196,33 @@ void CSSVariableReferenceValue::cacheSimpleReference()
     m_simpleReference = SimpleReference { variableName, functionId };
 }
 
-RefPtr<CSSVariableData> CSSVariableReferenceValue::tryResolveSimpleReference(Style::BuilderState& builderState) const
+RefPtr<CSSVariableData> CSSVariableReferenceValue::tryResolveSimpleReference(Style::Builder& builder) const
 {
     if (!m_simpleReference)
         return nullptr;
 
     // Shortcut for the simple common case of property:var(--foo)
 
-    auto* property = propertyValueForVariableName(m_simpleReference->name, m_simpleReference->functionId, builderState);
+    auto* property = propertyValueForVariableName(m_simpleReference->name, m_simpleReference->functionId, builder);
     if (!property || !std::holds_alternative<Ref<CSSVariableData>>(property->value()))
         return nullptr;
 
     return std::get<Ref<CSSVariableData>>(property->value()).ptr();
 }
 
-RefPtr<CSSVariableData> CSSVariableReferenceValue::resolveVariableReferences(Style::BuilderState& builderState) const 
+RefPtr<CSSVariableData> CSSVariableReferenceValue::resolveVariableReferences(Style::Builder& builder) const
 {
-    if (auto data = tryResolveSimpleReference(builderState))
+    if (auto data = tryResolveSimpleReference(builder))
         return data;
 
-    auto resolvedTokens = resolveTokenRange(m_data->tokenRange(), builderState);
+    auto resolvedTokens = resolveTokenRange(m_data->tokenRange(), builder);
     if (!resolvedTokens)
         return nullptr;
 
     return CSSVariableData::create(*resolvedTokens, context());
 }
 
-RefPtr<CSSValue> CSSVariableReferenceValue::resolveSingleValue(Style::BuilderState& builderState, CSSPropertyID propertyID) const
+RefPtr<CSSValue> CSSVariableReferenceValue::resolveSingleValue(Style::Builder& builder, CSSPropertyID propertyID) const
 {
     auto cacheValue = [&](auto data) {
         m_cachedValue = CSSPropertyParser::parseStylePropertyLonghand(propertyID, data->tokens(), context());
@@ -231,7 +231,7 @@ RefPtr<CSSValue> CSSVariableReferenceValue::resolveSingleValue(Style::BuilderSta
 #endif
     };
 
-    if (!resolveAndCacheValue(builderState, cacheValue))
+    if (!resolveAndCacheValue(builder, cacheValue))
         return nullptr;
 
     ASSERT(m_cachePropertyID == propertyID);

--- a/Source/WebCore/css/CSSVariableReferenceValue.h
+++ b/Source/WebCore/css/CSSVariableReferenceValue.h
@@ -43,7 +43,7 @@ class CSSParserToken;
 struct CSSParserContext;
 
 namespace Style {
-class BuilderState;
+class Builder;
 }
 
 enum CSSPropertyID : uint16_t;
@@ -56,10 +56,10 @@ public:
     bool equals(const CSSVariableReferenceValue&) const;
     String customCSSText(const CSS::SerializationContext&) const;
 
-    RefPtr<CSSVariableData> resolveVariableReferences(Style::BuilderState&) const;
+    RefPtr<CSSVariableData> resolveVariableReferences(Style::Builder&) const;
     const CSSParserContext& context() const;
 
-    RefPtr<CSSValue> resolveSingleValue(Style::BuilderState&, CSSPropertyID) const;
+    RefPtr<CSSValue> resolveSingleValue(Style::Builder&, CSSPropertyID) const;
 
     // The maximum number of tokens that may be produced by a var() reference or var() fallback value.
     // https://drafts.csswg.org/css-variables/#long-variables
@@ -67,18 +67,18 @@ public:
     
     const CSSVariableData& data() const { return m_data.get(); }
 
-    template<typename CacheFunction> bool resolveAndCacheValue(Style::BuilderState&, NOESCAPE const CacheFunction&) const;
+    template<typename CacheFunction> bool resolveAndCacheValue(Style::Builder&, NOESCAPE const CacheFunction&) const;
 
 private:
     explicit CSSVariableReferenceValue(Ref<CSSVariableData>&&);
 
-    std::optional<Vector<CSSParserToken>> resolveTokenRange(CSSParserTokenRange, Style::BuilderState&) const;
-    bool resolveVariableReference(CSSParserTokenRange, CSSValueID, Vector<CSSParserToken>&, Style::BuilderState&) const;
+    std::optional<Vector<CSSParserToken>> resolveTokenRange(CSSParserTokenRange, Style::Builder&) const;
+    bool resolveVariableReference(CSSParserTokenRange, CSSValueID, Vector<CSSParserToken>&, Style::Builder&) const;
     enum class FallbackResult : uint8_t { None, Valid, Invalid };
-    std::pair<FallbackResult, Vector<CSSParserToken>> resolveVariableFallback(const AtomString& variableName, CSSParserTokenRange, CSSValueID functionId, Style::BuilderState&) const;
+    std::pair<FallbackResult, Vector<CSSParserToken>> resolveVariableFallback(const AtomString& variableName, CSSParserTokenRange, CSSValueID functionId, Style::Builder&) const;
 
     void cacheSimpleReference();
-    RefPtr<CSSVariableData> tryResolveSimpleReference(Style::BuilderState&) const;
+    RefPtr<CSSVariableData> tryResolveSimpleReference(Style::Builder&) const;
 
     const Ref<CSSVariableData> m_data;
     mutable String m_stringValue;
@@ -98,17 +98,17 @@ private:
 };
 
 template<typename CacheFunction>
-bool CSSVariableReferenceValue::resolveAndCacheValue(Style::BuilderState& builderState, NOESCAPE const CacheFunction& cacheFunction) const
+bool CSSVariableReferenceValue::resolveAndCacheValue(Style::Builder& builder, NOESCAPE const CacheFunction& cacheFunction) const
 
 {
-    if (auto data = tryResolveSimpleReference(builderState)) {
+    if (auto data = tryResolveSimpleReference(builder)) {
         if (!arePointingToEqualData(m_cacheDependencyData, data))
             cacheFunction(data);
         m_cacheDependencyData = WTFMove(data);
         return true;
     }
 
-    auto resolvedTokens = resolveTokenRange(m_data->tokenRange(), builderState);
+    auto resolvedTokens = resolveTokenRange(m_data->tokenRange(), builder);
     if (!resolvedTokens)
         return false;
 

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -76,9 +76,8 @@
 namespace WebCore {
 namespace Style {
 
-BuilderState::BuilderState(Builder& builder, RenderStyle& style, BuilderContext&& context)
-    : m_builder(builder)
-    , m_styleMap(*this)
+BuilderState::BuilderState(RenderStyle& style, BuilderContext&& context)
+    : m_styleMap(*this)
     , m_style(style)
     , m_context(WTFMove(context))
     , m_cssToLengthConversionData(style, *this)

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -66,7 +66,6 @@ struct FilterProperty;
 
 namespace Style {
 
-class Builder;
 class BuilderState;
 struct Color;
 
@@ -90,9 +89,7 @@ struct BuilderContext {
 
 class BuilderState {
 public:
-    BuilderState(Builder&, RenderStyle&, BuilderContext&&);
-
-    Builder& builder() { return m_builder; }
+    BuilderState(RenderStyle&, BuilderContext&&);
 
     RenderStyle& style() { return m_style; }
     const RenderStyle& style() const { return m_style; }
@@ -220,8 +217,6 @@ private:
     void updateFontForZoomChange();
     void updateFontForGenericFamilyChange();
     void updateFontForOrientationChange();
-
-    Builder& m_builder;
 
     CSSToStyleMap m_styleMap;
 


### PR DESCRIPTION
#### 904a7c66c05d4870f51e53af04a292e7e338fb30
<pre>
Remove Style::Builder backpointer from BuilderState
<a href="https://bugs.webkit.org/show_bug.cgi?id=294666">https://bugs.webkit.org/show_bug.cgi?id=294666</a>
<a href="https://rdar.apple.com/problem/153719342">rdar://problem/153719342</a>

Reviewed by Alan Baradlay.

The only client for it is the variable reference resolution but we can just pass Builder there.

* Source/WebCore/css/CSSPendingSubstitutionValue.cpp:
(WebCore::CSSPendingSubstitutionValue::resolveValue const):
* Source/WebCore/css/CSSPendingSubstitutionValue.h:
* Source/WebCore/css/CSSVariableReferenceValue.cpp:
(WebCore::CSSVariableReferenceValue::resolveVariableFallback const):
(WebCore::propertyValueForVariableName):
(WebCore::CSSVariableReferenceValue::resolveVariableReference const):
(WebCore::CSSVariableReferenceValue::resolveTokenRange const):
(WebCore::CSSVariableReferenceValue::tryResolveSimpleReference const):
(WebCore::CSSVariableReferenceValue::resolveVariableReferences const):
(WebCore::CSSVariableReferenceValue::resolveSingleValue const):
* Source/WebCore/css/CSSVariableReferenceValue.h:
(WebCore::CSSVariableReferenceValue::resolveAndCacheValue const):
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::Builder):
(WebCore::Style::Builder::resolveVariableReferences):
(WebCore::Style::Builder::resolveCustomPropertyValue):
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::BuilderState):
* Source/WebCore/style/StyleBuilderState.h:
(WebCore::Style::BuilderState::builder): Deleted.

Canonical link: <a href="https://commits.webkit.org/296371@main">https://commits.webkit.org/296371@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35201d70bc24feabd67f65ffb45a094ecad6d673

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108320 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18404 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113529 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58754 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110283 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28670 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36530 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82247 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111268 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22727 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97572 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62683 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22141 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15709 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58260 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92095 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15765 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116651 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35374 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26049 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91276 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35747 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93848 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91077 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23208 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35961 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13730 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31126 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35276 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40814 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34993 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38347 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36674 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->