### PR TITLE
[MSE] Remove SourceBufferParser::Segment.

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -830,7 +830,6 @@ platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
 platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
 platform/graphics/cocoa/ImageAdapterCocoa.mm
 platform/graphics/cocoa/MediaPlayerCocoa.mm
-platform/graphics/cocoa/SourceBufferParser.cpp
 platform/graphics/controls/ApplePayButtonPart.cpp
 platform/graphics/controls/ButtonPart.h
 platform/graphics/controls/ColorWellPart.h

--- a/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp
@@ -132,7 +132,6 @@ class AudioFileReaderWebMData {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(AudioFileReaderWebMData);
 
 public:
-    const Ref<SharedBuffer> m_buffer;
 #if ENABLE(MEDIA_SOURCE)
     const Ref<AudioTrackPrivateWebM> m_track;
 #endif
@@ -186,7 +185,7 @@ std::unique_ptr<AudioFileReaderWebMData> AudioFileReader::demuxWebMData(std::spa
     auto parser = SourceBufferParserWebM::create();
     if (!parser)
         return nullptr;
-    auto buffer = SharedBuffer::create(data);
+    Ref buffer = SharedBuffer::create(data);
 
     std::optional<uint64_t> audioTrackId;
     MediaTime duration;
@@ -216,12 +215,11 @@ std::unique_ptr<AudioFileReaderWebMData> AudioFileReader::demuxWebMData(std::spa
             return;
         track->setDiscardPadding(discardPadding);
     });
-    SourceBufferParser::Segment segment(Ref { buffer.get() });
-    auto result = parser->appendData(WTFMove(segment));
+    auto result = parser->appendData(WTFMove(buffer));
     if (!track || !result)
         return nullptr;
     parser->flushPendingAudioSamples();
-    return makeUnique<AudioFileReaderWebMData>(AudioFileReaderWebMData { WTFMove(buffer), track.releaseNonNull(), WTFMove(duration), WTFMove(samples) });
+    return makeUnique<AudioFileReaderWebMData>(AudioFileReaderWebMData { track.releaseNonNull(), WTFMove(duration), WTFMove(samples) });
 }
 
 struct PassthroughUserData {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.h
@@ -58,7 +58,7 @@ public:
     AVStreamDataParser* streamDataParser() const { return m_parser.get(); }
 
     Type type() const { return Type::AVFObjC; }
-    Expected<void, PlatformMediaError> appendData(Segment&&, AppendFlags = AppendFlags::None) final;
+    Expected<void, PlatformMediaError> appendData(Ref<const SharedBuffer>&&, AppendFlags = AppendFlags::None) final;
     void flushPendingMediaData() final;
     void resetParserState() final;
     void invalidate() final;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
@@ -241,11 +241,10 @@ SourceBufferParserAVFObjC::~SourceBufferParserAVFObjC()
     [m_delegate invalidate];
 }
 
-Expected<void, PlatformMediaError> SourceBufferParserAVFObjC::appendData(Segment&& segment, AppendFlags flags)
+Expected<void, PlatformMediaError> SourceBufferParserAVFObjC::appendData(Ref<const SharedBuffer>&& segment, AppendFlags flags)
 {
     INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    auto sharedBuffer = segment.takeSharedBuffer();
-    auto nsData = sharedBuffer->makeContiguous()->createNSData();
+    RetainPtr nsData = segment->createNSData();
     if (m_parserStateWasReset || flags == AppendFlags::Discontinuity)
         [m_parser appendStreamData:nsData.get() withFlags:AVStreamDataParserStreamDataDiscontinuity];
     else

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -456,7 +456,8 @@ Ref<MediaPromise> SourceBufferPrivateAVFObjC::appendInternal(Ref<SharedBuffer>&&
                 protectedThis->didProvideContentKeyRequestInitializationDataForTrackID(WTFMove(initData), trackID, nullptr);
         });
 
-        return MediaPromise::createAndSettle(parser->appendData(WTFMove(data)));
+        Ref ensureDestroyedSharedBuffer = WTFMove(data);
+        return MediaPromise::createAndSettle(parser->appendData(WTFMove(ensureDestroyedSharedBuffer)));
     })->whenSettled(RunLoop::currentSingleton(), [weakThis = ThreadSafeWeakPtr { *this }](auto&& result) {
         if (RefPtr protectedThis = weakThis.get())
             protectedThis->appendCompleted(!!result);

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -309,10 +309,8 @@ void MediaPlayerPrivateWebM::dataReceived(const SharedBuffer& buffer)
         m_contentReceived += size;
     });
 
