### PR TITLE
[Style] Convert SVGPaint to use strong style types

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -213,6 +213,7 @@ set(WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/style/values/scroll-snap"
     "${WEBCORE_DIR}/style/values/shapes"
     "${WEBCORE_DIR}/style/values/sizing"
+    "${WEBCORE_DIR}/style/values/svg"
     "${WEBCORE_DIR}/style/values/text-decoration"
     "${WEBCORE_DIR}/style/values/transforms"
     "${WEBCORE_DIR}/svg"

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2808,6 +2808,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/sizing/StyleMinimumSize.h
     style/values/sizing/StylePreferredSize.h
 
+    style/values/svg/StyleSVGPaint.h
+
     style/values/text-decoration/StyleTextShadow.h
 
     style/values/transforms/StylePerspective.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3197,6 +3197,7 @@ style/values/shapes/StyleXywhFunction.cpp
 style/values/sizing/StyleMaximumSize.cpp
 style/values/sizing/StyleMinimumSize.cpp
 style/values/sizing/StylePreferredSize.cpp
+style/values/svg/StyleSVGPaint.cpp
 style/values/text-decoration/StyleTextShadow.cpp
 style/values/transforms/StyleRotate.cpp
 style/values/transforms/StylePerspective.cpp

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -2121,7 +2121,7 @@
             "initial": "transparent",
             "codegen-properties": {
                 "accepts-quirky-color": true,
-                "animation-wrapper": "VisitedAffectedStyleColorWrapper",
+                "animation-wrapper": "VisitedAffectedStyleTypeWrapper<Color>",
                 "visited-link-color-support": true,
                 "color-property": true,
                 "disables-native-appearance": true,
@@ -2675,7 +2675,7 @@
                     "resolver": "bottom"
                 },
                 "accepts-quirky-color": true,
-                "animation-wrapper": "VisitedAffectedStyleColorWrapper",
+                "animation-wrapper": "VisitedAffectedStyleTypeWrapper<Color>",
                 "render-style-initial": "currentColor",
                 "visited-link-color-support": true,
                 "color-property": true,
@@ -3256,7 +3256,7 @@
                     "resolver": "left"
                 },
                 "accepts-quirky-color": true,
-                "animation-wrapper": "VisitedAffectedStyleColorWrapper",
+                "animation-wrapper": "VisitedAffectedStyleTypeWrapper<Color>",
                 "render-style-initial": "currentColor",
                 "visited-link-color-support": true,
                 "color-property": true,
@@ -3365,7 +3365,7 @@
                     "resolver": "right"
                 },
                 "accepts-quirky-color": true,
-                "animation-wrapper": "VisitedAffectedStyleColorWrapper",
+                "animation-wrapper": "VisitedAffectedStyleTypeWrapper<Color>",
                 "render-style-initial": "currentColor",
                 "visited-link-color-support": true,
                 "color-property": true,
@@ -3529,7 +3529,7 @@
                     "resolver": "top"
                 },
                 "accepts-quirky-color": true,
-                "animation-wrapper": "VisitedAffectedStyleColorWrapper",
+                "animation-wrapper": "VisitedAffectedStyleTypeWrapper<Color>",
                 "render-style-initial": "currentColor",
                 "visited-link-color-support": true,
                 "color-property": true,
