### PR TITLE
Attempting to generate a text fragment from only whitespace should not crash the web process.

### DIFF
--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-selecting-only-whitespace-does-not-crash-expected.txt
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-selecting-only-whitespace-does-not-crash-expected.txt
@@ -1,0 +1,1 @@
+No Crash

--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-selecting-only-whitespace-does-not-crash.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-selecting-only-whitespace-does-not-crash.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8" />
+<title>Scroll to text fragment generation - ensure that we trim whitespace from the generated fragments.</title>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.addEventListener('load', () => {
+    const range = document.createRange();
+    range.selectNodeContents(document.getElementById("test"));
+    document.body.innerText = "No Crash";
+});
+</script>
+</head>
+<body>This is a very simple<span id="test"> </span>document.There is no text before 'this'.</body>
+</html>
+

--- a/Source/WebCore/dom/FragmentDirectiveGenerator.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveGenerator.cpp
@@ -88,6 +88,8 @@ static VisiblePosition startVisiblePositionForRangeRemovingLeadingWhitespace(con
     CharacterIterator characterIterator(range);
     while (!characterIterator.atEnd() && !characterIterator.text().isEmpty() && isASCIIWhitespace(characterIterator.text()[0]))
         characterIterator.advance(1);
+    if (characterIterator.atEnd())
+        return { makeContainerOffsetPosition(range.end) };
     return { makeContainerOffsetPosition(characterIterator.range().start) };
 }
 
@@ -96,6 +98,8 @@ static VisiblePosition endVisiblePositionForRangeRemovingTrailingWhitespace(cons
     BackwardsCharacterIterator characterIterator(range);
     while (!characterIterator.atEnd() && !characterIterator.text().isEmpty() && isASCIIWhitespace(characterIterator.text()[characterIterator.text().length() - 1]))
         characterIterator.advance(1);
+    if (characterIterator.atEnd())
+        return { makeContainerOffsetPosition(range.start) };
     return { makeContainerOffsetPosition(characterIterator.range().end) };
 }
 
@@ -157,6 +161,9 @@ void FragmentDirectiveGenerator::generateFragmentDirective(const SimpleRange& te
     auto textFromRange = createLiveRange(textFragmentRange)->toString().simplifyWhiteSpace(isASCIIWhitespace);
     VisiblePosition visibleStartPosition = startVisiblePositionForRangeRemovingLeadingWhitespace(textFragmentRange);
     VisiblePosition visibleEndPosition = endVisiblePositionForRangeRemovingTrailingWhitespace(textFragmentRange);
+
+    if (visibleStartPosition == visibleEndPosition)
+        return;
 
     VisiblePosition visiblePrefixEndPosition = beforeStartOfCurrentBlock(visibleStartPosition);
     VisiblePosition visibleSuffixStartPosition = afterEndOfCurrentBlock(visibleEndPosition);


### PR DESCRIPTION
#### 7eafa6d173c51bb1ae370ed57a4fb050d1351474
<pre>
Attempting to generate a text fragment from only whitespace should not crash the web process.
<a href="https://bugs.webkit.org/show_bug.cgi?id=294695">https://bugs.webkit.org/show_bug.cgi?id=294695</a>
<a href="https://rdar.apple.com/153254264">rdar://153254264</a>

Reviewed by Abrar Rahman Protyasha.

When trimming whitespace off of a range, I did not verify that
the range did not end up as collapsed. Add some checks to make sure
that the range is not collapsed instead of letting a crash happen.

* LayoutTests/http/tests/scroll-to-text-fragment/generation-selecting-only-whitespace-does-not-crash-expected.txt: Added.
* LayoutTests/http/tests/scroll-to-text-fragment/generation-selecting-only-whitespace-does-not-crash.html: Added.
* Source/WebCore/dom/FragmentDirectiveGenerator.cpp:
(WebCore::startVisiblePositionForRangeRemovingLeadingWhitespace):
(WebCore::endVisiblePositionForRangeRemovingTrailingWhitespace):
(WebCore::FragmentDirectiveGenerator::generateFragmentDirective):

Canonical link: <a href="https://commits.webkit.org/296402@main">https://commits.webkit.org/296402@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5762db813da8e786996c0428778ab2eb15565943

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108385 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28046 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18470 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113594 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58806 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110348 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28735 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36596 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82303 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111333 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22786 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97625 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62738 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22203 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15762 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58321 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92155 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15817 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116715 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35439 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26107 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91329 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35812 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93900 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91130 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23222 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36019 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13782 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31187 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35342 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40880 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35055 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38408 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36736 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->