### PR TITLE
[WPE] Measure browser binary size as part of the benchmark tests on the RPi bots

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/benchmark_results.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/benchmark_results.py
@@ -43,6 +43,7 @@ class BenchmarkResults(object):
         'Malloc': 'B',
         'Heap': 'B',
         'Allocations': 'B',
+        'Size': 'B',
         'Score': 'pt',
         'Power': 'W',
     }

--- a/Tools/Scripts/webkitpy/browserperfdash/plans/browser_binary_size.py
+++ b/Tools/Scripts/webkitpy/browserperfdash/plans/browser_binary_size.py
@@ -1,0 +1,86 @@
+# Copyright (C) 2025 Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import json
+import os
+from webkitpy.common.host import Host
+from webkitpy.port import configuration_options, platform_options, factory
+from webkitpy.binary_bundling.ldd import SharedObjectResolver
+
+PLUGIN_NAME = "browser-binary-size"
+
+
+def generate_json_for_benchmark(basename_sizes):
+    benchmark_json = {PLUGIN_NAME: {"metrics": {"Size": ["Total"]}, "tests": {}}}
+    test_data_entry = benchmark_json[PLUGIN_NAME]["tests"]
+    for browser_object in basename_sizes:
+        assert(browser_object not in test_data_entry), f"browser_object {browser_object} should be unique"
+        test_data_entry[browser_object] = {"metrics": {"Size": {"current": [basename_sizes[browser_object]]}}}
+    return benchmark_json
+
+
+def get_basenames_and_sizes(path_list):
+    basename_sizes = {}
+    for object_path in path_list:
+        object_base = os.path.basename(object_path)
+        if object_base in basename_sizes:
+            raise RuntimeError(f'There are repeated objects on the list. Object {object_path} is at least twice')
+        basename_sizes[object_base] = os.path.getsize(object_path)
+    return basename_sizes
+
+
+def get_browser_relevant_objects_glib(browser_driver):
+    required_binary = 'Tools/Scripts/run-minibrowser'
+    if not browser_driver.process_name.endswith(required_binary):
+        raise NotImplementedError(f'Getting the browser size data for browser "{browser_name}" is only supported when running the browser via "{required_binary}" and the driver was going to run "{browser_driver.process_name}"')
+    browser_relevant_objects = []
+    port_name = 'gtk' if browser_driver.browser_name == 'minibrowser-gtk' else 'wpe'
+    port_driver = factory.PortFactory(Host()).get(port_name)
+    browser_path = port_driver.get_browser_path('cog' if browser_driver.browser_name == 'cog' else 'MiniBrowser')
+    browser_relevant_objects.append(browser_path)
+    browser_env = port_driver.setup_environ_for_server()
+    libraries, interpreter = SharedObjectResolver('ldd', browser_env).get_libs_and_interpreter(browser_path)
+    browser_build_dir = port_driver._build_path()
+    for library in libraries:
+        if library.startswith(browser_build_dir):
+            browser_relevant_objects.append(library)
+    return browser_relevant_objects
+
+
+def run(browser_driver, results_file):
+    if browser_driver.platform == "linux" and browser_driver.browser_name in ['minibrowser-wpe', 'cog', 'minibrowser-gtk']:
+        browser_relevant_objects = get_browser_relevant_objects_glib(browser_driver)
+    else:
+        raise NotImplementedError(f'Getting the browser size data for browser "{browser_driver.browser_name}" and platform "{browser_driver.platform}" is not implemented')
+
+    browser_objects_sizes = get_basenames_and_sizes(browser_relevant_objects)
+    benchmark_output = generate_json_for_benchmark(browser_objects_sizes)
+    with open(results_file, "w") as f:
+        json.dump(benchmark_output, f, indent=2)
+
+
+# Register the plugin
+def register():
+    return {
+        "name": PLUGIN_NAME,
+        "run": run
+    }

--- a/Tools/Scripts/webkitpy/port/gtk.py
+++ b/Tools/Scripts/webkitpy/port/gtk.py
@@ -175,8 +175,11 @@ class GtkPort(GLibPort):
         configuration['version_name'] = self._display_server.capitalize() if self._display_server else 'Xvfb'
         return configuration
 
+    def get_browser_path(self, browser_name):
+        return self._build_path('bin', browser_name)
+
     def run_minibrowser(self, args):
-        miniBrowser = self._build_path('bin', 'MiniBrowser')
+        miniBrowser = self.get_browser_path('MiniBrowser')
         if not self._filesystem.isfile(miniBrowser):
             print("%s not found... Did you run build-webkit?" % miniBrowser)
             return 1

--- a/Tools/Scripts/webkitpy/port/wpe.py
+++ b/Tools/Scripts/webkitpy/port/wpe.py
@@ -111,6 +111,9 @@ class WPEPort(GLibPort):
     def cog_path_to(self, *components):
         return self._build_path('Tools', 'cog-prefix', 'src', 'cog-build', *components)
 
