### PR TITLE
The `initial-value` descriptor when registering Custom Properties can be optional

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-optional-initial-value-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-optional-initial-value-expected.txt
@@ -1,0 +1,3 @@
+
+PASS @property with empty initial-value should use space character
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-optional-initial-value.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-optional-initial-value.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Properties and Values API: optional initial-value descriptor</title>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api/#initial-value-descriptor">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/9078">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+@property --registered {
+  syntax: '*';
+  initial-value: ;
+  inherits: false;
+}
+#target {
+  --test-bg: var(--registered) green;
+  --test-fallback: var(--registered, red);
+  background-color: var(--test-bg, var(--test-fallback));
+}
+</style>
+<div id="target"></div>
+<script>
+test(function() {
+  const target = document.getElementById('target');
+  const style = getComputedStyle(target);
+  
+  // When initial-value is omitted (empty space), the property should be registered
+  // with a space character as the initial value, making var(--registered) green
+  // evaluate to " green" which is a valid color value.
+  assert_equals(style.backgroundColor, 'rgb(0, 128, 0)', 
+    'background-color should be green when @property has empty initial-value');
+}, '@property with empty initial-value should use space character');
+</script>

--- a/Source/WebCore/css/parser/CSSVariableParser.cpp
+++ b/Source/WebCore/css/parser/CSSVariableParser.cpp
@@ -263,9 +263,6 @@ bool CSSVariableParser::containsValidVariableReferences(CSSParserTokenRange rang
 
 RefPtr<CSSCustomPropertyValue> CSSVariableParser::parseDeclarationValue(const AtomString& variableName, CSSParserTokenRange range, const CSSParserContext& parserContext)
 {
-    if (range.atEnd())
-        return nullptr;
-
     auto type = classifyVariableRange(range, parserContext);
     if (!type)
         return nullptr;
@@ -281,9 +278,6 @@ RefPtr<CSSCustomPropertyValue> CSSVariableParser::parseDeclarationValue(const At
 
 RefPtr<const Style::CustomProperty> CSSVariableParser::parseInitialValueForUniversalSyntax(const AtomString& variableName, CSSParserTokenRange range)
 {
-    if (range.atEnd())
-        return nullptr;
-
     auto type = classifyVariableRange(range, strictCSSParserContext());
 
     if (!type || type->cssWideKeyword || type->classifyBlockResult.hasReferences)


### PR DESCRIPTION
#### 2cecd19a550c17d516cccd728888aba0098e6263
<pre>
The `initial-value` descriptor when registering Custom Properties can be optional
<a href="https://bugs.webkit.org/show_bug.cgi?id=276223">https://bugs.webkit.org/show_bug.cgi?id=276223</a>
<a href="https://rdar.apple.com/131288198">rdar://131288198</a>

Reviewed by Antti Koivisto.

This patch aligns WebKit with Web Specification [1]:

[1] <a href="https://drafts.css-houdini.org/css-properties-values-api/#initial-value-descriptor">https://drafts.css-houdini.org/css-properties-values-api/#initial-value-descriptor</a>

&quot;If the value of the syntax descriptor is the universal syntax definition, then
the initial-value descriptor is optional. If omitted, the initial value of the
property is the guaranteed-invalid value.&quot;

This patch removes early return in cases of parsing declaration value and initial
value for universal syntax.

Test: imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-optional-initial-value.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-optional-initial-value-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-optional-initial-value.html: Added.
* Source/WebCore/css/parser/CSSVariableParser.cpp:
(WebCore::CSSVariableParser::parseDeclarationValue):
(WebCore::CSSVariableParser::parseInitialValueForUniversalSyntax):

Canonical link: <a href="https://commits.webkit.org/303757@main">https://commits.webkit.org/303757@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3811079610a08a204bb517e2087ac62ee66af296

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133126 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5627 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44237 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140675 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85165 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fa1162a1-eaf8-477a-a1bf-9231dde32114) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134996 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6125 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5490 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101812 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69195 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3e287950-b1b2-40dd-a743-5185c95026f2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4325 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119306 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82609 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ea239925-b999-452b-8a17-2d0c980c36bf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4209 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1791 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113285 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37422 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143323 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5297 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38001 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110192 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5379 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4546 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110372 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28062 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4090 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115563 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58968 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5352 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33917 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5195 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68804 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5441 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5308 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->