-    // FIXME: Remove const_cast once https://bugs.webkit.org/show_bug.cgi?id=243370 is fixed.
-    SourceBufferParser::Segment segment(Ref { const_cast<SharedBuffer&>(buffer) });
-    invokeAsync(m_appendQueue, [segment = WTFMove(segment), parser = m_parser]() mutable {
-        return MediaPromise::createAndSettle(parser->appendData(WTFMove(segment)));
+    invokeAsync(m_appendQueue, [buffer = Ref { buffer }, parser = m_parser]() mutable {
+        return MediaPromise::createAndSettle(parser->appendData(WTFMove(buffer)));
     })->whenSettled(RunLoop::protectedMain(), [weakThis = ThreadSafeWeakPtr { *this }](auto&& result) {
         if (RefPtr protectedThis = weakThis.get())
             protectedThis->appendCompleted(!!result);

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParser.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParser.cpp
@@ -81,34 +81,6 @@ void SourceBufferParser::setMinimumAudioSampleDuration(float)
 {
 }
 
-SourceBufferParser::Segment::Segment(Ref<SharedBuffer>&& buffer)
-    : m_segment(WTFMove(buffer))
-{
-}
-
-size_t SourceBufferParser::Segment::size() const
-{
-    return m_segment->size();
-}
-
-auto SourceBufferParser::Segment::read(std::span<uint8_t> destination, size_t position) const -> ReadResult
-{
-    size_t segmentSize = size();
-    destination = destination.first(std::min(destination.size(), segmentSize - std::min(position, segmentSize)));
-    m_segment->copyTo(destination, position);
-    return destination.size();
-}
-
-Ref<SharedBuffer> SourceBufferParser::Segment::takeSharedBuffer()
-{
-    return std::exchange(m_segment, SharedBuffer::create());
-}
-
-Ref<SharedBuffer> SourceBufferParser::Segment::getData(size_t offet, size_t length) const
-{
-    return m_segment->getContiguousData(offet, length);
-}
-
 } // namespace WebCore
 
 #endif // ENABLE(MEDIA_SOURCE)

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParser.h
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParser.h
@@ -64,30 +64,12 @@ public:
         Discontinuity,
     };
 
-    class Segment {
-    public:
-        Segment(Ref<SharedBuffer>&&);
-        Segment(Segment&&) = default;
-        Ref<SharedBuffer> takeSharedBuffer();
-        Ref<SharedBuffer> getData(size_t offset, size_t length) const;
-
-        size_t size() const;
-
-        enum class ReadError { EndOfFile, FatalError };
-        using ReadResult = Expected<size_t, ReadError>;
-
-        ReadResult read(std::span<uint8_t> destination, size_t position = 0) const;
-
-    private:
-        Ref<SharedBuffer> m_segment;
-    };
-
     using CallOnClientThreadCallback = Function<void(Function<void()>&&)>;
     void setCallOnClientThreadCallback(CallOnClientThreadCallback&&);
 
     // appendData will be called on the SourceBufferPrivateAVFObjC data parser queue.
     // Other methods will be called on the main thread, but only once appendData has returned.
-    virtual Expected<void, PlatformMediaError> appendData(Segment&&, AppendFlags = AppendFlags::None) = 0;
+    virtual Expected<void, PlatformMediaError> appendData(Ref<const SharedBuffer>&&, AppendFlags = AppendFlags::None) = 0;
     virtual void flushPendingMediaData() = 0;
     virtual void resetParserState() = 0;
     virtual void invalidate() = 0;

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h
@@ -77,7 +77,7 @@ public:
     class SegmentReader;
 
     WEBCORE_EXPORT void createByteRangeSamples();
-    WEBCORE_EXPORT ExceptionOr<int> parse(SourceBufferParser::Segment&&);
+    WEBCORE_EXPORT ExceptionOr<int> parse(Ref<const SharedBuffer>&&);
     WEBCORE_EXPORT void resetState();
     WEBCORE_EXPORT void reset();
     WEBCORE_EXPORT void invalidate();
@@ -337,7 +337,7 @@ public:
     static bool isAvailable();
 
     Type type() const { return Type::WebM; }
-    WEBCORE_EXPORT Expected<void, PlatformMediaError> appendData(Segment&&, AppendFlags = AppendFlags::None) final;
+    WEBCORE_EXPORT Expected<void, PlatformMediaError> appendData(Ref<const SharedBuffer>&&, AppendFlags = AppendFlags::None) final;
     void flushPendingMediaData() final;
     void resetParserState() final { m_parser.resetState(); }
     void invalidate() final;


### PR DESCRIPTION
#### b98e5e1c6baa53edf0e7437baedab9f06e4dbd58
<pre>
[MSE] Remove SourceBufferParser::Segment.
<a href="https://bugs.webkit.org/show_bug.cgi?id=243370">https://bugs.webkit.org/show_bug.cgi?id=243370</a>
<a href="https://rdar.apple.com/97831219">rdar://97831219</a>

Reviewed by Youenn Fablet.

We remove the SourceBufferParser::Segment class and directly deal with
SharedBuffer.
To better control lifetime of the segment, we immediately move in SourceBufferParser::appendData
the rvalue Ref&lt;const SharedBuffer&gt;

Follow-up on 288710@main which fixed long standing issue in
WebMParser::SegmentReader::Read where if the data parsed was across two
segments, we could have returned corrupted data (this was a theoretical issue that couldn&apos;t be reproduced from JS).

No functional changes, covered by existing tests.

* Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp:
(WebCore::AudioFileReader::demuxWebMData const):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm:
(WebCore::SourceBufferParserAVFObjC::appendData):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::dataReceived):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParser.cpp:
(WebCore::SourceBufferParser::Segment::Segment): Deleted.
(WebCore::SourceBufferParser::Segment::size const): Deleted.
(WebCore::SourceBufferParser::Segment::read const): Deleted.
(WebCore::SourceBufferParser::Segment::takeSharedBuffer): Deleted.
(WebCore::SourceBufferParser::Segment::getData const): Deleted.
* Source/WebCore/platform/graphics/cocoa/SourceBufferParser.h:
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
(WebCore::WebMParser::parse):
(WebCore::SourceBufferParserWebM::appendData):
(WebCore::segmentReadErrorToWebmStatus): Deleted.
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h:

Canonical link: <a href="https://commits.webkit.org/296589@main">https://commits.webkit.org/296589@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8465c382e1bd412cbf22782bd747e01ee8631af5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108971 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28631 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19056 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114180 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59306 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110934 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29314 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37198 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82808 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111919 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23309 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98154 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63247 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22728 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16289 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58877 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92684 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16337 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117299 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36020 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26625 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91817 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36392 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94416 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91625 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23325 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36537 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14293 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31885 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35918 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41441 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35619 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38959 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37303 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->