### PR TITLE
[Style] Adopt standard interfaces with rest parameters for BasicShape conversion

### DIFF
--- a/Source/WebCore/style/values/shapes/StyleBasicShape.cpp
+++ b/Source/WebCore/style/values/shapes/StyleBasicShape.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "StyleBasicShape.h"
 
+#include "CSSBasicShapeValue.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
 
@@ -33,14 +34,45 @@ namespace Style {
 
 // MARK: - Conversion
 
-auto ToCSS<BasicShape>::operator()(const BasicShape& value, const RenderStyle& style) -> CSS::BasicShape
+auto ToCSS<BasicShape>::operator()(const BasicShape& value, const RenderStyle& style, PathConversion conversion) -> CSS::BasicShape
 {
-    return WTF::switchOn(value, [&](const auto& alternative) { return CSS::BasicShape { toCSS(alternative, style) }; });
+    return WTF::switchOn(value,
+        [&](const auto& shape) {
+            return CSS::BasicShape { toCSS(shape, style) };
+        },
+        [&](const PathFunction& path) {
+            return CSS::BasicShape { toCSS(path, style, conversion) };
+        }
+    );
 }
 
-auto ToStyle<CSS::BasicShape>::operator()(const CSS::BasicShape& value, const BuilderState& builderState) -> BasicShape
+auto ToStyle<CSS::BasicShape>::operator()(const CSS::BasicShape& value, const BuilderState& builderState, std::optional<float> zoom) -> BasicShape
 {
-    return WTF::switchOn(value, [&](const auto& alternative) { return BasicShape { toStyle(alternative, builderState) }; });
+    return WTF::switchOn(value,
+        [&](const auto& shape) {
+            return BasicShape { toStyle(shape, builderState) };
+        },
+        [&](const CSS::PathFunction& path) {
+            return BasicShape { toStyle(path, builderState, zoom) };
+        }
+    );
+}
+
+Ref<CSSValue> CSSValueCreation<BasicShape>::operator()(CSSValuePool&, const RenderStyle& style, const BasicShape& value, PathConversion conversion)
+{
+    return CSSBasicShapeValue::create(toCSS(value, style, conversion));
+}
+
+BasicShape CSSValueConversion<BasicShape>::operator()(BuilderState& builderState, const CSSValue& value, std::optional<float> zoom)
+{
+    return toStyle(downcast<CSSBasicShapeValue>(value).shape(), builderState, zoom);
+}
+
+// MARK: - Serialization
+
+void Serialize<BasicShape>::operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const BasicShape& value, PathConversion conversion)
+{
+    CSS::serializationForCSS(builder, context, toCSS(value, style, conversion));
 }
 
 // MARK: - Blending

--- a/Source/WebCore/style/values/shapes/StyleBasicShape.h
+++ b/Source/WebCore/style/values/shapes/StyleBasicShape.h
@@ -54,8 +54,15 @@ template<typename T> concept ShapeWithCenterCoordinate = std::same_as<T, CircleF
 
 // MARK: - Conversion
 
-template<> struct ToCSS<BasicShape> { auto operator()(const BasicShape&, const RenderStyle&) -> CSS::BasicShape; };
-template<> struct ToStyle<CSS::BasicShape> { auto operator()(const CSS::BasicShape&, const BuilderState&) -> BasicShape; };
+template<> struct ToCSS<BasicShape> { auto operator()(const BasicShape&, const RenderStyle&, PathConversion = PathConversion::None) -> CSS::BasicShape; };
+template<> struct ToStyle<CSS::BasicShape> { auto operator()(const CSS::BasicShape&, const BuilderState&, std::optional<float> zoom = 1.0f) -> BasicShape; };
+
+template<> struct CSSValueCreation<BasicShape> { Ref<CSSValue> operator()(CSSValuePool&, const RenderStyle&, const BasicShape&, PathConversion = PathConversion::None); };
+template<> struct CSSValueConversion<BasicShape> { BasicShape operator()(BuilderState&, const CSSValue&, std::optional<float> zoom = 1.0f); };
+
+// MARK: - Serialization
+
+template<> struct Serialize<BasicShape> { void operator()(StringBuilder&, const CSS::SerializationContext&, const RenderStyle&, const BasicShape&, PathConversion = PathConversion::None); };
 
 // MARK: - Blending
 

