### PR TITLE
[visionOS] Add delegate method to prevent docking from element fullscreen.

### DIFF
--- a/Source/WebKit/UIProcess/API/APIFullscreenClient.h
+++ b/Source/WebKit/UIProcess/API/APIFullscreenClient.h
@@ -57,6 +57,10 @@ public:
 #if PLATFORM(IOS_FAMILY)
     virtual void requestPresentingViewController(CompletionHandler<void(UIViewController *, NSError *)>&&) { }
 #endif
+
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+    virtual bool preventDocking(WebKit::WebPageProxy*) { return false; }
+#endif
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKFullscreenDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKFullscreenDelegate.h
@@ -43,6 +43,7 @@ WK_API_AVAILABLE(macos(10.13), ios(11.3))
 
 - (void)_webView:(WKWebView *)webView didFullscreenImageWithQuickLook:(CGSize)imageDimensions;
 - (void)_webView:(WKWebView *)webView requestPresentingViewControllerWithCompletionHandler:(void (^)(UIViewController * _Nullable, NSError * _Nullable))completionHandler;
+- (BOOL)_webViewPreventDockingFromElementFullscreen:(WKWebView *)webView;
 #else
 - (void)_webViewWillEnterFullscreen:(NSView *)webView;
 - (void)_webViewDidEnterFullscreen:(NSView *)webView;

--- a/Source/WebKit/UIProcess/Cocoa/FullscreenClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/FullscreenClient.h
@@ -57,6 +57,10 @@ public:
     void requestPresentingViewController(CompletionHandler<void(UIViewController *, NSError *)>&&) final;
 #endif
 
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+    bool preventDocking(WebPageProxy*) final;
+#endif
+
 private:
     WeakObjCPtr<WKWebView> m_webView;
     WeakObjCPtr<id <_WKFullscreenDelegate> > m_delegate;
@@ -78,6 +82,9 @@ private:
 #endif
 #if PLATFORM(IOS_FAMILY)
         bool webViewRequestPresentingViewController : 1 { false };
+#endif
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+        bool webViewPreventDockingFromElementFullscreen : 1 { false };
 #endif
     } m_delegateMethods;
 };

--- a/Source/WebKit/UIProcess/Cocoa/FullscreenClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/FullscreenClient.mm
@@ -63,6 +63,9 @@ void FullscreenClient::setDelegate(id <_WKFullscreenDelegate> delegate)
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     m_delegateMethods.webViewDidFullscreenImageWithQuickLook = [delegate respondsToSelector:@selector(_webView:didFullscreenImageWithQuickLook:)];
 #endif
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+    m_delegateMethods.webViewPreventDockingFromElementFullscreen = [delegate respondsToSelector:@selector(_webViewPreventDockingFromElementFullscreen:)];
+#endif
 }
 
 void FullscreenClient::willEnterFullscreen(WebPageProxy*)
@@ -147,4 +150,14 @@ void FullscreenClient::requestPresentingViewController(CompletionHandler<void(UI
 }
 #endif
 
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+bool FullscreenClient::preventDocking(WebPageProxy*)
+{
+    RetainPtr webView = m_webView.get();
+    if (m_delegateMethods.webViewPreventDockingFromElementFullscreen)
+        return [m_delegate.get() _webViewPreventDockingFromElementFullscreen:webView.get()];
+
+    return false;
+}
+#endif
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -55,6 +55,7 @@
 #import <wtf/WeakObjCPtr.h>
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
+#import "FullscreenClient.h"
 #import "WKSLinearMediaPlayer.h"
 #endif
 
@@ -484,7 +485,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     ASSERT(_valid);
 
     RefPtr page = self._webView._page.get();
-    if (!page || !page->preferences().linearMediaPlayerEnabled()) {
+    if (!page || !page->preferences().linearMediaPlayerEnabled() || page->fullscreenClient().preventDocking(page.get())) {
         [self _removeEnvironmentPickerButtonView];
         [self _removeEnvironmentFullscreenVideoButtonView];
         return;


### PR DESCRIPTION
#### 9338c51731f8745cb7817901be2fcc8f86e580c5
<pre>
[visionOS] Add delegate method to prevent docking from element fullscreen.
<a href="https://rdar.apple.com/145799817">rdar://145799817</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=294702">https://bugs.webkit.org/show_bug.cgi?id=294702</a>

Reviewed by Alex Christensen.

Safari on visionOS would like to prevent docking from element fullscreen when the
browser is in a certain state (spatial browsing).

To accomplish this, add a new delegate method to FullscreenClient that gives the
client the option to preventDocking (only for LinearMediaPlayer).

WKFullScreenViewController checks this method, and if configured to prevent, removes
the environment picker button / prevents it being added.

* Source/WebKit/UIProcess/API/APIFullscreenClient.h:
(API::FullscreenClient::preventDocking):
* Source/WebKit/UIProcess/API/Cocoa/_WKFullscreenDelegate.h:
* Source/WebKit/UIProcess/Cocoa/FullscreenClient.h:
* Source/WebKit/UIProcess/Cocoa/FullscreenClient.mm:
(WebKit::FullscreenClient::setDelegate):
(WebKit::FullscreenClient::preventDocking):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController configureEnvironmentPickerOrFullscreenVideoButtonView]):

Canonical link: <a href="https://commits.webkit.org/296597@main">https://commits.webkit.org/296597@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c4a51fa2fbdf4e6261a192ae589f229cc9da46d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108600 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28261 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18685 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113808 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58990 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28950 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36815 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82487 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111548 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22978 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97821 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62924 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22396 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58522 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92347 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16010 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116929 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35654 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26288 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91509 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36027 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94091 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91313 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23334 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36213 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13974 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31469 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35555 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41088 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35265 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38611 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36943 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->