### PR TITLE
Fix broken z-ordering on pages with "position: sticky"

### DIFF
--- a/LayoutTests/compositing/layer-creation/sticky-overlap-extent-expected.txt
+++ b/LayoutTests/compositing/layer-creation/sticky-overlap-extent-expected.txt
@@ -1,0 +1,221 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 2000.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 2000.00)
+      (contentsOpaque 1)
+      (children 41
+        (GraphicsLayer
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 150.00 150.00)
+              (contentsOpaque 1)
+            )
+          )
+        )
+        (GraphicsLayer
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 0.00 100.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 0.00 200.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 0.00 300.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 0.00 400.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 0.00 500.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 0.00 600.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 0.00 700.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 0.00 800.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 0.00 900.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 0.00 1000.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 0.00 1100.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 0.00 1200.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 0.00 1300.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 0.00 1400.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 0.00 1500.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 0.00 1600.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 0.00 1700.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 0.00 1800.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 0.00 1900.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 0.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 100.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 200.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 300.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 400.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 500.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 600.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 700.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 800.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 900.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 1000.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 1100.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 1200.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 1300.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 1400.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 1500.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 1600.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 1700.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 1800.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 1900.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/compositing/layer-creation/sticky-overlap-extent.html
+++ b/LayoutTests/compositing/layer-creation/sticky-overlap-extent.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+
+<html>
+    <head>
+        <style>
+            body {
+                margin: 0;
+                width: 800px;
+                height: 2000px;
+            }
+            .sticky {
+                position: sticky;
+                top: 0;
+                width: 150px;
+                height: 150px;
+                background: blue;
+            }
+            .dot {
+                position: absolute;
+                width: 50px;
+                height: 50px;
+                background-color: orange;
+            }
+        </style>
+        <script>
+            if (window.testRunner) {
+                testRunner.dumpAsText();
+            }
+
+            function setupDots() {
+                let across = 8;
+                let down = 20;
+                let spacing = 100;
+                let container = document.getElementById('dots-container');
+                for (let col = 0; col < across; ++col) {
+                    for (let row = 0; row < down; ++row) {
+                        let div = document.createElement('div');
+                        div.className = 'dot';
+                        div.style.left = col * spacing + 'px';
+                        div.style.top = row * spacing + 'px';
+                        container.appendChild(div);
+                    }
+                }
+            }
+
+            function doTest() {
+                setupDots();
+                if (window.testRunner) {
+                    document.getElementById('result').innerText = internals.layerTreeAsText(document);
+                }
+            }
+            window.addEventListener('load', doTest, false);
+        </script>
+    </head>
+    <body>
+        <div class="sticky"></div>
+        <div id="dots-container"></div>
+        <pre id="result"></pre>
+    </body>
+</html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1954,6 +1954,8 @@ fast/html/details-remove-summary-6-and-click.html [ Pass Failure ]
 webkit.org/b/165541 compositing/layer-creation/fixed-overlap-extent-rtl.html [ Failure ]
 webkit.org/b/165541 compositing/rtl/rtl-fixed-overflow.html [ Failure ]
 
+compositing/layer-creation/sticky-overlap-extent.html
+
 webkit.org/b/154612 compositing/repaint/fixed-background-scroll.html [ Pass Failure ]
 
 webkit.org/b/165589 pointer-lock/lock-lost-on-esc-in-fullscreen.html [ Skip ]

--- a/Source/WebCore/page/scrolling/ScrollingConstraints.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingConstraints.cpp
@@ -115,6 +115,27 @@ FloatPoint StickyPositionViewportConstraints::anchorLayerPositionAtLastLayout() 
     return m_layerPositionAtLastLayout + m_anchorLayerOffsetAtLastLayout;
 }
 
+FloatRect StickyPositionViewportConstraints::computeStickyExtent() const
+{
+    float minShiftX = 0;
+    float maxShiftX = 0;
+    float minShiftY = 0;
+    float maxShiftY = 0;
+    if (hasAnchorEdge(AnchorEdgeRight))
+        minShiftX = std::min<float>(0, m_containingBlockRect.x() - m_stickyBoxRect.x());
+    if (hasAnchorEdge(AnchorEdgeLeft))
+        maxShiftX = std::max<float>(0, m_containingBlockRect.maxX() - m_stickyBoxRect.maxX());
+    if (hasAnchorEdge(AnchorEdgeBottom))
+        minShiftY = std::min<float>(0, m_containingBlockRect.y() - m_stickyBoxRect.y());
+    if (hasAnchorEdge(AnchorEdgeTop))
+        maxShiftY = std::max<float>(0, m_containingBlockRect.maxY() - m_stickyBoxRect.maxY());
+    float minX = m_stickyBoxRect.x() + minShiftX;
+    float minY = m_stickyBoxRect.y() + minShiftY;
+    float maxX = m_stickyBoxRect.maxX() + maxShiftX;
+    float maxY = m_stickyBoxRect.maxY() + maxShiftY;
+    return FloatRect(minX, minY, maxX - minX, maxY - minY);
+}
+
 TextStream& operator<<(TextStream& ts, ScrollPositioningBehavior behavior)
 {
     switch (behavior) {

--- a/Source/WebCore/page/scrolling/ScrollingConstraints.h
+++ b/Source/WebCore/page/scrolling/ScrollingConstraints.h
@@ -179,6 +179,10 @@ public:
     FloatRect stickyBoxRect() const { return m_stickyBoxRect; }
     void setStickyBoxRect(const FloatRect& rect) { m_stickyBoxRect = rect; }
 
+    // Sticky extent is the smallest rectangle, in the scrolling ancestor's coordinate space, that encloses
+    // the sticky box at every permissible position during its sticky travel.
+    FloatRect computeStickyExtent() const;
+
     friend bool operator==(const StickyPositionViewportConstraints&, const StickyPositionViewportConstraints&) = default;
 
 private:


### PR DESCRIPTION
#### 1d76bd02c2320c67c98b5585b8286897d73fb051
<pre>
Fix broken z-ordering on pages with &quot;position: sticky&quot;

<a href="https://bugs.webkit.org/show_bug.cgi?id=238127">https://bugs.webkit.org/show_bug.cgi?id=238127</a>

Reviewed by Simon Fraser.

Sticky elements could move around without recomputing overlap extent,
which leads to incorrect z-ordering when a sticky element moves onto an
element that would otherwise be promoted to be composited for indirect
&quot;overlap&quot; reason. The bug is fixed using the same approach applied in
5b652c3 to &quot;position: fixed&quot; elements: expanding overlap extent to cover
all possible sticky positions.

Bug 238127 mentioned CSS grids, but the issue turned out to be more
general and at least applies to all sticky elements whose containing
block is the root element.

* LayoutTests/compositing/layer-creation/sticky-overlap-extent-expected.txt: Added.
* LayoutTests/compositing/layer-creation/sticky-overlap-extent.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/page/scrolling/ScrollingConstraints.cpp:
(WebCore::StickyPositionViewportConstraints::computeStickyExtent const):
* Source/WebCore/page/scrolling/ScrollingConstraints.h:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::computeExtent const):

Canonical link: <a href="https://commits.webkit.org/297346@main">https://commits.webkit.org/297346@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/826b6c240493cf6f6e87c74095c426bddcaaec51

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110819 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116848 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61087 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112782 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31162 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39068 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84255 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113767 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24896 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99792 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64697 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24257 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17933 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60644 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94283 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17994 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119642 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37864 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28139 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93215 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/110316 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38240 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96065 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93039 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23809 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38082 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15839 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/33838 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37757 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43227 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37418 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40756 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39125 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->