--- a/Source/WebCore/style/values/shapes/StylePathFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StylePathFunction.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2024-2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,6 +26,7 @@
 #include "StylePathFunction.h"
 
 #include "AffineTransform.h"
+#include "CSSPathValue.h"
 #include "FloatRect.h"
 #include "GeometryUtilities.h"
 #include "Path.h"
@@ -94,9 +95,9 @@ static SVGPathByteStream copySVGPathByteStream(const SVGPathByteStream& source, 
     return source;
 }
 
-auto ToCSS<Path::Data>::operator()(const Path::Data& value, const RenderStyle&) -> CSS::Path::Data
+auto ToCSS<Path::Data>::operator()(const Path::Data& value, const RenderStyle&, PathConversion conversion) -> CSS::Path::Data
 {
-    return { copySVGPathByteStream(value.byteStream, PathConversion::None) };
+    return { copySVGPathByteStream(value.byteStream, conversion) };
 }
 
 auto ToStyle<CSS::Path::Data>::operator()(const CSS::Path::Data& value, const BuilderState&) -> Path::Data
@@ -104,42 +105,33 @@ auto ToStyle<CSS::Path::Data>::operator()(const CSS::Path::Data& value, const Bu
     return { copySVGPathByteStream(value.byteStream, PathConversion::None) };
 }
 
-auto ToCSS<Path>::operator()(const Path& value, const RenderStyle& style) -> CSS::Path
+auto ToCSS<Path>::operator()(const Path& value, const RenderStyle& style, PathConversion conversion) -> CSS::Path
 {
     return {
         .fillRule = toCSS(value.fillRule, style),
-        .data = toCSS(value.data, style)
+        .data = toCSS(value.data, style, conversion)
     };
 }
 
-auto ToStyle<CSS::Path>::operator()(const CSS::Path& value, const BuilderState& state) -> Path
+auto ToStyle<CSS::Path>::operator()(const CSS::Path& value, const BuilderState& state, std::optional<float> zoom) -> Path
 {
     return {
         .fillRule = toStyle(value.fillRule, state),
         .data = toStyle(value.data, state),
-        .zoom = 1
+        .zoom = zoom.value_or(state.style().usedZoom())
     };
 }
 
-auto overrideToCSS(const Style::PathFunction& path, const RenderStyle& style, PathConversion conversion) -> CSS::PathFunction
+Ref<CSSValue> CSSValueCreation<PathFunction>::operator()(CSSValuePool&, const RenderStyle& style, const PathFunction& value, PathConversion conversion)
 {
-    return {
-        .parameters = CSS::Path {
-            .fillRule = Style::toCSS(path->fillRule, style),
-            .data = { copySVGPathByteStream(path->data.byteStream, conversion) }
-        }
-    };
+    return CSSPathValue::create(toCSS(value, style, conversion));
 }
 
-auto overrideToStyle(const CSS::PathFunction& path, const BuilderState& state, std::optional<float> zoom) -> PathFunction
+// MARK: - Serialization
+
+void Serialize<Path>::operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const Path& value, PathConversion conversion)
 {
-    return {
-        .parameters = Path {
-            .fillRule = toStyle(path->fillRule, state),
-            .data = toStyle(path->data, state),
-            .zoom = zoom.value_or(state.style().usedZoom())
-        }
-    };
+    CSS::serializationForCSS(builder, context, toCSS(value, style, conversion));
 }
 
 // MARK: - Path

--- a/Source/WebCore/style/values/shapes/StylePathFunction.h
+++ b/Source/WebCore/style/values/shapes/StylePathFunction.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2024-2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -61,19 +61,31 @@ template<size_t I> const auto& get(const Path& value)
         return value.zoom;
 }
 
-template<> struct ToCSS<Path> { auto operator()(const Path&, const RenderStyle&) -> CSS::Path; };
-template<> struct ToStyle<CSS::Path> { auto operator()(const CSS::Path&, const BuilderState&) -> Path; };
+// MARK: - Conversion
 
