### PR TITLE
box-shadow spread radius renders incorrectly

### DIFF
--- a/LayoutTests/fast/box-shadow/outset-shadow-negative-spread-radius-expected.html
+++ b/LayoutTests/fast/box-shadow/outset-shadow-negative-spread-radius-expected.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            margin: 0;
+        }
+        .box {
+            margin: 50px;
+            width: 200px;
+            height: 200px;
+            background-color: silver;
+            border-radius: 70px;
+        }
+        
+        .fake-shadow {
+            position: absolute;
+            top: 60px;
+            left: 310px;
+            width: 180px;
+            height: 180px;
+            background-color: black;
+            border-radius: 70px;
+        }
+    </style>
+</head>
+<body>
+    <div class="box" style="box-shadow: 250px 0 0 -10px black"></div>
+    <div class="fake-shadow"></div>
+</body>
+</html>

--- a/LayoutTests/fast/box-shadow/outset-shadow-negative-spread-radius.html
+++ b/LayoutTests/fast/box-shadow/outset-shadow-negative-spread-radius.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="fuzzy" content="maxDifference=0-20; totalPixels=0-34">
+    <style>
+        body {
+            margin: 0;
+        }
+        .box {
+            margin: 50px;
+            width: 200px;
+            height: 200px;
+            background-color: silver;
+            border-radius: 70px;
+        }
+    </style>
+</head>
+<body>
+    <div class="box" style="box-shadow: 250px 0 0 -10px black"></div>
+</body>
+</html>

--- a/LayoutTests/fast/box-shadow/outset-shadow-spread-radius-expected.html
+++ b/LayoutTests/fast/box-shadow/outset-shadow-spread-radius-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .box {
+            margin: 40px;
+            width: 400px;
+            height: 300px;
+            border: 10px solid blue;
+            border-radius: 30px;
+        }
+    </style>
+</head>
+<body>
+    <div class="box"></div>
+</body>
+</html>

