### PR TITLE
[SwiftUI] Add plumbing and test infrastructure to support more accurate scroll geometry reporting

### DIFF
--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -687,6 +687,8 @@ public:
 #endif
     virtual bool needsImageOverlayControllerForSelectionPainting() const { return false; }
 
+    virtual bool needsScrollGeometryUpdates() const { return false; }
+
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
     virtual void showMediaControlsContextMenu(FloatRect&&, Vector<MediaControlsContextMenuItem>&&, CompletionHandler<void(MediaControlsContextMenuItem::ID)>&& completionHandler) { completionHandler(MediaControlsContextMenuItem::invalidID); }
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -1283,6 +1283,8 @@ void LocalFrameView::didLayout(SingleThreadWeakPtr<RenderElement> layoutRoot, bo
 
     updateCanBlitOnScrollRecursively();
 
+    updateScrollGeometryContentSize();
+
     handleDeferredScrollUpdateAfterContentSizeChange();
 
     handleDeferredScrollbarsUpdate();
@@ -1293,6 +1295,18 @@ void LocalFrameView::didLayout(SingleThreadWeakPtr<RenderElement> layoutRoot, bo
 
     if (CheckedPtr markers = document->markersIfExists())
         markers->invalidateRectsForAllMarkers();
+}
+
+void LocalFrameView::updateScrollGeometryContentSize()
+{
+    if (!m_frame->isMainFrame())
+        return;
+
+    RefPtr page = m_frame->page();
+    if (!page || !page->chrome().client().needsScrollGeometryUpdates())
+        return;
+
+    m_scrollGeometryContentSize = contentsSize();
 }
 
 bool LocalFrameView::shouldDeferScrollUpdateAfterContentSizeChange()

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -392,7 +392,9 @@ public:
 #endif
 
     IntRect viewRectExpandedByContentInsets() const;
-    
+
+    IntSize scrollGeometryContentSize() const { return m_scrollGeometryContentSize; }
+
     bool fixedElementsLayoutRelativeToFrame() const;
 
     bool speculativeTilingEnabled() const { return m_speculativeTilingEnabled; }
@@ -833,6 +835,8 @@ private:
     void performFixedWidthAutoSize();
     void performSizeToContentAutoSize();
 
+    void updateScrollGeometryContentSize();
+
     void applyRecursivelyWithVisibleRect(NOESCAPE const Function<void(LocalFrameView& frameView, const IntRect& visibleRect)>&);
     void resumeVisibleImageAnimations(const IntRect& visibleRect);
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
@@ -1038,6 +1042,8 @@ private:
     int m_autoSizeFixedMinimumHeight { 0 };
     // The intrinsic content size decided by autosizing.
     IntSize m_autoSizeContentSize;
+
+    IntSize m_scrollGeometryContentSize;
 
     std::unique_ptr<ScrollableAreaSet> m_scrollableAreas;
     std::unique_ptr<ScrollableAreaSet> m_scrollableAreasForAnimatedScroll;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -132,6 +132,7 @@ header: "RemoteLayerBackingStore.h"
     Vector<IPC::AsyncReplyID> m_callbackIDs;
 
     WebCore::IntSize m_contentsSize;
+    WebCore::IntSize m_scrollGeometryContentSize;
     WebCore::IntPoint m_scrollOrigin;
     WebCore::LayoutSize m_baseLayoutViewportSize;
     WebCore::LayoutPoint m_minStableLayoutViewportOrigin;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -174,6 +174,9 @@ public:
     WebCore::IntSize contentsSize() const { return m_contentsSize; }
     void setContentsSize(const WebCore::IntSize& size) { m_contentsSize = size; };
 
+    WebCore::IntSize scrollGeometryContentSize() const { return m_scrollGeometryContentSize; }
+    void setScrollGeometryContentSize(const WebCore::IntSize& size) { m_scrollGeometryContentSize = size; };
+
     WebCore::IntPoint scrollOrigin() const { return m_scrollOrigin; }
     void setScrollOrigin(const WebCore::IntPoint& origin) { m_scrollOrigin = origin; };
 
@@ -293,6 +296,7 @@ private:
     Vector<TransactionCallbackID> m_callbackIDs;
 
     WebCore::IntSize m_contentsSize;
+    WebCore::IntSize m_scrollGeometryContentSize;
     WebCore::IntPoint m_scrollOrigin;
     WebCore::LayoutSize m_baseLayoutViewportSize;
     WebCore::LayoutPoint m_minStableLayoutViewportOrigin;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
@@ -274,6 +274,7 @@ String RemoteLayerTreeTransaction::description() const
 
     ts.dumpProperty("transactionID"_s, m_transactionID);
     ts.dumpProperty("contentsSize"_s, m_contentsSize);
+    ts.dumpProperty("scrollGeometryContentSize"_s, m_scrollGeometryContentSize);
     if (m_scrollOrigin != WebCore::IntPoint::zero())
         ts.dumpProperty("scrollOrigin"_s, m_scrollOrigin);
 

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -254,6 +254,8 @@ struct WebPageCreationParameters {
 
     bool needsFontAttributes { false };
 
+    bool needsScrollGeometryUpdates { false };
+
     // WebRTC members.
     bool iceCandidateFilteringEnabled { true };
     bool enumeratingAllNetworkInterfacesEnabled { false };

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -176,6 +176,8 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
 
     bool needsFontAttributes;
 
+    bool needsScrollGeometryUpdates;
+
     bool iceCandidateFilteringEnabled;
     bool enumeratingAllNetworkInterfacesEnabled;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2367,6 +2367,11 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
     _maximumViewportInset = maximumViewportInset;
 }
 
+- (void)_setNeedsScrollGeometryUpdates:(BOOL)needsScrollGeometryUpdates
+{
+    _page->setNeedsScrollGeometryUpdates(needsScrollGeometryUpdates);
+}
+
 #if ENABLE(WRITING_TOOLS)
 
 #pragma mark - Writing Tools API

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -625,6 +625,8 @@ RetainPtr<NSError> nsErrorFromExceptionDetails(const std::optional<WebCore::Exce
 
 @property (nonatomic, readonly) NSString *_nameForVisualIdentificationOverlay;
 
+- (void)_setNeedsScrollGeometryUpdates:(BOOL)needsScrollGeometryUpdates;
+
 - (void)_scrollToEdge:(_WKRectEdge)edge animated:(BOOL)animated;
 
 - (void)_requestTextExtraction:(CGRect)rect completionHandler:(void(^)(WKTextExtractionItem *))completionHandler;

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -441,7 +441,7 @@ void PageClientImplCocoa::didCommitLayerTree(const RemoteLayerTreeTransaction& t
 {
     if (auto& edges = transaction.fixedContainerEdges())
         [webView() _updateFixedContainerEdges:*edges];
-    [webView() _updateScrollGeometryWithContentOffset:transaction.scrollPosition() contentSize:transaction.contentsSize()];
+    [webView() _updateScrollGeometryWithContentOffset:transaction.scrollPosition() contentSize:transaction.scrollGeometryContentSize()];
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/WebPageWebView.swift
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageWebView.swift
@@ -184,4 +184,10 @@ extension WebPageWebView {
     }
 }
 
+extension WebPageWebView {
+    public func setNeedsScrollGeometryUpdates(_ value: Bool) {
+        self._setNeedsScrollGeometryUpdates(value)
+    }
+}
+
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2934,6 +2934,15 @@ WebCore::FloatPoint WebPageProxy::viewScrollPosition() const
     return pageClient ? pageClient->viewScrollPosition() : WebCore::FloatPoint { };
 }
 
+void WebPageProxy::setNeedsScrollGeometryUpdates(bool needsScrollGeometryUpdates)
+{
+    if (m_needsScrollGeometryUpdates == needsScrollGeometryUpdates)
+        return;
+
+    m_needsScrollGeometryUpdates = needsScrollGeometryUpdates;
+    send(Messages::WebPage::SetNeedsScrollGeometryUpdates(m_needsScrollGeometryUpdates));
+}
+
 void WebPageProxy::setSuppressVisibilityUpdates(bool flag)
 {
     if (m_suppressVisibilityUpdates == flag)
@@ -11906,6 +11915,7 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
 #endif
 
     parameters.needsFontAttributes = m_needsFontAttributes;
+    parameters.needsScrollGeometryUpdates = m_needsScrollGeometryUpdates;
     parameters.backgroundColor = internals().backgroundColor;
 
     parameters.overriddenMediaType = m_overriddenMediaType;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -991,7 +991,9 @@ public:
     void requestScroll(const WebCore::FloatPoint& scrollPosition, const WebCore::IntPoint& scrollOrigin, WebCore::ScrollIsAnimated);
     
     WebCore::FloatPoint viewScrollPosition() const;
-    
+
+    void setNeedsScrollGeometryUpdates(bool);
+
     void setHasActiveAnimatedScrolls(bool isRunning);
 
     void setPrivateClickMeasurement(std::nullopt_t);
@@ -3866,6 +3868,8 @@ private:
     bool m_isRunningModalJavaScriptDialog { false };
     bool m_isSuspended { false };
     bool m_isLockdownModeExplicitlySet { false };
+
+    bool m_needsScrollGeometryUpdates { false };
 
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
     RefPtr<ListDataObserver> m_linkDecorationFilteringDataUpdateObserver;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -2145,6 +2145,14 @@ void WebChromeClient::textAutosizingUsesIdempotentModeChanged()
 
 #endif
 
+bool WebChromeClient::needsScrollGeometryUpdates() const
+{
+    if (RefPtr page = m_page.get())
+        return page->needsScrollGeometryUpdates();
+
+    return false;
+}
+
 #if ENABLE(META_VIEWPORT)
 
 double WebChromeClient::baseViewportLayoutSizeScaleFactor() const

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -480,6 +480,8 @@ private:
 #endif
     }
 
+    bool needsScrollGeometryUpdates() const final;
+
 #if ENABLE(TEXT_AUTOSIZING)
     void textAutosizingUsesIdempotentModeChanged() final;
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1098,6 +1098,8 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
 
     m_needsFontAttributes = parameters.needsFontAttributes;
 
+    setNeedsScrollGeometryUpdates(parameters.needsScrollGeometryUpdates);
+
 #if ENABLE(WEB_RTC)
     if (!parameters.iceCandidateFilteringEnabled)
         page->disableICECandidateFiltering();
@@ -4965,6 +4967,7 @@ void WebPage::willCommitLayerTree(RemoteLayerTreeTransaction& layerTransaction, 
 #endif
 
     layerTransaction.setContentsSize(frameView->contentsSize());
+    layerTransaction.setScrollGeometryContentSize(frameView->scrollGeometryContentSize());
     layerTransaction.setScrollOrigin(frameView->scrollOrigin());
     layerTransaction.setPageScaleFactor(page->pageScaleFactor());
     layerTransaction.setRenderTreeSize(page->renderTreeSize());

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1881,6 +1881,9 @@ public:
     void setInteractionRegionsEnabled(bool);
 #endif
 
+    bool needsScrollGeometryUpdates() { return m_needsScrollGeometryUpdates; }
+    void setNeedsScrollGeometryUpdates(bool needsUpdates) { m_needsScrollGeometryUpdates = needsUpdates; }
+
     void startDeferringResizeEvents();
     void flushDeferredResizeEvents();
 
@@ -2829,6 +2832,8 @@ private:
 #if HAVE(UIKIT_RESIZABLE_WINDOWS)
     bool m_isWindowResizingEnabled { false };
 #endif
+
+    bool m_needsScrollGeometryUpdates { false };
 
     RefPtr<WebCore::Element> m_focusedElement;
     RefPtr<WebCore::Element> m_recentlyBlurredElement;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -767,6 +767,8 @@ messages -> WebPage WantsAsyncDispatchMessage {
     SetInteractionRegionsEnabled(bool enable)
 #endif
 
+    SetNeedsScrollGeometryUpdates(bool setNeedsScrollGeometryUpdates)
+
     GenerateTestReport(String message, String group);
 
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/CocoaWebViewAdapter.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/CocoaWebViewAdapter.swift
@@ -192,7 +192,12 @@ class CocoaWebViewAdapter: CocoaView, PlatformTextSearching {
 
     // MARK: Scroll Geometry
 
-    var onScrollGeometryChange: OnScrollGeometryChangeContext?
+    var onScrollGeometryChange: OnScrollGeometryChangeContext? = nil {
+        willSet {
+            webView?.setNeedsScrollGeometryUpdates(newValue != nil)
+        }
+    }
+
     private var currentScrollGeometry = ScrollGeometry(
         contentOffset: .zero,
         contentSize: .zero,

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -324,6 +324,7 @@ Tests/WebKitCocoa/WKPreferences.mm
 Tests/WebKitCocoa/WKPrinting.mm
 Tests/WebKitCocoa/WKProcessPoolConfiguration.mm
 Tests/WebKitCocoa/WKRequestActivatedElementInfo.mm
+Tests/WebKitCocoa/WKScrollGeometryTests.mm
 Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
 Tests/WebKitCocoa/WKURLSchemeHandler-leaks.mm
 Tests/WebKitCocoa/WKWebExtension.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -3821,6 +3821,7 @@
 		E532A15E2BDA271F00E79810 /* DataListTextSuggestionTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DataListTextSuggestionTests.mm; sourceTree = "<group>"; };
 		E540058727B3A8320005653A /* contenteditable-user-select-user-drag.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "contenteditable-user-select-user-drag.html"; sourceTree = "<group>"; };
 		E55999F62B476C2F00A3719F /* FullscreenLayoutParameters.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FullscreenLayoutParameters.mm; sourceTree = "<group>"; };
+		E5723F202DFF4FDC00A12F48 /* WKScrollGeometryTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKScrollGeometryTests.mm; sourceTree = "<group>"; };
 		E57B44C029ABFAA4006069DE /* qr-code.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "qr-code.png"; sourceTree = "<group>"; };
 		E589183B252BC90A0041DED5 /* DateTimeInputsAccessoryViewTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DateTimeInputsAccessoryViewTests.mm; sourceTree = "<group>"; };
 		E59CF8222C2D1E3700891383 /* adaptive-image-glyph.heic */ = {isa = PBXFileReference; lastKnownFileType = file; path = "adaptive-image-glyph.heic"; sourceTree = "<group>"; };
@@ -4774,6 +4775,7 @@
 				1CC4C74A288909F600A3B23D /* WKPrinting.mm */,
 				3781746C2198AE2400062C26 /* WKProcessPoolConfiguration.mm */,
 				44817A2E1F0486BF00003810 /* WKRequestActivatedElementInfo.mm */,
+				E5723F202DFF4FDC00A12F48 /* WKScrollGeometryTests.mm */,
 				5E4B1D2C1D404C6100053621 /* WKScrollViewDelegate.mm */,
 				51C683DD1EA134DB00650183 /* WKURLSchemeHandler-1.mm */,
 				5182C22D1F2BCB410059BA7C /* WKURLSchemeHandler-leaks.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKScrollGeometryTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKScrollGeometryTests.mm
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if PLATFORM(COCOA)
+
+#import "PlatformUtilities.h"
+#import "Test.h"
+#import "TestCocoa.h"
+#import "TestWKWebView.h"
+#import "Utilities.h"
+#import <wtf/RetainPtr.h>
+
+@interface WKWebView (ScrollGeometryTesting)
+- (void)_setNeedsScrollGeometryUpdates:(BOOL)needsScrollGeometryUpdates;
+@end
+
+@interface TestScrollGeometryDelegate : NSObject <WKUIDelegate>
+
+- (void)_webView:(WKWebView *)webView geometryDidChange:(WKScrollGeometry *)geometry;
+
+- (CGSize)currentContentSize;
+
+@end
+
+@implementation TestScrollGeometryDelegate {
+    RetainPtr<WKScrollGeometry> _currentGeometry;
+}
+
+- (void)_webView:(WKWebView *)webView geometryDidChange:(WKScrollGeometry *)geometry
+{
+    _currentGeometry = geometry;
+}
+
+- (CGSize)currentContentSize
+{
+    return [_currentGeometry contentSize];
+}
+
+@end
+
+static void runContentSizeTest(NSString *html, CGSize expectedSize, BOOL needsScrollGeometryUpdates = YES)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    [webView _setNeedsScrollGeometryUpdates:needsScrollGeometryUpdates];
+
+    RetainPtr delegate = adoptNS([[TestScrollGeometryDelegate alloc] init]);
+    [webView setUIDelegate:delegate.get()];
+
+    [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<!DOCTYPE html>%@", html]];
+
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_EQ([delegate currentContentSize], expectedSize);
+
+    [webView synchronouslyLoadHTMLString:html];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_EQ([delegate currentContentSize], expectedSize);
+}
+
+TEST(WKScrollGeometry, ContentSizeTallerThanWebView)
+{
+#if PLATFORM(IOS_FAMILY)
+    CGFloat expectedWidth = 980;
+#elif (PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED <= 150000)
+    CGFloat expectedWidth = 785;
+#else
+    CGFloat expectedWidth = 786;
+#endif
+
+    runContentSizeTest(@""
+        "<html>"
+        "<head>"
+        "<style>"
+        "    div { background: red; height: 10000px; }"
+        "</style>"
+        "</head>"
+        "<body>"
+        "<div>Test</div>"
+        "</body>"
+        "</html>", CGSizeMake(expectedWidth, 10016));
+}
+
+TEST(WKScrollGeometry, NoScrollGeometryUpdates)
+{
+    runContentSizeTest(@""
+        "<html>"
+        "<head>"
+        "<style>"
+        "    div { background: red; height: 10000px; }"
+        "</style>"
+        "</head>"
+        "<body>"
+        "<div>Test</div>"
+        "</body>"
+        "</html>", CGSizeZero, NO);
+}
+
+#endif


### PR DESCRIPTION
#### 7cfc79c2b3d82989bd001597f61053ecb65ff19c
<pre>
[SwiftUI] Add plumbing and test infrastructure to support more accurate scroll geometry reporting
<a href="https://bugs.webkit.org/show_bug.cgi?id=294694">https://bugs.webkit.org/show_bug.cgi?id=294694</a>
<a href="https://rdar.apple.com/153764316">rdar://153764316</a>

Reviewed by Richard Robinson, Wenson Hsieh, and Megan Gardner.

`webViewOnScrollGeometryChange` currently does not always report an accurate
content size.  The reported size should be a &quot;fitting size&quot; given the current
web view size. However, at this time the reported size is always the `FrameView`&apos;s
content size, which is often larger.

This patch works towards fixing the reported size by introducing plumbing to
only compute a content size for scroll geometry if needed, and reporting that
size back to SwiftUI. Additionally, testing capability for scroll geometry is
added.

A subsequent patch will fill out the implementation of
`LocalFrameView::updateScrollGeometryContentSize` to fix the described issue.
That patch will also introduce even more test cases, including ones that are
currently broken.

No behavior change.

* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::needsScrollGeometryUpdates const):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::didLayout):
(WebCore::LocalFrameView::updateScrollGeometryContentSize):

Recompute the content size for SwiftUI after every layout, but only if
scroll geometry updates are needed. This ensures expensive (to be added)
work is avoided when unnecessary.

For now, simply return `contentsSize()`, preserving the currently
implemented behavior.

* Source/WebCore/page/LocalFrameView.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:

Add a new field to `RemoteLayerTreeTransaction` so that content size changes
are reported in-sync with scroll position changes.

(WebKit::RemoteLayerTreeTransaction::scrollGeometryContentSize const):
(WebKit::RemoteLayerTreeTransaction::setScrollGeometryContentSize):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
(WebKit::RemoteLayerTreeTransaction::description const):
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _setNeedsScrollGeometryUpdates:]):

Add a hook for SwiftUI to let WebKit know scroll geometry updates are needed.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::didCommitLayerTree):
* Source/WebKit/UIProcess/Cocoa/WebPageWebView.swift:
(WebPageWebView.setNeedsScrollGeometryUpdates(_:)):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setNeedsScrollGeometryUpdates):
(WebKit::WebPageProxy::creationParameters):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::needsScrollGeometryUpdates const):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_textAnimationController):
(WebKit::WebPage::willCommitLayerTree):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/_WebKit_SwiftUI/Implementation/CocoaWebViewAdapter.swift:
(CocoaWebViewAdapter.onScrollGeometryChange):

Only perform scroll geometry content size computation if the view modifier is
in use.

* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKScrollGeometryTests.mm: Added.
(-[TestScrollGeometryDelegate _webView:geometryDidChange:]):
(-[TestScrollGeometryDelegate currentContentSize]):
(runContentSizeTest):

Test both quirks and standards mode.

(TEST(WKScrollGeometry, ContentSizeTallerThanWebView)):
(TEST(WKScrollGeometry, NoScrollGeometryUpdates)):

Canonical link: <a href="https://commits.webkit.org/296531@main">https://commits.webkit.org/296531@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3d85a62180b2dc8a56089547b2e1fdc38f89aec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108420 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28081 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18505 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113629 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58833 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110383 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36631 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82333 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111368 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22817 "Found 3 new test failures: fast/filter-image/clipped-filter.html http/tests/geolocation/geolocation-get-current-position-does-not-leak.https.html http/tests/security/cached-svg-image-with-css-cross-domain.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97658 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62769 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22233 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15796 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58355 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92186 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15850 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116750 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35474 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26134 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91360 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35847 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93933 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91161 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36050 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13813 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31214 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17568 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35377 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40914 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35088 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38438 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36771 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->