### PR TITLE
[webkitapipy] Add initial unit tests and hook into test-webkitpy

### DIFF
--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/mypy_unittest.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/mypy_unittest.py
@@ -20,42 +20,17 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[build-system]
-requires = ["setuptools>=61.0"]
-build-backend = "setuptools.build_meta"
+from pathlib import Path
+from unittest import TestCase
 
-[project]
-name = "webkitapipy"
-version = "0.1.0"
-authors = [
-  { name="Elliott Williams", email="emw@apple.com" },
-]
-description = "Tools for analyzing API and SPI usage of Mach-O binaries on Apple platforms."
-requires-python = ">=3.9"
-classifiers = [
-    'Development Status :: 1 - Planning',
-    'Intended Audience :: Developers',
-    'Operating System :: MacOS',
-    'Natural Language :: English',
-    'Programming Language :: Python :: 3',
-    'Topic :: Software Development :: Libraries :: Python Modules',
-]
-license = 'BSD-2-Clause'
+import mypy.api
 
-[project.optional-dependencies]
-internal = ['webkitapipy_additions']
 
-[project.scripts]
-audit-spi = "webkitapipy.program:main"
+class TypeAnnotations(TestCase):
+    longMessage = False
 
-[project.urls]
-Homepage = "https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/libraries/webkitapipy"
-Issues = "https://bugs.webkit.org"
-Repository = "https://github.com/WebKit/WebKit"
-
-[mypy]
-strict = true
-disallow_any_generics = false
-disallow_untyped_calls = false
-disallow_untyped_defs = false
-disallow_incomplete_defs = false
+    def test_mypy(self):
+        module_dir = Path(__file__).parent
+        stdout, stderr, status = mypy.api.run(['--pretty', str(module_dir)])
+        output = stdout if stdout and not stdout.isspace() else stderr
+        self.assertEqual(status, 0, output)

--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/program.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/program.py
@@ -159,7 +159,7 @@ def get_parser() -> argparse.ArgumentParser:
 def main(argv=None):
     webkitapipy_additions: Optional[ModuleType]
     try:
-        import webkitapipy_additions
+        import webkitapipy_additions.program
     except ImportError:
         webkitapipy_additions = None
 

--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb_unittest.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb_unittest.py
@@ -1,0 +1,71 @@
+# Copyright (C) 2025 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+
+from .sdkdb import SDKDB
+from .macho import APIReport
+
+# Fixtures:
+F = Path('/libdoesntexist.dylib')
+F_Hash = 1234567890
+R = APIReport(
+    file=F, arch='arm64e',
+    exports={'_WKDoesntExistLibraryVersion', '_OBJC_CLASS_$_WKDoesntExist'},
+    methods={'initWithData:'}
+)
+
+
+class TestSDKDB(TestCase):
+    def setUp(self):
+        self.dbfile = tempfile.NamedTemporaryFile(prefix='TestSDKDB-')
+        self.sdkdb = SDKDB(Path(self.dbfile.name))
+
+    def test_ingests_api_report(self):
+        # Given a file added to the cache:
+        with self.sdkdb:
+            self.assertFalse(self.sdkdb._cache_hit_preparing_to_insert(F, F_Hash))
+            self.sdkdb._add_api_report(R, F)
+
+        # Its symbols, classes, and implemented selectors should be added.
+        self.assertTrue(self.sdkdb.symbol('_WKDoesntExistLibraryVersion'))
+        self.assertTrue(self.sdkdb.symbol('_OBJC_CLASS_$_WKDoesntExist'))
+        self.assertTrue(self.sdkdb.objc_class('WKDoesntExist'))
+        self.assertTrue(self.sdkdb.objc_selector('initWithData:'))
+
+    def test_only_finds_declarations_from_used_inputs(self):
+        # Given a file added to the cache:
+        with self.sdkdb:
+            self.assertFalse(self.sdkdb._cache_hit_preparing_to_insert(F, F_Hash))
+            self.sdkdb._add_api_report(R, F)
+
+        # When a new connection is opened to the persisted data...
+        self.sdkdb = SDKDB(Path(self.dbfile.name))
+
+        # ...it should not find symbols from the file...
+        self.assertFalse(self.sdkdb.symbol('_WKDoesntExistLibraryVersion'))
+
+        # ...until the file is again added as in input.
+        self.assertTrue(self.sdkdb._cache_hit_preparing_to_insert(F, F_Hash))
+        self.assertTrue(self.sdkdb.symbol('_WKDoesntExistLibraryVersion'))

--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy_additions/program.pyi
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy_additions/program.pyi
@@ -20,42 +20,14 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[build-system]
-requires = ["setuptools>=61.0"]
-build-backend = "setuptools.build_meta"
+# Annotations for the internal-only webkitapi_additions library.
+# See <https://typing.python.org/en/latest/guides/writing_stubs.html>.
 
-[project]
-name = "webkitapipy"
-version = "0.1.0"
-authors = [
-  { name="Elliott Williams", email="emw@apple.com" },
-]
-description = "Tools for analyzing API and SPI usage of Mach-O binaries on Apple platforms."
-requires-python = ">=3.9"
-classifiers = [
-    'Development Status :: 1 - Planning',
-    'Intended Audience :: Developers',
-    'Operating System :: MacOS',
-    'Natural Language :: English',
-    'Programming Language :: Python :: 3',
-    'Topic :: Software Development :: Libraries :: Python Modules',
-]
-license = 'BSD-2-Clause'
+import argparse
 