--- a/LayoutTests/fast/box-shadow/outset-shadow-spread-radius.html
+++ b/LayoutTests/fast/box-shadow/outset-shadow-spread-radius.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="fuzzy" content="maxDifference=0-58; totalPixels=0-410">
+    <style>
+        .box {
+            margin: 50px;
+            width: 400px;
+            height: 300px;
+            box-shadow: 0 0 0 10px blue;
+            border-radius: 20px;
+        }
+    </style>
+</head>
+<body>
+    <div class="box"></div>
+</body>
+</html>

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -850,8 +850,23 @@ void BackgroundPainter::paintBoxShadow(const LayoutRect& paintRect, const Render
         };
 
         if (!Style::isInset(shadow)) {
-            auto shadowShape = borderShape;
-            shadowShape.inflate(shadowSpread);
+            auto shadowShape = [&] {
+                if (!shadowSpread)
+                    return borderShape;
+
+                if (shadowSpread > 0) {
+                    auto spreadRect = paintRect;
+                    spreadRect.inflate(shadowSpread);
+                    return BorderShape::shapeForOutsetRect(style, paintRect, spreadRect, { }, closedEdges);
+                }
+
+                auto spreadRect = paintRect;
+                auto inflateX = std::max(shadowSpread, -paintRect.width() / 2);
+                auto inflateY = std::max(shadowSpread, -paintRect.height() / 2);
+                spreadRect.inflate(LayoutSize { inflateX, inflateY });
+                return BorderShape::shapeForInsetRect(style, paintRect, spreadRect /* , closedEdges*/);
+            }();
+
             if (shadowShape.isEmpty())
                 continue;
 

--- a/Source/WebCore/rendering/BorderPainter.cpp
+++ b/Source/WebCore/rendering/BorderPainter.cpp
@@ -319,7 +319,7 @@ void BorderPainter::paintOutline(const LayoutRect& paintRect) const
     auto closedEdges = RectEdges<bool> { true };
 
     auto outlineEdgeWidths = RectEdges<LayoutUnit> { outlineWidth };
-    auto outlineShape = BorderShape::shapeForOutlineRect(styleToUse, paintRect, outerRect, outlineEdgeWidths, closedEdges);
+    auto outlineShape = BorderShape::shapeForOutsetRect(styleToUse, paintRect, outerRect, outlineEdgeWidths, closedEdges);
 
     auto bleedAvoidance = BleedAvoidance::ShrinkBackground;
     auto appliedClipAlready = false;

--- a/Source/WebCore/rendering/BorderShape.cpp
+++ b/Source/WebCore/rendering/BorderShape.cpp
@@ -102,7 +102,7 @@ BorderShape BorderShape::shapeForBorderRect(const RenderStyle& style, const Layo
     return BorderShape { borderRect, usedBorderWidths };
 }
 
-BorderShape BorderShape::shapeForOutlineRect(const RenderStyle& style, const LayoutRect& borderRect, const LayoutRect& outlineBoxRect, const RectEdges<LayoutUnit>& outlineWidths, RectEdges<bool> closedEdges)
+BorderShape BorderShape::shapeForOutsetRect(const RenderStyle& style, const LayoutRect& borderRect, const LayoutRect& outlineBoxRect, const RectEdges<LayoutUnit>& outlineWidths, RectEdges<bool> closedEdges)
 {
     // top, right, bottom, left.
     auto usedOutlineWidths = RectEdges<LayoutUnit> {
@@ -147,6 +147,27 @@ BorderShape BorderShape::shapeForOutlineRect(const RenderStyle& style, const Lay
     }
 
     return BorderShape { outlineBoxRect, usedOutlineWidths };
+}
+
+BorderShape BorderShape::shapeForInsetRect(const RenderStyle& style, const LayoutRect& borderRect, const LayoutRect& insetRect)
+{
+    if (style.hasBorderRadius()) {
+        auto radii = calcRadiiFor(style.borderRadii(), borderRect.size());
+
+        auto leftInset = std::max(insetRect.x() - borderRect.x(), 0_lu);
+        auto topInset = std::max(insetRect.y()- borderRect.y(), 0_lu);
+        auto rightInset = std::max(borderRect.maxX() - insetRect.maxX(), 0_lu);
+        auto bottomInset = std::max(borderRect.maxY() - insetRect.maxY(), 0_lu);
+
+        auto insetWidths = RectEdges<LayoutUnit> { topInset, rightInset, bottomInset, leftInset };
+        auto roundedRect = RoundedRect { borderRect, radii };
+
+        auto insetRoundedRect = computeInnerEdgeRoundedRect(roundedRect, insetWidths);
+
+        return BorderShape { insetRect, { }, insetRoundedRect.radii() };
+    }
+
+    return BorderShape { insetRect, { } };
 }
 
 BorderShape::BorderShape(const LayoutRect& borderRect, const RectEdges<LayoutUnit>& borderWidths)

--- a/Source/WebCore/rendering/BorderShape.h
+++ b/Source/WebCore/rendering/BorderShape.h
@@ -51,8 +51,11 @@ public:
     // overrideBorderWidths describe custom insets from the border box, used instead of the border widths from the style.
     static BorderShape shapeForBorderRect(const RenderStyle&, const LayoutRect& borderRect, const RectEdges<LayoutUnit>& overrideBorderWidths, RectEdges<bool> closedEdges = { true });
 
-    // Create a BorderShape suitable for rendering an outline. borderRect is provided to allow for scaling the corner radii.
-    static BorderShape shapeForOutlineRect(const RenderStyle&, const LayoutRect& borderRect, const LayoutRect& outlineBoxRect, const RectEdges<LayoutUnit>& outlineWidths, RectEdges<bool> closedEdges = { true });
+    // Create a BorderShape suitable for rendering an outline or outset shadow. borderRect is provided to allow for scaling the corner radii.
+    static BorderShape shapeForOutsetRect(const RenderStyle&, const LayoutRect& borderRect, const LayoutRect& outlineBoxRect, const RectEdges<LayoutUnit>& outlineWidths, RectEdges<bool> closedEdges = { true });
+
+    // Create a BorderShape suitable for rendering a shape inset from the box. borderRect is provided to allow for scaling the corner radii.
+    static BorderShape shapeForInsetRect(const RenderStyle&, const LayoutRect& borderRect, const LayoutRect& insetRect);
 
     BorderShape(const LayoutRect& borderRect, const RectEdges<LayoutUnit>& borderWidths);
     BorderShape(const LayoutRect& borderRect, const RectEdges<LayoutUnit>& borderWidths, const RoundedRectRadii&);


### PR DESCRIPTION
#### d78b2e061ed266abebebb35e2bcad06f8ac45c0b
<pre>
box-shadow spread radius renders incorrectly
<a href="https://bugs.webkit.org/show_bug.cgi?id=291633">https://bugs.webkit.org/show_bug.cgi?id=291633</a>
<a href="https://rdar.apple.com/149490613">rdar://149490613</a>

Reviewed by Alan Baradlay.

When a box with border-radius has an outset box-shadow, we should adjust
the radii to make the corners concentric. BackgroundPainter was using
`BorderShape::inflate()` but this scales the radii proportionally
to the entire box. Instead, adapt a function used for outlines, which
computes concentric corners given two rects.

We also need to reduce radii when the spread is negative, achieved
via the new `BorderShape::shapeForInsetRect()`.

* LayoutTests/fast/box-shadow/outset-shadow-negative-spread-radius-expected.html: Added.
* LayoutTests/fast/box-shadow/outset-shadow-negative-spread-radius.html: Added.
* LayoutTests/fast/box-shadow/outset-shadow-spread-radius-expected.html: Added.
* LayoutTests/fast/box-shadow/outset-shadow-spread-radius.html: Added.
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintBoxShadow const):
* Source/WebCore/rendering/BorderPainter.cpp:
(WebCore::BorderPainter::paintOutline const):
* Source/WebCore/rendering/BorderShape.cpp:
(WebCore::BorderShape::shapeForOutsetRect):
(WebCore::BorderShape::shapeForInsetRect):
(WebCore::BorderShape::shapeForOutlineRect): Deleted.
* Source/WebCore/rendering/BorderShape.h:
(WebCore::BorderShape::shapeForOutsetRect):
(WebCore::BorderShape::shapeForOutlineRect): Deleted.

Canonical link: <a href="https://commits.webkit.org/296481@main">https://commits.webkit.org/296481@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56d2cc5a61f6d83a514640c6a0a4d21d45d75230

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28324 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113874 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59048 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110626 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29013 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36881 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82547 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111611 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23041 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97882 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62984 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22459 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16019 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58581 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92411 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16070 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116995 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35717 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26346 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91565 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36090 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94151 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91369 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23276 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36274 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14034 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31554 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35618 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41151 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35328 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38674 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37005 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->