### PR TITLE
AX: In rare circumstances, a deadlock is possible in AXTreeStore::applyPendingChangesForAllIsolatedTrees()

### DIFF
--- a/Source/WebCore/accessibility/AXTreeStore.cpp
+++ b/Source/WebCore/accessibility/AXTreeStore.cpp
@@ -39,11 +39,11 @@ void AXTreeStore<AXIsolatedTree>::applyPendingChangesForAllIsolatedTrees()
     Locker locker { AXTreeStore<AXIsolatedTree>::s_storeLock };
     auto& map = AXTreeStore<AXIsolatedTree>::isolatedTreeMap();
     for (const auto& axIDToTree : map) {
-        if (RefPtr tree = axIDToTree.value.get(); tree && !tree->willBeDestroyed()) {
+        if (RefPtr tree = axIDToTree.value.get()) {
             // Only applyPendingChanges for trees that aren't about to be destroyed.
             // When a tree is destroyed, it tries to remove itself from AXTreeStore,
             // which requires taking s_storeLock, which we hold. This would cause a deadlock.
-            tree->applyPendingChanges();
+            tree->applyPendingChangesUnlessQueuedForDestruction();
         }
     }
 }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -401,7 +401,6 @@ public:
     static Ref<AXIsolatedTree> createEmpty(AXObjectCache&);
     constexpr bool isEmptyContentTree() const { return m_isEmptyContentTree; }
     virtual ~AXIsolatedTree();
-    bool willBeDestroyed();
 
     static void removeTreeForPageID(PageIdentifier);
 
@@ -509,6 +508,7 @@ public:
 
     // Called on AX thread from WebAccessibilityObjectWrapper methods.
     WEBCORE_EXPORT void applyPendingChanges();
+    void applyPendingChangesUnlessQueuedForDestruction();
 
     constexpr AXID treeID() const { return m_id; }
     constexpr ProcessID processID() const { return m_processID; }
@@ -544,6 +544,8 @@ private:
     // We can't destroy the tree on the main-thread (by removing all `Ref`s to it)
     // because it could be being used by the secondary thread to service an AX request.
     void queueForDestruction();
+
+    void applyPendingChangesLocked() WTF_REQUIRES_LOCK(m_changeLogLock);
 
     static HashMap<PageIdentifier, Ref<AXIsolatedTree>>& treePageCache() WTF_REQUIRES_LOCK(s_storeLock);
 


### PR DESCRIPTION
#### 56a9730f146942065c105acb782c30924059b62e
<pre>
AX: In rare circumstances, a deadlock is possible in AXTreeStore::applyPendingChangesForAllIsolatedTrees()
<a href="https://bugs.webkit.org/show_bug.cgi?id=294677">https://bugs.webkit.org/show_bug.cgi?id=294677</a>
<a href="https://rdar.apple.com/153746691">rdar://153746691</a>

Reviewed by Chris Fleizach.

Prior to this commit, AXTreeStore::applyPendingChangesForAllIsolatedTrees did this:

if (RefPtr tree = axIDToTree.value.get(); tree &amp;&amp; !tree-&gt;willBeDestroyed())
    tree-&gt;applyPendingChanges();

The reason it wanted to avoid applying pending changes if the tree will be destroyed is because this function holds
AXTreeStore::s_storeLock, and if a tree is queued to be destroyed, it will remove itself via AXTreeStore::remove, which
tries to take s_storeLock also, which would cause a deadlock.

However, despite checking willBeDestroyed(), a deadlock is still possible if the timing is just right:

  1. The AX thread checks willBeDestroyed() and finds the tree will not be destroyed, and thus enters the if-statement
  2. Immediately after, before the AX thread can actually start running applyPendingChanges(), the main-thread sets
     AXIsolatedTree::m_queuedForDestruction
  3. The AX thread then runs applyPendingChanges(), finds the tree in need of being destroyed, calling AXTreeStore::remove
     and thus deadlocking on s_storeLock as described above.

Fix this holding m_changeLogLock (which m_queuedForDestruction is guarded by) both for the m_queuedForDestruction check,
and the actual applyPendingChanges() call, preventing the issue.

* Source/WebCore/accessibility/AXTreeStore.cpp:
(WebCore::AXTreeStore&lt;AXIsolatedTree&gt;::applyPendingChangesForAllIsolatedTrees):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::applyPendingChangesUnlessQueuedForDestruction):
(WebCore::AXIsolatedTree::applyPendingChangesLocked):
(WebCore::AXIsolatedTree::willBeDestroyed): Deleted.
(WebCore::AXIsolatedTree::applyPendingChanges): Deleted.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
(WebCore::AXIsolatedTree::applyPendingChanges):

Canonical link: <a href="https://commits.webkit.org/296400@main">https://commits.webkit.org/296400@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ab06b3dff259cc36a7a51ab1d6726b7e32e44b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108357 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18441 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113566 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58786 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110320 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28707 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36568 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82277 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111305 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22764 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97605 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62712 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22181 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15743 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58293 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92132 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15798 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116687 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35411 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26085 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91305 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35784 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93881 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91106 "Found 2 new API test failures: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23218 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35990 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13763 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31167 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35313 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40851 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35028 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38381 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36708 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->