### PR TITLE
[JSC] Remove UInt32ToNumber with Checks when we know input is definitely positive

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -107,6 +107,47 @@ private:
         return false;
     }
 
+    static bool isPositive(Node* node, unsigned timeToLive = 3)
+    {
+        if (!timeToLive)
+            return false;
+
+        switch (node->op()) {
+        case ValueToInt32:
+        case DoubleRep:
+            return isPositive(node->child1().node(), timeToLive);
+        case ArithMul: {
+            if (node->isBinaryInt32UseKind()) {
+                if (node->child1().node() == node->child2().node())
+                    return true;
+            }
+            return isPositive(node->child1().node(), timeToLive - 1) && isPositive(node->child2().node(), timeToLive - 1);
+        }
+        case ArithBitAnd: {
+            if (node->child1()->isInt32Constant()) {
+                if (node->child1()->asInt32() >= 0)
+                    return true;
+            }
+            if (node->child2()->isInt32Constant()) {
+                if (node->child2()->asInt32() >= 0)
+                    return true;
+            }
+            return isPositive(node->child1().node(), timeToLive - 1) && isPositive(node->child2().node(), timeToLive - 1);
+        }
+        case DoubleConstant: {
+            JSValue immediateValue = node->asJSValue();
+            if (!immediateValue.isNumber())
+                return false;
+            double immediate = immediateValue.asNumber();
+            if (!std::isfinite(immediate))
+                return false;
+            return !std::signbit(immediate);
+        }
+        default:
+            return false;
+        }
+    }
+
     void handleNode()
     {
         switch (m_node->op()) {
@@ -173,14 +214,20 @@ private:
                 && m_node->child1()->child2()->isInt32Constant()
                 && (m_node->child1()->child2()->asInt32() & 0x1f)
                 && m_node->arithMode() != Arith::DoOverflow) {
-                m_node->convertToIdentity();
-                m_changed = true;
+                convertToIdentityOverChild1();
                 break;
             }
+
             if (bytecodeCanTruncateInteger(m_node->arithNodeFlags())) {
-                m_node->convertToIdentity();
-                m_changed = true;
+                convertToIdentityOverChild1();
                 break;
+            }
+
+            if (m_node->child1().useKind() == Int32Use && m_node->arithMode() == Arith::CheckOverflow) {
+                if (isPositive(m_node->child1().node())) {
+                    convertToIdentityOverChild1();
+                    break;
+                }
             }
             break;
             


### PR DESCRIPTION
#### 84d9389ab025d156ff73e8bf6ea15bf588411a4e
<pre>
[JSC] Remove UInt32ToNumber with Checks when we know input is definitely positive
<a href="https://bugs.webkit.org/show_bug.cgi?id=294704">https://bugs.webkit.org/show_bug.cgi?id=294704</a>
<a href="https://rdar.apple.com/153785738">rdar://153785738</a>

Reviewed by NOBODY (OOPS!).

This patch adds some simple strength reduction rule to remove
UInt32ToNumber with negative value check.

* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::isPositive):
(JSC::DFG::StrengthReductionPhase::handleNode):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84d9389ab025d156ff73e8bf6ea15bf588411a4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108417 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28078 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18502 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113626 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58830 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28767 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36628 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82329 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111365 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22815 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97654 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62765 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22230 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15791 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58352 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/100977 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92184 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15846 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116747 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/106976 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35471 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26132 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91356 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35844 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93929 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91157 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36047 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13810 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31211 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35374 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40911 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/131261 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35085 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35612 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38435 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36768 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->