### PR TITLE
[Tools][WPE][GTK] Support running browserperfdash-benchmark inside the flatpak SDK

### DIFF
--- a/Tools/Scripts/browserperfdash-benchmark
+++ b/Tools/Scripts/browserperfdash-benchmark
@@ -24,9 +24,18 @@
 
 
 import logging
+import os
 import sys
 
 from webkitpy.browserperfdash.browserperfdash_runner import main, format_logger
+
+
+if sys.platform.startswith('linux'):
+    top_level_directory = os.path.normpath(os.path.join(os.path.dirname(__file__), '..', '..'))
+    sys.path.insert(0, os.path.join(top_level_directory, 'Tools', 'flatpak'))
+
+    import flatpakutils
+    flatpakutils.run_in_sandbox_if_available(sys.argv)
 
 
 _log = logging.getLogger()


### PR DESCRIPTION
#### ecd6a615780c7d8a4ae6186c416316a5b27d0b9d
<pre>
[Tools][WPE][GTK] Support running browserperfdash-benchmark inside the flatpak SDK
<a href="https://bugs.webkit.org/show_bug.cgi?id=294723">https://bugs.webkit.org/show_bug.cgi?id=294723</a>

Reviewed by Philippe Normand.

Currently browserperfdash-benchmark is running outside of Flatpak SDK and the browser
is running inside (via executing run-minibrowser script).

However, to support the upcoming plugin-plans (bug 294625) it is needed to run the runner
also inside Flatpak SDK because the the plugin process runs on the same pid than the runner.
And for this plugins to work on the right environment they should use the Flapak SDK one
and not the host one. For example, if they want to run &apos;ldd&apos; that should happen inside the
flatpak SDK.

And this requires implementing a way of getting the TCP ports open from a given pid without
using &apos;lsof&apos; or &apos;python-psutil&apos; on simple_http_server_driver.py because neither of this two
tools is currently available on the Flatpak SDK.

* Tools/Scripts/browserperfdash-benchmark:
* Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/simple_http_server_driver.py:
(linux_proc_get_listening_ports):
(SimpleHTTPServerDriver._find_http_server_port):

Canonical link: <a href="https://commits.webkit.org/296421@main">https://commits.webkit.org/296421@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a19b5009cea71adfe7e8a2fce904c29fcbbccc9e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108468 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28129 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18553 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113677 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58871 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110431 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28818 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36679 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82371 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111416 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22857 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97697 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62807 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/107900 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22273 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15834 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58397 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92228 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15888 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116798 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35522 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26170 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91396 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35895 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93971 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91197 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36089 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13851 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31271 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17518 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35424 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35134 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38485 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36815 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->