-[project.optional-dependencies]
-internal = ['webkitapipy_additions']
+from webkitapipy.program import TSVReporter
+from webkitapipy.sdkdb import SDKDB as SDKDB
 
-[project.scripts]
-audit-spi = "webkitapipy.program:main"
+def get_parser() -> argparse.ArgumentParser: ...
+def configure_reporter(args: argparse.Namespace, db: SDKDB) -> TSVReporter: ...
 
-[project.urls]
-Homepage = "https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/libraries/webkitapipy"
-Issues = "https://bugs.webkit.org"
-Repository = "https://github.com/WebKit/WebKit"
-
-[mypy]
-strict = true
-disallow_any_generics = false
-disallow_untyped_calls = false
-disallow_untyped_defs = false
-disallow_incomplete_defs = false

--- a/Tools/Scripts/webkitpy/test/main.py
+++ b/Tools/Scripts/webkitpy/test/main.py
@@ -64,6 +64,11 @@ def main():
     AutoInstall.register(Package('reporelaypy', Version(0, 4, 1)), local=True)
     AutoInstall.register(Package('webkitflaskpy', Version(0, 3, 0)), local=True)
 
+    # Register testing-only packages.
+    AutoInstall.register(Package('mypy', Version(1, 16, 1)))
+    AutoInstall.register(Package('mypy_extensions', Version(1, 1, 0)))
+    AutoInstall.register(Package('pathspec', Version(0, 12, 1)))
+
     tester = Tester()
     tester.add_tree(os.path.join(_webkit_root, 'Tools', 'Scripts'), 'webkitpy')
     tester.add_tree(os.path.join(_webkit_root, 'Tools', 'Scripts', 'libraries', 'webkitcorepy'), 'webkitcorepy')
@@ -71,6 +76,7 @@ def main():
     tester.add_tree(os.path.join(_webkit_root, 'Tools', 'Scripts', 'libraries', 'webkitscmpy'), 'webkitscmpy')
     tester.add_tree(os.path.join(_webkit_root, 'Tools', 'Scripts', 'libraries', 'webkitflaskpy'), 'webkitflaskpy')
     tester.add_tree(os.path.join(_webkit_root, 'Tools', 'Scripts', 'libraries', 'reporelaypy'), 'reporelaypy')
+    tester.add_tree(os.path.join(_webkit_root, 'Tools', 'Scripts', 'libraries', 'webkitapipy'), 'webkitapipy')
     tester.add_tree(os.path.join(_webkit_root, 'Source', 'WebKit', 'Scripts'), 'webkit')
 
     tester.skip(('webkitpy.common.checkout.scm.scm_unittest',), 'are really, really, slow', 31818)


### PR DESCRIPTION
#### 49a2255d422e0799beb73477d56db72d74722552
<pre>
[webkitapipy] Add initial unit tests and hook into test-webkitpy
<a href="https://bugs.webkit.org/show_bug.cgi?id=294698">https://bugs.webkit.org/show_bug.cgi?id=294698</a>

Reviewed by Sam Sneddon.

audit-spi gets decent coverage via the iOS build, but as we fix bugs
it&apos;s valuable to be able to write regression tests. Add unit tests to
the library and teach `test-webkitpy` to run them.

To start, contribute tests for the recent windowing logic (#45871) and
ObjC class ingestion (#46874) bug fixes. These are by no means
exhaustive, but seem like a good place to start.

Also add a suite which runs mypy to check the library&apos;s type
annotations. Since changes to type annotations can cause failures at
distant call sites, I believe it&apos;s appropriate to treat them as unit
tests rather than a style check.

* Tools/Scripts/libraries/webkitapipy/mypy.ini: Added. Makes type
  checking succeed in internal builds.
* Tools/Scripts/libraries/webkitapipy/webkitapipy/mypy_unittest.py: Added.
* Tools/Scripts/libraries/webkitapipy/webkitapipy/program.py: Add pragma
  to avoid a typecheck error in open source, when webkitapipy_additions
  is not available.
* Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb.py:
(SDKDB.__del__): Support graceful exit when the database has been
  deleted on disk, such as when TestSDKDB deletes the temporary file
  before running `SDKDB.__del__()`.
(SDKDB._add_api_report): Split out from add_partial_sdkdb so that tests
  can call it without invoking the Mach-O reader.
* Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb_unittest.py: Added.
* Tools/Scripts/libraries/webkitapipy/webkitapipy_additions.pyi: Added
  type stubs for the internal library.
* Tools/Scripts/webkitpy/test/main.py:
(main): Auto-install mypy and its runtime dependencies.

Canonical link: <a href="https://commits.webkit.org/296534@main">https://commits.webkit.org/296534@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef6f7b45f770e6d6263a87fa04db5461b9f65e40

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108659 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28320 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113870 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59044 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110622 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29009 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36877 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82543 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111607 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23037 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97879 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62980 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/108091 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22455 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16016 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58577 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92407 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16067 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116991 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35713 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26345 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91563 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36086 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94148 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91367 "Found 2 new API test failures: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23300 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36269 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14031 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31546 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35614 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35324 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38670 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37001 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->