### PR TITLE
Implement `Element.currentCSSZoom`

### DIFF
--- a/LayoutTests/fast/zooming/currentCSSZoom-body-fixed-regression-test-expected.txt
+++ b/LayoutTests/fast/zooming/currentCSSZoom-body-fixed-regression-test-expected.txt
@@ -1,0 +1,1 @@
+currentCSSZoom (Should be "1"): 1

--- a/LayoutTests/fast/zooming/currentCSSZoom-body-fixed-regression-test.html
+++ b/LayoutTests/fast/zooming/currentCSSZoom-body-fixed-regression-test.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>currentCSSZoom Regression Test</title>
+  <script>
+    if (window.internals)
+      internals.setPageZoomFactor(2);
+  </script>
+</head>
+<body>
+<script>
+  if (window.testRunner)
+    testRunner.dumpAsText();
+
+  let zoomInfo;
+  if ('currentCSSZoom' in Element.prototype) {
+    zoomInfo = 'currentCSSZoom (Should be "1"): ' + document.body.currentCSSZoom;
+  } else {
+    zoomInfo = 'currentCSSZoom not supported';
+  }
+
+  document.body.innerText = zoomInfo;
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/Element-currentCSSZoom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/Element-currentCSSZoom-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Element.currentCSSZoom basic test assert_equals: Unzoomed content expected (number) 1 but got (undefined) undefined
-FAIL Element.currentCSSZoom reacts to style changes assert_equals: currentCSSZoom reacts to style changes expected (number) 2 but got (undefined) undefined
+PASS Element.currentCSSZoom basic test
+PASS Element.currentCSSZoom reacts to style changes
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2610,6 +2610,20 @@ EnableDebuggingFeaturesInSandbox:
     WebKit:
       default: false
 
+EnableElementCurrentCSSZoom:
+  type: bool
+  status: preview
+  category: dom
+  humanReadableName: "Enable Element.currentCSSZoom"
+  humanReadableDescription: "Enable Element.currentCSSZoom"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 EnableInheritURIQueryComponent:
   type: bool
   status: embedder

--- a/Source/WebCore/dom/Element+CSSOMView.idl
+++ b/Source/WebCore/dom/Element+CSSOMView.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -45,6 +45,7 @@ partial interface Element {
     readonly attribute long clientLeft;
     readonly attribute long clientWidth;
     readonly attribute long clientHeight;
+    [EnabledBySetting=EnableElementCurrentCSSZoom] readonly attribute double currentCSSZoom;
 
     // Non-standard: https://www.w3.org/Bugs/Public/show_bug.cgi?id=17152.
     undefined scrollIntoViewIfNeeded(optional boolean centerIfNeeded = true);

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1583,6 +1583,23 @@ int Element::clientHeight()
     return 0;
 }
 
+double Element::currentCSSZoom()
+{
+    Ref document = this->document();
+
+    document->updateStyleIfNeeded();
+
+    float initialZoom = 1.0f;
+    if (RefPtr frame = document->frame()) {
+        if (!document->printing())
+            initialZoom = frame->pageZoomFactor();
+    }
+
+    if (CheckedPtr renderer = this->renderer())
+        return renderer->style().usedZoom() / initialZoom;
+    return 1.0;
+}
+
 ALWAYS_INLINE LocalFrame* Element::documentFrameWithNonNullView() const
 {
     auto* frame = document().frame();

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -302,6 +302,7 @@ public:
     WEBCORE_EXPORT int clientTop();
     WEBCORE_EXPORT int clientWidth();
     WEBCORE_EXPORT int clientHeight();
+    double currentCSSZoom();
 
     virtual int scrollLeft();
     virtual int scrollTop();


### PR DESCRIPTION
#### b762099c12ff80afa3ceac3af500f63d976e448a
<pre>
Implement `Element.currentCSSZoom`

<a href="https://bugs.webkit.org/show_bug.cgi?id=279881">https://bugs.webkit.org/show_bug.cgi?id=279881</a>
<a href="https://rdar.apple.com/136662584">rdar://136662584</a>

Reviewed by Anne van Kesteren.

This patch implements `currentCSSZoom` as per web specification [1] and
aligns with Gecko / Firefox and Blink / Chrome.

[1] <a href="https://drafts.csswg.org/cssom-view/#dom-element-currentcsszoom">https://drafts.csswg.org/cssom-view/#dom-element-currentcsszoom</a>

This is implemented behind flag while being enabled on &apos;Safari Technology Preview&apos;.

* Source/WebCore/dom/Element+CSSOMView.idl:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::currentCSSZoom):
* Source/WebCore/dom/Element.h:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml: Enabled in `preview`
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/Element-currentCSSZoom-expected.txt: Progression
* LayoutTests/fast/zooming/currentCSSZoom-body-fixed-regression-test.html:
* LayoutTests/fast/zooming/currentCSSZoom-body-fixed-regression-test-expected.txt:

Canonical link: <a href="https://commits.webkit.org/296856@main">https://commits.webkit.org/296856@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7d1c83cb3f972858298ab06be065d824440e735

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109782 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29440 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19870 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115803 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60017 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111745 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38028 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83427 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112730 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24002 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98862 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63890 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23381 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17010 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59597 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/102273 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93371 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17053 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118595 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/108334 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36821 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27277 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92430 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37194 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95129 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92252 "Found 3 new API test failures: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy, /WebKitGTK/TestResources:/webkit/WebKitWebResource/get-data-error (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23508 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37221 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14965 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32658 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36716 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42186 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/132610 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36376 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35895 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39718 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38085 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->