### PR TITLE
[WTF] Refactor `normalizedFloat` and Add Test Cases

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp
@@ -464,6 +464,23 @@ TEST(WTF, clampInfinityToInteger)
     EXPECT_EQ(10U, clampTo<unsigned>(-std::numeric_limits<float>::infinity(), 10, 20));
 }
 
+TEST(WTF, normalizedFloat)
+{
+    EXPECT_EQ(normalizedFloat(std::numeric_limits<float>::min()), std::numeric_limits<float>::min());
+    EXPECT_EQ(normalizedFloat(-std::numeric_limits<float>::min()), -std::numeric_limits<float>::min());
+    EXPECT_EQ(normalizedFloat(std::numeric_limits<float>::denorm_min()), std::numeric_limits<float>::min());
+    EXPECT_EQ(normalizedFloat(-std::numeric_limits<float>::denorm_min()), -std::numeric_limits<float>::min());
+    EXPECT_EQ(normalizedFloat(0.0f), 0.0f);
+    EXPECT_EQ(normalizedFloat(-0.0f), -0.0f);
+    EXPECT_EQ(normalizedFloat(1.0f), 1.0f);
+    EXPECT_EQ(normalizedFloat(-1.0f), -1.0f);
+    EXPECT_EQ(normalizedFloat(1.17549e-38), std::numeric_limits<float>::min());
+    EXPECT_EQ(normalizedFloat(-1.17549e-38), -std::numeric_limits<float>::min());
+    EXPECT_EQ(normalizedFloat(std::numeric_limits<float>::infinity()), std::numeric_limits<float>::infinity());
+    EXPECT_EQ(normalizedFloat(-std::numeric_limits<float>::infinity()), -std::numeric_limits<float>::infinity());
+    EXPECT_TRUE(std::isnan(normalizedFloat(std::numeric_limits<float>::quiet_NaN())));
+}
+
 TEST(WTF, roundUpToPowerOfTwo)
 {
     EXPECT_EQ(roundUpToPowerOfTwo(1U), 1U);


### PR DESCRIPTION
#### 1c8a852bc709ddc4b1d05e051a259dce530751c1
<pre>
[WTF] Refactor `normalizedFloat` and Add Test Cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=294707">https://bugs.webkit.org/show_bug.cgi?id=294707</a>

Reviewed by Darin Adler.

This patch adds test cases for `normalizedFloat`.

* Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp:
(TestWebKitAPI::TEST(WTF, normalizedFloat)):

Canonical link: <a href="https://commits.webkit.org/296987@main">https://commits.webkit.org/296987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d34aaf2337441c582e04fab04de02026bd3e4d38

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110084 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29743 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20175 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116106 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60332 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112047 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30421 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38330 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83695 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113032 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24261 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99136 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64139 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23628 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17271 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59902 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93635 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17327 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118897 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37124 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27520 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92663 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37496 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95404 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92489 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23594 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37476 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15218 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/33006 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37018 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36680 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40020 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38389 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->