### PR TITLE
CSS TypedOM crash under BuilderFunctions::applyValueTranslate

### DIFF
--- a/LayoutTests/fast/css/cssom-translate-crash-expected.txt
+++ b/LayoutTests/fast/css/cssom-translate-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/fast/css/cssom-translate-crash.html
+++ b/LayoutTests/fast/css/cssom-translate-crash.html
@@ -1,0 +1,8 @@
+<script>
+window.testRunner?.dumpAsText();
+
+const n2 = document.createElement('div');
+document.documentElement.appendChild(n2);
+n2.attributeStyleMap.set('translate', ...document.documentElement.computedStyleMap().getAll('border-image-slice'));
+</script>
+This test passes if it doesn't crash.

--- a/Source/WebCore/css/DOMMatrixReadOnly.cpp
+++ b/Source/WebCore/css/DOMMatrixReadOnly.cpp
@@ -230,8 +230,7 @@ ExceptionOr<DOMMatrixReadOnly::AbstractMatrix> DOMMatrixReadOnly::parseStringInt
     if (string.isEmpty())
         return AbstractMatrix { };
 
-    CSSToLengthConversionData conversionData;
-    auto operations = CSSPropertyParserHelpers::parseTransformRaw(string, CSSParserContext(HTMLStandardMode), conversionData);
+    auto operations = CSSPropertyParserHelpers::parseTransformRaw(string, CSSParserContext(HTMLStandardMode));
     if (!operations)
         return Exception { ExceptionCode::SyntaxError };
 

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -565,8 +565,12 @@ std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> consume
         case CSSCustomPropertySyntax::Type::String:
             return { downcast<CSSPrimitiveValue>(value).stringValue() };
         case CSSCustomPropertySyntax::Type::TransformFunction:
-        case CSSCustomPropertySyntax::Type::TransformList:
-            return { Style::CustomProperty::Transform { Style::createTransformOperation(value, builderState.cssToLengthConversionData()) } };
+        case CSSCustomPropertySyntax::Type::TransformList: {
+            auto operation = Style::createTransformOperation(value, builderState);
+            if (!operation)
+                return { };
+            return { Style::CustomProperty::Transform { *operation } };
+        }
         case CSSCustomPropertySyntax::Type::Unknown:
             return { };
         }

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Transform.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Transform.cpp
@@ -44,6 +44,8 @@
 #include "CSSToLengthConversionData.h"
 #include "CSSValueList.h"
 #include "CSSValuePool.h"
+#include "RenderStyle.h"
+#include "StyleBuilderState.h"
 #include "TransformOperations.h"
 #include "TransformOperationsBuilder.h"
 
@@ -410,7 +412,7 @@ RefPtr<CSSValue> consumeScale(CSSParserTokenRange& range, CSS::PropertyParserSta
     return CSSValueList::createSpaceSeparated(x.releaseNonNull());
 }
 
-std::optional<TransformOperations> parseTransformRaw(const String& string, const CSSParserContext& context, const CSSToLengthConversionData& conversionData)
+std::optional<TransformOperations> parseTransformRaw(const String& string, const CSSParserContext& context)
 {
     auto tokenizer = CSSTokenizer(string);
     auto range = tokenizer.tokenRange();
@@ -429,10 +431,13 @@ std::optional<TransformOperations> parseTransformRaw(const String& string, const
     if (!range.atEnd())
         return { };
 
-    if (!parsedValue->canResolveDependenciesWithConversionData(conversionData))
+    auto dummyStyle = RenderStyle::create();
+    auto dummyState = Style::BuilderState { dummyStyle };
+
+    if (!parsedValue->canResolveDependenciesWithConversionData(dummyState.cssToLengthConversionData()))
         return { };
 
-    return Style::createTransformOperations(*parsedValue, conversionData);
+    return Style::createTransformOperations(*parsedValue, dummyState);
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Transform.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Transform.h
@@ -57,7 +57,7 @@ RefPtr<CSSValue> consumeScale(CSSParserTokenRange&, CSS::PropertyParserState&);
 RefPtr<CSSValue> consumeRotate(CSSParserTokenRange&, CSS::PropertyParserState&);
 
 // MARK: <'transform'> parsing (raw)
-std::optional<TransformOperations> parseTransformRaw(const String&, const CSSParserContext&, const CSSToLengthConversionData&);
+std::optional<TransformOperations> parseTransformRaw(const String&, const CSSParserContext&);
 
 } // namespace CSSPropertyParserHelpers
 } // namespace WebCore

