### PR TITLE
[Liquid Glass] [macOS] quantamagazine.org: tab bar flickers when scrolling against the top of the page

### DIFF
--- a/LayoutTests/fast/page-color-sampling/color-sampling-stability-for-same-element-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-stability-for-same-element-expected.txt
@@ -1,0 +1,12 @@
+PASS colorsAfterScrollingDown.top is "rgb(200, 0, 0)"
+PASS colorsAfterScrollingDown.left is null
+PASS colorsAfterScrollingDown.right is null
+PASS colorsAfterScrollingDown.bottom is null
+PASS colorsAfterScrollingUp.top is "rgb(200, 0, 0)"
+PASS colorsAfterScrollingUp.left is null
+PASS colorsAfterScrollingUp.right is null
+PASS colorsAfterScrollingUp.bottom is null
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/page-color-sampling/color-sampling-stability-for-same-element.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-stability-for-same-element.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+    body, html {
+        width: 100%;
+        margin: 0;
+        font-family: system-ui;
+        background: #eee;
+    }
+
+    header {
+        position: fixed;
+        top: 0;
+        width: 100%;
+        height: 50px;
+        z-index: 100;
+        background: linear-gradient(to bottom, #aaa, #eee);
+    }
+
+    .header-content {
+        width: 100%;
+        height: 50px;
+        background: rgb(200, 0, 0);
+    }
+
+    .tall {
+        width: 10px;
+        height: 5000px;
+    }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+    window.internals?.settings.setAllowUnclampedScrollPosition(true);
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        await UIHelper.setObscuredInsets(100, 0, 0, 0);
+        await UIHelper.ensurePresentationUpdate();
+
+        const header = document.querySelector("header");
+        const headerContent = document.createElement("div");
+        headerContent.classList.add("header-content");
+
+        addEventListener("scroll", () => {
+            if (pageYOffset < 500)
+                headerContent.remove();
+            else if (!headerContent.parentElement)
+                header.appendChild(headerContent);
+        });
+
+        scrollTo(0, 1000);
+        await UIHelper.ensurePresentationUpdate();
+
+        colorsAfterScrollingDown = await UIHelper.fixedContainerEdgeColors();
+        shouldBeEqualToString("colorsAfterScrollingDown.top", "rgb(200, 0, 0)");
+        shouldBeNull("colorsAfterScrollingDown.left");
+        shouldBeNull("colorsAfterScrollingDown.right");
+        shouldBeNull("colorsAfterScrollingDown.bottom");
+
+        scrollTo(0, 0);
+        await UIHelper.ensurePresentationUpdate();
+
+        colorsAfterScrollingUp = await UIHelper.fixedContainerEdgeColors();
+        shouldBeEqualToString("colorsAfterScrollingUp.top", "rgb(200, 0, 0)");
+        shouldBeNull("colorsAfterScrollingUp.left");
+        shouldBeNull("colorsAfterScrollingUp.right");
+        shouldBeNull("colorsAfterScrollingUp.bottom");
+
+        finishJSTest();
+    });
+    </script>
+</head>
+<body>
+    <header>
+    </header>
+    <div class="tall"></div>
+</body>
+</html>

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2231,6 +2231,11 @@ std::pair<FixedContainerEdges, WeakElementEdges> LocalFrameView::fixedContainerE
             continue;
         }
 
+        if (page->lastFixedContainer(side) == result.container && page->fixedContainerEdges().hasFixedEdge(side)) {
+            edges.colors.setAt(side, page->fixedContainerEdges().colors.at(side));
+            continue;
+        }
+
         edges.colors.setAt(side, PageColorSampler::predominantColor(*page, computeSamplingRect(result.container->renderStyle(), side)));
     }
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5320,6 +5320,11 @@ void Page::updateFixedContainerEdges(BoxSideSet sides)
     m_fixedContainerEdgesAndElements = std::make_pair(makeUniqueRef<FixedContainerEdges>(WTFMove(edges)), WTFMove(elements));
 }
 
+Element* Page::lastFixedContainer(BoxSide side) const
+{
+    return m_fixedContainerEdgesAndElements.second.at(side).get();
+}
+
 void Page::setPortsForUpgradingInsecureSchemeForTesting(uint16_t upgradeFromInsecurePort, uint16_t upgradeToSecurePort)
 {
     m_portsForUpgradingInsecureSchemeForTesting = { upgradeFromInsecurePort, upgradeToSecurePort };

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -915,6 +915,7 @@ public:
 
     WEBCORE_EXPORT void updateFixedContainerEdges(OptionSet<BoxSideFlag>);
     const FixedContainerEdges& fixedContainerEdges() const { return m_fixedContainerEdgesAndElements.first; }
+    Element* lastFixedContainer(BoxSide) const;
 
 #if ENABLE(WEB_PAGE_SPATIAL_BACKDROP)
     WEBCORE_EXPORT std::optional<SpatialBackdropSource> spatialBackdropSource() const;


### PR DESCRIPTION
#### 4778085003950fa1be48f2c70bb52d9c85ed3598
<pre>
[Liquid Glass] [macOS] quantamagazine.org: tab bar flickers when scrolling against the top of the page
<a href="https://bugs.webkit.org/show_bug.cgi?id=294689">https://bugs.webkit.org/show_bug.cgi?id=294689</a>
<a href="https://rdar.apple.com/153120810">rdar://153120810</a>

Reviewed by Aditya Keerthi.

Further improve sampled color stability for fixed elements around the edges of the viewport by
falling back to the previously sampled color if the hit-tested element has not changed. While this
may leave the top sampled color different than the current color of the fixed element, it avoids
common scenarios where the background of Safari&apos;s tab bar changes too frequently or flickers.

Note that this also has potential performance benefits, since we&apos;ll only snapshot and sample an
element once, until we stop hit-testing to it.

* LayoutTests/fast/page-color-sampling/color-sampling-stability-for-same-element-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/color-sampling-stability-for-same-element.html: Added.

Add a layout test with a top fixed header loosely based on quantamagazine.org; verifies that the
sampled color remains stable after scrolling down (showing the solid orange color), and then
scrolling back up.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fixedContainerEdges const):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::lastFixedContainer const):
* Source/WebCore/page/Page.h:

Canonical link: <a href="https://commits.webkit.org/296401@main">https://commits.webkit.org/296401@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7070a0a3fbde203a4b68b966936ff479095976cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108375 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28036 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18459 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113584 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58800 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110338 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28725 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36586 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82293 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111323 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22780 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97620 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62728 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22197 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15757 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58311 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92149 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15812 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116705 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35429 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/26100 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91320 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35802 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93895 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91121 "Found 2 new API test failures: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23223 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36010 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13777 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31181 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35332 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40870 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35046 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38399 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36726 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->