### PR TITLE
[WPE] WPE Platform: add initial API tests for wayland platform

### DIFF
--- a/Tools/Scripts/run-gtk-tests
+++ b/Tools/Scripts/run-gtk-tests
@@ -86,6 +86,9 @@ class GtkTestRunner(TestRunner):
     def is_qt_test(self, test_program):
         return False
 
+    def is_wpe_platform_wayland_test(self, test_program):
+        return False
+
 if __name__ == "__main__":
     runner_args = get_runner_args(sys.argv)
     flatpakutils.run_in_sandbox_if_available(runner_args)

--- a/Tools/Scripts/run-wpe-tests
+++ b/Tools/Scripts/run-wpe-tests
@@ -46,6 +46,9 @@ class WPETestRunner(TestRunner):
     def is_qt_test(self, test_program):
         return os.path.basename(os.path.dirname(test_program)) == "WPEQt"
 
+    def is_wpe_platform_wayland_test(self, test_program):
+        return os.path.basename(os.path.dirname(test_program)) == "WPEPlatform" and "Wayland" in os.path.basename(test_program)
+
 if __name__ == "__main__":
     runner_args = get_runner_args(sys.argv)
     flatpakutils.run_in_sandbox_if_available([runner_args[0], "--wpe"] + runner_args[1:])