--- a/Source/WebCore/css/query/ContainerQueryFeatures.cpp
+++ b/Source/WebCore/css/query/ContainerQueryFeatures.cpp
@@ -179,7 +179,7 @@ struct StyleFeatureSchema : public FeatureSchema {
             // Resolve the queried custom property value for var() references, css-wide keywords and registered properties.
             auto builderContext = Style::BuilderContext {
                 context.document.get(),
-                *context.conversionData.parentStyle(),
+                context.conversionData.parentStyle(),
                 context.conversionData.rootStyle(),
                 context.conversionData.elementForContainerUnitResolution()
             };

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -642,7 +642,7 @@ inline TransformOperations BuilderConverter::convertTransform(BuilderState& buil
     CSSToLengthConversionData conversionData = builderState.useSVGZoomRulesForLength() ?
         builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
         : builderState.cssToLengthConversionData();
-    return createTransformOperations(value, conversionData);
+    return createTransformOperations(value, builderState);
 }
 
 inline String BuilderConverter::convertString(BuilderState& builderState, const CSSValue& value)

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -76,6 +76,12 @@
 namespace WebCore {
 namespace Style {
 
+BuilderState::BuilderState(RenderStyle& style)
+    : m_styleMap(*this)
+    , m_style(style)
+{
+}
+
 BuilderState::BuilderState(RenderStyle& style, BuilderContext&& context)
     : m_styleMap(*this)
     , m_style(style)

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -79,26 +79,27 @@ struct BuilderPositionTryFallback {
 };
 
 struct BuilderContext {
-    const Ref<const Document> document;
-    const RenderStyle& parentStyle;
-    const RenderStyle* rootElementStyle = nullptr;
-    RefPtr<const Element> element = nullptr;
+    const RefPtr<const Document> document { };
+    const RenderStyle* parentStyle { };
+    const RenderStyle* rootElementStyle { };
+    RefPtr<const Element> element { };
     CheckedPtr<TreeResolutionState> treeResolutionState { };
     std::optional<BuilderPositionTryFallback> positionTryFallback { };
 };
 
 class BuilderState {
 public:
+    BuilderState(RenderStyle&);
     BuilderState(RenderStyle&, BuilderContext&&);
 
     RenderStyle& style() { return m_style; }
     const RenderStyle& style() const { return m_style; }
 
-    const RenderStyle& parentStyle() const { return m_context.parentStyle; }
+    const RenderStyle& parentStyle() const { return *m_context.parentStyle; }
     const RenderStyle* rootElementStyle() const { return m_context.rootElementStyle; }
 
-    const Document& document() const { return m_context.document.get(); }
-    Ref<const Document> protectedDocument() const { return m_context.document; }
+    const Document& document() const { return *m_context.document; }
+    Ref<const Document> protectedDocument() const { return *m_context.document; }
     const Element* element() const { return m_context.element.get(); }
 
     inline void setZoom(float);

--- a/Source/WebCore/style/StyleCustomPropertyRegistry.cpp
+++ b/Source/WebCore/style/StyleCustomPropertyRegistry.cpp
@@ -198,10 +198,9 @@ auto CustomPropertyRegistry::parseInitialValue(const Document& document, const A
 
     // We don't need to provide a real context style since only computationally independent values are allowed (no 'em' etc).
     auto placeholderStyle = RenderStyle::create();
-    auto placeholderMatchResult = MatchResult::create();
-    Style::Builder builder { placeholderStyle, { document, RenderStyle::defaultStyleSingleton() }, placeholderMatchResult, { } };
+    Style::BuilderState dummyState { placeholderStyle, { &document } };
 
-    auto initialValue = CSSPropertyParser::parseTypedCustomPropertyInitialValue(propertyName, syntax, tokenRange, builder.state(), { document });
+    auto initialValue = CSSPropertyParser::parseTypedCustomPropertyInitialValue(propertyName, syntax, tokenRange, dummyState, { document });
     if (!initialValue)
         return makeUnexpected(ParseInitialValueError::DidNotParse);
 

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -305,7 +305,7 @@ BuilderContext Resolver::builderContext(State& state)
 {
     return {
         document(),
-        *state.parentStyle(),
+        state.parentStyle(),
         state.rootElementStyle(),
         state.element(),
         state.treeResolutionState()

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -880,7 +880,7 @@ std::unique_ptr<RenderStyle> TreeResolver::resolveAgainInDifferentContext(const 
 
     auto builderContext = BuilderContext {
         m_document.get(),
-        parentStyle,
+        &parentStyle,
         resolutionContext.documentElementStyle,
         &styleable.element,
         &m_treeResolutionState,
@@ -919,7 +919,7 @@ UncheckedKeyHashSet<AnimatableCSSProperty> TreeResolver::applyCascadeAfterAnimat
 {
     auto builderContext = BuilderContext {
         m_document.get(),
-        *resolutionContext.parentStyle,
+        resolutionContext.parentStyle,
         resolutionContext.documentElementStyle,
         &element,
         &m_treeResolutionState

--- a/Source/WebCore/style/TransformOperationsBuilder.h
+++ b/Source/WebCore/style/TransformOperationsBuilder.h
@@ -41,8 +41,10 @@ class TransformOperations;
 
 namespace Style {
 
-Ref<TransformOperation> createTransformOperation(const CSSValue&, const CSSToLengthConversionData&);
-TransformOperations createTransformOperations(const CSSValue&, const CSSToLengthConversionData&);
+class BuilderState;
+
+RefPtr<TransformOperation> createTransformOperation(const CSSValue&, BuilderState&);
+TransformOperations createTransformOperations(const CSSValue&, BuilderState&);
 
 } // namespace Style
 } // namespace WebCore


### PR DESCRIPTION
#### 00b74e1a7b8cb148b8500e731132c1d881c21ab4
<pre>
CSS TypedOM crash under BuilderFunctions::applyValueTranslate
<a href="https://bugs.webkit.org/show_bug.cgi?id=294670">https://bugs.webkit.org/show_bug.cgi?id=294670</a>
<a href="https://rdar.apple.com/146650025">rdar://146650025</a>

Reviewed by Darin Adler.

Use BuilderConverter::requiredDowncast&lt;&gt; to check for correct types when building transforms.

* LayoutTests/fast/css/cssom-translate-crash-expected.txt: Added.
* LayoutTests/fast/css/cssom-translate-crash.html: Added.
* Source/WebCore/css/DOMMatrixReadOnly.cpp:
(WebCore::DOMMatrixReadOnly::parseStringIntoAbstractMatrix):
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::consumeTypedCustomPropertyValue):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Transform.cpp:
(WebCore::CSSPropertyParserHelpers::parseTransformRaw):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Transform.h:
* Source/WebCore/css/query/ContainerQueryFeatures.cpp:
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertTransform):
* Source/WebCore/style/StyleBuilderState.h:
(WebCore::Style::BuilderState::parentStyle const):
(WebCore::Style::BuilderState::document const):
(WebCore::Style::BuilderState::protectedDocument const):

Make it simpler to construct a dummy BuilderState without Builder.

* Source/WebCore/style/StyleCustomPropertyRegistry.cpp:
(WebCore::Style::CustomPropertyRegistry::parseInitialValue):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::builderContext):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveAgainInDifferentContext):
(WebCore::Style::TreeResolver::applyCascadeAfterAnimation):
* Source/WebCore/style/TransformOperationsBuilder.cpp:
(WebCore::Style::createMatrixTransformOperation):
(WebCore::Style::createMatrix3dTransformOperation):
(WebCore::Style::createRotateTransformOperation):
(WebCore::Style::createRotate3dTransformOperation):
(WebCore::Style::createRotateXTransformOperation):
(WebCore::Style::createRotateYTransformOperation):
(WebCore::Style::createRotateZTransformOperation):
(WebCore::Style::createSkewTransformOperation):
(WebCore::Style::createSkewXTransformOperation):
(WebCore::Style::createSkewYTransformOperation):
(WebCore::Style::createScaleTransformOperation):
(WebCore::Style::createScale3dTransformOperation):
(WebCore::Style::createScaleXTransformOperation):
(WebCore::Style::createScaleYTransformOperation):
(WebCore::Style::createScaleZTransformOperation):
(WebCore::Style::createTranslateTransformOperation):
(WebCore::Style::createTranslate3dTransformOperation):
(WebCore::Style::createTranslateXTransformOperation):
(WebCore::Style::createTranslateYTransformOperation):
(WebCore::Style::createTranslateZTransformOperation):
(WebCore::Style::createPerspectiveTransformOperation):

Pass BuilderState to various create* functions and use requiredFunctionDowncast&lt;&gt; for checked safe downcasts.
Return a RefPtr instead of a Ref.

(WebCore::Style::createTransformOperation):
(WebCore::Style::createTransformOperations):
(WebCore::Style::resolveAsNumberAtIndex): Deleted.
* Source/WebCore/style/TransformOperationsBuilder.h:

Canonical link: <a href="https://commits.webkit.org/296528@main">https://commits.webkit.org/296528@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da024d5b708346a46247471c414dbea460a2d84a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108818 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18903 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114026 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/59179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110781 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29162 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37042 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/82679 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/59179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111766 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23170 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98010 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63118 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22593 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/16148 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58730 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/92541 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16196 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117147 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35868 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26491 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/91699 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36241 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94277 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91509 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23294 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36402 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14158 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35768 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/41300 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35470 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38815 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37155 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->