+    def get_browser_path(self, browser_name):
+        return self.cog_path_to('launcher', browser_name) if browser_name == 'cog' else self._build_path('bin', browser_name)
+
     def browser_name(self):
         """Returns the lower case name of the browser to be used (Cog or MiniBrowser)
 
@@ -147,7 +150,7 @@ class WPEPort(GLibPort):
         miniBrowser = None
 
         if self.browser_name() == "cog":
-            miniBrowser = self.cog_path_to('launcher', 'cog')
+            miniBrowser = self.get_browser_path("cog")
             if not self._filesystem.isfile(miniBrowser):
                 _log.warning("Cog not found 😢. If you wish to enable it, rebuild with `-DENABLE_COG=ON`. Falling back to good old MiniBrowser")
                 miniBrowser = None
@@ -159,7 +162,7 @@ class WPEPort(GLibPort):
 
         if not miniBrowser:
             print("Using default MiniBrowser")
-            miniBrowser = self._build_path('bin', 'MiniBrowser')
+            miniBrowser = self.get_browser_path("MiniBrowser")
             if not self._filesystem.isfile(miniBrowser):
                 _log.warning("%s not found... Did you run build-webkit?" % miniBrowser)
                 return 1

--- a/Tools/Scripts/webkitpy/port/wpe_unittest.py
+++ b/Tools/Scripts/webkitpy/port/wpe_unittest.py
@@ -155,3 +155,13 @@ class WPEPortTest(port_testcase.PortTestCase):
                 self.assertTrue(url in mock_command)
                 self.assertFalse('--platform' in mock_command)
                 self.assertFalse('-P' in mock_command)
+
+    def test_get_browser_path(self):
+        port = self.make_port()
+        self._mock_port_cog_is_built(port)
+        # do not rename or remove port.get_browser_path() without also
+        # updating webkitpy/browserperfdash/plans/browser_binary_size.py
+        mb_path = port.get_browser_path('MiniBrowser')
+        self.assertTrue(mb_path.endswith('/MiniBrowser'))
+        cog_path = port.get_browser_path('cog')
+        self.assertTrue(cog_path.endswith('/cog'))


### PR DESCRIPTION
#### 1dfcb0e870a6cb8cf0a3ec2790d72394242af13d
<pre>
[WPE] Measure browser binary size as part of the benchmark tests on the RPi bots
<a href="https://bugs.webkit.org/show_bug.cgi?id=294625">https://bugs.webkit.org/show_bug.cgi?id=294625</a>

Reviewed by Nikolas Zimmermann.

This patch implements a new benchmark plan named &apos;browser-binary-size&apos; that can
be run with the script browserperfdash-benchmark and which will gather the size
in bytes of the browser and the relevant browser libraries and send those to
the dashboard. By relevant browser libraries we understand those that are not
provided by the system or the third-party libraries system (jhbuild/flatpak)

An example of the data that it sends in the case of WPE MiniBrowser is this
one:

Size:Total: 179MB
     MiniBrowser:Size: 3.51MB
     libWPEPlatform-2.0.so.0:Size: 3.62MB
     libWPEWebKit-2.0.so.1:Size: 172MB

Note: it sends the data in bytes, above is the pretty-print version of it.

The idea is to run this &apos;browser-binary-size&apos; report continously as part of
the battery of benchmark tests that we run on the build.webkit.org CI and
send this data to the browserperfdash dashboard to keep a track of this
sizes and be able to easily tell when the sizes changed.

In order to accomodate this new type of benchmark plan in the design of
browserperfdash a new type of plan plugins is created. Those plugins
consist on independent python files that register themselves with a
plugin-name string and a entry-point function that receive as parameters
the browser object (from run-benchmark) and the path to a temporal file
where it should write the data with the results in json format.

For now only one of this plugins is there: &apos;browser-binary-size&apos;, but
the design allows to easily ship more random plugin-plans in the future.

This new type of plan-plugins are meant to measure something in the browser
(like binary-size) but they don&apos;t need to execute the browser itself.
This contrasts with the existing run-benchmark plans, which are meant to
execute the browser on a specific webpage that runs some benchmarks within
the browser.

Also, a few related or needed features are implemented, like:

  - Support on browserperfdash-benchmark for saving the json results sent to
the server in a local directory
  - Support on browserperfdash-benchmark for reading and dumping to stdout the
parsed information from those saved json results

* Tools/Scripts/webkitpy/benchmark_runner/benchmark_results.py:
(BenchmarkResults):
* Tools/Scripts/webkitpy/browserperfdash/browserperfdash_runner.py:
(parse_args):
(BrowserPerfDashRunner.__init__):
(BrowserPerfDashRunner._get_plan_version_hash):
(BrowserPerfDashRunner):
(BrowserPerfDashRunner._load_and_list_plan_plugins):
(BrowserPerfDashRunner._is_benchmark_runner_plan):
(BrowserPerfDashRunner.is_browserperfdash_runner_plan):
(BrowserPerfDashRunner.available_plans):
(BrowserPerfDashRunner._run_benchmark_runner_plan):
(BrowserPerfDashRunner._run_plan):
(BrowserPerfDashRunner._save_to_results_directory):
(BrowserPerfDashRunner.run):
(read_results_json):
(main):
(BrowserPerfDashRunner._get_test_version_string): Deleted.
* Tools/Scripts/webkitpy/browserperfdash/plans/browser_binary_size.py: Added.
(generate_json_for_benchmark):
(get_basenames_and_sizes):
(get_browser_relevant_objects_glib):
(run):
(register):
* Tools/Scripts/webkitpy/port/gtk.py:
(GtkPort.get_browser_path):
(GtkPort.run_minibrowser):
* Tools/Scripts/webkitpy/port/wpe.py:
(WPEPort.get_browser_path):
(WPEPort.run_minibrowser):
* Tools/Scripts/webkitpy/port/wpe_unittest.py:
(WPEPortTest.test_browser_cog_parameters_platform_override_via_environ):
(WPEPortTest):
(WPEPortTest.test_get_browser_path):

Canonical link: <a href="https://commits.webkit.org/296425@main">https://commits.webkit.org/296425@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/944106da42ecd8b278e8a64b4a44d0a11a863c2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108506 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28167 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18591 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/113715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/58904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110469 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28856 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36719 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/113715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/58904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111454 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/22894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/97734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/113715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/107938 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/22311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/15872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/58430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/92264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/15925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/116836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35560 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26205 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/116836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35933 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/94008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/116836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/36125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/13889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17519 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35462 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35171 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38523 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36852 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->