### PR TITLE
[GTK][WPE][Skia] Fix LoongArch build failure

### DIFF
--- a/Source/ThirdParty/skia/CMakeLists.txt
+++ b/Source/ThirdParty/skia/CMakeLists.txt
@@ -80,6 +80,7 @@ add_library(Skia STATIC
     src/core/SkBitmapProcState_matrixProcs.cpp
     src/core/SkBitmapProcState_opts.cpp
     src/core/SkBitmapProcState_opts_ssse3.cpp
+    src/core/SkBitmapProcState_opts_lasx.cpp
     src/core/SkBlendMode.cpp
     src/core/SkBlendModeBlender.cpp
     src/core/SkBlitMask_opts.cpp
@@ -87,6 +88,7 @@ add_library(Skia STATIC
     src/core/SkBlitRow_D32.cpp
     src/core/SkBlitRow_opts.cpp
     src/core/SkBlitRow_opts_hsw.cpp
+    src/core/SkBlitRow_opts_lasx.cpp
     src/core/SkBlitter.cpp
     src/core/SkBlitter_A8.cpp
     src/core/SkBlitter_ARGB32.cpp
@@ -246,6 +248,7 @@ add_library(Skia STATIC
     src/core/SkSwizzler_opts_hsw.cpp
     src/core/SkSynchronizedResourceCache.cpp
     src/core/SkSwizzler_opts_ssse3.cpp
+    src/core/SkSwizzler_opts_lasx.cpp
     src/core/SkTaskGroup.cpp
     src/core/SkTextBlob.cpp
     src/core/SkTypeface.cpp
@@ -779,6 +782,7 @@ add_library(Skia STATIC
 
     src/opts/SkOpts_hsw.cpp
     src/opts/SkOpts_skx.cpp
+    src/opts/SkOpts_lasx.cpp
 
     src/ports/SkGlobalInitialization_default.cpp
     src/ports/SkImageGenerator_skia.cpp
@@ -1106,6 +1110,27 @@ if (Skia_SkCMS_SKX_OPTS)
     WEBKIT_ADD_COMPILER_FLAGS(CXX SOURCE modules/skcms/src/skcms_TransformSkx.cc ${Skia_SkCMS_SKX_FLAGS})
 else ()
     target_compile_definitions(Skia PRIVATE SKCMS_DISABLE_SKX)
+endif ()
+
+if (WTF_CPU_LOONGARCH64)
+    # Work arounds for building with GCC (instead of Clang).
+
+    # To work around https://github.com/llvm/llvm-project/issues/110834
+    # the GN system does not pass -fno-lax-vector-conversions to Clang on
+    # LoongArch, unintentionally allowing the LASX optimized code to rely
+    # on the relaxed vector conversion rule.  See
+    # https://skia-review.googlesource.com/c/skia/+/908137 for a proper fix
+    # but work around it here for now.
+    WEBKIT_ADD_TARGET_CXX_FLAGS(Skia "-flax-vector-conversions")
+
+    # #pragma GCC target is only supported by GCC >= 15, thus the Skia code
+    # base cannot use it for LoongArch if building with GCC.  Pass a
+    # command line option to work around.  The GN building system does the
+    # same.
+    WEBKIT_ADD_COMPILER_FLAGS(CXX SOURCE src/core/SkBitmapProcState_opts_lasx.cpp -mlasx)
+    WEBKIT_ADD_COMPILER_FLAGS(CXX SOURCE src/core/SkSwizzler_opts_lasx.cpp -mlasx)
+    WEBKIT_ADD_COMPILER_FLAGS(CXX SOURCE src/core/SkBlitRow_opts_lasx.cpp -mlasx)
+    WEBKIT_ADD_COMPILER_FLAGS(CXX SOURCE src/opts/SkOpts_lasx.cpp -mlasx)
 endif ()
 
 add_library(Skia::Skia ALIAS Skia)


### PR DESCRIPTION
#### 7565d2ca19d48e4bc1d771c1f0292d1d6d391146
<pre>
[GTK][WPE][Skia] Fix LoongArch build failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=280505">https://bugs.webkit.org/show_bug.cgi?id=280505</a>

Reviewed by Adrian Perez de Castro.

The shipped skia code fails to build as at now because some files are
missing from the cmake building system.  Add those files and work around
some issues building them with GCC.

* Source/ThirdParty/skia/CMakeLists.txt:

Canonical link: <a href="https://commits.webkit.org/296614@main">https://commits.webkit.org/296614@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/183c3153f87300c669056d8df0fbe1d5c28bf782

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108472 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28133 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18557 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113681 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58875 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28822 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36684 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82373 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111420 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22862 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97705 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62809 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22279 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15842 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58400 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92233 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15896 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116802 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35526 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26176 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91398 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35899 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93979 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91199 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36094 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13860 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31274 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17608 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35428 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35137 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38489 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36819 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->