### PR TITLE
Use GameController API to determine mouse pointer availability instead of BKSMousePointerService

### DIFF
--- a/Source/WebKit/Modules/Internal/WebKitInternal.h
+++ b/Source/WebKit/Modules/Internal/WebKitInternal.h
@@ -28,6 +28,7 @@
 #import <wtf/Platform.h>
 
 #import "WKMaterialHostingSupport.h"
+#import "WKMouseDeviceObserver.h"
 #import "WKPreferencesInternal.h"
 #import "WKScrollGeometry.h"
 #import "WKSeparatedImageView.h"

--- a/Source/WebKit/Platform/spi/ios/BackBoardServicesSPI.h
+++ b/Source/WebKit/Platform/spi/ios/BackBoardServicesSPI.h
@@ -33,28 +33,10 @@ DECLARE_SYSTEM_HEADER
 #import <BackBoardServices/BKSAnimationFence_Private.h>
 #import <BackBoardServices/BKSHIDEventAttributes.h>
 #import <BackBoardServices/BKSHIDEventKeyCommand.h>
-#import <BackBoardServices/BKSMousePointerService.h>
 
 #else
 
 #import "BaseBoardSPI.h"
-
-@interface BKSAnimationFenceHandle : NSObject
-- (mach_port_t)CAPort;
-@end
-
-@class BKSMousePointerDevice;
-
-@protocol BKSMousePointerDeviceObserver <NSObject>
-@optional
-- (void)mousePointerDevicesDidConnect:(NSSet<BKSMousePointerDevice *> *)mousePointerDevices;
-- (void)mousePointerDevicesDidDisconnect:(NSSet<BKSMousePointerDevice *> *)mousePointerDevices;
-@end
-
-@interface BKSMousePointerService : NSObject
-+ (BKSMousePointerService *)sharedInstance;
-- (id<BSInvalidatable>)addPointerDeviceObserver:(id<BKSMousePointerDeviceObserver>)observer;
-@end
 
 typedef NS_OPTIONS(NSInteger, BKSKeyModifierFlags) {
     BKSKeyModifierShift = 1 << 17,

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -813,10 +813,7 @@ typedef NS_ENUM(NSInteger, UIWKGestureType) {
 - (UIPanGestureRecognizer *)gestureRecognizerForInteractiveTransition:(_UINavigationInteractiveTransitionBase *)interactiveTransition WithTarget:(id)target action:(SEL)action;
 @end
 
-@class BKSAnimationFenceHandle;
-
 @interface UIWindow ()
-+ (BKSAnimationFenceHandle *)_synchronizedDrawingFence;
 + (mach_port_t)_synchronizeDrawingAcrossProcesses;
 - (void)_setWindowResolution:(CGFloat)resolution displayIfChanged:(BOOL)displayIfChanged;
 - (uint32_t)_contextId;

--- a/Source/WebKit/UIProcess/WKMouseDeviceObserver.swift
+++ b/Source/WebKit/UIProcess/WKMouseDeviceObserver.swift
@@ -1,0 +1,105 @@
+// Copyright (C) 2025 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if HAVE_MOUSE_DEVICE_OBSERVATION
+
+internal import GameController
+internal import WebKit_Internal
+
+@objc @implementation extension WKMouseDeviceObserver {
+    private static let shared = WKMouseDeviceObserver()
+
+    @nonobjc private var connectionObservationTask: Task<Void, Never>? = nil
+    @nonobjc private var disconnectionObservationTask: Task<Void, Never>? = nil
+
+    private var startCount = 0
+    private var connectedDeviceCount = 0 {
+        didSet {
+            precondition(connectedDeviceCount >= 0)
+
+            if oldValue == 0 && connectedDeviceCount > 0 {
+                mousePointerDevicesDidChange(true)
+                return
+            }
+
+            if oldValue > 0 && connectedDeviceCount == 0 {
+                mousePointerDevicesDidChange(false)
+            }
+        }
+    }
+
+    var hasMouseDevice: Bool {
+        connectedDeviceCount > 0
+    }
+
+    override init() {
+    }
+
+    class func sharedInstance() -> WKMouseDeviceObserver {
+        shared
+    }
+
+    func start() {
+        precondition(startCount >= 0)
+
+        startCount += 1
+        guard startCount == 1 else {
+            return
+        }
+
+        connectionObservationTask = Task {
+            let connectSequence = NotificationCenter.default.notifications(named: .GCMouseDidConnect).map { $0.object is GCMouse }
+            for await _ in connectSequence {
+                connectedDeviceCount += 1
+            }
+        }
+
+        disconnectionObservationTask = Task {
+            let disconnectSequence = NotificationCenter.default.notifications(named: .GCMouseDidDisconnect).map { $0.object is GCMouse }
+            for await _ in disconnectSequence {
+                connectedDeviceCount -= 1
+            }
+        }
+    }
+
+    func stop() {
+        guard startCount > 0 else {
+            return
+        }
+
+        startCount -= 1
+
+        guard startCount == 0 else {
+            return
+        }
+
+        connectionObservationTask?.cancel()
+        disconnectionObservationTask?.cancel()
+    }
+
+    func _setHasMouseDevice(forTesting hasMouseDevice: Bool) {
+        connectedDeviceCount = hasMouseDevice ? 1 : 0
+    }
+}
+
+#endif // HAVE_MOUSE_DEVICE_OBSERVATION

--- a/Source/WebKit/UIProcess/ios/WKMouseDeviceObserver.h
+++ b/Source/WebKit/UIProcess/ios/WKMouseDeviceObserver.h
@@ -23,29 +23,33 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <wtf/Platform.h>
+
 #if HAVE(MOUSE_DEVICE_OBSERVATION)
 
-#import "BackBoardServicesSPI.h"
+NS_HEADER_AUDIT_BEGIN(nullability, sendability)
 
-namespace WebKit {
-class WebProcessProxy;
-}
-
-@interface WKMouseDeviceObserver : NSObject<BKSMousePointerDeviceObserver>
+NS_SWIFT_UI_ACTOR
+@interface WKMouseDeviceObserver : NSObject
 
 + (WKMouseDeviceObserver *)sharedInstance;
 + (instancetype)new NS_UNAVAILABLE;
-- (instancetype)init NS_UNAVAILABLE;
 
 - (void)start;
-- (void)startWithCompletionHandler:(void (^)(void))completionHandler;
 - (void)stop;
-- (void)stopWithCompletionHandler:(void (^)(void))completionHandler;
 
 @property (nonatomic, readonly) BOOL hasMouseDevice;
 
 - (void)_setHasMouseDeviceForTesting:(BOOL)hasMouseDevice;
 
 @end
+
+@interface WKMouseDeviceObserver (Cpp)
+
+- (void)mousePointerDevicesDidChange:(BOOL)hasMouseDevice;
+
+@end
+
+NS_HEADER_AUDIT_END(nullability, sendability)
 
 #endif // HAVE(MOUSE_DEVICE_OBSERVATION)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -220,6 +220,7 @@
 		07F327F22CB09B74006D9918 /* _WKTextPreview.h in Headers */ = {isa = PBXBuildFile; fileRef = 07F327F02CB085A4006D9918 /* _WKTextPreview.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		07F6B5592D719323009F206D /* _WKRectEdge+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07F6B5582D719323009F206D /* _WKRectEdge+Extras.swift */; };
 		07FAA74B2CE947AA00128360 /* WebPage+Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07FAA74A2CE947AA00128360 /* WebPage+Navigation.swift */; };
+		07FEBC9A2E035A8B004A6D5D /* WKMouseDeviceObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07FEBC992E035950004A6D5D /* WKMouseDeviceObserver.swift */; };
 		0D4599052C86B00F00435F48 /* WKDigitalCredentialsPicker.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D9D28E72C81473B002CB4C7 /* WKDigitalCredentialsPicker.h */; };
 		0DD656D42C8F0A4400278C3B /* DigitalCredentialsCoordinator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D20EA1C2C59E2F900CA61BD /* DigitalCredentialsCoordinator.h */; };
 		0E97D74D200E900400BF6643 /* SafeBrowsingSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E97D74C200E8FF300BF6643 /* SafeBrowsingSPI.h */; };
