### PR TITLE
[JSC] Fix WebAssembly table import validation for non-nullable reference types

### DIFF
--- a/JSTests/wasm/stress/defaultable-imported-table.js
+++ b/JSTests/wasm/stress/defaultable-imported-table.js
@@ -1,0 +1,15 @@
+// (module
+//  (table (export "t") 0 0 (ref any)
+//    (i32.const 0) (ref.i31)
+//  )
+// )
+const wasm1 = new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 4, 13, 1, 64, 0, 100, 110, 1, 0, 0, 65, 0, 251, 28, 11, 7, 5, 1, 1, 116, 1, 0]);
+const module1 = new WebAssembly.Module(wasm1);
+const instance1 = new WebAssembly.Instance(module1);
+
+// (module
+//   (import "M" "t" (table 0 0 (ref any)))
+// )
+const wasm2 = new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 2, 11, 1, 1, 77, 1, 116, 1, 100, 110, 1, 0, 0]);
+const module2 = new WebAssembly.Module(wasm2);
+const instance2 = new WebAssembly.Instance(module2, { M: { t: instance1.exports.t } });

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -294,7 +294,7 @@ auto SectionParser::parseTableHelper(bool isImport) -> PartialResult
 
     WASM_PARSER_FAIL_IF(!parseValueType(m_info, type), "can't parse Table type"_s);
     WASM_PARSER_FAIL_IF(!isRefType(type), "Table type should be a ref type, got "_s, type);
-    if (!hasInitExpr)
+    if (!hasInitExpr && !isImport)
         WASM_PARSER_FAIL_IF(!isDefaultableType(type), "Table's type must be defaultable"_s);
 
     uint32_t initial;


### PR DESCRIPTION
#### 6da47c63a9391911c9337dbb7b145ae89a669c8d
<pre>
[JSC] Fix WebAssembly table import validation for non-nullable reference types
<a href="https://bugs.webkit.org/show_bug.cgi?id=293030">https://bugs.webkit.org/show_bug.cgi?id=293030</a>

Reviewed by Yusuke Suzuki.

WebAssembly table import validation was incorrectly failing when importing
tables with non-nullable reference types like `ref any`. The issue was that
the defaultable type constraint was being applied to imported tables, even
though this constraint should only apply to newly created tables[1].

Imported tables are already initialized by the exporting module, so they
don&apos;t need to satisfy the defaultable type requirement. This patch changes
the validation logic to skip the defaultable check for imported tables while
preserving it for locally created tables.

[1]: <a href="https://github.com/WebAssembly/function-references/blob/74d2ec81d15efd3c0f2fba46a023f376101d8e46/proposals/function-references/Overview.md#defaultability">https://github.com/WebAssembly/function-references/blob/74d2ec81d15efd3c0f2fba46a023f376101d8e46/proposals/function-references/Overview.md#defaultability</a>

Canonical link: <a href="https://commits.webkit.org/296409@main">https://commits.webkit.org/296409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8dfd567b7d1e2d9337499a6cdf4c6c2b01883b74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108347 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28008 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18431 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113556 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58778 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28697 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36557 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82269 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111295 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22753 "Found 1 new test failure: http/tests/geolocation/geolocation-get-current-position-does-not-leak.https.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97595 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62704 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22170 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15732 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58283 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/100910 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92121 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15788 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116677 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/106906 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35401 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26074 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91296 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35774 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93871 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91097 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23230 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35984 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13753 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31159 "Hash 8dfd567b for PR 46908 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35303 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40841 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/131191 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35019 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35603 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38373 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36700 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->