--- a/Tools/TestWebKitAPI/Tests/WPEPlatform/TestDisplayWayland.cpp
+++ b/Tools/TestWebKitAPI/Tests/WPEPlatform/TestDisplayWayland.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2025 Igalia, S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "WPEWaylandPlatformTest.h"
+#include <wpe/wayland/wpe-wayland.h>
+
+namespace TestWebKitAPI {
+
+#define skipIfNotUnderWayland() \
+    { \
+        static const char* display = g_getenv("WAYLAND_DISPLAY"); \
+        if (!display || !*display) { \
+            g_test_skip("Not running under Wayland"); \
+            return; \
+        } \
+    }
+
+static void testDisplayWaylandConnect(WPEWaylandPlatformTest* test, gconstpointer)
+{
+    skipIfNotUnderWayland();
+
+    GUniqueOutPtr<GError> error;
+    g_assert_true(wpe_display_connect(test->display(), &error.outPtr()));
+    g_assert_nonnull(wpe_display_wayland_get_wl_display(WPE_DISPLAY_WAYLAND(test->display())));
+    g_assert_no_error(error.get());
+
+    // Can't connect twice.
+    g_assert_false(wpe_display_connect(test->display(), &error.outPtr()));
+    g_assert_error(error.get(), WPE_DISPLAY_ERROR, WPE_DISPLAY_ERROR_CONNECTION_FAILED);
+
+    // Connect to invalid display fails.
+    GRefPtr<WPEDisplay> display = adoptGRef(wpe_display_wayland_new());
+    g_assert_true(WPE_IS_DISPLAY_WAYLAND(display.get()));
+    g_assert_false(wpe_display_wayland_connect(WPE_DISPLAY_WAYLAND(display.get()), "invalid", &error.outPtr()));
+    g_assert_error(error.get(), WPE_DISPLAY_ERROR, WPE_DISPLAY_ERROR_CONNECTION_FAILED);
+
+    // Connect to the default display using wpe_display_wayland_connect().
+    g_assert_true(wpe_display_wayland_connect(WPE_DISPLAY_WAYLAND(display.get()), nullptr, &error.outPtr()));
+    g_assert_no_error(error.get());
+    g_assert_nonnull(wpe_display_wayland_get_wl_display(WPE_DISPLAY_WAYLAND(display.get())));
+}
+
+void beforeAll()
+{
+    WPEWaylandPlatformTest::add("DisplayWayland", "connect", testDisplayWaylandConnect);
+}
+
+void afterAll()
+{
+}
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/glib/WPEPlatform/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/glib/WPEPlatform/CMakeLists.txt
@@ -59,6 +59,12 @@ set(WPEPlatformTest_SOURCES
     ${TOOLS_DIR}/TestWebKitAPI/glib/WPEPlatform/WPEPlatformTestMain.cpp
 )
 
+if (ENABLE_WPE_PLATFORM_WAYLAND)
+    list(APPEND WPEPlatformTest_SOURCES
+        ${TOOLS_DIR}/TestWebKitAPI/glib/WPEPlatform/WPEWaylandPlatformTest.cpp
+    )
+endif ()
+
 set(WPEPlatformTest_PRIVATE_INCLUDE_DIRECTORIES
     ${CMAKE_BINARY_DIR}
     ${TOOLS_DIR}/TestWebKitAPI/glib/WPEPlatform
@@ -103,3 +109,7 @@ endmacro()
 ADD_WPE_PLATFORM_TEST(TestDisplay ${TOOLS_DIR}/TestWebKitAPI/Tests/WPEPlatform/TestDisplay.cpp)
 ADD_WPE_PLATFORM_TEST(TestDisplayDefault ${TOOLS_DIR}/TestWebKitAPI/Tests/WPEPlatform/TestDisplayDefault.cpp)
 ADD_WPE_PLATFORM_TEST(TestSettings ${TOOLS_DIR}/TestWebKitAPI/Tests/WPEPlatform/TestSettings.cpp)
+
+if (ENABLE_WPE_PLATFORM_WAYLAND)
+    ADD_WPE_PLATFORM_TEST(TestDisplayWayland ${TOOLS_DIR}/TestWebKitAPI/Tests/WPEPlatform/TestDisplayWayland.cpp)
+endif ()

--- a/Tools/TestWebKitAPI/glib/WPEPlatform/WPEWaylandPlatformTest.cpp
+++ b/Tools/TestWebKitAPI/glib/WPEPlatform/WPEWaylandPlatformTest.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPEWaylandPlatformTest.h"
+
+#include <wpe/wayland/wpe-wayland.h>
+
+namespace TestWebKitAPI {
+
+WPEWaylandPlatformTest::WPEWaylandPlatformTest()
+    : m_display(adoptGRef(wpe_display_wayland_new()))
+{
+    g_assert_true(WPE_IS_DISPLAY_WAYLAND(m_display.get()));
+    assertObjectIsDeletedWhenTestFinishes(m_display.get());
+}
+
+WPEWaylandPlatformTest::~WPEWaylandPlatformTest() = default;
+
+} // namespace TestWebKitAPI
+

--- a/Tools/TestWebKitAPI/glib/WPEPlatform/WPEWaylandPlatformTest.h
+++ b/Tools/TestWebKitAPI/glib/WPEPlatform/WPEWaylandPlatformTest.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "WPEPlatformTest.h"
+#include <wtf/glib/GRefPtr.h>
+
+namespace TestWebKitAPI {
+
+class WPEWaylandPlatformTest : public WPEPlatformTest {
+public:
+    WPE_PLATFORM_TEST_FIXTURE(WPEWaylandPlatformTest);
+
+    WPEWaylandPlatformTest();
+    ~WPEWaylandPlatformTest();
+
+    WPEDisplay* display() const { return m_display.get(); }
+
+private:
+    GRefPtr<WPEDisplay> m_display;
+};
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 4141c4843eadde5c961cf70ac4e86cc3d9f986ae
<pre>
[WPE] WPE Platform: add initial API tests for wayland platform
<a href="https://bugs.webkit.org/show_bug.cgi?id=294671">https://bugs.webkit.org/show_bug.cgi?id=294671</a>

Reviewed by Carlos Alberto Lopez Perez.

Add an intial test to check we can create a WPEDisplayWayland and
connect to the wayland display. The script run-wpe-tests now detects if
a WPE Platform Wayland test is going to be run and it starts a weston
driver to ensure there&apos;s a wayland display to connect.

Canonical link: <a href="https://commits.webkit.org/296508@main">https://commits.webkit.org/296508@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1254a45afed0970536494e867f18880591daa9f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108758 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28419 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18843 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113969 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59142 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110721 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29108 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36983 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82630 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111706 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23127 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97961 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63067 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22548 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16098 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58670 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/92497 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16147 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117090 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35812 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26443 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91653 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36185 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94228 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91459 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36356 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14110 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31699 "Hash b1254a45 for PR 46900 does not build (failure)") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17558 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35712 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35422 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38769 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37100 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->