### PR TITLE
[WPE] REGRESSION(296393@main): build broken with libwebrtc enabled

### DIFF
--- a/Source/ThirdParty/libwebrtc/CMakeLists.txt
+++ b/Source/ThirdParty/libwebrtc/CMakeLists.txt
@@ -30,8 +30,6 @@ if (NOT APPLE)
 endif ()
 
 set(webrtc_SOURCES
-    Source/third_party/abseil-cpp/absl/base/inline_variable_test_a.cc
-    Source/third_party/abseil-cpp/absl/base/inline_variable_test_b.cc
     Source/third_party/abseil-cpp/absl/base/internal/atomic_hook_test_helper.cc
     Source/third_party/abseil-cpp/absl/base/internal/cycleclock.cc
     Source/third_party/abseil-cpp/absl/base/internal/exception_safety_testing.cc
@@ -86,7 +84,6 @@ set(webrtc_SOURCES
     Source/third_party/abseil-cpp/absl/random/internal/distribution_test_util.cc
     Source/third_party/abseil-cpp/absl/random/internal/gaussian_distribution_gentables.cc
     Source/third_party/abseil-cpp/absl/random/internal/nanobenchmark.cc
-    Source/third_party/abseil-cpp/absl/random/internal/pool_urbg.cc
     Source/third_party/abseil-cpp/absl/random/internal/randen.cc
     Source/third_party/abseil-cpp/absl/random/internal/randen_detect.cc
     Source/third_party/abseil-cpp/absl/random/internal/randen_hwaes.cc
@@ -101,7 +98,6 @@ set(webrtc_SOURCES
     Source/third_party/abseil-cpp/absl/strings/ascii.cc
     Source/third_party/abseil-cpp/absl/strings/charconv.cc
     Source/third_party/abseil-cpp/absl/strings/cord_analysis.cc
-    Source/third_party/abseil-cpp/absl/strings/cord_buffer.cc
     Source/third_party/abseil-cpp/absl/strings/cord.cc
     Source/third_party/abseil-cpp/absl/strings/escaping.cc
     Source/third_party/abseil-cpp/absl/strings/internal/charconv_bigint.cc
@@ -158,9 +154,6 @@ set(webrtc_SOURCES
     Source/third_party/abseil-cpp/absl/time/internal/cctz/src/zone_info_source.cc
     Source/third_party/abseil-cpp/absl/time/internal/test_util.cc
     Source/third_party/abseil-cpp/absl/time/time.cc
-    Source/third_party/abseil-cpp/absl/types/bad_any_cast.cc
-    Source/third_party/abseil-cpp/absl/types/bad_optional_access.cc
-    Source/third_party/abseil-cpp/absl/types/bad_variant_access.cc
     Source/third_party/boringssl/err_data.c
     Source/third_party/boringssl/src/crypto/asn1/a_bitstr.c
     Source/third_party/boringssl/src/crypto/asn1/a_bool.c


### PR DESCRIPTION
#### 46b678876be71aef8d8062322d95090907f3fa85
<pre>
[WPE] REGRESSION(296393@main): build broken with libwebrtc enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=294716">https://bugs.webkit.org/show_bug.cgi?id=294716</a>

Reviewed by Philippe Normand.

Remove some files from the build that are not present in the new version.

* Source/ThirdParty/libwebrtc/CMakeLists.txt:

Canonical link: <a href="https://commits.webkit.org/296431@main">https://commits.webkit.org/296431@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dad06a5a79738386182149e45e08b6184e521362

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28110 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18534 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113658 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58855 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28799 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36660 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82355 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111397 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22839 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97682 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62791 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22255 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15819 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58381 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92210 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15873 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116779 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35503 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26156 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91380 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35876 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93956 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91181 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36072 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13836 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31246 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17521 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35405 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35115 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38466 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36796 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->