@@ -3388,6 +3389,8 @@
 		07F327F12CB085A4006D9918 /* _WKTextPreview.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKTextPreview.mm; sourceTree = "<group>"; };
 		07F6B5582D719323009F206D /* _WKRectEdge+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "_WKRectEdge+Extras.swift"; sourceTree = "<group>"; };
 		07FAA74A2CE947AA00128360 /* WebPage+Navigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebPage+Navigation.swift"; sourceTree = "<group>"; };
+		07FEBC992E035950004A6D5D /* WKMouseDeviceObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKMouseDeviceObserver.swift; sourceTree = "<group>"; };
+		07FEBC9C2E036C6D004A6D5D /* WKMouseDeviceObserver.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKMouseDeviceObserver.mm; path = ios/WKMouseDeviceObserver.mm; sourceTree = "<group>"; };
 		0867D6A5FE840307C02AAC07 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		089C1667FE841158C02AAC07 /* en */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		0D02BE3129B6D0F7005852BF /* WebGPUInternalError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebGPUInternalError.h; sourceTree = "<group>"; };
@@ -7159,7 +7162,6 @@
 		944045782B8CE78700613886 /* WebCryptoClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebCryptoClient.cpp; sourceTree = "<group>"; };
 		944045792B8CE78700613886 /* WebCryptoClient.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; fileEncoding = 4; path = WebCryptoClient.h; sourceTree = "<group>"; };
 		950F287E252414E900B74F1C /* WKMouseDeviceObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WKMouseDeviceObserver.h; path = ios/WKMouseDeviceObserver.h; sourceTree = "<group>"; };
-		950F287F252414EA00B74F1C /* WKMouseDeviceObserver.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WKMouseDeviceObserver.mm; path = ios/WKMouseDeviceObserver.mm; sourceTree = "<group>"; };
 		950FECF0285026EA0002DE4E /* AutomaticReloadPaymentRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AutomaticReloadPaymentRequest.h; sourceTree = "<group>"; };
 		950FECF22850271E0002DE4E /* RecurringPaymentRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RecurringPaymentRequest.h; sourceTree = "<group>"; };
 		950FECF32850271F0002DE4E /* PaymentTokenContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PaymentTokenContext.h; sourceTree = "<group>"; };
@@ -11838,7 +11840,8 @@
 				71BAA73125FFCCBA00D7CD5D /* WKModelView.h */,
 				71BAA73225FFCCBA00D7CD5D /* WKModelView.mm */,
 				950F287E252414E900B74F1C /* WKMouseDeviceObserver.h */,
