### PR TITLE
[Liquid Glass] [iPhone] reddit.com: bottom magic pocket is missing after dismissing “Open in app”

### DIFF
--- a/LayoutTests/fast/page-color-sampling/color-sampling-fixed-popup.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-fixed-popup.html
@@ -39,7 +39,8 @@
         shouldBeNull("edgeColorsBeforeUnparenting.right");
         shouldBeNull("edgeColorsBeforeUnparenting.bottom");
 
-        document.querySelector(".banner").remove();
+        document.querySelector(".banner.one").remove();
+        document.querySelector(".banner.two").style.visibility = "hidden";
         edgeColorsAfterUnparenting = await UIHelper.fixedContainerEdgeColors();
         shouldBeNull("edgeColorsAfterUnparenting.top");
         shouldBeNull("edgeColorsAfterUnparenting.left");
@@ -51,7 +52,10 @@
     </script>
 </head>
 <body>
-<div class="banner">
+<div class="banner one">
+    <div class="banner-content"></div>
+</div>
+<div class="banner two">
     <div class="banner-content"></div>
 </div>
 <div class="tall"></div>

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5309,7 +5309,11 @@ void Page::updateFixedContainerEdges(BoxSideSet sides)
             if (!lastElement)
                 continue;
 
-            if (!lastElement->renderer())
+            CheckedPtr renderer = lastElement->renderer();
+            if (!renderer)
+                continue;
+
+            if (renderer->style().usedVisibility() != Visibility::Visible)
                 continue;
 
             elements.setAt(side, WTFMove(lastElement));


### PR DESCRIPTION
#### 79e0755449072c09a63298c0d534ec225026e73b
<pre>
[Liquid Glass] [iPhone] reddit.com: bottom magic pocket is missing after dismissing “Open in app”
<a href="https://bugs.webkit.org/show_bug.cgi?id=294711">https://bugs.webkit.org/show_bug.cgi?id=294711</a>
<a href="https://rdar.apple.com/153195857">rdar://153195857</a>

Reviewed by Aditya Keerthi.

Make another small adjustment to the sampling heuristic, such that we avoid carrying over the last
sampled color in the case where the sampled element is hidden (i.e. `visibility: hidden;`). This
ensures that the “Open in app” banner&apos;s sampled color on the bottom edge does not linger around
after the user dismisses the modal UI.

* LayoutTests/fast/page-color-sampling/color-sampling-fixed-popup.html:

Augment this test by adding a second banner that&apos;s hidden using `visibility: hidden;`.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateFixedContainerEdges):

Canonical link: <a href="https://commits.webkit.org/296411@main">https://commits.webkit.org/296411@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33ea1fc62946f58aa72fc342bc391f5c01508e7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108432 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28093 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18517 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113641 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58840 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110395 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28782 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36643 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82339 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111380 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22827 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97669 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62775 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22243 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15804 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58364 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92198 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15858 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116762 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35486 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/26141 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91366 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35859 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93941 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91167 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23231 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36057 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13821 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31225 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35388 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40923 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35098 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38449 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36779 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->