@@ -4450,10 +4450,10 @@
                 }
             ],
             "codegen-properties": {
-                "animation-wrapper": "VisitedAffectedSVGPaintWrapper",
-                "animation-wrapper-requires-override-parameters": ["CSSPropertyID::CSSPropertyFill", "&RenderStyle::fillPaintType", "&RenderStyle::fillPaintColor", "&RenderStyle::setFillPaintColor", "&RenderStyle::visitedFillPaintType", "&RenderStyle::visitedFillPaintColor", "&RenderStyle::setVisitedFillPaintColor"],
+                "animation-wrapper": "VisitedAffectedStyleTypeWrapper<SVGPaint>",
+                "animation-wrapper-requires-override-parameters": ["CSSPropertyID::CSSPropertyFill", "&RenderStyle::fill", "&RenderStyle::setFill", "&RenderStyle::visitedLinkFill", "&RenderStyle::setVisitedLinkFill"],
                 "style-builder-custom": "All",
-                "style-extractor-custom": true,
+                "style-extractor-converter": "StyleType<SVGPaint>",
                 "svg": true,
                 "color-property": true,
                 "parser-grammar": "none | <color> | [ <url> [ none | <color> ]? ]",
@@ -4529,7 +4529,7 @@
             "animation-type": "by computed value",
             "initial": "black",
             "codegen-properties": {
-                "animation-wrapper": "StyleColorWrapper",
+                "animation-wrapper": "StyleTypeWrapper<Color>",
                 "animation-wrapper-requires-render-style": true,
                 "svg": true,
                 "color-property": true,
@@ -4960,7 +4960,7 @@
             "animation-type": "by computed value",
             "initial": "white",
             "codegen-properties": {
-                "animation-wrapper": "StyleColorWrapper",
+                "animation-wrapper": "StyleTypeWrapper<Color>",
                 "animation-wrapper-requires-render-style": true,
                 "svg": true,
                 "color-property": true,
@@ -6625,7 +6625,7 @@
             "initial": "currentColor",
             "initial-comment": "Current spec initial value is 'auto'",
             "codegen-properties": {
-                "animation-wrapper": "VisitedAffectedStyleColorWrapper",
+                "animation-wrapper": "VisitedAffectedStyleTypeWrapper<Color>",
                 "render-style-initial": "currentColor",
                 "visited-link-color-support": true,
                 "color-property": true,
@@ -7485,7 +7485,7 @@
             "animation-type": "by computed value",
             "initial": "black",
             "codegen-properties": {
-                "animation-wrapper": "StyleColorWrapper",
+                "animation-wrapper": "StyleTypeWrapper<Color>",
                 "animation-wrapper-requires-render-style": true,
                 "svg": true,
                 "color-property": true,
@@ -7527,10 +7527,10 @@
                 }
             ],
             "codegen-properties": {
-                "animation-wrapper": "VisitedAffectedSVGPaintWrapper",
-                "animation-wrapper-requires-override-parameters": ["CSSPropertyID::CSSPropertyStroke", "&RenderStyle::strokePaintType", "&RenderStyle::strokePaintColor", "&RenderStyle::setStrokePaintColor", "&RenderStyle::visitedStrokePaintType", "&RenderStyle::visitedStrokePaintColor", "&RenderStyle::setVisitedStrokePaintColor"],
+                "animation-wrapper": "VisitedAffectedStyleTypeWrapper<SVGPaint>",
+                "animation-wrapper-requires-override-parameters": ["CSSPropertyID::CSSPropertyStroke", "&RenderStyle::stroke", "&RenderStyle::setStroke", "&RenderStyle::visitedLinkStroke", "&RenderStyle::setVisitedLinkStroke"],
                 "style-builder-custom": "All",
-                "style-extractor-custom": true,
+                "style-extractor-converter": "StyleType<SVGPaint>",
                 "svg": true,
                 "color-property": true,
                 "parser-grammar": "none | <color> | [ <url> [ none | <color> ]? ]",
@@ -7666,8 +7666,8 @@
             "inherited": true,
             "initial": "transparent",
             "codegen-properties": {
-                "animation-wrapper": "StyleColorWrapper",
-                "animation-wrapper-comment": "FIXME: Why doesn't this use VisitedAffectedStyleColorWrapper",
+                "animation-wrapper": "StyleTypeWrapper<Color>",
+                "animation-wrapper-comment": "FIXME: Why doesn't this use VisitedAffectedStyleTypeWrapper<Color>",
                 "animation-wrapper-requires-override-parameters": ["CSSPropertyID::CSSPropertyStrokeColor", "&RenderStyle::strokeColor", "&RenderStyle::setStrokeColor"],
                 "style-builder-custom": "Value",
                 "visited-link-color-support": true,
@@ -9270,7 +9270,7 @@
                 "aliases": [
                     "-webkit-column-rule-color"
                 ],
-                "animation-wrapper": "VisitedAffectedStyleColorWrapper",
+                "animation-wrapper": "VisitedAffectedStyleTypeWrapper<Color>",
                 "render-style-initial": "currentColor",
                 "visited-link-color-support": true,
                 "color-property": true,
@@ -10879,7 +10879,7 @@
                 "aliases": [
                     "-webkit-text-decoration-color"
                 ],
-                "animation-wrapper": "VisitedAffectedStyleColorWrapper",
+                "animation-wrapper": "VisitedAffectedStyleTypeWrapper<Color>",
                 "render-style-initial": "currentColor",
                 "visited-link-color-support": true,
                 "color-property": true,
@@ -11033,7 +11033,7 @@
                     "-epub-text-emphasis-color",
                     "-webkit-text-emphasis-color"
                 ],
-                "animation-wrapper": "VisitedAffectedStyleColorWrapper",
+                "animation-wrapper": "VisitedAffectedStyleTypeWrapper<Color>",
                 "render-style-initial": "currentColor",
                 "visited-link-color-support": true,
                 "color-property": true,
@@ -11085,7 +11085,7 @@
             "inherited": true,
             "initial": "currentColor",
             "codegen-properties": {
-                "animation-wrapper": "VisitedAffectedStyleColorWrapper",
+                "animation-wrapper": "VisitedAffectedStyleTypeWrapper<Color>",
                 "render-style-initial": "currentColor",
                 "visited-link-color-support": true,
                 "color-property": true,
@@ -11131,7 +11131,7 @@
             "inherited": true,
             "initial": "currentColor",
             "codegen-properties": {
-                "animation-wrapper": "VisitedAffectedStyleColorWrapper",
+                "animation-wrapper": "VisitedAffectedStyleTypeWrapper<Color>",
                 "render-style-initial": "currentColor",
                 "visited-link-color-support": true,
                 "color-property": true,

--- a/Source/WebCore/css/CSSValueList.h
+++ b/Source/WebCore/css/CSSValueList.h
@@ -33,7 +33,7 @@ using CSSValueListBuilder = Vector<Ref<CSSValue>, CSSValueListBuilderInlineCapac
 class CSSValueContainingVector : public CSSValue {
 public:
     unsigned size() const { return m_size; }
-    const CSSValue& operator[](unsigned index) const;
+    const CSSValue& operator[](unsigned index) const LIFETIME_BOUND;
 
     struct iterator {
         using iterator_category = std::forward_iterator_tag;
@@ -72,9 +72,9 @@ public:
 
     // Consider removing these functions and having callers use size() and operator[] instead.
     unsigned length() const { return size(); }
-    const CSSValue* item(unsigned index) const { return index < size() ? &(*this)[index] : nullptr; }
+    const CSSValue* item(unsigned index) const LIFETIME_BOUND { return index < size() ? &(*this)[index] : nullptr; }
     RefPtr<const CSSValue> protectedItem(unsigned index) const { return item(index); }
-    const CSSValue* itemWithoutBoundsCheck(unsigned index) const { return &(*this)[index]; }
+    const CSSValue* itemWithoutBoundsCheck(unsigned index) const LIFETIME_BOUND { return &(*this)[index]; }
 
     IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>&) const;
 

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -550,10 +550,8 @@ std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> consume
             auto doubleValue = downcast<CSSPrimitiveValue>(value).resolveAsResolution(builderState.cssToLengthConversionData());
             return { Style::CustomProperty::Numeric { doubleValue, CSSUnitType::CSS_DPPX } };
         }
-        case CSSCustomPropertySyntax::Type::Color: {
-            auto color = builderState.createStyleColor(value, Style::ForVisitedLink::No);
-            return { WTFMove(color) };
-        }
+        case CSSCustomPropertySyntax::Type::Color:
+            return { Style::toStyleFromCSSValue<Style::Color>(builderState, value, Style::ForVisitedLink::No) };
         case CSSCustomPropertySyntax::Type::Image: {
             auto styleImage = builderState.createStyleImage(value);
             if (!styleImage)

--- a/Source/WebCore/css/scripts/process-css-properties.py
+++ b/Source/WebCore/css/scripts/process-css-properties.py
@@ -3939,9 +3939,9 @@ class GenerateStyleBuilderGenerated:
 
     def _generate_color_property_value_setter(self, to, property, value):
         to.write(f"if (builderState.applyPropertyToRegularStyle())")
-        to.write(f"    builderState.style().{property.codegen_properties.render_style_setter}(builderState.createStyleColor({value}, ForVisitedLink::No));")
+        to.write(f"    builderState.style().{property.codegen_properties.render_style_setter}(BuilderConverter::convertStyleType<Color>(builderState, {value}, ForVisitedLink::No));")
         to.write(f"if (builderState.applyPropertyToVisitedLinkStyle())")
-        to.write(f"    builderState.style().setVisitedLink{property.codegen_properties.render_style_name_for_methods}(builderState.createStyleColor({value}, ForVisitedLink::Yes));")
+        to.write(f"    builderState.style().setVisitedLink{property.codegen_properties.render_style_name_for_methods}(BuilderConverter::convertStyleType<Color>(builderState, {value}, ForVisitedLink::Yes));")
 
     # Animation property setters.
 
@@ -4149,7 +4149,7 @@ class GenerateStyleBuilderGenerated:
                 elif property.codegen_properties.style_builder_conditional_converter:
                     return f"WTFMove(convertedValue.value())"
                 elif property.codegen_properties.color_property and not property.codegen_properties.visited_link_color_support:
-                    return f"builderState.createStyleColor(value, ForVisitedLink::No)"
+                    return f"BuilderConverter::convertStyleType<Color>(builderState, value, ForVisitedLink::No)"
                 else:
                     return "fromCSSValueDeducingType(builderState, value)"
 

--- a/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/StyleBuilderGenerated.cpp
+++ b/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/StyleBuilderGenerated.cpp
@@ -254,7 +254,7 @@ public:
     }
     static void applyValueTestColor(BuilderState& builderState, CSSValue& value)
     {
-        builderState.style().setTestColor(builderState.createStyleColor(value, ForVisitedLink::No));
+        builderState.style().setTestColor(BuilderConverter::convertStyleType<Color>(builderState, value, ForVisitedLink::No));
     }
     static void applyInitialTestColorAllowsTypesAbsolute(BuilderState& builderState)
     {
@@ -266,7 +266,7 @@ public:
     }
     static void applyValueTestColorAllowsTypesAbsolute(BuilderState& builderState, CSSValue& value)
     {
-        builderState.style().setTestColorAllowsTypesAbsolute(builderState.createStyleColor(value, ForVisitedLink::No));
+        builderState.style().setTestColorAllowsTypesAbsolute(BuilderConverter::convertStyleType<Color>(builderState, value, ForVisitedLink::No));
     }
     static void applyInitialTestColorPropertyWithNoVisitedLinkSupport(BuilderState& builderState)
     {
@@ -278,7 +278,7 @@ public:
     }
     static void applyValueTestColorPropertyWithNoVisitedLinkSupport(BuilderState& builderState, CSSValue& value)
     {
-        builderState.style().setTestColorPropertyWithNoVisitedLinkSupport(builderState.createStyleColor(value, ForVisitedLink::No));
+        builderState.style().setTestColorPropertyWithNoVisitedLinkSupport(BuilderConverter::convertStyleType<Color>(builderState, value, ForVisitedLink::No));
     }
     static void applyInitialTestColorPropertyWithVisitedLinkSupport(BuilderState& builderState)
     {
@@ -297,9 +297,9 @@ public:
     static void applyValueTestColorPropertyWithVisitedLinkSupport(BuilderState& builderState, CSSValue& value)
     {
         if (builderState.applyPropertyToRegularStyle())
-            builderState.style().setTestColorPropertyWithVisitedLinkSupport(builderState.createStyleColor(fromCSSValueDeducingType(builderState, value), ForVisitedLink::No));
+            builderState.style().setTestColorPropertyWithVisitedLinkSupport(BuilderConverter::convertStyleType<Color>(builderState, fromCSSValueDeducingType(builderState, value), ForVisitedLink::No));
         if (builderState.applyPropertyToVisitedLinkStyle())
-            builderState.style().setVisitedLinkTestColorPropertyWithVisitedLinkSupport(builderState.createStyleColor(fromCSSValueDeducingType(builderState, value), ForVisitedLink::Yes));
+            builderState.style().setVisitedLinkTestColorPropertyWithVisitedLinkSupport(BuilderConverter::convertStyleType<Color>(builderState, fromCSSValueDeducingType(builderState, value), ForVisitedLink::Yes));
     }
     static void applyInitialTestCustomExtractor(BuilderState& builderState)
     {

--- a/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/StyleExtractorGenerated.cpp
+++ b/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/StyleExtractorGenerated.cpp
@@ -5,6 +5,7 @@
 
 #include "CSSPrimitiveValueMappings.h"
 #include "CSSProperty.h"
+#include "ColorSerialization.h"
 #include "RenderStyle.h"
 #include "StyleExtractorConverter.h"
 #include "StyleExtractorCustom.h"
@@ -168,42 +169,42 @@ public:
     }
     static RefPtr<CSSValue> extractTestColor(ExtractorState& extractorState)
     {
-        return ExtractorConverter::convertColor(extractorState, extractorState.style.testColor());
+        return ExtractorConverter::convertStyleType<Color>(extractorState, extractorState.style.testColor());
     }
     static void extractTestColorSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
     {
-        ExtractorSerializer::serializeColor(extractorState, builder, context, extractorState.style.testColor());
+        ExtractorSerializer::serializeStyleType<Color>(extractorState, builder, context, extractorState.style.testColor());
     }
     static RefPtr<CSSValue> extractTestColorAllowsTypesAbsolute(ExtractorState& extractorState)
     {
-        return ExtractorConverter::convertColor(extractorState, extractorState.style.testColorAllowsTypesAbsolute());
+        return ExtractorConverter::convertStyleType<Color>(extractorState, extractorState.style.testColorAllowsTypesAbsolute());
     }
     static void extractTestColorAllowsTypesAbsoluteSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
     {
-        ExtractorSerializer::serializeColor(extractorState, builder, context, extractorState.style.testColorAllowsTypesAbsolute());
+        ExtractorSerializer::serializeStyleType<Color>(extractorState, builder, context, extractorState.style.testColorAllowsTypesAbsolute());
     }
     static RefPtr<CSSValue> extractTestColorPropertyWithNoVisitedLinkSupport(ExtractorState& extractorState)
     {
-        return ExtractorConverter::convertColor(extractorState, extractorState.style.testColorPropertyWithNoVisitedLinkSupport());
+        return ExtractorConverter::convertStyleType<Color>(extractorState, extractorState.style.testColorPropertyWithNoVisitedLinkSupport());
     }
     static void extractTestColorPropertyWithNoVisitedLinkSupportSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
     {
-        ExtractorSerializer::serializeColor(extractorState, builder, context, extractorState.style.testColorPropertyWithNoVisitedLinkSupport());
+        ExtractorSerializer::serializeStyleType<Color>(extractorState, builder, context, extractorState.style.testColorPropertyWithNoVisitedLinkSupport());
     }
     static RefPtr<CSSValue> extractTestColorPropertyWithVisitedLinkSupport(ExtractorState& extractorState)
     {
         if (extractorState.allowVisitedStyle) {
             return extractorState.pool.createColorValue(extractorState.style.visitedDependentColor(CSSPropertyID::CSSPropertyTestColorPropertyWithVisitedLinkSupport));
         }
-        return ExtractorConverter::convertColor(extractorState, extractorState.style.testColorPropertyWithVisitedLinkSupport());
+        return ExtractorConverter::convertStyleType<Color>(extractorState, extractorState.style.testColorPropertyWithVisitedLinkSupport());
     }
     static void extractTestColorPropertyWithVisitedLinkSupportSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
     {
         if (extractorState.allowVisitedStyle) {
-            builder.append(serializationForCSS(extractorState.style.visitedDependentColor(CSSPropertyID::CSSPropertyTestColorPropertyWithVisitedLinkSupport)));
+            builder.append(WebCore::serializationForCSS(extractorState.style.visitedDependentColor(CSSPropertyID::CSSPropertyTestColorPropertyWithVisitedLinkSupport)));
             return;
         }
-        ExtractorSerializer::serializeColor(extractorState, builder, context, extractorState.style.testColorPropertyWithVisitedLinkSupport());
+        ExtractorSerializer::serializeStyleType<Color>(extractorState, builder, context, extractorState.style.testColorPropertyWithVisitedLinkSupport());
     }
     static RefPtr<CSSValue> extractTestExtractorConverter(ExtractorState& extractorState)
     {

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -281,20 +281,20 @@ static bool colorIsChallengingToHighlight(const Color& color)
 
 static bool styleIsChallengingToHighlight(const RenderStyle& style)
 {
-    auto fillPaintType = style.fillPaintType();
+    auto fillPaintType = style.fill().type;
 
-    if (fillPaintType == SVGPaintType::None) {
-        auto strokePaintType = style.strokePaintType();
-        if (strokePaintType != SVGPaintType::RGBColor && strokePaintType != SVGPaintType::CurrentColor)
+    if (fillPaintType == Style::SVGPaintType::None) {
+        auto strokePaintType = style.stroke().type;
+        if (strokePaintType != Style::SVGPaintType::RGBColor && strokePaintType != Style::SVGPaintType::CurrentColor)
             return false;
 
-        return colorIsChallengingToHighlight(style.colorResolvingCurrentColor(style.strokePaintColor()));
+        return colorIsChallengingToHighlight(style.colorResolvingCurrentColor(style.stroke().color));
     }
 
-    if (fillPaintType != SVGPaintType::RGBColor && fillPaintType != SVGPaintType::CurrentColor)
+    if (fillPaintType != Style::SVGPaintType::RGBColor && fillPaintType != Style::SVGPaintType::CurrentColor)
         return false;
 
-    return colorIsChallengingToHighlight(style.colorResolvingCurrentColor(style.fillPaintColor()));
+    return colorIsChallengingToHighlight(style.colorResolvingCurrentColor(style.fill().color));
 }
 
 static bool isGuardContainer(const Element& element)

--- a/Source/WebCore/rendering/ReferencedSVGResources.cpp
+++ b/Source/WebCore/rendering/ReferencedSVGResources.cpp
@@ -169,14 +169,14 @@ ReferencedSVGResources::SVGElementIdentifierAndTagPairs ReferencedSVGResources::
         }
     }
 
-    if (svgStyle.fillPaintType() >= SVGPaintType::URINone) {
-        auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(svgStyle.fillPaintUri(), document);
+    if (svgStyle.fill().type >= Style::SVGPaintType::URINone) {
+        auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(svgStyle.fill().url, document);
         if (!resourceID.isEmpty())
             referencedResources.append({ resourceID, { SVGNames::linearGradientTag, SVGNames::radialGradientTag, SVGNames::patternTag } });
     }
 
-    if (svgStyle.strokePaintType() >= SVGPaintType::URINone) {
-        auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(svgStyle.strokePaintUri(), document);
+    if (svgStyle.stroke().type >= Style::SVGPaintType::URINone) {
+        auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(svgStyle.stroke().url, document);
         if (!resourceID.isEmpty())
             referencedResources.append({ resourceID, { SVGNames::linearGradientTag, SVGNames::radialGradientTag, SVGNames::patternTag } });
     }

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -552,16 +552,16 @@ RenderSVGResourcePaintServer* RenderLayerModelObject::svgFillPaintServerResource
         return nullptr;
 
     const auto& svgStyle = style.svgStyle();
-    if (svgStyle.fillPaintType() < SVGPaintType::URINone)
+    if (svgStyle.fill().type < Style::SVGPaintType::URINone)
         return nullptr;
 
-    if (RefPtr referencedElement = ReferencedSVGResources::referencedPaintServerElement(treeScopeForSVGReferences(), svgStyle.fillPaintUri())) {
+    if (RefPtr referencedElement = ReferencedSVGResources::referencedPaintServerElement(treeScopeForSVGReferences(), svgStyle.fill().url)) {
         if (auto* referencedPaintServerRenderer = dynamicDowncast<RenderSVGResourcePaintServer>(referencedElement->renderer()))
             return referencedPaintServerRenderer;
     }
 
     if (auto* element = this->element())
-        document().addPendingSVGResource(AtomString(svgStyle.fillPaintUri().resolved.string()), downcast<SVGElement>(*element));
+        document().addPendingSVGResource(AtomString(svgStyle.fill().url.resolved.string()), downcast<SVGElement>(*element));
 
     return nullptr;
 }
@@ -572,16 +572,16 @@ RenderSVGResourcePaintServer* RenderLayerModelObject::svgStrokePaintServerResour
         return nullptr;
 
     const auto& svgStyle = style.svgStyle();
-    if (svgStyle.strokePaintType() < SVGPaintType::URINone)
+    if (svgStyle.stroke().type < Style::SVGPaintType::URINone)
         return nullptr;
 
-    if (RefPtr referencedElement = ReferencedSVGResources::referencedPaintServerElement(treeScopeForSVGReferences(), svgStyle.strokePaintUri())) {
+    if (RefPtr referencedElement = ReferencedSVGResources::referencedPaintServerElement(treeScopeForSVGReferences(), svgStyle.stroke().url)) {
         if (auto* referencedPaintServerRenderer = dynamicDowncast<RenderSVGResourcePaintServer>(referencedElement->renderer()))
             return referencedPaintServerRenderer;
     }
 
     if (auto* element = this->element())
-        document().addPendingSVGResource(AtomString(svgStyle.strokePaintUri().resolved.string()), downcast<SVGElement>(*element));
+        document().addPendingSVGResource(AtomString(svgStyle.stroke().url.resolved.string()), downcast<SVGElement>(*element));
 
     return nullptr;
 }

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2940,7 +2940,7 @@ const Style::Color& RenderStyle::unresolvedColorForProperty(CSSPropertyID colorP
     case CSSPropertyBorderTopColor:
         return visitedLink ? visitedLinkBorderTopColor() : borderTopColor();
     case CSSPropertyFill:
-        return fillPaintColor();
+        return fill().color;
     case CSSPropertyFloodColor:
         return floodColor();
     case CSSPropertyLightingColor:
@@ -2950,7 +2950,7 @@ const Style::Color& RenderStyle::unresolvedColorForProperty(CSSPropertyID colorP
     case CSSPropertyStopColor:
         return stopColor();
     case CSSPropertyStroke:
-        return strokePaintColor();
+        return stroke().color;
     case CSSPropertyStrokeColor:
         return visitedLink ? visitedLinkStrokeColor() : strokeColor();
     case CSSPropertyBorderBlockEndColor:

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -200,7 +200,6 @@ enum class Resize : uint8_t;
 enum class RubyPosition : uint8_t;
 enum class RubyAlign : uint8_t;
 enum class RubyOverhang : bool;
-enum class SVGPaintType : uint8_t;
 enum class ScrollAxis : uint8_t;
 enum class ScrollSnapStop : bool;
 enum class ScrollbarWidth : uint8_t;
@@ -307,6 +306,7 @@ struct Perspective;
 struct PositionTryFallback;
 struct PreferredSize;
 struct Rotate;
+struct SVGPaint;
 struct Scale;
 struct ScopedName;
 struct ScrollMarginEdge;
@@ -1794,23 +1794,19 @@ public:
     const SVGRenderStyle& svgStyle() const { return m_svgStyle; }
     inline SVGRenderStyle& accessSVGStyle();
 
-    inline SVGPaintType fillPaintType() const;
-    inline SVGPaintType visitedFillPaintType() const;
-    inline const Style::Color& fillPaintColor() const;
-    inline const Style::Color& visitedFillPaintColor() const;
-    inline void setFillPaintColor(Style::Color&&);
-    inline void setVisitedFillPaintColor(Style::Color&&);
+    inline const Style::SVGPaint& fill() const;
+    inline const Style::SVGPaint& visitedLinkFill() const;
+    inline void setFill(Style::SVGPaint&&);
+    inline void setVisitedLinkFill(Style::SVGPaint&&);
     inline void setHasExplicitlySetColor(bool);
     inline bool hasExplicitlySetColor() const;
     inline float fillOpacity() const;
     inline void setFillOpacity(float);
 
-    inline SVGPaintType strokePaintType() const;
-    inline SVGPaintType visitedStrokePaintType() const;
-    inline const Style::Color& strokePaintColor() const;
-    inline const Style::Color& visitedStrokePaintColor() const;
-    inline void setStrokePaintColor(Style::Color&&);
-    inline void setVisitedStrokePaintColor(Style::Color&&);
+    inline const Style::SVGPaint& stroke() const;
+    inline const Style::SVGPaint& visitedLinkStroke() const;
+    inline void setStroke(Style::SVGPaint&&);
+    inline void setVisitedLinkStroke(Style::SVGPaint&&);
     inline float strokeOpacity() const;
     inline void setStrokeOpacity(float);
     inline const FixedVector<Length>& strokeDashArray() const;

--- a/Source/WebCore/rendering/style/SVGRenderStyle.cpp
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.cpp
@@ -170,12 +170,12 @@ bool SVGRenderStyle::changeRequiresLayout(const SVGRenderStyle& other) const
         return true; 
 
     // Some stroke properties, requires relayouts, as the cached stroke boundaries need to be recalculated.
-    if (m_strokeData->paintType != other.m_strokeData->paintType
-        || m_strokeData->paintUri != other.m_strokeData->paintUri
+    if (m_strokeData->paint.type != other.m_strokeData->paint.type
+        || m_strokeData->paint.url != other.m_strokeData->paint.url
         || m_strokeData->dashArray != other.m_strokeData->dashArray
         || m_strokeData->dashOffset != other.m_strokeData->dashOffset
-        || m_strokeData->visitedLinkPaintUri != other.m_strokeData->visitedLinkPaintUri
-        || m_strokeData->visitedLinkPaintType != other.m_strokeData->visitedLinkPaintType)
+        || m_strokeData->visitedLinkPaint.type != other.m_strokeData->visitedLinkPaint.type
+        || m_strokeData->visitedLinkPaint.url != other.m_strokeData->visitedLinkPaint.url)
         return true;
 
     // vector-effect changes require a re-layout.
@@ -189,16 +189,16 @@ bool SVGRenderStyle::changeRequiresRepaint(const SVGRenderStyle& other, bool cur
 {
     if (this == &other) {
         ASSERT(currentColorDiffers);
-        return containsCurrentColor(m_strokeData->paintColor)
-            || containsCurrentColor(m_strokeData->visitedLinkPaintColor)
+        return containsCurrentColor(m_strokeData->paint.color)
+            || containsCurrentColor(m_strokeData->visitedLinkPaint.color)
             || containsCurrentColor(m_miscData->floodColor)
             || containsCurrentColor(m_miscData->lightingColor)
-            || containsCurrentColor(m_fillData->paintColor);
+            || containsCurrentColor(m_fillData->paint.color); // FIXME: Should this be checking m_fillData->visitedLinkPaint.color as well?
     }
 
     if (m_strokeData->opacity != other.m_strokeData->opacity
-        || colorChangeRequiresRepaint(m_strokeData->paintColor, other.m_strokeData->paintColor, currentColorDiffers)
-        || colorChangeRequiresRepaint(m_strokeData->visitedLinkPaintColor, other.m_strokeData->visitedLinkPaintColor, currentColorDiffers))
+        || colorChangeRequiresRepaint(m_strokeData->paint.color, other.m_strokeData->paint.color, currentColorDiffers)
+        || colorChangeRequiresRepaint(m_strokeData->visitedLinkPaint.color, other.m_strokeData->visitedLinkPaint.color, currentColorDiffers))
         return true;
 
     // Painting related properties only need repaints. 
@@ -208,9 +208,9 @@ bool SVGRenderStyle::changeRequiresRepaint(const SVGRenderStyle& other, bool cur
         return true;
 
     // If fill data changes, we just need to repaint. Fill boundaries are not influenced by this, only by the Path, that RenderSVGPath contains.
-    if (m_fillData->paintType != other.m_fillData->paintType 
-        || colorChangeRequiresRepaint(m_fillData->paintColor, other.m_fillData->paintColor, currentColorDiffers)
-        || m_fillData->paintUri != other.m_fillData->paintUri 
+    if (m_fillData->paint.type != other.m_fillData->paint.type
+        || colorChangeRequiresRepaint(m_fillData->paint.color, other.m_fillData->paint.color, currentColorDiffers)
+        || m_fillData->paint.url != other.m_fillData->paint.url
         || m_fillData->opacity != other.m_fillData->opacity)
         return true;
 
@@ -242,12 +242,7 @@ void SVGRenderStyle::conservativelyCollectChangedAnimatableProperties(const SVGR
     auto conservativelyCollectChangedAnimatablePropertiesViaFillData = [&](auto& first, auto& second) {
         if (first.opacity != second.opacity)
             changingProperties.m_properties.set(CSSPropertyFillOpacity);
-        if (first.paintColor != second.paintColor
-            || first.visitedLinkPaintColor != second.visitedLinkPaintColor
-            || first.paintUri != second.paintUri
-            || first.visitedLinkPaintUri != second.visitedLinkPaintUri
-            || first.paintType != second.paintType
-            || first.visitedLinkPaintType != second.visitedLinkPaintType)
+        if (first.paint != second.paint || first.visitedLinkPaint != second.visitedLinkPaint)
             changingProperties.m_properties.set(CSSPropertyFill);
     };
 
@@ -258,12 +253,7 @@ void SVGRenderStyle::conservativelyCollectChangedAnimatableProperties(const SVGR
             changingProperties.m_properties.set(CSSPropertyStrokeDashoffset);
         if (first.dashArray != second.dashArray)
             changingProperties.m_properties.set(CSSPropertyStrokeDasharray);
-        if (first.paintColor != second.paintColor
-            || first.visitedLinkPaintColor != second.visitedLinkPaintColor
-            || first.paintUri != second.paintUri
-            || first.visitedLinkPaintUri != second.visitedLinkPaintUri
-            || first.paintType != second.paintType
-            || first.visitedLinkPaintType != second.visitedLinkPaintType)
+        if (first.paint != second.paint || first.visitedLinkPaint != second.visitedLinkPaint)
             changingProperties.m_properties.set(CSSPropertyStroke);
     };
 

--- a/Source/WebCore/rendering/style/SVGRenderStyleDefs.cpp
+++ b/Source/WebCore/rendering/style/SVGRenderStyleDefs.cpp
@@ -42,24 +42,16 @@ DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleFillData);
 
 StyleFillData::StyleFillData()
     : opacity(SVGRenderStyle::initialFillOpacity())
-    , paintColor(SVGRenderStyle::initialFillPaintColor())
-    , visitedLinkPaintColor(SVGRenderStyle::initialFillPaintColor())
-    , paintUri(SVGRenderStyle::initialFillPaintUri())
-    , visitedLinkPaintUri(SVGRenderStyle::initialFillPaintUri())
-    , paintType(SVGRenderStyle::initialFillPaintType())
-    , visitedLinkPaintType(SVGRenderStyle::initialFillPaintType())
+    , paint(SVGRenderStyle::initialFill())
+    , visitedLinkPaint(SVGRenderStyle::initialFill())
 {
 }
 
 inline StyleFillData::StyleFillData(const StyleFillData& other)
     : RefCounted<StyleFillData>()
     , opacity(other.opacity)
-    , paintColor(other.paintColor)
-    , visitedLinkPaintColor(other.visitedLinkPaintColor)
-    , paintUri(other.paintUri)
-    , visitedLinkPaintUri(other.visitedLinkPaintUri)
-    , paintType(other.paintType)
-    , visitedLinkPaintType(other.visitedLinkPaintType)
+    , paint(other.paint)
+    , visitedLinkPaint(other.visitedLinkPaint)
 {
 }
 
@@ -72,53 +64,36 @@ Ref<StyleFillData> StyleFillData::copy() const
 void StyleFillData::dumpDifferences(TextStream& ts, const StyleFillData& other) const
 {
     LOG_IF_DIFFERENT(opacity);
-    LOG_IF_DIFFERENT(paintColor);
-    LOG_IF_DIFFERENT(visitedLinkPaintColor);
-    LOG_IF_DIFFERENT(paintUri);
-    LOG_IF_DIFFERENT(visitedLinkPaintUri);
-    LOG_IF_DIFFERENT(paintType);
-    LOG_IF_DIFFERENT(visitedLinkPaintType);
+    LOG_IF_DIFFERENT(paint);
+    LOG_IF_DIFFERENT(visitedLinkPaint);
 }
 #endif
 
 bool StyleFillData::operator==(const StyleFillData& other) const
 {
     return opacity == other.opacity
-        && paintColor == other.paintColor
-        && visitedLinkPaintColor == other.visitedLinkPaintColor
-        && paintUri == other.paintUri
-        && visitedLinkPaintUri == other.visitedLinkPaintUri
-        && paintType == other.paintType
-        && visitedLinkPaintType == other.visitedLinkPaintType;
-    
+        && paint == other.paint
+        && visitedLinkPaint == other.visitedLinkPaint;
 }
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleStrokeData);
 
 StyleStrokeData::StyleStrokeData()
     : opacity(SVGRenderStyle::initialStrokeOpacity())
-    , paintColor(SVGRenderStyle::initialStrokePaintColor())
-    , visitedLinkPaintColor(SVGRenderStyle::initialStrokePaintColor())
-    , paintUri(SVGRenderStyle::initialStrokePaintUri())
-    , visitedLinkPaintUri(SVGRenderStyle::initialStrokePaintUri())
+    , paint(SVGRenderStyle::initialStroke())
+    , visitedLinkPaint(SVGRenderStyle::initialStroke())
     , dashOffset(RenderStyle::zeroLength())
     , dashArray(SVGRenderStyle::initialStrokeDashArray())
-    , paintType(SVGRenderStyle::initialStrokePaintType())
-    , visitedLinkPaintType(SVGRenderStyle::initialStrokePaintType())
 {
 }
 
 inline StyleStrokeData::StyleStrokeData(const StyleStrokeData& other)
     : RefCounted<StyleStrokeData>()
     , opacity(other.opacity)
-    , paintColor(other.paintColor)
-    , visitedLinkPaintColor(other.visitedLinkPaintColor)
-    , paintUri(other.paintUri)
-    , visitedLinkPaintUri(other.visitedLinkPaintUri)
+    , paint(other.paint)
+    , visitedLinkPaint(other.visitedLinkPaint)
     , dashOffset(other.dashOffset)
     , dashArray(other.dashArray)
-    , paintType(other.paintType)
-    , visitedLinkPaintType(other.visitedLinkPaintType)
 {
 }
 
@@ -130,30 +105,20 @@ Ref<StyleStrokeData> StyleStrokeData::copy() const
 bool StyleStrokeData::operator==(const StyleStrokeData& other) const
 {
     return opacity == other.opacity
-        && paintColor == other.paintColor
-        && visitedLinkPaintColor == other.visitedLinkPaintColor
-        && paintUri == other.paintUri
-        && visitedLinkPaintUri == other.visitedLinkPaintUri
+        && paint == other.paint
+        && visitedLinkPaint == other.visitedLinkPaint
         && dashOffset == other.dashOffset
-        && dashArray == other.dashArray
-        && paintType == other.paintType
-        && visitedLinkPaintType == other.visitedLinkPaintType;
+        && dashArray == other.dashArray;
 }
 
 #if !LOG_DISABLED
 void StyleStrokeData::dumpDifferences(TextStream& ts, const StyleStrokeData& other) const
 {
     LOG_IF_DIFFERENT(opacity);
-    LOG_IF_DIFFERENT(paintColor);
-    LOG_IF_DIFFERENT(visitedLinkPaintColor);
-    LOG_IF_DIFFERENT(paintUri);
-    LOG_IF_DIFFERENT(visitedLinkPaintUri);
-
+    LOG_IF_DIFFERENT(paint);
+    LOG_IF_DIFFERENT(visitedLinkPaint);
     LOG_IF_DIFFERENT(dashOffset);
     LOG_IF_DIFFERENT(dashArray);
-
-    LOG_IF_DIFFERENT(paintType);
-    LOG_IF_DIFFERENT(visitedLinkPaintType);
 }
 #endif
 
@@ -457,20 +422,6 @@ TextStream& operator<<(TextStream& ts, MaskType value)
     return ts;
 }
 
-TextStream& operator<<(TextStream& ts, SVGPaintType paintType)
-{
-    switch (paintType) {
-    case SVGPaintType::RGBColor: ts << "rgb-color"_s; break;
-    case SVGPaintType::None: ts << "none"_s; break;
-    case SVGPaintType::CurrentColor: ts << "current-color"_s; break;
-    case SVGPaintType::URINone: ts << "uri-none"_s; break;
-    case SVGPaintType::URICurrentColor: ts << "uri-current-color"_s; break;
-    case SVGPaintType::URIRGBColor: ts << "uri-rgb-color"_s; break;
-    case SVGPaintType::URI: ts << "uri"_s; break;
-    }
-    return ts;
-}
-
 TextStream& operator<<(TextStream& ts, ShapeRendering value)
 {
     switch (value) {
@@ -504,26 +455,18 @@ TextStream& operator<<(TextStream& ts, VectorEffect value)
 TextStream& operator<<(TextStream& ts, const StyleFillData& data)
 {
     ts.dumpProperty("opacity"_s, data.opacity);
-    ts.dumpProperty("paint-color"_s, data.paintColor);
-    ts.dumpProperty("visited link paint-color"_s, data.visitedLinkPaintColor);
-    ts.dumpProperty("paint uri"_s, data.paintUri);
-    ts.dumpProperty("visited link paint uri"_s, data.visitedLinkPaintUri);
-    ts.dumpProperty("visited link paint type"_s, data.paintType);
-    ts.dumpProperty("visited link paint type"_s, data.visitedLinkPaintType);
+    ts.dumpProperty("paint"_s, data.paint);
+    ts.dumpProperty("visited link paint"_s, data.visitedLinkPaint);
     return ts;
 }
 
 TextStream& operator<<(TextStream& ts, const StyleStrokeData& data)
 {
     ts.dumpProperty("opacity"_s, data.opacity);
-    ts.dumpProperty("paint-color"_s, data.paintColor);
-    ts.dumpProperty("visited link paint-color"_s, data.visitedLinkPaintColor);
-    ts.dumpProperty("paint uri"_s, data.paintUri);
-    ts.dumpProperty("visited link paint uri"_s, data.visitedLinkPaintUri);
+    ts.dumpProperty("paint"_s, data.paint);
+    ts.dumpProperty("visited link paint"_s, data.visitedLinkPaint);
     ts.dumpProperty("dashOffset"_s, data.dashOffset);
     ts.dumpProperty("dash array"_s, data.dashArray);
-    ts.dumpProperty("visited link paint type"_s, data.paintType);
-    ts.dumpProperty("visited link paint type"_s, data.visitedLinkPaintType);
     return ts;
 }
 

--- a/Source/WebCore/rendering/style/SVGRenderStyleDefs.h
+++ b/Source/WebCore/rendering/style/SVGRenderStyleDefs.h
@@ -33,6 +33,7 @@
 #include "StyleBoxShadow.h"
 #include "StyleColor.h"
 #include "StylePathData.h"
+#include "StyleSVGPaint.h"
 #include "StyleURL.h"
 #include <wtf/FixedVector.h>
 #include <wtf/RefCounted.h>
@@ -46,17 +47,6 @@ namespace WebCore {
 
 class CSSValue;
 class CSSValueList;
-class SVGPaint;
-
-enum class SVGPaintType : uint8_t {
-    RGBColor,
-    None,
-    CurrentColor,
-    URINone,
-    URICurrentColor,
-    URIRGBColor,
-    URI
-};
 
 enum class BaselineShift : uint8_t {
     Baseline,
@@ -158,12 +148,8 @@ public:
 #endif
 
     float opacity;
-    Style::Color paintColor;
-    Style::Color visitedLinkPaintColor;
-    Style::URL paintUri;
-    Style::URL visitedLinkPaintUri;
-    SVGPaintType paintType;
-    SVGPaintType visitedLinkPaintType;
+    Style::SVGPaint paint;
+    Style::SVGPaint visitedLinkPaint;
 
 private:
     StyleFillData();
@@ -184,18 +170,10 @@ public:
 #endif
 
     float opacity;
-
-    Style::Color paintColor;
-    Style::Color visitedLinkPaintColor;
-
-    Style::URL paintUri;
-    Style::URL visitedLinkPaintUri;
-
+    Style::SVGPaint paint;
+    Style::SVGPaint visitedLinkPaint;
     Length dashOffset;
     FixedVector<Length> dashArray;
-
-    SVGPaintType paintType;
-    SVGPaintType visitedLinkPaintType;
 
 private:
     StyleStrokeData();
@@ -328,7 +306,6 @@ WTF::TextStream& operator<<(WTF::TextStream&, ColorRendering);
 WTF::TextStream& operator<<(WTF::TextStream&, DominantBaseline);
 WTF::TextStream& operator<<(WTF::TextStream&, GlyphOrientation);
 WTF::TextStream& operator<<(WTF::TextStream&, MaskType);
-WTF::TextStream& operator<<(WTF::TextStream&, SVGPaintType);
 WTF::TextStream& operator<<(WTF::TextStream&, ShapeRendering);
 WTF::TextStream& operator<<(WTF::TextStream&, TextAnchor);
 WTF::TextStream& operator<<(WTF::TextStream&, VectorEffect);

--- a/Source/WebCore/rendering/svg/SVGPaintServerHandling.h
+++ b/Source/WebCore/rendering/svg/SVGPaintServerHandling.h
@@ -82,20 +82,20 @@ public:
     {
         // When rendering the mask for a RenderSVGResourceClipper, always use the initial fill paint server.
         if (targetRenderer.view().frameView().paintBehavior().contains(PaintBehavior::RenderingSVGClipOrMask))
-            return op == Operation::Fill ? SVGRenderStyle::initialFillPaintColor().resolvedColor() : SVGRenderStyle::initialStrokePaintColor().resolvedColor();
+            return op == Operation::Fill ? SVGRenderStyle::initialFill().color.resolvedColor() : SVGRenderStyle::initialStroke().color.resolvedColor();
 
-        auto paintType = op == Operation::Fill ? style.svgStyle().fillPaintType() : style.svgStyle().strokePaintType();
-        if (paintType == SVGPaintType::None)
+        auto paintType = op == Operation::Fill ? style.svgStyle().fill().type : style.svgStyle().stroke().type;
+        if (paintType == Style::SVGPaintType::None)
             return { };
 
-        if (paintType >= SVGPaintType::URINone) {
+        if (paintType >= Style::SVGPaintType::URINone) {
             if (allowPaintServerURIResolving == URIResolving::Disabled) {
                 // If we found no paint server, and no fallback is desired, stop here.
                 // We can only get here, if we previously requested a paint server, attempted to
                 // prepare a fill or stroke operation, which failed. It can fail if, for example,
                 // the paint sever is a gradient, gradientUnits are set to 'objectBoundingBox' and
                 // the target is an one-dimensional object without a defined 'objectBoundingBox' (<line>).
-                if (paintType == SVGPaintType::URI || paintType == SVGPaintType::URINone)
+                if (paintType == Style::SVGPaintType::URI || paintType == Style::SVGPaintType::URINone)
                     return { };
             } else {
                 auto paintServerForOperation = [&]() {
@@ -109,12 +109,12 @@ public:
                     return paintServer;
 
                 // If we found no paint server, and no fallback is desired, stop here.
-                if (paintType == SVGPaintType::URI || paintType == SVGPaintType::URINone)
+                if (paintType == Style::SVGPaintType::URI || paintType == Style::SVGPaintType::URINone)
                     return { };
             }
         }
 
-        // SVGPaintType::CurrentColor / SVGPaintType::RGBColor / SVGPaintType::URICurrentColor / SVGPaintType::URIRGBColor handling.
+        // Style::SVGPaintType::{CurrentColor, RGBColor, URICurrentColor, URIRGBColor} handling.
         auto color = resolveColorFromStyle<op>(style);
         if (inheritColorFromParentStyleIfNeeded<op>(targetRenderer, color))
             return color;
@@ -148,22 +148,22 @@ private:
     {
         Ref svgStyle = style.svgStyle();
         if (op == Operation::Fill)
-            return resolveColorFromStyle(style, svgStyle->fillPaintType(), svgStyle->fillPaintColor(), svgStyle->visitedLinkFillPaintType(), svgStyle->visitedLinkFillPaintColor());
-        return resolveColorFromStyle(style, svgStyle->strokePaintType(), svgStyle->strokePaintColor(), svgStyle->visitedLinkStrokePaintType(), svgStyle->visitedLinkStrokePaintColor());
+            return resolveColorFromStyle(style, svgStyle->fill(), svgStyle->visitedLinkFill());
+        return resolveColorFromStyle(style, svgStyle->stroke(), svgStyle->visitedLinkStroke());
     }
 
-    static inline Color resolveColorFromStyle(const RenderStyle& style, SVGPaintType paintType, const Style::Color& paintColor, SVGPaintType visitedLinkPaintType, const Style::Color& visitedLinkPaintColor)
+    static inline Color resolveColorFromStyle(const RenderStyle& style, const Style::SVGPaint& paint, const Style::SVGPaint& visitedLinkPaint)
     {
         // All paint types except None / URI / URINone handle solid colors.
-        ASSERT_UNUSED(paintType, paintType != SVGPaintType::None);
-        ASSERT(paintType != SVGPaintType::URI);
-        ASSERT(paintType != SVGPaintType::URINone);
+        ASSERT(paint.type != Style::SVGPaintType::None);
+        ASSERT(paint.type != Style::SVGPaintType::URI);
+        ASSERT(paint.type != Style::SVGPaintType::URINone);
 
-        auto color = style.colorResolvingCurrentColor(paintColor);
+        auto color = style.colorResolvingCurrentColor(paint.color);
         if (style.insideLink() == InsideLink::InsideVisited) {
             // FIXME: This code doesn't support the uri component of the visited link paint, https://bugs.webkit.org/show_bug.cgi?id=70006
-            if (visitedLinkPaintType == SVGPaintType::RGBColor) {
-                const auto& visitedColor = style.colorResolvingCurrentColor(visitedLinkPaintColor);
+            if (visitedLinkPaint.type == Style::SVGPaintType::RGBColor) {
+                const auto& visitedColor = style.colorResolvingCurrentColor(visitedLinkPaint.color);
                 if (visitedColor.isValid())
                     color = visitedColor.colorWithAlpha(color.alphaAsFloat());
             }
@@ -180,7 +180,7 @@ private:
         if (!renderer.parent())
             return false;
         Ref parentSVGStyle = renderer.parent()->style().svgStyle();
-        color = renderer.style().colorResolvingCurrentColor(op == Operation::Fill ? parentSVGStyle->fillPaintColor() : parentSVGStyle->strokePaintColor());
+        color = renderer.style().colorResolvingCurrentColor(op == Operation::Fill ? parentSVGStyle->fill().color : parentSVGStyle->stroke().color);
         return true;
     }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp
@@ -59,24 +59,24 @@ static inline LegacyRenderSVGResource* requestPaintingResource(RenderSVGResource
         
         // But always use the initial fill paint server.
         LegacyRenderSVGResourceSolidColor* colorResource = LegacyRenderSVGResource::sharedSolidPaintingResource();
-        colorResource->setColor(SVGRenderStyle::initialFillPaintColor().resolvedColor());
+        colorResource->setColor(SVGRenderStyle::initialFill().color.resolvedColor());
         return colorResource;
     }
 
     const auto& svgStyle = style.svgStyle();
-    auto paintType = applyToFill ? svgStyle.fillPaintType() : svgStyle.strokePaintType();
+    auto paintType = applyToFill ? svgStyle.fill().type : svgStyle.stroke().type;
 
     // If we have no fill/stroke, return nullptr.
-    if (paintType == SVGPaintType::None)
+    if (paintType == Style::SVGPaintType::None)
         return nullptr;
 
     Color color;
     switch (paintType) {
-    case SVGPaintType::CurrentColor:
-    case SVGPaintType::RGBColor:
-    case SVGPaintType::URICurrentColor:
-    case SVGPaintType::URIRGBColor:
-        color = style.colorResolvingCurrentColor(applyToFill ? svgStyle.fillPaintColor() : svgStyle.strokePaintColor());
+    case Style::SVGPaintType::CurrentColor:
+    case Style::SVGPaintType::RGBColor:
+    case Style::SVGPaintType::URICurrentColor:
+    case Style::SVGPaintType::URIRGBColor:
+        color = style.colorResolvingCurrentColor(applyToFill ? svgStyle.fill().color : svgStyle.stroke().color);
         break;
     default:
         break;
@@ -84,19 +84,19 @@ static inline LegacyRenderSVGResource* requestPaintingResource(RenderSVGResource
 
     if (style.insideLink() == InsideLink::InsideVisited) {
         // FIXME: This code doesn't support the uri component of the visited link paint, https://bugs.webkit.org/show_bug.cgi?id=70006
-        SVGPaintType visitedPaintType = applyToFill ? svgStyle.visitedLinkFillPaintType() : svgStyle.visitedLinkStrokePaintType();
+        auto visitedPaintType = applyToFill ? svgStyle.visitedLinkFill().type : svgStyle.visitedLinkStroke().type;
 
-        // For SVGPaintType::CurrentColor, 'color' already contains the 'visitedColor'.
-        if (visitedPaintType < SVGPaintType::URINone && visitedPaintType != SVGPaintType::CurrentColor) {
-            const Color& visitedColor = style.colorResolvingCurrentColor(applyToFill ? svgStyle.visitedLinkFillPaintColor() : svgStyle.visitedLinkStrokePaintColor());
+        // For Style::SVGPaintType::CurrentColor, 'color' already contains the 'visitedColor'.
+        if (visitedPaintType < Style::SVGPaintType::URINone && visitedPaintType != Style::SVGPaintType::CurrentColor) {
+            const Color& visitedColor = style.colorResolvingCurrentColor(applyToFill ? svgStyle.visitedLinkFill().color : svgStyle.visitedLinkStroke().color);
             if (visitedColor.isValid())
                 color = visitedColor.colorWithAlpha(color.alphaAsFloat());
         }
     }
 
     // If the primary resource is just a color, return immediately.
-    LegacyRenderSVGResourceSolidColor* colorResource = LegacyRenderSVGResource::sharedSolidPaintingResource();
-    if (paintType < SVGPaintType::URINone) {
+    auto* colorResource = LegacyRenderSVGResource::sharedSolidPaintingResource();
+    if (paintType < Style::SVGPaintType::URINone) {
         colorResource->setColor(color);
         return colorResource;
     }
@@ -113,7 +113,7 @@ static inline LegacyRenderSVGResource* requestPaintingResource(RenderSVGResource
     // If the requested resource is not available, return the color resource or 'none'.
     if (!uriResource) {
         // The fallback is 'none'. (SVG2 say 'none' is implied when no fallback is specified.)
-        if (paintType == SVGPaintType::URINone)
+        if (paintType == Style::SVGPaintType::URINone)
             return nullptr;
 
         colorResource->setColor(color);

--- a/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
@@ -184,13 +184,13 @@ static inline bool isChainableResource(const SVGElement& element, const SVGEleme
     return false;
 }
 
-static inline bool svgPaintTypeHasURL(const SVGPaintType& paintType)
+static inline bool svgPaintTypeHasURL(const Style::SVGPaintType& paintType)
 {
     switch (paintType) {
-    case SVGPaintType::URI:
-    case SVGPaintType::URINone:
-    case SVGPaintType::URICurrentColor:
-    case SVGPaintType::URIRGBColor:
+    case Style::SVGPaintType::URI:
+    case Style::SVGPaintType::URINone:
+    case Style::SVGPaintType::URICurrentColor:
+    case Style::SVGPaintType::URIRGBColor:
         return true;
     default:
         break;
@@ -198,12 +198,12 @@ static inline bool svgPaintTypeHasURL(const SVGPaintType& paintType)
     return false;
 }
 
-static inline LegacyRenderSVGResourceContainer* paintingResourceFromSVGPaint(TreeScope& treeScope, const SVGPaintType& paintType, const Style::URL& paintUri, AtomString& id, bool& hasPendingResource)
+static inline LegacyRenderSVGResourceContainer* paintingResourceFromSVGPaint(TreeScope& treeScope, const Style::SVGPaint& paint, AtomString& id, bool& hasPendingResource)
 {
-    if (!svgPaintTypeHasURL(paintType))
+    if (!svgPaintTypeHasURL(paint.type))
         return nullptr;
 
-    id = SVGURIReference::fragmentIdentifierFromIRIString(paintUri, treeScope.protectedDocumentScope());
+    id = SVGURIReference::fragmentIdentifierFromIRIString(paint.url, treeScope.protectedDocumentScope());
     CheckedPtr container = getRenderSVGResourceContainerById(treeScope, id);
     if (!container) {
         hasPendingResource = true;
@@ -297,7 +297,7 @@ std::unique_ptr<SVGResources> SVGResources::buildCachedResources(const RenderEle
         if (svgStyle.hasFill()) {
             bool hasPendingResource = false;
             AtomString id;
-            if (auto* fill = paintingResourceFromSVGPaint(treeScope, svgStyle.fillPaintType(), svgStyle.fillPaintUri(), id, hasPendingResource))
+            if (auto* fill = paintingResourceFromSVGPaint(treeScope, svgStyle.fill(), id, hasPendingResource))
                 ensureResources(foundResources).setFill(fill);
             else if (hasPendingResource)
                 treeScope->addPendingSVGResource(id, element);
@@ -306,7 +306,7 @@ std::unique_ptr<SVGResources> SVGResources::buildCachedResources(const RenderEle
         if (svgStyle.hasStroke()) {
             bool hasPendingResource = false;
             AtomString id;
-            if (auto* stroke = paintingResourceFromSVGPaint(treeScope, svgStyle.strokePaintType(), svgStyle.strokePaintUri(), id, hasPendingResource))
+            if (auto* stroke = paintingResourceFromSVGPaint(treeScope, svgStyle.stroke(), id, hasPendingResource))
                 ensureResources(foundResources).setStroke(stroke);
             else if (hasPendingResource)
                 treeScope->addPendingSVGResource(id, element);

--- a/Source/WebCore/rendering/svg/legacy/SVGResourcesCache.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResourcesCache.cpp
@@ -184,10 +184,10 @@ void SVGResourcesCache::clientStyleChanged(RenderElement& renderer, StyleDiffere
         Ref oldSVGStyle = oldStyle->svgStyle();
         Ref newSVGStyle = newStyle.svgStyle();
 
-        if (oldSVGStyle->fillPaintUri() != newSVGStyle->fillPaintUri())
+        if (oldSVGStyle->fill().url != newSVGStyle->fill().url)
             return true;
 
-        if (oldSVGStyle->strokePaintUri() != newSVGStyle->strokePaintUri())
+        if (oldSVGStyle->stroke().url != newSVGStyle->stroke().url)
             return true;
 
         return false;

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -104,6 +104,7 @@
 #include "StyleReflection.h"
 #include "StyleResolveForFont.h"
 #include "StyleRotate.h"
+#include "StyleSVGPaint.h"
 #include "StyleScale.h"
 #include "StyleScrollMargin.h"
 #include "StyleScrollPadding.h"
@@ -1247,8 +1248,8 @@ inline std::optional<ScrollbarColor> BuilderConverter::convertScrollbarColor(Bui
         return { };
 
     return ScrollbarColor {
-        builderState.createStyleColor(pair->first()),
-        builderState.createStyleColor(pair->second()),
+        convertStyleType<Color>(builderState, pair->first(), ForVisitedLink::No),
+        convertStyleType<Color>(builderState, pair->second(), ForVisitedLink::No),
     };
 }
 
@@ -1666,7 +1667,7 @@ inline bool BuilderConverter::convertTouchCallout(BuilderState& builderState, co
 #if ENABLE(TOUCH_EVENTS)
 inline Color BuilderConverter::convertTapHighlightColor(BuilderState& builderState, const CSSValue& value)
 {
-    return builderState.createStyleColor(value);
+    return convertStyleType<Color>(builderState, value, ForVisitedLink::No);
 }
 #endif
 

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -157,16 +157,6 @@ FilterOperations BuilderState::createAppleColorFilterOperations(const CSSValue& 
     return createAppleColorFilterOperations(filterValue->filter());
 }
 
-Color BuilderState::createStyleColor(const CSSValue& value, ForVisitedLink forVisitedLink) const
-{
-    if (!element() || !element()->isLink())
-        forVisitedLink = ForVisitedLink::No;
-
-    if (RefPtr color = dynamicDowncast<CSSColorValue>(value))
-        return toStyle(color->color(), *this, forVisitedLink);
-    return toStyle(CSS::Color { CSS::KeywordColor { value.valueID() } }, *this, forVisitedLink);
-}
-
 void BuilderState::registerContentAttribute(const AtomString& attributeLocalName)
 {
     if (style().pseudoElementType() == PseudoId::Before || style().pseudoElementType() == PseudoId::After)

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -124,7 +124,6 @@ public:
     FilterOperations createFilterOperations(const CSSValue&) const;
     FilterOperations createAppleColorFilterOperations(const CSS::AppleColorFilterProperty&) const;
     FilterOperations createAppleColorFilterOperations(const CSSValue&) const;
-    Color createStyleColor(const CSSValue&, ForVisitedLink = ForVisitedLink::No) const;
 
     const Vector<AtomString>& registeredContentAttributes() const { return m_registeredContentAttributes; }
     void registerContentAttribute(const AtomString& attributeLocalName);

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -172,7 +172,6 @@ public:
     // MARK: SVG conversions
 
     static Ref<CSSValue> convertSVGURIReference(ExtractorState&, const URL&);
-    static Ref<CSSValue> convertSVGPaint(ExtractorState&, SVGPaintType, const URL&, const Color&);
 
     // MARK: Transform conversions
 
@@ -474,22 +473,6 @@ inline Ref<CSSValue> ExtractorConverter::convertSVGURIReference(ExtractorState& 
     if (marker.isNone())
         return CSSPrimitiveValue::create(CSSValueNone);
     return CSSURLValue::create(toCSS(marker, state.style));
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertSVGPaint(ExtractorState& state, SVGPaintType paintType, const URL& url, const Color& color)
-{
-    if (paintType >= SVGPaintType::URINone) {
-        CSSValueListBuilder values;
-        values.append(CSSURLValue::create(toCSS(url, state.style)));
-        if (paintType == SVGPaintType::URINone)
-            values.append(CSSPrimitiveValue::create(CSSValueNone));
-        else if (paintType == SVGPaintType::URICurrentColor || paintType == SVGPaintType::URIRGBColor)
-            values.append(convertStyleType(state, color));
-        return CSSValueList::createSpaceSeparated(WTFMove(values));
-    }
-    if (paintType == SVGPaintType::None)
-        return CSSPrimitiveValue::create(CSSValueNone);
-    return convertStyleType(state, color);
 }
 
 // MARK: - Transform conversions

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -47,8 +47,6 @@ public:
     static Ref<CSSValue> extractAspectRatio(ExtractorState&);
     static Ref<CSSValue> extractDirection(ExtractorState&);
     static Ref<CSSValue> extractWritingMode(ExtractorState&);
-    static Ref<CSSValue> extractFill(ExtractorState&);
-    static Ref<CSSValue> extractStroke(ExtractorState&);
     static Ref<CSSValue> extractFloat(ExtractorState&);
     static Ref<CSSValue> extractClip(ExtractorState&);
     static Ref<CSSValue> extractContent(ExtractorState&);
@@ -157,8 +155,6 @@ public:
     static void extractAspectRatioSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractDirectionSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractWritingModeSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
-    static void extractFillSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
-    static void extractStrokeSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractFloatSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractClipSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractContentSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
@@ -1280,26 +1276,6 @@ inline Ref<CSSValue> ExtractorCustom::extractWritingMode(ExtractorState& state)
 inline void ExtractorCustom::extractWritingModeSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext&)
 {
     builder.append(nameLiteralForSerialization(extractWritingModeValueID(state)));
-}
-
-inline Ref<CSSValue> ExtractorCustom::extractFill(ExtractorState& state)
-{
-    return ExtractorConverter::convertSVGPaint(state, state.style.svgStyle().fillPaintType(), state.style.svgStyle().fillPaintUri(), state.style.svgStyle().fillPaintColor());
-}
-
-inline void ExtractorCustom::extractFillSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
-{
-    ExtractorSerializer::serializeSVGPaint(state, builder, context, state.style.svgStyle().fillPaintType(), state.style.svgStyle().fillPaintUri(), state.style.svgStyle().fillPaintColor());
-}
-
-inline Ref<CSSValue> ExtractorCustom::extractStroke(ExtractorState& state)
-{
-    return ExtractorConverter::convertSVGPaint(state, state.style.svgStyle().strokePaintType(), state.style.svgStyle().strokePaintUri(), state.style.svgStyle().strokePaintColor());
-}
-
-inline void ExtractorCustom::extractStrokeSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
-{
-    ExtractorSerializer::serializeSVGPaint(state, builder, context, state.style.svgStyle().strokePaintType(), state.style.svgStyle().strokePaintUri(), state.style.svgStyle().strokePaintColor());
 }
 
 inline Ref<CSSValue> ExtractorCustom::extractFloat(ExtractorState& state)

--- a/Source/WebCore/style/StyleExtractorSerializer.h
+++ b/Source/WebCore/style/StyleExtractorSerializer.h
@@ -82,7 +82,6 @@ public:
     // MARK: SVG serializations
 
     static void serializeSVGURIReference(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const URL&);
-    static void serializeSVGPaint(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, SVGPaintType, const URL&, const Color&);
 
     // MARK: Transform serializations
 
@@ -480,35 +479,6 @@ inline void ExtractorSerializer::serializeSVGURIReference(ExtractorState& state,
     }
 
     serializationForCSS(builder, context, state.style, marker);
-}
-
-inline void ExtractorSerializer::serializeSVGPaint(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, SVGPaintType paintType, const URL& url, const Color& color)
-{
-    switch (paintType) {
-    case SVGPaintType::URI:
-        CSS::serializationForCSS(builder, context, toCSS(url, state.style));
-        return;
-
-    case SVGPaintType::URINone:
-        CSS::serializationForCSS(builder, context, toCSS(url, state.style));
-        builder.append(' ');
-        [[fallthrough]];
-    case SVGPaintType::None:
-        CSS::serializationForCSS(builder, context, CSS::Keyword::None { });
-        return;
-
-    case SVGPaintType::URICurrentColor:
-    case SVGPaintType::URIRGBColor:
-        CSS::serializationForCSS(builder, context, toCSS(url, state.style));
-        builder.append(' ');
-        [[fallthrough]];
-    case SVGPaintType::RGBColor:
-    case SVGPaintType::CurrentColor:
-        serializeStyleType(state, builder, context, color);
-        return;
-    }
-
-    RELEASE_ASSERT_NOT_REACHED();
 }
 
 // MARK: - Transform serializations

--- a/Source/WebCore/style/values/color/StyleColor.h
+++ b/Source/WebCore/style/values/color/StyleColor.h
@@ -187,9 +187,23 @@ template<> struct ToStyle<CSS::Color> {
     auto operator()(const CSS::Color&, const BuilderState&) -> Color;
 };
 
-template<> struct CSSValueCreation<Color> {
-    Ref<CSSValue> operator()(CSSValuePool&, const RenderStyle&, const Color&);
+template<> struct CSSValueConversion<Color> {
+    auto operator()(BuilderState&, const CSSValue&, ForVisitedLink) -> Color;
 };
+template<> struct CSSValueCreation<Color> {
+    auto operator()(CSSValuePool&, const RenderStyle&, const Color&) -> Ref<CSSValue>;
+};
+
+// MARK: - Blending
+
+template<> struct Blending<Color> {
+    auto equals(const Color&, const Color&, const RenderStyle&, const RenderStyle&) -> bool;
+    auto canBlend(const Color&, const Color&) -> bool;
+    constexpr auto requiresInterpolationForAccumulativeIteration(const Color&, const Color&) -> bool { return true; }
+    auto blend(const Color&, const Color&, const RenderStyle&, const RenderStyle&, const BlendingContext&) -> Color;
+};
+
+// MARK: - Color Implementation
 
 template<typename... F> decltype(auto) Color::switchOn(F&&... f) const
 {

--- a/Source/WebCore/style/values/svg/StyleSVGPaint.cpp
+++ b/Source/WebCore/style/values/svg/StyleSVGPaint.cpp
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleSVGPaint.h"
+
+#include "AnimationUtilities.h"
+#include "ColorBlending.h"
+#include "StyleBuilderConverter.h"
+#include "StyleBuilderState.h"
+#include "StyleColor.h"
+#include "StyleForVisitedLink.h"
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+namespace Style {
+
+auto CSSValueConversion<SVGPaint>::operator()(BuilderState& state, const CSSValue& value, ForVisitedLink forVisitedLink) -> SVGPaint
+{
+    // <paint> = none | <color> | <url> [none | <color>]? 
+
+    if (RefPtr list = dynamicDowncast<CSSValueList>(value)) {
+        RefPtr firstValue = list->protectedItem(0);
+        RefPtr urlValue = BuilderConverter::requiredDowncast<CSSURLValue>(state, *firstValue);
+        if (!urlValue) {
+            return {
+                .type = SVGPaintType::None,
+                .url = URL::none(),
+                .color = Color::currentColor()
+            };
+        }
+
+        auto url = toStyle(urlValue->url(), state);
+
+        if (list->size() == 1) {
+            return {
+                .type = SVGPaintType::URI,
+                .url = WTFMove(url),
+            };
+        }
+
+        RefPtr secondItem = list->protectedItem(1);
+        if (RefPtr primitiveValue = dynamicDowncast<const CSSPrimitiveValue>(secondItem)) {
+            switch (primitiveValue->valueID()) {
+            case CSSValueNone:
+                return {
+                    .type = SVGPaintType::URINone,
+                    .url = WTFMove(url),
+                };
+            case CSSValueCurrentcolor: {
+                state.style().setDisallowsFastPathInheritance();
+                return {
+                    .type = SVGPaintType::URICurrentColor,
+                    .url = WTFMove(url),
+                    .color = Color::currentColor(),
+                };
+            }
+            default:
+                break;
+            }
+        }
+
+        return {
+            .type = SVGPaintType::URIRGBColor,
+            .url = WTFMove(url),
+            .color = toStyleFromCSSValue<Color>(state, *list->item(1), forVisitedLink)
+        };
+    }
+
+
+    if (RefPtr urlValue = dynamicDowncast<CSSURLValue>(value)) {
+        return {
+            .type = SVGPaintType::URI,
+            .url = toStyle(urlValue->url(), state),
+        };
+    }
+
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        switch (primitiveValue->valueID()) {
+        case CSSValueNone:
+            return {
+                .type = SVGPaintType::None,
+            };
+        case CSSValueCurrentcolor: {
+            state.style().setDisallowsFastPathInheritance();
+            return {
+                .type = SVGPaintType::CurrentColor,
+                .color = Color::currentColor(),
+            };
+        }
+        default:
+            break;
+        }
+    }
+
+    return {
+        .type = SVGPaintType::RGBColor,
+        .color = toStyleFromCSSValue<Color>(state, value, forVisitedLink)
+    };
+}
+
+// MARK: - Blending
+
+auto Blending<SVGPaint>::equals(const SVGPaint& a, const SVGPaint& b, const RenderStyle& aStyle, const RenderStyle& bStyle) -> bool
+{
+    if (a.type != b.type)
+        return false;
+
+    // We only support animations between SVGPaints that are pure Color values.
+    // For everything else we must return true for this method, otherwise
+    // we will try to animate between values forever.
+    if (a.type == SVGPaintType::RGBColor)
+        return equalsForBlending(a.color, b.color, aStyle, bStyle);
+
+    return true;
+}
+
+auto Blending<SVGPaint>::canBlend(const SVGPaint& a, const SVGPaint& b) -> bool
+{
+    auto isValidPaintType = [](SVGPaintType paintType) {
+        return paintType == SVGPaintType::RGBColor || paintType == SVGPaintType::CurrentColor;
+    };
+
+    if (!isValidPaintType(a.type) || !isValidPaintType(b.type))
+        return false;
+    if (a.color.isCurrentColor() && b.color.isCurrentColor())
+        return false;
+    return true;
+}
+
+auto Blending<SVGPaint>::blend(const SVGPaint& a, const SVGPaint& b, const RenderStyle& aStyle, const RenderStyle& bStyle, const BlendingContext& context) -> SVGPaint
+{
+    return SVGPaint {
+        .type = a.type,
+        .url = URL::none(),
+        .color = WebCore::blend(aStyle.colorResolvingCurrentColor(a.color), bStyle.colorResolvingCurrentColor(b.color), context)
+    };
+}
+
+// MARK: - Logging
+
+TextStream& operator<<(TextStream& ts, SVGPaintType paintType)
+{
+    switch (paintType) {
+    case SVGPaintType::RGBColor: ts << "rgb-color"_s; break;
+    case SVGPaintType::None: ts << "none"_s; break;
+    case SVGPaintType::CurrentColor: ts << "current-color"_s; break;
+    case SVGPaintType::URINone: ts << "uri-none"_s; break;
+    case SVGPaintType::URICurrentColor: ts << "uri-current-color"_s; break;
+    case SVGPaintType::URIRGBColor: ts << "uri-rgb-color"_s; break;
+    case SVGPaintType::URI: ts << "uri"_s; break;
+    }
+    return ts;
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/svg/StyleSVGPaint.h
+++ b/Source/WebCore/style/values/svg/StyleSVGPaint.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StyleColor.h"
+#include "StyleURL.h"
+
+namespace WebCore {
+namespace Style {
+
+enum class ForVisitedLink : bool;
+
+enum class SVGPaintType : uint8_t {
+    RGBColor,
+    None,
+    CurrentColor,
+    URINone,
+    URICurrentColor,
+    URIRGBColor,
+    URI
+};
+
+// <paint> = none | <color> | <url> [none | <color>]? | context-fill | context-stroke
+// NOTE: `context-fill` and `context-stroke` are not implemented.
+// https://svgwg.org/svg2-draft/painting.html#SpecifyingPaint
+struct SVGPaint {
+    // Models Variant<CSS::Keyword::None, Color, URL, SpaceSeparatedTuple<URL, CSS::Keyword::None>, SpaceSeparatedTuple<URL, Color>>;
+
+    SVGPaintType type;
+    URL url { URL::none() };
+    Color color { Color::currentColor() };
+
+    template<typename F> decltype(auto) switchOn(F&& functor) const
+    {
+        switch (type) {
+        case SVGPaintType::None:
+            return functor(CSS::Keyword::None { });
+        case SVGPaintType::RGBColor:
+        case SVGPaintType::CurrentColor:
+            return functor(color);
+        case SVGPaintType::URINone:
+            return functor(SpaceSeparatedTuple { url, CSS::Keyword::None { } });
+        case SVGPaintType::URICurrentColor:
+        case SVGPaintType::URIRGBColor:
+            return functor(SpaceSeparatedTuple { url, color });
+        case SVGPaintType::URI:
+            return functor(url);
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
+    bool operator==(const SVGPaint&) const = default;
+};
+
+// MARK: - Conversion
+
+template<> struct CSSValueConversion<SVGPaint> { auto operator()(BuilderState&, const CSSValue&, ForVisitedLink) -> SVGPaint; };
+
+// MARK: - Blending
+
+template<> struct Blending<SVGPaint> {
+    auto equals(const SVGPaint&, const SVGPaint&, const RenderStyle&, const RenderStyle&) -> bool;
+    auto canBlend(const SVGPaint&, const SVGPaint&) -> bool;
+    auto blend(const SVGPaint&, const SVGPaint&, const RenderStyle&, const RenderStyle&, const BlendingContext&) -> SVGPaint;
+};
+
+// MARK: - Logging
+
+WTF::TextStream& operator<<(WTF::TextStream&, SVGPaintType);
+
+} // namespace Style
+} // namespace WebCore
+
+template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::SVGPaint> = true;


### PR DESCRIPTION
#### 10247d5959d865e817cf18d901b07c4b233289e6
<pre>
[Style] Convert SVGPaint to use strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=294691">https://bugs.webkit.org/show_bug.cgi?id=294691</a>

Reviewed by Darin Adler.

Bundles the SVGPaintType, Color and URL values that make up the
`fill` and `stoke` CSS properties into a new `Style::SVGPaint`
type and uses the style interfaces to implement conversion / blending.

Implementing blending required adding support for custom `equalsForBlending`
(called from the existing interpolation wrapper virtual function
`equals`) to the `Blending` interface. With that in place, we are
also able to implement the Blending interface for `Style::Color` and
remove a few more custom interpolation wrappers.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValueList.h:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
* Source/WebCore/css/scripts/process-css-properties.py:
* Source/WebCore/css/scripts/test/TestCSSPropertiesResults/StyleBuilderGenerated.cpp:
* Source/WebCore/css/scripts/test/TestCSSPropertiesResults/StyleExtractorGenerated.cpp:
* Source/WebCore/page/InteractionRegion.cpp:
* Source/WebCore/rendering/ReferencedSVGResources.cpp:
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/SVGRenderStyle.cpp:
* Source/WebCore/rendering/style/SVGRenderStyle.h:
* Source/WebCore/rendering/style/SVGRenderStyleDefs.cpp:
* Source/WebCore/rendering/style/SVGRenderStyleDefs.h:
* Source/WebCore/rendering/svg/SVGPaintServerHandling.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp:
* Source/WebCore/rendering/svg/legacy/SVGResources.cpp:
* Source/WebCore/rendering/svg/legacy/SVGResourcesCache.cpp:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleBuilderCustom.h:
* Source/WebCore/style/StyleBuilderState.cpp:
* Source/WebCore/style/StyleBuilderState.h:
* Source/WebCore/style/StyleExtractorConverter.h:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/StyleExtractorSerializer.h:
* Source/WebCore/style/StyleInterpolationWrappers.h:
* Source/WebCore/style/values/StyleValueTypes.h:
* Source/WebCore/style/values/color/StyleColor.cpp:
* Source/WebCore/style/values/color/StyleColor.h:
* Source/WebCore/style/values/svg/StyleSVGPaint.cpp: Added.
* Source/WebCore/style/values/svg/StyleSVGPaint.h: Added.

Canonical link: <a href="https://commits.webkit.org/296445@main">https://commits.webkit.org/296445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b98c116c1a9ed3ad049578d75dd3414ff16ffdff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108559 "14 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28220 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18644 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113768 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/58959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110522 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36774 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/82458 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/58959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111507 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22939 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97782 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62894 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22356 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15922 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58483 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92309 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15973 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116889 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35613 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/26254 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/91476 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35986 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94054 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91277 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23252 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36171 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13937 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31379 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35515 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41050 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35227 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38576 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36905 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->