### PR TITLE
DNR: Parsing of translated content blocker rules should be done off the main thread

### DIFF
--- a/Source/WebCore/contentextensions/ContentExtensionCompiler.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionCompiler.cpp
@@ -281,7 +281,7 @@ std::error_code compileRuleList(ContentExtensionCompilationClient& client, Strin
 {
 #if ASSERT_ENABLED
     callOnMainThread([ruleJSON = ruleJSON.isolatedCopy(), parsedRuleList = crossThreadCopy(parsedRuleList)] {
-        ASSERT(parseRuleList(ruleJSON).value() == parsedRuleList);
+        ASSERT(parseRuleList(ruleJSON, WebCore::ContentExtensions::CSSSelectorsAllowed::Yes).value() == parsedRuleList);
     });
 #endif
 

--- a/Source/WebCore/contentextensions/ContentExtensionParser.h
+++ b/Source/WebCore/contentextensions/ContentExtensionParser.h
@@ -40,7 +40,12 @@ namespace ContentExtensions {
 
 class ContentExtensionRule;
 
-WEBCORE_EXPORT Expected<Vector<ContentExtensionRule>, std::error_code> parseRuleList(const String&);
+enum class CSSSelectorsAllowed : bool {
+    No,
+    Yes
+};
+
+WEBCORE_EXPORT Expected<Vector<ContentExtensionRule>, std::error_code> parseRuleList(const String&, CSSSelectorsAllowed);
 WEBCORE_EXPORT bool isValidCSSSelector(const String&);
 
 CSSParserContext contentExtensionCSSParserContext();

--- a/Source/WebKit/UIProcess/API/APIContentRuleList.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentRuleList.cpp
@@ -78,9 +78,9 @@ bool ContentRuleList::supportsRegularExpression(const WTF::String& regex)
     return false;
 }
 
-std::error_code ContentRuleList::parseRuleList(const WTF::String& ruleList)
+std::error_code ContentRuleList::parseRuleList(const WTF::String& ruleList, WebCore::ContentExtensions::CSSSelectorsAllowed cssSelectorsAllowed)
 {
-    auto result = WebCore::ContentExtensions::parseRuleList(ruleList);
+    auto result = WebCore::ContentExtensions::parseRuleList(ruleList, cssSelectorsAllowed);
     if (result.has_value())
         return { };
 

--- a/Source/WebKit/UIProcess/API/APIContentRuleList.h
+++ b/Source/WebKit/UIProcess/API/APIContentRuleList.h
@@ -27,6 +27,7 @@
 
 #include "APIObject.h"
 #include "NetworkCacheData.h"
+#include <WebCore/ContentExtensionParser.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
@@ -50,7 +51,7 @@ public:
     const WebKit::WebCompiledContentRuleList& compiledRuleList() const { return m_compiledRuleList.get(); }
     
     static bool supportsRegularExpression(const WTF::String&);
-    static std::error_code parseRuleList(const WTF::String&);
+    static std::error_code parseRuleList(const WTF::String&, WebCore::ContentExtensions::CSSSelectorsAllowed);
 
 private:
     Ref<WebKit::WebCompiledContentRuleList> m_compiledRuleList;

--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.h
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "APIObject.h"
+#include <WebCore/ContentExtensionParser.h>
 #include <system_error>
 #include <wtf/text/WTFString.h>
 
@@ -67,7 +68,7 @@ public:
     void lookupContentRuleList(WTF::String&& identifier, CompletionHandler<void(RefPtr<API::ContentRuleList>, std::error_code)>);
     void removeContentRuleList(WTF::String&& identifier, CompletionHandler<void(std::error_code)>);
 
-    void compileContentRuleListFile(WTF::String&& filePath, WTF::String&& identifier, WTF::String&& json, CompletionHandler<void(RefPtr<API::ContentRuleList>, std::error_code)>);
+    void compileContentRuleListFile(WTF::String&& filePath, WTF::String&& identifier, WTF::String&& json, WebCore::ContentExtensions::CSSSelectorsAllowed, CompletionHandler<void(RefPtr<API::ContentRuleList>, std::error_code)>);
     void lookupContentRuleListFile(WTF::String&& filePath, WTF::String&& identifier, CompletionHandler<void(RefPtr<API::ContentRuleList>, std::error_code)>);
     void removeContentRuleListFile(WTF::String&& filePath, CompletionHandler<void(std::error_code)>);
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleList.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleList.mm
@@ -28,6 +28,7 @@
 
 #import "WKError.h"
 #import "WebCompiledContentRuleList.h"
+#import <WebCore/ContentExtensionParser.h>
 #import <WebCore/WebCoreObjCExtras.h>
 
 @implementation WKContentRuleList
@@ -74,7 +75,7 @@
 + (NSError *)_parseRuleList:(NSString *)ruleList
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    std::error_code error = API::ContentRuleList::parseRuleList(ruleList);
+    std::error_code error = API::ContentRuleList::parseRuleList(ruleList, WebCore::ContentExtensions::CSSSelectorsAllowed::Yes);
     if (!error)
         return nil;
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -4795,7 +4795,7 @@ void WebExtensionContext::compileDeclarativeNetRequestRules(NSArray *rulesData, 
                     }
                 }
 
-                API::ContentRuleListStore::defaultStoreSingleton().compileContentRuleListFile(declarativeNetRequestContentRuleListFilePath(), uniqueIdentifier().isolatedCopy(), String(webKitRules), [this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), hashOfWebKitRules](RefPtr<API::ContentRuleList> ruleList, std::error_code error) mutable {
+                API::ContentRuleListStore::defaultStoreSingleton().compileContentRuleListFile(declarativeNetRequestContentRuleListFilePath(), uniqueIdentifier().isolatedCopy(), String(webKitRules), WebCore::ContentExtensions::CSSSelectorsAllowed::No, [this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), hashOfWebKitRules](RefPtr<API::ContentRuleList> ruleList, std::error_code error) mutable {
                     if (error) {
                         RELEASE_LOG_ERROR(Extensions, "Error compiling declarativeNetRequest rules: %{public}s", error.message().c_str());
                         completionHandler(false);

--- a/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
@@ -142,7 +142,7 @@ public:
     {
         CompiledContentExtensionData extensionData;
         InMemoryContentExtensionCompilationClient client(extensionData);
-        auto parsedRules = ContentExtensions::parseRuleList(filter);
+        auto parsedRules = ContentExtensions::parseRuleList(filter, WebCore::ContentExtensions::CSSSelectorsAllowed::Yes);
         auto compilerError = ContentExtensions::compileRuleList(client, WTFMove(filter), WTFMove(parsedRules.value()));
 
         // Compiling should always succeed here. We have other tests for compile failures.
@@ -1400,7 +1400,7 @@ void checkCompilerError(String&& json, std::error_code expectedError)
 {
     CompiledContentExtensionData extensionData;
     InMemoryContentExtensionCompilationClient client(extensionData);
-    auto parsedRules = ContentExtensions::parseRuleList(json);
+    auto parsedRules = ContentExtensions::parseRuleList(json, WebCore::ContentExtensions::CSSSelectorsAllowed::Yes);
     std::error_code compilerError;
     if (parsedRules.has_value())
         compilerError = ContentExtensions::compileRuleList(client, WTFMove(json), WTFMove(parsedRules.value()));


### PR DESCRIPTION
#### cf3fc160de0cc6098114087d485b0f989123108d
<pre>
DNR: Parsing of translated content blocker rules should be done off the main thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=294679">https://bugs.webkit.org/show_bug.cgi?id=294679</a>
<a href="https://rdar.apple.com/153200218">rdar://153200218</a>

Reviewed by Alex Christensen.

The only part that isn&apos;t thread safe about parsing of the content blocker rules is parsing the CSS
selectors used in display-none rules. However, these will currently never be present in translated rules from
DNR. If we add support for turning DNR rules into content blocker CSS display-none rules, we will need
to revisit this. This PR adds a variable indicating whether or not CSS selectors will be expected in parsing
all the way down the stack. If a CSS selector is seen when it isn&apos;t expected, an assert will be hit and
the rule will be ignored.

A better fix here would be to make the CSS parsing thread safe, and that is tracked by:
<a href="https://rdar.apple.com/153748194">rdar://153748194</a> (CSS selector validation in content blocker rule list parsing should be thread safe)

* Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp:
(API::ContentRuleListStore::compileContentRuleList):
(API::ContentRuleListStore::compileContentRuleListFile):
* Source/WebKit/UIProcess/API/APIContentRuleListStore.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::compileDeclarativeNetRequestRules):

Canonical link: <a href="https://commits.webkit.org/296408@main">https://commits.webkit.org/296408@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcbc1765a937f14f37497aa899af7c9c1620708a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108404 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28065 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18489 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113613 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/58821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110367 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28754 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36615 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/82317 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/58821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111352 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22804 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97643 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62752 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22220 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/15780 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58340 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/92174 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15835 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116734 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35458 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/26121 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/91344 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35831 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93918 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91144 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23227 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/36043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13800 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31201 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35361 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/40898 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35072 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38424 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36755 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->