-template<> struct ToCSS<Path::Data> { auto operator()(const Path::Data&, const RenderStyle&) -> CSS::Path::Data; };
+// Non-standard parameters, `conversion` and `zoom`, are needed in some instances of Style <-> CSS conversions for Path.
+
+template<> struct ToCSS<Path> { auto operator()(const Path&, const RenderStyle&, PathConversion = PathConversion::None) -> CSS::Path; };
+template<> struct ToStyle<CSS::Path> { auto operator()(const CSS::Path&, const BuilderState&, std::optional<float> zoom = 1.0f) -> Path; };
+
+template<> struct ToCSS<Path::Data> { auto operator()(const Path::Data&, const RenderStyle&, PathConversion = PathConversion::None) -> CSS::Path::Data; };
 template<> struct ToStyle<CSS::Path::Data> { auto operator()(const CSS::Path::Data&, const BuilderState&) -> Path::Data; };
 
-// Non-standard parameters, `conversion` and `zoom`, are needed in some instances of Style <-> CSS conversions
-// for Path, so additional "override" conversion operators are provided here.
-auto overrideToCSS(const PathFunction&, const RenderStyle&, PathConversion) -> CSS::PathFunction;
-auto overrideToStyle(const CSS::PathFunction&, const Style::BuilderState&, std::optional<float> zoom) -> PathFunction;
+template<> struct CSSValueCreation<PathFunction> { Ref<CSSValue> operator()(CSSValuePool&, const RenderStyle&, const PathFunction&, PathConversion = PathConversion::None); };
+
+// MARK: - Serialization
+
+template<> struct Serialize<Path> { void operator()(StringBuilder&, const CSS::SerializationContext&, const RenderStyle&, const Path&, PathConversion = PathConversion::None); };
+
+// MARK: - Path
 
 template<> struct PathComputation<Path> { WebCore::Path operator()(const Path&, const FloatRect&); };
+
+// MARK: - Wind Rule
+
 template<> struct WindRuleComputation<Path> { WebCore::WindRule operator()(const Path&); };
+
+// MARK: - Blending
 
 template<> struct Blending<Path> {
     auto canBlend(const Path&, const Path&) -> bool;


### PR DESCRIPTION
#### 9d0ec2206fd7253fb4870f57b81a1997cafbb9a6
<pre>
[Style] Adopt standard interfaces with rest parameters for BasicShape conversion
<a href="https://bugs.webkit.org/show_bug.cgi?id=294674">https://bugs.webkit.org/show_bug.cgi?id=294674</a>

Reviewed by Darin Adler.

Now that we have rest parameters everywhere we can adopt
the standard interfaces for conversions for BasicShape.

* Source/WebCore/style/StyleBuilderConverter.h:
    - Replace convertBasicShape with standard convertStyleType for BasicShape,
      passing the appropriate zoom value via rest parameter.

* Source/WebCore/style/StyleExtractorConverter.h:
    - Replace convertBasicShape with standard convertStyleType for BasicShape,
      passing the appropriate path conversion value via rest parameter.

* Source/WebCore/style/StyleExtractorSerializer.h:
    - Replace serializeBasicShape with standard serializeStyleType for BasicShape,
      passing the appropriate path conversion value via rest parameter.

* Source/WebCore/style/values/shapes/StyleBasicShape.cpp:
* Source/WebCore/style/values/shapes/StyleBasicShape.h:
* Source/WebCore/style/values/shapes/StylePathFunction.cpp:
* Source/WebCore/style/values/shapes/StylePathFunction.h:
    - Add PathConversion parameter to ToCSS conversion.
    - Add zoom parameter to ToStyle conversion.
    - Add missing CSSValueCreation, CSSValueConversion and Serialize
      interfaces using appropriate additional parameters.

Canonical link: <a href="https://commits.webkit.org/296403@main">https://commits.webkit.org/296403@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d28e63b28b5d2134075e30d69ae419e384f34589

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108343 "10 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18427 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113552 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58775 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110306 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28693 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82270 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111291 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22749 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97591 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62705 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22165 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15728 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58280 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92117 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15784 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116674 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35397 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26070 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91293 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35770 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93867 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91094 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23224 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35981 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13749 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31156 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35299 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40837 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35016 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38370 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36697 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->