-				950F287F252414EA00B74F1C /* WKMouseDeviceObserver.mm */,
+				07FEBC9C2E036C6D004A6D5D /* WKMouseDeviceObserver.mm */,
+				07FEBC992E035950004A6D5D /* WKMouseDeviceObserver.swift */,
 				F4C627E62A7AC17400F546BF /* WKMouseInteraction.h */,
 				F4C627E52A7AC17300F546BF /* WKMouseInteraction.mm */,
 				52C25B442D0C1B9100A26AB8 /* WKPageHostedModelView.h */,
@@ -21095,6 +21098,7 @@
 				637281A321ADC744009E0DE6 /* WKDownloadProgress.mm in Sources */,
 				5CE9120D2293C219005BEC78 /* WKMain.mm in Sources */,
 				E502E4F82D4810EA00C3D56D /* WKMaterialHostingSupport.swift in Sources */,
+				07FEBC9A2E035A8B004A6D5D /* WKMouseDeviceObserver.swift in Sources */,
 				07CB79982CE943E400199C49 /* WKNavigationDelegateAdapter.swift in Sources */,
 				DF84CEE4249AA24D009096F6 /* WKPDFHUDView.mm in Sources */,
 				33E743E82D66C0AC00AC715E /* WKPDFPageNumberIndicator.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm
@@ -52,7 +52,7 @@
 
 @interface WKMouseDeviceObserver
 + (WKMouseDeviceObserver *)sharedInstance;
-- (void)startWithCompletionHandler:(void (^)(void))completionHandler;
+- (void)start;
 - (void)_setHasMouseDeviceForTesting:(BOOL)hasMouseDevice;
 @end
 
@@ -509,12 +509,7 @@ TEST_F(iOSMouseSupport, MouseInitiallyDisconnected)
 {
     WKMouseDeviceObserver *mouseDeviceObserver = [NSClassFromString(@"WKMouseDeviceObserver") sharedInstance];
 
-    __block bool didStartMouseDeviceObserver = false;
-    [mouseDeviceObserver startWithCompletionHandler:^{
-        didStartMouseDeviceObserver = true;
-    }];
-    TestWebKitAPI::Util::run(&didStartMouseDeviceObserver);
-
+    [mouseDeviceObserver start];
     [mouseDeviceObserver _setHasMouseDeviceForTesting:NO];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
@@ -544,12 +539,7 @@ TEST_F(iOSMouseSupport, MouseInitiallyConnected)
 {
     WKMouseDeviceObserver *mouseDeviceObserver = [NSClassFromString(@"WKMouseDeviceObserver") sharedInstance];
 
-    __block bool didStartMouseDeviceObserver = false;
-    [mouseDeviceObserver startWithCompletionHandler:^{
-        didStartMouseDeviceObserver = true;
-    }];
-    TestWebKitAPI::Util::run(&didStartMouseDeviceObserver);
-
+    [mouseDeviceObserver start];
     [mouseDeviceObserver _setHasMouseDeviceForTesting:YES];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
@@ -579,12 +569,7 @@ TEST_F(iOSMouseSupport, MouseLaterDisconnected)
 {
     WKMouseDeviceObserver *mouseDeviceObserver = [NSClassFromString(@"WKMouseDeviceObserver") sharedInstance];
 
-    __block bool didStartMouseDeviceObserver = false;
-    [mouseDeviceObserver startWithCompletionHandler:^{
-        didStartMouseDeviceObserver = true;
-    }];
-    TestWebKitAPI::Util::run(&didStartMouseDeviceObserver);
-
+    [mouseDeviceObserver start];
     [mouseDeviceObserver _setHasMouseDeviceForTesting:YES];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
@@ -616,12 +601,7 @@ TEST_F(iOSMouseSupport, MouseLaterConnected)
 {
     WKMouseDeviceObserver *mouseDeviceObserver = [NSClassFromString(@"WKMouseDeviceObserver") sharedInstance];
 
-    __block bool didStartMouseDeviceObserver = false;
-    [mouseDeviceObserver startWithCompletionHandler:^{
-        didStartMouseDeviceObserver = true;
-    }];
-    TestWebKitAPI::Util::run(&didStartMouseDeviceObserver);
-
+    [mouseDeviceObserver start];
     [mouseDeviceObserver _setHasMouseDeviceForTesting:NO];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);


### PR DESCRIPTION
#### 7fe4d93de5c66c57bb0994b1699b212e542fef6c
<pre>
Use GameController API to determine mouse pointer availability instead of BKSMousePointerService
<a href="https://bugs.webkit.org/show_bug.cgi?id=294709">https://bugs.webkit.org/show_bug.cgi?id=294709</a>
<a href="https://rdar.apple.com/153328349">rdar://153328349</a>

Reviewed by Aditya Keerthi.

GameController offers API to determine mouse pointer availability through notifications, so switch to using that for
the implementation of WKMouseDeviceObserver instead of BackBoard.

Consequently, remove a lot of SPI forward declarations.

* Source/WebKit/Modules/Internal/WebKitInternal.h:
* Source/WebKit/Platform/spi/ios/BackBoardServicesSPI.h:
* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/WKMouseDeviceObserver.swift: Added.
(WKMouseDeviceObserver.connectionObservationTask):
(WKMouseDeviceObserver.disconnectionObservationTask):
(WKMouseDeviceObserver.hasMouseDevice):
(WKMouseDeviceObserver.sharedInstance):
(WKMouseDeviceObserver.start):
(WKMouseDeviceObserver.stop):
(WKMouseDeviceObserver._setHasMouseDevice(forTesting:)):
* Source/WebKit/UIProcess/ios/WKMouseDeviceObserver.h:
* Source/WebKit/UIProcess/ios/WKMouseDeviceObserver.mm:
(-[WKMouseDeviceObserver mousePointerDevicesDidChange:]):
(+[WKMouseDeviceObserver sharedInstance]): Deleted.
(-[WKMouseDeviceObserver init]): Deleted.
(-[WKMouseDeviceObserver start]): Deleted.
(-[WKMouseDeviceObserver startWithCompletionHandler:]): Deleted.
(-[WKMouseDeviceObserver stop]): Deleted.
(-[WKMouseDeviceObserver stopWithCompletionHandler:]): Deleted.
(-[WKMouseDeviceObserver _setHasMouseDeviceForTesting:]): Deleted.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/296457@main">https://commits.webkit.org/296457@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62c3ad46639a09d4c116b6d6b1c517e82ba558f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108593 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113801 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58983 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110556 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28943 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36808 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82480 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111541 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22972 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97812 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62917 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22388 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15951 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58515 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92341 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16002 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116922 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35647 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26280 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91502 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36020 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94083 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91305 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23258 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36205 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13966 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35548 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41081 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35258 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38604 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36936 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->