### PR TITLE
WebCore: Replace UChar with char16_t

### DIFF
--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
@@ -195,7 +195,7 @@ ApplicationManifest::Direction ApplicationManifestParser::parseDir(const JSON::O
     };
     static constexpr SortedArrayMap directions { directionMappings };
 
-    if (auto* dirValue = directions.tryGet(StringView(stringValue).trim(isASCIIWhitespace<UChar>)))
+    if (auto* dirValue = directions.tryGet(StringView(stringValue).trim(isASCIIWhitespace<char16_t>)))
         return *dirValue;
 
     logDeveloperWarning(makeString('"', stringValue, "\" is not a valid dir."_s));
@@ -222,7 +222,7 @@ ApplicationManifest::Display ApplicationManifestParser::parseDisplay(const JSON:
     };
     static constexpr SortedArrayMap displayValues { displayValueMappings };
 
-    if (auto* displayValue = displayValues.tryGet(StringView(stringValue).trim(isASCIIWhitespace<UChar>)))
+    if (auto* displayValue = displayValues.tryGet(StringView(stringValue).trim(isASCIIWhitespace<char16_t>)))
         return *displayValue;
 
     logDeveloperWarning(makeString("\""_s, stringValue, "\" is not a valid display mode."_s));
@@ -254,7 +254,7 @@ const std::optional<ScreenOrientationLockType> ApplicationManifestParser::parseO
 
     static SortedArrayMap orientationValues { orientationValueMappings };
 
-    if (auto* orientationValue = orientationValues.tryGet(StringView(stringValue).trim(isASCIIWhitespace<UChar>)))
+    if (auto* orientationValue = orientationValues.tryGet(StringView(stringValue).trim(isASCIIWhitespace<char16_t>)))
         return *orientationValue;
 
     logDeveloperWarning(makeString("\""_s, stringValue, "\" is not a valid orientation."_s));
@@ -356,7 +356,7 @@ Vector<ApplicationManifest::Icon> ApplicationManifestParser::parseIcons(const JS
                 purposes.add(ApplicationManifest::Icon::Purpose::Any);
                 currentIcon.purposes = purposes;
             } else {
-                for (auto keyword : StringView(purposeStringValue).trim(isASCIIWhitespace<UChar>).splitAllowingEmptyEntries(' ')) {
+                for (auto keyword : StringView(purposeStringValue).trim(isASCIIWhitespace<char16_t>).splitAllowingEmptyEntries(' ')) {
                     if (equalLettersIgnoringASCIICase(keyword, "monochrome"_s))
                         purposes.add(ApplicationManifest::Icon::Purpose::Monochrome);
                     else if (equalLettersIgnoringASCIICase(keyword, "maskable"_s))

--- a/Source/WebCore/Modules/cache/DOMCache.cpp
+++ b/Source/WebCore/Modules/cache/DOMCache.cpp
@@ -174,7 +174,7 @@ static inline bool hasResponseVaryStarHeaderValue(const FetchResponse& response)
     auto varyValue = response.headers().internalHeaders().get(WebCore::HTTPHeaderName::Vary);
     bool hasStar = false;
     varyValue.split(',', [&](StringView view) {
-        if (!hasStar && view.trim(isASCIIWhitespaceWithoutFF<UChar>) == "*"_s)
+        if (!hasStar && view.trim(isASCIIWhitespaceWithoutFF<char16_t>) == "*"_s)
             hasStar = true;
     });
     return hasStar;

--- a/Source/WebCore/Modules/cache/DOMCacheEngine.cpp
+++ b/Source/WebCore/Modules/cache/DOMCacheEngine.cpp
@@ -99,7 +99,7 @@ bool queryCacheMatch(const ResourceRequest& request, const ResourceRequest& cach
     varyValue.split(',', [&](StringView view) {
         if (isVarying)
             return;
-        auto nameView = view.trim(isASCIIWhitespaceWithoutFF<UChar>);
+        auto nameView = view.trim(isASCIIWhitespaceWithoutFF<char16_t>);
         if (nameView == "*"_s) {
             isVarying = true;
             return;

--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -237,7 +237,7 @@ CookieStore::~CookieStore()
 static bool containsInvalidCharacters(const String& string)
 {
     // The invalid characters are specified at https://wicg.github.io/cookie-store/#set-a-cookie.
-    return string.contains([](UChar character) {
+    return string.contains([](char16_t character) {
         return character == 0x003B || character == 0x007F || (character <= 0x001F && character != 0x0009);
     });
 }

--- a/Source/WebCore/Modules/entriesapi/DOMFileSystem.cpp
+++ b/Source/WebCore/Modules/entriesapi/DOMFileSystem.cpp
@@ -94,7 +94,7 @@ static ExceptionOr<Vector<Ref<FileSystemEntry>>> toFileSystemEntries(ScriptExecu
 }
 
 // https://wicg.github.io/entries-api/#name
-static bool isValidPathNameCharacter(UChar c)
+static bool isValidPathNameCharacter(char16_t c)
 {
     return c != '\0' && c != '/' && c != '\\';
 }

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -54,7 +54,7 @@ static inline Ref<Blob> blobFromData(ScriptExecutionContext* context, Vector<uin
 }
 
 // https://mimesniff.spec.whatwg.org/#http-quoted-string-token-code-point
-static bool isHTTPQuotedStringTokenCodePoint(UChar c)
+static bool isHTTPQuotedStringTokenCodePoint(char16_t c)
 {
     return c == 0x09
         || (c >= 0x20 && c <= 0x7E)
@@ -99,7 +99,7 @@ static HashMap<String, String> parseParameters(StringView input, size_t position
             size_t valueBegin = position;
             while (position < input.length() && input[position] != ';')
                 position++;
-            parameterValue = input.substring(valueBegin, position - valueBegin).trim(isASCIIWhitespaceWithoutFF<UChar>);
+            parameterValue = input.substring(valueBegin, position - valueBegin).trim(isASCIIWhitespaceWithoutFF<char16_t>);
         }
 
         if (parameterName.length()
@@ -114,7 +114,7 @@ static HashMap<String, String> parseParameters(StringView input, size_t position
 // https://mimesniff.spec.whatwg.org/#parsing-a-mime-type
 static std::optional<MimeType> parseMIMEType(const String& contentType)
 {
-    String input = contentType.trim(isASCIIWhitespaceWithoutFF<UChar>);
+    String input = contentType.trim(isASCIIWhitespaceWithoutFF<char16_t>);
     size_t slashIndex = input.find('/');
     if (slashIndex == notFound)
         return std::nullopt;
@@ -124,7 +124,7 @@ static std::optional<MimeType> parseMIMEType(const String& contentType)
         return std::nullopt;
     
     size_t semicolonIndex = input.find(';', slashIndex);
-    String subtype = input.substring(slashIndex + 1, semicolonIndex - slashIndex - 1).trim(isASCIIWhitespaceWithoutFF<UChar>);
+    String subtype = input.substring(slashIndex + 1, semicolonIndex - slashIndex - 1).trim(isASCIIWhitespaceWithoutFF<char16_t>);
     if (!subtype.length() || !isValidHTTPToken(subtype))
         return std::nullopt;
 
@@ -180,7 +180,7 @@ RefPtr<DOMFormData> FetchBodyConsumer::packageFormData(ScriptExecutionContext* c
             size_t contentTypeBegin = header.findIgnoringASCIICase(contentTypeCharacters);
             if (contentTypeBegin != notFound) {
                 size_t contentTypeEnd = header.find(oneNewLine, contentTypeBegin);
-                contentType = StringView(header).substring(contentTypeBegin + contentTypePrefixLength, contentTypeEnd - contentTypeBegin - contentTypePrefixLength).trim(isASCIIWhitespaceWithoutFF<UChar>).toString();
+                contentType = StringView(header).substring(contentTypeBegin + contentTypePrefixLength, contentTypeEnd - contentTypeBegin - contentTypePrefixLength).trim(isASCIIWhitespaceWithoutFF<char16_t>).toString();
             }
 
             form.append(name, File::create(context, Blob::create(context, Vector(body), Blob::normalizedContentType(contentType)).get(), filename).get(), filename);

--- a/Source/WebCore/Modules/fetch/FetchHeaders.cpp
+++ b/Source/WebCore/Modules/fetch/FetchHeaders.cpp
@@ -75,7 +75,7 @@ static ExceptionOr<void> appendSetCookie(const String& value, Vector<String>& se
 
 static ExceptionOr<void> appendToHeaderMap(const String& name, const String& value, HTTPHeaderMap& headers, Vector<String>& setCookieValues, FetchHeaders::Guard guard)
 {
-    String normalizedValue = value.trim(isASCIIWhitespaceWithoutFF<UChar>);
+    String normalizedValue = value.trim(isASCIIWhitespaceWithoutFF<char16_t>);
     if (equalIgnoringASCIICase(name, "set-cookie"_s))
         return appendSetCookie(normalizedValue, setCookieValues, guard);
 
@@ -98,7 +98,7 @@ static ExceptionOr<void> appendToHeaderMap(const String& name, const String& val
 static ExceptionOr<void> appendToHeaderMap(const HTTPHeaderMap::HTTPHeaderMapConstIterator::KeyValue& header, HTTPHeaderMap& headers, FetchHeaders::Guard guard)
 {
     ASSERT(!equalIgnoringASCIICase(header.key, "set-cookie"_s));
-    String normalizedValue = header.value.trim(isASCIIWhitespaceWithoutFF<UChar>);
+    String normalizedValue = header.value.trim(isASCIIWhitespaceWithoutFF<char16_t>);
     auto canWriteResult = canWriteHeader(header.key, normalizedValue, header.value, guard);
     if (canWriteResult.hasException())
         return canWriteResult.releaseException();
@@ -236,7 +236,7 @@ ExceptionOr<bool> FetchHeaders::has(const String& name) const
 
 ExceptionOr<void> FetchHeaders::set(const String& name, const String& value)
 {
-    String normalizedValue = value.trim(isASCIIWhitespaceWithoutFF<UChar>);
+    String normalizedValue = value.trim(isASCIIWhitespaceWithoutFF<char16_t>);
     auto canWriteResult = canWriteHeader(name, normalizedValue, normalizedValue, m_guard);
     if (canWriteResult.hasException())
         return canWriteResult.releaseException();
@@ -259,7 +259,7 @@ ExceptionOr<void> FetchHeaders::set(const String& name, const String& value)
 void FetchHeaders::filterAndFill(const HTTPHeaderMap& headers, Guard guard)
 {
     for (auto& header : headers) {
-        String normalizedValue = header.value.trim(isASCIIWhitespaceWithoutFF<UChar>);
+        String normalizedValue = header.value.trim(isASCIIWhitespaceWithoutFF<char16_t>);
         auto canWriteResult = canWriteHeader(header.key, normalizedValue, header.value, guard);
         if (canWriteResult.hasException())
             continue;

--- a/Source/WebCore/Modules/indexeddb/IDBKey.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKey.cpp
@@ -72,7 +72,7 @@ IDBKey::IDBKey(IndexedDB::KeyType type, double number)
 IDBKey::IDBKey(const String& value)
     : m_type(IndexedDB::KeyType::String)
     , m_value(value)
-    , m_sizeEstimate(OverheadSize + value.length() * sizeof(UChar))
+    , m_sizeEstimate(OverheadSize + value.length() * sizeof(char16_t))
 {
 }
 

--- a/Source/WebCore/Modules/indexeddb/IDBKeyPath.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyPath.cpp
@@ -90,15 +90,15 @@ const uint32_t unicodeLetter = U_GC_L_MASK | U_GC_NL_MASK;
 const uint32_t unicodeCombiningMark = U_GC_MN_MASK | U_GC_MC_MASK;
 const uint32_t unicodeDigit = U_GC_ND_MASK;
 const uint32_t unicodeConnectorPunctuation = U_GC_PC_MASK;
-const UChar ZWNJ = 0x200C;
-const UChar ZWJ = 0x200D;
+const char16_t ZWNJ = 0x200C;
+const char16_t ZWJ = 0x200D;
 
-static inline bool isIdentifierStartCharacter(UChar c)
+static inline bool isIdentifierStartCharacter(char16_t c)
 {
     return (U_GET_GC_MASK(c) & unicodeLetter) || (c == '$') || (c == '_');
 }
 
-static inline bool isIdentifierCharacter(UChar c)
+static inline bool isIdentifierCharacter(char16_t c)
 {
     return (U_GET_GC_MASK(c) & (unicodeLetter | unicodeCombiningMark | unicodeDigit | unicodeConnectorPunctuation)) || (c == '$') || (c == '_') || (c == ZWNJ) || (c == ZWJ);
 }

--- a/Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp
@@ -326,7 +326,7 @@ static WARN_UNUSED_RETURN bool decodeKey(std::span<const uint8_t>& data, IDBKeyD
         if (data.size() < length * 2)
             return false;
 
-        Vector<UChar> buffer;
+        Vector<char16_t> buffer;
         buffer.reserveInitialCapacity(length);
         for (size_t i = 0; i < length; i++) {
             uint16_t ch;

--- a/Source/WebCore/Modules/mediastream/RTCDTMFSender.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDTMFSender.cpp
@@ -82,7 +82,7 @@ String RTCDTMFSender::toneBuffer() const
     return m_tones;
 }
 
-static inline bool isToneCharacterInvalid(UChar character)
+static inline bool isToneCharacterInvalid(char16_t character)
 {
     if (character >= '0' && character <= '9')
         return false;

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -1040,7 +1040,7 @@ URL HTMLModelElement::selectEnvironmentMapURL() const
 
     if (hasAttributeWithoutSynchronization(environmentmapAttr)) {
         const auto& attr = attributeWithoutSynchronization(environmentmapAttr).string().trim(isASCIIWhitespace);
-        if (StringView(attr).containsOnly<isASCIIWhitespace<UChar>>())
+        if (StringView(attr).containsOnly<isASCIIWhitespace<char16_t>>())
             return { };
         return getURLAttribute(environmentmapAttr);
     }

--- a/Source/WebCore/Modules/url-pattern/URLPatternParser.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternParser.cpp
@@ -535,7 +535,7 @@ String escapePatternString(StringView input)
 }
 
 // https://urlpattern.spec.whatwg.org/#is-a-valid-name-code-point
-bool isValidNameCodepoint(UChar codepoint, URLPatternUtilities::IsFirst first)
+bool isValidNameCodepoint(char16_t codepoint, URLPatternUtilities::IsFirst first)
 {
     if (first == URLPatternUtilities::IsFirst::Yes)
         return u_hasBinaryProperty(codepoint, UCHAR_ID_START) || codepoint == '_' || codepoint == '$';

--- a/Source/WebCore/Modules/url-pattern/URLPatternParser.h
+++ b/Source/WebCore/Modules/url-pattern/URLPatternParser.h
@@ -97,7 +97,7 @@ ASCIILiteral convertModifierToString(Modifier);
 std::pair<String, Vector<String>> generateRegexAndNameList(const Vector<Part>& partList, const URLPatternStringOptions&);
 String generatePatternString(const Vector<Part>& partList, const URLPatternStringOptions&);
 String escapePatternString(StringView input);
-bool isValidNameCodepoint(UChar codepoint, URLPatternUtilities::IsFirst);
+bool isValidNameCodepoint(char16_t codepoint, URLPatternUtilities::IsFirst);
 
 
 } // namespace URLPatternUtilities

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
@@ -86,7 +86,7 @@ static bool isValidDecoderConfig(const WebCodecsAudioDecoderConfig& config)
 {
     // https://w3c.github.io/webcodecs/#valid-audiodecoderconfig
     // 1. If codec is empty after stripping leading and trailing ASCII whitespace, return false.
-    if (StringView(config.codec).trim(isASCIIWhitespace<UChar>).isEmpty())
+    if (StringView(config.codec).trim(isASCIIWhitespace<char16_t>).isEmpty())
         return false;
 
     // 2. If description is [detached], return false.

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
@@ -98,7 +98,7 @@ static bool isSupportedEncoderCodec(const WebCodecsAudioEncoderConfig& config)
 
 static bool isValidEncoderConfig(const WebCodecsAudioEncoderConfig& config)
 {
-    if (StringView(config.codec).trim(isASCIIWhitespace<UChar>).isEmpty())
+    if (StringView(config.codec).trim(isASCIIWhitespace<char16_t>).isEmpty())
         return false;
 
     if (!config.sampleRate || !config.numberOfChannels)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
@@ -85,7 +85,7 @@ static bool isValidDecoderConfig(const WebCodecsVideoDecoderConfig& config)
 {
     // https://w3c.github.io/webcodecs/#valid-videodecoderconfig
     // 1. If codec is empty after stripping leading and trailing ASCII whitespace, return false.
-    if (StringView(config.codec).trim(isASCIIWhitespace<UChar>).isEmpty())
+    if (StringView(config.codec).trim(isASCIIWhitespace<char16_t>).isEmpty())
         return false;
 
     // 2. If one of codedWidth or codedHeight is provided but the other isn’t, return false.

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
@@ -85,7 +85,7 @@ static bool isSupportedEncoderCodec(const String& codec, const SettingsValues& s
 
 static bool isValidEncoderConfig(const WebCodecsVideoEncoderConfig& config)
 {
-    if (StringView(config.codec).trim(isASCIIWhitespace<UChar>).isEmpty())
+    if (StringView(config.codec).trim(isASCIIWhitespace<char16_t>).isEmpty())
         return false;
 
     if (!config.width || !config.height)

--- a/Source/WebCore/Modules/websockets/ThreadableWebSocketChannelClientWrapper.h
+++ b/Source/WebCore/Modules/websockets/ThreadableWebSocketChannelClientWrapper.h
@@ -86,8 +86,8 @@ private:
     RefPtr<WorkerThreadableWebSocketChannel::Peer> m_peer;
     bool m_failedWebSocketChannelCreation;
     // ThreadSafeRefCounted must not have String member variables.
-    Vector<UChar> m_subprotocol;
-    Vector<UChar> m_extensions;
+    Vector<char16_t> m_subprotocol;
+    Vector<char16_t> m_extensions;
     bool m_suspended;
     Vector<std::unique_ptr<ScriptExecutionContext::Task>> m_pendingTasks;
 };

--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -85,12 +85,12 @@ Lock WebSocket::s_allActiveWebSocketsLock;
 
 const size_t maxReasonSizeInBytes = 123;
 
-static inline bool isValidProtocolCharacter(UChar character)
+static inline bool isValidProtocolCharacter(char16_t character)
 {
     // Hybi-10 says "(Subprotocol string must consist of) characters in the range U+0021 to U+007E not including
     // separator characters as defined in [RFC2616]."
-    const UChar minimumProtocolCharacter = '!'; // U+0021.
-    const UChar maximumProtocolCharacter = '~'; // U+007E.
+    const char16_t minimumProtocolCharacter = '!'; // U+0021.
+    const char16_t maximumProtocolCharacter = '~'; // U+007E.
     return character >= minimumProtocolCharacter && character <= maximumProtocolCharacter
         && character != '"' && character != '(' && character != ')' && character != ',' && character != '/'
         && !(character >= ':' && character <= '@') // U+003A - U+0040 (':', ';', '<', '=', '>', '?', '@').

--- a/Source/WebCore/Modules/websockets/WebSocketExtensionDispatcher.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketExtensionDispatcher.cpp
@@ -53,7 +53,7 @@ void WebSocketExtensionDispatcher::addProcessor(std::unique_ptr<WebSocketExtensi
     }
     ASSERT(processor->handshakeString().length());
     ASSERT(!processor->handshakeString().contains('\n'));
-    ASSERT(!processor->handshakeString().contains(static_cast<UChar>('\0')));
+    ASSERT(!processor->handshakeString().contains(static_cast<char16_t>('\0')));
     m_processors.append(WTFMove(processor));
 }
 

--- a/Source/WebCore/Modules/websockets/WebSocketExtensionParser.h
+++ b/Source/WebCore/Modules/websockets/WebSocketExtensionParser.h
@@ -38,7 +38,7 @@ namespace WebCore {
 
 class WebSocketExtensionParser {
 public:
-    // FIXME: What character encoding are we parsing? Specify LChar, char8_t, UChar, or something else here.
+    // FIXME: What character encoding are we parsing? Specify LChar, char8_t, char16_t, or something else here.
     explicit WebSocketExtensionParser(std::span<const uint8_t> data)
         : m_data(data)
     {
@@ -46,7 +46,7 @@ public:
     bool finished();
     bool parsedSuccessfully();
 
-    // FIXME: What character encoding are we parsing? Specify LChar, char8_t, UChar, or something else here.
+    // FIXME: What character encoding are we parsing? Specify LChar, char8_t, char16_t, or something else here.
     bool parseExtension(String& extensionToken, HashMap<String, String>& parameters);
 
 private:

--- a/Source/WebCore/PAL/pal/text/DecodeEscapeSequences.h
+++ b/Source/WebCore/PAL/pal/text/DecodeEscapeSequences.h
@@ -60,7 +60,7 @@ struct Unicode16BitEscapeSequence {
         StringBuilder builder;
         builder.reserveCapacity(numberOfSequences);
         while (numberOfSequences--) {
-            UChar codeUnit = (toASCIIHexValue(run[2]) << 12) | (toASCIIHexValue(run[3]) << 8) | (toASCIIHexValue(run[4]) << 4) | toASCIIHexValue(run[5]);
+            char16_t codeUnit = (toASCIIHexValue(run[2]) << 12) | (toASCIIHexValue(run[3]) << 8) | (toASCIIHexValue(run[4]) << 4) | toASCIIHexValue(run[5]);
             builder.append(codeUnit);
             run = run.substring(SequenceSize);
         }

--- a/Source/WebCore/PAL/pal/text/EncodingTables.cpp
+++ b/Source/WebCore/PAL/pal/text/EncodingTables.cpp
@@ -33,7 +33,7 @@
 
 namespace PAL {
 
-static void ucnv_toUnicode_span(UConverter* converter, std::span<UChar> target, std::span<const uint8_t> source, int32_t* offsets, UBool flush, UErrorCode& error)
+static void ucnv_toUnicode_span(UConverter* converter, std::span<char16_t> target, std::span<const uint8_t> source, int32_t* offsets, UBool flush, UErrorCode& error)
 {
     auto* targetStart = target.data();
     auto* targetEnd = std::to_address(target.end());
@@ -44,7 +44,7 @@ static void ucnv_toUnicode_span(UConverter* converter, std::span<UChar> target, 
 
 #if ASSERT_ENABLED
 // From https://encoding.spec.whatwg.org/index-jis0208.txt
-constexpr std::array<std::pair<uint16_t, UChar>, 7724> jis0208Reference { {
+constexpr std::array<std::pair<uint16_t, char16_t>, 7724> jis0208Reference { {
     { 0, 0x3000 }, { 1, 0x3001 }, { 2, 0x3002 }, { 3, 0xFF0C }, { 4, 0xFF0E }, { 5, 0x30FB }, { 6, 0xFF1A }, { 7, 0xFF1B },
     { 8, 0xFF1F }, { 9, 0xFF01 }, { 10, 0x309B }, { 11, 0x309C }, { 12, 0x00B4 }, { 13, 0xFF40 }, { 14, 0x00A8 }, { 15, 0xFF3E },
     { 16, 0xFFE3 }, { 17, 0xFF3F }, { 18, 0x30FD }, { 19, 0x30FE }, { 20, 0x309D }, { 21, 0x309E }, { 22, 0x3003 }, { 23, 0x4EDD },
@@ -1015,7 +1015,7 @@ constexpr std::array<std::pair<uint16_t, UChar>, 7724> jis0208Reference { {
 #endif // ASSERT_ENABLED
 
 // These are values from https://encoding.spec.whatwg.org/index-jis0208.txt that are not in ICU.
-constexpr std::array<std::pair<uint16_t, UChar>, 388> jis0208Extras { {
+constexpr std::array<std::pair<uint16_t, char16_t>, 388> jis0208Extras { {
     { 10716, 0x2170 }, { 10717, 0x2171 }, { 10718, 0x2172 }, { 10719, 0x2173 }, { 10720, 0x2174 }, { 10721, 0x2175 }, { 10722, 0x2176 }, { 10723, 0x2177 },
     { 10724, 0x2178 }, { 10725, 0x2179 }, { 10726, 0x2160 }, { 10727, 0x2161 }, { 10728, 0x2162 }, { 10729, 0x2163 }, { 10730, 0x2164 }, { 10731, 0x2165 },
     { 10732, 0x2166 }, { 10733, 0x2167 }, { 10734, 0x2168 }, { 10735, 0x2169 }, { 10736, 0xffe2 }, { 10737, 0xffe4 }, { 10738, 0xff07 }, { 10739, 0xff02 },
@@ -1067,13 +1067,13 @@ constexpr std::array<std::pair<uint16_t, UChar>, 388> jis0208Extras { {
     { 11100, 0x9d6b }, { 11101, 0xfa2d }, { 11102, 0x9e19 }, { 11103, 0x9ed1 }
 } };
 
-const std::array<std::pair<uint16_t, UChar>, 7724>& jis0208()
+const std::array<std::pair<uint16_t, char16_t>, 7724>& jis0208()
 {
     // Allocate this at runtime because building it at compile time would make the binary much larger and this is often not used.
-    static std::array<std::pair<uint16_t, UChar>, 7724>* array;
+    static std::array<std::pair<uint16_t, char16_t>, 7724>* array;
     static std::once_flag flag;
     std::call_once(flag, [] {
-        array = new std::array<std::pair<uint16_t, UChar>, 7724>;
+        array = new std::array<std::pair<uint16_t, char16_t>, 7724>;
         size_t arrayIndex = 0;
         
         UErrorCode error = U_ZERO_ERROR;
@@ -1082,7 +1082,7 @@ const std::array<std::pair<uint16_t, UChar>, 7724>& jis0208()
 
         constexpr size_t range = 94;
         std::array<uint8_t, 2> icuInput;
-        UChar icuOutput;
+        char16_t icuOutput;
         for (size_t i = 0; i < range; i++) {
             for (size_t j = 0; j < range; j++) {
                 icuInput[0] = 0xA1 + i;
@@ -1106,7 +1106,7 @@ const std::array<std::pair<uint16_t, UChar>, 7724>& jis0208()
 
 #if ASSERT_ENABLED
 // From https://encoding.spec.whatwg.org/index-jis0212.txt
-const std::array<std::pair<uint16_t, UChar>, 6067> jis0212Reference { {
+const std::array<std::pair<uint16_t, char16_t>, 6067> jis0212Reference { {
     { 108, 0x02D8 }, { 109, 0x02C7 }, { 110, 0x00B8 }, { 111, 0x02D9 }, { 112, 0x02DD }, { 113, 0x00AF }, { 114, 0x02DB }, { 115, 0x02DA },
     { 116, 0xFF5E }, { 117, 0x0384 }, { 118, 0x0385 }, { 127, 0x00A1 }, { 128, 0x00A6 }, { 129, 0x00BF }, { 168, 0x00BA }, { 169, 0x00AA },
     { 170, 0x00A9 }, { 171, 0x00AE }, { 172, 0x2122 }, { 173, 0x00A4 }, { 174, 0x2116 }, { 534, 0x0386 }, { 535, 0x0388 }, { 536, 0x0389 },
@@ -1869,13 +1869,13 @@ const std::array<std::pair<uint16_t, UChar>, 6067> jis0212Reference { {
 } };
 #endif // ASSERT_ENABLED
 
-const std::array<std::pair<uint16_t, UChar>, 6067>& jis0212()
+const std::array<std::pair<uint16_t, char16_t>, 6067>& jis0212()
 {
     // Allocate this at runtime because building it at compile time would make the binary much larger and this is often not used.
-    static std::array<std::pair<uint16_t, UChar>, 6067>* array;
+    static std::array<std::pair<uint16_t, char16_t>, 6067>* array;
     static std::once_flag flag;
     std::call_once(flag, [] {
-        array = new std::array<std::pair<uint16_t, UChar>, 6067>();
+        array = new std::array<std::pair<uint16_t, char16_t>, 6067>();
         size_t arrayIndex = 0;
         
         UErrorCode error = U_ZERO_ERROR;
@@ -1884,7 +1884,7 @@ const std::array<std::pair<uint16_t, UChar>, 6067>& jis0212()
 
         constexpr size_t range = 94;
         std::array<uint8_t, 3> icuInput;
-        UChar icuOutput;
+        char16_t icuOutput;
         for (size_t i = 0; i < range; i++) {
             for (size_t j = 0; j < range; j++) {
                 icuInput[0] = 0x8F;
@@ -4891,7 +4891,7 @@ const std::array<std::pair<uint16_t, char32_t>, 18590>& big5()
         ASSERT(!error);
 
         std::array<uint8_t, 2> icuInput;
-        UChar icuOutput;
+        char16_t icuOutput;
 
         // These are the ranges from https://encoding.spec.whatwg.org/index-big5.txt that have valid pointers.
         constexpr std::array<std::pair<uint16_t, uint16_t>, 60> big5PointerRanges { {
@@ -4932,7 +4932,7 @@ const std::array<std::pair<uint16_t, char32_t>, 18590>& big5()
 
 #if ASSERT_ENABLED
 // From https://encoding.spec.whatwg.org/index-euc-kr.txt
-const std::array<std::pair<uint16_t, UChar>, 17048> eucKRDecodingIndexReference { {
+const std::array<std::pair<uint16_t, char16_t>, 17048> eucKRDecodingIndexReference { {
     { 0, 0xAC02 }, { 1, 0xAC03 }, { 2, 0xAC05 }, { 3, 0xAC06 }, { 4, 0xAC0B }, { 5, 0xAC0C }, { 6, 0xAC0D }, { 7, 0xAC0E },
     { 8, 0xAC0F }, { 9, 0xAC18 }, { 10, 0xAC1E }, { 11, 0xAC1F }, { 12, 0xAC21 }, { 13, 0xAC22 }, { 14, 0xAC23 }, { 15, 0xAC25 },
     { 16, 0xAC26 }, { 17, 0xAC27 }, { 18, 0xAC28 }, { 19, 0xAC29 }, { 20, 0xAC2A }, { 21, 0xAC2B }, { 22, 0xAC2E }, { 23, 0xAC32 },
@@ -7067,19 +7067,19 @@ const std::array<std::pair<uint16_t, UChar>, 17048> eucKRDecodingIndexReference 
 } };
 #endif
 
-const std::array<std::pair<uint16_t, UChar>, 17048>& eucKR()
+const std::array<std::pair<uint16_t, char16_t>, 17048>& eucKR()
 {
     // Allocate this at runtime because building it at compile time would make the binary much larger and this is often not used.
-    static std::array<std::pair<uint16_t, UChar>, 17048>* array;
+    static std::array<std::pair<uint16_t, char16_t>, 17048>* array;
     static std::once_flag flag;
     std::call_once(flag, [] {
-        array = new std::array<std::pair<uint16_t, UChar>, 17048>;
+        array = new std::array<std::pair<uint16_t, char16_t>, 17048>;
         UErrorCode error = U_ZERO_ERROR;
         auto icuConverter = ICUConverterPtr { ucnv_open("windows-949", &error) };
         ASSERT(U_SUCCESS(error));
-        auto getPair = [icuConverter = WTFMove(icuConverter)] (uint16_t pointer) -> std::optional<std::pair<uint16_t, UChar>> {
+        auto getPair = [icuConverter = WTFMove(icuConverter)] (uint16_t pointer) -> std::optional<std::pair<uint16_t, char16_t>> {
             std::array<uint8_t, 2> icuInput { static_cast<uint8_t>(pointer / 190u + 0x81), static_cast<uint8_t>(pointer % 190u + 0x41) };
-            std::array<UChar, 2> icuOutput;
+            std::array<char16_t, 2> icuOutput;
             UErrorCode error = U_ZERO_ERROR;
             ucnv_toUnicode_span(icuConverter.get(), std::span { icuOutput }, std::span { icuInput }, nullptr, true, error);
             if (icuOutput[0] == 0xFFFD)
@@ -7103,7 +7103,7 @@ const std::array<std::pair<uint16_t, UChar>, 17048>& eucKR()
 
 #if ASSERT_ENABLED
 // From https://encoding.spec.whatwg.org/index-gb18030.txt
-const std::array<UChar, 23940> gb18030Reference { {
+const std::array<char16_t, 23940> gb18030Reference { {
     0x4E02, 0x4E04, 0x4E05, 0x4E06, 0x4E0F, 0x4E12, 0x4E17, 0x4E1F, 0x4E20, 0x4E21, 0x4E23, 0x4E26, 0x4E29, 0x4E2E, 0x4E2F, 0x4E31,
     0x4E33, 0x4E35, 0x4E37, 0x4E3C, 0x4E40, 0x4E41, 0x4E42, 0x4E44, 0x4E46, 0x4E4A, 0x4E51, 0x4E55, 0x4E57, 0x4E5A, 0x4E5B, 0x4E62,
     0x4E63, 0x4E64, 0x4E65, 0x4E67, 0x4E68, 0x4E6A, 0x4E6B, 0x4E6C, 0x4E6D, 0x4E6E, 0x4E6F, 0x4E72, 0x4E74, 0x4E75, 0x4E76, 0x4E77,
@@ -8604,13 +8604,13 @@ const std::array<UChar, 23940> gb18030Reference { {
 } };
 #endif
 
-const std::array<UChar, 23940>& gb18030()
+const std::array<char16_t, 23940>& gb18030()
 {
     // Allocate this at runtime because building it at compile time would make the binary much larger and this is often not used.
-    static std::array<UChar, 23940>* array;
+    static std::array<char16_t, 23940>* array;
     static std::once_flag flag;
     std::call_once(flag, [] {
-        array = new std::array<UChar, 23940>;
+        array = new std::array<char16_t, 23940>;
         UErrorCode error = U_ZERO_ERROR;
         auto icuConverter = ICUConverterPtr { ucnv_open("gb18030", &error) };
         for (size_t pointer = 0; pointer < 23940; ++pointer) {
@@ -8619,7 +8619,7 @@ const std::array<UChar, 23940>& gb18030()
                 static_cast<uint8_t>(pointer % 190)
             };
             icuInput[1] += (icuInput[1] < 0x3F) ? 0x40 : 0x41;
-            UChar icuOutput { 0 };
+            char16_t icuOutput { 0 };
             ucnv_toUnicode_span(icuConverter.get(), singleElementSpan(icuOutput), std::span { icuInput }, nullptr, true, error);
             ASSERT(!error);
             ASSERT(icuOutput != 0xFFFD);
@@ -8633,7 +8633,7 @@ const std::array<UChar, 23940>& gb18030()
         }
 
 #if !HAVE(GB_18030_2022)
-        static std::array<std::pair<size_t, UChar>, 18> gb18030_2022Differences { {
+        static std::array<std::pair<size_t, char16_t>, 18> gb18030_2022Differences { {
             { 7182, 0xfe10 },
             { 7183, 0xfe12 },
             { 7184, 0xfe11 },

--- a/Source/WebCore/PAL/pal/text/EncodingTables.h
+++ b/Source/WebCore/PAL/pal/text/EncodingTables.h
@@ -34,11 +34,11 @@
 
 namespace PAL {
 
-const std::array<std::pair<uint16_t, UChar>, 7724>& jis0208();
-const std::array<std::pair<uint16_t, UChar>, 6067>& jis0212();
+const std::array<std::pair<uint16_t, char16_t>, 7724>& jis0208();
+const std::array<std::pair<uint16_t, char16_t>, 6067>& jis0212();
 const std::array<std::pair<uint16_t, char32_t>, 18590>& big5();
-const std::array<std::pair<uint16_t, UChar>, 17048>& eucKR();
-const std::array<UChar, 23940>& gb18030();
+const std::array<std::pair<uint16_t, char16_t>, 17048>& eucKR();
+const std::array<char16_t, 23940>& gb18030();
 
 void checkEncodingTableInvariants();
 

--- a/Source/WebCore/PAL/pal/text/TextCodecASCIIFastPath.h
+++ b/Source/WebCore/PAL/pal/text/TextCodecASCIIFastPath.h
@@ -38,7 +38,7 @@ template<> struct UCharByteFiller<4> {
         memcpySpan(destination, source.first(4));
     }
     
-    static void copy(std::span<UChar> destination, std::span<const uint8_t> source)
+    static void copy(std::span<char16_t> destination, std::span<const uint8_t> source)
     {
         destination[0] = source[0];
         destination[1] = source[1];
@@ -52,7 +52,7 @@ template<> struct UCharByteFiller<8> {
         memcpySpan(destination, source.first(8));
     }
 
-    static void copy(std::span<UChar> destination, std::span<const uint8_t> source)
+    static void copy(std::span<char16_t> destination, std::span<const uint8_t> source)
     {
         destination[0] = source[0];
         destination[1] = source[1];
@@ -70,7 +70,7 @@ inline void copyASCIIMachineWord(std::span<LChar> destination, std::span<const u
     UCharByteFiller<sizeof(WTF::MachineWord)>::copy(destination, source);
 }
 
-inline void copyASCIIMachineWord(std::span<UChar> destination, std::span<const uint8_t> source)
+inline void copyASCIIMachineWord(std::span<char16_t> destination, std::span<const uint8_t> source)
 {
     UCharByteFiller<sizeof(WTF::MachineWord)>::copy(destination, source);
 }

--- a/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
@@ -167,7 +167,7 @@ void TextCodecCJK::registerCodecs(TextCodecRegistrar registrar)
     });
 }
 
-using JIS0208EncodeIndex = std::array<std::pair<UChar, uint16_t>, sizeof(jis0208()) / sizeof(jis0208()[0])>;
+using JIS0208EncodeIndex = std::array<std::pair<char16_t, uint16_t>, sizeof(jis0208()) / sizeof(jis0208()[0])>;
 static const JIS0208EncodeIndex& jis0208EncodeIndex()
 {
     // Allocate this at runtime because building it at compile time would make the binary much larger and this is often not used.
@@ -224,12 +224,12 @@ String TextCodecCJK::decodeCommon(std::span<const uint8_t> bytes, bool flush, bo
     return result.toString();
 }
 
-static std::optional<UChar> codePointJIS0208(uint16_t pointer)
+static std::optional<char16_t> codePointJIS0208(uint16_t pointer)
 {
     return findFirstInSortedPairs(jis0208(), pointer);
 }
 
-static std::optional<UChar> codePointJIS0212(uint16_t pointer)
+static std::optional<char16_t> codePointJIS0212(uint16_t pointer)
 {
     return findFirstInSortedPairs(jis0212(), pointer);
 }
@@ -278,7 +278,7 @@ static Vector<uint8_t> eucJPEncode(StringView string, Function<void(char32_t, Ve
     result.reserveInitialCapacity(string.length());
 
     auto characters = string.upconvertedCharacters();
-    for (WTF::CodePointIterator<UChar> iterator(characters); !iterator.atEnd(); ++iterator) {
+    for (WTF::CodePointIterator<char16_t> iterator(characters); !iterator.atEnd(); ++iterator) {
         auto codePoint = *iterator;
         if (isASCII(codePoint)) {
             result.append(codePoint);
@@ -335,12 +335,12 @@ String TextCodecCJK::iso2022JPDecode(std::span<const uint8_t> bytes, bool flush,
             }
             if (byte == 0x5C) {
                 m_iso2022JPOutput = false;
-                result.append(static_cast<UChar>(0x00A5));
+                result.append(static_cast<char16_t>(0x00A5));
                 break;
             }
             if (byte == 0x7E) {
                 m_iso2022JPOutput = false;
-                result.append(static_cast<UChar>(0x203E));
+                result.append(static_cast<char16_t>(0x203E));
                 break;
             }
             if (byte <= 0x7F && byte != 0x0E && byte != 0x0F && byte != 0x1B && byte != 0x5C && byte != 0x7E) {
@@ -357,7 +357,7 @@ String TextCodecCJK::iso2022JPDecode(std::span<const uint8_t> bytes, bool flush,
             }
             if (byte >= 0x21 && byte <= 0x5F) {
                 m_iso2022JPOutput = false;
-                result.append(static_cast<UChar>(0xFF61 - 0x21 + byte));
+                result.append(static_cast<char16_t>(0xFF61 - 0x21 + byte));
                 break;
             }
             m_iso2022JPOutput = false;
@@ -595,7 +595,7 @@ static Vector<uint8_t> iso2022JPEncode(StringView string, Function<void(char32_t
     };
 
     auto characters = string.upconvertedCharacters();
-    for (WTF::CodePointIterator<UChar> iterator(characters); !iterator.atEnd(); ++iterator)
+    for (WTF::CodePointIterator<char16_t> iterator(characters); !iterator.atEnd(); ++iterator)
         parseCodePoint(*iterator);
 
     if (state != State::ASCII)
@@ -614,7 +614,7 @@ String TextCodecCJK::shiftJISDecode(std::span<const uint8_t> bytes, bool flush, 
             if ((byte >= 0x40 && byte <= 0x7E) || (byte >= 0x80 && byte <= 0xFC)) {
                 uint16_t pointer = (lead - leadOffset) * 188 + byte - offset;
                 if (pointer >= 8836 && pointer <= 10715) {
-                    result.append(static_cast<UChar>(0xE000 - 8836 + pointer));
+                    result.append(static_cast<char16_t>(0xE000 - 8836 + pointer));
                     return SawError::No;
                 }
                 if (auto codePoint = codePointJIS0208(pointer)) {
@@ -631,7 +631,7 @@ String TextCodecCJK::shiftJISDecode(std::span<const uint8_t> bytes, bool flush, 
             return SawError::No;
         }
         if (byte >= 0xA1 && byte <= 0xDF) {
-            result.append(static_cast<UChar>(0xFF61 - 0xA1 + byte));
+            result.append(static_cast<char16_t>(0xFF61 - 0xA1 + byte));
             return SawError::No;
         }
         if ((byte >= 0x81 && byte <= 0x9F) || (byte >= 0xE0 && byte <= 0xFC)) {
@@ -649,7 +649,7 @@ static Vector<uint8_t> shiftJISEncode(StringView string, Function<void(char32_t,
     result.reserveInitialCapacity(string.length());
 
     auto characters = string.upconvertedCharacters();
-    for (WTF::CodePointIterator<UChar> iterator(characters); !iterator.atEnd(); ++iterator) {
+    for (WTF::CodePointIterator<char16_t> iterator(characters); !iterator.atEnd(); ++iterator) {
         auto codePoint = *iterator;
         if (isASCII(codePoint) || codePoint == 0x0080) {
             result.append(codePoint);
@@ -693,7 +693,7 @@ static Vector<uint8_t> shiftJISEncode(StringView string, Function<void(char32_t,
     return result;
 }
 
-using EUCKREncodingIndex = std::array<std::pair<UChar, uint16_t>, sizeof(eucKR()) / sizeof(eucKR()[0])>;
+using EUCKREncodingIndex = std::array<std::pair<char16_t, uint16_t>, sizeof(eucKR()) / sizeof(eucKR()[0])>;
 static const EUCKREncodingIndex& eucKREncodingIndex()
 {
     // Allocate this at runtime because building it at compile time would make the binary much larger and this is often not used.
@@ -717,7 +717,7 @@ static Vector<uint8_t> eucKREncode(StringView string, Function<void(char32_t, Ve
     result.reserveInitialCapacity(string.length());
 
     auto characters = string.upconvertedCharacters();
-    for (WTF::CodePointIterator<UChar> iterator(characters); !iterator.atEnd(); ++iterator) {
+    for (WTF::CodePointIterator<char16_t> iterator(characters); !iterator.atEnd(); ++iterator) {
         auto codePoint = *iterator;
         if (isASCII(codePoint)) {
             result.append(codePoint);
@@ -788,7 +788,7 @@ static Vector<uint8_t> big5Encode(StringView string, Function<void(char32_t, Vec
     result.reserveInitialCapacity(string.length());
 
     auto characters = string.upconvertedCharacters();
-    for (WTF::CodePointIterator<UChar> iterator(characters); !iterator.atEnd(); ++iterator) {
+    for (WTF::CodePointIterator<char16_t> iterator(characters); !iterator.atEnd(); ++iterator) {
         auto codePoint = *iterator;
         if (isASCII(codePoint)) {
             result.append(codePoint);
@@ -881,7 +881,7 @@ static uint32_t gb18030RangesPointer(char32_t codePoint)
     return pointerOffset + codePoint - offset;
 }
 
-using GB18030EncodeIndex = std::array<std::pair<UChar, uint16_t>, 23940>;
+using GB18030EncodeIndex = std::array<std::pair<char16_t, uint16_t>, 23940>;
 static const GB18030EncodeIndex& gb18030EncodeIndex()
 {
     // Allocate this at runtime because building it at compile time would make the binary much larger and this is often not used.
@@ -900,7 +900,7 @@ static const GB18030EncodeIndex& gb18030EncodeIndex()
 // https://unicode-org.atlassian.net/browse/ICU-22357
 // The 2-byte values are handled correctly by values from gb18030()
 // but these need to be exceptions from gb18030Ranges().
-static std::optional<uint16_t> gb18030AsymmetricEncode(UChar codePoint)
+static std::optional<uint16_t> gb18030AsymmetricEncode(char16_t codePoint)
 {
     switch (codePoint) {
     case 0xE81E: return 0xFE59;
@@ -1022,7 +1022,7 @@ static Vector<uint8_t> gbEncodeShared(StringView string, Function<void(char32_t,
     result.reserveInitialCapacity(string.length());
 
     auto characters = string.upconvertedCharacters();
-    for (WTF::CodePointIterator<UChar> iterator(characters); !iterator.atEnd(); ++iterator) {
+    for (WTF::CodePointIterator<char16_t> iterator(characters); !iterator.atEnd(); ++iterator) {
         auto codePoint = *iterator;
         if (isASCII(codePoint)) {
             result.append(codePoint);

--- a/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
@@ -174,9 +174,9 @@ void TextCodecICU::createICUConverter() const
         ucnv_setFallback(m_converter.get(), true);
 }
 
-int TextCodecICU::decodeToBuffer(std::span<UChar> targetSpan, std::span<const uint8_t>& sourceSpan, int32_t* offsets, bool flush, UErrorCode& error)
+int TextCodecICU::decodeToBuffer(std::span<char16_t> targetSpan, std::span<const uint8_t>& sourceSpan, int32_t* offsets, bool flush, UErrorCode& error)
 {
-    UChar* targetStart = targetSpan.data();
+    char16_t* targetStart = targetSpan.data();
     error = U_ZERO_ERROR;
     auto* source = byteCast<char>(sourceSpan.data());
     auto* sourceLimit = byteCast<char>(std::to_address(sourceSpan.end()));
@@ -235,7 +235,7 @@ String TextCodecICU::decode(std::span<const uint8_t> source, bool flush, bool st
 
     StringBuilder result;
 
-    std::array<UChar, ConversionBufferSize> buffer;
+    std::array<char16_t, ConversionBufferSize> buffer;
     auto target = std::span { buffer };
     int32_t* offsets = nullptr;
     UErrorCode err = U_ZERO_ERROR;
@@ -260,7 +260,7 @@ String TextCodecICU::decode(std::span<const uint8_t> source, bool flush, bool st
 
 // Invalid character handler when writing escaped entities for unrepresentable
 // characters. See the declaration of TextCodec::encode for more.
-static void urlEscapedEntityCallback(const void* context, UConverterFromUnicodeArgs* fromUArgs, const UChar* codeUnits, int32_t length,
+static void urlEscapedEntityCallback(const void* context, UConverterFromUnicodeArgs* fromUArgs, const char16_t* codeUnits, int32_t length,
     UChar32 codePoint, UConverterCallbackReason reason, UErrorCode* error)
 {
     if (reason == UCNV_UNASSIGNED) {

--- a/Source/WebCore/PAL/pal/text/TextCodecICU.h
+++ b/Source/WebCore/PAL/pal/text/TextCodecICU.h
@@ -52,7 +52,7 @@ private:
     void createICUConverter() const;
     void releaseICUConverter() const;
 
-    int decodeToBuffer(std::span<UChar> buffer, std::span<const uint8_t>& source, int32_t* offsets, bool flush, UErrorCode&);
+    int decodeToBuffer(std::span<char16_t> buffer, std::span<const uint8_t>& source, int32_t* offsets, bool flush, UErrorCode&);
 
     ASCIILiteral m_encodingName;
     ASCIILiteral const m_canonicalConverterName;

--- a/Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp
@@ -34,7 +34,7 @@
 
 namespace PAL {
 
-static constexpr std::array<UChar, 256> latin1ConversionTable = {
+static constexpr std::array<char16_t, 256> latin1ConversionTable = {
     0x0000, 0x0001, 0x0002, 0x0003, 0x0004, 0x0005, 0x0006, 0x0007, // 00-07
     0x0008, 0x0009, 0x000A, 0x000B, 0x000C, 0x000D, 0x000E, 0x000F, // 08-0F
     0x0010, 0x0011, 0x0012, 0x0013, 0x0014, 0x0015, 0x0016, 0x0017, // 10-17
@@ -153,7 +153,7 @@ useLookupTable:
     return result;
     
 upConvertTo16Bit:
-    std::span<UChar> characters16;
+    std::span<char16_t> characters16;
     String result16 = String::createUninitialized(bytes.size(), characters16);
 
     auto destination16 = characters16;
@@ -232,7 +232,7 @@ Vector<uint8_t> TextCodecLatin1::encode(StringView string, UnencodableHandling h
         size_t index = 0;
 
         // Convert and simultaneously do a check to see if it's all ASCII.
-        UChar ored = 0;
+        char16_t ored = 0;
         for (auto character : string.codeUnits()) {
             result[index++] = character;
             ored |= character;

--- a/Source/WebCore/PAL/pal/text/TextCodecSingleByte.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecSingleByte.cpp
@@ -53,8 +53,8 @@ enum class TextCodecSingleByte::Encoding : uint8_t {
     KOI8U,
 };
 
-using SingleByteDecodeTable = std::array<UChar, 128>;
-using SingleByteEncodeTableEntry = std::pair<UChar, uint8_t>;
+using SingleByteDecodeTable = std::array<char16_t, 128>;
+using SingleByteEncodeTableEntry = std::pair<char16_t, uint8_t>;
 using SingleByteEncodeTable = std::span<const SingleByteEncodeTableEntry>;
 
 // From https://encoding.spec.whatwg.org/index-iso-8859-3.txt with 0xFFFD filling the gaps
@@ -283,7 +283,7 @@ static String decode(const SingleByteDecodeTable& table, std::span<const uint8_t
             result.append(byte);
             return;
         }
-        UChar codePoint = table[byte - 0x80];
+        char16_t codePoint = table[byte - 0x80];
         if (codePoint == replacementCharacter)
             sawError = true;
         result.append(codePoint);

--- a/Source/WebCore/PAL/pal/text/TextCodecUTF16.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecUTF16.cpp
@@ -75,7 +75,7 @@ String TextCodecUTF16::decode(std::span<const uint8_t> bytes, bool flush, bool, 
     StringBuilder result;
     result.reserveCapacity(bytes.size() / 2);
 
-    auto processCodeUnit = [&] (UChar codeUnit) {
+    auto processCodeUnit = [&] (char16_t codeUnit) {
         if (std::exchange(m_shouldStripByteOrderMark, false) && codeUnit == byteOrderMark)
             return;
         if (m_leadSurrogate) {

--- a/Source/WebCore/PAL/pal/text/TextCodecUTF16.h
+++ b/Source/WebCore/PAL/pal/text/TextCodecUTF16.h
@@ -46,7 +46,7 @@ private:
 
     bool m_littleEndian;
     std::optional<uint8_t> m_leadByte;
-    std::optional<UChar> m_leadSurrogate;
+    std::optional<char16_t> m_leadSurrogate;
     bool m_shouldStripByteOrderMark { false };
 };
 

--- a/Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp
@@ -167,7 +167,7 @@ static inline int decodeNonASCIISequence(std::span<const uint8_t> sequence, uint
     return ((sequence[0] << 18) + (sequence[1] << 12) + (sequence[2] << 6) + sequence[3]) - 0x03C82080;
 }
 
-static inline std::span<UChar> appendCharacter(std::span<UChar> destination, int character)
+static inline std::span<char16_t> appendCharacter(std::span<char16_t> destination, int character)
 {
     ASSERT(character != nonCharacter);
     ASSERT(!U_IS_SURROGATE(character));
@@ -237,7 +237,7 @@ bool TextCodecUTF8::handlePartialSequence(std::span<LChar>& destination, std::sp
     return false;
 }
 
-void TextCodecUTF8::handlePartialSequence(std::span<UChar>& destination, std::span<const uint8_t>& source, bool flush, bool stopOnError, bool& sawError)
+void TextCodecUTF8::handlePartialSequence(std::span<char16_t>& destination, std::span<const uint8_t>& source, bool flush, bool stopOnError, bool& sawError)
 {
     ASSERT(m_partialSequenceSize);
     do {
@@ -392,7 +392,7 @@ String TextCodecUTF8::decode(std::span<const uint8_t> bytes, bool flush, bool st
     return String::adopt(WTFMove(buffer));
 
 upConvertTo16Bit:
-    StringBuffer<UChar> buffer16(bufferSize);
+    StringBuffer<char16_t> buffer16(bufferSize);
 
     auto destination16 = buffer16.span();
 

--- a/Source/WebCore/PAL/pal/text/TextCodecUTF8.h
+++ b/Source/WebCore/PAL/pal/text/TextCodecUTF8.h
@@ -47,7 +47,7 @@ private:
     Vector<uint8_t> encode(StringView, UnencodableHandling) const final;
 
     bool handlePartialSequence(std::span<LChar>& destination, std::span<const uint8_t>& source, bool flush);
-    void handlePartialSequence(std::span<UChar>& destination, std::span<const uint8_t>& source, bool flush, bool stopOnError, bool& sawError);
+    void handlePartialSequence(std::span<char16_t>& destination, std::span<const uint8_t>& source, bool flush, bool stopOnError, bool& sawError);
     void consumePartialSequenceByte();
 
     int m_partialSequenceSize { 0 };

--- a/Source/WebCore/PAL/pal/text/TextCodecUserDefined.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecUserDefined.cpp
@@ -53,7 +53,7 @@ String TextCodecUserDefined::decode(std::span<const uint8_t> bytes, bool, bool, 
     StringBuilder result;
     result.reserveCapacity(bytes.size());
     for (char byte : bytes)
-        result.append(static_cast<UChar>(byte & 0xF7FF));
+        result.append(static_cast<char16_t>(byte & 0xF7FF));
     return result.toString();
 }
 
@@ -82,7 +82,7 @@ Vector<uint8_t> TextCodecUserDefined::encode(StringView string, UnencodableHandl
         size_t index = 0;
 
         // Convert and simultaneously do a check to see if it's all ASCII.
-        UChar ored = 0;
+        char16_t ored = 0;
         for (auto character : string.codeUnits()) {
             result[index++] = character;
             ored |= character;

--- a/Source/WebCore/PAL/pal/text/TextEncoding.cpp
+++ b/Source/WebCore/PAL/pal/text/TextEncoding.cpp
@@ -113,7 +113,7 @@ bool TextEncoding::isJapanese() const
     return isJapaneseEncoding(m_name);
 }
 
-UChar TextEncoding::backslashAsCurrencySymbol() const
+char16_t TextEncoding::backslashAsCurrencySymbol() const
 {
     return shouldShowBackslashAsCurrencySymbolIn(m_name) ? 0x00A5 : '\\';
 }

--- a/Source/WebCore/PAL/pal/text/TextEncoding.h
+++ b/Source/WebCore/PAL/pal/text/TextEncoding.h
@@ -54,7 +54,7 @@ public:
     PAL_EXPORT Vector<uint8_t> encode(StringView, PAL::UnencodableHandling, NFCNormalize = NFCNormalize::Yes) const;
     Vector<uint8_t> encodeForURLParsing(StringView string) const final { return encode(string, PAL::UnencodableHandling::URLEncodedEntities, NFCNormalize::No); }
 
-    UChar backslashAsCurrencySymbol() const;
+    char16_t backslashAsCurrencySymbol() const;
     bool isByteBasedEncoding() const { return !isNonByteBasedEncoding(); }
 
 private:
@@ -62,7 +62,7 @@ private:
     bool isUTF7Encoding() const;
 
     ASCIILiteral m_name;
-    UChar m_backslashAsCurrencySymbol;
+    char16_t m_backslashAsCurrencySymbol;
 };
 
 inline bool operator==(const TextEncoding& a, const TextEncoding& b) { return a.name() == b.name(); }

--- a/Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp
+++ b/Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp
@@ -332,7 +332,7 @@ static ASCIILiteral atomCanonicalTextEncodingName(std::span<const LChar> name)
     return textEncodingNameMap.get<HashTranslatorTextEncodingName>(name);
 }
 
-static ASCIILiteral atomCanonicalTextEncodingName(std::span<const UChar> characters)
+static ASCIILiteral atomCanonicalTextEncodingName(std::span<const char16_t> characters)
 {
     if (characters.size() > maxEncodingNameLength)
         return { };

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -2610,7 +2610,7 @@ static AXTextChangeContext secureContext(AccessibilityObject& object, AXTextChan
         if (text.isEmpty())
             return;
 
-        std::span<UChar> characters;
+        std::span<char16_t> characters;
         text = String::createUninitialized(text.length(), characters);
         for (unsigned i = 0; i < text.length(); ++i)
             characters[i] = maskingCharacter;
@@ -4188,7 +4188,7 @@ CharacterOffset AXObjectCache::nextBoundary(const CharacterOffset& characterOffs
 
     auto searchRange = rangeForNodeContents(*boundary);
 
-    Vector<UChar, 1024> string;
+    Vector<char16_t, 1024> string;
     unsigned prefixLength = 0;
     
     if (requiresContextForWordBoundary(characterAfter(characterOffset))) {
@@ -4233,7 +4233,7 @@ CharacterOffset AXObjectCache::previousBoundary(const CharacterOffset& character
         return CharacterOffset();
     
     auto searchRange = rangeForNodeContents(*boundary);
-    Vector<UChar, 1024> string;
+    Vector<char16_t, 1024> string;
     unsigned suffixLength = 0;
 
     if (needsContextAtParagraphStart == NeedsContextAtParagraphStart::Yes && startCharacterOffsetOfParagraph(characterOffset).isEqual(characterOffset)) {

--- a/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
@@ -92,7 +92,7 @@ void AccessibilityMathMLElement::addChildren()
 String AccessibilityMathMLElement::textUnderElement(TextUnderElementMode mode) const
 {
     if (m_isAnonymousOperator && !mode.isHidden()) {
-        UChar operatorChar = downcast<RenderMathMLOperator>(*m_renderer).textContent();
+        char16_t operatorChar = downcast<RenderMathMLOperator>(*m_renderer).textContent();
         return operatorChar ? String(span(operatorChar)) : String();
     }
 

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1571,7 +1571,7 @@ AXTextRuns AccessibilityRenderObject::textRuns()
 
         lineString.reserveCapacity(lineString.length() + text.length());
         for (unsigned i = 0; i < text.length(); i++) {
-            UChar character = text[i];
+            char16_t character = text[i];
             if (character == '\t' && collapseTabs)
                 lineString.append(' ');
             else if (character == '\n' && collapseNewlines)

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h
@@ -192,8 +192,8 @@ private:
     CString text(int, int) const;
     CString textAtOffset(int, TextGranularity, int&, int&) const;
     int characterAtOffset(int) const;
-    std::optional<unsigned> characterOffset(UChar, int) const;
-    std::optional<unsigned> characterIndex(UChar, unsigned) const;
+    std::optional<unsigned> characterOffset(char16_t, int) const;
+    std::optional<unsigned> characterIndex(char16_t, unsigned) const;
     IntRect textExtents(int, int, Atspi::CoordinateType) const; 
     int offsetAtPoint(const IntPoint&, Atspi::CoordinateType) const;
     IntPoint boundsForSelection(const VisibleSelection&) const;

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -500,7 +500,7 @@ int AccessibilityObjectAtspi::characterAtOffset(int offset) const
     return g_utf8_get_char(g_utf8_offset_to_pointer(utf8Text.data(), offset));
 }
 
-std::optional<unsigned> AccessibilityObjectAtspi::characterOffset(UChar character, int index) const
+std::optional<unsigned> AccessibilityObjectAtspi::characterOffset(char16_t character, int index) const
 {
     auto utf16Text = text();
     unsigned start = 0;
@@ -519,7 +519,7 @@ std::optional<unsigned> AccessibilityObjectAtspi::characterOffset(UChar characte
     return UTF16OffsetToUTF8(mapping, offset);
 }
 
-std::optional<unsigned> AccessibilityObjectAtspi::characterIndex(UChar character, unsigned offset) const
+std::optional<unsigned> AccessibilityObjectAtspi::characterIndex(char16_t character, unsigned offset) const
 {
     auto utf16Text = text();
     auto utf8Text = utf16Text.utf8();

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -2357,7 +2357,7 @@ private:
         unsigned length = str.length();
 
         // Guard against overflow
-        if (length > (std::numeric_limits<uint32_t>::max() - sizeof(uint32_t)) / sizeof(UChar)) {
+        if (length > (std::numeric_limits<uint32_t>::max() - sizeof(uint32_t)) / sizeof(char16_t)) {
             fail();
             return;
         }
@@ -3581,7 +3581,7 @@ private:
 
     static bool readString(std::span<const uint8_t>& span, String& str, unsigned length, bool is8Bit, ShouldAtomize shouldAtomize)
     {
-        if (length >= std::numeric_limits<int32_t>::max() / sizeof(UChar))
+        if (length >= std::numeric_limits<int32_t>::max() / sizeof(char16_t))
             return false;
 
         if (is8Bit) {
@@ -3594,18 +3594,18 @@ private:
             return true;
         }
 
-        size_t size = length * sizeof(UChar);
+        size_t size = length * sizeof(char16_t);
         if (span.size() < size)
             return false;
 
 #if ASSUME_LITTLE_ENDIAN
         auto stringSpan = consumeSpan(span, size);
         if (shouldAtomize == ShouldAtomize::Yes)
-            str = AtomString(spanReinterpretCast<const UChar>(stringSpan));
+            str = AtomString(spanReinterpretCast<const char16_t>(stringSpan));
         else
-            str = String(spanReinterpretCast<const UChar>(stringSpan));
+            str = String(spanReinterpretCast<const char16_t>(stringSpan));
 #else
-        std::span<UChar> characters;
+        std::span<char16_t> characters;
         str = String::createUninitialized(length, characters);
         for (unsigned i = 0; i < length; ++i) {
             uint16_t c;

--- a/Source/WebCore/contentextensions/ContentExtensionParser.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionParser.cpp
@@ -83,7 +83,7 @@ static Expected<Vector<String>, std::error_code> getDomainList(const JSON::Array
             domain = domain.substring(1);
         }
 
-        std::array<std::pair<UChar, ASCIILiteral>, 9> escapeTable { {
+        std::array<std::pair<char16_t, ASCIILiteral>, 9> escapeTable { {
             { '\\', "\\\\"_s },
             { '{', "\\{"_s },
             { '}', "\\}"_s },

--- a/Source/WebCore/contentextensions/DFAMinimizer.cpp
+++ b/Source/WebCore/contentextensions/DFAMinimizer.cpp
@@ -399,7 +399,7 @@ struct ActionKey {
         , state(Valid)
     {
         SuperFastHash hasher;
-        hasher.addCharactersAssumingAligned(reinterpret_cast<const UChar*>(&dfa->actions[actionsStart]), actionsLength * sizeof(uint64_t) / sizeof(UChar));
+        hasher.addCharactersAssumingAligned(reinterpret_cast<const char16_t*>(&dfa->actions[actionsStart]), actionsLength * sizeof(uint64_t) / sizeof(char16_t));
         hash = hasher.hash();
     }
 

--- a/Source/WebCore/contentextensions/HashableActionList.h
+++ b/Source/WebCore/contentextensions/HashableActionList.h
@@ -47,7 +47,7 @@ struct HashableActionList {
     {
         std::ranges::sort(actions);
         SuperFastHash hasher;
-        hasher.addCharactersAssumingAligned(reinterpret_cast<const UChar*>(actions.span().data()), actions.size() * sizeof(uint64_t) / sizeof(UChar));
+        hasher.addCharactersAssumingAligned(reinterpret_cast<const char16_t*>(actions.span().data()), actions.size() * sizeof(uint64_t) / sizeof(char16_t));
         hash = hasher.hash();
     }
 

--- a/Source/WebCore/contentextensions/Term.h
+++ b/Source/WebCore/contentextensions/Term.h
@@ -74,7 +74,7 @@ public:
     bool isValid() const;
 
     // CharacterSet terms only.
-    void addCharacter(UChar character, bool isCaseSensitive);
+    void addCharacter(char16_t character, bool isCaseSensitive);
 
     // Group terms only.
     void extendGroupSubpattern(const Term&);
@@ -133,13 +133,13 @@ private:
 
     class CharacterSet {
     public:
-        void set(UChar character)
+        void set(char16_t character)
         {
             RELEASE_ASSERT(character < 128);
             m_characters[character / 64] |= (uint64_t(1) << (character % 64));
         }
         
-        bool get(UChar character) const
+        bool get(char16_t character) const
         {
             RELEASE_ASSERT(character < 128);
             return m_characters[character / 64] & (uint64_t(1) << (character % 64));
@@ -238,7 +238,7 @@ inline String Term::toString() const
     case TermType::CharacterSet: {
         StringBuilder builder;
         builder.append('[');
-        for (UChar c = 0; c < 128; c++) {
+        for (char16_t c = 0; c < 128; c++) {
             if (m_atomData.characterSet.get(c)) {
                 if (isASCIIPrintable(c) && !isUnicodeCompatibleASCIIWhitespace(c))
                     builder.append(c);
@@ -278,7 +278,7 @@ inline Term::Term(UniversalTransitionTag)
     : m_termType(TermType::CharacterSet)
 {
     new (NotNull, &m_atomData.characterSet) CharacterSet();
-    for (UChar i = 1; i < 128; ++i)
+    for (char16_t i = 1; i < 128; ++i)
         m_atomData.characterSet.set(i);
 }
 
@@ -350,7 +350,7 @@ inline bool Term::isValid() const
     return m_termType != TermType::Empty;
 }
 
-inline void Term::addCharacter(UChar character, bool isCaseSensitive)
+inline void Term::addCharacter(char16_t character, bool isCaseSensitive)
 {
     ASSERT(isASCII(character));
 
@@ -583,28 +583,28 @@ inline void Term::generateSubgraphForAtom(NFA& nfa, ImmutableCharNFANodeBuilder&
         break;
     case TermType::CharacterSet: {
         if (!m_atomData.characterSet.inverted()) {
-            UChar i = 0;
+            char16_t i = 0;
             while (true) {
                 while (i < 128 && !m_atomData.characterSet.get(i))
                     ++i;
                 if (i == 128)
                     break;
 
-                UChar start = i;
+                char16_t start = i;
                 ++i;
                 while (i < 128 && m_atomData.characterSet.get(i))
                     ++i;
                 source.addTransition(start, i - 1, destination);
             }
         } else {
-            UChar i = 1;
+            char16_t i = 1;
             while (true) {
                 while (i < 128 && m_atomData.characterSet.get(i))
                     ++i;
                 if (i == 128)
                     break;
 
-                UChar start = i;
+                char16_t start = i;
                 ++i;
                 while (i < 128 && !m_atomData.characterSet.get(i))
                     ++i;

--- a/Source/WebCore/contentextensions/URLFilterParser.cpp
+++ b/Source/WebCore/contentextensions/URLFilterParser.cpp
@@ -76,7 +76,7 @@ public:
         return m_parseStatus;
     }
 
-    void atomPatternCharacter(UChar character, bool)
+    void atomPatternCharacter(char16_t character, bool)
     {
         if (hasError())
             return;
@@ -179,7 +179,7 @@ public:
         m_floatingTerm = Term(Term::CharacterSetTerm, inverted);
     }
 
-    void atomCharacterClassAtom(UChar character)
+    void atomCharacterClassAtom(char16_t character)
     {
         if (hasError())
             return;
@@ -192,7 +192,7 @@ public:
         m_floatingTerm.addCharacter(character, m_patternIsCaseSensitive);
     }
 
-    void atomCharacterClassRange(UChar a, UChar b)
+    void atomCharacterClassRange(char16_t a, char16_t b)
     {
         if (hasError())
             return;
@@ -203,7 +203,7 @@ public:
         ASSERT(isASCII(b));
 
         for (unsigned i = a; i <= b; ++i)
-            m_floatingTerm.addCharacter(static_cast<UChar>(i), m_patternIsCaseSensitive);
+            m_floatingTerm.addCharacter(static_cast<char16_t>(i), m_patternIsCaseSensitive);
     }
 
     void atomClassStringDisjunction(Vector<Vector<char32_t>>)

--- a/Source/WebCore/css/CSSCounterStyle.cpp
+++ b/Source/WebCore/css/CSSCounterStyle.cpp
@@ -155,7 +155,7 @@ String CSSCounterStyle::counterForSystemAdditive(unsigned value) const
 enum class Formality : bool { Informal, Formal };
 
 // This table format was derived from an old draft of the CSS specification: 3 group markers, 3 digit markers, 10 digits, negative sign.
-static String counterForSystemCJK(int number, const std::array<UChar, 17>& table, Formality formality)
+static String counterForSystemCJK(int number, const std::array<char16_t, 17>& table, Formality formality)
 {
     enum AbstractCJKCharacter {
         NoChar,
@@ -222,7 +222,7 @@ static String counterForSystemCJK(int number, const std::array<UChar, 17>& table
 
     // Convert into characters, omitting consecutive runs of digit0 and trailing digit0.
     unsigned length = 0;
-    std::array<UChar, bufferLength + 1> characters;
+    std::array<char16_t, bufferLength + 1> characters;
     auto last = NoChar;
     if (needsNegativeSign)
         characters[length++] = table[NegativeSign - 1];
@@ -237,7 +237,7 @@ static String counterForSystemCJK(int number, const std::array<UChar, 17>& table
     if (last == Digit0)
         --length;
 
-    return std::span<const UChar> { characters }.first(length);
+    return std::span<const char16_t> { characters }.first(length);
 }
 
 String CSSCounterStyle::counterForSystemDisclosureClosed(WritingMode writingMode)
@@ -265,7 +265,7 @@ String CSSCounterStyle::counterForSystemDisclosureOpen(WritingMode writingMode)
 
 String CSSCounterStyle::counterForSystemSimplifiedChineseInformal(int value)
 {
-    static constexpr std::array<UChar, 17> simplifiedChineseInformalTable {
+    static constexpr std::array<char16_t, 17> simplifiedChineseInformalTable {
         0x842C, 0x5104, 0x5146, // These three group markers are probably wrong; OK because we don't use this on big enough numbers.
         0x5341, 0x767E, 0x5343,
         0x96F6, 0x4E00, 0x4E8C, 0x4E09, 0x56DB,
@@ -277,7 +277,7 @@ String CSSCounterStyle::counterForSystemSimplifiedChineseInformal(int value)
 
 String CSSCounterStyle::counterForSystemSimplifiedChineseFormal(int value)
 {
-    static constexpr std::array<UChar, 17> simplifiedChineseFormalTable {
+    static constexpr std::array<char16_t, 17> simplifiedChineseFormalTable {
         0x842C, 0x5104, 0x5146, // These three group markers are probably wrong; OK because we don't use this on big enough numbers.
         0x62FE, 0x4F70, 0x4EDF,
         0x96F6, 0x58F9, 0x8D30, 0x53C1, 0x8086,
@@ -289,7 +289,7 @@ String CSSCounterStyle::counterForSystemSimplifiedChineseFormal(int value)
 
 String CSSCounterStyle::counterForSystemTraditionalChineseInformal(int value)
 {
-    static constexpr std::array<UChar, 17> traditionalChineseInformalTable {
+    static constexpr std::array<char16_t, 17> traditionalChineseInformalTable {
         0x842C, 0x5104, 0x5146,
         0x5341, 0x767E, 0x5343,
         0x96F6, 0x4E00, 0x4E8C, 0x4E09, 0x56DB,
@@ -301,7 +301,7 @@ String CSSCounterStyle::counterForSystemTraditionalChineseInformal(int value)
 
 String CSSCounterStyle::counterForSystemTraditionalChineseFormal(int value)
 {
-    static constexpr std::array<UChar, 17> traditionalChineseFormalTable {
+    static constexpr std::array<char16_t, 17> traditionalChineseFormalTable {
         0x842C, 0x5104, 0x5146, // These three group markers are probably wrong; OK because we don't use this on big enough numbers.
         0x62FE, 0x4F70, 0x4EDF,
         0x96F6, 0x58F9, 0x8CB3, 0x53C3, 0x8086,
@@ -316,7 +316,7 @@ String CSSCounterStyle::counterForSystemEthiopicNumeric(unsigned value)
     ASSERT(value >= 1);
 
     if (value == 1) {
-        UChar ethiopicDigitOne = 0x1369;
+        char16_t ethiopicDigitOne = 0x1369;
         return span(ethiopicDigitOne);
     }
 
@@ -327,7 +327,7 @@ String CSSCounterStyle::counterForSystemEthiopicNumeric(unsigned value)
         value /= 100;
     }
 
-    std::array<UChar, groups.size() * 3> buffer;
+    std::array<char16_t, groups.size() * 3> buffer;
     unsigned length = 0;
     bool isMostSignificantGroup = true;
     for (int i = groups.size() - 1; i >= 0; --i) {
@@ -350,7 +350,7 @@ String CSSCounterStyle::counterForSystemEthiopicNumeric(unsigned value)
             isMostSignificantGroup = false;
     }
 
-    return std::span<const UChar> { buffer }.first(length);
+    return std::span<const char16_t> { buffer }.first(length);
 }
 
 String CSSCounterStyle::initialRepresentation(int value, WritingMode writingMode) const

--- a/Source/WebCore/css/CSSProperty.h
+++ b/Source/WebCore/css/CSSProperty.h
@@ -83,7 +83,7 @@ public:
     static bool isInLogicalPropertyGroup(CSSPropertyID);
     static bool areInSameLogicalPropertyGroupWithDifferentMappingLogic(CSSPropertyID, CSSPropertyID);
     static bool isDescriptorOnly(CSSPropertyID);
-    static UChar listValuedPropertySeparator(CSSPropertyID);
+    static char16_t listValuedPropertySeparator(CSSPropertyID);
     static bool isListValuedProperty(CSSPropertyID propertyID) { return !!listValuedPropertySeparator(propertyID) || propertyID == CSSPropertyCustom; }
     static bool allowsNumberOrIntegerInput(CSSPropertyID);
 

--- a/Source/WebCore/css/CSSStyleProperties.cpp
+++ b/Source/WebCore/css/CSSStyleProperties.cpp
@@ -93,7 +93,7 @@ static PropertyNamePrefix propertyNamePrefix(const StringImpl& propertyName)
     ASSERT(propertyName.length());
 
     // First character of the prefix within the property name may be upper or lowercase.
-    UChar firstChar = toASCIILower(propertyName[0]);
+    char16_t firstChar = toASCIILower(propertyName[0]);
     switch (firstChar) {
     case 'e':
         if (matchesCSSPropertyNamePrefix(propertyName, "epub"_s))
@@ -165,7 +165,7 @@ static CSSPropertyID parseJavaScriptCSSPropertyName(const AtomString& propertyNa
         return CSSPropertyInvalid;
 
     for (; i < length; ++i) {
-        UChar c = (*propertyNameString)[i];
+        char16_t c = (*propertyNameString)[i];
         if (!c || !isASCII(c))
             return CSSPropertyInvalid; // illegal character
         if (isASCIIUpper(c)) {

--- a/Source/WebCore/css/CSSValueList.cpp
+++ b/Source/WebCore/css/CSSValueList.cpp
@@ -176,7 +176,7 @@ Ref<CSSValueList> CSSValueList::createSpaceSeparated(Ref<CSSValue> value1, Ref<C
     return adoptRef(*new CSSValueList(SpaceSeparator, WTFMove(value1), WTFMove(value2), WTFMove(value3), WTFMove(value4)));
 }
 
-Ref<CSSValueList> CSSValueList::create(UChar separator, CSSValueListBuilder builder)
+Ref<CSSValueList> CSSValueList::create(char16_t separator, CSSValueListBuilder builder)
 {
     switch (separator) {
     case ',':

--- a/Source/WebCore/css/CSSValueList.h
+++ b/Source/WebCore/css/CSSValueList.h
@@ -99,7 +99,7 @@ private:
 
 class CSSValueList final : public CSSValueContainingVector {
 public:
-    static Ref<CSSValueList> create(UChar separator, CSSValueListBuilder);
+    static Ref<CSSValueList> create(char16_t separator, CSSValueListBuilder);
 
     static Ref<CSSValueList> createCommaSeparated(CSSValueListBuilder);
     static Ref<CSSValueList> createCommaSeparated(Ref<CSSValue>); // FIXME: Upgrade callers to not use a list at all.

--- a/Source/WebCore/css/CSSVariableData.cpp
+++ b/Source/WebCore/css/CSSVariableData.cpp
@@ -77,7 +77,7 @@ CSSVariableData::CSSVariableData(const CSSParserTokenRange& range, const CSSPars
         if (m_backingString.is8Bit())
             updateBackingStringsInTokens<LChar>();
         else
-            updateBackingStringsInTokens<UChar>();
+            updateBackingStringsInTokens<char16_t>();
     }
 }
 

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -541,7 +541,7 @@ static bool attributeValueMatches(const Attribute& attribute, CSSSelector::Match
     case CSSSelector::Match::List:
         {
             // Ignore empty selectors or selectors containing spaces.
-            if (selectorValue.isEmpty() || selectorValue.find(isASCIIWhitespace<UChar>) != notFound)
+            if (selectorValue.isEmpty() || selectorValue.find(isASCIIWhitespace<char16_t>) != notFound)
                 return false;
 
             unsigned startSearchAt = 0;

--- a/Source/WebCore/css/parser/CSSParserToken.cpp
+++ b/Source/WebCore/css/parser/CSSParserToken.cpp
@@ -365,7 +365,7 @@ CSSParserToken::CSSParserToken(unsigned nonNewlineWhitespaceCount)
 }
 
 // Just a helper used for Delimiter tokens.
-CSSParserToken::CSSParserToken(CSSParserTokenType type, UChar c)
+CSSParserToken::CSSParserToken(CSSParserTokenType type, char16_t c)
     : m_type(type)
     , m_blockType(NotBlock)
     , m_delimiter(c)
@@ -449,7 +449,7 @@ StringView CSSParserToken::unitString() const
     return value().substring(m_nonUnitPrefixLength);
 }
 
-UChar CSSParserToken::delimiter() const
+char16_t CSSParserToken::delimiter() const
 {
     ASSERT(m_type == DelimiterToken);
     return m_delimiter;

--- a/Source/WebCore/css/parser/CSSParserToken.h
+++ b/Source/WebCore/css/parser/CSSParserToken.h
@@ -103,7 +103,7 @@ public:
     CSSParserToken(CSSParserTokenType, StringView, BlockType = NotBlock);
 
     explicit CSSParserToken(unsigned nonNewlineWhitespaceCount); // NonNewlineWhitespaceToken
-    CSSParserToken(CSSParserTokenType, UChar); // for DelimiterToken
+    CSSParserToken(CSSParserTokenType, char16_t); // for DelimiterToken
     CSSParserToken(double, NumericValueType, NumericSign, StringView originalText); // for NumberToken
 
     CSSParserToken(HashTokenType, StringView);
@@ -121,7 +121,7 @@ public:
     CSSParserTokenType type() const { return static_cast<CSSParserTokenType>(m_type); }
     StringView value() const { return { m_valueDataCharRaw, m_valueLength, m_valueIs8Bit }; }
 
-    UChar delimiter() const;
+    char16_t delimiter() const;
     NumericSign numericSign() const;
     NumericValueType numericValueType() const;
     double numericValue() const;
@@ -174,10 +174,10 @@ private:
     bool m_valueIs8Bit : 1 { false };
     bool m_isBackedByStringLiteral : 1 { false };
     unsigned m_valueLength { 0 };
-    const void* m_valueDataCharRaw { nullptr }; // Either LChar* or UChar*.
+    const void* m_valueDataCharRaw { nullptr }; // Either LChar* or char16_t*.
 
     union {
-        UChar m_delimiter;
+        char16_t m_delimiter;
         HashTokenType m_hashTokenType;
         double m_numericValue;
         mutable int m_id;

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+UnicodeRange.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+UnicodeRange.cpp
@@ -38,7 +38,7 @@
 namespace WebCore {
 namespace CSSPropertyParserHelpers {
 
-static bool consumeOptionalDelimiter(CSSParserTokenRange& range, UChar value)
+static bool consumeOptionalDelimiter(CSSParserTokenRange& range, char16_t value)
 {
     if (!(range.peek().type() == DelimiterToken && range.peek().delimiter() == value))
         return false;
@@ -64,7 +64,7 @@ static bool consumeAndAppendOptionalNumber(StringBuilder& builder, CSSParserToke
     return true;
 }
 
-static bool consumeAndAppendOptionalDelimiter(StringBuilder& builder, CSSParserTokenRange& range, UChar value)
+static bool consumeAndAppendOptionalDelimiter(StringBuilder& builder, CSSParserTokenRange& range, char16_t value)
 {
     if (!consumeOptionalDelimiter(range, value))
         return false;

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -1043,7 +1043,7 @@ CSSSelector::Relation CSSSelectorParser::consumeCombinator(CSSParserTokenRange& 
     if (range.peek().type() != DelimiterToken)
         return fallbackResult;
 
-    UChar delimiter = range.peek().delimiter();
+    char16_t delimiter = range.peek().delimiter();
 
     if (delimiter == '+' || delimiter == '~' || delimiter == '>') {
         range.consumeIncludingWhitespace();

--- a/Source/WebCore/css/parser/CSSTokenizer.cpp
+++ b/Source/WebCore/css/parser/CSSTokenizer.cpp
@@ -144,36 +144,36 @@ bool CSSTokenizer::isWhitespace(CSSParserTokenType type)
     return type == NonNewlineWhitespaceToken || type == NewlineToken;
 }
 
-bool CSSTokenizer::isNewline(UChar cc)
+bool CSSTokenizer::isNewline(char16_t cc)
 {
     // We check \r and \f here, since we have no preprocessing stage
     return (cc == '\r' || cc == '\n' || cc == '\f');
 }
 
-CSSParserToken CSSTokenizer::newline(UChar)
+CSSParserToken CSSTokenizer::newline(char16_t)
 {
     return CSSParserToken(NewlineToken);
 }
 
 // http://dev.w3.org/csswg/css-syntax/#check-if-two-code-points-are-a-valid-escape
-static bool twoCharsAreValidEscape(UChar first, UChar second)
+static bool twoCharsAreValidEscape(char16_t first, char16_t second)
 {
     return first == '\\' && !CSSTokenizer::isNewline(second);
 }
 
-void CSSTokenizer::reconsume(UChar c)
+void CSSTokenizer::reconsume(char16_t c)
 {
     m_input.pushBack(c);
 }
 
-UChar CSSTokenizer::consume()
+char16_t CSSTokenizer::consume()
 {
-    UChar current = m_input.nextInputChar();
+    char16_t current = m_input.nextInputChar();
     m_input.advance();
     return current;
 }
 
-CSSParserToken CSSTokenizer::whitespace(UChar)
+CSSParserToken CSSTokenizer::whitespace(char16_t)
 {
     auto startOffset = m_input.offset();
     m_input.advanceUntilNewlineOrNonWhitespace();
@@ -202,37 +202,37 @@ CSSParserToken CSSTokenizer::blockEnd(CSSParserTokenType type, CSSParserTokenTyp
     return CSSParserToken(type);
 }
 
-CSSParserToken CSSTokenizer::leftParenthesis(UChar)
+CSSParserToken CSSTokenizer::leftParenthesis(char16_t)
 {
     return blockStart(LeftParenthesisToken);
 }
 
-CSSParserToken CSSTokenizer::rightParenthesis(UChar)
+CSSParserToken CSSTokenizer::rightParenthesis(char16_t)
 {
     return blockEnd(RightParenthesisToken, LeftParenthesisToken);
 }
 
-CSSParserToken CSSTokenizer::leftBracket(UChar)
+CSSParserToken CSSTokenizer::leftBracket(char16_t)
 {
     return blockStart(LeftBracketToken);
 }
 
-CSSParserToken CSSTokenizer::rightBracket(UChar)
+CSSParserToken CSSTokenizer::rightBracket(char16_t)
 {
     return blockEnd(RightBracketToken, LeftBracketToken);
 }
 
-CSSParserToken CSSTokenizer::leftBrace(UChar)
+CSSParserToken CSSTokenizer::leftBrace(char16_t)
 {
     return blockStart(LeftBraceToken);
 }
 
-CSSParserToken CSSTokenizer::rightBrace(UChar)
+CSSParserToken CSSTokenizer::rightBrace(char16_t)
 {
     return blockEnd(RightBraceToken, LeftBraceToken);
 }
 
-CSSParserToken CSSTokenizer::plusOrFullStop(UChar cc)
+CSSParserToken CSSTokenizer::plusOrFullStop(char16_t cc)
 {
     if (nextCharsAreNumber(cc)) {
         reconsume(cc);
@@ -241,7 +241,7 @@ CSSParserToken CSSTokenizer::plusOrFullStop(UChar cc)
     return CSSParserToken(DelimiterToken, cc);
 }
 
-CSSParserToken CSSTokenizer::asterisk(UChar cc)
+CSSParserToken CSSTokenizer::asterisk(char16_t cc)
 {
     ASSERT_UNUSED(cc, cc == '*');
     if (consumeIfNext('='))
@@ -249,7 +249,7 @@ CSSParserToken CSSTokenizer::asterisk(UChar cc)
     return CSSParserToken(DelimiterToken, '*');
 }
 
-CSSParserToken CSSTokenizer::lessThan(UChar cc)
+CSSParserToken CSSTokenizer::lessThan(char16_t cc)
 {
     ASSERT_UNUSED(cc, cc == '<');
     if (m_input.peek(0) == '!' && m_input.peek(1) == '-' && m_input.peek(2) == '-') {
@@ -259,12 +259,12 @@ CSSParserToken CSSTokenizer::lessThan(UChar cc)
     return CSSParserToken(DelimiterToken, '<');
 }
 
-CSSParserToken CSSTokenizer::comma(UChar)
+CSSParserToken CSSTokenizer::comma(char16_t)
 {
     return CSSParserToken(CommaToken);
 }
 
-CSSParserToken CSSTokenizer::hyphenMinus(UChar cc)
+CSSParserToken CSSTokenizer::hyphenMinus(char16_t cc)
 {
     if (nextCharsAreNumber(cc)) {
         reconsume(cc);
@@ -281,7 +281,7 @@ CSSParserToken CSSTokenizer::hyphenMinus(UChar cc)
     return CSSParserToken(DelimiterToken, cc);
 }
 
-CSSParserToken CSSTokenizer::solidus(UChar cc)
+CSSParserToken CSSTokenizer::solidus(char16_t cc)
 {
     if (consumeIfNext('*')) {
         // These get ignored, but we need a value to return.
@@ -292,19 +292,19 @@ CSSParserToken CSSTokenizer::solidus(UChar cc)
     return CSSParserToken(DelimiterToken, cc);
 }
 
-CSSParserToken CSSTokenizer::colon(UChar)
+CSSParserToken CSSTokenizer::colon(char16_t)
 {
     return CSSParserToken(ColonToken);
 }
 
-CSSParserToken CSSTokenizer::semiColon(UChar)
+CSSParserToken CSSTokenizer::semiColon(char16_t)
 {
     return CSSParserToken(SemicolonToken);
 }
 
-CSSParserToken CSSTokenizer::hash(UChar cc)
+CSSParserToken CSSTokenizer::hash(char16_t cc)
 {
-    UChar nextChar = m_input.peek(0);
+    char16_t nextChar = m_input.peek(0);
     if (isNameCodePoint(nextChar) || twoCharsAreValidEscape(nextChar, m_input.peek(1))) {
         HashTokenType type = nextCharsAreIdentifier() ? HashTokenId : HashTokenUnrestricted;
         return CSSParserToken(type, consumeName());
@@ -313,7 +313,7 @@ CSSParserToken CSSTokenizer::hash(UChar cc)
     return CSSParserToken(DelimiterToken, cc);
 }
 
-CSSParserToken CSSTokenizer::circumflexAccent(UChar cc)
+CSSParserToken CSSTokenizer::circumflexAccent(char16_t cc)
 {
     ASSERT_UNUSED(cc, cc == '^');
     if (consumeIfNext('='))
@@ -321,7 +321,7 @@ CSSParserToken CSSTokenizer::circumflexAccent(UChar cc)
     return CSSParserToken(DelimiterToken, '^');
 }
 
-CSSParserToken CSSTokenizer::dollarSign(UChar cc)
+CSSParserToken CSSTokenizer::dollarSign(char16_t cc)
 {
     ASSERT_UNUSED(cc, cc == '$');
     if (consumeIfNext('='))
@@ -329,7 +329,7 @@ CSSParserToken CSSTokenizer::dollarSign(UChar cc)
     return CSSParserToken(DelimiterToken, '$');
 }
 
-CSSParserToken CSSTokenizer::verticalLine(UChar cc)
+CSSParserToken CSSTokenizer::verticalLine(char16_t cc)
 {
     ASSERT_UNUSED(cc, cc == '|');
     if (consumeIfNext('='))
@@ -339,7 +339,7 @@ CSSParserToken CSSTokenizer::verticalLine(UChar cc)
     return CSSParserToken(DelimiterToken, '|');
 }
 
-CSSParserToken CSSTokenizer::tilde(UChar cc)
+CSSParserToken CSSTokenizer::tilde(char16_t cc)
 {
     ASSERT_UNUSED(cc, cc == '~');
     if (consumeIfNext('='))
@@ -347,7 +347,7 @@ CSSParserToken CSSTokenizer::tilde(UChar cc)
     return CSSParserToken(DelimiterToken, '~');
 }
 
-CSSParserToken CSSTokenizer::commercialAt(UChar cc)
+CSSParserToken CSSTokenizer::commercialAt(char16_t cc)
 {
     ASSERT_UNUSED(cc, cc == '@');
     if (nextCharsAreIdentifier())
@@ -355,7 +355,7 @@ CSSParserToken CSSTokenizer::commercialAt(UChar cc)
     return CSSParserToken(DelimiterToken, '@');
 }
 
-CSSParserToken CSSTokenizer::reverseSolidus(UChar cc)
+CSSParserToken CSSTokenizer::reverseSolidus(char16_t cc)
 {
     if (twoCharsAreValidEscape(cc, m_input.peek(0))) {
         reconsume(cc);
@@ -364,24 +364,24 @@ CSSParserToken CSSTokenizer::reverseSolidus(UChar cc)
     return CSSParserToken(DelimiterToken, cc);
 }
 
-CSSParserToken CSSTokenizer::asciiDigit(UChar cc)
+CSSParserToken CSSTokenizer::asciiDigit(char16_t cc)
 {
     reconsume(cc);
     return consumeNumericToken();
 }
 
-CSSParserToken CSSTokenizer::nameStart(UChar cc)
+CSSParserToken CSSTokenizer::nameStart(char16_t cc)
 {
     reconsume(cc);
     return consumeIdentLikeToken();
 }
 
-CSSParserToken CSSTokenizer::stringStart(UChar cc)
+CSSParserToken CSSTokenizer::stringStart(char16_t cc)
 {
     return consumeStringTokenUntil(cc);
 }
 
-CSSParserToken CSSTokenizer::endOfFile(UChar)
+CSSParserToken CSSTokenizer::endOfFile(char16_t)
 {
     return CSSParserToken(EOFToken);
 }
@@ -529,7 +529,7 @@ CSSParserToken CSSTokenizer::nextToken()
     // State-machine tokenizers are easier to write to handle
     // incremental tokenization of partial sources.
     // However, for now we follow the spec exactly.
-    UChar cc = consume();
+    char16_t cc = consume();
     CodePoint codePointFunc = 0;
 
     if (isASCII(cc)) {
@@ -556,7 +556,7 @@ CSSParserToken CSSTokenizer::consumeNumber()
     NumericSign sign = NoSign;
     unsigned numberLength = 0;
 
-    UChar next = m_input.peek(0);
+    char16_t next = m_input.peek(0);
     if (next == '+') {
         ++numberLength;
         sign = PlusSign;
@@ -610,7 +610,7 @@ CSSParserToken CSSTokenizer::consumeIdentLikeToken()
             // The spec is slightly different so as to avoid dropping whitespace
             // tokens, but they wouldn't be used and this is easier.
             m_input.advanceUntilNonWhitespace();
-            UChar next = m_input.peek(0);
+            char16_t next = m_input.peek(0);
             if (next != '"' && next != '\'')
                 return consumeURLToken();
         }
@@ -620,11 +620,11 @@ CSSParserToken CSSTokenizer::consumeIdentLikeToken()
 }
 
 // http://dev.w3.org/csswg/css-syntax/#consume-a-string-token
-CSSParserToken CSSTokenizer::consumeStringTokenUntil(UChar endingCodePoint)
+CSSParserToken CSSTokenizer::consumeStringTokenUntil(char16_t endingCodePoint)
 {
     // Strings without escapes get handled without allocations
     for (unsigned size = 0; ; size++) {
-        UChar cc = m_input.peek(size);
+        char16_t cc = m_input.peek(size);
         if (cc == endingCodePoint) {
             unsigned startOffset = m_input.offset();
             m_input.advance(size + 1);
@@ -640,7 +640,7 @@ CSSParserToken CSSTokenizer::consumeStringTokenUntil(UChar endingCodePoint)
 
     StringBuilder output;
     while (true) {
-        UChar cc = consume();
+        char16_t cc = consume();
         if (cc == endingCodePoint || cc == kEndOfFileMarker)
             return CSSParserToken(StringToken, registerString(output.toString()));
         if (isNewline(cc)) {
@@ -660,7 +660,7 @@ CSSParserToken CSSTokenizer::consumeStringTokenUntil(UChar endingCodePoint)
 }
 
 // http://dev.w3.org/csswg/css-syntax/#non-printable-code-point
-static bool isNonPrintableCodePoint(UChar cc)
+static bool isNonPrintableCodePoint(char16_t cc)
 {
     return cc <= '\x8' || cc == '\xb' || (cc >= '\xe' && cc <= '\x1f') || cc == '\x7f';
 }
@@ -672,7 +672,7 @@ CSSParserToken CSSTokenizer::consumeURLToken()
 
     // URL tokens without escapes get handled without allocations
     for (unsigned size = 0; ; size++) {
-        UChar cc = m_input.peek(size);
+        char16_t cc = m_input.peek(size);
         if (cc == ')') {
             unsigned startOffset = m_input.offset();
             m_input.advance(size + 1);
@@ -684,7 +684,7 @@ CSSParserToken CSSTokenizer::consumeURLToken()
 
     StringBuilder result;
     while (true) {
-        UChar cc = consume();
+        char16_t cc = consume();
         if (cc == ')' || cc == kEndOfFileMarker)
             return CSSParserToken(UrlToken, registerString(result.toString()));
 
@@ -717,7 +717,7 @@ CSSParserToken CSSTokenizer::consumeURLToken()
 void CSSTokenizer::consumeBadUrlRemnants()
 {
     while (true) {
-        UChar cc = consume();
+        char16_t cc = consume();
         if (cc == ')' || cc == kEndOfFileMarker)
             return;
         if (twoCharsAreValidEscape(cc, m_input.peek(0)))
@@ -728,7 +728,7 @@ void CSSTokenizer::consumeBadUrlRemnants()
 void CSSTokenizer::consumeSingleWhitespaceIfNext()
 {
     // We check for \r\n and ASCII whitespace since we don't do preprocessing
-    UChar next = m_input.peek(0);
+    char16_t next = m_input.peek(0);
     if (next == '\r' && m_input.peek(1) == '\n')
         m_input.advance(2);
     else if (isASCIIWhitespace(next))
@@ -737,7 +737,7 @@ void CSSTokenizer::consumeSingleWhitespaceIfNext()
 
 void CSSTokenizer::consumeUntilCommentEndFound()
 {
-    UChar c = consume();
+    char16_t c = consume();
     while (true) {
         if (c == kEndOfFileMarker)
             return;
@@ -751,7 +751,7 @@ void CSSTokenizer::consumeUntilCommentEndFound()
     }
 }
 
-bool CSSTokenizer::consumeIfNext(UChar character)
+bool CSSTokenizer::consumeIfNext(char16_t character)
 {
     // Since we're not doing replacement we can't tell the difference from
     // a NUL in the middle and the kEndOfFileMarker, so character must not be
@@ -769,7 +769,7 @@ StringView CSSTokenizer::consumeName()
 {
     // Names without escapes get handled without allocations
     for (unsigned size = 0; ; ++size) {
-        UChar cc = m_input.peek(size);
+        char16_t cc = m_input.peek(size);
         if (isNameCodePoint(cc))
             continue;
         // peek will return NUL when we hit the end of the
@@ -786,7 +786,7 @@ StringView CSSTokenizer::consumeName()
 
     StringBuilder result;
     while (true) {
-        UChar cc = consume();
+        char16_t cc = consume();
         if (isNameCodePoint(cc)) {
             result.append(cc);
             continue;
@@ -803,7 +803,7 @@ StringView CSSTokenizer::consumeName()
 // http://dev.w3.org/csswg/css-syntax/#consume-an-escaped-code-point
 char32_t CSSTokenizer::consumeEscape()
 {
-    UChar cc = consume();
+    char16_t cc = consume();
     ASSERT(!isNewline(cc));
     if (isASCIIHexDigit(cc)) {
         unsigned consumedHexDigits = 1;
@@ -832,9 +832,9 @@ bool CSSTokenizer::nextTwoCharsAreValidEscape()
 }
 
 // http://www.w3.org/TR/css3-syntax/#starts-with-a-number
-bool CSSTokenizer::nextCharsAreNumber(UChar first)
+bool CSSTokenizer::nextCharsAreNumber(char16_t first)
 {
-    UChar second = m_input.peek(0);
+    char16_t second = m_input.peek(0);
     if (isASCIIDigit(first))
         return true;
     if (first == '+' || first == '-')
@@ -846,16 +846,16 @@ bool CSSTokenizer::nextCharsAreNumber(UChar first)
 
 bool CSSTokenizer::nextCharsAreNumber()
 {
-    UChar first = consume();
+    char16_t first = consume();
     bool areNumber = nextCharsAreNumber(first);
     reconsume(first);
     return areNumber;
 }
 
 // http://dev.w3.org/csswg/css-syntax/#would-start-an-identifier
-bool CSSTokenizer::nextCharsAreIdentifier(UChar first)
+bool CSSTokenizer::nextCharsAreIdentifier(char16_t first)
 {
-    UChar second = m_input.peek(0);
+    char16_t second = m_input.peek(0);
     if (isNameStartCodePoint(first) || twoCharsAreValidEscape(first, second))
         return true;
 
@@ -867,7 +867,7 @@ bool CSSTokenizer::nextCharsAreIdentifier(UChar first)
 
 bool CSSTokenizer::nextCharsAreIdentifier()
 {
-    UChar first = consume();
+    char16_t first = consume();
     bool areIdentifier = nextCharsAreIdentifier(first);
     reconsume(first);
     return areIdentifier;

--- a/Source/WebCore/css/parser/CSSTokenizer.h
+++ b/Source/WebCore/css/parser/CSSTokenizer.h
@@ -56,7 +56,7 @@ public:
     unsigned tokenCount();
 
     static bool isWhitespace(CSSParserTokenType);
-    static bool isNewline(UChar);
+    static bool isNewline(char16_t);
 
     Vector<String>&& escapedStringsForAdoption() { return WTFMove(m_stringPool); }
 
@@ -65,67 +65,67 @@ private:
 
     CSSParserToken nextToken();
 
-    UChar consume();
-    void reconsume(UChar);
+    char16_t consume();
+    void reconsume(char16_t);
 
     String preprocessString(const String&);
 
     CSSParserToken consumeNumericToken();
     CSSParserToken consumeIdentLikeToken();
     CSSParserToken consumeNumber();
-    CSSParserToken consumeStringTokenUntil(UChar);
+    CSSParserToken consumeStringTokenUntil(char16_t);
     CSSParserToken consumeURLToken();
 
     void consumeBadUrlRemnants();
     void consumeSingleWhitespaceIfNext();
     void consumeUntilCommentEndFound();
 
-    bool consumeIfNext(UChar);
+    bool consumeIfNext(char16_t);
     StringView consumeName();
     char32_t consumeEscape();
 
     bool nextTwoCharsAreValidEscape();
-    bool nextCharsAreNumber(UChar);
+    bool nextCharsAreNumber(char16_t);
     bool nextCharsAreNumber();
-    bool nextCharsAreIdentifier(UChar);
+    bool nextCharsAreIdentifier(char16_t);
     bool nextCharsAreIdentifier();
 
     CSSParserToken blockStart(CSSParserTokenType);
     CSSParserToken blockStart(CSSParserTokenType blockType, CSSParserTokenType, StringView);
     CSSParserToken blockEnd(CSSParserTokenType, CSSParserTokenType startType);
 
-    CSSParserToken newline(UChar);
-    CSSParserToken whitespace(UChar);
-    CSSParserToken leftParenthesis(UChar);
-    CSSParserToken rightParenthesis(UChar);
-    CSSParserToken leftBracket(UChar);
-    CSSParserToken rightBracket(UChar);
-    CSSParserToken leftBrace(UChar);
-    CSSParserToken rightBrace(UChar);
-    CSSParserToken plusOrFullStop(UChar);
-    CSSParserToken comma(UChar);
-    CSSParserToken hyphenMinus(UChar);
-    CSSParserToken asterisk(UChar);
-    CSSParserToken lessThan(UChar);
-    CSSParserToken solidus(UChar);
-    CSSParserToken colon(UChar);
-    CSSParserToken semiColon(UChar);
-    CSSParserToken hash(UChar);
-    CSSParserToken circumflexAccent(UChar);
-    CSSParserToken dollarSign(UChar);
-    CSSParserToken verticalLine(UChar);
-    CSSParserToken tilde(UChar);
-    CSSParserToken commercialAt(UChar);
-    CSSParserToken reverseSolidus(UChar);
-    CSSParserToken asciiDigit(UChar);
-    CSSParserToken letterU(UChar);
-    CSSParserToken nameStart(UChar);
-    CSSParserToken stringStart(UChar);
-    CSSParserToken endOfFile(UChar);
+    CSSParserToken newline(char16_t);
+    CSSParserToken whitespace(char16_t);
+    CSSParserToken leftParenthesis(char16_t);
+    CSSParserToken rightParenthesis(char16_t);
+    CSSParserToken leftBracket(char16_t);
+    CSSParserToken rightBracket(char16_t);
+    CSSParserToken leftBrace(char16_t);
+    CSSParserToken rightBrace(char16_t);
+    CSSParserToken plusOrFullStop(char16_t);
+    CSSParserToken comma(char16_t);
+    CSSParserToken hyphenMinus(char16_t);
+    CSSParserToken asterisk(char16_t);
+    CSSParserToken lessThan(char16_t);
+    CSSParserToken solidus(char16_t);
+    CSSParserToken colon(char16_t);
+    CSSParserToken semiColon(char16_t);
+    CSSParserToken hash(char16_t);
+    CSSParserToken circumflexAccent(char16_t);
+    CSSParserToken dollarSign(char16_t);
+    CSSParserToken verticalLine(char16_t);
+    CSSParserToken tilde(char16_t);
+    CSSParserToken commercialAt(char16_t);
+    CSSParserToken reverseSolidus(char16_t);
+    CSSParserToken asciiDigit(char16_t);
+    CSSParserToken letterU(char16_t);
+    CSSParserToken nameStart(char16_t);
+    CSSParserToken stringStart(char16_t);
+    CSSParserToken endOfFile(char16_t);
 
     StringView registerString(const String&);
 
-    using CodePoint = CSSParserToken (CSSTokenizer::*)(UChar);
+    using CodePoint = CSSParserToken (CSSTokenizer::*)(char16_t);
     static const std::array<CodePoint, 128> codePoints;
 
     Vector<CSSParserTokenType, 8> m_blockStack;

--- a/Source/WebCore/css/parser/CSSTokenizerInputStream.h
+++ b/Source/WebCore/css/parser/CSSTokenizerInputStream.h
@@ -44,7 +44,7 @@ public:
 
     // Gets the char in the stream. Will return (NUL) kEndOfFileMarker when at the
     // end of the stream.
-    UChar nextInputChar() const
+    char16_t nextInputChar() const
     {
         if (m_offset >= m_stringLength)
             return kEndOfFileMarker;
@@ -53,7 +53,7 @@ public:
 
     // Gets the char at lookaheadOffset from the current stream position. Will
     // return NUL (kEndOfFileMarker) if the stream position is at the end.
-    UChar peek(unsigned lookaheadOffset) const
+    char16_t peek(unsigned lookaheadOffset) const
     {
         if ((m_offset + lookaheadOffset) >= m_stringLength)
             return kEndOfFileMarker;
@@ -61,7 +61,7 @@ public:
     }
 
     void advance(unsigned offset = 1) { m_offset += offset; }
-    void pushBack(UChar cc)
+    void pushBack(char16_t cc)
     {
         --m_offset;
         ASSERT_UNUSED(cc, nextInputChar() == cc);
@@ -69,7 +69,7 @@ public:
 
     double getDouble(unsigned start, unsigned end) const;
 
-    template<bool characterPredicate(UChar)>
+    template<bool characterPredicate(char16_t)>
     unsigned skipWhilePredicate(unsigned offset)
     {
         if (m_string->is8Bit()) {

--- a/Source/WebCore/css/parser/SizesCalcParser.cpp
+++ b/Source/WebCore/css/parser/SizesCalcParser.cpp
@@ -49,7 +49,7 @@ float SizesCalcParser::result() const
     return m_result;
 }
 
-static bool operatorPriority(UChar cc, bool& highPriority)
+static bool operatorPriority(char16_t cc, bool& highPriority)
 {
     if (cc == '+' || cc == '-')
         highPriority = false;
@@ -206,7 +206,7 @@ bool SizesCalcParser::calcToReversePolishNotation(CSSParserTokenRange range)
     return true;
 }
 
-static bool operateOnStack(Vector<SizesCalcValue>& stack, UChar operation)
+static bool operateOnStack(Vector<SizesCalcValue>& stack, char16_t operation)
 {
     if (stack.size() < 2)
         return false;

--- a/Source/WebCore/css/parser/SizesCalcParser.h
+++ b/Source/WebCore/css/parser/SizesCalcParser.h
@@ -39,7 +39,7 @@ class Document;
 struct SizesCalcValue {
     double value;
     bool isLength;
-    UChar operation;
+    char16_t operation;
 
     SizesCalcValue()
         : value(0)

--- a/Source/WebCore/css/scripts/process-css-properties.py
+++ b/Source/WebCore/css/scripts/process-css-properties.py
@@ -3398,7 +3398,7 @@ class GenerateCSSPropertyNames:
 
             self.generation_context.generate_property_id_switch_function(
                 to=writer,
-                signature="UChar CSSProperty::listValuedPropertySeparator(CSSPropertyID id)",
+                signature="char16_t CSSProperty::listValuedPropertySeparator(CSSPropertyID id)",
                 iterable=(p for p in self.properties_and_descriptors.style_properties.all if p.codegen_properties.separator),
                 mapping=lambda p: f"return '{ p.codegen_properties.separator[0] }';",
                 default="break;",

--- a/Source/WebCore/css/scripts/process-css-pseudo-selectors.py
+++ b/Source/WebCore/css/scripts/process-css-pseudo-selectors.py
@@ -442,7 +442,7 @@ class GPerfOutputGenerator:
         }""")
 
         writer.write_block(f"""
-        static inline const SelectorPseudoClassOrCompatibilityPseudoElementEntry* findPseudoClassAndCompatibilityElementName(std::span<const UChar> characters)
+        static inline const SelectorPseudoClassOrCompatibilityPseudoElementEntry* findPseudoClassAndCompatibilityElementName(std::span<const char16_t> characters)
         {{
             constexpr unsigned maxKeywordLength = {longest_keyword_length};
             std::array<LChar, maxKeywordLength> buffer;
@@ -450,7 +450,7 @@ class GPerfOutputGenerator:
                 return nullptr;
 
             for (size_t i = 0; i < characters.size(); ++i) {{
-                UChar character = characters[i];
+                char16_t character = characters[i];
                 if (!isLatin1(character))
                     return nullptr;
 
@@ -484,7 +484,7 @@ class GPerfOutputGenerator:
             }""")
 
         writer.write_block(f"""
-            static inline std::optional<CSSSelector::PseudoElement> findPseudoElementName(std::span<const UChar> characters)
+            static inline std::optional<CSSSelector::PseudoElement> findPseudoElementName(std::span<const char16_t> characters)
             {{
                 constexpr unsigned maxKeywordLength = {longest_keyword_length};
                 std::array<LChar, maxKeywordLength> buffer;
@@ -492,7 +492,7 @@ class GPerfOutputGenerator:
                     return std::nullopt;
 
                 for (size_t i = 0; i < characters.size(); ++i) {{
-                    UChar character = characters[i];
+                    char16_t character = characters[i];
                     if (!isLatin1(character))
                         return std::nullopt;
 

--- a/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSPropertyNames.gperf
+++ b/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSPropertyNames.gperf
@@ -639,7 +639,7 @@ const WTF::BitSet<cssPropertyIDEnumValueCount> CSSProperty::physicalProperties =
     return result;
 })();
 
-UChar CSSProperty::listValuedPropertySeparator(CSSPropertyID id)
+char16_t CSSProperty::listValuedPropertySeparator(CSSPropertyID id)
 {
     switch (id) {
     default:

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -1514,7 +1514,7 @@ static FunctionType constructFragmentsInternal(const CSSSelector* rootSelector, 
             break;
         }
         case CSSSelector::Match::List:
-            if (selector->value().find(isASCIIWhitespace<UChar>) != notFound)
+            if (selector->value().find(isASCIIWhitespace<char16_t>) != notFound)
                 return FunctionType::CannotMatchAnything;
             [[fallthrough]];
         case CSSSelector::Match::Begin:

--- a/Source/WebCore/dom/DatasetDOMStringMap.cpp
+++ b/Source/WebCore/dom/DatasetDOMStringMap.cpp
@@ -56,7 +56,7 @@ static String convertAttributeNameToPropertyName(const String& name)
 
     unsigned length = name.length();
     for (unsigned i = 5; i < length; ++i) {
-        UChar character = name[i];
+        char16_t character = name[i];
         if (character != '-')
             stringBuilder.append(character);
         else {
@@ -112,7 +112,7 @@ static AtomString convertPropertyNameToAttributeName(const String& name)
     StringImpl* nameImpl = name.impl();
     if (nameImpl->is8Bit())
         return convertPropertyNameToAttributeName<LChar>(*nameImpl);
-    return convertPropertyNameToAttributeName<UChar>(*nameImpl);
+    return convertPropertyNameToAttributeName<char16_t>(*nameImpl);
 }
 
 void DatasetDOMStringMap::ref()

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1176,7 +1176,7 @@ void Document::setMarkupUnsafe(const String& markup, OptionSet<ParserContentPoli
         auto body = HTMLBodyElement::create(*this);
         html->appendChild(body);
         body->beginParsingChildren();
-        if (tryFastParsingHTMLFragment(StringView { markup }.substring(markup.find(isNotASCIIWhitespace<UChar>)), *this, body, body, policy)) [[likely]] {
+        if (tryFastParsingHTMLFragment(StringView { markup }.substring(markup.find(isNotASCIIWhitespace<char16_t>)), *this, body, body, policy)) [[likely]] {
             body->finishParsingChildren();
             auto head = HTMLHeadElement::create(*this);
             html->insertBefore(head, body.ptr());
@@ -7176,7 +7176,7 @@ static bool isValidNameNonASCII(std::span<const LChar> characters)
     return true;
 }
 
-static bool isValidNameNonASCII(std::span<const UChar> characters)
+static bool isValidNameNonASCII(std::span<const char16_t> characters)
 {
     for (size_t i = 0; i < characters.size();) {
         bool first = !i;

--- a/Source/WebCore/dom/Position.cpp
+++ b/Source/WebCore/dom/Position.cpp
@@ -1121,7 +1121,7 @@ Position Position::leadingWhitespacePosition(Affinity affinity, bool considerNon
     RefPtr previousNode = prev.deprecatedNode();
     if (prev != *this && inSameEnclosingBlockFlowElement(node.get(), previousNode.get())) {
         if (auto* previousText = dynamicDowncast<Text>(*previousNode)) {
-            UChar c = previousText->data()[prev.deprecatedEditingOffset()];
+            char16_t c = previousText->data()[prev.deprecatedEditingOffset()];
             if (considerNonCollapsibleWhitespace ? (isASCIIWhitespace(c) || c == noBreakSpace) : deprecatedIsCollapsibleWhitespace(c)) {
                 if (isEditablePosition(prev))
                     return prev;
@@ -1140,7 +1140,7 @@ Position Position::trailingWhitespacePosition(Affinity, bool considerNonCollapsi
         return { };
     
     VisiblePosition v(*this);
-    UChar c = v.characterAfter();
+    char16_t c = v.characterAfter();
     // The space must not be in another paragraph and it must be editable.
     if (!isEndOfParagraph(v) && v.next(CannotCrossEditingBoundary).isNotNull())
         if (considerNonCollapsibleWhitespace ? (isASCIIWhitespace(c) || c == noBreakSpace) : deprecatedIsCollapsibleWhitespace(c))

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -330,7 +330,7 @@ bool ScriptElement::requestClassicScript(const String& sourceURL)
     ASSERT(element->isConnected());
     ASSERT(!m_loadableScript);
     Ref document = element->document();
-    if (!StringView(sourceURL).containsOnly<isASCIIWhitespace<UChar>>()) {
+    if (!StringView(sourceURL).containsOnly<isASCIIWhitespace<char16_t>>()) {
         auto script = LoadableClassicScript::create(element->nonce(), element->attributeWithoutSynchronization(HTMLNames::integrityAttr), referrerPolicy(), fetchPriority(),
             element->attributeWithoutSynchronization(HTMLNames::crossoriginAttr), scriptCharset(), element->localName(), element->isInUserAgentShadowTree(), hasAsyncAttribute());
 
@@ -370,7 +370,7 @@ bool ScriptElement::requestModuleScript(const String& sourceText, const TextPosi
         ASSERT(element->isConnected());
 
         String sourceURL = sourceAttributeValue();
-        if (StringView(sourceURL).containsOnly<isASCIIWhitespace<UChar>>()) {
+        if (StringView(sourceURL).containsOnly<isASCIIWhitespace<char16_t>>()) {
             dispatchErrorEvent();
             return false;
         }

--- a/Source/WebCore/dom/SpaceSplitString.cpp
+++ b/Source/WebCore/dom/SpaceSplitString.cpp
@@ -145,7 +145,7 @@ bool SpaceSplitString::spaceSplitStringContainsValue(StringView spaceSplitString
 
     if (value.is8Bit())
         return spaceSplitStringContainsValueInternal<LChar>(shouldFoldCase == ShouldFoldCase::Yes ? StringView { spaceSplitString.convertToASCIILowercase() } : spaceSplitString, value);
-    return spaceSplitStringContainsValueInternal<UChar>(shouldFoldCase == ShouldFoldCase::Yes ? StringView { spaceSplitString.convertToASCIILowercase() } : spaceSplitString, value);
+    return spaceSplitStringContainsValueInternal<char16_t>(shouldFoldCase == ShouldFoldCase::Yes ? StringView { spaceSplitString.convertToASCIILowercase() } : spaceSplitString, value);
 }
 
 class TokenCounter {

--- a/Source/WebCore/dom/TextDecoder.cpp
+++ b/Source/WebCore/dom/TextDecoder.cpp
@@ -43,7 +43,7 @@ TextDecoder::~TextDecoder() = default;
 ExceptionOr<Ref<TextDecoder>> TextDecoder::create(const String& label, Options options)
 {
     auto trimmedLabel = label.trim(isASCIIWhitespace);
-    const UChar nullCharacter = '\0';
+    const char16_t nullCharacter = '\0';
     if (trimmedLabel.contains(nullCharacter))
         return Exception { ExceptionCode::RangeError };
     auto decoder = adoptRef(*new TextDecoder(trimmedLabel, options));

--- a/Source/WebCore/dom/TextEncoderStreamEncoder.h
+++ b/Source/WebCore/dom/TextEncoderStreamEncoder.h
@@ -42,7 +42,7 @@ public:
 private:
     TextEncoderStreamEncoder() = default;
 
-    std::optional<UChar> m_pendingLeadSurrogate;
+    std::optional<char16_t> m_pendingLeadSurrogate;
 };
 
 }

--- a/Source/WebCore/dom/make_names.pl
+++ b/Source/WebCore/dom/make_names.pl
@@ -945,7 +945,7 @@ sub printTagNameHeaderFile
     print F "inline LazyNeverDestroyed<EnumeratedArray<TagName, AtomString, lastTagNameEnumValue>> tagNameStrings;\n";
     print F "\n";
     print F "WEBCORE_EXPORT void initializeTagNameStrings();\n";
-    print F "TagName findTagName(std::span<const UChar>);\n";
+    print F "TagName findTagName(std::span<const char16_t>);\n";
     print F "#if ASSERT_ENABLED\n";
     print F "TagName findTagName(const String&);\n";
     print F "#endif\n";
@@ -1036,7 +1036,7 @@ sub printTagNameCppFile
     generateFindBody(\%allElements, \&byElementNameOrder, "parsedTagName", "TagName", "parsedTagEnumValue");
     print F "}\n";
     print F "\n";
-    print F "TagName findTagName(std::span<const UChar> buffer)\n";
+    print F "TagName findTagName(std::span<const char16_t> buffer)\n";
     print F "{\n";
     print F "    return findTagFromBuffer(buffer);\n";
     print F "}\n";
@@ -1123,7 +1123,7 @@ sub printNodeNameHeaderFile
     print F "\n";
     print F "NodeName findNodeName(Namespace, const String&);\n";
     print F "ElementName findHTMLElementName(std::span<const LChar>);\n";
-    print F "ElementName findHTMLElementName(std::span<const UChar>);\n";
+    print F "ElementName findHTMLElementName(std::span<const char16_t>);\n";
     print F "ElementName findHTMLElementName(const String&);\n";
     print F "ElementName findSVGElementName(const String&);\n";
     print F "ElementName findMathMLElementName(const String&);\n";
@@ -1267,7 +1267,7 @@ sub printNodeNameCppFile
     print F "    return findHTMLNodeName(buffer);\n";
     print F "}\n";
     print F "\n";
-    print F "ElementName findHTMLElementName(std::span<const UChar> buffer)\n";
+    print F "ElementName findHTMLElementName(std::span<const char16_t> buffer)\n";
     print F "{\n";
     print F "    return findHTMLNodeName(buffer);\n";
     print F "}\n";

--- a/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -945,7 +945,7 @@ void CompositeEditCommand::rebalanceWhitespaceAt(const Position& position)
     rebalanceWhitespaceOnTextSubstring(*textNode, position.offsetInContainerNode(), position.offsetInContainerNode());
 }
 
-static bool isWhitespaceForRebalance(Text& textNode, UChar character)
+static bool isWhitespaceForRebalance(Text& textNode, char16_t character)
 {
     return deprecatedIsEditingWhitespace(character) && (character != '\n' || !textNode.renderer() || !textNode.renderer()->style().preserveNewline());
 }

--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -368,7 +368,7 @@ int lastOffsetForEditing(const Node& node)
     return editingIgnoresContent(node) ? 1 : 0;
 }
 
-bool isAmbiguousBoundaryCharacter(UChar character)
+bool isAmbiguousBoundaryCharacter(char16_t character)
 {
     // These are characters that can behave as word boundaries, but can appear within words.
     // If they are just typed, i.e. if they are immediately followed by a caret, we want to delay text checking until the next character has been typed.

--- a/Source/WebCore/editing/Editing.h
+++ b/Source/WebCore/editing/Editing.h
@@ -217,12 +217,12 @@ Position adjustedSelectionStartForStyleComputation(const VisibleSelection&);
 // -------------------------------------------------------------------------
 
 // FIXME: This is only one of many definitions of whitespace. Possibly never the right one to use.
-bool deprecatedIsEditingWhitespace(UChar);
+bool deprecatedIsEditingWhitespace(char16_t);
 
 // FIXME: Can't answer this question correctly without being passed the white-space mode.
-bool deprecatedIsCollapsibleWhitespace(UChar);
+bool deprecatedIsCollapsibleWhitespace(char16_t);
 
-bool isAmbiguousBoundaryCharacter(UChar);
+bool isAmbiguousBoundaryCharacter(char16_t);
 
 String stringWithRebalancedWhitespace(const String&, bool startIsStartOfParagraph, bool shouldEmitNBSPbeforeEnd);
 const String& nonBreakingSpaceString();
@@ -236,18 +236,18 @@ IntRect absoluteBoundsForLocalCaretRect(RenderBlock* rendererForCaretPainting, c
 
 // -------------------------------------------------------------------------
 
-inline bool deprecatedIsEditingWhitespace(UChar c)
+inline bool deprecatedIsEditingWhitespace(char16_t c)
 {
     return c == noBreakSpace || c == ' ' || c == '\n' || c == '\t';
 }
 
 // FIXME: Can't really answer this question correctly without knowing the white-space mode.
-inline bool deprecatedIsCollapsibleWhitespace(UChar c)
+inline bool deprecatedIsCollapsibleWhitespace(char16_t c)
 {
     return c == ' ' || c == '\n';
 }
 
-bool isAmbiguousBoundaryCharacter(UChar);
+bool isAmbiguousBoundaryCharacter(char16_t);
 
 inline bool editingIgnoresContent(const Node& node)
 {

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -2831,7 +2831,7 @@ void FrameSelection::expandSelectionToStartOfWordContainingCaretSelection()
     moveTo(s2, e1);
 }
 
-UChar FrameSelection::characterInRelationToCaretSelection(int amount) const
+char16_t FrameSelection::characterInRelationToCaretSelection(int amount) const
 {
     auto position = m_selection.visibleStart();
     if (amount < 0) {
@@ -2856,7 +2856,7 @@ bool FrameSelection::selectionAtWordStart() const
         previousCount++;
         if (isStartOfParagraph(position))
             return previousCount != 1;
-        if (UChar c = position.characterAfter())
+        if (char16_t c = position.characterAfter())
             return deprecatedIsSpaceOrNewline(c) || c == noBreakSpace || (u_ispunct(c) && c != ',' && c != '-' && c != '\'');
     }
     return true;
@@ -2889,7 +2889,7 @@ VisibleSelection FrameSelection::wordSelectionContainingCaretSelection(const Vis
         return VisibleSelection();
 
     if (isEndOfParagraph(endVisiblePosBeforeExpansion)) {
-        UChar c(endVisiblePosBeforeExpansion.characterBefore());
+        char16_t c(endVisiblePosBeforeExpansion.characterBefore());
         if (deprecatedIsSpaceOrNewline(c) || c == noBreakSpace) {
             // End of paragraph with space.
             return VisibleSelection();
@@ -2932,7 +2932,7 @@ VisibleSelection FrameSelection::wordSelectionContainingCaretSelection(const Vis
             // Empty document
             return VisibleSelection();
         }
-        UChar c(previous.characterAfter());
+        char16_t c(previous.characterAfter());
         if (deprecatedIsSpaceOrNewline(c) || c == noBreakSpace) {
             // Space at end of line
             return VisibleSelection();
@@ -2947,7 +2947,7 @@ VisibleSelection FrameSelection::wordSelectionContainingCaretSelection(const Vis
             // On empty line
             return VisibleSelection();
         }
-        UChar c(previous.characterAfter());
+        char16_t c(previous.characterAfter());
         if (deprecatedIsSpaceOrNewline(c) || c == noBreakSpace) {
             // Space at end of line
             return VisibleSelection();
@@ -2967,7 +2967,7 @@ VisibleSelection FrameSelection::wordSelectionContainingCaretSelection(const Vis
     // Now loop backwards until we find a non-space.
     while (endVisiblePos != startVisiblePos) {
         VisiblePosition previous(endVisiblePos.previous());
-        UChar c(previous.characterAfter());
+        char16_t c(previous.characterAfter());
         if (!deprecatedIsSpaceOrNewline(c) && c != noBreakSpace)
             break;
         endVisiblePos = previous;

--- a/Source/WebCore/editing/FrameSelection.h
+++ b/Source/WebCore/editing/FrameSelection.h
@@ -242,7 +242,7 @@ public:
     WEBCORE_EXPORT void expandSelectionToWordContainingCaretSelection();
     WEBCORE_EXPORT std::optional<SimpleRange> wordRangeContainingCaretSelection();
     WEBCORE_EXPORT void expandSelectionToStartOfWordContainingCaretSelection();
-    WEBCORE_EXPORT UChar characterInRelationToCaretSelection(int amount) const;
+    WEBCORE_EXPORT char16_t characterInRelationToCaretSelection(int amount) const;
     WEBCORE_EXPORT bool selectionAtSentenceStart() const;
     WEBCORE_EXPORT bool selectionAtWordStart() const;
     WEBCORE_EXPORT std::optional<SimpleRange> rangeByMovingCurrentSelection(int amount) const;

--- a/Source/WebCore/editing/InsertTextCommand.cpp
+++ b/Source/WebCore/editing/InsertTextCommand.cpp
@@ -95,7 +95,7 @@ bool InsertTextCommand::performTrivialReplace(const String& text, bool selectIns
     if (!endingSelection().isRange())
         return false;
 
-    if (text.contains([](UChar c) { return c == '\t' || c == ' ' || c == '\n'; }))
+    if (text.contains([](char16_t c) { return c == '\t' || c == ' ' || c == '\n'; }))
         return false;
 
     Position start = endingSelection().start();

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -191,7 +191,7 @@ void MarkupAccumulator::appendCharactersReplacingEntities(StringBuilder& result,
     if (source.is8Bit())
         appendCharactersReplacingEntitiesInternal<LChar>(result, source, entityMask);
     else
-        appendCharactersReplacingEntitiesInternal<UChar>(result, source, entityMask);
+        appendCharactersReplacingEntitiesInternal<char16_t>(result, source, entityMask);
 }
 
 MarkupAccumulator::MarkupAccumulator(Vector<Ref<Node>>* nodes, ResolveURLs resolveURLs, SerializationSyntax serializationSyntax, SerializeShadowRoots serializeShadowRoots, Vector<Ref<ShadowRoot>>&& explicitShadowRoots, const Vector<MarkupExclusionRule>& exclusionRules)

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -118,7 +118,7 @@ public:
 #if !UCONFIG_NO_COLLATION
 
 private:
-    bool isBadMatch(const UChar*, size_t length) const;
+    bool isBadMatch(const char16_t*, size_t length) const;
     bool isWordStartMatch(size_t start, size_t length) const;
     bool isWordEndMatch(size_t start, size_t length) const;
 
@@ -126,26 +126,26 @@ private:
     const StringView::UpconvertedCharacters m_targetCharacters;
     FindOptions m_options;
 
-    Vector<UChar> m_buffer;
+    Vector<char16_t> m_buffer;
     size_t m_overlap;
     size_t m_prefixLength;
     bool m_atBreak;
     bool m_needsMoreContext;
 
     const bool m_targetRequiresKanaWorkaround;
-    Vector<UChar> m_normalizedTarget;
-    mutable Vector<UChar> m_normalizedMatch;
+    Vector<char16_t> m_normalizedTarget;
+    mutable Vector<char16_t> m_normalizedMatch;
 
 #else
 
 private:
-    void append(UChar, bool isCharacterStart);
+    void append(char16_t, bool isCharacterStart);
     size_t length() const;
 
     String m_target;
     FindOptions m_options;
 
-    Vector<UChar> m_buffer;
+    Vector<char16_t> m_buffer;
     Vector<bool> m_isCharacterStartBuffer;
     bool m_isBufferFull;
     size_t m_cursor;
@@ -334,7 +334,7 @@ inline void TextIteratorCopyableText::set(String&& string, unsigned offset, unsi
     m_length = length;
 }
 
-inline void TextIteratorCopyableText::set(UChar singleCharacter)
+inline void TextIteratorCopyableText::set(char16_t singleCharacter)
 {
     m_singleCharacter = singleCharacter;
     m_string = String();
@@ -699,7 +699,7 @@ void TextIterator::handleTextRun()
         // Determine what the next text run will be, but don't advance yet
         auto nextTextRun = InlineIterator::nextTextBoxInLogicalOrder(m_textRun, m_textRunLogicalOrderCache);
         if (runStart < runEnd) {
-            auto isNewlineOrTab = [&](UChar character) {
+            auto isNewlineOrTab = [&](char16_t character) {
                 return character == '\n' || character == '\t';
             };
             // Handle either a single newline or tab character (which becomes a space),
@@ -1179,7 +1179,7 @@ void TextIterator::exitNode(Node* exitedNode)
     }
 }
 
-void TextIterator::emitCharacter(UChar character, RefPtr<Node>&& characterNode, RefPtr<Node>&& offsetBaseNode, int textStartOffset, int textEndOffset)
+void TextIterator::emitCharacter(char16_t character, RefPtr<Node>&& characterNode, RefPtr<Node>&& offsetBaseNode, int textStartOffset, int textEndOffset)
 {
     ASSERT(characterNode);
     m_hasEmitted = true;
@@ -1486,7 +1486,7 @@ void SimplifiedBackwardsTextIterator::exitNode()
     }
 }
 
-void SimplifiedBackwardsTextIterator::emitCharacter(UChar c, RefPtr<Node>&& node, int startOffset, int endOffset)
+void SimplifiedBackwardsTextIterator::emitCharacter(char16_t c, RefPtr<Node>&& node, int startOffset, int endOffset)
 {
     ASSERT(node);
     m_positionNode = WTFMove(node);
@@ -1715,7 +1715,7 @@ StringView WordAwareIterator::text() const
 
 // --------
 
-static inline UChar foldQuoteMarkAndReplaceNoBreakSpace(UChar c)
+static inline char16_t foldQuoteMarkAndReplaceNoBreakSpace(char16_t c)
 {
     switch (c) {
     case hebrewPunctuationGershayim:
@@ -1849,7 +1849,7 @@ static inline void unlockSearcher()
 // We refer to the above technique as the "kana workaround". The next few
 // functions are helper functinos for the kana workaround.
 
-static inline bool isKanaLetter(UChar character)
+static inline bool isKanaLetter(char16_t character)
 {
     // Hiragana letters.
     if (character >= 0x3041 && character <= 0x3096)
@@ -1868,7 +1868,7 @@ static inline bool isKanaLetter(UChar character)
     return false;
 }
 
-static inline bool isSmallKanaLetter(UChar character)
+static inline bool isSmallKanaLetter(char16_t character)
 {
     ASSERT(isKanaLetter(character));
 
@@ -1929,7 +1929,7 @@ static inline bool isSmallKanaLetter(UChar character)
 
 enum VoicedSoundMarkType { NoVoicedSoundMark, VoicedSoundMark, SemiVoicedSoundMark };
 
-static inline VoicedSoundMarkType composedVoicedSoundMark(UChar character)
+static inline VoicedSoundMarkType composedVoicedSoundMark(char16_t character)
 {
     ASSERT(isKanaLetter(character));
 
@@ -1996,7 +1996,7 @@ static inline VoicedSoundMarkType composedVoicedSoundMark(UChar character)
     return NoVoicedSoundMark;
 }
 
-static inline bool isCombiningVoicedSoundMark(UChar character)
+static inline bool isCombiningVoicedSoundMark(char16_t character)
 {
     switch (character) {
     case 0x3099: // COMBINING KATAKANA-HIRAGANA VOICED SOUND MARK
@@ -2017,7 +2017,7 @@ static inline bool containsKanaLetters(const String& pattern)
     return false;
 }
 
-static void normalizeCharacters(const UChar* characters, unsigned length, Vector<UChar>& buffer)
+static void normalizeCharacters(const char16_t* characters, unsigned length, Vector<char16_t>& buffer)
 {
     UErrorCode status = U_ZERO_ERROR;
     auto* normalizer = unorm2_getNFCInstance(&status);
@@ -2199,7 +2199,7 @@ inline void SearchBuffer::reachedBreak()
     m_atBreak = true;
 }
 
-inline bool SearchBuffer::isBadMatch(const UChar* match, size_t matchLength) const
+inline bool SearchBuffer::isBadMatch(const char16_t* match, size_t matchLength) const
 {
     // This function implements the kana workaround. If usearch treats
     // it as a match, but we do not want to, then it's a "bad match".
@@ -2417,7 +2417,7 @@ inline bool SearchBuffer::atBreak() const
     return !m_cursor && !m_isBufferFull;
 }
 
-inline void SearchBuffer::append(UChar c, bool isStart)
+inline void SearchBuffer::append(char16_t c, bool isStart)
 {
     m_buffer[m_cursor] = foldQuoteMarkAndReplaceNoBreakSpace(c);
     m_isCharacterStartBuffer[m_cursor] = isStart;
@@ -2427,7 +2427,7 @@ inline void SearchBuffer::append(UChar c, bool isStart)
     }
 }
 
-inline size_t SearchBuffer::append(const UChar* characters, size_t length)
+inline size_t SearchBuffer::append(const char16_t* characters, size_t length)
 {
     ASSERT(length);
     if (!(m_options & CaseInsensitive)) {
@@ -2435,7 +2435,7 @@ inline size_t SearchBuffer::append(const UChar* characters, size_t length)
         return 1;
     }
     constexpr int maxFoldedCharacters = 16; // sensible maximum is 3, this should be more than enough
-    UChar foldedCharacters[maxFoldedCharacters];
+    char16_t foldedCharacters[maxFoldedCharacters];
     UErrorCode status = U_ZERO_ERROR;
     int numFoldedCharacters = u_strFoldCase(foldedCharacters, maxFoldedCharacters, characters, 1, U_FOLD_CASE_DEFAULT, &status);
     ASSERT(U_SUCCESS(status));
@@ -2455,7 +2455,7 @@ inline bool SearchBuffer::needsMoreContext() const
     return false;
 }
 
-void SearchBuffer::prependContext(const UChar*, size_t)
+void SearchBuffer::prependContext(const char16_t*, size_t)
 {
     ASSERT_NOT_REACHED();
 }
@@ -2468,9 +2468,9 @@ inline size_t SearchBuffer::search(size_t& start)
         return 0;
 
     size_t tailSpace = m_target.length() - m_cursor;
-    if (memcmp(&m_buffer[m_cursor], m_target.characters(), tailSpace * sizeof(UChar)) != 0)
+    if (memcmp(&m_buffer[m_cursor], m_target.characters(), tailSpace * sizeof(char16_t)) != 0)
         return 0;
-    if (memcmp(&m_buffer[0], m_target.characters() + tailSpace, m_cursor * sizeof(UChar)) != 0)
+    if (memcmp(&m_buffer[0], m_target.characters() + tailSpace, m_cursor * sizeof(char16_t)) != 0)
         return 0;
 
     start = length();

--- a/Source/WebCore/editing/TextIterator.h
+++ b/Source/WebCore/editing/TextIterator.h
@@ -83,10 +83,10 @@ public:
     void reset();
     void set(String&&);
     void set(String&&, unsigned offset, unsigned length);
-    void set(UChar);
+    void set(char16_t);
 
 private:
-    UChar m_singleCharacter { 0 };
+    char16_t m_singleCharacter { 0 };
     String m_string;
     unsigned m_offset { 0 };
     unsigned m_length { 0 };
@@ -131,7 +131,7 @@ private:
     bool handleNonTextNode();
     void handleTextRun();
     void handleTextNodeFirstLetter(RenderTextFragment&);
-    void emitCharacter(UChar, RefPtr<Node>&& characterNode, RefPtr<Node>&& offsetBaseNode, int textStartOffset, int textEndOffset);
+    void emitCharacter(char16_t, RefPtr<Node>&& characterNode, RefPtr<Node>&& offsetBaseNode, int textStartOffset, int textEndOffset);
     void emitText(Text& textNode, RenderText&, int textStartOffset, int textEndOffset);
     void revertToRemainingTextRun();
 
@@ -178,7 +178,7 @@ private:
     // Used to do the whitespace collapsing logic.
     RefPtr<Text> m_lastTextNode;
     bool m_lastTextNodeEndedWithCollapsedSpace { false };
-    UChar m_lastCharacter { 0 };
+    char16_t m_lastCharacter { 0 };
 
     // Used when deciding whether to emit a "positioning" (e.g. newline) before any other content
     bool m_hasEmitted { false };
@@ -208,7 +208,7 @@ private:
     RenderText* handleFirstLetter(int& startOffset, int& offsetInNode);
     bool handleReplacedElement();
     bool handleNonTextNode();
-    void emitCharacter(UChar, RefPtr<Node>&&, int startOffset, int endOffset);
+    void emitCharacter(char16_t, RefPtr<Node>&&, int startOffset, int endOffset);
     bool advanceRespectingRange(Node*);
 
     const TextIteratorBehaviors m_behaviors;
@@ -235,7 +235,7 @@ private:
 
     // Used to do the whitespace logic.
     RefPtr<Text> m_lastTextNode;
-    UChar m_lastCharacter { 0 };
+    char16_t m_lastCharacter { 0 };
 
     // Whether m_node has advanced beyond the iteration range (i.e. m_startContainer).
     bool m_havePassedStartContainer { false };
@@ -303,7 +303,7 @@ private:
     TextIteratorCopyableText m_previousText;
 
     // Many chunks from text iterator concatenated.
-    Vector<UChar> m_buffer;
+    Vector<char16_t> m_buffer;
 
     // Did we have to look ahead in the text iterator to confirm the current chunk?
     bool m_didLookAhead { true };

--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -148,17 +148,17 @@ void TextManipulationController::startObservingParagraphs(ManipulationItemCallba
     flushPendingItemsForCallback();
 }
 
-static bool isInPrivateUseArea(UChar character)
+static bool isInPrivateUseArea(char16_t character)
 {
     return 0xE000 <= character && character <= 0xF8FF;
 }
 
-static bool isTokenDelimiter(UChar character)
+static bool isTokenDelimiter(char16_t character)
 {
     return isHTMLLineBreak(character) || isInPrivateUseArea(character);
 }
 
-static bool isNotSpace(UChar character)
+static bool isNotSpace(char16_t character)
 {
     if (character == noBreakSpace)
         return false;

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -240,7 +240,7 @@ void VisibleSelection::appendTrailingWhitespace()
 
     CharacterIterator charIt(*makeSimpleRange(m_end, makeBoundaryPointAfterNodeContents(*scope)), TextIteratorBehavior::EmitsCharactersBetweenAllVisiblePositions);
     for (; !charIt.atEnd() && charIt.text().length(); charIt.advance(1)) {
-        UChar c = charIt.text()[0];
+        char16_t c = charIt.text()[0];
         if ((!deprecatedIsSpaceOrNewline(c) && c != noBreakSpace) || c == '\n')
             break;
         m_end = makeDeprecatedLegacyPosition(charIt.range().end);

--- a/Source/WebCore/editing/VisibleUnits.cpp
+++ b/Source/WebCore/editing/VisibleUnits.cpp
@@ -246,7 +246,7 @@ static const InlineIterator::LeafBoxIterator logicallyNextBox(const VisiblePosit
 }
 
 static UBreakIterator* wordBreakIteratorForMinOffsetBoundary(const VisiblePosition& visiblePosition, InlineIterator::TextBoxIterator textBox,
-    unsigned& previousBoxLength, bool& previousBoxInDifferentLine, Vector<UChar, 1024>& string)
+    unsigned& previousBoxLength, bool& previousBoxInDifferentLine, Vector<char16_t, 1024>& string)
 {
     previousBoxInDifferentLine = false;
 
@@ -271,7 +271,7 @@ static UBreakIterator* wordBreakIteratorForMinOffsetBoundary(const VisiblePositi
 }
 
 static UBreakIterator* wordBreakIteratorForMaxOffsetBoundary(const VisiblePosition& visiblePosition, InlineIterator::TextBoxIterator textBox,
-    bool& nextBoxInDifferentLine, Vector<UChar, 1024>& string)
+    bool& nextBoxInDifferentLine, Vector<char16_t, 1024>& string)
 {
     nextBoxInDifferentLine = false;
 
@@ -327,7 +327,7 @@ static VisiblePosition visualWordPosition(const VisiblePosition& visiblePosition
     std::optional<VisiblePosition> previousPosition;
     UBreakIterator* iter = nullptr;
 
-    Vector<UChar, 1024> string;
+    Vector<char16_t, 1024> string;
 
     while (1) {
         VisiblePosition adjacentCharacterPosition = direction == MoveRight ? current.right(true) : current.left(true); 
@@ -420,7 +420,7 @@ VisiblePosition rightWordPosition(const VisiblePosition& visiblePosition, bool s
 }
 
 
-static void prepend(Vector<UChar, 1024>& buffer, StringView string)
+static void prepend(Vector<char16_t, 1024>& buffer, StringView string)
 {
     unsigned oldSize = buffer.size();
     unsigned length = string.length();
@@ -430,7 +430,7 @@ static void prepend(Vector<UChar, 1024>& buffer, StringView string)
         buffer[i] = string[i];
 }
 
-static void prependRepeatedCharacter(Vector<UChar, 1024>& buffer, UChar character, unsigned count)
+static void prependRepeatedCharacter(Vector<char16_t, 1024>& buffer, char16_t character, unsigned count)
 {
     unsigned oldSize = buffer.size();
     buffer.grow(oldSize + count);
@@ -439,7 +439,7 @@ static void prependRepeatedCharacter(Vector<UChar, 1024>& buffer, UChar characte
         buffer[i] = character;
 }
 
-static void appendRepeatedCharacter(Vector<UChar, 1024>& buffer, UChar character, unsigned count)
+static void appendRepeatedCharacter(Vector<char16_t, 1024>& buffer, char16_t character, unsigned count)
 {
     unsigned oldSize = buffer.size();
     buffer.grow(oldSize + count);
@@ -447,7 +447,7 @@ static void appendRepeatedCharacter(Vector<UChar, 1024>& buffer, UChar character
         buffer[oldSize + i] = character;
 }
 
-unsigned suffixLengthForRange(const SimpleRange& forwardsScanRange, Vector<UChar, 1024>& string)
+unsigned suffixLengthForRange(const SimpleRange& forwardsScanRange, Vector<char16_t, 1024>& string)
 {
     unsigned suffixLength = 0;
     TextIterator forwardsIterator(forwardsScanRange);
@@ -463,7 +463,7 @@ unsigned suffixLengthForRange(const SimpleRange& forwardsScanRange, Vector<UChar
     return suffixLength;
 }
 
-unsigned prefixLengthForRange(const SimpleRange& backwardsScanRange, Vector<UChar, 1024>& string)
+unsigned prefixLengthForRange(const SimpleRange& backwardsScanRange, Vector<char16_t, 1024>& string)
 {
     unsigned prefixLength = 0;
     SimplifiedBackwardsTextIterator backwardsIterator(backwardsScanRange);
@@ -479,7 +479,7 @@ unsigned prefixLengthForRange(const SimpleRange& backwardsScanRange, Vector<UCha
     return prefixLength;
 }
 
-unsigned backwardSearchForBoundaryWithTextIterator(SimplifiedBackwardsTextIterator& it, Vector<UChar, 1024>& string, unsigned suffixLength, BoundarySearchFunction searchFunction)
+unsigned backwardSearchForBoundaryWithTextIterator(SimplifiedBackwardsTextIterator& it, Vector<char16_t, 1024>& string, unsigned suffixLength, BoundarySearchFunction searchFunction)
 {
     unsigned next = 0;
     bool needMoreContext = false;
@@ -509,7 +509,7 @@ unsigned backwardSearchForBoundaryWithTextIterator(SimplifiedBackwardsTextIterat
     return next;
 }
 
-unsigned forwardSearchForBoundaryWithTextIterator(TextIterator& it, Vector<UChar, 1024>& string, unsigned prefixLength, BoundarySearchFunction searchFunction)
+unsigned forwardSearchForBoundaryWithTextIterator(TextIterator& it, Vector<char16_t, 1024>& string, unsigned prefixLength, BoundarySearchFunction searchFunction)
 {
     unsigned next = 0;
     bool needMoreContext = false;
@@ -548,7 +548,7 @@ static VisiblePosition previousBoundary(const VisiblePosition& position, Boundar
     if (!boundary)
         return { };
 
-    Vector<UChar, 1024> string;
+    Vector<char16_t, 1024> string;
     unsigned suffixLength = 0;
 
     auto searchRange = makeSimpleRange(makeBoundaryPointBeforeNodeContents(*boundary), position);
@@ -597,7 +597,7 @@ static VisiblePosition nextBoundary(const VisiblePosition& c, BoundarySearchFunc
 
     Ref boundaryDocument = boundary->document();
 
-    Vector<UChar, 1024> string;
+    Vector<char16_t, 1024> string;
     unsigned prefixLength = 0;
 
     if (requiresContextForWordBoundary(c.characterAfter())) {

--- a/Source/WebCore/editing/VisibleUnits.h
+++ b/Source/WebCore/editing/VisibleUnits.h
@@ -119,10 +119,10 @@ unsigned startWordBoundary(StringView, unsigned, BoundarySearchContextAvailabili
 unsigned endWordBoundary(StringView, unsigned, BoundarySearchContextAvailability, bool&);
 unsigned startSentenceBoundary(StringView, unsigned, BoundarySearchContextAvailability, bool&);
 unsigned endSentenceBoundary(StringView, unsigned, BoundarySearchContextAvailability, bool&);
-unsigned suffixLengthForRange(const SimpleRange&, Vector<UChar, 1024>&);
-unsigned prefixLengthForRange(const SimpleRange&, Vector<UChar, 1024>&);
-unsigned backwardSearchForBoundaryWithTextIterator(SimplifiedBackwardsTextIterator&, Vector<UChar, 1024>&, unsigned, BoundarySearchFunction);
-unsigned forwardSearchForBoundaryWithTextIterator(TextIterator&, Vector<UChar, 1024>&, unsigned, BoundarySearchFunction);
+unsigned suffixLengthForRange(const SimpleRange&, Vector<char16_t, 1024>&);
+unsigned prefixLengthForRange(const SimpleRange&, Vector<char16_t, 1024>&);
+unsigned backwardSearchForBoundaryWithTextIterator(SimplifiedBackwardsTextIterator&, Vector<char16_t, 1024>&, unsigned, BoundarySearchFunction);
+unsigned forwardSearchForBoundaryWithTextIterator(TextIterator&, Vector<char16_t, 1024>&, unsigned, BoundarySearchFunction);
 RefPtr<Node> findStartOfParagraph(Node*, Node*, Node*, int&, Position::AnchorType&, EditingBoundaryCrossingRule);
 RefPtr<Node> findEndOfParagraph(Node*, Node*, Node*, int&, Position::AnchorType&, EditingBoundaryCrossingRule);
 

--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -2133,7 +2133,7 @@ void HTMLConverter::_processText(Text& text)
         StringBuilder builder;
         LChar noBreakSpaceRepresentation = 0;
         for (unsigned i = 0; i < count; i++) {
-            UChar c = originalString.characterAt(i);
+            char16_t c = originalString.characterAt(i);
             bool isWhitespace = c == ' ' || c == '\n' || c == '\r' || c == '\t' || c == 0xc || c == 0x200b;
             if (isWhitespace)
                 wasSpace = (!wasLeading || !suppressLeadingSpace);

--- a/Source/WebCore/html/DOMTokenList.cpp
+++ b/Source/WebCore/html/DOMTokenList.cpp
@@ -48,7 +48,7 @@ DOMTokenList::DOMTokenList(Element& element, const QualifiedName& attributeName,
 
 static inline bool tokenContainsHTMLSpace(StringView token)
 {
-    return token.find(isASCIIWhitespace<UChar>) != notFound;
+    return token.find(isASCIIWhitespace<char16_t>) != notFound;
 }
 
 ExceptionOr<void> DOMTokenList::validateToken(StringView token)

--- a/Source/WebCore/html/EmailInputType.cpp
+++ b/Source/WebCore/html/EmailInputType.cpp
@@ -71,7 +71,7 @@ bool EmailInputType::typeMismatchFor(const String& value) const
     if (!protectedElement()->multiple())
         return !isValidEmailAddress(value);
     for (auto& address : value.splitAllowingEmptyEntries(',')) {
-        if (!isValidEmailAddress(StringView(address).trim(isASCIIWhitespace<UChar>)))
+        if (!isValidEmailAddress(StringView(address).trim(isASCIIWhitespace<char16_t>)))
             return true;
     }
     return false;

--- a/Source/WebCore/html/FTPDirectoryDocument.cpp
+++ b/Source/WebCore/html/FTPDirectoryDocument.cpp
@@ -94,7 +94,7 @@ private:
     bool m_skipLF { false };
     
     size_t m_size { 254 };
-    Vector<UChar> m_buffer;
+    Vector<char16_t> m_buffer;
     size_t m_destIndex { 0 };
     StringBuilder m_carryOver;
     
@@ -355,7 +355,7 @@ void FTPDirectoryDocumentParser::append(RefPtr<StringImpl>&& inputSource)
     m_destIndex = 0;
     SegmentedString string { String { WTFMove(inputSource) } };
     while (!string.isEmpty()) {
-        UChar c = string.currentCharacter();
+        char16_t c = string.currentCharacter();
 
         if (c == '\r') {
             m_buffer[m_destIndex++] = '\n';

--- a/Source/WebCore/html/FormController.cpp
+++ b/Source/WebCore/html/FormController.cpp
@@ -117,7 +117,7 @@ private:
 
 FormController::SavedFormState FormController::SavedFormState::consumeSerializedState(AtomStringVectorReader& reader)
 {
-    auto isNotFormControlTypeCharacter = [](UChar character) {
+    auto isNotFormControlTypeCharacter = [](char16_t character) {
         return !(character == '-' || isASCIILower(character));
     };
 

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -434,7 +434,7 @@ static Ref<DocumentFragment> textToFragment(Document& document, const String& te
 
     for (unsigned start = 0, length = text.length(); start < length; ) {
         // Find next line break.
-        UChar c = 0;
+        char16_t c = 0;
         unsigned i;
         for (i = start; i < length; i++) {
             c = text[i];
@@ -486,7 +486,7 @@ ExceptionOr<void> HTMLElement::setInnerText(String&& text)
 {
     // FIXME: This doesn't take whitespace collapsing into account at all.
 
-    if (!text.contains([](UChar c) { return c == '\n' || c == '\r'; })) {
+    if (!text.contains([](char16_t c) { return c == '\n' || c == '\r'; })) {
         stringReplaceAll(WTFMove(text));
         return { };
     }
@@ -520,7 +520,7 @@ ExceptionOr<void> HTMLElement::setOuterText(String&& text)
     RefPtr<Node> newChild;
 
     // Convert text to fragment with <br> tags instead of linebreaks if needed.
-    if (text.contains([](UChar c) { return c == '\n' || c == '\r'; }))
+    if (text.contains([](char16_t c) { return c == '\n' || c == '\r'; }))
         newChild = textToFragment(protectedDocument(), WTFMove(text));
     else
         newChild = Text::create(protectedDocument(), WTFMove(text));
@@ -824,7 +824,7 @@ std::optional<SRGBA<uint8_t>> HTMLElement::parseLegacyColorValue(StringView stri
     if (string.isEmpty())
         return std::nullopt;
 
-    string = string.trim(isASCIIWhitespace<UChar>);
+    string = string.trim(isASCIIWhitespace<char16_t>);
     if (string.isEmpty())
         return Color::black;
 

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -258,7 +258,7 @@ static String extractMIMETypeFromTypeAttributeForLookup(const String& typeAttrib
     auto semicolonIndex = typeAttribute.find(';');
     if (semicolonIndex == notFound)
         return typeAttribute.trim(isASCIIWhitespace);
-    return StringView(typeAttribute).left(semicolonIndex).trim(isASCIIWhitespace<UChar>).toStringWithoutCopying();
+    return StringView(typeAttribute).left(semicolonIndex).trim(isASCIIWhitespace<char16_t>).toStringWithoutCopying();
 }
 
 ImageCandidate HTMLImageElement::bestFitSourceFromPictureElement()

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1451,7 +1451,7 @@ ExceptionOr<void> HTMLInputElement::showPicker()
     return { };
 }
 
-static inline bool isRFC2616TokenCharacter(UChar ch)
+static inline bool isRFC2616TokenCharacter(char16_t ch)
 {
     return isASCII(ch) && ch > ' ' && ch != '"' && ch != '(' && ch != ')' && ch != ',' && ch != '/' && (ch < ':' || ch > '@') && (ch < '[' || ch > ']') && ch != '{' && ch != '}' && ch != 0x7f;
 }
@@ -1482,7 +1482,7 @@ static Vector<String> parseAcceptAttribute(StringView acceptString, bool (*predi
         return types;
 
     for (auto splitType : acceptString.split(',')) {
-        auto trimmedType = splitType.trim(isASCIIWhitespace<UChar>);
+        auto trimmedType = splitType.trim(isASCIIWhitespace<char16_t>);
         if (trimmedType.isEmpty())
             continue;
         if (!predicate(trimmedType))
@@ -2406,7 +2406,7 @@ String HTMLInputElement::placeholder() const
     if (!containsHTMLLineBreak(attributeValue)) [[likely]]
         return attributeValue;
 
-    return attributeValue.removeCharacters([](UChar character) {
+    return attributeValue.removeCharacters([](char16_t character) {
         return isHTMLLineBreak(character);
     });
 }

--- a/Source/WebCore/html/HTMLScriptElement.cpp
+++ b/Source/WebCore/html/HTMLScriptElement.cpp
@@ -274,10 +274,10 @@ bool HTMLScriptElement::isScriptPreventedByAttributes() const
     auto& eventAttribute = attributeWithoutSynchronization(eventAttr);
     auto& forAttribute = attributeWithoutSynchronization(forAttr);
     if (!eventAttribute.isNull() && !forAttribute.isNull()) {
-        if (!equalLettersIgnoringASCIICase(StringView(forAttribute).trim(isASCIIWhitespace<UChar>), "window"_s))
+        if (!equalLettersIgnoringASCIICase(StringView(forAttribute).trim(isASCIIWhitespace<char16_t>), "window"_s))
             return true;
 
-        auto eventAttributeView = StringView(eventAttribute).trim(isASCIIWhitespace<UChar>);
+        auto eventAttributeView = StringView(eventAttribute).trim(isASCIIWhitespace<char16_t>);
         if (!equalLettersIgnoringASCIICase(eventAttributeView, "onload"_s) && !equalLettersIgnoringASCIICase(eventAttributeView, "onload()"_s))
             return true;
     }

--- a/Source/WebCore/html/HTMLTablePartElement.cpp
+++ b/Source/WebCore/html/HTMLTablePartElement.cpp
@@ -64,7 +64,7 @@ void HTMLTablePartElement::collectPresentationalHintsForAttribute(const Qualifie
         addHTMLColorToStyle(style, CSSPropertyBackgroundColor, value);
         break;
     case AttributeNames::backgroundAttr:
-        if (!StringView(value).containsOnly<isASCIIWhitespace<UChar>>())
+        if (!StringView(value).containsOnly<isASCIIWhitespace<char16_t>>())
             style.setProperty(CSSProperty(CSSPropertyBackgroundImage, CSSImageValue::create(document().completeURL(value))));
         break;
     case AttributeNames::valignAttr:

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -169,7 +169,7 @@ void HTMLTextFormControlElement::forwardEvent(Event& event)
         innerText->defaultEventHandler(event);
 }
 
-static bool isNotLineBreak(UChar ch) { return ch != newlineCharacter && ch != carriageReturn; }
+static bool isNotLineBreak(char16_t ch) { return ch != newlineCharacter && ch != carriageReturn; }
 
 bool HTMLTextFormControlElement::isPlaceholderEmpty() const
 {

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -300,7 +300,7 @@ bool HTMLVideoElement::isURLAttribute(const Attribute& attribute) const
 const AtomString& HTMLVideoElement::imageSourceURL() const
 {
     const auto& url = attributeWithoutSynchronization(posterAttr);
-    if (!StringView(url).containsOnly<isASCIIWhitespace<UChar>>())
+    if (!StringView(url).containsOnly<isASCIIWhitespace<char16_t>>())
         return url;
     return m_defaultPosterURL;
 }

--- a/Source/WebCore/html/NumberInputType.cpp
+++ b/Source/WebCore/html/NumberInputType.cpp
@@ -241,7 +241,7 @@ String NumberInputType::serialize(const Decimal& value) const
     return serializeForNumberType(value);
 }
 
-static bool isE(UChar ch)
+static bool isE(char16_t ch)
 {
     return ch == 'e' || ch == 'E';
 }

--- a/Source/WebCore/html/PermissionsPolicy.cpp
+++ b/Source/WebCore/html/PermissionsPolicy.cpp
@@ -100,7 +100,7 @@ static ASCIILiteral toFeatureNameForLogging(PermissionsPolicy::Feature feature)
 // https://w3c.github.io/webappsec-permissions-policy/#serialized-policy-directive
 static std::pair<PermissionsPolicy::Feature, StringView> readFeatureIdentifier(StringView value)
 {
-    value = value.trim(isASCIIWhitespace<UChar>);
+    value = value.trim(isASCIIWhitespace<char16_t>);
 
     PermissionsPolicy::Feature feature = PermissionsPolicy::Feature::Invalid;
     StringView remainingValue;
@@ -268,8 +268,8 @@ static bool checkPermissionsPolicy(const PermissionsPolicy& permissionsPolicy, P
 // Similar to https://infra.spec.whatwg.org/#split-on-ascii-whitespace but only extract one token at a time.
 static std::pair<StringView, StringView> splitOnAsciiWhiteSpace(StringView input)
 {
-    input = input.trim(isASCIIWhitespace<UChar>);
-    auto position = input.find(isASCIIWhitespace<UChar>);
+    input = input.trim(isASCIIWhitespace<char16_t>);
+    auto position = input.find(isASCIIWhitespace<char16_t>);
     if (position == notFound)
         return { input, StringView { } };
 

--- a/Source/WebCore/html/TypeAhead.cpp
+++ b/Source/WebCore/html/TypeAhead.cpp
@@ -62,7 +62,7 @@ int TypeAhead::handleEvent(KeyboardEvent* event, MatchModeFlags matchMode)
     Seconds delta = event->timeStamp() - m_lastTypeTime;
     m_lastTypeTime = event->timeStamp();
 
-    UChar c = event->charCode();
+    char16_t c = event->charCode();
 
     if (delta > typeAheadTimeout)
         m_buffer.clear();

--- a/Source/WebCore/html/TypeAhead.h
+++ b/Source/WebCore/html/TypeAhead.h
@@ -59,7 +59,7 @@ public:
 private:
     TypeAheadDataSource* m_dataSource;
     MonotonicTime m_lastTypeTime;
-    UChar m_repeatingChar;
+    char16_t m_repeatingChar;
     StringBuilder m_buffer;
 };
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2812,7 +2812,7 @@ bool CanvasRenderingContext2DBase::canDrawText(double x, double y, bool fill, st
     return true;
 }
 
-static inline bool isSpaceThatNeedsReplacing(UChar c)
+static inline bool isSpaceThatNeedsReplacing(char16_t c)
 {
     // According to specification all space characters should be replaced with 0x0020 space character.
     // http://www.whatwg.org/specs/web-apps/current-work/multipage/the-canvas-element.html#text-preparation-algorithm
@@ -2830,7 +2830,7 @@ String CanvasRenderingContext2DBase::normalizeSpaces(const String& text)
         return text;
 
     unsigned textLength = text.length();
-    Vector<UChar> charVector(textLength);
+    Vector<char16_t> charVector(textLength);
     StringView(text).getCharacters(charVector.mutableSpan());
 
     charVector[i++] = ' ';

--- a/Source/WebCore/html/parser/AtomHTMLToken.h
+++ b/Source/WebCore/html/parser/AtomHTMLToken.h
@@ -71,7 +71,7 @@ public:
 
     // Characters
 
-    std::span<const UChar> characters() const;
+    std::span<const char16_t> characters() const;
     bool charactersIsAll8BitData() const;
 
     // Comment
@@ -92,7 +92,7 @@ private:
     // We don't want to copy the characters out of the HTMLToken, so we keep a pointer to its buffer instead.
     // This buffer is owned by the HTMLToken and causes a lifetime dependence between these objects.
     // FIXME: Add a mechanism for "internalizing" the characters when the HTMLToken is destroyed.
-    std::span<const UChar> m_externalCharacters; // Character
+    std::span<const char16_t> m_externalCharacters; // Character
 
     Type m_type;
     TagName m_tagName; // StartTag, EndTag.
@@ -159,7 +159,7 @@ inline const Vector<Attribute>& AtomHTMLToken::attributes() const
     return m_attributes;
 }
 
-inline std::span<const UChar> AtomHTMLToken::characters() const
+inline std::span<const char16_t> AtomHTMLToken::characters() const
 {
     ASSERT(m_type == Type::Character);
     return m_externalCharacters;

--- a/Source/WebCore/html/parser/CSSPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/CSSPreloadScanner.cpp
@@ -53,7 +53,7 @@ void CSSPreloadScanner::scan(const HTMLToken::DataVector& data, PreloadRequestSt
     ASSERT(!m_requests);
     SetForScope change(m_requests, &requests);
 
-    for (UChar c : data) {
+    for (char16_t c : data) {
         if (m_state == DoneParsingImportRules)
             break;
 
@@ -75,7 +75,7 @@ bool CSSPreloadScanner::hasFinishedRuleValue() const
     return m_ruleValue[m_ruleValue.size() - 1] == ')';
 }
 
-inline void CSSPreloadScanner::tokenize(UChar c)
+inline void CSSPreloadScanner::tokenize(char16_t c)
 {
     // We are just interested in @import rules, no need for real tokenization here
     // Searching for other types of resources is probably low payoff.
@@ -172,7 +172,7 @@ inline void CSSPreloadScanner::tokenize(UChar c)
     }
 }
 
-static String parseCSSStringOrURL(std::span<const UChar> characters)
+static String parseCSSStringOrURL(std::span<const char16_t> characters)
 {
     size_t offset = 0;
     size_t reducedLength = characters.size();
@@ -221,7 +221,7 @@ static bool hasValidImportConditions(StringView conditions)
     if (conditions.isEmpty())
         return true;
 
-    conditions = conditions.trim(isASCIIWhitespace<UChar>);
+    conditions = conditions.trim(isASCIIWhitespace<char16_t>);
 
     // FIXME: Support multiple conditions.
     // FIXME: Support media queries.

--- a/Source/WebCore/html/parser/CSSPreloadScanner.h
+++ b/Source/WebCore/html/parser/CSSPreloadScanner.h
@@ -57,14 +57,14 @@ private:
         DoneParsingImportRules,
     };
 
-    inline void tokenize(UChar);
+    inline void tokenize(char16_t);
     void emitRule();
     bool hasFinishedRuleValue() const;
 
     State m_state;
-    Vector<UChar> m_rule;
-    Vector<UChar> m_ruleValue;
-    Vector<UChar> m_ruleConditions;
+    Vector<char16_t> m_rule;
+    Vector<char16_t> m_ruleValue;
+    Vector<char16_t> m_ruleConditions;
 
     // Only non-zero during scan()
     PreloadRequestStream* m_requests;

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -183,7 +183,7 @@ template<typename CharacterType> static inline bool isCharAfterUnquotedAttribute
 template<typename CharacterType>
 class HTMLFastPathParser {
     using CharacterSpan = std::span<const CharacterType>;
-    static_assert(std::is_same_v<CharacterType, UChar> || std::is_same_v<CharacterType, LChar>);
+    static_assert(std::is_same_v<CharacterType, char16_t> || std::is_same_v<CharacterType, LChar>);
 
 public:
     HTMLFastPathParser(CharacterSpan source, Document& document, ContainerNode& destinationParent)
@@ -234,7 +234,7 @@ private:
     unsigned m_elementDepth { 0 };
     // 32 matches that used by HTMLToken::Attribute.
     Vector<CharacterType, 32> m_charBuffer;
-    Vector<UChar> m_ucharBuffer;
+    Vector<char16_t> m_ucharBuffer;
     // The inline capacity matches HTMLToken::AttributeList.
     Vector<Attribute, 10> m_attributeBuffer;
     Vector<AtomStringImpl*> m_attributeNames;
@@ -721,7 +721,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         return HTMLNameCache::makeAttributeValue(m_ucharBuffer.span());
     }
 
-    void scanHTMLCharacterReference(Vector<UChar>& out)
+    void scanHTMLCharacterReference(Vector<char16_t>& out)
     {
         ASSERT(*m_parsingBuffer == '&');
         m_parsingBuffer.advance();

--- a/Source/WebCore/html/parser/HTMLEntityParser.cpp
+++ b/Source/WebCore/html/parser/HTMLEntityParser.cpp
@@ -36,7 +36,7 @@
 
 namespace WebCore {
 
-static constexpr std::array<UChar, 32> windowsLatin1ExtensionArray {
+static constexpr std::array<char16_t, 32> windowsLatin1ExtensionArray {
     0x20AC, 0x0081, 0x201A, 0x0192, 0x201E, 0x2026, 0x2020, 0x2021, // 80-87
     0x02C6, 0x2030, 0x0160, 0x2039, 0x0152, 0x008D, 0x017D, 0x008F, // 88-8F
     0x0090, 0x2018, 0x2019, 0x201C, 0x201D, 0x2022, 0x2013, 0x2014, // 90-97
@@ -45,19 +45,19 @@ static constexpr std::array<UChar, 32> windowsLatin1ExtensionArray {
 
 constexpr DecodedHTMLEntity::DecodedHTMLEntity() = default;
 
-constexpr DecodedHTMLEntity::DecodedHTMLEntity(UChar first)
+constexpr DecodedHTMLEntity::DecodedHTMLEntity(char16_t first)
     : m_length { 1 }
     , m_characters { first }
 {
 }
 
-constexpr DecodedHTMLEntity::DecodedHTMLEntity(UChar first, UChar second)
+constexpr DecodedHTMLEntity::DecodedHTMLEntity(char16_t first, char16_t second)
     : m_length { 2 }
     , m_characters { first, second }
 {
 }
 
-constexpr DecodedHTMLEntity::DecodedHTMLEntity(UChar first, UChar second, UChar third)
+constexpr DecodedHTMLEntity::DecodedHTMLEntity(char16_t first, char16_t second, char16_t third)
     : m_length { 3 }
     , m_characters { first, second, third }
 {
@@ -74,7 +74,7 @@ static constexpr DecodedHTMLEntity makeEntity(char32_t character)
         return { replacementCharacter };
     if ((character & ~0x1F) != 0x80) {
         if (U_IS_BMP(character)) {
-            UChar codeUnit = character;
+            char16_t codeUnit = character;
             return { codeUnit };
         }
         return { U16_LEAD(character), U16_TRAIL(character) };
@@ -91,9 +91,9 @@ static DecodedHTMLEntity makeEntity(const Checked<uint32_t, RecordOverflow>& cha
 
 static constexpr DecodedHTMLEntity makeEntity(HTMLEntityTableEntry entry)
 {
-    UChar second = entry.optionalSecondCharacter;
+    char16_t second = entry.optionalSecondCharacter;
     if (U_IS_BMP(entry.firstCharacter)) {
-        UChar first = entry.firstCharacter;
+        char16_t first = entry.firstCharacter;
         if (!second)
             return { first };
         return { first, second };
@@ -108,14 +108,14 @@ public:
     explicit SegmentedStringSource(SegmentedString&);
 
     bool isEmpty() const { return m_source.isEmpty(); }
-    UChar currentCharacter() const { return m_source.currentCharacter(); }
+    char16_t currentCharacter() const { return m_source.currentCharacter(); }
     void advance();
     void pushEverythingBack();
     void pushBackButKeep(unsigned keepCount);
 
 private:
     SegmentedString& m_source;
-    Vector<UChar, 64> m_consumedCharacters;
+    Vector<char16_t, 64> m_consumedCharacters;
 };
 
 template<typename CharacterType> class StringParsingBufferSource {
@@ -123,7 +123,7 @@ public:
     explicit StringParsingBufferSource(StringParsingBuffer<CharacterType>&);
 
     static bool isEmpty() { return false; }
-    UChar currentCharacter() const { return m_source.atEnd() ? 0 : *m_source; }
+    char16_t currentCharacter() const { return m_source.atEnd() ? 0 : *m_source; }
     void advance() { m_source.advance(); }
     void pushEverythingBack() { m_source.setPosition(m_startPosition); }
     void pushBackButKeep(unsigned keepCount) { m_source.setPosition(m_startPosition.subspan(keepCount)); }
@@ -167,7 +167,7 @@ void SegmentedStringSource::pushBackButKeep(unsigned keepCount)
 template<typename SourceType> DecodedHTMLEntity consumeDecimalHTMLEntity(SourceType& source)
 {
     Checked<uint32_t, RecordOverflow> result = 0;
-    UChar character = source.currentCharacter();
+    char16_t character = source.currentCharacter();
     do {
         source.advance();
         if (source.isEmpty()) {
@@ -185,7 +185,7 @@ template<typename SourceType> DecodedHTMLEntity consumeDecimalHTMLEntity(SourceT
 template<typename SourceType> DecodedHTMLEntity consumeHexHTMLEntity(SourceType& source)
 {
     Checked<uint32_t, RecordOverflow> result = 0;
-    UChar character = source.currentCharacter();
+    char16_t character = source.currentCharacter();
     do {
         source.advance();
         if (source.isEmpty()) {
@@ -201,10 +201,10 @@ template<typename SourceType> DecodedHTMLEntity consumeHexHTMLEntity(SourceType&
     return makeEntity(result);
 }
 
-template<typename SourceType> DecodedHTMLEntity consumeNamedHTMLEntity(SourceType& source, UChar additionalAllowedCharacter)
+template<typename SourceType> DecodedHTMLEntity consumeNamedHTMLEntity(SourceType& source, char16_t additionalAllowedCharacter)
 {
     HTMLEntitySearch entitySearch;
-    UChar character;
+    char16_t character;
     do {
         character = source.currentCharacter();
         entitySearch.advance(character);
@@ -237,12 +237,12 @@ template<typename SourceType> DecodedHTMLEntity consumeNamedHTMLEntity(SourceTyp
     return { };
 }
 
-template<typename SourceType> DecodedHTMLEntity consumeHTMLEntity(SourceType source, UChar additionalAllowedCharacter)
+template<typename SourceType> DecodedHTMLEntity consumeHTMLEntity(SourceType source, char16_t additionalAllowedCharacter)
 {
     if (source.isEmpty())
         return DecodedHTMLEntity::ConstructNotEnoughCharacters;
 
-    UChar character = source.currentCharacter();
+    char16_t character = source.currentCharacter();
     if (isASCIIAlpha(character))
         return consumeNamedHTMLEntity(source, additionalAllowedCharacter);
     if (character != '#')
@@ -276,7 +276,7 @@ template<typename SourceType> DecodedHTMLEntity consumeHTMLEntity(SourceType sou
     return { };
 }
 
-DecodedHTMLEntity consumeHTMLEntity(SegmentedString& source, UChar additionalAllowedCharacter)
+DecodedHTMLEntity consumeHTMLEntity(SegmentedString& source, char16_t additionalAllowedCharacter)
 {
     return consumeHTMLEntity(SegmentedStringSource { source }, additionalAllowedCharacter);
 }
@@ -286,9 +286,9 @@ DecodedHTMLEntity consumeHTMLEntity(StringParsingBuffer<LChar>& source)
     return consumeHTMLEntity(StringParsingBufferSource<LChar> { source }, 0);
 }
 
-DecodedHTMLEntity consumeHTMLEntity(StringParsingBuffer<UChar>& source)
+DecodedHTMLEntity consumeHTMLEntity(StringParsingBuffer<char16_t>& source)
 {
-    return consumeHTMLEntity(StringParsingBufferSource<UChar> { source }, 0);
+    return consumeHTMLEntity(StringParsingBufferSource<char16_t> { source }, 0);
 }
 
 DecodedHTMLEntity decodeNamedHTMLEntityForXMLParser(const char* name)

--- a/Source/WebCore/html/parser/HTMLEntityParser.h
+++ b/Source/WebCore/html/parser/HTMLEntityParser.h
@@ -38,11 +38,11 @@ class DecodedHTMLEntity;
 class SegmentedString;
 
 // This function expects a null character at the end, otherwise it assumes the source is partial.
-DecodedHTMLEntity consumeHTMLEntity(SegmentedString&, UChar additionalAllowedCharacter = 0);
+DecodedHTMLEntity consumeHTMLEntity(SegmentedString&, char16_t additionalAllowedCharacter = 0);
 
 // This function assumes the source is complete, and does not expect a null character.
 DecodedHTMLEntity consumeHTMLEntity(StringParsingBuffer<LChar>&);
-DecodedHTMLEntity consumeHTMLEntity(StringParsingBuffer<UChar>&);
+DecodedHTMLEntity consumeHTMLEntity(StringParsingBuffer<char16_t>&);
 
 // This function does not check for "not enough characters" at all.
 DecodedHTMLEntity decodeNamedHTMLEntityForXMLParser(const char*);
@@ -50,9 +50,9 @@ DecodedHTMLEntity decodeNamedHTMLEntityForXMLParser(const char*);
 class DecodedHTMLEntity {
 public:
     constexpr DecodedHTMLEntity();
-    constexpr DecodedHTMLEntity(UChar);
-    constexpr DecodedHTMLEntity(UChar, UChar);
-    constexpr DecodedHTMLEntity(UChar, UChar, UChar);
+    constexpr DecodedHTMLEntity(char16_t);
+    constexpr DecodedHTMLEntity(char16_t, char16_t);
+    constexpr DecodedHTMLEntity(char16_t, char16_t, char16_t);
 
     enum ConstructNotEnoughCharactersType { ConstructNotEnoughCharacters };
     constexpr DecodedHTMLEntity(ConstructNotEnoughCharactersType);
@@ -60,12 +60,12 @@ public:
     constexpr bool failed() const { return !m_length; }
     constexpr bool notEnoughCharacters() const { return m_notEnoughCharacters; }
 
-    constexpr std::span<const UChar> span() const LIFETIME_BOUND { return std::span { m_characters }.first(m_length); }
+    constexpr std::span<const char16_t> span() const LIFETIME_BOUND { return std::span { m_characters }.first(m_length); }
 
 private:
     uint8_t m_length { 0 };
     bool m_notEnoughCharacters { false };
-    std::array<UChar, 3> m_characters;
+    std::array<char16_t, 3> m_characters;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/parser/HTMLEntitySearch.cpp
+++ b/Source/WebCore/html/parser/HTMLEntitySearch.cpp
@@ -37,9 +37,9 @@ HTMLEntitySearch::HTMLEntitySearch()
 {
 }
 
-HTMLEntitySearch::CompareResult HTMLEntitySearch::compare(const HTMLEntityTableEntry* entry, UChar nextCharacter) const
+HTMLEntitySearch::CompareResult HTMLEntitySearch::compare(const HTMLEntityTableEntry* entry, char16_t nextCharacter) const
 {
-    UChar entryNextCharacter;
+    char16_t entryNextCharacter;
     if (entry->nameLengthExcludingSemicolon < m_currentLength + 1) {
         if (!entry->nameIncludesTrailingSemicolon || entry->nameLengthExcludingSemicolon < m_currentLength)
             return Before;
@@ -51,7 +51,7 @@ HTMLEntitySearch::CompareResult HTMLEntitySearch::compare(const HTMLEntityTableE
     return entryNextCharacter < nextCharacter ? Before : After;
 }
 
-const HTMLEntityTableEntry* HTMLEntitySearch::findFirst(UChar nextCharacter) const
+const HTMLEntityTableEntry* HTMLEntitySearch::findFirst(char16_t nextCharacter) const
 {
     auto span = m_entries;
     if (span.size() == 1)
@@ -75,7 +75,7 @@ const HTMLEntityTableEntry* HTMLEntitySearch::findFirst(UChar nextCharacter) con
     return &span.back();
 }
 
-const HTMLEntityTableEntry* HTMLEntitySearch::findLast(UChar nextCharacter) const
+const HTMLEntityTableEntry* HTMLEntitySearch::findLast(char16_t nextCharacter) const
 {
     auto span = m_entries;
     if (span.size() == 1)
@@ -99,7 +99,7 @@ const HTMLEntityTableEntry* HTMLEntitySearch::findLast(UChar nextCharacter) cons
     return &span.front();
 }
 
-void HTMLEntitySearch::advance(UChar nextCharacter)
+void HTMLEntitySearch::advance(char16_t nextCharacter)
 {
     ASSERT(isEntityPrefix());
     if (!m_currentLength) {

--- a/Source/WebCore/html/parser/HTMLEntitySearch.h
+++ b/Source/WebCore/html/parser/HTMLEntitySearch.h
@@ -34,7 +34,7 @@ class HTMLEntitySearch {
 public:
     HTMLEntitySearch();
 
-    void advance(UChar);
+    void advance(char16_t);
 
     bool isEntityPrefix() const { return m_entries.data(); }
     unsigned currentLength() const { return m_currentLength; }
@@ -43,9 +43,9 @@ public:
 
 private:
     enum CompareResult { Before, Prefix, After };
-    CompareResult compare(const HTMLEntityTableEntry*, UChar) const;
-    const HTMLEntityTableEntry* findFirst(UChar) const;
-    const HTMLEntityTableEntry* findLast(UChar) const;
+    CompareResult compare(const HTMLEntityTableEntry*, char16_t) const;
+    const HTMLEntityTableEntry* findFirst(char16_t) const;
+    const HTMLEntityTableEntry* findLast(char16_t) const;
 
     void fail() { m_entries = { }; }
 

--- a/Source/WebCore/html/parser/HTMLEntityTable.h
+++ b/Source/WebCore/html/parser/HTMLEntityTable.h
@@ -45,7 +45,7 @@ struct HTMLEntityTableEntry {
 class HTMLEntityTable {
 public:
     static std::span<const HTMLEntityTableEntry> entries();
-    static std::span<const HTMLEntityTableEntry> entriesStartingWith(UChar);
+    static std::span<const HTMLEntityTableEntry> entriesStartingWith(char16_t);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/parser/HTMLMetaCharsetParser.cpp
+++ b/Source/WebCore/html/parser/HTMLMetaCharsetParser.cpp
@@ -66,7 +66,7 @@ static StringView extractCharset(StringView value)
         while (pos < length && value[pos] <= ' ')
             ++pos;
 
-        UChar quoteMark = 0;
+        char16_t quoteMark = 0;
         if (pos < length && (value[pos] == '"' || value[pos] == '\''))
             quoteMark = value[pos++];
 
@@ -120,7 +120,7 @@ PAL::TextEncoding HTMLMetaCharsetParser::encodingFromMetaAttributes(std::span<co
     }
 
     if (mode == Charset || (mode == Pragma && gotPragma))
-        return charset.trim(isASCIIWhitespace<UChar>);
+        return charset.trim(isASCIIWhitespace<char16_t>);
 
     return PAL::TextEncoding();
 }

--- a/Source/WebCore/html/parser/HTMLNameCache.h
+++ b/Source/WebCore/html/parser/HTMLNameCache.h
@@ -34,7 +34,7 @@ namespace WebCore {
 
 class HTMLNameCache {
 public:
-    ALWAYS_INLINE static QualifiedName makeAttributeQualifiedName(std::span<const UChar> string)
+    ALWAYS_INLINE static QualifiedName makeAttributeQualifiedName(std::span<const char16_t> string)
     {
         return makeQualifiedName(string);
     }
@@ -44,7 +44,7 @@ public:
         return makeQualifiedName(string);
     }
 
-    ALWAYS_INLINE static AtomString makeAttributeValue(std::span<const UChar> string)
+    ALWAYS_INLINE static AtomString makeAttributeValue(std::span<const char16_t> string)
     {
         return makeAtomString(string);
     }
@@ -100,7 +100,7 @@ private:
         return *slot;
     }
 
-    ALWAYS_INLINE static size_t slotIndex(UChar firstCharacter, UChar lastCharacter, UChar length)
+    ALWAYS_INLINE static size_t slotIndex(char16_t firstCharacter, char16_t lastCharacter, char16_t length)
     {
         unsigned hash = (firstCharacter << 6) ^ ((lastCharacter << 14) ^ firstCharacter);
         hash += (hash >> 14) + (length << 14);
@@ -108,13 +108,13 @@ private:
         return (hash + (hash >> 6)) % capacity;
     }
 
-    ALWAYS_INLINE static AtomString& atomStringCacheSlot(UChar firstCharacter, UChar lastCharacter, UChar length)
+    ALWAYS_INLINE static AtomString& atomStringCacheSlot(char16_t firstCharacter, char16_t lastCharacter, char16_t length)
     {
         auto index = slotIndex(firstCharacter, lastCharacter, length);
         return atomStringCache()[index];
     }
 
-    ALWAYS_INLINE static RefPtr<QualifiedName::QualifiedNameImpl>& qualifiedNameCacheSlot(UChar firstCharacter, UChar lastCharacter, UChar length)
+    ALWAYS_INLINE static RefPtr<QualifiedName::QualifiedNameImpl>& qualifiedNameCacheSlot(char16_t firstCharacter, char16_t lastCharacter, char16_t length)
     {
         auto index = slotIndex(firstCharacter, lastCharacter, length);
         return qualifiedNameCache()[index];

--- a/Source/WebCore/html/parser/HTMLParserIdioms.cpp
+++ b/Source/WebCore/html/parser/HTMLParserIdioms.cpp
@@ -64,7 +64,7 @@ Decimal parseToDecimalForNumberType(StringView string, const Decimal& fallbackVa
         return fallbackValue;
 
     // String::toDouble() accepts leading + and whitespace characters, which are not valid here.
-    const UChar firstCharacter = string[0];
+    const char16_t firstCharacter = string[0];
     if (firstCharacter != '-' && firstCharacter != '.' && !isASCIIDigit(firstCharacter))
         return fallbackValue;
 
@@ -93,7 +93,7 @@ double parseToDoubleForNumberType(StringView string, double fallbackValue)
         return fallbackValue;
 
     // String::toDouble() accepts leading + and whitespace characters, which are not valid here.
-    UChar firstCharacter = string[0];
+    char16_t firstCharacter = string[0];
     if (firstCharacter != '-' && firstCharacter != '.' && !isASCIIDigit(firstCharacter))
         return fallbackValue;
 
@@ -272,7 +272,7 @@ static inline bool isHTMLSpaceOrDelimiter(CharacterType character)
     return isASCIIWhitespace(character) || character == ',' || character == ';';
 }
 
-static inline bool isNumberStart(UChar character)
+static inline bool isNumberStart(char16_t character)
 {
     return isASCIIDigit(character) || character == '.' || character == '-';
 }

--- a/Source/WebCore/html/parser/HTMLParserIdioms.h
+++ b/Source/WebCore/html/parser/HTMLParserIdioms.h
@@ -35,8 +35,8 @@ class QualifiedName;
 
 template<typename CharacterType> bool isComma(CharacterType);
 template<typename CharacterType> bool isHTMLSpaceOrComma(CharacterType);
-bool isHTMLLineBreak(UChar);
-bool isHTMLSpaceButNotLineBreak(UChar);
+bool isHTMLLineBreak(char16_t);
+bool isHTMLSpaceButNotLineBreak(char16_t);
 
 // 2147483647 is 2^31 - 1.
 static const unsigned maxHTMLNonNegativeInteger = 2147483647;
@@ -94,7 +94,7 @@ std::optional<HTMLDimension> parseHTMLMultiLength(StringView);
 
 // Inline implementations of some of the functions declared above.
 
-inline bool isHTMLLineBreak(UChar character)
+inline bool isHTMLLineBreak(char16_t character)
 {
     return character <= '\r' && (character == '\n' || character == '\r');
 }
@@ -103,7 +103,7 @@ ALWAYS_INLINE bool containsHTMLLineBreak(StringView view)
 {
     if (view.is8Bit())
         return charactersContain<LChar, '\r', '\n'>(view.span8());
-    return charactersContain<UChar, '\r', '\n'>(view.span16());
+    return charactersContain<char16_t, '\r', '\n'>(view.span16());
 }
 
 template<typename CharacterType> inline bool isComma(CharacterType character)
@@ -116,7 +116,7 @@ template<typename CharacterType> inline bool isHTMLSpaceOrComma(CharacterType ch
     return isComma(character) || isASCIIWhitespace(character);
 }
 
-inline bool isHTMLSpaceButNotLineBreak(UChar character)
+inline bool isHTMLSpaceButNotLineBreak(char16_t character)
 {
     return isASCIIWhitespace(character) && !isHTMLLineBreak(character);
 }

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -202,7 +202,7 @@ private:
         if (match(attributeName, srcAttr))
             setURLToLoad(attributeValue);
         else if (match(attributeName, crossoriginAttr))
-            m_crossOriginMode = attributeValue.trim(isASCIIWhitespace<UChar>).toString();
+            m_crossOriginMode = attributeValue.trim(isASCIIWhitespace<char16_t>).toString();
         else if (match(attributeName, charsetAttr))
             m_charset = attributeValue.toString();
     }
@@ -212,7 +212,7 @@ private:
         if (match(attributeName, posterAttr))
             setURLToLoad(attributeValue);
         else if (match(attributeName, crossoriginAttr))
-            m_crossOriginMode = attributeValue.trim(isASCIIWhitespace<UChar>).toString();
+            m_crossOriginMode = attributeValue.trim(isASCIIWhitespace<char16_t>).toString();
     }
 
     void processAttribute(const AtomString& attributeName, StringView attributeValue, const Vector<bool>& pictureState)
@@ -310,7 +310,7 @@ private:
             else if (match(attributeName, charsetAttr))
                 m_charset = attributeValue.toString();
             else if (match(attributeName, crossoriginAttr))
-                m_crossOriginMode = attributeValue.trim(isASCIIWhitespace<UChar>).toString();
+                m_crossOriginMode = attributeValue.trim(isASCIIWhitespace<char16_t>).toString();
             else if (match(attributeName, nonceAttr))
                 m_nonceAttribute = attributeValue.toString();
             else if (match(attributeName, asAttr))
@@ -364,7 +364,7 @@ private:
 
     void setURLToLoadAllowingReplacement(StringView value)
     {
-        auto trimmedURL = value.trim(isASCIIWhitespace<UChar>);
+        auto trimmedURL = value.trim(isASCIIWhitespace<char16_t>);
         if (trimmedURL.isEmpty())
             return;
         m_urlToLoad = trimmedURL.toString();
@@ -489,7 +489,7 @@ void TokenPreloadScanner::scan(const HTMLToken& token, Vector<std::unique_ptr<Pr
         TagId tagId = tagIdFor(token.name());
         if (tagId == TagId::Template) {
             bool isDeclarativeShadowRoot = false;
-            static constexpr UChar shadowRootAsUChar[] = { 's', 'h', 'a', 'd', 'o', 'w', 'r', 'o', 'o', 't', 'm', 'o', 'd', 'e' };
+            static constexpr char16_t shadowRootAsUChar[] = { 's', 'h', 'a', 'd', 'o', 'w', 'r', 'o', 'o', 't', 'm', 'o', 'd', 'e' };
             const auto* shadowRootModeAttribute = findAttribute(token.attributes(), shadowRootAsUChar);
             if (shadowRootModeAttribute) {
                 String shadowRootValue(shadowRootModeAttribute->value);
@@ -535,7 +535,7 @@ void TokenPreloadScanner::scan(const HTMLToken& token, Vector<std::unique_ptr<Pr
 void TokenPreloadScanner::updatePredictedBaseURL(const HTMLToken& token, bool shouldRestrictBaseURLSchemes)
 {
     ASSERT(m_predictedBaseElementURL.isEmpty());
-    static constexpr UChar hrefAsUChar[] = { 'h', 'r', 'e', 'f' };
+    static constexpr char16_t hrefAsUChar[] = { 'h', 'r', 'e', 'f' };
     auto* hrefAttribute = findAttribute(token.attributes(), hrefAsUChar);
     if (!hrefAttribute)
         return;

--- a/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
+++ b/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
@@ -129,7 +129,7 @@ static bool parseDescriptors(Vector<StringView>& descriptors, DescriptorParsingR
         if (descriptor.isEmpty())
             continue;
         unsigned descriptorCharPosition = descriptor.length() - 1;
-        UChar descriptorChar = descriptor[descriptorCharPosition];
+        char16_t descriptorChar = descriptor[descriptorCharPosition];
         descriptor = descriptor.left(descriptorCharPosition);
         if (descriptorChar == 'x') {
             if (result.hasDensity() || result.hasHeight() || result.hasWidth())
@@ -214,7 +214,7 @@ Vector<ImageCandidate> parseImageCandidatesFromSrcsetAttribute(StringView attrib
     if (attribute.is8Bit())
         return parseImageCandidatesFromSrcsetAttribute<LChar>(attribute.span8());
     else
-        return parseImageCandidatesFromSrcsetAttribute<UChar>(attribute.span16());
+        return parseImageCandidatesFromSrcsetAttribute<char16_t>(attribute.span16());
 }
 
 void getURLsFromSrcsetAttribute(const Element& element, StringView attribute, ListHashSet<URL>& urls)

--- a/Source/WebCore/html/parser/HTMLToken.h
+++ b/Source/WebCore/html/parser/HTMLToken.h
@@ -34,8 +34,8 @@ namespace WebCore {
 struct DoctypeData {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(DoctypeData);
 public:
-    Vector<UChar> publicIdentifier;
-    Vector<UChar> systemIdentifier;
+    Vector<char16_t> publicIdentifier;
+    Vector<char16_t> systemIdentifier;
     bool hasPublicIdentifier { false };
     bool hasSystemIdentifier { false };
     bool forceQuirks { false };
@@ -55,12 +55,12 @@ public:
     };
 
     struct Attribute {
-        Vector<UChar, 32> name;
-        Vector<UChar, 64> value;
+        Vector<char16_t, 32> name;
+        Vector<char16_t, 64> value;
     };
 
     typedef Vector<Attribute, 10> AttributeList;
-    typedef Vector<UChar, 256> DataVector;
+    typedef Vector<char16_t, 256> DataVector;
 
     HTMLToken() = default;
 
@@ -76,20 +76,20 @@ public:
 
     const DataVector& name() const;
 
-    void appendToName(UChar);
+    void appendToName(char16_t);
 
     // DOCTYPE.
 
     void beginDOCTYPE();
-    void beginDOCTYPE(UChar);
+    void beginDOCTYPE(char16_t);
 
     void setForceQuirks();
 
     void setPublicIdentifierToEmptyString();
     void setSystemIdentifierToEmptyString();
 
-    void appendToPublicIdentifier(UChar);
-    void appendToSystemIdentifier(UChar);
+    void appendToPublicIdentifier(char16_t);
+    void appendToSystemIdentifier(char16_t);
 
     std::unique_ptr<DoctypeData> releaseDoctypeData();
 
@@ -104,8 +104,8 @@ public:
     void beginEndTag(const Vector<LChar, 32>&);
 
     void beginAttribute();
-    void appendToAttributeName(UChar);
-    void appendToAttributeValue(UChar);
+    void appendToAttributeName(char16_t);
+    void appendToAttributeValue(char16_t);
     void appendToAttributeValue(unsigned index, StringView value);
     template<typename CharacterType> void appendToAttributeValue(std::span<const CharacterType>);
     void endAttribute();
@@ -122,7 +122,7 @@ public:
     bool charactersIsAll8BitData() const;
 
     void appendToCharacter(LChar);
-    void appendToCharacter(UChar);
+    void appendToCharacter(char16_t);
     void appendToCharacter(const Vector<LChar, 32>&);
     template<typename CharacterType> void appendToCharacter(std::span<const CharacterType>);
 
@@ -134,11 +134,11 @@ public:
     void beginComment();
     void appendToComment(char);
     void appendToComment(ASCIILiteral);
-    void appendToComment(UChar);
+    void appendToComment(char16_t);
 
 private:
     DataVector m_data;
-    UChar m_data8BitCheck { 0 };
+    char16_t m_data8BitCheck { 0 };
     Type m_type { Type::Uninitialized };
 
     // For StartTag and EndTag
@@ -176,7 +176,7 @@ inline const HTMLToken::DataVector& HTMLToken::name() const
     return m_data;
 }
 
-inline void HTMLToken::appendToName(UChar character)
+inline void HTMLToken::appendToName(char16_t character)
 {
     ASSERT(m_type == Type::StartTag || m_type == Type::EndTag || m_type == Type::DOCTYPE);
     ASSERT(character);
@@ -197,7 +197,7 @@ inline void HTMLToken::beginDOCTYPE()
     m_doctypeData = makeUnique<DoctypeData>();
 }
 
-inline void HTMLToken::beginDOCTYPE(UChar character)
+inline void HTMLToken::beginDOCTYPE(char16_t character)
 {
     ASSERT(character);
     beginDOCTYPE();
@@ -219,7 +219,7 @@ inline void HTMLToken::setSystemIdentifierToEmptyString()
     m_doctypeData->systemIdentifier.clear();
 }
 
-inline void HTMLToken::appendToPublicIdentifier(UChar character)
+inline void HTMLToken::appendToPublicIdentifier(char16_t character)
 {
     ASSERT(character);
     ASSERT(m_type == Type::DOCTYPE);
@@ -227,7 +227,7 @@ inline void HTMLToken::appendToPublicIdentifier(UChar character)
     m_doctypeData->publicIdentifier.append(character);
 }
 
-inline void HTMLToken::appendToSystemIdentifier(UChar character)
+inline void HTMLToken::appendToSystemIdentifier(char16_t character)
 {
     ASSERT(character);
     ASSERT(m_type == Type::DOCTYPE);
@@ -310,7 +310,7 @@ inline void HTMLToken::endAttribute()
 #endif
 }
 
-inline void HTMLToken::appendToAttributeName(UChar character)
+inline void HTMLToken::appendToAttributeName(char16_t character)
 {
     ASSERT(character);
     ASSERT(m_type == Type::StartTag || m_type == Type::EndTag);
@@ -318,7 +318,7 @@ inline void HTMLToken::appendToAttributeName(UChar character)
     m_currentAttribute->name.append(character);
 }
 
-inline void HTMLToken::appendToAttributeValue(UChar character)
+inline void HTMLToken::appendToAttributeValue(char16_t character)
 {
     ASSERT(character);
     ASSERT(m_type == Type::StartTag || m_type == Type::EndTag);
@@ -366,7 +366,7 @@ inline void HTMLToken::appendToCharacter(LChar character)
     m_data.append(character);
 }
 
-inline void HTMLToken::appendToCharacter(UChar character)
+inline void HTMLToken::appendToCharacter(char16_t character)
 {
     ASSERT(m_type == Type::Uninitialized || m_type == Type::Character);
     m_type = Type::Character;
@@ -386,7 +386,7 @@ inline void HTMLToken::appendToCharacter(std::span<const CharacterType> characte
 {
     m_type = Type::Character;
     m_data.append(characters);
-    if constexpr (std::is_same_v<CharacterType, UChar>) {
+    if constexpr (std::is_same_v<CharacterType, char16_t>) {
         if (!charactersIsAll8BitData())
             return;
         for (auto character : characters)
@@ -425,7 +425,7 @@ inline void HTMLToken::appendToComment(ASCIILiteral literal)
     m_data.append(literal.span8());
 }
 
-inline void HTMLToken::appendToComment(UChar character)
+inline void HTMLToken::appendToComment(char16_t character)
 {
     ASSERT(character);
     ASSERT(m_type == Type::Comment);
@@ -433,7 +433,7 @@ inline void HTMLToken::appendToComment(UChar character)
     m_data8BitCheck |= character;
 }
 
-inline const HTMLToken::Attribute* findAttribute(const HTMLToken::AttributeList& attributes, std::span<const UChar> name)
+inline const HTMLToken::Attribute* findAttribute(const HTMLToken::AttributeList& attributes, std::span<const char16_t> name)
 {
     for (auto& attribute : attributes) {
         // FIXME: The one caller that uses this probably wants to ignore letter case.

--- a/Source/WebCore/html/parser/HTMLTokenizer.cpp
+++ b/Source/WebCore/html/parser/HTMLTokenizer.cpp
@@ -39,7 +39,7 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-static inline LChar convertASCIIAlphaToLower(UChar character)
+static inline LChar convertASCIIAlphaToLower(char16_t character)
 {
     ASSERT(isASCIIAlpha(character));
     return toASCIILowerUnchecked(character);
@@ -68,7 +68,7 @@ HTMLTokenizer::HTMLTokenizer(const HTMLParserOptions& options)
 {
 }
 
-inline void HTMLTokenizer::bufferASCIICharacter(UChar character)
+inline void HTMLTokenizer::bufferASCIICharacter(char16_t character)
 {
     ASSERT(character != kEndOfFileMarker);
     ASSERT(isASCII(character));
@@ -76,7 +76,7 @@ inline void HTMLTokenizer::bufferASCIICharacter(UChar character)
     m_token.appendToCharacter(narrowedCharacter);
 }
 
-inline void HTMLTokenizer::bufferCharacter(UChar character)
+inline void HTMLTokenizer::bufferCharacter(char16_t character)
 {
     ASSERT(character != kEndOfFileMarker);
     m_token.appendToCharacter(character);
@@ -150,7 +150,7 @@ void HTMLTokenizer::flushBufferedEndTag()
     m_temporaryBuffer.clear();
 }
 
-bool HTMLTokenizer::commitToPartialEndTag(SegmentedString& source, UChar character, State state)
+bool HTMLTokenizer::commitToPartialEndTag(SegmentedString& source, char16_t character, State state)
 {
     ASSERT(source.currentCharacter() == character);
     appendToTemporaryBuffer(character);
@@ -200,7 +200,7 @@ bool HTMLTokenizer::processToken(SegmentedString& source)
 
     if (!m_preprocessor.peek(source, isNullCharacterSkippingState(m_state)))
         return haveBufferedCharacterToken();
-    UChar character = m_preprocessor.nextInputCharacter();
+    char16_t character = m_preprocessor.nextInputCharacter();
 
     // https://html.spec.whatwg.org/#tokenization
     switch (m_state) {
@@ -1396,7 +1396,7 @@ void HTMLTokenizer::updateStateFor(const AtomString& tagName)
         m_state = RAWTEXTState;
 }
 
-inline void HTMLTokenizer::appendToTemporaryBuffer(UChar character)
+inline void HTMLTokenizer::appendToTemporaryBuffer(char16_t character)
 {
     ASSERT(isASCII(character));
     m_temporaryBuffer.append(character);
@@ -1409,7 +1409,7 @@ inline bool HTMLTokenizer::temporaryBufferIs(ASCIILiteral expectedString)
     return equal(m_temporaryBuffer.span().data(), expectedString.span8());
 }
 
-inline void HTMLTokenizer::appendToPossibleEndTag(UChar character)
+inline void HTMLTokenizer::appendToPossibleEndTag(char16_t character)
 {
     ASSERT(isASCII(character));
     m_bufferedEndTagName.append(character);

--- a/Source/WebCore/html/parser/HTMLTokenizer.h
+++ b/Source/WebCore/html/parser/HTMLTokenizer.h
@@ -157,8 +157,8 @@ private:
 
     void parseError();
 
-    void bufferASCIICharacter(UChar);
-    void bufferCharacter(UChar);
+    void bufferASCIICharacter(char16_t);
+    void bufferCharacter(char16_t);
     template<typename CharacterType> void bufferCharacters(std::span<const CharacterType>);
     void bufferCharacters(ASCIILiteral literal) { bufferCharacters(literal.span8()); }
 
@@ -168,16 +168,16 @@ private:
 
     // Return true if we wil emit a character token before dealing with the buffered end tag.
     void flushBufferedEndTag();
-    bool commitToPartialEndTag(SegmentedString&, UChar, State);
+    bool commitToPartialEndTag(SegmentedString&, char16_t, State);
     bool commitToCompleteEndTag(SegmentedString&);
 
-    void appendToTemporaryBuffer(UChar);
+    void appendToTemporaryBuffer(char16_t);
     bool temporaryBufferIs(ASCIILiteral);
 
     // Sometimes we speculatively consume input characters and we don't know whether they represent
     // end tags or RCDATA, etc. These functions help manage these state.
     bool inEndTagBufferingState() const;
-    void appendToPossibleEndTag(UChar);
+    void appendToPossibleEndTag(char16_t);
     void saveEndTagNameIfNeeded();
     bool isAppropriateEndTag() const;
 
@@ -192,12 +192,12 @@ private:
     mutable HTMLToken m_token;
 
     // https://html.spec.whatwg.org/#additional-allowed-character
-    UChar m_additionalAllowedCharacter { 0 };
+    char16_t m_additionalAllowedCharacter { 0 };
 
     // https://html.spec.whatwg.org/#preprocessing-the-input-stream
     InputStreamPreprocessor<HTMLTokenizer> m_preprocessor;
 
-    Vector<UChar, 32> m_appropriateEndTagName;
+    Vector<char16_t, 32> m_appropriateEndTagName;
 
     // https://html.spec.whatwg.org/#temporary-buffer
     Vector<LChar, 32> m_temporaryBuffer;

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -82,7 +82,7 @@ CustomElementConstructionData::~CustomElementConstructionData() = default;
 
 namespace {
 
-inline bool isASCIIWhitespaceOrReplacementCharacter(UChar character)
+inline bool isASCIIWhitespaceOrReplacementCharacter(char16_t character)
 {
     return isASCIIWhitespace(character) || character == replacementCharacter;
 }
@@ -202,7 +202,7 @@ public:
         ASSERT(!isEmpty());
         Vector<LChar, 8> whitespace;
         do {
-            UChar character = m_text[0];
+            char16_t character = m_text[0];
             if (isASCIIWhitespace(character))
                 whitespace.append(character);
             m_text = m_text.substring(1);
@@ -218,7 +218,7 @@ public:
     }
 
 private:
-    template<bool characterPredicate(UChar)> void skipLeading()
+    template<bool characterPredicate(char16_t)> void skipLeading()
     {
         ASSERT(!isEmpty());
         while (characterPredicate(m_text[0])) {
@@ -228,7 +228,7 @@ private:
         }
     }
 
-    template<bool characterPredicate(UChar)> String takeLeading()
+    template<bool characterPredicate(char16_t)> String takeLeading()
     {
         ASSERT(!isEmpty());
         StringView start = m_text;

--- a/Source/WebCore/html/parser/InputStreamPreprocessor.h
+++ b/Source/WebCore/html/parser/InputStreamPreprocessor.h
@@ -41,7 +41,7 @@ public:
     {
     }
 
-    ALWAYS_INLINE UChar nextInputCharacter() const { return m_nextInputCharacter; }
+    ALWAYS_INLINE char16_t nextInputCharacter() const { return m_nextInputCharacter; }
 
     // Returns whether we succeeded in peeking at the next character.
     // The only way we can fail to peek is if there are no more
@@ -57,7 +57,7 @@ public:
         // fast-reject branch for characters that don't require special
         // handling. Please run the parser benchmark whenever you touch
         // this function. It's very hot.
-        constexpr UChar specialCharacterMask = '\n' | '\r' | '\0';
+        constexpr char16_t specialCharacterMask = '\n' | '\r' | '\0';
         if (m_nextInputCharacter & ~specialCharacterMask) [[likely]] {
             m_skipNextNewLine = false;
             return true;
@@ -117,7 +117,7 @@ private:
     Tokenizer& m_tokenizer;
 
     // http://www.whatwg.org/specs/web-apps/current-work/#next-input-character
-    UChar m_nextInputCharacter { 0 };
+    char16_t m_nextInputCharacter { 0 };
     bool m_skipNextNewLine { false };
 };
 

--- a/Source/WebCore/html/parser/create-html-entity-table
+++ b/Source/WebCore/html/parser/create-html-entity-table
@@ -194,7 +194,7 @@ std::span<const char> HTMLEntityTableEntry::nameCharacters() const
     return staticEntityStringStorage.span().subspan(nameCharactersOffset);
 }
 
-std::span<const HTMLEntityTableEntry> HTMLEntityTable::entriesStartingWith(UChar c)
+std::span<const HTMLEntityTableEntry> HTMLEntityTable::entriesStartingWith(char16_t c)
 {
     if (c >= 'A' && c <= 'Z') {
         auto* start = &staticEntityTable[uppercaseOffset[c - 'A']];

--- a/Source/WebCore/html/shadow/DateTimeNumericFieldElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeNumericFieldElement.cpp
@@ -168,7 +168,7 @@ void DateTimeNumericFieldElement::handleKeyboardEvent(KeyboardEvent& keyboardEve
     if (keyboardEvent.type() != eventNames().keypressEvent)
         return;
 
-    auto charCode = static_cast<UChar>(keyboardEvent.charCode());
+    auto charCode = static_cast<char16_t>(keyboardEvent.charCode());
     String number = localeForOwner().convertFromLocalizedNumber(span(charCode));
     int digit = number[0] - '0';
     if (digit < 0 || digit > 9)

--- a/Source/WebCore/html/track/BufferedLineReader.cpp
+++ b/Source/WebCore/html/track/BufferedLineReader.cpp
@@ -53,7 +53,7 @@ std::optional<String> BufferedLineReader::nextLine()
     bool shouldReturnLine = false;
     bool checkForLF = false;
     while (!m_buffer.isEmpty()) {
-        UChar character = m_buffer.currentCharacter();
+        char16_t character = m_buffer.currentCharacter();
         m_buffer.advance();
 
         if (character == newlineCharacter || character == carriageReturn) {

--- a/Source/WebCore/html/track/TrackBase.cpp
+++ b/Source/WebCore/html/track/TrackBase.cpp
@@ -122,12 +122,12 @@ static bool isValidBCP47LanguageTag(const String& languageTag)
     if (length < 2 || length > 100)
         return false;
 
-    UChar firstChar = languageTag[0];
+    char16_t firstChar = languageTag[0];
 
     if (!isASCIIAlpha(firstChar))
         return false;
 
-    UChar secondChar = languageTag[1];
+    char16_t secondChar = languageTag[1];
 
     if (length == 2)
         return isASCIIAlpha(secondChar);
@@ -155,7 +155,7 @@ static bool isValidBCP47LanguageTag(const String& languageTag)
         nextCharIndexToCheck = 2;
 
     for (; nextCharIndexToCheck < length; ++nextCharIndexToCheck) {
-        UChar c = languageTag[nextCharIndexToCheck];
+        char16_t c = languageTag[nextCharIndexToCheck];
         if (isASCIIAlphanumeric(c) || c == '-')
             continue;
         return false;
@@ -178,7 +178,7 @@ void TrackBase::setLanguage(const AtomString& language)
         return;
 
     String message;
-    if (language.contains((UChar)'\0'))
+    if (language.contains((char16_t)'\0'))
         message = "The language contains a null character and is not a valid BCP 47 language tag."_s;
     else
         message = makeString("The language '"_s, language, "' is not a valid BCP 47 language tag."_s);

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -644,7 +644,7 @@ int VTTCue::calculateComputedLinePosition() const
     return n;
 }
 
-static bool isCueParagraphSeparator(UChar character)
+static bool isCueParagraphSeparator(char16_t character)
 {
     // Within a cue, paragraph boundaries are only denoted by Type B characters,
     // such as U+000A LINE FEED (LF), U+0085 NEXT LINE (NEL), and U+2029 PARAGRAPH SEPARATOR.
@@ -676,11 +676,11 @@ void VTTCue::determineTextDirection()
         return;
 
     for (size_t i = 0; i < paragraph.length(); ++i) {
-        UChar current = paragraph[i];
+        char16_t current = paragraph[i];
         if (!current || isCueParagraphSeparator(current))
             return;
 
-        if (UChar current = paragraph[i]) {
+        if (char16_t current = paragraph[i]) {
             UCharDirection charDirection = u_charDirection(current);
             if (charDirection == U_LEFT_TO_RIGHT) {
                 m_displayDirection = CSSValueLtr;

--- a/Source/WebCore/html/track/VTTRegion.cpp
+++ b/Source/WebCore/html/track/VTTRegion.cpp
@@ -146,8 +146,8 @@ void VTTRegion::setRegionSettings(const String& inputString)
 
     while (!input.isAtEnd()) {
         // Step 1 - Split input on spaces.
-        input.skipWhile<isASCIIWhitespace<UChar>>();
-        VTTScanner::Run valueRun = input.collectUntil<isASCIIWhitespace<UChar>>();
+        input.skipWhile<isASCIIWhitespace<char16_t>>();
+        VTTScanner::Run valueRun = input.collectUntil<isASCIIWhitespace<char16_t>>();
         auto settingValue = input.extractString(valueRun);
         VTTScanner setting(settingValue);
 
@@ -188,7 +188,7 @@ static inline bool parsedEntireRun(const VTTScanner& input, const VTTScanner::Ru
 
 void VTTRegion::parseSettingValue(RegionSetting setting, VTTScanner& input)
 {
-    VTTScanner::Run valueRun = input.collectUntil<isASCIIWhitespace<UChar>>();
+    VTTScanner::Run valueRun = input.collectUntil<isASCIIWhitespace<char16_t>>();
 
     switch (setting) {
     case Id: {

--- a/Source/WebCore/html/track/VTTScanner.cpp
+++ b/Source/WebCore/html/track/VTTScanner.cpp
@@ -184,8 +184,8 @@ auto VTTScanner::createRun(Position start, Position end) const -> Run
         return Run { span8.subspan(start8 - span8.data(), end8 - start8) };
     }
     auto span16 = m_source.span16();
-    auto* start16 = static_cast<const UChar*>(start);
-    auto* end16 = static_cast<const UChar*>(end);
+    auto* start16 = static_cast<const char16_t*>(start);
+    auto* end16 = static_cast<const char16_t*>(end);
     RELEASE_ASSERT(start16 >= span16.data());
     return Run { span16.subspan(start16 - span16.data(), end16 - start16) };
 }

--- a/Source/WebCore/html/track/VTTScanner.h
+++ b/Source/WebCore/html/track/VTTScanner.h
@@ -60,14 +60,14 @@ public:
             m_data.characters8 = data;
         }
 
-        explicit Run(std::span<const UChar> data)
+        explicit Run(std::span<const char16_t> data)
             : m_is8Bit(false)
         {
             m_data.characters16 = data;
         }
 
         std::span<const LChar> span8() const { RELEASE_ASSERT(m_is8Bit); return m_data.characters8; }
-        std::span<const UChar> span16() const { RELEASE_ASSERT(!m_is8Bit); return m_data.characters16; }
+        std::span<const char16_t> span16() const { RELEASE_ASSERT(!m_is8Bit); return m_data.characters16; }
 
         Position start() const
         {
@@ -91,7 +91,7 @@ public:
                 : characters8()
             { }
             std::span<const LChar> characters8;
-            std::span<const UChar> characters16;
+            std::span<const char16_t> characters16;
         } m_data;
         bool m_is8Bit;
     };
@@ -110,21 +110,21 @@ public:
     // Skip (advance the input pointer) as long as the specified
     // |characterPredicate| returns true, and the input pointer is not passed
     // the end of the input.
-    template<bool characterPredicate(UChar)>
+    template<bool characterPredicate(char16_t)>
     void skipWhile();
 
     // Like skipWhile, but using a negated predicate.
-    template<bool characterPredicate(UChar)>
+    template<bool characterPredicate(char16_t)>
     void skipUntil();
 
     // Return the run of characters for which the specified
     // |characterPredicate| returns true. The start of the run will be the
     // current input pointer.
-    template<bool characterPredicate(UChar)>
+    template<bool characterPredicate(char16_t)>
     Run collectWhile();
 
     // Like collectWhile, but using a negated predicate.
-    template<bool characterPredicate(UChar)>
+    template<bool characterPredicate(char16_t)>
     Run collectUntil();
 
     // Scan the string |toMatch|, using the specified |run| as the sequence to
@@ -166,20 +166,20 @@ protected:
         return std::to_address(m_data.characters16.end());
     }
     void seekTo(Position);
-    UChar currentChar() const;
+    char16_t currentChar() const;
     void advance(size_t amount = 1);
     union Characters {
         Characters()
             : characters8()
         { }
         std::span<const LChar> characters8;
-        std::span<const UChar> characters16;
+        std::span<const char16_t> characters16;
     } m_data;
     const String m_source;
     bool m_is8Bit;
 };
 
-template<bool characterPredicate(UChar)>
+template<bool characterPredicate(char16_t)>
 inline void VTTScanner::skipWhile()
 {
     if (m_is8Bit)
@@ -188,7 +188,7 @@ inline void VTTScanner::skipWhile()
         WTF::skipWhile<characterPredicate>(m_data.characters16);
 }
 
-template<bool characterPredicate(UChar)>
+template<bool characterPredicate(char16_t)>
 inline void VTTScanner::skipUntil()
 {
     if (m_is8Bit)
@@ -197,7 +197,7 @@ inline void VTTScanner::skipUntil()
         WTF::skipUntil<characterPredicate>(m_data.characters16);
 }
 
-template<bool characterPredicate(UChar)>
+template<bool characterPredicate(char16_t)>
 inline VTTScanner::Run VTTScanner::collectWhile()
 {
     if (m_is8Bit) {
@@ -210,7 +210,7 @@ inline VTTScanner::Run VTTScanner::collectWhile()
     return Run { m_data.characters16.first(current.data() - m_data.characters16.data()) };
 }
 
-template<bool characterPredicate(UChar)>
+template<bool characterPredicate(char16_t)>
 inline VTTScanner::Run VTTScanner::collectUntil()
 {
     if (m_is8Bit) {
@@ -232,13 +232,13 @@ inline void VTTScanner::seekTo(Position position)
         m_data.characters8 = span8.subspan(position8 - span8.data());
     } else {
         auto span16 = m_source.span16();
-        auto* position16 = static_cast<const UChar*>(position);
+        auto* position16 = static_cast<const char16_t*>(position);
         RELEASE_ASSERT(position16 >= span16.data());
         m_data.characters16 = span16.subspan(position16 - span16.data());
     }
 }
 
-inline UChar VTTScanner::currentChar() const
+inline char16_t VTTScanner::currentChar() const
 {
     return m_is8Bit ? m_data.characters8.front() : m_data.characters16.front();
 }

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -438,25 +438,25 @@ WebVTTParser::ParseState WebVTTParser::collectTimingsAndSettings(const String& l
 
     // Collect WebVTT cue timings and settings. (5.3 WebVTT cue timings and settings parsing.)
     // Steps 1 - 3 - Let input be the string being parsed and position be a pointer into input
-    input.skipWhile<isASCIIWhitespace<UChar>>();
+    input.skipWhile<isASCIIWhitespace<char16_t>>();
 
     // Steps 4 - 5 - Collect a WebVTT timestamp. If that fails, then abort and return failure. Otherwise, let cue's text track cue start time be the collected time.
     if (!collectTimeStamp(input, m_currentStartTime))
         return BadCue;
     
-    input.skipWhile<isASCIIWhitespace<UChar>>();
+    input.skipWhile<isASCIIWhitespace<char16_t>>();
 
     // Steps 6 - 9 - If the next three characters are not "-->", abort and return failure.
     if (!input.scan("-->"_span8))
         return BadCue;
     
-    input.skipWhile<isASCIIWhitespace<UChar>>();
+    input.skipWhile<isASCIIWhitespace<char16_t>>();
 
     // Steps 10 - 11 - Collect a WebVTT timestamp. If that fails, then abort and return failure. Otherwise, let cue's text track cue end time be the collected time.
     if (!collectTimeStamp(input, m_currentEndTime))
         return BadCue;
 
-    input.skipWhile<isASCIIWhitespace<UChar>>();
+    input.skipWhile<isASCIIWhitespace<char16_t>>();
 
     // Step 12 - Parse the WebVTT settings for the cue (conducted in TextTrackCue).
     m_currentSettings = input.restOfInputAsString();

--- a/Source/WebCore/html/track/WebVTTTokenizer.cpp
+++ b/Source/WebCore/html/track/WebVTTTokenizer.cpp
@@ -86,7 +86,7 @@ WebVTTTokenizer::WebVTTTokenizer(const String& input)
     m_input.close();
 }
 
-static void ProcessEntity(SegmentedString& source, StringBuilder& result, UChar additionalAllowedCharacter = 0)
+static void ProcessEntity(SegmentedString& source, StringBuilder& result, char16_t additionalAllowedCharacter = 0)
 {
     auto decoded = consumeHTMLEntity(source, additionalAllowedCharacter);
     if (decoded.failed() || decoded.notEnoughCharacters())
@@ -102,7 +102,7 @@ bool WebVTTTokenizer::nextToken(WebVTTToken& token)
     if (m_input.isEmpty() || !m_preprocessor.peek(m_input))
         return false;
 
-    UChar character = m_preprocessor.nextInputCharacter();
+    char16_t character = m_preprocessor.nextInputCharacter();
     if (character == kEndOfFileMarker) {
         m_preprocessor.advance(m_input);
         return false;

--- a/Source/WebCore/inspector/InspectorOverlayLabel.cpp
+++ b/Source/WebCore/inspector/InspectorOverlayLabel.cpp
@@ -210,7 +210,7 @@ struct ComputedContentRun {
 
 Path InspectorOverlayLabel::draw(GraphicsContext& context, float maximumLineWidth)
 {
-    constexpr UChar ellipsis = 0x2026;
+    constexpr char16_t ellipsis = 0x2026;
 
     auto font = systemFont();
     float lineHeight = font.metricsOfPrimaryFont().height();

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -362,7 +362,7 @@ void StyleSheetHandler::endRuleHeader(unsigned offset)
     if (m_parsedText.is8Bit())
         setRuleHeaderEnd<LChar>(m_parsedText.span8().first(offset));
     else
-        setRuleHeaderEnd<UChar>(m_parsedText.span16().first(offset));
+        setRuleHeaderEnd<char16_t>(m_parsedText.span16().first(offset));
 }
 
 void StyleSheetHandler::observeSelector(unsigned startOffset, unsigned endOffset)
@@ -486,7 +486,7 @@ void StyleSheetHandler::fixUnparsedPropertyRanges(CSSRuleSourceData* ruleData)
         return;
     }
     
-    fixUnparsedProperties<UChar>(m_parsedText.span16(), ruleData);
+    fixUnparsedProperties<char16_t>(m_parsedText.span16(), ruleData);
 }
 
 void StyleSheetHandler::observeProperty(unsigned startOffset, unsigned endOffset, bool isImportant, bool isParsed)
@@ -1472,7 +1472,7 @@ Ref<Inspector::Protocol::CSS::CSSStyle> InspectorStyleSheet::buildObjectForStyle
     return result;
 }
 
-static inline bool isNotSpaceOrTab(UChar character)
+static inline bool isNotSpaceOrTab(char16_t character)
 {
     return character != ' ' && character != '\t';
 }

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -147,7 +147,7 @@ using namespace Inspector;
 using namespace HTMLNames;
 
 static const size_t maxTextSize = 10000;
-static const UChar horizontalEllipsisUChar[] = { horizontalEllipsis, 0 };
+static const char16_t horizontalEllipsisUChar[] = { horizontalEllipsis, 0 };
 
 static std::optional<Color> parseColor(RefPtr<JSON::Object>&& colorObject)
 {

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -389,10 +389,10 @@ bool TextUtil::mayBreakInBetween(String previousContent, const RenderStyle& prev
     auto lineBreakIteratorFactory = CachedLineBreakIteratorFactory { nextContent, nextContentStyle.computedLocale(), TextUtil::lineBreakIteratorMode(nextContentStyle.lineBreak()), TextUtil::contentAnalysis(nextContentStyle.wordBreak()) };
     auto previousContentLength = previousContent.length();
     // FIXME: We should look into the entire uncommitted content for more text context.
-    UChar lastCharacter = previousContentLength ? previousContent[previousContentLength - 1] : 0;
+    char16_t lastCharacter = previousContentLength ? previousContent[previousContentLength - 1] : 0;
     if (lastCharacter == softHyphen && previousContentStyle.hyphens() == Hyphens::None)
         return false;
-    UChar secondToLastCharacter = previousContentLength > 1 ? previousContent[previousContentLength - 2] : 0;
+    char16_t secondToLastCharacter = previousContentLength > 1 ? previousContent[previousContentLength - 2] : 0;
     lineBreakIteratorFactory.priorContext().set({ secondToLastCharacter, lastCharacter });
     // Now check if we can break right at the inline item boundary.
     // With the [ex-ample], findNextBreakablePosition should return the startPosition (0).
@@ -732,7 +732,7 @@ bool TextUtil::hasPositionDependentContentWidth(StringView textContent)
 {
     if (textContent.is8Bit())
         return charactersContain<LChar, tabCharacter>(textContent.span8());
-    return charactersContain<UChar, tabCharacter>(textContent.span16());
+    return charactersContain<char16_t, tabCharacter>(textContent.span16());
 }
 
 char32_t TextUtil::lastBaseCharacterFromText(StringView string)

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
@@ -216,7 +216,7 @@ static void printTextForSubtree(const RenderElement& renderer, size_t& character
     for (auto& child : childrenOfType<RenderObject>(downcast<RenderElement>(renderer))) {
         if (is<RenderText>(child)) {
             auto text = downcast<RenderText>(child).text();
-            auto textView = StringView { text }.trim(isASCIIWhitespace<UChar>);
+            auto textView = StringView { text }.trim(isASCIIWhitespace<char16_t>);
             auto length = std::min<size_t>(charactersLeft, textView.length());
             stream << textView.left(length);
             charactersLeft -= length;

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -802,7 +802,7 @@ static AtomString extractContentLanguageFromHeader(const String& header)
     auto commaIndex = header.find(',');
     if (commaIndex == notFound)
         return AtomString { header.trim(isASCIIWhitespace) };
-    return StringView(header).left(commaIndex).trim(isASCIIWhitespace<UChar>).toAtomString();
+    return StringView(header).left(commaIndex).trim(isASCIIWhitespace<char16_t>).toAtomString();
 }
 
 void FrameLoader::didBeginDocument(bool dispatch, LocalDOMWindow* previousWindow)

--- a/Source/WebCore/loader/HTTPHeaderField.cpp
+++ b/Source/WebCore/loader/HTTPHeaderField.cpp
@@ -32,8 +32,8 @@ namespace WebCore {
 
 std::optional<HTTPHeaderField> HTTPHeaderField::create(String&& unparsedName, String&& unparsedValue)
 {
-    auto trimmedName = StringView(unparsedName).trim(isTabOrSpace<UChar>);
-    auto trimmedValue = StringView(unparsedValue).trim(isTabOrSpace<UChar>);
+    auto trimmedName = StringView(unparsedName).trim(isTabOrSpace<char16_t>);
+    auto trimmedValue = StringView(unparsedValue).trim(isTabOrSpace<char16_t>);
     if (!RFC7230::isValidName(trimmedName) || !RFC7230::isValidValue(trimmedValue))
         return std::nullopt;
 

--- a/Source/WebCore/loader/HeaderFieldTokenizer.cpp
+++ b/Source/WebCore/loader/HeaderFieldTokenizer.cpp
@@ -38,7 +38,7 @@ HeaderFieldTokenizer::HeaderFieldTokenizer(const String& headerField)
     skipSpaces();
 }
 
-bool HeaderFieldTokenizer::consume(UChar c)
+bool HeaderFieldTokenizer::consume(char16_t c)
 {
     ASSERT(!isTabOrSpace(c));
 
@@ -106,7 +106,7 @@ void HeaderFieldTokenizer::skipSpaces()
         ++m_index;
 }
 
-void HeaderFieldTokenizer::consumeBeforeAnyCharMatch(const Vector<UChar>& chars)
+void HeaderFieldTokenizer::consumeBeforeAnyCharMatch(const Vector<char16_t>& chars)
 {
     ASSERT(chars.size() > 0U && chars.size() < 3U);
 

--- a/Source/WebCore/loader/HeaderFieldTokenizer.h
+++ b/Source/WebCore/loader/HeaderFieldTokenizer.h
@@ -41,7 +41,7 @@ public:
     // string from the |header_field| input. Return |true| on success. Return
     // |false| if the separator character, the token or the quoted string is
     // missing or invalid.
-    bool consume(UChar);
+    bool consume(char16_t);
     String consumeToken();
     String consumeTokenOrQuotedString();
 
@@ -49,7 +49,7 @@ public:
     // the Vector parameter are found.
     // Because we potentially have to iterate through the entire Vector for each
     // character of the base string, the Vector should be small (< 3 members).
-    void consumeBeforeAnyCharMatch(const Vector<UChar>&);
+    void consumeBeforeAnyCharMatch(const Vector<char16_t>&);
 
     bool isConsumed() const { return m_index >= m_input.length(); }
 

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -219,7 +219,7 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
     // Do not load any image if the 'src' attribute is missing or if it is
     // an empty string.
     CachedResourceHandle<CachedImage> newImage;
-    if (!attr.isNull() && !StringView(attr).containsOnly<isASCIIWhitespace<UChar>>()) {
+    if (!attr.isNull() && !StringView(attr).containsOnly<isASCIIWhitespace<char16_t>>()) {
         ResourceLoaderOptions options = CachedResourceLoader::defaultCachedResourceOptions();
         options.contentSecurityPolicyImposition = element->isInUserAgentShadowTree() ? ContentSecurityPolicyImposition::SkipPolicyCheck : ContentSecurityPolicyImposition::DoPolicyCheck;
         options.loadedFromPluginElement = is<HTMLPlugInElement>(element) ? LoadedFromPluginElement::Yes : LoadedFromPluginElement::No;
@@ -589,7 +589,7 @@ void ImageLoader::decode(Ref<DeferredPromise>&& promise)
     }
 
     auto attr = protectedElement()->imageSourceURL();
-    if (StringView(attr).containsOnly<isASCIIWhitespace<UChar>>()) {
+    if (StringView(attr).containsOnly<isASCIIWhitespace<char16_t>>()) {
         rejectDecodePromises("Missing source URL."_s);
         return;
     }

--- a/Source/WebCore/loader/ResourceCryptographicDigest.cpp
+++ b/Source/WebCore/loader/ResourceCryptographicDigest.cpp
@@ -80,7 +80,7 @@ template<typename CharacterType> static std::optional<ResourceCryptographicDiges
     return std::nullopt;
 }
 
-std::optional<ResourceCryptographicDigest> parseCryptographicDigest(StringParsingBuffer<UChar>& buffer)
+std::optional<ResourceCryptographicDigest> parseCryptographicDigest(StringParsingBuffer<char16_t>& buffer)
 {
     return parseCryptographicDigestImpl(buffer);
 }
@@ -113,7 +113,7 @@ template<typename CharacterType> static std::optional<EncodedResourceCryptograph
     return EncodedResourceCryptographicDigest { *algorithm, beginHashValue.first(buffer.position() - beginHashValue.data()) };
 }
 
-std::optional<EncodedResourceCryptographicDigest> parseEncodedCryptographicDigest(StringParsingBuffer<UChar>& buffer)
+std::optional<EncodedResourceCryptographicDigest> parseEncodedCryptographicDigest(StringParsingBuffer<char16_t>& buffer)
 {
     return parseEncodedCryptographicDigestImpl(buffer);
 }

--- a/Source/WebCore/loader/ResourceCryptographicDigest.h
+++ b/Source/WebCore/loader/ResourceCryptographicDigest.h
@@ -66,10 +66,10 @@ struct EncodedResourceCryptographicDigest {
     String digest;
 };
 
-std::optional<ResourceCryptographicDigest> parseCryptographicDigest(StringParsingBuffer<UChar>&);
+std::optional<ResourceCryptographicDigest> parseCryptographicDigest(StringParsingBuffer<char16_t>&);
 std::optional<ResourceCryptographicDigest> parseCryptographicDigest(StringParsingBuffer<LChar>&);
 
-std::optional<EncodedResourceCryptographicDigest> parseEncodedCryptographicDigest(StringParsingBuffer<UChar>&);
+std::optional<EncodedResourceCryptographicDigest> parseEncodedCryptographicDigest(StringParsingBuffer<char16_t>&);
 std::optional<EncodedResourceCryptographicDigest> parseEncodedCryptographicDigest(StringParsingBuffer<LChar>&);
 
 std::optional<ResourceCryptographicDigest> decodeEncodedResourceCryptographicDigest(const EncodedResourceCryptographicDigest&);

--- a/Source/WebCore/loader/TextResourceDecoder.cpp
+++ b/Source/WebCore/loader/TextResourceDecoder.cpp
@@ -41,8 +41,8 @@ namespace WebCore {
 using namespace HTMLNames;
 
 // You might think we should put these find functions elsewhere, perhaps with the
-// similar functions that operate on UChar, but arguably only the decoder has
-// a reason to process strings of char rather than UChar.
+// similar functions that operate on char16_t, but arguably only the decoder has
+// a reason to process strings of char rather than char16_t.
 
 static size_t find(std::span<const uint8_t> subject, std::span<const uint8_t> target)
 {

--- a/Source/WebCore/loader/appcache/ApplicationCacheResource.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheResource.cpp
@@ -71,14 +71,14 @@ int64_t ApplicationCacheResource::estimatedSizeInStorage()
     m_estimatedSizeInStorage = data().size();
 
     for (const auto& headerField : response().httpHeaderFields())
-        m_estimatedSizeInStorage += (headerField.key.length() + headerField.value.length() + 2) * sizeof(UChar);
+        m_estimatedSizeInStorage += (headerField.key.length() + headerField.value.length() + 2) * sizeof(char16_t);
 
-    m_estimatedSizeInStorage += url().string().length() * sizeof(UChar);
+    m_estimatedSizeInStorage += url().string().length() * sizeof(char16_t);
     m_estimatedSizeInStorage += sizeof(int); // response().m_httpStatusCode
-    m_estimatedSizeInStorage += response().url().string().length() * sizeof(UChar);
+    m_estimatedSizeInStorage += response().url().string().length() * sizeof(char16_t);
     m_estimatedSizeInStorage += sizeof(unsigned); // dataId
-    m_estimatedSizeInStorage += response().mimeType().length() * sizeof(UChar);
-    m_estimatedSizeInStorage += response().textEncodingName().length() * sizeof(UChar);
+    m_estimatedSizeInStorage += response().mimeType().length() * sizeof(char16_t);
+    m_estimatedSizeInStorage += response().textEncodingName().length() * sizeof(char16_t);
 
     return m_estimatedSizeInStorage;
 }

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -87,7 +87,7 @@ static const CFStringRef LegacyWebArchiveResourceTextEncodingNameKey = CFSTR("We
 static const CFStringRef LegacyWebArchiveResourceResponseKey = CFSTR("WebResourceResponse");
 static const CFStringRef LegacyWebArchiveResourceResponseVersionKey = CFSTR("WebResourceResponseVersion");
 
-static bool isUnreservedURICharacter(UChar character)
+static bool isUnreservedURICharacter(char16_t character)
 {
     return isASCIIAlphanumeric(character) || character == '-' || character == '.' || character == '_' || character == '~';
 }
@@ -105,7 +105,7 @@ static String getFileNameFromURIComponent(StringView input)
     StringBuilder result;
     result.reserveCapacity(length);
     for (unsigned index = 0; index < length; ++index) {
-        UChar character = decodedInput->characterAt(index);
+        char16_t character = decodedInput->characterAt(index);
         if (isUnreservedURICharacter(character)) {
             result.append(character);
             continue;

--- a/Source/WebCore/mathml/MathMLPresentationElement.cpp
+++ b/Source/WebCore/mathml/MathMLPresentationElement.cpp
@@ -91,12 +91,12 @@ MathMLElement::Length MathMLPresentationElement::parseNumberAndUnit(StringView s
 {
     LengthType lengthType = LengthType::UnitLess;
     unsigned stringLength = string.length();
-    UChar lastChar = string[stringLength - 1];
+    char16_t lastChar = string[stringLength - 1];
     if (lastChar == '%') {
         lengthType = LengthType::Percentage;
         stringLength--;
     } else if (stringLength >= 2) {
-        UChar penultimateChar = string[stringLength - 2];
+        char16_t penultimateChar = string[stringLength - 2];
         if (penultimateChar == 'c' && lastChar == 'm')
             lengthType = LengthType::Cm;
         if (penultimateChar == 'e' && lastChar == 'm')
@@ -184,13 +184,13 @@ MathMLElement::Length MathMLPresentationElement::parseMathMLLength(const String&
 
     // We first skip whitespace from both ends of the string.
     StringView stringView = string;
-    StringView trimmedLength = stringView.trim(isASCIIWhitespaceWithoutFF<UChar>);
+    StringView trimmedLength = stringView.trim(isASCIIWhitespaceWithoutFF<char16_t>);
 
     if (trimmedLength.isEmpty())
         return Length();
 
     // We consider the most typical case: a number followed by an optional unit.
-    UChar firstChar = trimmedLength[0];
+    char16_t firstChar = trimmedLength[0];
     if (isASCIIDigit(firstChar) || firstChar == '-' || firstChar == '.')
         return parseNumberAndUnit(trimmedLength, acceptLegacyMathMLLengths);
 

--- a/Source/WebCore/mathml/MathMLTokenElement.cpp
+++ b/Source/WebCore/mathml/MathMLTokenElement.cpp
@@ -81,7 +81,7 @@ bool MathMLTokenElement::childShouldCreateRenderer(const Node& child) const
 
 std::optional<char32_t> MathMLTokenElement::convertToSingleCodePoint(StringView string)
 {
-    auto codePoints = string.trim(isASCIIWhitespaceWithoutFF<UChar>).codePoints();
+    auto codePoints = string.trim(isASCIIWhitespaceWithoutFF<char16_t>).codePoints();
     auto iterator = codePoints.begin();
     if (iterator == codePoints.end())
         return std::nullopt;

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -284,7 +284,7 @@ static void openNewWindow(const URL& urlToLoad, LocalFrame& frame, Event* event,
 
 #if PLATFORM(GTK)
 
-static void insertUnicodeCharacter(UChar character, LocalFrame& frame)
+static void insertUnicodeCharacter(char16_t character, LocalFrame& frame)
 {
     String text(span(character));
     if (!frame.protectedEditor()->shouldInsertText(text, frame.selection().selection().toNormalizedRange(), EditorInsertAction::Typed))

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -3889,7 +3889,7 @@ bool EventHandler::isKeyEventAllowedInFullScreen(const PlatformKeyboardEvent& ke
     if (keyEvent.type() == PlatformKeyboardEvent::Type::Char) {
         if (keyEvent.text().length() != 1)
             return false;
-        UChar character = keyEvent.text()[0];
+        char16_t character = keyEvent.text()[0];
         return character == ' ';
     }
 

--- a/Source/WebCore/page/EventSource.cpp
+++ b/Source/WebCore/page/EventSource.cpp
@@ -384,7 +384,7 @@ void EventSource::parseEventStreamLine(unsigned position, std::optional<unsigned
         m_eventName = m_receiveBuffer.subspan(position, valueLength);
     else if (field == "id"_s) {
         StringView parsedEventId = m_receiveBuffer.subspan(position, valueLength);
-        constexpr UChar nullCharacter = '\0';
+        constexpr char16_t nullCharacter = '\0';
         if (!parsedEventId.contains(nullCharacter))
             m_currentlyParsedEventId = parsedEventId.toString();
     } else if (field == "retry"_s) {

--- a/Source/WebCore/page/EventSource.h
+++ b/Source/WebCore/page/EventSource.h
@@ -118,7 +118,7 @@ private:
     const Ref<TextResourceDecoder> m_decoder;
     RefPtr<ThreadableLoader> m_loader;
     EventLoopTimerHandle m_connectTimer;
-    Vector<UChar> m_receiveBuffer;
+    Vector<char16_t> m_receiveBuffer;
     bool m_discardTrailingNewline { false };
     bool m_requestInFlight { false };
     bool m_isSuspendedForBackForwardCache { false };
@@ -126,7 +126,7 @@ private:
     bool m_shouldReconnectOnResume { false };
 
     AtomString m_eventName;
-    Vector<UChar> m_data;
+    Vector<char16_t> m_data;
     String m_currentlyParsedEventId;
     String m_lastEventId;
     uint64_t m_reconnectDelay { defaultReconnectDelay };

--- a/Source/WebCore/page/LoginStatus.cpp
+++ b/Source/WebCore/page/LoginStatus.cpp
@@ -33,7 +33,7 @@
 
 namespace WebCore {
 
-using CodeUnitMatchFunction = bool (*)(UChar);
+using CodeUnitMatchFunction = bool (*)(char16_t);
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(LoginStatus);
 
@@ -51,7 +51,7 @@ ExceptionOr<UniqueRef<LoginStatus>> LoginStatus::create(const RegistrableDomain&
     if (length > UsernameMaxLength)
         return Exception { ExceptionCode::SyntaxError, makeString("LoginStatus usernames cannot be longer than "_s, UsernameMaxLength) };
 
-    auto spaceOrNewline = username.find([](UChar ch) {
+    auto spaceOrNewline = username.find([](char16_t ch) {
         return deprecatedIsSpaceOrNewline(ch);
     });
     if (spaceOrNewline != notFound)

--- a/Source/WebCore/page/WindowFeatures.cpp
+++ b/Source/WebCore/page/WindowFeatures.cpp
@@ -42,7 +42,7 @@ static std::optional<bool> boolFeature(const DialogFeaturesMap&, ASCIILiteral ke
 static std::optional<float> floatFeature(const DialogFeaturesMap&, ASCIILiteral key, float min, float max);
 
 // https://html.spec.whatwg.org/#feature-separator
-static bool isSeparator(UChar character, FeatureMode mode)
+static bool isSeparator(char16_t character, FeatureMode mode)
 {
     if (mode == FeatureMode::Viewport)
         return character == ' ' || character == '\t' || character == '\n' || character == '\r' || character == '=' || character == ',';
@@ -106,7 +106,7 @@ OptionSet<DisabledAdaptations> parseDisabledAdaptations(StringView disabledAdapt
 {
     OptionSet<DisabledAdaptations> disabledAdaptations;
     for (auto name : disabledAdaptationsString.split(',')) {
-        auto trimmedName = name.trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
+        auto trimmedName = name.trim(isUnicodeCompatibleASCIIWhitespace<char16_t>);
         if (equalIgnoringASCIICase(trimmedName, watchAdaptationName()))
             disabledAdaptations.add(DisabledAdaptations::Watch);
     }
@@ -251,12 +251,12 @@ static DialogFeaturesMap parseDialogFeaturesMap(StringView string)
         if (separatorPosition == notFound)
             separatorPosition = colonPosition;
 
-        auto key = featureString.left(separatorPosition).trim(isUnicodeCompatibleASCIIWhitespace<UChar>).toString();
+        auto key = featureString.left(separatorPosition).trim(isUnicodeCompatibleASCIIWhitespace<char16_t>).toString();
 
         // Null string for value indicates key without value.
         String value;
         if (separatorPosition != notFound) {
-            auto valueView = featureString.substring(separatorPosition + 1).trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
+            auto valueView = featureString.substring(separatorPosition + 1).trim(isUnicodeCompatibleASCIIWhitespace<char16_t>);
             value = valueView.left(valueView.find(' ')).toString();
         }
 

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
@@ -471,7 +471,7 @@ void ContentSecurityPolicyDirectiveList::parse(const String& policy, ContentSecu
     // A meta tag delievered CSP could contain invalid HTTP header values depending on how it was formatted in the document.
     // We want to store the CSP as a valid HTTP header for e.g. blob URL inheritance.
     if (policyFrom == ContentSecurityPolicy::PolicyFrom::HTTPEquivMeta) {
-        m_header = policy.trim(isASCIIWhitespaceWithoutFF<UChar>).removeCharacters([](auto c) {
+        m_header = policy.trim(isASCIIWhitespaceWithoutFF<char16_t>).removeCharacters([](auto c) {
             return c == 0x00 || c == '\r' || c == '\n';
         });
     } else

--- a/Source/WebCore/page/csp/ContentSecurityPolicyTrustedTypesDirective.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyTrustedTypesDirective.cpp
@@ -67,7 +67,7 @@ ContentSecurityPolicyTrustedTypesDirective::ContentSecurityPolicyTrustedTypesDir
 
 bool ContentSecurityPolicyTrustedTypesDirective::allows(const String& value, bool isDuplicate, AllowTrustedTypePolicy& details) const
 {
-    auto invalidPolicy = value.find([](UChar ch) {
+    auto invalidPolicy = value.find([](char16_t ch) {
         return !isPolicyNameCharacter(ch);
     });
 

--- a/Source/WebCore/page/ios/FrameIOS.mm
+++ b/Source/WebCore/page/ios/FrameIOS.mm
@@ -127,7 +127,7 @@ NSArray *LocalFrame::wordsInCurrentParagraph() const
 
     if (!isStartOfParagraph(end)) {
         VisiblePosition previous = end.previous();
-        UChar c(previous.characterAfter());
+        char16_t c(previous.characterAfter());
         // FIXME: Should use something from ICU or ASCIICType that is not subject to POSIX current language rather than iswpunct.
         if (!iswpunct(c) && !deprecatedIsSpaceOrNewline(c) && c != noBreakSpace)
             end = startOfWord(end);
@@ -166,7 +166,7 @@ NSArray *LocalFrame::wordsInCurrentParagraph() const
 
     if ([words count] > 0 && isEndOfParagraph(position) && !isStartOfParagraph(position)) {
         VisiblePosition previous = position.previous();
-        UChar c(previous.characterAfter());
+        char16_t c(previous.characterAfter());
         if (!deprecatedIsSpaceOrNewline(c) && c != noBreakSpace)
             [words removeLastObject];
     }
@@ -742,7 +742,7 @@ NSArray *LocalFrame::interpretationsForCurrentRoot() const
     for (auto& marker : markersInRoot)
         interpretationsCount *= std::get<Vector<String>>(marker->data()).size() + 1;
 
-    Vector<Vector<UChar>> interpretations;
+    Vector<Vector<char16_t>> interpretations;
     interpretations.grow(interpretationsCount);
 
     Position precedingTextStartPosition = makeDeprecatedLegacyPosition(root, 0);

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -565,7 +565,7 @@ static void extractRenderedTokens(Vector<TokenAndBlockOffset>& tokensAndOffsets,
             if (textRenderer->hasRenderedText()) {
                 Vector<Token> tokens;
                 for (auto token : textRenderer->text().simplifyWhiteSpace(isASCIIWhitespace).split(' ')) {
-                    auto candidate = token.removeCharacters([](UChar character) {
+                    auto candidate = token.removeCharacters([](char16_t character) {
                         return !u_isalpha(character) && !u_isdigit(character);
                     });
                     if (!candidate.isEmpty())
@@ -664,7 +664,7 @@ static Vector<std::pair<String, FloatRect>> extractAllTextAndRectsRecursive(Docu
         if (RefPtr frameOwner = dynamicDowncast<HTMLFrameOwnerElement>(*node))
             frameOwners.add(frameOwner.releaseNonNull());
 
-        auto trimmedText = iterator.text().trim(isASCIIWhitespace<UChar>);
+        auto trimmedText = iterator.text().trim(isASCIIWhitespace<char16_t>);
         if (trimmedText.isEmpty())
             continue;
 

--- a/Source/WebCore/platform/ContentType.cpp
+++ b/Source/WebCore/platform/ContentType.cpp
@@ -109,7 +109,7 @@ String ContentType::parameter(const String& parameterName) const
         start = equalSignPosition + 1;
         end = m_type.find(';', start);
     }
-    return StringView { m_type }.substring(start, end - start).trim(isASCIIWhitespace<UChar>).toString();
+    return StringView { m_type }.substring(start, end - start).trim(isASCIIWhitespace<char16_t>).toString();
 }
 
 String ContentType::containerType() const
@@ -123,7 +123,7 @@ static inline Vector<String> splitParameters(StringView parametersView)
 {
     Vector<String> result;
     for (auto view : parametersView.split(','))
-        result.append(view.trim(isASCIIWhitespace<UChar>).toString());
+        result.append(view.trim(isASCIIWhitespace<char16_t>).toString());
     return result;
 }
 

--- a/Source/WebCore/platform/Length.cpp
+++ b/Source/WebCore/platform/Length.cpp
@@ -47,7 +47,7 @@ struct SameSizeAsLength {
 };
 static_assert(sizeof(Length) == sizeof(SameSizeAsLength), "length should stay small");
 
-static Length parseLength(std::span<const UChar> data)
+static Length parseLength(std::span<const char16_t> data)
 {
     if (data.empty())
         return Length(1, LengthType::Relative);
@@ -69,7 +69,7 @@ static Length parseLength(std::span<const UChar> data)
         ++i;
 
     bool ok;
-    UChar next = (i < data.size()) ? data[i] : ' ';
+    char16_t next = (i < data.size()) ? data[i] : ' ';
     if (next == '%') {
         // IE quirk: accept decimal fractions for percentages.
         double r = charactersToDouble(data.first(doubleLength), &ok);
@@ -85,7 +85,7 @@ static Length parseLength(std::span<const UChar> data)
     return Length(0, LengthType::Relative);
 }
 
-static unsigned countCharacter(StringImpl& string, UChar character)
+static unsigned countCharacter(StringImpl& string, char16_t character)
 {
     unsigned count = 0;
     unsigned length = string.length();

--- a/Source/WebCore/platform/MIMETypeRegistry.cpp
+++ b/Source/WebCore/platform/MIMETypeRegistry.cpp
@@ -603,7 +603,7 @@ bool MIMETypeRegistry::isTextMIMEType(const String& mimeType)
             && !equalLettersIgnoringASCIICase(mimeType, "text/xsl"_s));
 }
 
-static inline bool isValidXMLMIMETypeChar(UChar c)
+static inline bool isValidXMLMIMETypeChar(char16_t c)
 {
     // Valid characters per RFCs 3023 and 2045: 0-9a-zA-Z_-+~!$^{}|.%'`#&*
     return isASCIIAlphanumeric(c) || c == '!' || c == '#' || c == '$' || c == '%' || c == '&' || c == '\'' || c == '*' || c == '+'

--- a/Source/WebCore/platform/ReferrerPolicy.cpp
+++ b/Source/WebCore/platform/ReferrerPolicy.cpp
@@ -74,7 +74,7 @@ std::optional<ReferrerPolicy> parseReferrerPolicy(StringView policyString, Refer
         // Implementing https://www.w3.org/TR/2017/CR-referrer-policy-20170126/#parse-referrer-policy-from-header.
         std::optional<ReferrerPolicy> result;
         for (auto tokenView : policyString.split(',')) {
-            auto token = parseReferrerPolicyToken(tokenView.trim(isASCIIWhitespaceWithoutFF<UChar>), ShouldParseLegacyKeywords::No);
+            auto token = parseReferrerPolicyToken(tokenView.trim(isASCIIWhitespaceWithoutFF<char16_t>), ShouldParseLegacyKeywords::No);
             if (token && token.value() != ReferrerPolicy::EmptyString)
                 result = token.value();
         }

--- a/Source/WebCore/platform/SharedStringHash.cpp
+++ b/Source/WebCore/platform/SharedStringHash.cpp
@@ -215,7 +215,7 @@ SharedStringHash computeSharedStringHash(const String& url)
     return computeSharedStringHashInline(url.span16());
 }
 
-SharedStringHash computeSharedStringHash(std::span<const UChar> url)
+SharedStringHash computeSharedStringHash(std::span<const char16_t> url)
 {
     return computeSharedStringHashInline(url);
 }

--- a/Source/WebCore/platform/SharedStringHash.h
+++ b/Source/WebCore/platform/SharedStringHash.h
@@ -43,7 +43,7 @@ struct SharedStringHashHash {
 
 // Returns the hash of the string that will be used for visited link coloring.
 WEBCORE_EXPORT SharedStringHash computeSharedStringHash(const String& url);
-WEBCORE_EXPORT SharedStringHash computeSharedStringHash(std::span<const UChar> url);
+WEBCORE_EXPORT SharedStringHash computeSharedStringHash(std::span<const char16_t> url);
 
 // Resolves the potentially relative URL "attributeURL" relative to the given
 // base URL, and returns the hash of the string that will be used for visited

--- a/Source/WebCore/platform/TelephoneNumberDetector.h
+++ b/Source/WebCore/platform/TelephoneNumberDetector.h
@@ -35,7 +35,7 @@ namespace TelephoneNumberDetector {
 
 void prewarm();
 bool isSupported();
-bool find(std::span<const UChar> buffer, int* startPos, int* endPos);
+bool find(std::span<const char16_t> buffer, int* startPos, int* endPos);
 
 } // namespace TelephoneNumberDetector
 } // namespace WebCore

--- a/Source/WebCore/platform/cocoa/KeyEventCocoa.mm
+++ b/Source/WebCore/platform/cocoa/KeyEventCocoa.mm
@@ -191,7 +191,7 @@ String keyForCharCode(unichar charCode)
     case NSNextFunctionKey:
         return "Unidentified"_s;
     default:
-        return span(*reinterpret_cast<const UChar*>(&charCode));
+        return span(*reinterpret_cast<const char16_t*>(&charCode));
     }
 }
 

--- a/Source/WebCore/platform/cocoa/TelephoneNumberDetectorCocoa.cpp
+++ b/Source/WebCore/platform/cocoa/TelephoneNumberDetectorCocoa.cpp
@@ -71,7 +71,7 @@ bool isSupported()
     return phoneNumbersScanner() != nullptr;
 }
 
-bool find(std::span<const UChar> buffer, int* startPos, int* endPos)
+bool find(std::span<const char16_t> buffer, int* startPos, int* endPos)
 {
     ASSERT(isSupported());
     return DDDFAScannerFirstResultInUnicharArray(phoneNumbersScanner(), reinterpret_cast<const UniChar*>(buffer.data()), buffer.size(), startPos, endPos);

--- a/Source/WebCore/platform/graphics/ComplexTextController.cpp
+++ b/Source/WebCore/platform/graphics/ComplexTextController.cpp
@@ -303,7 +303,7 @@ void ComplexTextController::advanceByCombiningCharacterSequence(const CachedText
     unsigned remainingCharacters = m_end - currentIndex;
     ASSERT(remainingCharacters);
 
-    std::array<UChar, 2> buffer;
+    std::array<char16_t, 2> buffer;
     unsigned bufferLength = 1;
     buffer[0] = m_run.get()[currentIndex];
     buffer[1] = 0;
@@ -333,7 +333,7 @@ void ComplexTextController::collectComplexTextRuns()
 
     // We break up glyph run generation for the string by Font.
 
-    std::span<const UChar> baseOfString = [&] {
+    std::span<const char16_t> baseOfString = [&] {
         // We need a 16-bit string to pass to Core Text.
         if (!m_run->is8Bit())
             return m_run->span16();
@@ -718,7 +718,7 @@ void ComplexTextController::adjustGlyphsAndAdvances()
                 if (characterIndex > previousCharacterIndex)
                     isMonotonic = false;
             }
-            UChar character = charactersSpan[characterIndex];
+            char16_t character = charactersSpan[characterIndex];
 
             bool treatAsSpace = FontCascade::treatAsSpace(character);
             CGGlyph glyph = glyphs[glyphIndex];
@@ -884,7 +884,7 @@ void ComplexTextController::adjustGlyphsAndAdvances()
 
 // Missing glyphs run constructor. Core Text will not generate a run of missing glyphs, instead falling back on
 // glyphs from LastResort. We want to use the primary font's missing glyph in order to match the fast text code path.
-ComplexTextController::ComplexTextRun::ComplexTextRun(const Font& font, std::span<const UChar> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd, bool ltr)
+ComplexTextController::ComplexTextRun::ComplexTextRun(const Font& font, std::span<const char16_t> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd, bool ltr)
     : m_font(font)
     , m_characters(characters)
     , m_indexBegin(indexBegin)
@@ -917,7 +917,7 @@ ComplexTextController::ComplexTextRun::ComplexTextRun(const Font& font, std::spa
     m_baseAdvances.fill(FloatSize(m_font->widthForGlyph(0, Font::SyntheticBoldInclusion::Exclude), 0), m_glyphCount);
 }
 
-ComplexTextController::ComplexTextRun::ComplexTextRun(const Vector<FloatSize>& advances, const Vector<FloatPoint>& origins, const Vector<Glyph>& glyphs, const Vector<unsigned>& stringIndices, FloatSize initialAdvance, const Font& font, std::span<const UChar> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd, bool ltr)
+ComplexTextController::ComplexTextRun::ComplexTextRun(const Vector<FloatSize>& advances, const Vector<FloatPoint>& origins, const Vector<Glyph>& glyphs, const Vector<unsigned>& stringIndices, FloatSize initialAdvance, const Font& font, std::span<const char16_t> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd, bool ltr)
     : m_baseAdvances(advances)
     , m_glyphOrigins(origins)
     , m_glyphs(glyphs)

--- a/Source/WebCore/platform/graphics/ComplexTextController.h
+++ b/Source/WebCore/platform/graphics/ComplexTextController.h
@@ -84,29 +84,29 @@ public:
 
     class ComplexTextRun : public RefCounted<ComplexTextRun> {
     public:
-        static Ref<ComplexTextRun> create(CTRunRef ctRun, const Font& font, std::span<const UChar> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd)
+        static Ref<ComplexTextRun> create(CTRunRef ctRun, const Font& font, std::span<const char16_t> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd)
         {
             return adoptRef(*new ComplexTextRun(ctRun, font, characters, stringLocation, indexBegin, indexEnd));
         }
 
-        static Ref<ComplexTextRun> create(hb_buffer_t* buffer, const Font& font, std::span<const UChar> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd)
+        static Ref<ComplexTextRun> create(hb_buffer_t* buffer, const Font& font, std::span<const char16_t> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd)
         {
             return adoptRef(*new ComplexTextRun(buffer, font, characters, stringLocation, indexBegin, indexEnd));
         }
 
-        static Ref<ComplexTextRun> create(const Font& font, std::span<const UChar> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd, bool ltr)
+        static Ref<ComplexTextRun> create(const Font& font, std::span<const char16_t> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd, bool ltr)
         {
             return adoptRef(*new ComplexTextRun(font, characters, stringLocation, indexBegin, indexEnd, ltr));
         }
 
-        static Ref<ComplexTextRun> create(const Vector<FloatSize>& advances, const Vector<FloatPoint>& origins, const Vector<Glyph>& glyphs, const Vector<unsigned>& stringIndices, FloatSize initialAdvance, const Font& font, std::span<const UChar> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd, bool ltr)
+        static Ref<ComplexTextRun> create(const Vector<FloatSize>& advances, const Vector<FloatPoint>& origins, const Vector<Glyph>& glyphs, const Vector<unsigned>& stringIndices, FloatSize initialAdvance, const Font& font, std::span<const char16_t> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd, bool ltr)
         {
             return adoptRef(*new ComplexTextRun(advances, origins, glyphs, stringIndices, initialAdvance, font, characters, stringLocation, indexBegin, indexEnd, ltr));
         }
 
         unsigned glyphCount() const { return m_glyphCount; }
         const Font& font() const { return m_font; }
-        std::span<const UChar> characters() const { return m_characters; }
+        std::span<const char16_t> characters() const { return m_characters; }
         unsigned stringLocation() const { return m_stringLocation; }
         size_t stringLength() const { return m_characters.size(); }
         ALWAYS_INLINE unsigned indexAt(unsigned) const;
@@ -125,10 +125,10 @@ public:
         float textAutospaceSize() const { return m_textAutospaceSize; }
 
     private:
-        ComplexTextRun(CTRunRef, const Font&, std::span<const UChar> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd);
-        ComplexTextRun(hb_buffer_t*, const Font&, std::span<const UChar> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd);
-        ComplexTextRun(const Font&, std::span<const UChar> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd, bool ltr);
-        WEBCORE_EXPORT ComplexTextRun(const Vector<FloatSize>& advances, const Vector<FloatPoint>& origins, const Vector<Glyph>& glyphs, const Vector<unsigned>& stringIndices, FloatSize initialAdvance, const Font&, std::span<const UChar> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd, bool ltr);
+        ComplexTextRun(CTRunRef, const Font&, std::span<const char16_t> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd);
+        ComplexTextRun(hb_buffer_t*, const Font&, std::span<const char16_t> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd);
+        ComplexTextRun(const Font&, std::span<const char16_t> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd, bool ltr);
+        WEBCORE_EXPORT ComplexTextRun(const Vector<FloatSize>& advances, const Vector<FloatPoint>& origins, const Vector<Glyph>& glyphs, const Vector<unsigned>& stringIndices, FloatSize initialAdvance, const Font&, std::span<const char16_t> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd, bool ltr);
 
         using BaseAdvancesVector = Vector<FloatSize, 64>;
         using GlyphVector = Vector<CGGlyph, 64>;
@@ -141,7 +141,7 @@ public:
         CoreTextIndicesVector m_coreTextIndices;
         FloatSize m_initialAdvance;
         SingleThreadWeakRef<const Font> m_font;
-        std::span<const UChar> m_characters;
+        std::span<const char16_t> m_characters;
         unsigned m_indexBegin;
         unsigned m_indexEnd;
         unsigned m_glyphCount;
@@ -161,7 +161,7 @@ private:
 
     void collectComplexTextRuns();
 
-    void collectComplexTextRunsForCharacters(std::span<const UChar>, unsigned stringLocation, const Font*);
+    void collectComplexTextRunsForCharacters(std::span<const char16_t>, unsigned stringLocation, const Font*);
     void adjustGlyphsAndAdvances();
 
     unsigned indexOfCurrentRun(unsigned& leftmostGlyph);
@@ -178,7 +178,7 @@ private:
     Vector<CGGlyph, 256> m_adjustedGlyphs;
     Vector<float, 256> m_textAutoSpaceSpacings;
 
-    Vector<UChar, 256> m_smallCapsBuffer;
+    Vector<char16_t, 256> m_smallCapsBuffer;
 
     // There is a 3-level hierarchy here. At the top, we are interested in m_run.string(). We partition that string
     // into Lines, each of which is a sequence of characters which should use the same Font. Core Text then partitions

--- a/Source/WebCore/platform/graphics/ComposedCharacterClusterTextIterator.h
+++ b/Source/WebCore/platform/graphics/ComposedCharacterClusterTextIterator.h
@@ -32,8 +32,8 @@ namespace WebCore {
 
 class ComposedCharacterClusterTextIterator {
 public:
-    // The passed in UChar pointer starts at 'currentIndex'. The iterator operates on the range [currentIndex, lastIndex].
-    ComposedCharacterClusterTextIterator(std::span<const UChar> characters, unsigned currentIndex, unsigned lastIndex)
+    // The passed in char16_t pointer starts at 'currentIndex'. The iterator operates on the range [currentIndex, lastIndex].
+    ComposedCharacterClusterTextIterator(std::span<const char16_t> characters, unsigned currentIndex, unsigned lastIndex)
         : m_iterator(characters, { }, TextBreakIterator::CaretMode { }, nullAtom())
         , m_characters(characters)
         , m_originalIndex(currentIndex)
@@ -70,18 +70,18 @@ public:
         m_currentIndex = index;
     }
 
-    std::span<const UChar> remainingCharacters() const
+    std::span<const char16_t> remainingCharacters() const
     {
         auto relativeIndex = m_currentIndex - m_originalIndex;
         return m_characters.subspan(relativeIndex);
     }
 
     unsigned currentIndex() const { return m_currentIndex; }
-    std::span<const UChar> characters() const { return m_characters; }
+    std::span<const char16_t> characters() const { return m_characters; }
 
 private:
     CachedTextBreakIterator m_iterator;
-    std::span<const UChar> m_characters;
+    std::span<const char16_t> m_characters;
     const unsigned m_originalIndex { 0 };
     unsigned m_currentIndex { 0 };
     const unsigned m_lastIndex { 0 };

--- a/Source/WebCore/platform/graphics/Font.cpp
+++ b/Source/WebCore/platform/graphics/Font.cpp
@@ -200,7 +200,7 @@ RenderingResourceIdentifier FontInternalAttributes::ensureRenderingResourceIdent
     return *renderingResourceIdentifier;
 }
 
-static bool fillGlyphPage(GlyphPage& pageToFill, std::span<const UChar> buffer, const Font& font)
+static bool fillGlyphPage(GlyphPage& pageToFill, std::span<const char16_t> buffer, const Font& font)
 {
     bool hasGlyphs = pageToFill.fill(buffer);
 #if ENABLE(OPENTYPE_VERTICAL)
@@ -328,9 +328,9 @@ static std::optional<size_t> codePointSupportIndex(char32_t codePoint)
 }
 
 #if PLATFORM(WIN)
-static void overrideControlCharacters(Vector<UChar>& buffer, unsigned start, unsigned end)
+static void overrideControlCharacters(Vector<char16_t>& buffer, unsigned start, unsigned end)
 {
-    auto overwriteCodePoints = [&](unsigned minimum, unsigned maximum, UChar newCodePoint) {
+    auto overwriteCodePoints = [&](unsigned minimum, unsigned maximum, char16_t newCodePoint) {
         unsigned begin = std::max(start, minimum);
         unsigned complete = std::min(end, maximum);
         for (unsigned i = begin; i < complete; ++i) {
@@ -339,7 +339,7 @@ static void overrideControlCharacters(Vector<UChar>& buffer, unsigned start, uns
         }
     };
 
-    auto overwriteCodePoint = [&](UChar codePoint, UChar newCodePoint) {
+    auto overwriteCodePoint = [&](char16_t codePoint, char16_t newCodePoint) {
         ASSERT(codePointSupportIndex(codePoint));
         if (codePoint >= start && codePoint < end)
             buffer[codePoint - start] = newCodePoint;
@@ -383,7 +383,7 @@ static RefPtr<GlyphPage> createAndFillGlyphPage(unsigned pageNumber, const Font&
     unsigned glyphPageSize = GlyphPage::sizeForPageNumber(pageNumber);
 
     unsigned start = GlyphPage::startingCodePointInPageNumber(pageNumber);
-    Vector<UChar> buffer(glyphPageSize * 2 + 2);
+    Vector<char16_t> buffer(glyphPageSize * 2 + 2);
     unsigned bufferLength;
     if (U_IS_BMP(start)) {
         bufferLength = glyphPageSize;

--- a/Source/WebCore/platform/graphics/FontCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCache.cpp
@@ -463,7 +463,7 @@ bool FontCache::useBackslashAsYenSignForFamily(const AtomString& family)
         return false;
 
     if (m_familiesUsingBackslashAsYenSign.isEmpty()) {
-        auto add = [&] (ASCIILiteral name, std::initializer_list<UChar> unicodeName) {
+        auto add = [&] (ASCIILiteral name, std::initializer_list<char16_t> unicodeName) {
             m_familiesUsingBackslashAsYenSign.add(AtomString { name });
             m_familiesUsingBackslashAsYenSign.add(AtomString(std::span { unicodeName }));
         };

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -606,7 +606,7 @@ String FontCascade::normalizeSpaces(std::span<const LChar> characters)
     return normalizeSpacesInternal(characters);
 }
 
-String FontCascade::normalizeSpaces(std::span<const UChar> characters)
+String FontCascade::normalizeSpaces(std::span<const char16_t> characters)
 {
     return normalizeSpacesInternal(characters);
 }
@@ -672,7 +672,7 @@ FontCascade::CodePath FontCascade::codePath(const TextRun& run, std::optional<un
     return characterRangeCodePath(run.span16());
 }
 
-FontCascade::CodePath FontCascade::characterRangeCodePath(std::span<const UChar> span)
+FontCascade::CodePath FontCascade::characterRangeCodePath(std::span<const char16_t> span)
 {
     // FIXME: Should use a UnicodeSet in ports where ICU is used. Note that we 
     // can't simply use UnicodeCharacter Property/class because some characters
@@ -807,7 +807,7 @@ FontCascade::CodePath FontCascade::characterRangeCodePath(std::span<const UChar>
             if (i + 1 == size)
                 continue;
 
-            UChar next = span[++i];
+            char16_t next = span[++i];
             if (!U16_IS_TRAIL(next))
                 continue;
 
@@ -1149,7 +1149,7 @@ std::pair<unsigned, bool> FontCascade::expansionOpportunityCountInternal(std::sp
     return std::make_pair(count, isAfterExpansion);
 }
 
-std::pair<unsigned, bool> FontCascade::expansionOpportunityCountInternal(std::span<const UChar> characters, TextDirection direction, ExpansionBehavior expansionBehavior)
+std::pair<unsigned, bool> FontCascade::expansionOpportunityCountInternal(std::span<const char16_t> characters, TextDirection direction, ExpansionBehavior expansionBehavior)
 {
     unsigned count = 0;
     bool isAfterExpansion = expansionBehavior.left == ExpansionBehavior::Behavior::Forbid;

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -233,7 +233,7 @@ public:
     enum class CodePath : uint8_t { Auto, Simple, Complex, SimpleWithGlyphOverflow };
     WEBCORE_EXPORT CodePath codePath(const TextRun&, std::optional<unsigned> from = std::nullopt, std::optional<unsigned> to = std::nullopt) const;
     static CodePath characterRangeCodePath(std::span<const LChar>) { return CodePath::Simple; }
-    WEBCORE_EXPORT static CodePath characterRangeCodePath(std::span<const UChar>);
+    WEBCORE_EXPORT static CodePath characterRangeCodePath(std::span<const char16_t>);
 
     bool primaryFontIsSystemFont() const;
 
@@ -268,7 +268,7 @@ private:
     void adjustSelectionRectForComplexText(const TextRun&, LayoutRect& selectionRect, unsigned from, unsigned to) const;
 
     static std::pair<unsigned, bool> expansionOpportunityCountInternal(std::span<const LChar>, TextDirection, ExpansionBehavior);
-    static std::pair<unsigned, bool> expansionOpportunityCountInternal(std::span<const UChar>, TextDirection, ExpansionBehavior);
+    static std::pair<unsigned, bool> expansionOpportunityCountInternal(std::span<const char16_t>, TextDirection, ExpansionBehavior);
 
     friend struct WidthIterator;
     friend class ComplexTextController;
@@ -321,7 +321,7 @@ public:
     static bool treatAsZeroWidthSpaceInComplexScript(char32_t c) { return c < space || (c >= deleteCharacter && c < noBreakSpace) || c == softHyphen || c == zeroWidthSpace || (c >= leftToRightMark && c <= rightToLeftMark) || (c >= leftToRightEmbed && c <= rightToLeftOverride) || c == zeroWidthNoBreakSpace || isInvisibleReplacementObjectCharacter(c); }
     static bool canReceiveTextEmphasis(char32_t);
 
-    static inline UChar normalizeSpaces(UChar character)
+    static inline char16_t normalizeSpaces(char16_t character)
     {
         if (treatAsSpace(character))
             return space;
@@ -333,7 +333,7 @@ public:
     }
 
     static String normalizeSpaces(std::span<const LChar>);
-    static String normalizeSpaces(std::span<const UChar>);
+    static String normalizeSpaces(std::span<const char16_t>);
     static String normalizeSpaces(StringView);
 
     bool useBackslashAsYenSymbol() const { return m_useBackslashAsYenSymbol; }

--- a/Source/WebCore/platform/graphics/GlyphPage.h
+++ b/Source/WebCore/platform/graphics/GlyphPage.h
@@ -126,7 +126,7 @@ public:
     }
 
     // Implemented by the platform.
-    bool fill(std::span<const UChar> characterBuffer);
+    bool fill(std::span<const char16_t> characterBuffer);
 
 private:
     explicit GlyphPage(const Font& font)

--- a/Source/WebCore/platform/graphics/Latin1TextIterator.h
+++ b/Source/WebCore/platform/graphics/Latin1TextIterator.h
@@ -28,7 +28,7 @@ namespace WebCore {
 class Latin1TextIterator {
 public:
     // The passed in LChar pointer starts at 'currentIndex'. The iterator operates on the range [currentIndex, lastIndex].
-    // 'endCharacter' denotes the maximum length of the UChar array, which might exceed 'lastIndex'.
+    // 'endCharacter' denotes the maximum length of the char16_t array, which might exceed 'lastIndex'.
     Latin1TextIterator(std::span<const LChar> characters, unsigned currentIndex, unsigned lastIndex)
         : m_characters(characters)
         , m_currentIndex(currentIndex)

--- a/Source/WebCore/platform/graphics/StringTruncator.cpp
+++ b/Source/WebCore/platform/graphics/StringTruncator.cpp
@@ -42,7 +42,7 @@ namespace WebCore {
 
 constexpr size_t stringBufferSize = 2048;
 
-typedef unsigned TruncationFunction(const String&, unsigned length, unsigned keepCount, std::span<UChar> buffer, bool shouldInsertEllipsis);
+typedef unsigned TruncationFunction(const String&, unsigned length, unsigned keepCount, std::span<char16_t> buffer, bool shouldInsertEllipsis);
 
 static inline int textBreakAtOrPreceding(UBreakIterator* it, int offset)
 {
@@ -59,7 +59,7 @@ static inline int boundedTextBreakFollowing(UBreakIterator* it, int offset, int 
     return result == UBRK_DONE ? length : result;
 }
 
-static unsigned centerTruncateToBuffer(const String& string, unsigned length, unsigned keepCount, std::span<UChar> buffer, bool shouldInsertEllipsis)
+static unsigned centerTruncateToBuffer(const String& string, unsigned length, unsigned keepCount, std::span<char16_t> buffer, bool shouldInsertEllipsis)
 {
     ASSERT_WITH_SECURITY_IMPLICATION(keepCount < length);
     ASSERT_WITH_SECURITY_IMPLICATION(keepCount < stringBufferSize);
@@ -100,7 +100,7 @@ static unsigned centerTruncateToBuffer(const String& string, unsigned length, un
     return truncatedLength;
 }
 
-static unsigned rightTruncateToBuffer(const String& string, unsigned length, unsigned keepCount, std::span<UChar> buffer, bool shouldInsertEllipsis)
+static unsigned rightTruncateToBuffer(const String& string, unsigned length, unsigned keepCount, std::span<char16_t> buffer, bool shouldInsertEllipsis)
 {
     ASSERT_WITH_SECURITY_IMPLICATION(keepCount < length);
     ASSERT_WITH_SECURITY_IMPLICATION(keepCount < stringBufferSize);
@@ -130,7 +130,7 @@ static unsigned rightTruncateToBuffer(const String& string, unsigned length, uns
     return truncatedLength;
 }
 
-static unsigned rightClipToCharacterBuffer(const String& string, unsigned length, unsigned keepCount, std::span<UChar> buffer, bool)
+static unsigned rightClipToCharacterBuffer(const String& string, unsigned length, unsigned keepCount, std::span<char16_t> buffer, bool)
 {
     ASSERT(keepCount < length);
     ASSERT(keepCount < stringBufferSize);
@@ -142,7 +142,7 @@ static unsigned rightClipToCharacterBuffer(const String& string, unsigned length
     return keepLength;
 }
 
-static unsigned rightClipToWordBuffer(const String& string, unsigned length, unsigned keepCount, std::span<UChar> buffer, bool)
+static unsigned rightClipToWordBuffer(const String& string, unsigned length, unsigned keepCount, std::span<char16_t> buffer, bool)
 {
     ASSERT(keepCount < length);
     ASSERT(keepCount < stringBufferSize);
@@ -164,7 +164,7 @@ static unsigned rightClipToWordBuffer(const String& string, unsigned length, uns
     return keepLength;
 }
 
-static unsigned leftTruncateToBuffer(const String& string, unsigned length, unsigned keepCount, std::span<UChar> buffer, bool shouldInsertEllipsis)
+static unsigned leftTruncateToBuffer(const String& string, unsigned length, unsigned keepCount, std::span<char16_t> buffer, bool shouldInsertEllipsis)
 {
     ASSERT(keepCount < length);
     ASSERT(keepCount < stringBufferSize);
@@ -193,7 +193,7 @@ static unsigned leftTruncateToBuffer(const String& string, unsigned length, unsi
     return length - adjustedStartIndex;
 }
 
-static float stringWidth(const FontCascade& renderer, std::span<const UChar> characters)
+static float stringWidth(const FontCascade& renderer, std::span<const char16_t> characters)
 {
     TextRun run(StringView { characters });
     return renderer.width(run);
@@ -211,7 +211,7 @@ static String truncateString(const String& string, float maxWidth, const FontCas
 
     float currentEllipsisWidth = shouldInsertEllipsis ? stringWidth(font, span(horizontalEllipsis)) : customTruncationElementWidth;
 
-    std::array<UChar, stringBufferSize> stringBuffer;
+    std::array<char16_t, stringBufferSize> stringBuffer;
     unsigned truncatedLength;
     unsigned keepCount;
     unsigned length = string.length();
@@ -224,7 +224,7 @@ static String truncateString(const String& string, float maxWidth, const FontCas
         truncatedLength = centerTruncateToBuffer(string, length, keepCount, stringBuffer, shouldInsertEllipsis);
     } else {
         keepCount = length;
-        StringView(string).getCharacters(std::span<UChar> { stringBuffer });
+        StringView(string).getCharacters(std::span<char16_t> { stringBuffer });
         truncatedLength = length;
     }
 
@@ -291,7 +291,7 @@ static String truncateString(const String& string, float maxWidth, const FontCas
         truncatedLength = truncateToBuffer(string, length, keepCount, stringBuffer, shouldInsertEllipsis);
     }
     
-    return std::span<const UChar> { stringBuffer }.first(truncatedLength);
+    return std::span<const char16_t> { stringBuffer }.first(truncatedLength);
 }
 
 String StringTruncator::centerTruncate(const String& string, float maxWidth, const FontCascade& font)

--- a/Source/WebCore/platform/graphics/SurrogatePairAwareTextIterator.h
+++ b/Source/WebCore/platform/graphics/SurrogatePairAwareTextIterator.h
@@ -27,9 +27,9 @@ namespace WebCore {
 
 class SurrogatePairAwareTextIterator {
 public:
-    // The passed in UChar pointer starts at 'currentIndex'. The iterator operates on the range [currentIndex, lastIndex].
-    // 'endIndex' denotes the maximum length of the UChar array, which might exceed 'lastIndex'.
-    SurrogatePairAwareTextIterator(std::span<const UChar> characters, unsigned currentIndex, unsigned lastIndex)
+    // The passed in char16_t pointer starts at 'currentIndex'. The iterator operates on the range [currentIndex, lastIndex].
+    // 'endIndex' denotes the maximum length of the char16_t array, which might exceed 'lastIndex'.
+    SurrogatePairAwareTextIterator(std::span<const char16_t> characters, unsigned currentIndex, unsigned lastIndex)
         : m_characters(characters)
         , m_currentIndex(currentIndex)
         , m_originalIndex(currentIndex)
@@ -62,17 +62,17 @@ public:
         m_currentIndex = index;
     }
 
-    std::span<const UChar> remainingCharacters() const
+    std::span<const char16_t> remainingCharacters() const
     {
         auto relativeIndex = m_currentIndex - m_originalIndex;
         return m_characters.subspan(relativeIndex);
     }
 
     unsigned currentIndex() const { return m_currentIndex; }
-    std::span<const UChar> characters() const { return m_characters; }
+    std::span<const char16_t> characters() const { return m_characters; }
 
 private:
-    std::span<const UChar> m_characters;
+    std::span<const char16_t> m_characters;
     unsigned m_currentIndex { 0 };
     const unsigned m_originalIndex { 0 };
     const unsigned m_lastIndex { 0 };

--- a/Source/WebCore/platform/graphics/TextBoxIterator.h
+++ b/Source/WebCore/platform/graphics/TextBoxIterator.h
@@ -42,7 +42,7 @@ public:
     unsigned offset() const { return m_offset; }
     void increment() { m_offset++; }
     bool atEnd() const { return !m_textRun || m_offset >= m_textRun->length(); }
-    UChar current() const { return (*m_textRun)[m_offset]; }
+    char16_t current() const { return (*m_textRun)[m_offset]; }
     UCharDirection direction() const { return atEnd() ? U_OTHER_NEUTRAL : u_charDirection(current()); }
 
     friend bool operator==(const TextBoxIterator&, const TextBoxIterator&) = default;

--- a/Source/WebCore/platform/graphics/TextRun.h
+++ b/Source/WebCore/platform/graphics/TextRun.h
@@ -118,11 +118,11 @@ public:
         return result;
     }
 
-    UChar operator[](unsigned i) const { RELEASE_ASSERT(i < m_text.length()); return m_text[i]; }
+    char16_t operator[](unsigned i) const { RELEASE_ASSERT(i < m_text.length()); return m_text[i]; }
     std::span<const LChar> span8() const LIFETIME_BOUND { ASSERT(is8Bit()); return m_text.span8(); }
-    std::span<const UChar> span16() const LIFETIME_BOUND { ASSERT(!is8Bit()); return m_text.span16(); }
+    std::span<const char16_t> span16() const LIFETIME_BOUND { ASSERT(!is8Bit()); return m_text.span16(); }
     std::span<const LChar> subspan8(unsigned i) const LIFETIME_BOUND { return span8().subspan(i); }
-    std::span<const UChar> subspan16(unsigned i) const LIFETIME_BOUND { return span16().subspan(i); }
+    std::span<const char16_t> subspan16(unsigned i) const LIFETIME_BOUND { return span16().subspan(i); }
 
     bool is8Bit() const { return m_text.is8Bit(); }
     unsigned length() const { return m_text.length(); }

--- a/Source/WebCore/platform/graphics/WidthCache.h
+++ b/Source/WebCore/platform/graphics/WidthCache.h
@@ -64,10 +64,10 @@ private:
                 copySmallCharacters(std::span { m_characters }, string.span8());
             else
                 copySmallCharacters(std::span { m_characters }, string.span16());
-            m_hashAndLength = WYHash::computeHashAndMaskTop8Bits(std::span<const UChar> { m_characters }.first(s_capacity)) | (length << 24);
+            m_hashAndLength = WYHash::computeHashAndMaskTop8Bits(std::span<const char16_t> { m_characters }.first(s_capacity)) | (length << 24);
         }
 
-        const UChar* characters() const { return m_characters.data(); }
+        const char16_t* characters() const { return m_characters.data(); }
         unsigned length() const { return m_hashAndLength >> 24; }
         unsigned hash() const { return m_hashAndLength & 0x00ffffffU; }
 
@@ -81,9 +81,9 @@ private:
         static constexpr unsigned s_deletedValueLength = s_capacity + 1;
 
         template<typename CharacterType>
-        ALWAYS_INLINE static void copySmallCharacters(std::span<UChar, s_capacity> destination, std::span<const CharacterType> source)
+        ALWAYS_INLINE static void copySmallCharacters(std::span<char16_t, s_capacity> destination, std::span<const CharacterType> source)
         {
-            if constexpr (std::is_same_v<CharacterType, UChar>)
+            if constexpr (std::is_same_v<CharacterType, char16_t>)
                 memcpySpan(destination, source);
             else {
                 for (auto [sourceCharacter, destinationCharacter] : zippedRange(source, destination))
@@ -91,7 +91,7 @@ private:
             }
         }
 
-        std::array<UChar, s_capacity> m_characters { };
+        std::array<char16_t, s_capacity> m_characters { };
         unsigned m_hashAndLength { 0 };
     };
 
@@ -173,7 +173,7 @@ private:
         float* value;
         if (length == 1) {
             // The map use 0 for empty key, thus we do +1 here to avoid conflicting against empty key.
-            // This is fine since the key is uint32_t while character is UChar. So +1 never causes overflow.
+            // This is fine since the key is uint32_t while character is char16_t. So +1 never causes overflow.
             uint32_t character = text[0];
             auto addResult = m_singleCharMap.fastAdd(character + 1, entry);
             isNewEntry = addResult.isNewEntry;

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
@@ -841,7 +841,7 @@ bool MediaPlayerPrivateAVFoundation::extractKeyURIKeyIDAndCertificateFromInitDat
     if (!keyURIArray)
         return false;
 
-    keyURI = spanReinterpretCast<const UChar>(keyURIArray->span().first(keyURILength));
+    keyURI = spanReinterpretCast<const char16_t>(keyURIArray->span().first(keyURILength));
     offset += keyURILength;
 
     uint32_t keyIDLength = initDataView->get<uint32_t>(offset, true, &status);
@@ -853,7 +853,7 @@ bool MediaPlayerPrivateAVFoundation::extractKeyURIKeyIDAndCertificateFromInitDat
     if (!keyIDArray)
         return false;
 
-    keyID = spanReinterpretCast<const UChar>(keyIDArray->span().first(keyIDLength));
+    keyID = spanReinterpretCast<const char16_t>(keyIDArray->span().first(keyIDLength));
     offset += keyIDLength;
 
     uint32_t certificateLength = initDataView->get<uint32_t>(offset, true, &status);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -2143,7 +2143,7 @@ bool MediaPlayerPrivateAVFoundationObjC::shouldWaitForLoadingOfResource(AVAssetR
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
         // Create an initData with the following layout:
         // [4 bytes: keyURI size], [keyURI size bytes: keyURI]
-        unsigned keyURISize = keyURI.length() * sizeof(UChar);
+        unsigned keyURISize = keyURI.length() * sizeof(char16_t);
         auto initDataBuffer = ArrayBuffer::create(4 + keyURISize, 1);
         unsigned byteLength = initDataBuffer->byteLength();
         auto initDataView = JSC::DataView::create(initDataBuffer.copyRef(), 0, byteLength);

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -3372,15 +3372,15 @@ GraphicsLayerCA::CloneID GraphicsLayerCA::ReplicaState::cloneID() const
 {
     size_t depth = m_replicaBranches.size();
 
-    const size_t bitsPerUChar = sizeof(UChar) * 8;
+    const size_t bitsPerUChar = sizeof(char16_t) * 8;
     size_t vectorSize = (depth + bitsPerUChar - 1) / bitsPerUChar;
     
-    Vector<UChar> result(vectorSize, 0);
+    Vector<char16_t> result(vectorSize, 0);
 
     // Create a string from the bit sequence which we can use to identify the clone.
     // Note that the string may contain embedded nulls, but that's OK.
     for (size_t i = 0; i < depth; ++i) {
-        UChar& currChar = result[i / bitsPerUChar];
+        char16_t& currChar = result[i / bitsPerUChar];
         currChar = (currChar << 1) | m_replicaBranches[i];
     }
     

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -746,7 +746,7 @@ void FontCache::platformPurgeInactiveFontData()
 }
 
 #if PLATFORM(IOS_FAMILY)
-static inline bool isArabicCharacter(UChar character)
+static inline bool isArabicCharacter(char16_t character)
 {
     return character >= 0x0600 && character <= 0x06FF;
 }
@@ -778,7 +778,7 @@ static RetainPtr<CTFontRef> lookupFallbackFont(CTFontRef font, FontSelectionValu
     // (used to?) perform poorly. In order to speed up the browser, we block those fonts, and use other faster fonts instead.
     // However, this performance analysis was done, like, 10 years ago, and the probability that these fonts are still too slow
     // seems quite low. We should re-analyze performance to see if we can delete this code.
-    UChar firstCharacter = characterCluster[0];
+    char16_t firstCharacter = characterCluster[0];
     if (isArabicCharacter(firstCharacter)) {
         auto familyName = adoptCF(static_cast<CFStringRef>(CTFontCopyAttribute(result.get(), kCTFontFamilyNameAttribute)));
         if (fontFamilyShouldNotBeUsedForArabic(familyName.get())) {
@@ -828,11 +828,11 @@ RefPtr<Font> FontCache::systemFallbackForCharacterCluster(const FontDescription&
 
 ASCIILiteral FontCache::platformAlternateFamilyName(const String& familyName)
 {
-    static const UChar heitiString[] = { 0x9ed1, 0x4f53 };
-    static const UChar songtiString[] = { 0x5b8b, 0x4f53 };
-    static const UChar weiruanXinXiMingTi[] = { 0x5fae, 0x8edf, 0x65b0, 0x7d30, 0x660e, 0x9ad4 };
-    static const UChar weiruanYaHeiString[] = { 0x5fae, 0x8f6f, 0x96c5, 0x9ed1 };
-    static const UChar weiruanZhengHeitiString[] = { 0x5fae, 0x8edf, 0x6b63, 0x9ed1, 0x9ad4 };
+    static const char16_t heitiString[] = { 0x9ed1, 0x4f53 };
+    static const char16_t songtiString[] = { 0x5b8b, 0x4f53 };
+    static const char16_t weiruanXinXiMingTi[] = { 0x5fae, 0x8edf, 0x65b0, 0x7d30, 0x660e, 0x9ad4 };
+    static const char16_t weiruanYaHeiString[] = { 0x5fae, 0x8f6f, 0x96c5, 0x9ed1 };
+    static const char16_t weiruanZhengHeitiString[] = { 0x5fae, 0x8edf, 0x6b63, 0x9ed1, 0x9ad4 };
 
     static constexpr ASCIILiteral songtiSC = "Songti SC"_s;
     static constexpr ASCIILiteral songtiTC = "Songti TC"_s;

--- a/Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm
+++ b/Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm
@@ -59,7 +59,7 @@ static std::span<const CGSize> CTRunGetAdvancesSpan(CTRunRef ctRun)
     return unsafeMakeSpan(baseAdvances, CTRunGetGlyphCount(ctRun));
 }
 
-ComplexTextController::ComplexTextRun::ComplexTextRun(CTRunRef ctRun, const Font& font, std::span<const UChar> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd)
+ComplexTextController::ComplexTextRun::ComplexTextRun(CTRunRef ctRun, const Font& font, std::span<const char16_t> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd)
     : m_initialAdvance(CTRunGetInitialAdvance(ctRun))
     , m_font(font)
     , m_characters(characters)
@@ -136,7 +136,7 @@ ComplexTextController::ComplexTextRun::ComplexTextRun(CTRunRef ctRun, const Font
 }
 
 struct ProviderInfo {
-    std::span<const UChar> characters;
+    std::span<const char16_t> characters;
     RetainPtr<CFDictionaryRef> attributes;
 };
 
@@ -173,7 +173,7 @@ static CFDictionaryRef typesetterOptions()
     return options.get().get();
 }
 
-void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const UChar> characters, unsigned stringLocation, const Font* font)
+void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const char16_t> characters, unsigned stringLocation, const Font* font)
 {
     if (!font) {
         // Create a run of missing glyphs from the primary font.

--- a/Source/WebCore/platform/graphics/coretext/GlyphPageCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/GlyphPageCoreText.cpp
@@ -36,7 +36,7 @@
 
 namespace WebCore {
 
-static bool shouldFillWithVerticalGlyphs(std::span<const UChar> buffer, const Font& font)
+static bool shouldFillWithVerticalGlyphs(std::span<const char16_t> buffer, const Font& font)
 {
     if (!font.hasVerticalGlyphs())
         return false;
@@ -48,7 +48,7 @@ static bool shouldFillWithVerticalGlyphs(std::span<const UChar> buffer, const Fo
 }
 
 
-bool GlyphPage::fill(std::span<const UChar> buffer)
+bool GlyphPage::fill(std::span<const char16_t> buffer)
 {
     ASSERT(buffer.size() == GlyphPage::size || buffer.size() == 2 * GlyphPage::size);
 

--- a/Source/WebCore/platform/graphics/freetype/GlyphPageTreeNodeFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/GlyphPageTreeNodeFreeType.cpp
@@ -41,7 +41,7 @@
 
 namespace WebCore {
 
-bool GlyphPage::fill(std::span<const UChar> buffer)
+bool GlyphPage::fill(std::span<const char16_t> buffer)
 {
     const Font& font = this->font();
     cairo_scaled_font_t* scaledFont = font.platformData().scaledFont();

--- a/Source/WebCore/platform/graphics/harfbuzz/ComplexTextControllerHarfBuzz.cpp
+++ b/Source/WebCore/platform/graphics/harfbuzz/ComplexTextControllerHarfBuzz.cpp
@@ -132,7 +132,7 @@ static hb_font_funcs_t* harfBuzzFontFunctions()
     return fontFunctions;
 }
 
-ComplexTextController::ComplexTextRun::ComplexTextRun(hb_buffer_t* buffer, const Font& font, std::span<const UChar> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd)
+ComplexTextController::ComplexTextRun::ComplexTextRun(hb_buffer_t* buffer, const Font& font, std::span<const char16_t> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd)
     : m_initialAdvance(0, 0)
     , m_font(font)
     , m_characters(characters)
@@ -241,7 +241,7 @@ struct HBRun {
     UScriptCode script;
 };
 
-static std::optional<HBRun> findNextRun(std::span<const UChar> characters, unsigned offset)
+static std::optional<HBRun> findNextRun(std::span<const char16_t> characters, unsigned offset)
 {
     SurrogatePairAwareTextIterator textIterator(characters.subspan(offset), offset, characters.size());
     char32_t character;
@@ -308,7 +308,7 @@ static hb_script_t findScriptForVerticalGlyphSubstitution(hb_face_t* face)
     return HB_SCRIPT_INVALID;
 }
 
-void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const UChar> characters, unsigned stringLocation, const Font* font)
+void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const char16_t> characters, unsigned stringLocation, const Font* font)
 {
     if (!font) {
         // Create a run of missing glyphs from the primary font.

--- a/Source/WebCore/platform/graphics/opentype/OpenTypeUtilities.cpp
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeUtilities.cpp
@@ -178,7 +178,7 @@ void EOTHeader::appendBigEndianString(const BigEndianUShort* string, unsigned sh
 {
     size_t oldSize = m_buffer.size();
     m_buffer.grow(oldSize + length + 2 * sizeof(unsigned short));
-    UChar* dst = reinterpret_cast<UChar*>(m_buffer.mutableSpan().subspan(oldSize).data());
+    char16_t* dst = reinterpret_cast<char16_t*>(m_buffer.mutableSpan().subspan(oldSize).data());
     unsigned i = 0;
     dst[i++] = length;
     unsigned numCharacters = length / 2;
@@ -219,7 +219,7 @@ bool renameFont(const SharedBuffer& fontData, const String& fontName, Vector<uin
     const int nameRecordCount = 5;
 
     // Rounded up to a multiple of 4 to simplify the checksum calculation.
-    size_t nameTableSize = ((offsetof(nameTable, nameRecords) + nameRecordCount * sizeof(nameRecord) + fontName.length() * sizeof(UChar)) & ~3) + 4;
+    size_t nameTableSize = ((offsetof(nameTable, nameRecords) + nameRecordCount * sizeof(nameRecord) + fontName.length() * sizeof(char16_t)) & ~3) + 4;
 
     rewrittenFontData.resize(fontData.size() + nameTableSize);
     auto dataSpan = rewrittenFontData.mutableSpan();
@@ -240,7 +240,7 @@ bool renameFont(const SharedBuffer& fontData, const String& fontName, Vector<uin
         name->nameRecords[i].encodingID = 1;
         name->nameRecords[i].languageID = 0x0409;
         name->nameRecords[i].offset = 0;
-        name->nameRecords[i].length = fontName.length() * sizeof(UChar);
+        name->nameRecords[i].length = fontName.length() * sizeof(char16_t);
     }
 
     // The required 'name' record types: Family, Style, Unique, Full and PostScript.

--- a/Source/WebCore/platform/graphics/skia/ComplexTextControllerSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ComplexTextControllerSkia.cpp
@@ -42,7 +42,7 @@ static inline float harfBuzzPositionToFloat(hb_position_t value)
     return static_cast<float>(value) / (1 << 16);
 }
 
-ComplexTextController::ComplexTextRun::ComplexTextRun(hb_buffer_t* buffer, const Font& font, std::span<const UChar> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd)
+ComplexTextController::ComplexTextRun::ComplexTextRun(hb_buffer_t* buffer, const Font& font, std::span<const char16_t> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd)
     : m_initialAdvance(0, 0)
     , m_font(font)
     , m_characters(characters)
@@ -105,7 +105,7 @@ struct HBRun {
     UScriptCode script;
 };
 
-static std::optional<HBRun> findNextRun(std::span<const UChar> characters, unsigned offset)
+static std::optional<HBRun> findNextRun(std::span<const char16_t> characters, unsigned offset)
 {
     SurrogatePairAwareTextIterator textIterator(characters.subspan(offset), offset, characters.size());
     char32_t character;
@@ -161,7 +161,7 @@ struct RTL {
 };
 
 template <typename IterationData>
-static void forEachHBRun(const std::span<const UChar>& characters, Function<void(const HBRun&)>&& callback)
+static void forEachHBRun(const std::span<const char16_t>& characters, Function<void(const HBRun&)>&& callback)
 {
     IterationData data;
 
@@ -182,7 +182,7 @@ static void forEachHBRun(const std::span<const UChar>& characters, Function<void
     }
 }
 
-void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const UChar> characters, unsigned stringLocation, const Font* font)
+void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const char16_t> characters, unsigned stringLocation, const Font* font)
 {
     ASSERT(!characters.empty());
 

--- a/Source/WebCore/platform/graphics/skia/GlyphPageSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GlyphPageSkia.cpp
@@ -34,7 +34,7 @@
 
 namespace WebCore {
 
-bool GlyphPage::fill(std::span<const UChar> buffer)
+bool GlyphPage::fill(std::span<const char16_t> buffer)
 {
     const Font& font = this->font();
     auto* skiaHarfBuzzFont = font.platformData().skiaHarfBuzzFont();

--- a/Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp
+++ b/Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-static bool shapeByUniscribe(const UChar* str, int len, SCRIPT_ITEM& item, const Font* fontData,
+static bool shapeByUniscribe(const char16_t* str, int len, SCRIPT_ITEM& item, const Font* fontData,
     Vector<WORD>& glyphs, Vector<WORD>& clusters,
     Vector<SCRIPT_VISATTR>& visualAttributes)
 {
@@ -168,7 +168,7 @@ static Vector<unsigned> stringIndicesFromClusters(const Vector<WORD>& clusters, 
     return stringIndices;
 }
 
-void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const UChar> cp, unsigned stringLocation, const Font* font)
+void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const char16_t> cp, unsigned stringLocation, const Font* font)
 {
     if (!font) {
         // Create a run of missing glyphs from the primary font.
@@ -199,7 +199,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
 
     for (int i = 0; i < numItems; i++) {
         // Determine the string for this item.
-        const UChar* str = cp.data() + items[i].iCharPos;
+        const char16_t* str = cp.data() + items[i].iCharPos;
         int length = items[i+1].iCharPos - items[i].iCharPos;
         SCRIPT_ITEM& item = items[i];
 

--- a/Source/WebCore/platform/graphics/win/FontCacheSkiaWin.cpp
+++ b/Source/WebCore/platform/graphics/win/FontCacheSkiaWin.cpp
@@ -40,7 +40,7 @@ static String fontsPath()
     DWORD size = GetEnvironmentVariable(fontsEnvironmentVariable, nullptr, 0);
     if (!size)
         return { };
-    Vector<UChar> buffer(size);
+    Vector<char16_t> buffer(size);
     // The return size doesn't include the terminating null character.
     if (GetEnvironmentVariable(fontsEnvironmentVariable, wcharFrom(buffer.mutableSpan().data()), size) != size - 1)
         return { };

--- a/Source/WebCore/platform/graphics/win/FontCacheWin.cpp
+++ b/Source/WebCore/platform/graphics/win/FontCacheWin.cpp
@@ -191,7 +191,7 @@ static bool currentFontContainsCharacter(HDC hdc, StringView stringView)
     char32_t utf32Character = *stringView.codePoints().begin();
     if (U_IS_SUPPLEMENTARY(utf32Character))
         return currentFontContainsCharacterNonBMP(hdc, stringView);
-    UChar character = utf32Character;
+    char16_t character = utf32Character;
 
     static Vector<char, 512> glyphsetBuffer;
     glyphsetBuffer.resize(GetFontUnicodeRanges(hdc, 0));
@@ -206,7 +206,7 @@ static bool currentFontContainsCharacter(HDC hdc, StringView stringView)
     return i && glyphset->ranges[i - 1].wcLow + glyphset->ranges[i - 1].cGlyphs > character;
 }
 
-static HFONT createMLangFont(IMLangFontLinkType* langFontLink, HDC hdc, DWORD codePageMask, UChar character = 0)
+static HFONT createMLangFont(IMLangFontLinkType* langFontLink, HDC hdc, DWORD codePageMask, char16_t character = 0)
 {
     HFONT MLangFont;
     HFONT hfont = 0;
@@ -229,7 +229,7 @@ RefPtr<Font> FontCache::systemFallbackForCharacterCluster(const FontDescription&
     IMLangFontLinkType* langFontLink = getFontLinkInterface();
 
     if (stringView.length() == 1 && langFontLink) {
-        UChar character = stringView[0];
+        char16_t character = stringView[0];
         // Try MLang font linking first.
         DWORD codePages = 0;
         if (SUCCEEDED(langFontLink->GetCharCodePages(character, &codePages))) {
@@ -310,7 +310,7 @@ RefPtr<Font> FontCache::systemFallbackForCharacterCluster(const FontDescription&
 
         LOGFONT logFont;
         logFont.lfCharSet = DEFAULT_CHARSET;
-        StringView(linkedFonts->at(linkedFontIndex)).getCharacters(spanReinterpretCast<UChar>(std::span<wchar_t> { logFont.lfFaceName }));
+        StringView(linkedFonts->at(linkedFontIndex)).getCharacters(spanReinterpretCast<char16_t>(std::span<wchar_t> { logFont.lfFaceName }));
         logFont.lfFaceName[linkedFonts->at(linkedFontIndex).length()] = 0;
         EnumFontFamiliesEx(hdc, &logFont, linkedFontEnumProc, reinterpret_cast<LPARAM>(&hfont), 0);
         linkedFontIndex++;
@@ -502,7 +502,7 @@ GDIObject<HFONT> createGDIFont(const AtomString& family, LONG desiredWeight, boo
     LOGFONT logFont;
     logFont.lfCharSet = DEFAULT_CHARSET;
     StringView truncatedFamily = StringView(family).left(static_cast<unsigned>(LF_FACESIZE - 1));
-    truncatedFamily.getCharacters(spanReinterpretCast<UChar>(std::span<wchar_t> { logFont.lfFaceName }));
+    truncatedFamily.getCharacters(spanReinterpretCast<char16_t>(std::span<wchar_t> { logFont.lfFaceName }));
     logFont.lfFaceName[truncatedFamily.length()] = 0;
     logFont.lfPitchAndFamily = 0;
 
@@ -607,7 +607,7 @@ Vector<FontSelectionCapabilities> FontCache::getFontSelectionCapabilitiesInFamil
     LOGFONT logFont;
     logFont.lfCharSet = DEFAULT_CHARSET;
     StringView truncatedFamily = StringView(familyName).left(static_cast<unsigned>(LF_FACESIZE - 1));
-    truncatedFamily.getCharacters(spanReinterpretCast<UChar>(std::span<wchar_t> { logFont.lfFaceName }));
+    truncatedFamily.getCharacters(spanReinterpretCast<char16_t>(std::span<wchar_t> { logFont.lfFaceName }));
     logFont.lfFaceName[truncatedFamily.length()] = 0;
     logFont.lfPitchAndFamily = 0;
 

--- a/Source/WebCore/platform/graphics/win/GlyphPageTreeNodeWin.cpp
+++ b/Source/WebCore/platform/graphics/win/GlyphPageTreeNodeWin.cpp
@@ -35,7 +35,7 @@
 
 namespace WebCore {
 
-bool GlyphPage::fill(std::span<const UChar> buffer)
+bool GlyphPage::fill(std::span<const char16_t> buffer)
 {
     ASSERT(buffer.size() == GlyphPage::size || buffer.size() == 2 * GlyphPage::size);
 

--- a/Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp
+++ b/Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp
@@ -1320,7 +1320,7 @@ String PlatformKeyboardEvent::singleCharacterString(unsigned val)
 
         String retVal;
         if (uchar16)
-            retVal = String(unsafeMakeSpan((UChar*)uchar16, static_cast<size_t>(nwc)));
+            retVal = String(unsafeMakeSpan((char16_t*)uchar16, static_cast<size_t>(nwc)));
         else
             retVal = String();
 

--- a/Source/WebCore/platform/ios/KeyEventIOS.mm
+++ b/Source/WebCore/platform/ios/KeyEventIOS.mm
@@ -271,7 +271,7 @@ int windowsKeyCodeForCharCode(unichar charCode)
     return 0;
 }
 
-static bool isFunctionKey(UChar charCode)
+static bool isFunctionKey(char16_t charCode)
 {
     switch (charCode) {
     // WebKit uses Unicode PUA codes in the OpenStep reserve range for some special keys.

--- a/Source/WebCore/platform/mac/StringUtilities.mm
+++ b/Source/WebCore/platform/mac/StringUtilities.mm
@@ -34,8 +34,8 @@ namespace WebCore {
 static String wildcardRegexPatternString(const String& string)
 {
     String metaCharacters = ".|+?()[]{}^$"_s;
-    UChar escapeCharacter = '\\';
-    UChar wildcardCharacter = '*';
+    char16_t escapeCharacter = '\\';
+    char16_t wildcardCharacter = '*';
     
     StringBuilder stringBuilder;
     

--- a/Source/WebCore/platform/network/CacheValidation.cpp
+++ b/Source/WebCore/platform/network/CacheValidation.cpp
@@ -177,7 +177,7 @@ bool redirectChainAllowsReuse(RedirectChainCacheStatus redirectChainCacheStatus,
     return false;
 }
 
-inline bool isCacheHeaderSeparator(UChar c)
+inline bool isCacheHeaderSeparator(char16_t c)
 {
     // http://tools.ietf.org/html/rfc7230#section-3.2.6
     switch (c) {
@@ -206,7 +206,7 @@ inline bool isCacheHeaderSeparator(UChar c)
     }
 }
 
-inline bool isControlCharacterOrSpace(UChar character)
+inline bool isControlCharacterOrSpace(char16_t character)
 {
     return character <= ' ' || character == 127;
 }
@@ -378,7 +378,7 @@ static Vector<std::pair<String, String>> collectVaryingRequestHeadersInternal(co
 
     Vector<std::pair<String, String>> headers;
     for (auto varyHeaderName : StringView(varyValue).split(',')) {
-        auto headerName = varyHeaderName.trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
+        auto headerName = varyHeaderName.trim(isUnicodeCompatibleASCIIWhitespace<char16_t>);
         headers.append(std::pair { headerName.toString(), headerValueForVaryFunction(headerName) });
     }
     return headers;

--- a/Source/WebCore/platform/network/DataURLDecoder.cpp
+++ b/Source/WebCore/platform/network/DataURLDecoder.cpp
@@ -114,13 +114,13 @@ public:
         // formatTypeStart might be at the begining of "base64" or "charset=...".
         size_t formatTypeStart = mediaTypeEnd + 1;
         auto formatType = header.substring(formatTypeStart, header.length() - formatTypeStart);
-        formatType = formatType.trim(isASCIIWhitespaceWithoutFF<UChar>);
+        formatType = formatType.trim(isASCIIWhitespaceWithoutFF<char16_t>);
 
         isBase64 = equalLettersIgnoringASCIICase(formatType, "base64"_s);
 
         // If header does not end with "base64", mediaType should be the whole header.
         auto mediaType = (isBase64 ? header.left(mediaTypeEnd) : header).toString();
-        mediaType = mediaType.trim(isASCIIWhitespaceWithoutFF<UChar>);
+        mediaType = mediaType.trim(isASCIIWhitespaceWithoutFF<char16_t>);
         if (mediaType.startsWith(';'))
             mediaType = makeString("text/plain"_s, mediaType);
 

--- a/Source/WebCore/platform/network/HTTPParsers.cpp
+++ b/Source/WebCore/platform/network/HTTPParsers.cpp
@@ -55,7 +55,7 @@ namespace WebCore {
 // True if characters which satisfy the predicate are present, incrementing
 // "pos" to the next character which does not satisfy the predicate.
 // Note: might return pos == str.length().
-static inline bool skipWhile(const String& str, unsigned& pos, NOESCAPE const Function<bool(const UChar)>& predicate)
+static inline bool skipWhile(const String& str, unsigned& pos, NOESCAPE const Function<bool(const char16_t)>& predicate)
 {
     const unsigned start = pos;
     const unsigned len = str.length();
@@ -68,7 +68,7 @@ static inline bool skipWhile(const String& str, unsigned& pos, NOESCAPE const Fu
 // Note: Might return pos == str.length()
 static inline bool skipWhiteSpace(const String& str, unsigned& pos)
 {
-    skipWhile(str, pos, isTabOrSpace<UChar>);
+    skipWhile(str, pos, isTabOrSpace<char16_t>);
     return pos < str.length();
 }
 
@@ -115,7 +115,7 @@ static inline bool skipValue(const String& str, unsigned& pos)
 bool isValidReasonPhrase(const String& value)
 {
     for (unsigned i = 0; i < value.length(); ++i) {
-        UChar c = value[i];
+        char16_t c = value[i];
         if (c == 0x7F || !isLatin1(c) || (c < 0x20 && c != '\t'))
             return false;
     }
@@ -125,7 +125,7 @@ bool isValidReasonPhrase(const String& value)
 // See https://fetch.spec.whatwg.org/#concept-header
 bool isValidHTTPHeaderValue(const String& value)
 {
-    UChar c = value[0];
+    char16_t c = value[0];
     if (isTabOrSpace(c))
         return false;
     c = value[value.length() - 1];
@@ -143,7 +143,7 @@ bool isValidHTTPHeaderValue(const String& value)
 bool isValidAcceptHeaderValue(const String& value)
 {
     for (unsigned i = 0; i < value.length(); ++i) {
-        UChar c = value[i];
+        char16_t c = value[i];
 
         // First check for alphanumeric for performance reasons then allowlist four delimiter characters.
         if (isASCIIAlphanumeric(c) || c == ',' || c == '/' || c == ';' || c == '=')
@@ -163,7 +163,7 @@ bool isValidAcceptHeaderValue(const String& value)
 static bool containsCORSUnsafeRequestHeaderBytes(const String& value)
 {
     for (unsigned i = 0; i < value.length(); ++i) {
-        UChar c = value[i];
+        char16_t c = value[i];
         // https://fetch.spec.whatwg.org/#cors-unsafe-request-header-byte
         if ((c < 0x20 && c != '\t') || (c == '"' || c == '(' || c == ')' || c == ':' || c == '<' || c == '>' || c == '?'
             || c == '@' || c == '[' || c == '\\' || c == ']' || c == 0x7B || c == '{' || c == '}' || c == 0x7F))
@@ -178,7 +178,7 @@ static bool containsCORSUnsafeRequestHeaderBytes(const String& value)
 bool isValidLanguageHeaderValue(const String& value)
 {
     for (unsigned i = 0; i < value.length(); ++i) {
-        UChar c = value[i];
+        char16_t c = value[i];
         if (isASCIIAlphanumeric(c) || c == ' ' || c == '*' || c == ',' || c == '-' || c == '.' || c == ';' || c == '=')
             continue;
         return false;
@@ -191,7 +191,7 @@ bool isValidHTTPToken(StringView value)
 {
     if (value.isEmpty())
         return false;
-    for (UChar c : value.codeUnits()) {
+    for (char16_t c : value.codeUnits()) {
         if (!RFC7230::isTokenCharacter(c))
             return false;
     }
@@ -206,7 +206,7 @@ bool isValidHTTPToken(const String& value)
 #if USE(GLIB)
 // True if the character at the given position satisifies a predicate, incrementing "pos" by one.
 // Note: Might return pos == str.length()
-static inline bool skipCharacter(const String& value, unsigned& pos, Function<bool(const UChar)>&& predicate)
+static inline bool skipCharacter(const String& value, unsigned& pos, Function<bool(const char16_t)>&& predicate)
 {
     if (pos < value.length() && predicate(value[pos])) {
         ++pos;
@@ -217,9 +217,9 @@ static inline bool skipCharacter(const String& value, unsigned& pos, Function<bo
 
 // True if the "expected" character is at the given position, incrementing "pos" by one.
 // Note: Might return pos == str.length()
-static inline bool skipCharacter(const String& value, unsigned& pos, const UChar expected)
+static inline bool skipCharacter(const String& value, unsigned& pos, const char16_t expected)
 {
-    return skipCharacter(value, pos, [expected](const UChar c) {
+    return skipCharacter(value, pos, [expected](const char16_t c) {
         return c == expected;
     });
 }
@@ -344,12 +344,12 @@ StringView filenameFromHTTPContentDisposition(StringView value)
         if (valueStartPos == notFound)
             continue;
 
-        auto key = keyValuePair.left(valueStartPos).trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
+        auto key = keyValuePair.left(valueStartPos).trim(isUnicodeCompatibleASCIIWhitespace<char16_t>);
 
         if (key.isEmpty() || key != "filename"_s)
             continue;
 
-        auto value = keyValuePair.substring(valueStartPos + 1).trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
+        auto value = keyValuePair.substring(valueStartPos + 1).trim(isUnicodeCompatibleASCIIWhitespace<char16_t>);
 
         // Remove quotes if there are any
         if (value.length() > 1 && value[0] == '\"')
@@ -367,7 +367,7 @@ String extractMIMETypeFromMediaType(const String& mediaType)
     unsigned length = mediaType.length();
 
     for (; position < length; ++position) {
-        UChar c = mediaType[position];
+        char16_t c = mediaType[position];
         if (!isTabOrSpace(c))
             break;
     }
@@ -379,7 +379,7 @@ String extractMIMETypeFromMediaType(const String& mediaType)
 
     unsigned typeEnd = position;
     for (; position < length; ++position) {
-        UChar c = mediaType[position];
+        char16_t c = mediaType[position];
 
         // While RFC 2616 does not allow it, other browsers allow multiple values in the HTTP media
         // type header field, Content-Type. In such cases, the media type string passed here may contain
@@ -537,7 +537,7 @@ XSSProtectionDisposition parseXSSProtectionHeader(const String& header, String& 
 ContentTypeOptionsDisposition parseContentTypeOptionsHeader(StringView header)
 {
     StringView leftToken = header.left(header.find(','));
-    if (equalLettersIgnoringASCIICase(leftToken.trim(isASCIIWhitespaceWithoutFF<UChar>), "nosniff"_s))
+    if (equalLettersIgnoringASCIICase(leftToken.trim(isASCIIWhitespaceWithoutFF<char16_t>), "nosniff"_s))
         return ContentTypeOptionsDisposition::Nosniff;
     return ContentTypeOptionsDisposition::None;
 }
@@ -565,7 +565,7 @@ XFrameOptionsDisposition parseXFrameOptionsHeader(StringView header)
         return result;
 
     for (auto currentHeader : header.splitAllowingEmptyEntries(',')) {
-        currentHeader = currentHeader.trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
+        currentHeader = currentHeader.trim(isUnicodeCompatibleASCIIWhitespace<char16_t>);
         XFrameOptionsDisposition currentValue = XFrameOptionsDisposition::None;
         if (equalLettersIgnoringASCIICase(currentHeader, "deny"_s))
             currentValue = XFrameOptionsDisposition::Deny;
@@ -596,7 +596,7 @@ OptionSet<ClearSiteDataValue> parseClearSiteDataHeader(const ResourceResponse& r
         return result;
 
     for (auto value : StringView(headerValue).split(',')) {
-        auto trimmedValue = value.trim(isASCIIWhitespaceWithoutFF<UChar>);
+        auto trimmedValue = value.trim(isASCIIWhitespaceWithoutFF<char16_t>);
         if (trimmedValue == "\"cache\""_s)
             result.add(ClearSiteDataValue::Cache);
         else if (trimmedValue == "\"cookies\""_s)
@@ -618,7 +618,7 @@ bool parseRange(StringView range, RangeAllowWhitespace allowWhitespace, long lon
     rangeStart = rangeEnd = -1;
 
     // Only 0x20 and 0x09 matter as newlines are already gone by the time we parse a header value.
-    if (allowWhitespace == RangeAllowWhitespace::No && range.find(isTabOrSpace<UChar>) != notFound)
+    if (allowWhitespace == RangeAllowWhitespace::No && range.find(isTabOrSpace<char16_t>) != notFound)
         return false;
 
     // The "bytes" unit identifier should be present.
@@ -626,7 +626,7 @@ bool parseRange(StringView range, RangeAllowWhitespace allowWhitespace, long lon
     if (!startsWithLettersIgnoringASCIICase(range, "bytes"_s))
         return false;
 
-    auto byteRange = range.substring(bytesLength).trim(isASCIIWhitespaceWithoutFF<UChar>);
+    auto byteRange = range.substring(bytesLength).trim(isASCIIWhitespaceWithoutFF<char16_t>);
 
     if (!byteRange.startsWith('='))
         return false;
@@ -852,7 +852,7 @@ bool isForbiddenHeader(const String& name, StringView value)
         return true;
     if (equalLettersIgnoringASCIICase(name, "x-http-method-override"_s) || equalLettersIgnoringASCIICase(name, "x-http-method"_s) || equalLettersIgnoringASCIICase(name, "x-method-override"_s)) {
         for (auto methodValue : StringView(value).split(',')) {
-            auto method = methodValue.trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
+            auto method = methodValue.trim(isUnicodeCompatibleASCIIWhitespace<char16_t>);
             if (isForbiddenMethod(method))
                 return true;
         }
@@ -1004,7 +1004,7 @@ bool isSafeMethod(const String& method)
 
 CrossOriginResourcePolicy parseCrossOriginResourcePolicyHeader(StringView header)
 {
-    auto trimmedHeader = header.trim(isASCIIWhitespaceWithoutFF<UChar>);
+    auto trimmedHeader = header.trim(isASCIIWhitespaceWithoutFF<char16_t>);
 
     if (trimmedHeader.isEmpty())
         return CrossOriginResourcePolicy::None;

--- a/Source/WebCore/platform/network/MIMEHeader.cpp
+++ b/Source/WebCore/platform/network/MIMEHeader.cpp
@@ -72,7 +72,7 @@ static KeyValueMap retrieveKeyValuePairs(WebCore::SharedBufferChunkReader& buffe
             // This is not a key value pair, ignore.
             continue;
         }
-        key = StringView(line).left(semicolonIndex).trim(isUnicodeCompatibleASCIIWhitespace<UChar>).convertToASCIILowercase();
+        key = StringView(line).left(semicolonIndex).trim(isUnicodeCompatibleASCIIWhitespace<char16_t>).convertToASCIILowercase();
         value.append(StringView(line).substring(semicolonIndex + 1));
     }
     // Store the last property if there is one.
@@ -122,7 +122,7 @@ RefPtr<MIMEHeader> MIMEHeader::parseHeader(SharedBufferChunkReader& buffer)
 
 MIMEHeader::Encoding MIMEHeader::parseContentTransferEncoding(StringView text)
 {
-    auto encoding = text.trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
+    auto encoding = text.trim(isUnicodeCompatibleASCIIWhitespace<char16_t>);
     if (equalLettersIgnoringASCIICase(encoding, "base64"_s))
         return Base64;
     if (equalLettersIgnoringASCIICase(encoding, "quoted-printable"_s))

--- a/Source/WebCore/platform/network/ParsedContentType.cpp
+++ b/Source/WebCore/platform/network/ParsedContentType.cpp
@@ -44,17 +44,17 @@ static void skipSpaces(StringView input, unsigned& startIndex)
         ++startIndex;
 }
 
-static bool isQuotedStringTokenCharacter(UChar c)
+static bool isQuotedStringTokenCharacter(char16_t c)
 {
     return (c >= ' ' && c <= '~') || (c >= 0x80 && c <= 0xFF) || c == '\t';
 }
 
-static bool isTokenCharacter(UChar c)
+static bool isTokenCharacter(char16_t c)
 {
     return isASCII(c) && c > ' ' && c != '"' && c != '(' && c != ')' && c != ',' && c != '/' && (c < ':' || c > '@') && (c < '[' || c > ']');
 }
 
-using CharacterMeetsCondition = bool (*)(UChar);
+using CharacterMeetsCondition = bool (*)(char16_t);
 
 static StringView parseToken(StringView input, unsigned& startIndex, CharacterMeetsCondition characterMeetsCondition, Mode mode, bool skipTrailingWhitespace = false)
 {
@@ -85,7 +85,7 @@ static StringView parseToken(StringView input, unsigned& startIndex, CharacterMe
     return input.substring(tokenStart, tokenEnd - tokenStart);
 }
 
-static bool isNotQuoteOrBackslash(UChar ch)
+static bool isNotQuoteOrBackslash(char16_t ch)
 {
     return ch != '"' && ch != '\\';
 }
@@ -103,7 +103,7 @@ static String collectHTTPQuotedString(StringView input, unsigned& startIndex)
         builder.append(input.substring(positionStart, position - positionStart));
         if (position >= inputLength)
             break;
-        UChar quoteOrBackslash = input[position++];
+        char16_t quoteOrBackslash = input[position++];
         if (quoteOrBackslash == '\\') {
             if (position >= inputLength) {
                 builder.append(quoteOrBackslash);
@@ -205,22 +205,22 @@ static StringView parseQuotedString(StringView input, unsigned& startIndex)
 //               ; Must be in quoted-string,
 //               ; to use within parameter values
 
-static bool isNotForwardSlash(UChar ch)
+static bool isNotForwardSlash(char16_t ch)
 {
     return ch != '/';
 }
 
-static bool isNotSemicolon(UChar ch)
+static bool isNotSemicolon(char16_t ch)
 {
     return ch != ';';
 }
 
-static bool isNotSemicolonOrEqualSign(UChar ch)
+static bool isNotSemicolonOrEqualSign(char16_t ch)
 {
     return ch != ';' && ch != '=';
 }
 
-static bool containsNewline(UChar ch)
+static bool containsNewline(char16_t ch)
 {
     return ch == '\r' || ch == '\n';
 }
@@ -329,7 +329,7 @@ bool ParsedContentType::parseContentType(Mode mode)
 
 std::optional<ParsedContentType> ParsedContentType::create(const String& contentType, Mode mode)
 {
-    ParsedContentType parsedContentType(mode == Mode::Rfc2045 ? contentType : contentType.trim(isASCIIWhitespaceWithoutFF<UChar>));
+    ParsedContentType parsedContentType(mode == Mode::Rfc2045 ? contentType : contentType.trim(isASCIIWhitespaceWithoutFF<char16_t>));
     if (!parsedContentType.parseContentType(mode))
         return std::nullopt;
     return { WTFMove(parsedContentType) };
@@ -369,7 +369,7 @@ void ParsedContentType::setContentType(String&& contentRange, Mode mode)
 {
     m_mimeType = WTFMove(contentRange);
     if (mode == Mode::MimeSniff)
-        m_mimeType = StringView(m_mimeType).trim(isASCIIWhitespaceWithoutFF<UChar>).convertToASCIILowercase();
+        m_mimeType = StringView(m_mimeType).trim(isASCIIWhitespaceWithoutFF<char16_t>).convertToASCIILowercase();
     else
         m_mimeType = m_mimeType.trim(deprecatedIsSpaceOrNewline);
 }

--- a/Source/WebCore/platform/network/RFC7230.cpp
+++ b/Source/WebCore/platform/network/RFC7230.cpp
@@ -31,7 +31,7 @@
 
 namespace RFC7230 {
 
-bool isTokenCharacter(UChar c)
+bool isTokenCharacter(char16_t c)
 {
     return isASCIIAlpha(c) || isASCIIDigit(c)
         || c == '!' || c == '#' || c == '$'
@@ -41,7 +41,7 @@ bool isTokenCharacter(UChar c)
         || c == '`' || c == '|' || c == '~';
 }
 
-bool isDelimiter(UChar c)
+bool isDelimiter(char16_t c)
 {
     return c == '(' || c == ')' || c == ','
         || c == '/' || c == ':' || c == ';'
@@ -51,23 +51,23 @@ bool isDelimiter(UChar c)
         || c == '}' || c == '"';
 }
 
-static bool isVisibleCharacter(UChar c)
+static bool isVisibleCharacter(char16_t c)
 {
     return isTokenCharacter(c) || isDelimiter(c);
 }
 
 template<size_t min, size_t max>
-static bool isInRange(UChar c)
+static bool isInRange(char16_t c)
 {
     return c >= min && c <= max;
 }
 
-static bool isOBSText(UChar c)
+static bool isOBSText(char16_t c)
 {
     return isInRange<0x80, 0xFF>(c);
 }
 
-static bool isQuotedTextCharacter(UChar c)
+static bool isQuotedTextCharacter(char16_t c)
 {
     return isTabOrSpace(c)
         || c == 0x21
@@ -76,14 +76,14 @@ static bool isQuotedTextCharacter(UChar c)
         || isOBSText(c);
 }
 
-bool isQuotedPairSecondOctet(UChar c)
+bool isQuotedPairSecondOctet(char16_t c)
 {
     return isTabOrSpace(c)
         || isVisibleCharacter(c)
         || isOBSText(c);
 }
 
-bool isCommentText(UChar c)
+bool isCommentText(char16_t c)
 {
     return isTabOrSpace(c)
         || isInRange<0x21, 0x27>(c)
@@ -116,7 +116,7 @@ bool isValidValue(StringView value)
     bool hadNonWhitespace = false;
 
     for (size_t i = 0; i < value.length(); ++i) {
-        UChar c = value[i];
+        char16_t c = value[i];
         switch (state) {
         case State::OptionalWhitespace:
             if (isTabOrSpace(c))

--- a/Source/WebCore/platform/network/RFC7230.h
+++ b/Source/WebCore/platform/network/RFC7230.h
@@ -30,10 +30,10 @@
 
 namespace RFC7230 {
 
-bool isTokenCharacter(UChar);
-bool isCommentText(UChar);
-bool isQuotedPairSecondOctet(UChar);
-bool isDelimiter(UChar);
+bool isTokenCharacter(char16_t);
+bool isCommentText(char16_t);
+bool isQuotedPairSecondOctet(char16_t);
+bool isDelimiter(char16_t);
 bool isValidName(StringView);
 bool isValidValue(StringView);
 

--- a/Source/WebCore/platform/network/ResourceResponseBase.cpp
+++ b/Source/WebCore/platform/network/ResourceResponseBase.cpp
@@ -827,7 +827,7 @@ bool ResourceResponseBase::isAttachment() const
     lazyInit(AllFields);
 
     auto value = m_httpHeaderFields.get(HTTPHeaderName::ContentDisposition);
-    return equalLettersIgnoringASCIICase(StringView(value).left(value.find(';')).trim(isUnicodeCompatibleASCIIWhitespace<UChar>), "attachment"_s);
+    return equalLettersIgnoringASCIICase(StringView(value).left(value.find(';')).trim(isUnicodeCompatibleASCIIWhitespace<char16_t>), "attachment"_s);
 }
 
 bool ResourceResponseBase::isAttachmentWithFilename() const
@@ -839,7 +839,7 @@ bool ResourceResponseBase::isAttachmentWithFilename() const
         return false;
 
     StringView contentDispositionView { contentDisposition };
-    if (!equalLettersIgnoringASCIICase(contentDispositionView.left(contentDispositionView.find(';')).trim(isUnicodeCompatibleASCIIWhitespace<UChar>), "attachment"_s))
+    if (!equalLettersIgnoringASCIICase(contentDispositionView.left(contentDispositionView.find(';')).trim(isUnicodeCompatibleASCIIWhitespace<char16_t>), "attachment"_s))
         return false;
 
     return !filenameFromHTTPContentDisposition(contentDispositionView).isNull();
@@ -883,7 +883,7 @@ bool ResourceResponseBase::equalForWebKitLegacyChallengeComparison(const Resourc
 bool ResourceResponseBase::containsInvalidHTTPHeaders() const
 {
     for (auto& header : httpHeaderFields()) {
-        if (!isValidHTTPHeaderValue(header.value.trim(isASCIIWhitespaceWithoutFF<UChar>)))
+        if (!isValidHTTPHeaderValue(header.value.trim(isASCIIWhitespaceWithoutFF<char16_t>)))
             return true;
     }
     return false;

--- a/Source/WebCore/platform/network/TimingAllowOrigin.cpp
+++ b/Source/WebCore/platform/network/TimingAllowOrigin.cpp
@@ -42,7 +42,7 @@ bool passesTimingAllowOriginCheck(const ResourceResponse& response, const Securi
     const auto& timingAllowOriginString = response.httpHeaderField(HTTPHeaderName::TimingAllowOrigin);
     const auto& securityOrigin = initiatorSecurityOrigin.toString();
     for (auto originWithSpace : StringView(timingAllowOriginString).split(',')) {
-        auto origin = originWithSpace.trim(isASCIIWhitespaceWithoutFF<UChar>);
+        auto origin = originWithSpace.trim(isASCIIWhitespaceWithoutFF<char16_t>);
         if (origin == "*"_s || origin == securityOrigin)
             return true;
     }

--- a/Source/WebCore/platform/network/soup/ResourceResponseSoup.cpp
+++ b/Source/WebCore/platform/network/soup/ResourceResponseSoup.cpp
@@ -104,7 +104,7 @@ static String sanitizeFilename(const String& filename)
         return filename;
 
     // Trim leading/trailing whitespaces, path separators and dots
-    auto result = filename.trim([](UChar character) -> bool {
+    auto result = filename.trim([](char16_t character) -> bool {
         return deprecatedIsSpaceOrNewline(character) || character == '/' || character == '\\' || character == '.';
     });
 

--- a/Source/WebCore/platform/sql/SQLiteDatabase.cpp
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.cpp
@@ -789,7 +789,7 @@ static Expected<sqlite3_stmt*, int> constructAndPrepareStatement(SQLiteDatabase&
 
 Expected<SQLiteStatement, int> SQLiteDatabase::prepareStatementSlow(StringView queryString)
 {
-    auto query = queryString.trim(isUnicodeCompatibleASCIIWhitespace<UChar>).utf8();
+    auto query = queryString.trim(isUnicodeCompatibleASCIIWhitespace<char16_t>).utf8();
     auto sqlStatement = constructAndPrepareStatement(*this, query.spanIncludingNullTerminator());
     if (!sqlStatement) {
         RELEASE_LOG_ERROR(SQLDatabase, "SQLiteDatabase::prepareStatement: Failed to prepare statement %" PUBLIC_LOG_STRING, query.data());
@@ -810,7 +810,7 @@ Expected<SQLiteStatement, int> SQLiteDatabase::prepareStatement(ASCIILiteral que
 
 Expected<UniqueRef<SQLiteStatement>, int> SQLiteDatabase::prepareHeapStatementSlow(StringView queryString)
 {
-    auto query = queryString.trim(isUnicodeCompatibleASCIIWhitespace<UChar>).utf8();
+    auto query = queryString.trim(isUnicodeCompatibleASCIIWhitespace<char16_t>).utf8();
     auto sqlStatement = constructAndPrepareStatement(*this, query.spanIncludingNullTerminator());
     if (!sqlStatement) {
         RELEASE_LOG_ERROR(SQLDatabase, "SQLiteDatabase::prepareHeapStatement: Failed to prepare statement %" PUBLIC_LOG_STRING, query.data());

--- a/Source/WebCore/platform/sql/SQLiteStatement.cpp
+++ b/Source/WebCore/platform/sql/SQLiteStatement.cpp
@@ -110,8 +110,8 @@ int SQLiteStatement::bindBlob(int index, const String& text)
     // String::characters() returns 0 for the empty string, which SQLite
     // treats as a null, so we supply a non-null pointer for that case.
     auto upconvertedCharacters = StringView(text).upconvertedCharacters();
-    UChar anyCharacter = 0;
-    std::span<const UChar> characters;
+    char16_t anyCharacter = 0;
+    std::span<const char16_t> characters;
     if (text.isEmpty() && !text.isNull())
         characters = unsafeMakeSpan(&anyCharacter, 0);
     else
@@ -278,7 +278,7 @@ String SQLiteStatement::columnBlobAsString(int col)
     if (columnCount() <= col)
         return String();
 
-    auto blob = sqliteColumnBlob<UChar>(m_statement, col);
+    auto blob = sqliteColumnBlob<char16_t>(m_statement, col);
     if (!blob.data())
         return emptyString();
     return StringImpl::create8BitIfPossible(blob);

--- a/Source/WebCore/platform/text/DateTimeFormat.cpp
+++ b/Source/WebCore/platform/text/DateTimeFormat.cpp
@@ -89,7 +89,7 @@ static constexpr std::array upperCaseToFieldTypeMap {
     DateTimeFormat::FieldTypeRFC822Zone, // Z
 };
 
-static DateTimeFormat::FieldType mapCharacterToFieldType(const UChar ch)
+static DateTimeFormat::FieldType mapCharacterToFieldType(const char16_t ch)
 {
     if (isASCIIUpper(ch))
         return upperCaseToFieldTypeMap[ch - 'A'];
@@ -115,7 +115,7 @@ bool DateTimeFormat::parse(const String& source, TokenHandler& tokenHandler)
     int fieldCounter = 0;
 
     for (unsigned int index = 0; index < source.length(); ++index) {
-        const UChar ch = source[index];
+        const char16_t ch = source[index];
         switch (state) {
         case StateInQuote:
             if (ch == '\'') {
@@ -240,7 +240,7 @@ bool DateTimeFormat::parse(const String& source, TokenHandler& tokenHandler)
     return false;
 }
 
-static bool isASCIIAlphabetOrQuote(UChar ch)
+static bool isASCIIAlphabetOrQuote(char16_t ch)
 {
     return isASCIIAlpha(ch) || ch == '\'';
 }

--- a/Source/WebCore/platform/text/LocaleICU.cpp
+++ b/Source/WebCore/platform/text/LocaleICU.cpp
@@ -98,7 +98,7 @@ String LocaleICU::decimalSymbol(UNumberFormatSymbol symbol)
     ASSERT(U_SUCCESS(status) || needsToGrowToProduceBuffer(status));
     if (U_FAILURE(status) && !needsToGrowToProduceBuffer(status))
         return String();
-    StringBuffer<UChar> buffer(bufferLength);
+    StringBuffer<char16_t> buffer(bufferLength);
     status = U_ZERO_ERROR;
     unum_getSymbol(m_numberFormat, symbol, buffer.characters(), bufferLength, &status);
     if (U_FAILURE(status))
@@ -113,7 +113,7 @@ String LocaleICU::decimalTextAttribute(UNumberFormatTextAttribute tag)
     ASSERT(U_SUCCESS(status) || needsToGrowToProduceBuffer(status));
     if (U_FAILURE(status) && !needsToGrowToProduceBuffer(status))
         return String();
-    StringBuffer<UChar> buffer(bufferLength);
+    StringBuffer<char16_t> buffer(bufferLength);
     status = U_ZERO_ERROR;
     unum_getTextAttribute(m_numberFormat, tag, buffer.characters(), bufferLength, &status);
     ASSERT(U_SUCCESS(status));
@@ -163,7 +163,7 @@ bool LocaleICU::initializeShortDateFormat()
 
 UDateFormat* LocaleICU::openDateFormat(UDateFormatStyle timeStyle, UDateFormatStyle dateStyle) const
 {
-    const UChar gmtTimezone[3] = {'G', 'M', 'T'};
+    const char16_t gmtTimezone[3] = {'G', 'M', 'T'};
     UErrorCode status = U_ZERO_ERROR;
     return udat_open(timeStyle, dateStyle, m_locale.data(), gmtTimezone, std::size(gmtTimezone), 0, -1, &status);
 }
@@ -177,7 +177,7 @@ static String getDateFormatPattern(const UDateFormat* dateFormat)
     int32_t length = udat_toPattern(dateFormat, true, 0, 0, &status);
     if (!needsToGrowToProduceBuffer(status) || !length)
         return emptyString();
-    StringBuffer<UChar> buffer(length);
+    StringBuffer<char16_t> buffer(length);
     status = U_ZERO_ERROR;
     udat_toPattern(dateFormat, true, buffer.characters(), length, &status);
     if (U_FAILURE(status))
@@ -199,7 +199,7 @@ std::unique_ptr<Vector<String>> LocaleICU::createLabelVector(const UDateFormat* 
         int32_t length = udat_getSymbols(dateFormat, type, startIndex + i, 0, 0, &status);
         if (!needsToGrowToProduceBuffer(status))
             return makeUnique<Vector<String>>();
-        StringBuffer<UChar> buffer(length);
+        StringBuffer<char16_t> buffer(length);
         status = U_ZERO_ERROR;
         udat_getSymbols(dateFormat, type, startIndex + i, buffer.characters(), length, &status);
         if (U_FAILURE(status))
@@ -272,7 +272,7 @@ String LocaleICU::dateFormat()
     return m_dateFormat;
 }
 
-static String getFormatForSkeleton(const char* locale, const UChar* skeleton, int32_t skeletonLength)
+static String getFormatForSkeleton(const char* locale, const char16_t* skeleton, int32_t skeletonLength)
 {
     String format = "yyyy-MM"_s;
     UErrorCode status = U_ZERO_ERROR;
@@ -282,7 +282,7 @@ static String getFormatForSkeleton(const char* locale, const UChar* skeleton, in
     status = U_ZERO_ERROR;
     int32_t length = udatpg_getBestPattern(patternGenerator, skeleton, skeletonLength, 0, 0, &status);
     if (needsToGrowToProduceBuffer(status) && length) {
-        StringBuffer<UChar> buffer(length);
+        StringBuffer<char16_t> buffer(length);
         status = U_ZERO_ERROR;
         udatpg_getBestPattern(patternGenerator, skeleton, skeletonLength, buffer.characters(), length, &status);
         if (U_SUCCESS(status))
@@ -298,7 +298,7 @@ String LocaleICU::monthFormat()
         return m_monthFormat;
     // Gets a format for "MMMM" because Windows API always provides formats for
     // "MMMM" in some locales.
-    const UChar skeleton[] = { 'y', 'y', 'y', 'y', 'M', 'M', 'M', 'M' };
+    const char16_t skeleton[] = { 'y', 'y', 'y', 'y', 'M', 'M', 'M', 'M' };
     m_monthFormat = getFormatForSkeleton(m_locale.data(), skeleton, std::size(skeleton));
     return m_monthFormat;
 }
@@ -307,7 +307,7 @@ String LocaleICU::shortMonthFormat()
 {
     if (!m_shortMonthFormat.isNull())
         return m_shortMonthFormat;
-    const UChar skeleton[] = { 'y', 'y', 'y', 'y', 'M', 'M', 'M' };
+    const char16_t skeleton[] = { 'y', 'y', 'y', 'y', 'M', 'M', 'M' };
     m_shortMonthFormat = getFormatForSkeleton(m_locale.data(), skeleton, std::size(skeleton));
     return m_shortMonthFormat;
 }

--- a/Source/WebCore/platform/text/PlatformLocale.cpp
+++ b/Source/WebCore/platform/text/PlatformLocale.cpp
@@ -323,7 +323,7 @@ String Locale::convertFromLocalizedNumber(const String& localized)
         else if (symbolIndex == GroupSeparatorIndex)
             return input;
         else
-            builder.append(static_cast<UChar>('0' + symbolIndex));
+            builder.append(static_cast<char16_t>('0' + symbolIndex));
     }
     String converted = builder.toString();
     // Ignore trailing '.', but will reject '.'-only string later.

--- a/Source/WebCore/platform/text/SegmentedString.cpp
+++ b/Source/WebCore/platform/text/SegmentedString.cpp
@@ -251,7 +251,7 @@ SegmentedString::AdvancePastResult SegmentedString::advancePastSlowCase(ASCIILit
     ASSERT(length <= maxLength);
     if (length > this->length())
         return NotEnoughCharacters;
-    std::array<UChar, maxLength> consumedCharacters;
+    std::array<char16_t, maxLength> consumedCharacters;
     for (unsigned i = 0; i < length; ++i) {
         auto character = m_currentCharacter;
         if (characterMismatch(character, literal[i], lettersIgnoringASCIICase)) {

--- a/Source/WebCore/platform/text/SegmentedString.h
+++ b/Source/WebCore/platform/text/SegmentedString.h
@@ -69,7 +69,7 @@ public:
 
     String toString() const;
 
-    UChar currentCharacter() const { return m_currentCharacter; }
+    char16_t currentCharacter() const { return m_currentCharacter; }
 
     OrdinalNumber currentColumn() const;
     OrdinalNumber currentLine() const;
@@ -84,8 +84,8 @@ private:
         Substring(String&&);
         explicit Substring(StringView);
 
-        UChar currentCharacter() const;
-        UChar currentCharacterPreIncrement();
+        char16_t currentCharacter() const;
+        char16_t currentCharacterPreIncrement();
 
         unsigned numberOfCharactersConsumed() const;
         void appendTo(StringBuilder&) const;
@@ -100,7 +100,7 @@ private:
                 : currentCharacter8()
             { }
             std::span<const LChar> currentCharacter8;
-            std::span<const UChar> currentCharacter16;
+            std::span<const char16_t> currentCharacter16;
         } s;
         bool is8Bit { true };
         bool doNotExcludeLineNumbers { true };
@@ -139,7 +139,7 @@ private:
 
     bool m_isClosed { false };
 
-    UChar m_currentCharacter { 0 };
+    char16_t m_currentCharacter { 0 };
 
     unsigned m_numberOfCharactersConsumedPriorToCurrentSubstring { 0 };
     unsigned m_numberOfCharactersConsumedPriorToCurrentLine { 0 };
@@ -180,13 +180,13 @@ inline unsigned SegmentedString::Substring::numberOfCharactersConsumed() const
     return originalLength - length();
 }
 
-ALWAYS_INLINE UChar SegmentedString::Substring::currentCharacter() const
+ALWAYS_INLINE char16_t SegmentedString::Substring::currentCharacter() const
 {
     ASSERT(length());
     return is8Bit ? s.currentCharacter8.front() : s.currentCharacter16.front();
 }
 
-ALWAYS_INLINE UChar SegmentedString::Substring::currentCharacterPreIncrement()
+ALWAYS_INLINE char16_t SegmentedString::Substring::currentCharacterPreIncrement()
 {
     ASSERT(length());
     if (is8Bit) {

--- a/Source/WebCore/platform/text/SuffixTree.h
+++ b/Source/WebCore/platform/text/SuffixTree.h
@@ -34,13 +34,13 @@ namespace WebCore {
 
 class UnicodeCodebook {
 public:
-    static int codeWord(UChar c) { return c; }
-    enum { codeSize = 1 << 8 * sizeof(UChar) };
+    static int codeWord(char16_t c) { return c; }
+    enum { codeSize = 1 << 8 * sizeof(char16_t) };
 };
 
 class ASCIICodebook {
 public:
-    static int codeWord(UChar c) { return c & (codeSize - 1); }
+    static int codeWord(char16_t c) { return c & (codeSize - 1); }
     enum { codeSize = 1 << (8 * sizeof(char) - 1) };
 };
 

--- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
+++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
@@ -152,7 +152,7 @@ HGLOBAL createGlobalData(const URL& url, const String& title)
     String mutableURL(url.string());
     String mutableTitle(title);
     SIZE_T size = mutableURL.length() + mutableTitle.length() + 2; // +1 for "\n" and +1 for null terminator
-    HGLOBAL cbData = ::GlobalAlloc(GPTR, size * sizeof(UChar));
+    HGLOBAL cbData = ::GlobalAlloc(GPTR, size * sizeof(char16_t));
 
     if (cbData) {
         PWSTR buffer = static_cast<PWSTR>(GlobalLock(cbData));
@@ -164,10 +164,10 @@ HGLOBAL createGlobalData(const URL& url, const String& title)
 
 HGLOBAL createGlobalData(const String& str)
 {
-    HGLOBAL vm = ::GlobalAlloc(GPTR, (str.length() + 1) * sizeof(UChar));
+    HGLOBAL vm = ::GlobalAlloc(GPTR, (str.length() + 1) * sizeof(char16_t));
     if (!vm)
         return 0;
-    auto buffer = unsafeMakeSpan(static_cast<UChar*>(GlobalLock(vm)), str.length() + 1);
+    auto buffer = unsafeMakeSpan(static_cast<char16_t*>(GlobalLock(vm)), str.length() + 1);
     StringView(str).getCharacters(buffer);
     buffer[str.length()] = 0;
     GlobalUnlock(vm);
@@ -418,7 +418,7 @@ void setFileDescriptorData(IDataObject* dataObject, int size, const String& pass
     fgd->fgd[0].nFileSizeLow = size;
 
     int maxSize = std::min<int>(pathname.length(), std::size(fgd->fgd[0].cFileName));
-    CopyMemory(fgd->fgd[0].cFileName, pathname.charactersWithNullTermination()->span().data(), maxSize * sizeof(UChar));
+    CopyMemory(fgd->fgd[0].cFileName, pathname.charactersWithNullTermination()->span().data(), maxSize * sizeof(char16_t));
     GlobalUnlock(medium.hGlobal);
 
     dataObject->SetData(fileDescriptorFormat(), &medium, TRUE);
@@ -786,14 +786,14 @@ static const ClipboardFormatMap& getClipboardMap()
     static ClipboardFormatMap formatMap;
     if (formatMap.isEmpty()) {
         formatMap.add(htmlFormat()->cfFormat, new ClipboardDataItem(htmlFormat(), getUTF8Data, setUTF8Data));
-        formatMap.add(texthtmlFormat()->cfFormat, new ClipboardDataItem(texthtmlFormat(), getStringData<UChar>, setUCharData));
+        formatMap.add(texthtmlFormat()->cfFormat, new ClipboardDataItem(texthtmlFormat(), getStringData<char16_t>, setUCharData));
         formatMap.add(plainTextFormat()->cfFormat,  new ClipboardDataItem(plainTextFormat(), getStringData<char>, setUTF8Data));
-        formatMap.add(plainTextWFormat()->cfFormat,  new ClipboardDataItem(plainTextWFormat(), getStringData<UChar>, setUCharData));
+        formatMap.add(plainTextWFormat()->cfFormat,  new ClipboardDataItem(plainTextWFormat(), getStringData<char16_t>, setUCharData));
         formatMap.add(cfHDropFormat()->cfFormat,  new ClipboardDataItem(cfHDropFormat(), getHDropData, setHDropData));
         formatMap.add(filenameFormat()->cfFormat,  new ClipboardDataItem(filenameFormat(), getStringData<char>, setUTF8Data));
-        formatMap.add(filenameWFormat()->cfFormat,  new ClipboardDataItem(filenameWFormat(), getStringData<UChar>, setUCharData));
+        formatMap.add(filenameWFormat()->cfFormat,  new ClipboardDataItem(filenameWFormat(), getStringData<char16_t>, setUCharData));
         formatMap.add(urlFormat()->cfFormat,  new ClipboardDataItem(urlFormat(), getStringData<char>, setUTF8Data));
-        formatMap.add(urlWFormat()->cfFormat,  new ClipboardDataItem(urlWFormat(), getStringData<UChar>, setUCharData));
+        formatMap.add(urlWFormat()->cfFormat,  new ClipboardDataItem(urlWFormat(), getStringData<char16_t>, setUCharData));
     }
     return formatMap;
 }

--- a/Source/WebCore/platform/win/KeyEventWin.cpp
+++ b/Source/WebCore/platform/win/KeyEventWin.cpp
@@ -218,7 +218,7 @@ static int windowsKeycodeWithLocation(WPARAM keycode, LPARAM keyData)
     return regeneratedVirtualKeyCode ? regeneratedVirtualKeyCode : keycode;
 }
 
-static inline String singleCharacterString(UChar c)
+static inline String singleCharacterString(char16_t c)
 {
     return span(c);
 }

--- a/Source/WebCore/platform/win/PasteboardWin.cpp
+++ b/Source/WebCore/platform/win/PasteboardWin.cpp
@@ -607,13 +607,13 @@ static String fileSystemPathFromURLOrTitle(const String& urlString, const String
 {
     static const size_t fsPathMaxLengthExcludingNullTerminator = MAX_PATH - 1;
     bool usedURL = false;
-    std::array<UChar, MAX_PATH> fsPathBuffer;
+    std::array<char16_t, MAX_PATH> fsPathBuffer;
     fsPathBuffer[0] = 0;
     int fsPathMaxLengthExcludingExtension = fsPathMaxLengthExcludingNullTerminator - extension.length();
 
     if (!title.isEmpty()) {
         size_t len = std::min<size_t>(title.length(), fsPathMaxLengthExcludingExtension);
-        StringView(title).left(len).getCharacters(std::span<UChar> { fsPathBuffer });
+        StringView(title).left(len).getCharacters(std::span<char16_t> { fsPathBuffer });
         fsPathBuffer[len] = 0;
         pathRemoveBadFSCharacters(wcharFrom(fsPathBuffer.data()), len);
     }
@@ -628,10 +628,10 @@ static String fileSystemPathFromURLOrTitle(const String& urlString, const String
         auto lastComponent = url.lastPathComponent();
         if (url.protocolIsFile() || (!isLink && !lastComponent.isEmpty())) {
             len = std::min<DWORD>(fsPathMaxLengthExcludingExtension, lastComponent.length());
-            lastComponent.left(len).getCharacters(std::span<UChar> { fsPathBuffer });
+            lastComponent.left(len).getCharacters(std::span<char16_t> { fsPathBuffer });
         } else {
             len = std::min<DWORD>(fsPathMaxLengthExcludingExtension, urlString.length());
-            StringView(urlString).left(len).getCharacters(std::span<UChar> { fsPathBuffer });
+            StringView(urlString).left(len).getCharacters(std::span<char16_t> { fsPathBuffer });
         }
         fsPathBuffer[len] = 0;
         pathRemoveBadFSCharacters(wcharFrom(fsPathBuffer.data()), len);
@@ -645,7 +645,7 @@ static String fileSystemPathFromURLOrTitle(const String& urlString, const String
         return String(wcharFrom(fsPathBuffer.data()));
     }
 
-    return makeString(const_cast<const UChar*>(fsPathBuffer.data()), extension);
+    return makeString(const_cast<const char16_t*>(fsPathBuffer.data()), extension);
 }
 
 // writeFileToDataObject takes ownership of fileDescriptor and fileContent
@@ -729,7 +729,7 @@ void Pasteboard::writeURLToDataObject(const URL& kurl, const String& titleStr)
     fgd->fgd[0].nFileSizeLow = content.length();
 
     unsigned maxSize = std::min<unsigned>(fsPath.length(), std::size(fgd->fgd[0].cFileName));
-    StringView(fsPath).left(maxSize).getCharacters(spanReinterpretCast<UChar>(std::span<wchar_t> { fgd->fgd[0].cFileName }));
+    StringView(fsPath).left(maxSize).getCharacters(spanReinterpretCast<char16_t>(std::span<wchar_t> { fgd->fgd[0].cFileName }));
     GlobalUnlock(urlFileDescriptor);
 
     char* fileContents = static_cast<char*>(GlobalLock(urlFileContent));
@@ -967,7 +967,7 @@ static HGLOBAL createGlobalImageFileDescriptor(const String& url, const String& 
     }
 
     int maxSize = std::min<int>(fsPath.length(), std::size(fgd->fgd[0].cFileName));
-    StringView(fsPath).left(maxSize).getCharacters(spanReinterpretCast<UChar>(std::span<wchar_t> { fgd->fgd[0].cFileName }));
+    StringView(fsPath).left(maxSize).getCharacters(spanReinterpretCast<char16_t>(std::span<wchar_t> { fgd->fgd[0].cFileName }));
     GlobalUnlock(memObj);
 
     return memObj;

--- a/Source/WebCore/platform/win/WindowsKeyNames.cpp
+++ b/Source/WebCore/platform/win/WindowsKeyNames.cpp
@@ -286,7 +286,7 @@ String WindowsKeyNames::domKeyFromParams(WPARAM virtualKey, LPARAM lParam)
     return "Unidentified"_s;
 }
 
-String WindowsKeyNames::domKeyFromChar(UChar c)
+String WindowsKeyNames::domKeyFromChar(char16_t c)
 {
     switch (c) {
     case '\x1b':

--- a/Source/WebCore/platform/win/WindowsKeyNames.h
+++ b/Source/WebCore/platform/win/WindowsKeyNames.h
@@ -41,7 +41,7 @@ public:
     WEBCORE_EXPORT WindowsKeyNames();
 
     WEBCORE_EXPORT String domKeyFromParams(WPARAM, LPARAM);
-    WEBCORE_EXPORT String domKeyFromChar(UChar);
+    WEBCORE_EXPORT String domKeyFromChar(char16_t);
     WEBCORE_EXPORT String domCodeFromLParam(LPARAM);
 
     enum class KeyModifier : uint8_t;

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -144,7 +144,7 @@ inline SessionFeature sessionFeatureFromReferenceSpaceType(ReferenceSpaceType re
 
 inline std::optional<SessionFeature> parseSessionFeatureDescriptor(StringView string)
 {
-    auto feature = string.trim(isUnicodeCompatibleASCIIWhitespace<UChar>).convertToASCIILowercase();
+    auto feature = string.trim(isUnicodeCompatibleASCIIWhitespace<char16_t>).convertToASCIILowercase();
 
     if (feature == "viewer"_s)
         return SessionFeature::ReferenceSpaceTypeViewer;

--- a/Source/WebCore/rendering/BreakLines.h
+++ b/Source/WebCore/rendering/BreakLines.h
@@ -69,10 +69,10 @@ private:
     // Helper functions.
     enum BreakClass : uint16_t;
     template<LineBreakRules, NoBreakSpaceBehavior>
-    static inline BreakClass classify(UChar character);
+    static inline BreakClass classify(char16_t character);
 
     template<NoBreakSpaceBehavior>
-    static inline bool isBreakableSpace(UChar character);
+    static inline bool isBreakableSpace(char16_t character);
 
     // Data types.
     enum BreakClass : uint16_t {
@@ -115,12 +115,12 @@ private:
 
     class LineBreakTable {
     public:
-        static constexpr UChar firstCharacter = '!';
-        static constexpr UChar lastCharacter = 0xFF;
+        static constexpr char16_t firstCharacter = '!';
+        static constexpr char16_t lastCharacter = 0xFF;
         static constexpr unsigned rowCount = lastCharacter - firstCharacter + 1;
         static constexpr unsigned columnCount = (lastCharacter - firstCharacter) / 8 + 1;
 
-        static inline bool unsafeLookup(UChar before, UChar after) // Must range check before calling.
+        static inline bool unsafeLookup(char16_t before, char16_t after) // Must range check before calling.
         {
             const unsigned beforeIndex = before - firstCharacter;
             const unsigned afterIndex = after - firstCharacter;
@@ -134,7 +134,7 @@ private:
 
 
 template<BreakLines::NoBreakSpaceBehavior nonBreakingSpaceBehavior>
-inline bool BreakLines::isBreakableSpace(UChar character)
+inline bool BreakLines::isBreakableSpace(char16_t character)
 {
     switch (character) {
     case ' ':
@@ -293,8 +293,8 @@ inline unsigned BreakLines::nextBreakablePosition(CachedLineBreakIteratorFactory
             : nextBreakablePosition<LChar, rules, words, spaces>(lineBreakIteratorFactory, stringView.span8(), startPosition);
     }
     return words == WordBreakBehavior::KeepAll
-        ? nextBreakableSpace<UChar, spaces>(stringView.span16(), startPosition)
-        : nextBreakablePosition<UChar, rules, words, spaces>(lineBreakIteratorFactory, stringView.span16(), startPosition);
+        ? nextBreakableSpace<char16_t, spaces>(stringView.span16(), startPosition)
+        : nextBreakablePosition<char16_t, rules, words, spaces>(lineBreakIteratorFactory, stringView.span16(), startPosition);
 }
 
 
@@ -325,16 +325,16 @@ inline bool BreakLines::isBreakable(CachedLineBreakIteratorFactory& lineBreakIte
 }
 
 template<BreakLines::LineBreakRules rules, BreakLines::NoBreakSpaceBehavior nonBreakingSpaceBehavior>
-inline BreakLines::BreakClass BreakLines::classify(UChar character)
+inline BreakLines::BreakClass BreakLines::classify(char16_t character)
 {
     // This function is optimized for letters and NBSP.
     // See LineBreak.txt for classification.
 
-    static constexpr UChar blockLast3 = ~0x07;
-    static constexpr UChar blockLast4 = ~0x0F;
-    static constexpr UChar blockLast6 = ~0x3F;
-    static constexpr UChar blockLast7 = ~0x7F;
-    static constexpr UChar blockLast8 = ~0xFF;
+    static constexpr char16_t blockLast3 = ~0x07;
+    static constexpr char16_t blockLast4 = ~0x0F;
+    static constexpr char16_t blockLast6 = ~0x3F;
+    static constexpr char16_t blockLast7 = ~0x7F;
+    static constexpr char16_t blockLast8 = ~0xFF;
 
     switch ((character & blockLast7) / 0x80) {
         // Compilers are not smart enough to make a jump table if the step is not 1.

--- a/Source/WebCore/rendering/LegacyInlineIterator.cpp
+++ b/Source/WebCore/rendering/LegacyInlineIterator.cpp
@@ -31,11 +31,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace WebCore {
 
-UCharDirection LegacyInlineIterator::surrogateTextDirection(UChar currentCodeUnit) const
+UCharDirection LegacyInlineIterator::surrogateTextDirection(char16_t currentCodeUnit) const
 {
     RenderText& text = downcast<RenderText>(*m_renderer);
-    UChar lead;
-    UChar trail;
+    char16_t lead;
+    char16_t trail;
     if (U16_IS_LEAD(currentCodeUnit)) {
         lead = currentCodeUnit;
         trail = text.characterAt(m_pos + 1);

--- a/Source/WebCore/rendering/LegacyInlineIterator.h
+++ b/Source/WebCore/rendering/LegacyInlineIterator.h
@@ -102,14 +102,14 @@ public:
     inline bool atTextParagraphSeparator() const;
     inline bool atParagraphSeparator() const;
 
-    UChar current() const;
-    UChar previousInSameNode() const;
+    char16_t current() const;
+    char16_t previousInSameNode() const;
     ALWAYS_INLINE UCharDirection direction() const;
 
 private:
-    UChar characterAt(unsigned) const;
+    char16_t characterAt(unsigned) const;
 
-    UCharDirection surrogateTextDirection(UChar currentCodeUnit) const;
+    UCharDirection surrogateTextDirection(char16_t currentCodeUnit) const;
 
     RenderElement* m_root { nullptr };
     RenderObject* m_renderer { nullptr };
@@ -331,7 +331,7 @@ inline bool LegacyInlineIterator::atEnd() const
     return !m_renderer;
 }
 
-inline UChar LegacyInlineIterator::characterAt(unsigned index) const
+inline char16_t LegacyInlineIterator::characterAt(unsigned index) const
 {
     auto* textRenderer = dynamicDowncast<RenderText>(m_renderer);
     if (!textRenderer)
@@ -339,12 +339,12 @@ inline UChar LegacyInlineIterator::characterAt(unsigned index) const
     return textRenderer->characterAt(index);
 }
 
-inline UChar LegacyInlineIterator::current() const
+inline char16_t LegacyInlineIterator::current() const
 {
     return characterAt(m_pos);
 }
 
-inline UChar LegacyInlineIterator::previousInSameNode() const
+inline char16_t LegacyInlineIterator::previousInSameNode() const
 {
     return characterAt(m_pos - 1);
 }
@@ -355,7 +355,7 @@ ALWAYS_INLINE UCharDirection LegacyInlineIterator::direction() const
         return U_OTHER_NEUTRAL;
 
     if (auto* textRenderer = dynamicDowncast<RenderText>(*m_renderer); textRenderer) [[likely]] {
-        UChar codeUnit = textRenderer->characterAt(m_pos);
+        char16_t codeUnit = textRenderer->characterAt(m_pos);
         if (U16_IS_SINGLE(codeUnit)) [[likely]]
             return u_charDirection(codeUnit);
         return surrogateTextDirection(codeUnit);

--- a/Source/WebCore/rendering/LegacyLineLayout.cpp
+++ b/Source/WebCore/rendering/LegacyLineLayout.cpp
@@ -72,7 +72,7 @@ static void determineDirectionality(TextDirection& dir, LegacyInlineIterator ite
     while (!iter.atEnd()) {
         if (iter.atParagraphSeparator())
             return;
-        if (UChar current = iter.current()) {
+        if (char16_t current = iter.current()) {
             UCharDirection charDirection = u_charDirection(current);
             if (charDirection == U_LEFT_TO_RIGHT) {
                 dir = TextDirection::LTR;

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -3093,7 +3093,7 @@ TextRun RenderBlock::constructTextRun(std::span<const LChar> characters, const R
     return constructTextRun(StringView { characters }, style, expansion);
 }
 
-TextRun RenderBlock::constructTextRun(std::span<const UChar> characters, const RenderStyle& style, ExpansionBehavior expansion)
+TextRun RenderBlock::constructTextRun(std::span<const char16_t> characters, const RenderStyle& style, ExpansionBehavior expansion)
 {
     return constructTextRun(StringView { characters }, style, expansion);
 }
@@ -3475,16 +3475,16 @@ String RenderBlock::updateSecurityDiscCharacters(const RenderStyle& style, Strin
     if (style.textSecurity() == TextSecurity::None)
         return WTFMove(string);
     // This PUA character in the system font is used to render password field dots on Cocoa platforms.
-    constexpr UChar textSecurityDiscPUACodePoint = 0xF79A;
+    constexpr char16_t textSecurityDiscPUACodePoint = 0xF79A;
     Ref font = style.fontCascade().primaryFont();
     if (!(font->platformData().isSystemFont() && font->glyphForCharacter(textSecurityDiscPUACodePoint)))
         return WTFMove(string);
 
     // See RenderText::setRenderedText()
 #if PLATFORM(IOS_FAMILY)
-    constexpr UChar discCharacterToReplace = blackCircle;
+    constexpr char16_t discCharacterToReplace = blackCircle;
 #else
-    constexpr UChar discCharacterToReplace = bullet;
+    constexpr char16_t discCharacterToReplace = bullet;
 #endif
 
     return makeStringByReplacingAll(string, discCharacterToReplace, textSecurityDiscPUACodePoint);

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -151,7 +151,7 @@ public:
         ExpansionBehavior = ExpansionBehavior::defaultBehavior());
     static TextRun constructTextRun(std::span<const LChar> characters, const RenderStyle&,
         ExpansionBehavior = ExpansionBehavior::defaultBehavior());
-    static TextRun constructTextRun(std::span<const UChar> characters, const RenderStyle&,
+    static TextRun constructTextRun(std::span<const char16_t> characters, const RenderStyle&,
         ExpansionBehavior = ExpansionBehavior::defaultBehavior());
 
     LayoutUnit paginationStrut() const;

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -4494,7 +4494,7 @@ static inline void stripTrailingSpace(float& inlineMax, float& inlineMin, Render
 {
     if (auto* renderText = dynamicDowncast<RenderText>(trailingSpaceChild)) {
         // Collapse away the trailing space at the end of a block.
-        const UChar space = ' ';
+        const char16_t space = ' ';
         const FontCascade& font = renderText->style().fontCascade(); // FIXME: This ignores first-line.
         float spaceWidth = font.width(RenderBlock::constructTextRun(span(space), renderText->style()));
         inlineMax -= spaceWidth + font.wordSpacing();

--- a/Source/WebCore/rendering/RenderFileUploadControl.cpp
+++ b/Source/WebCore/rendering/RenderFileUploadControl.cpp
@@ -281,7 +281,7 @@ void RenderFileUploadControl::computeIntrinsicLogicalWidths(LayoutUnit& minLogic
     }
     // Figure out how big the filename space needs to be for a given number of characters
     // (using "0" as the nominal character).
-    const UChar character = '0';
+    const char16_t character = '0';
     const String characterAsString = span(character);
     const FontCascade& font = style().fontCascade();
     // FIXME: Remove the need for this const_cast by making constructTextRun take a const RenderObject*.

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -112,7 +112,7 @@ static String reversed(StringView string)
     auto length = string.length();
     if (length <= 1)
         return string.toString();
-    std::span<UChar> characters;
+    std::span<char16_t> characters;
     auto result = String::createUninitialized(length, characters);
     for (unsigned i = 0; i < length; ++i)
         characters[i] = string[length - i - 1];

--- a/Source/WebCore/rendering/RenderQuote.cpp
+++ b/Source/WebCore/rendering/RenderQuote.cpp
@@ -54,10 +54,10 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(RenderQuote);
 struct QuotesForLanguage {
     std::span<const char> language;
     uint8_t checkFurther { 0 };
-    UChar open1 { 0 };
-    UChar close1 { 0 };
-    UChar open2 { 0 };
-    UChar close2 { 0 };
+    char16_t open1 { 0 };
+    char16_t close1 { 0 };
+    char16_t open2 { 0 };
+    char16_t close2 { 0 };
 };
 
 // Table of quotes from http://www.whatwg.org/specs/web-apps/current-work/multipage/rendering.html#quotes
@@ -249,10 +249,10 @@ constexpr unsigned maxDistinctQuoteCharacters = 16;
 
 #if ASSERT_ENABLED
 
-static void checkNumberOfDistinctQuoteCharacters(UChar character)
+static void checkNumberOfDistinctQuoteCharacters(char16_t character)
 {
     ASSERT(character);
-    static std::array<UChar, maxDistinctQuoteCharacters> distinctQuoteCharacters;
+    static std::array<char16_t, maxDistinctQuoteCharacters> distinctQuoteCharacters;
     for (unsigned i = 0; i < maxDistinctQuoteCharacters; ++i) {
         if (distinctQuoteCharacters[i] == character)
             return;
@@ -402,7 +402,7 @@ static const QuotesForLanguage* quotesForLanguage(const String& language)
 
     Vector<char> languageKeyBuffer(length);
     for (unsigned i = 0; i < length; ++i) {
-        UChar character = toASCIILower(language[i]);
+        char16_t character = toASCIILower(language[i]);
         if (!(isASCIILower(character) || character == '-'))
             return nullptr;
         languageKeyBuffer[i] = static_cast<char>(character);
@@ -411,12 +411,12 @@ static const QuotesForLanguage* quotesForLanguage(const String& language)
     return binaryFindQuotes({ languageKeyBuffer.span() });
 }
 
-static StringImpl* stringForQuoteCharacter(UChar character)
+static StringImpl* stringForQuoteCharacter(char16_t character)
 {
     // Use linear search because there is a small number of distinct characters, thus binary search is unneeded.
     ASSERT(character);
     struct StringForCharacter {
-        UChar character;
+        char16_t character;
         StringImpl* string;
     };
     static std::array<StringForCharacter, maxDistinctQuoteCharacters> strings;

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -160,7 +160,7 @@ static HashMap<SingleThreadWeakRef<const RenderText>, SingleThreadWeakPtr<Render
     return map;
 }
 
-static constexpr UChar convertNoBreakSpaceToSpace(UChar character)
+static constexpr char16_t convertNoBreakSpaceToSpace(char16_t character)
 {
     return character == noBreakSpace ? ' ' : character;
 }
@@ -172,7 +172,7 @@ static inline size_t capitalizeCharacter(String textContent, unsigned startChara
         return 0;
     }
 
-    auto capitalize = [&](const UChar* contentToCapitalize, size_t length) -> size_t {
+    auto capitalize = [&](const char16_t* contentToCapitalize, size_t length) -> size_t {
         if (length == 1) {
             if ((*contentToCapitalize >= 'A' && *contentToCapitalize <= 'Z') || *contentToCapitalize == ' ')
                 return 0;
@@ -183,7 +183,7 @@ static inline size_t capitalizeCharacter(String textContent, unsigned startChara
             }
         }
 
-        UChar capitalizedCharacter;
+        char16_t capitalizedCharacter;
         UErrorCode status = U_ZERO_ERROR;
         auto realLength = u_strToTitle(&capitalizedCharacter, 1, contentToCapitalize, length, nullptr, "", &status);
         if (U_SUCCESS(status) && realLength == 1) {
@@ -192,7 +192,7 @@ static inline size_t capitalizeCharacter(String textContent, unsigned startChara
         }
 
         // Decomposed ligatures may need more space.
-        std::span<UChar> capitalizedStringData;
+        std::span<char16_t> capitalizedStringData;
         auto capitalizedString = String::createUninitialized(realLength, capitalizedStringData);
         status = U_ZERO_ERROR;
         u_strToTitle(capitalizedStringData.data(), capitalizedStringData.size(), contentToCapitalize, length, nullptr, "", &status);
@@ -222,11 +222,11 @@ static inline size_t capitalizeCharacter(String textContent, unsigned startChara
 
 String capitalize(const String& string)
 {
-    Vector<UChar> previousCharacter(1, ' ');
+    Vector<char16_t> previousCharacter(1, ' ');
     return capitalize(string, previousCharacter);
 }
 
-String capitalize(const String& string, Vector<UChar> previousCharacter)
+String capitalize(const String& string, Vector<char16_t> previousCharacter)
 {
     int32_t length = string.length();
     int32_t previousCharacterLength = previousCharacter.size();
@@ -235,7 +235,7 @@ String capitalize(const String& string, Vector<UChar> previousCharacter)
     static_assert(String::MaxLength < std::numeric_limits<unsigned>::max(), "Must be able to add one without overflowing unsigned");
 
     // Replace NO BREAK SPACE with a normal spaces since ICU does not treat it as a word separator.
-    Vector<UChar> stringWithPrevious(previousCharacterLength + length);
+    Vector<char16_t> stringWithPrevious(previousCharacterLength + length);
     for (int32_t i = 0; i < previousCharacterLength; ++i)
         stringWithPrevious[i] = convertNoBreakSpaceToSpace(previousCharacter[i]);
     for (int32_t i = previousCharacterLength; i < length + previousCharacterLength; ++i)
@@ -954,12 +954,12 @@ ALWAYS_INLINE float RenderText::widthFromCacheConsideringPossibleTrailingSpace(c
     });
 }
 
-inline bool isHangablePunctuationAtLineStart(UChar c)
+inline bool isHangablePunctuationAtLineStart(char16_t c)
 {
     return U_GET_GC_MASK(c) & (U_GC_PS_MASK | U_GC_PI_MASK | U_GC_PF_MASK);
 }
 
-inline bool isHangablePunctuationAtLineEnd(UChar c)
+inline bool isHangablePunctuationAtLineEnd(char16_t c)
 {
     return U_GET_GC_MASK(c) & (U_GC_PE_MASK | U_GC_PI_MASK | U_GC_PF_MASK);
 }
@@ -990,7 +990,7 @@ float RenderText::hangablePunctuationEndWidth(unsigned index) const
     return widthFromCache(style.fontCascade(), index, 1, 0, 0, 0, style);
 }
 
-bool RenderText::isHangableStopOrComma(UChar c)
+bool RenderText::isHangableStopOrComma(char16_t c)
 {
     return c == 0x002C || c == 0x002E || c == 0x060C || c == 0x06D4 || c == 0x3001
         || c == 0x3002 || c == 0xFF0C || c == 0xFF0E || c == 0xFE50 || c == 0xFE51
@@ -1108,7 +1108,7 @@ RenderText::Widths RenderText::trimmedPreferredWidths(float leadWidth, bool& str
     return widths;
 }
 
-static inline bool isSpaceAccordingToStyle(UChar c, const RenderStyle& style)
+static inline bool isSpaceAccordingToStyle(char16_t c, const RenderStyle& style)
 {
     return c == ' ' || (c == noBreakSpace && style.nbspMode() == NBSPMode::Space);
 }
@@ -1293,7 +1293,7 @@ void RenderText::computePreferredLogicalWidths(float leadWidth, SingleThreadWeak
         && contentAnalysis == TextBreakIterator::ContentAnalysis::Mechanical;
 
     for (unsigned i = 0; i < length; i++) {
-        UChar c = string[i];
+        char16_t c = string[i];
 
         bool previousCharacterIsSpace = isSpace;
 
@@ -1340,7 +1340,7 @@ void RenderText::computePreferredLogicalWidths(float leadWidth, SingleThreadWeak
         bool betweenWords = true;
         unsigned j = i;
         while (c != '\n' && !isSpaceAccordingToStyle(c, style) && c != '\t' && c != zeroWidthSpace && (c != softHyphen || style.hyphens() == Hyphens::None)) {
-            UChar previousCharacter = c;
+            char16_t previousCharacter = c;
             j++;
             if (j == length)
                 break;
@@ -1545,7 +1545,7 @@ static inline bool isInlineFlowOrEmptyText(const RenderObject& renderer)
     return textRenderer && textRenderer->text().isEmpty();
 }
 
-Vector<UChar> RenderText::previousCharacter() const
+Vector<char16_t> RenderText::previousCharacter() const
 {
     const RenderObject* previousText = this;
     while ((previousText = previousText->previousInPreOrder())) {
@@ -1555,7 +1555,7 @@ Vector<UChar> RenderText::previousCharacter() const
             break;
     }
     auto* renderText = dynamicDowncast<RenderText>(previousText);
-    Vector<UChar> previous;
+    Vector<char16_t> previous;
     if (!renderText)
         previous.append(' ');
     else {
@@ -1586,7 +1586,7 @@ Vector<UChar> RenderText::previousCharacter() const
 static String convertToFullSizeKana(const String& string)
 {
     // https://www.w3.org/TR/css-text-3/#small-kana
-    static constexpr std::pair<char32_t, UChar> kanasMap[] = {
+    static constexpr std::pair<char32_t, char16_t> kanasMap[] = {
         { 0x3041, 0x3042 },
         { 0x3043, 0x3044 },
         { 0x3045, 0x3046 },
@@ -1673,11 +1673,11 @@ static String convertToFullSizeKana(const String& string)
 
 String applyTextTransform(const RenderStyle& style, const String& text)
 {
-    Vector<UChar> previousCharacter(1, ' ');
+    Vector<char16_t> previousCharacter(1, ' ');
     return applyTextTransform(style, text, previousCharacter);
 }
 
-String applyTextTransform(const RenderStyle& style, const String& text, Vector<UChar> previousCharacter)
+String applyTextTransform(const RenderStyle& style, const String& text, Vector<char16_t> previousCharacter)
 {
     auto transform = style.textTransform();
 
@@ -1759,7 +1759,7 @@ void RenderText::setRenderedText(const String& newText)
     }
 }
 
-void RenderText::secureText(UChar maskingCharacter)
+void RenderText::secureText(char16_t maskingCharacter)
 {
     // This hides the text by replacing all the characters with the masking character.
     // Offsets within the hidden text have to match offsets within the original text
@@ -1771,7 +1771,7 @@ void RenderText::secureText(UChar maskingCharacter)
     if (!length)
         return;
 
-    UChar characterToReveal = 0;
+    char16_t characterToReveal = 0;
     unsigned revealedCharactersOffset = 0;
 
     if (m_hasSecureTextTimer) {
@@ -1784,7 +1784,7 @@ void RenderText::secureText(UChar maskingCharacter)
         }
     }
 
-    std::span<UChar> characters;
+    std::span<char16_t> characters;
     m_text = String::createUninitialized(length, characters);
 
     for (unsigned i = 0; i < length; ++i)

--- a/Source/WebCore/rendering/RenderText.h
+++ b/Source/WebCore/rendering/RenderText.h
@@ -98,7 +98,7 @@ public:
 
     bool hasEmptyText() const { return m_text.isEmpty(); }
 
-    UChar characterAt(unsigned) const;
+    char16_t characterAt(unsigned) const;
     size_t length() const { return text().length(); }
 
     float width(unsigned from, unsigned length, const FontCascade&, float xPos, SingleThreadWeakHashSet<const Font>* fallbackFonts = nullptr, GlyphOverflow* = nullptr) const;
@@ -127,7 +127,7 @@ public:
     float hangablePunctuationEndWidth(unsigned index) const;
     unsigned firstCharacterIndexStrippingSpaces() const;
     unsigned lastCharacterIndexStrippingSpaces() const;
-    static bool isHangableStopOrComma(UChar);
+    static bool isHangableStopOrComma(char16_t);
     
     WEBCORE_EXPORT virtual IntRect linesBoundingBox() const;
     WEBCORE_EXPORT IntPoint firstRunLocation() const;
@@ -200,7 +200,7 @@ protected:
     void willBeDestroyed() override;
 
     virtual void setRenderedText(const String&);
-    virtual Vector<UChar> previousCharacter() const;
+    virtual Vector<char16_t> previousCharacter() const;
 
     virtual void setTextInternal(const String&, bool force);
 
@@ -226,7 +226,7 @@ private:
     float widthFromCache(const FontCascade&, unsigned start, unsigned len, float xPos, SingleThreadWeakHashSet<const Font>* fallbackFonts, GlyphOverflow*, const RenderStyle&) const;
     bool computeUseBackslashAsYenSymbol() const;
 
-    void secureText(UChar mask);
+    void secureText(char16_t mask);
 
     LayoutRect collectSelectionGeometriesForLineBoxes(const RenderLayerModelObject* repaintContainer, bool clipToVisibleContent, Vector<FloatQuad>*);
 
@@ -269,14 +269,14 @@ private:
     unsigned m_fontCodePath : 2 { 0 };
 };
 
-String applyTextTransform(const RenderStyle&, const String&, Vector<UChar> previousCharacter);
+String applyTextTransform(const RenderStyle&, const String&, Vector<char16_t> previousCharacter);
 String applyTextTransform(const RenderStyle&, const String&);
-String capitalize(const String&, Vector<UChar> previousCharacter);
+String capitalize(const String&, Vector<char16_t> previousCharacter);
 String capitalize(const String&);
 TextBreakIterator::LineMode::Behavior mapLineBreakToIteratorMode(LineBreak);
 TextBreakIterator::ContentAnalysis mapWordBreakToContentAnalysis(WordBreak);
 
-inline UChar RenderText::characterAt(unsigned i) const
+inline char16_t RenderText::characterAt(unsigned i) const
 {
     return i >= length() ? 0 : text()[i];
 }

--- a/Source/WebCore/rendering/RenderTextControl.cpp
+++ b/Source/WebCore/rendering/RenderTextControl.cpp
@@ -148,7 +148,7 @@ float RenderTextControl::getAverageCharWidth()
     if (style().fontCascade().fastAverageCharWidthIfAvailable(width))
         return width;
 
-    const UChar ch = '0';
+    const char16_t ch = '0';
     const String str = span(ch);
     const FontCascade& font = style().fontCascade();
     TextRun textRun = constructTextRun(str, style(), ExpansionBehavior::allowRightOnly());

--- a/Source/WebCore/rendering/RenderTextFragment.cpp
+++ b/Source/WebCore/rendering/RenderTextFragment.cpp
@@ -87,12 +87,12 @@ void RenderTextFragment::setTextInternal(const String& newText, bool force)
     ASSERT(!textNode() || textNode()->renderer() == this);
 }
 
-Vector<UChar> RenderTextFragment::previousCharacter() const
+Vector<char16_t> RenderTextFragment::previousCharacter() const
 {
     if (start()) {
         String original = textNode() ? textNode()->data() : contentString();
         if (!original.isNull() && start() <= original.length()) {
-            Vector<UChar> previous;
+            Vector<char16_t> previous;
             previous.append(original[start() - 1]);
             return previous;
         }

--- a/Source/WebCore/rendering/RenderTextFragment.h
+++ b/Source/WebCore/rendering/RenderTextFragment.h
@@ -60,7 +60,7 @@ public:
 private:
     void setTextInternal(const String&, bool force) override;
 
-    Vector<UChar> previousCharacter() const override;
+    Vector<char16_t> previousCharacter() const override;
 
     unsigned m_start;
     unsigned m_end;

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -161,7 +161,7 @@ String quoteAndEscapeNonPrintables(StringView s)
     StringBuilder result;
     result.append('"');
     for (unsigned i = 0; i != s.length(); ++i) {
-        UChar c = s[i];
+        char16_t c = s[i];
         if (c == '\\') {
             result.append("\\\\"_s);
         } else if (c == '"') {

--- a/Source/WebCore/rendering/line/BreakingContext.h
+++ b/Source/WebCore/rendering/line/BreakingContext.h
@@ -275,7 +275,7 @@ inline LayoutUnit inlineLogicalWidth(const RenderObject& renderer, bool checkSta
 inline bool shouldSkipWhitespaceAfterStartObject(RenderBlockFlow& block, RenderObject* renderer, LineWhitespaceCollapsingState& lineWhitespaceCollapsingState)
 {
     if (CheckedPtr nextText = dynamicDowncast<RenderText>(nextInlineRendererSkippingEmpty(block, renderer)); nextText && nextText->text().length() > 0) {
-        UChar nextChar = nextText->characterAt(0);
+        char16_t nextChar = nextText->characterAt(0);
         if (nextText->style().isCollapsibleWhiteSpace(nextChar)) {
             lineWhitespaceCollapsingState.startIgnoringSpaces(LegacyInlineIterator(nullptr, renderer, 0));
             return true;
@@ -319,7 +319,7 @@ inline void BreakingContext::handleEmptyInline()
         m_hangsAtEnd = false;
 }
 
-inline void nextCharacter(UChar& currentCharacter, UChar& lastCharacter, UChar& secondToLastCharacter)
+inline void nextCharacter(char16_t& currentCharacter, char16_t& lastCharacter, char16_t& secondToLastCharacter)
 {
     secondToLastCharacter = lastCharacter;
     lastCharacter = currentCharacter;
@@ -385,8 +385,8 @@ inline bool BreakingContext::handleText()
     SingleThreadWeakHashSet<const Font> fallbackFonts;
     m_hasFormerOpportunity = false;
     bool canBreakMidWord = breakWords || breakAll;
-    UChar lastCharacter = m_renderTextInfo.lineBreakIteratorFactory.priorContext().lastCharacter();
-    UChar secondToLastCharacter = m_renderTextInfo.lineBreakIteratorFactory.priorContext().secondToLastCharacter();
+    char16_t lastCharacter = m_renderTextInfo.lineBreakIteratorFactory.priorContext().lastCharacter();
+    char16_t secondToLastCharacter = m_renderTextInfo.lineBreakIteratorFactory.priorContext().secondToLastCharacter();
     // Non-zero only when kerning is enabled and TextLayout isn't used, in which case we measure
     // words with their trailing space, then subtract its width.
     TextLayout* textLayout = m_renderTextInfo.layout.get();
@@ -395,7 +395,7 @@ inline bool BreakingContext::handleText()
         ASSERT(&renderer == m_current.renderer());
         bool previousCharacterIsSpace = m_currentCharacterIsSpace;
         bool previousCharacterIsWS = m_currentCharacterIsWS;
-        UChar c = m_current.current(); // FIXME: It's silly to pull out a single surrogate from the content and attempt to do anything useful with it.
+        char16_t c = m_current.current(); // FIXME: It's silly to pull out a single surrogate from the content and attempt to do anything useful with it.
         m_currentCharacterIsSpace = c == ' ' || c == '\t' || (!m_preservesNewline && (c == '\n'));
 
         // A single preserved leading white-space doesn't fulfill the 'betweenWords' condition, however it's indeed a

--- a/Source/WebCore/rendering/line/LineInlineHeaders.h
+++ b/Source/WebCore/rendering/line/LineInlineHeaders.h
@@ -91,7 +91,7 @@ inline bool requiresLineBox(const LegacyInlineIterator& it, const LineInfo& line
     if (!shouldCollapseWhiteSpace(&it.renderer()->style(), lineInfo, whitespacePosition))
         return true;
 
-    UChar current = it.current();
+    char16_t current = it.current();
     auto preservesNewline = !it.renderer()->isRenderSVGInlineText() && it.renderer()->style().preserveNewline();
     bool notJustWhitespace = current != ' ' && current != '\t' && current != softHyphen && (current != '\n' || preservesNewline) && !skipNonBreakingSpace(it, lineInfo);
     return notJustWhitespace || rendererIsEmptyInline;

--- a/Source/WebCore/rendering/mathml/MathOperator.cpp
+++ b/Source/WebCore/rendering/mathml/MathOperator.cpp
@@ -64,10 +64,10 @@ static inline float advanceWidthForGlyph(const GlyphData& data)
 // FIXME: This hardcoded data can be removed when OpenType MATH font are widely available (http://wkbug/156837).
 struct StretchyCharacter {
     char32_t character;
-    UChar topChar;
-    UChar extensionChar;
-    UChar bottomChar;
-    UChar middleChar;
+    char16_t topChar;
+    char16_t extensionChar;
+    char16_t bottomChar;
+    char16_t middleChar;
 };
 
 static constexpr std::array stretchyCharacters {

--- a/Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp
@@ -41,7 +41,7 @@
 #include "RenderMathMLOperator.h"
 #include <wtf/TZoneMallocInlines.h>
 
-static const UChar gRadicalCharacter = 0x221A;
+static const char16_t gRadicalCharacter = 0x221A;
 
 namespace WebCore {
 

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -714,7 +714,7 @@ public:
     inline bool preserveNewline() const;
     static constexpr bool collapseWhiteSpace(WhiteSpaceCollapse);
     inline bool collapseWhiteSpace() const;
-    inline bool isCollapsibleWhiteSpace(UChar) const;
+    inline bool isCollapsibleWhiteSpace(char16_t) const;
     inline bool breakOnlyAfterWhiteSpace() const;
     inline bool breakWords() const;
 

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -912,7 +912,7 @@ inline Length RenderStyle::initialLineHeight()
     return LengthType::Normal;
 }
 
-inline bool RenderStyle::isCollapsibleWhiteSpace(UChar character) const
+inline bool RenderStyle::isCollapsibleWhiteSpace(char16_t character) const
 {
     switch (character) {
     case ' ':

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -83,7 +83,7 @@ namespace WebCore {
  */
 class TextStreamSeparator {
 public:
-    TextStreamSeparator(UChar s)
+    TextStreamSeparator(char16_t s)
         : m_separator(s)
         , m_needToSeparate(false)
     {
@@ -92,7 +92,7 @@ public:
 private:
     friend TextStream& operator<<(TextStream&, TextStreamSeparator&);
 
-    UChar m_separator;
+    char16_t m_separator;
     bool m_needToSeparate;
 };
 

--- a/Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp
@@ -91,7 +91,7 @@ static inline void processRenderSVGInlineText(const RenderSVGInlineText& text, u
 
     // FIXME: This is not a complete whitespace collapsing implementation; it doesn't handle newlines or tabs.
     for (unsigned i = 0; i < length; ++i) {
-        UChar character = string[i];
+        char16_t character = string[i];
         if (character == ' ' && lastCharacterWasSpace)
             continue;
 

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
@@ -248,7 +248,7 @@ static inline void dumpTextBoxes(Vector<InlineIterator::SVGTextBoxIterator>& box
         fprintf(stderr, "        textBox properties, start=%d, len=%d, box direction=%d\n", textBox->start(), textBox->len(), (int)textBox->direction());
         fprintf(stderr, "   textRenderer properties, textLength=%d\n", textBox->renderer().text().length());
 
-        const auto* characters = textBox->renderer().text().characters<UChar>();
+        const auto* characters = textBox->renderer().text().characters<char16_t>();
 
         unsigned fragmentCount = fragments.size();
         for (unsigned i = 0; i < fragmentCount; ++i) {
@@ -524,7 +524,7 @@ void SVGTextLayoutEngine::layoutTextOnLineOrPath(InlineIterator::SVGTextBoxItera
         float angle = SVGTextLayoutAttributes::isEmptyValue(data.rotate) ? 0 : data.rotate;
 
         // Calculate glyph orientation angle.
-        const UChar* currentCharacter = characters.subspan(m_visualCharacterOffset).data();
+        const char16_t* currentCharacter = characters.subspan(m_visualCharacterOffset).data();
         float orientationAngle = baselineLayout.calculateGlyphOrientationAngle(m_isVerticalText, svgStyle, *currentCharacter);
 
         // Calculate glyph advance & x/y orientation shifts.

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
@@ -136,7 +136,7 @@ float SVGTextLayoutEngineBaseline::calculateAlignmentBaselineShift(bool isVertic
     return 0;
 }
 
-float SVGTextLayoutEngineBaseline::calculateGlyphOrientationAngle(bool isVerticalText, const SVGRenderStyle& style, const UChar& character) const
+float SVGTextLayoutEngineBaseline::calculateGlyphOrientationAngle(bool isVerticalText, const SVGRenderStyle& style, const char16_t& character) const
 {
     switch (isVerticalText ? style.glyphOrientationVertical() : style.glyphOrientationHorizontal()) {
     case GlyphOrientation::Auto:

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.h
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.h
@@ -38,7 +38,7 @@ public:
 
     float calculateBaselineShift(const SVGRenderStyle&) const;
     float calculateAlignmentBaselineShift(bool isVerticalText, const RenderSVGInlineText& textRenderer) const;
-    float calculateGlyphOrientationAngle(bool isVerticalText, const SVGRenderStyle&, const UChar& character) const;
+    float calculateGlyphOrientationAngle(bool isVerticalText, const SVGRenderStyle&, const char16_t& character) const;
     float calculateGlyphAdvanceAndOrientation(bool isVerticalText, SVGTextMetrics&, float angle, float& xOrientationShift, float& yOrientationShift) const;
 
 private:

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngineSpacing.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngineSpacing.cpp
@@ -34,9 +34,9 @@ SVGTextLayoutEngineSpacing::SVGTextLayoutEngineSpacing(const FontCascade& font)
 {
 }
 
-float SVGTextLayoutEngineSpacing::calculateCSSSpacing(const UChar* currentCharacter)
+float SVGTextLayoutEngineSpacing::calculateCSSSpacing(const char16_t* currentCharacter)
 {
-    const UChar* lastCharacter = m_lastCharacter;
+    const char16_t* lastCharacter = m_lastCharacter;
     m_lastCharacter = currentCharacter;
 
     if (!m_font.letterSpacing() && !m_font.wordSpacing())

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngineSpacing.h
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngineSpacing.h
@@ -34,11 +34,11 @@ class SVGTextLayoutEngineSpacing {
 public:
     SVGTextLayoutEngineSpacing(const FontCascade&);
 
-    float calculateCSSSpacing(const UChar* currentCharacter);
+    float calculateCSSSpacing(const char16_t* currentCharacter);
 
 private:
     const FontCascade& m_font;
-    const UChar* m_lastCharacter;
+    const char16_t* m_lastCharacter;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp
@@ -148,7 +148,7 @@ struct MeasureTextData {
     bool processRenderer { false };
 };
 
-std::tuple<unsigned, UChar> SVGTextMetricsBuilder::measureTextRenderer(RenderSVGInlineText& text, const MeasureTextData& data, std::tuple<unsigned, UChar> state)
+std::tuple<unsigned, char16_t> SVGTextMetricsBuilder::measureTextRenderer(RenderSVGInlineText& text, const MeasureTextData& data, std::tuple<unsigned, char16_t> state)
 {
     auto [valueListPosition, lastCharacter] = state;
     SVGTextLayoutAttributes* attributes = text.layoutAttributes();
@@ -185,7 +185,7 @@ std::tuple<unsigned, UChar> SVGTextMetricsBuilder::measureTextRenderer(RenderSVG
 
             // m_canUseSimplifiedTextMeasuring ensures that this does not include surrogate pairs. So we do not need to consider about them.
             for (unsigned i = 0; i < length; ++i) {
-                UChar currentCharacter = view.characterAt(i);
+                char16_t currentCharacter = view.characterAt(i);
                 ASSERT(!U16_IS_LEAD(currentCharacter));
                 if (currentCharacter == space && !preserveWhiteSpace && (!lastCharacter || lastCharacter == space)) {
                     if (data.processRenderer)
@@ -217,7 +217,7 @@ std::tuple<unsigned, UChar> SVGTextMetricsBuilder::measureTextRenderer(RenderSVG
     int surrogatePairCharacters = 0;
     unsigned skippedCharacters = 0;
     while (advance()) {
-        UChar currentCharacter = m_run[m_textPosition];
+        char16_t currentCharacter = m_run[m_textPosition];
         if (currentCharacter == space && !preserveWhiteSpace && (!lastCharacter || lastCharacter == space)) {
             if (data.processRenderer)
                 textMetricsValues->append(SVGTextMetrics(SVGTextMetrics::SkippedSpaceMetrics));
@@ -250,7 +250,7 @@ std::tuple<unsigned, UChar> SVGTextMetricsBuilder::measureTextRenderer(RenderSVG
 void SVGTextMetricsBuilder::walkTree(RenderElement& start, RenderSVGInlineText* stopAtLeaf, MeasureTextData& data)
 {
     unsigned valueListPosition = 0;
-    UChar lastCharacter = 0;
+    char16_t lastCharacter = 0;
     CheckedPtr child = start.firstChild();
     while (child) {
         if (auto* text = dynamicDowncast<RenderSVGInlineText>(*child)) {

--- a/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.h
+++ b/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.h
@@ -46,7 +46,7 @@ private:
 
     void initializeMeasurementWithTextRenderer(RenderSVGInlineText&);
     void walkTree(RenderElement&, RenderSVGInlineText* stopAtLeaf, MeasureTextData&);
-    std::tuple<unsigned, UChar> measureTextRenderer(RenderSVGInlineText&, const MeasureTextData&, std::tuple<unsigned, UChar>);
+    std::tuple<unsigned, char16_t> measureTextRenderer(RenderSVGInlineText&, const MeasureTextData&, std::tuple<unsigned, char16_t>);
 
     SingleThreadWeakPtr<RenderSVGInlineText> m_text;
     TextRun m_run;

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderMathML.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderMathML.cpp
@@ -86,7 +86,7 @@ void RenderTreeBuilder::MathML::attach(RenderMathMLFenced& parent, RenderPtr<Ren
         // |count| is now the number of element children that will be before our new separator, i.e. it's the 1-based index of the separator.
 
         if (count > 0) {
-            UChar separator;
+            char16_t separator;
 
             // Use the last separator if we've run out of specified separators.
             if (count > separators->length())

--- a/Source/WebCore/svg/SVGAnimationElement.cpp
+++ b/Source/WebCore/svg/SVGAnimationElement.cpp
@@ -64,7 +64,7 @@ static Vector<float> parseKeyTimes(StringView value, bool verifyOrder)
     Vector<float> result;
 
     for (auto keyTime : keyTimes) {
-        keyTime = keyTime.trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
+        keyTime = keyTime.trim(isUnicodeCompatibleASCIIWhitespace<char16_t>);
 
         bool ok;
         float time = keyTime.toFloat(ok);
@@ -172,7 +172,7 @@ void SVGAnimationElement::attributeChanged(const QualifiedName& name, const Atom
         // http://www.w3.org/TR/SVG11/animate.html#ValuesAttribute
         m_values.clear();
         newValue.string().split(';', [this](StringView innerValue) {
-            m_values.append(innerValue.trim(isASCIIWhitespace<UChar>).toString());
+            m_values.append(innerValue.trim(isASCIIWhitespace<char16_t>).toString());
         });
         updateAnimationMode();
         break;

--- a/Source/WebCore/svg/SVGFitToViewBox.cpp
+++ b/Source/WebCore/svg/SVGFitToViewBox.cpp
@@ -101,7 +101,7 @@ std::optional<FloatRect> SVGFitToViewBox::parseViewBox(StringParsingBuffer<LChar
     return parseViewBoxGeneric(buffer, validate);
 }
 
-std::optional<FloatRect> SVGFitToViewBox::parseViewBox(StringParsingBuffer<UChar>& buffer, bool validate)
+std::optional<FloatRect> SVGFitToViewBox::parseViewBox(StringParsingBuffer<char16_t>& buffer, bool validate)
 {
     return parseViewBoxGeneric(buffer, validate);
 }

--- a/Source/WebCore/svg/SVGFitToViewBox.h
+++ b/Source/WebCore/svg/SVGFitToViewBox.h
@@ -68,7 +68,7 @@ protected:
     bool parseAttribute(const QualifiedName&, const AtomString&);
     std::optional<FloatRect> parseViewBox(StringView);
     std::optional<FloatRect> parseViewBox(StringParsingBuffer<LChar>&, bool validate = true);
-    std::optional<FloatRect> parseViewBox(StringParsingBuffer<UChar>&, bool validate = true);
+    std::optional<FloatRect> parseViewBox(StringParsingBuffer<char16_t>&, bool validate = true);
 
 private:
     template<typename CharacterType> std::optional<FloatRect> parseViewBoxGeneric(StringParsingBuffer<CharacterType>&, bool validate = true);

--- a/Source/WebCore/svg/SVGParserUtilities.cpp
+++ b/Source/WebCore/svg/SVGParserUtilities.cpp
@@ -155,7 +155,7 @@ std::optional<float> parseNumber(StringParsingBuffer<LChar>& buffer, SuffixSkipp
     return genericParseNumber(buffer, skip);
 }
 
-std::optional<float> parseNumber(StringParsingBuffer<UChar>& buffer, SuffixSkippingPolicy skip)
+std::optional<float> parseNumber(StringParsingBuffer<char16_t>& buffer, SuffixSkippingPolicy skip)
 {
     return genericParseNumber(buffer, skip);
 }
@@ -198,7 +198,7 @@ std::optional<bool> parseArcFlag(StringParsingBuffer<LChar>& buffer)
     return genericParseArcFlag(buffer);
 }
 
-std::optional<bool> parseArcFlag(StringParsingBuffer<UChar>& buffer)
+std::optional<bool> parseArcFlag(StringParsingBuffer<char16_t>& buffer)
 {
     return genericParseArcFlag(buffer);
 }
@@ -422,7 +422,7 @@ std::optional<FloatPoint> parseFloatPoint(StringParsingBuffer<LChar>& buffer)
     return genericParseFloatPoint(buffer);
 }
 
-std::optional<FloatPoint> parseFloatPoint(StringParsingBuffer<UChar>& buffer)
+std::optional<FloatPoint> parseFloatPoint(StringParsingBuffer<char16_t>& buffer)
 {
     return genericParseFloatPoint(buffer);
 }

--- a/Source/WebCore/svg/SVGParserUtilities.h
+++ b/Source/WebCore/svg/SVGParserUtilities.h
@@ -38,19 +38,19 @@ enum class SuffixSkippingPolicy {
 };
 
 std::optional<float> parseNumber(StringParsingBuffer<LChar>&, SuffixSkippingPolicy = SuffixSkippingPolicy::Skip);
-std::optional<float> parseNumber(StringParsingBuffer<UChar>&, SuffixSkippingPolicy = SuffixSkippingPolicy::Skip);
+std::optional<float> parseNumber(StringParsingBuffer<char16_t>&, SuffixSkippingPolicy = SuffixSkippingPolicy::Skip);
 std::optional<float> parseNumber(StringView, SuffixSkippingPolicy = SuffixSkippingPolicy::Skip);
 
 std::optional<std::pair<float, float>> parseNumberOptionalNumber(StringView);
 
 std::optional<bool> parseArcFlag(StringParsingBuffer<LChar>&);
-std::optional<bool> parseArcFlag(StringParsingBuffer<UChar>&);
+std::optional<bool> parseArcFlag(StringParsingBuffer<char16_t>&);
 
 std::optional<FloatPoint> parsePoint(StringView);
 std::optional<FloatRect> parseRect(StringView);
 
 std::optional<FloatPoint> parseFloatPoint(StringParsingBuffer<LChar>&);
-std::optional<FloatPoint> parseFloatPoint(StringParsingBuffer<UChar>&);
+std::optional<FloatPoint> parseFloatPoint(StringParsingBuffer<char16_t>&);
 
 std::optional<std::pair<UnicodeRanges, HashSet<String>>> parseKerningUnicodeString(StringView);
 std::optional<HashSet<String>> parseGlyphName(StringView);

--- a/Source/WebCore/svg/SVGPathStringViewSource.h
+++ b/Source/WebCore/svg/SVGPathStringViewSource.h
@@ -51,7 +51,7 @@ private:
     bool m_is8BitSource;
     union {
         StringParsingBuffer<LChar> m_buffer8;
-        StringParsingBuffer<UChar> m_buffer16;
+        StringParsingBuffer<char16_t> m_buffer16;
     };
 };
 

--- a/Source/WebCore/svg/SVGPreserveAspectRatioValue.cpp
+++ b/Source/WebCore/svg/SVGPreserveAspectRatioValue.cpp
@@ -78,7 +78,7 @@ bool SVGPreserveAspectRatioValue::parse(StringParsingBuffer<LChar>& buffer, bool
     return parseInternal(buffer, validate);
 }
 
-bool SVGPreserveAspectRatioValue::parse(StringParsingBuffer<UChar>& buffer, bool validate)
+bool SVGPreserveAspectRatioValue::parse(StringParsingBuffer<char16_t>& buffer, bool validate)
 {
     return parseInternal(buffer, validate);
 }

--- a/Source/WebCore/svg/SVGPreserveAspectRatioValue.h
+++ b/Source/WebCore/svg/SVGPreserveAspectRatioValue.h
@@ -74,7 +74,7 @@ public:
 
     bool parse(StringView);
     bool parse(StringParsingBuffer<LChar>&, bool validate);
-    bool parse(StringParsingBuffer<UChar>&, bool validate);
+    bool parse(StringParsingBuffer<char16_t>&, bool validate);
 
     String valueAsString() const;
 

--- a/Source/WebCore/svg/SVGStringList.cpp
+++ b/Source/WebCore/svg/SVGStringList.cpp
@@ -31,7 +31,7 @@
 
 namespace WebCore {
 
-bool SVGStringList::parse(StringView data, UChar delimiter)
+bool SVGStringList::parse(StringView data, char16_t delimiter)
 {
     clearItems();
 

--- a/Source/WebCore/svg/SVGStringList.h
+++ b/Source/WebCore/svg/SVGStringList.h
@@ -51,7 +51,7 @@ public:
             m_items.append(emptyString());
     }
 
-    bool parse(StringView, UChar delimiter);
+    bool parse(StringView, char16_t delimiter);
     String valueAsString() const override;
 };
 

--- a/Source/WebCore/svg/SVGToOTFFontConversion.cpp
+++ b/Source/WebCore/svg/SVGToOTFFontConversion.cpp
@@ -1007,11 +1007,11 @@ void SVGToOTFFontConverter::appendVMTXTable()
 
 static String codepointToString(char32_t codepoint)
 {
-    std::array<UChar, 2> buffer;
+    std::array<char16_t, 2> buffer;
     uint8_t length = 0;
     UBool error = false;
     U16_APPEND(buffer, length, 2, codepoint, error);
-    return error ? String() : String(std::span<UChar> { buffer }.first(length));
+    return error ? String() : String(std::span<char16_t> { buffer }.first(length));
 }
 
 Vector<Glyph, 1> SVGToOTFFontConverter::glyphsForCodepoint(char32_t codepoint) const

--- a/Source/WebCore/svg/SVGTransformList.cpp
+++ b/Source/WebCore/svg/SVGTransformList.cpp
@@ -130,7 +130,7 @@ bool SVGTransformList::parse(StringParsingBuffer<LChar>& buffer)
     return parseGeneric(buffer, ListReplacement::Append);
 }
 
-bool SVGTransformList::parse(StringParsingBuffer<UChar>& buffer)
+bool SVGTransformList::parse(StringParsingBuffer<char16_t>& buffer)
 {
     return parseGeneric(buffer, ListReplacement::Append);
 }

--- a/Source/WebCore/svg/SVGTransformList.h
+++ b/Source/WebCore/svg/SVGTransformList.h
@@ -70,7 +70,7 @@ private:
     };
     template<typename CharacterType> bool parseGeneric(StringParsingBuffer<CharacterType>&, ListReplacement = ListReplacement::Append);
     bool parse(StringParsingBuffer<LChar>&);
-    bool parse(StringParsingBuffer<UChar>&);
+    bool parse(StringParsingBuffer<char16_t>&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGTransformable.cpp
+++ b/Source/WebCore/svg/SVGTransformable.cpp
@@ -260,7 +260,7 @@ std::optional<SVGTransformValue::SVGTransformType> SVGTransformable::parseTransf
     return parseTransformTypeGeneric(buffer);
 }
 
-std::optional<SVGTransformValue::SVGTransformType> SVGTransformable::parseTransformType(StringParsingBuffer<UChar>& buffer)
+std::optional<SVGTransformValue::SVGTransformType> SVGTransformable::parseTransformType(StringParsingBuffer<char16_t>& buffer)
 {
     return parseTransformTypeGeneric(buffer);
 }

--- a/Source/WebCore/svg/SVGTransformable.h
+++ b/Source/WebCore/svg/SVGTransformable.h
@@ -40,7 +40,7 @@ public:
 
     static std::optional<SVGTransformValue::SVGTransformType> parseTransformType(StringView);
     static std::optional<SVGTransformValue::SVGTransformType> parseTransformType(StringParsingBuffer<LChar>&);
-    static std::optional<SVGTransformValue::SVGTransformType> parseTransformType(StringParsingBuffer<UChar>&);
+    static std::optional<SVGTransformValue::SVGTransformType> parseTransformType(StringParsingBuffer<char16_t>&);
 
     AffineTransform localCoordinateSpaceTransform(CTMScope) const override { return animatedLocalTransform(); }
     virtual AffineTransform animatedLocalTransform() const = 0;

--- a/Source/WebCore/svg/SVGZoomAndPan.cpp
+++ b/Source/WebCore/svg/SVGZoomAndPan.cpp
@@ -45,7 +45,7 @@ std::optional<SVGZoomAndPanType> SVGZoomAndPan::parseZoomAndPan(StringParsingBuf
     return parseZoomAndPanGeneric(buffer);
 }
 
-std::optional<SVGZoomAndPanType> SVGZoomAndPan::parseZoomAndPan(StringParsingBuffer<UChar>& buffer)
+std::optional<SVGZoomAndPanType> SVGZoomAndPan::parseZoomAndPan(StringParsingBuffer<char16_t>& buffer)
 {
     return parseZoomAndPanGeneric(buffer);
 }

--- a/Source/WebCore/svg/SVGZoomAndPan.h
+++ b/Source/WebCore/svg/SVGZoomAndPan.h
@@ -49,7 +49,7 @@ protected:
     SVGZoomAndPan() = default;
 
     static std::optional<SVGZoomAndPanType> parseZoomAndPan(StringParsingBuffer<LChar>&);
-    static std::optional<SVGZoomAndPanType> parseZoomAndPan(StringParsingBuffer<UChar>&);
+    static std::optional<SVGZoomAndPanType> parseZoomAndPan(StringParsingBuffer<char16_t>&);
 
 private:
     SVGZoomAndPanType m_zoomAndPan { SVGPropertyTraits<SVGZoomAndPanType>::initialValue() };

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -330,7 +330,7 @@ SMILTime SVGSMILElement::parseOffsetValue(StringView data)
 {
     bool ok;
     double result = 0;
-    auto parse = data.trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
+    auto parse = data.trim(isUnicodeCompatibleASCIIWhitespace<char16_t>);
     if (parse.endsWith('h'))
         result = parse.left(parse.length() - 1).toDouble(ok) * 60 * 60;
     else if (parse.endsWith("min"_s))
@@ -351,7 +351,7 @@ SMILTime SVGSMILElement::parseClockValue(StringView data)
     if (data.isNull())
         return SMILTime::unresolved();
 
-    auto parse = data.trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
+    auto parse = data.trim(isUnicodeCompatibleASCIIWhitespace<char16_t>);
     if (parse == indefiniteAtom())
         return SMILTime::indefinite();
 
@@ -379,7 +379,7 @@ SMILTime SVGSMILElement::parseClockValue(StringView data)
     
 bool SVGSMILElement::parseCondition(StringView value, BeginOrEnd beginOrEnd)
 {
-    auto parseString = value.trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
+    auto parseString = value.trim(isUnicodeCompatibleASCIIWhitespace<char16_t>);
     
     double sign = 1.;
     size_t pos = parseString.find('+');
@@ -393,8 +393,8 @@ bool SVGSMILElement::parseCondition(StringView value, BeginOrEnd beginOrEnd)
     if (pos == notFound)
         conditionString = parseString;
     else {
-        conditionString = parseString.left(pos).trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
-        auto offsetString = parseString.substring(pos + 1).trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
+        conditionString = parseString.left(pos).trim(isUnicodeCompatibleASCIIWhitespace<char16_t>);
+        auto offsetString = parseString.substring(pos + 1).trim(isUnicodeCompatibleASCIIWhitespace<char16_t>);
         offset = parseOffsetValue(offsetString);
         if (offset.isUnresolved())
             return false;

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -803,7 +803,7 @@ ExceptionOr<void> XMLHttpRequest::setRequestHeader(const String& name, const Str
     if (readyState() != OPENED || m_sendFlag)
         return Exception { ExceptionCode::InvalidStateError };
 
-    String normalizedValue = value.trim(isASCIIWhitespaceWithoutFF<UChar>);
+    String normalizedValue = value.trim(isASCIIWhitespaceWithoutFF<char16_t>);
     if (!isValidHTTPToken(name) || !isValidHTTPHeaderValue(normalizedValue))
         return Exception { ExceptionCode::SyntaxError };
 

--- a/Source/WebCore/xml/XPathFunctions.cpp
+++ b/Source/WebCore/xml/XPathFunctions.cpp
@@ -48,7 +48,7 @@ namespace XPath {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Function);
 
-static inline bool isWhitespace(UChar c)
+static inline bool isWhitespace(char16_t c)
 {
     return c == ' ' || c == '\n' || c == '\r' || c == '\t';
 }
@@ -611,10 +611,10 @@ Value FunNormalizeSpace::evaluate() const
     // https://www.w3.org/TR/1999/REC-xpath-19991116/#function-normalize-space
     if (!argumentCount()) {
         String s = Value(Expression::evaluationContext().node.get()).toString();
-        return s.simplifyWhiteSpace(isASCIIWhitespaceWithoutFF<UChar>);
+        return s.simplifyWhiteSpace(isASCIIWhitespaceWithoutFF<char16_t>);
     }
     String s = argument(0).evaluate().toString();
-    return s.simplifyWhiteSpace(isASCIIWhitespaceWithoutFF<UChar>);
+    return s.simplifyWhiteSpace(isASCIIWhitespaceWithoutFF<char16_t>);
 }
 
 Value FunTranslate::evaluate() const
@@ -636,7 +636,7 @@ Value FunTranslate::evaluate() const
     StringBuilder result;
 
     for (unsigned i1 = 0; i1 < s1.length(); ++i1) {
-        UChar ch = s1[i1];
+        char16_t ch = s1[i1];
         size_t i2 = s2.find(ch);
         
         if (i2 == notFound)

--- a/Source/WebCore/xml/XPathParser.cpp
+++ b/Source/WebCore/xml/XPathParser.cpp
@@ -69,7 +69,7 @@ struct Parser::Token {
 
 enum XMLCat { NameStart, NameCont, NotPartOfName };
 
-static XMLCat charCat(UChar character)
+static XMLCat charCat(char16_t character)
 {
     if (character == '_')
         return NameStart;
@@ -169,7 +169,7 @@ char Parser::peekAheadHelper()
 {
     if (m_nextPos + 1 >= m_data.length())
         return 0;
-    UChar next = m_data[m_nextPos + 1];
+    char16_t next = m_data[m_nextPos + 1];
     if (next >= 0xff)
         return 0;
     return next;
@@ -179,7 +179,7 @@ char Parser::peekCurHelper()
 {
     if (m_nextPos >= m_data.length())
         return 0;
-    UChar next = m_data[m_nextPos];
+    char16_t next = m_data[m_nextPos];
     if (next >= 0xff)
         return 0;
     return next;
@@ -187,7 +187,7 @@ char Parser::peekCurHelper()
 
 Parser::Token Parser::lexString()
 {
-    UChar delimiter = m_data[m_nextPos];
+    char16_t delimiter = m_data[m_nextPos];
     int startPos = m_nextPos + 1;
 
     for (m_nextPos = startPos; m_nextPos < m_data.length(); ++m_nextPos) {
@@ -211,7 +211,7 @@ Parser::Token Parser::lexNumber()
 
     // Go until end or a non-digits character.
     for (; m_nextPos < m_data.length(); ++m_nextPos) {
-        UChar aChar = m_data[m_nextPos];
+        char16_t aChar = m_data[m_nextPos];
         if (aChar >= 0xff) break;
 
         if (!isASCIIDigit(aChar)) {

--- a/Source/WebCore/xml/XPathValue.cpp
+++ b/Source/WebCore/xml/XPathValue.cpp
@@ -92,7 +92,7 @@ double Value::toNumber() const
         // String::toDouble() supports exponential notation, which is not allowed in XPath.
         unsigned len = str.length();
         for (unsigned i = 0; i < len; ++i) {
-            UChar c = str[i];
+            char16_t c = str[i];
             if (!isASCIIDigit(c) && c != '.'  && c != '-')
                 return std::numeric_limits<double>::quiet_NaN();
         }

--- a/Source/WebCore/xml/XSLStyleSheetLibxslt.cpp
+++ b/Source/WebCore/xml/XSLStyleSheetLibxslt.cpp
@@ -142,7 +142,7 @@ bool XSLStyleSheet::parseString(const String& string)
     auto upconvertedCharacters = StringView(string).upconvertedCharacters();
     const char* buffer = reinterpret_cast<const char*>(upconvertedCharacters.get());
     CheckedUint32 unsignedSize = string.length();
-    unsignedSize *= sizeof(UChar);
+    unsignedSize *= sizeof(char16_t);
     if (unsignedSize.hasOverflowed() || unsignedSize > static_cast<unsigned>(std::numeric_limits<int>::max()))
         return false;
 

--- a/Source/WebCore/xml/parser/MarkupTokenizerInlines.h
+++ b/Source/WebCore/xml/parser/MarkupTokenizerInlines.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-inline bool isTokenizerWhitespace(UChar character)
+inline bool isTokenizerWhitespace(char16_t character)
 {
     return character == ' ' || character == '\x0A' || character == '\x09' || character == '\x0C';
 }

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -698,7 +698,7 @@ void XMLDocumentParser::doWrite(const String& parseString)
 
         // FIXME: Can we parse 8-bit strings directly as Latin-1 instead of upconverting to UTF-16?
         switchToUTF16(context->context());
-        xmlParseChunk(context->context(), reinterpret_cast<const char*>(StringView(parseString).upconvertedCharacters().get()), sizeof(UChar) * parseString.length(), 0);
+        xmlParseChunk(context->context(), reinterpret_cast<const char*>(StringView(parseString).upconvertedCharacters().get()), sizeof(char16_t) * parseString.length(), 0);
 
         // JavaScript (which may be run under the xmlParseChunk callstack) may
         // cause the parser to be stopped or detached.
@@ -1173,7 +1173,7 @@ static xmlEntityPtr sharedXHTMLEntity()
     return &entity;
 }
 
-static size_t convertUTF16EntityToUTF8(std::span<const UChar> utf16Entity, std::span<char8_t> target)
+static size_t convertUTF16EntityToUTF8(std::span<const char16_t> utf16Entity, std::span<char8_t> target)
 {
     auto result = WTF::Unicode::convert(utf16Entity, target);
     if (result.code != WTF::Unicode::ConversionResultCode::Success)
@@ -1393,7 +1393,7 @@ xmlDocPtr xmlDocPtrForString(CachedResourceLoader& cachedResourceLoader, const S
 
     const bool is8Bit = source.is8Bit();
     auto characters = is8Bit ? byteCast<char>(source.span8()) : spanReinterpretCast<const char>(source.span16());
-    size_t sizeInBytes = source.length() * (is8Bit ? sizeof(LChar) : sizeof(UChar));
+    size_t sizeInBytes = source.length() * (is8Bit ? sizeof(LChar) : sizeof(char16_t));
     const char* encoding = is8Bit ? "iso-8859-1" : nativeEndianUTF16Encoding();
 
     XMLDocumentParserScope scope(&cachedResourceLoader, errorFunc);
@@ -1525,7 +1525,7 @@ std::optional<HashMap<String, String>> parseAttributes(CachedResourceLoader& cac
 
     XMLDocumentParserScope scope(&cachedResourceLoader);
     // FIXME: Can we parse 8-bit strings directly as Latin-1 instead of upconverting to UTF-16?
-    xmlParseChunk(parser->context(), reinterpret_cast<const char*>(StringView(parseString).upconvertedCharacters().get()), parseString.length() * sizeof(UChar), 1);
+    xmlParseChunk(parser->context(), reinterpret_cast<const char*>(StringView(parseString).upconvertedCharacters().get()), parseString.length() * sizeof(char16_t), 1);
 
     return attributes;
 }


### PR DESCRIPTION
#### 33060da551682b19c77413ce2a6c3f8d78bf10cd
<pre>
WebCore: Replace UChar with char16_t
<a href="https://bugs.webkit.org/show_bug.cgi?id=294727">https://bugs.webkit.org/show_bug.cgi?id=294727</a>
<a href="https://rdar.apple.com/153821613">rdar://153821613</a>

Reviewed by Alex Christensen.

This is a plain textual substitution to replace \bUChar\b with char16_t
throughout WebCore. WebKit overall wants to move from ICU types (e.g. UChar,
UChar32) to standard C++ types (char16_t, char32_t). This PR is one of a series
doing the next step, which is converting UChar to char16_t. Because UChar was
already a typedef to char16_t, no functional changes should occur.

* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp:
(WebCore::ApplicationManifestParser::parseDir):
(WebCore::ApplicationManifestParser::parseDisplay):
(WebCore::ApplicationManifestParser::parseOrientation):
(WebCore::ApplicationManifestParser::parseIcons):
* Source/WebCore/Modules/cache/DOMCache.cpp:
(WebCore::hasResponseVaryStarHeaderValue):
* Source/WebCore/Modules/cache/DOMCacheEngine.cpp:
(WebCore::DOMCacheEngine::queryCacheMatch):
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::containsInvalidCharacters):
* Source/WebCore/Modules/entriesapi/DOMFileSystem.cpp:
(WebCore::isValidPathNameCharacter):
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::isHTTPQuotedStringTokenCodePoint):
(WebCore::parseParameters):
(WebCore::parseMIMEType):
(WebCore::FetchBodyConsumer::packageFormData):
* Source/WebCore/Modules/fetch/FetchHeaders.cpp:
(WebCore::appendToHeaderMap):
(WebCore::FetchHeaders::set):
(WebCore::FetchHeaders::filterAndFill):
* Source/WebCore/Modules/indexeddb/IDBKey.cpp:
(WebCore::IDBKey::IDBKey):
* Source/WebCore/Modules/indexeddb/IDBKeyPath.cpp:
* Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp:
(WebCore::decodeKey):
* Source/WebCore/Modules/mediastream/RTCDTMFSender.cpp:
(WebCore::isToneCharacterInvalid):
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::selectEnvironmentMapURL const):
* Source/WebCore/Modules/url-pattern/URLPatternParser.cpp:
(WebCore::URLPatternUtilities::isValidNameCodepoint):
* Source/WebCore/Modules/url-pattern/URLPatternParser.h:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp:
(WebCore::isValidDecoderConfig):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp:
(WebCore::isValidEncoderConfig):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
(WebCore::isValidDecoderConfig):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
(WebCore::isValidEncoderConfig):
* Source/WebCore/Modules/websockets/ThreadableWebSocketChannelClientWrapper.h:
* Source/WebCore/Modules/websockets/WebSocket.cpp:
(WebCore::isValidProtocolCharacter):
* Source/WebCore/Modules/websockets/WebSocketExtensionDispatcher.cpp:
(WebCore::WebSocketExtensionDispatcher::addProcessor):
* Source/WebCore/Modules/websockets/WebSocketExtensionParser.h:
* Source/WebCore/PAL/pal/text/DecodeEscapeSequences.h:
(PAL::Unicode16BitEscapeSequence::decodeRun):
* Source/WebCore/PAL/pal/text/EncodingTables.cpp:
(PAL::ucnv_toUnicode_span):
(PAL::jis0208):
(PAL::jis0212):
(PAL::big5):
(PAL::eucKR):
(PAL::gb18030):
* Source/WebCore/PAL/pal/text/EncodingTables.h:
* Source/WebCore/PAL/pal/text/TextCodecASCIIFastPath.h:
(PAL::UCharByteFiller&lt;4&gt;::copy):
(PAL::UCharByteFiller&lt;8&gt;::copy):
(PAL::copyASCIIMachineWord):
* Source/WebCore/PAL/pal/text/TextCodecCJK.cpp:
(PAL::codePointJIS0208):
(PAL::codePointJIS0212):
(PAL::eucJPEncode):
(PAL::TextCodecCJK::iso2022JPDecode):
(PAL::iso2022JPEncode):
(PAL::TextCodecCJK::shiftJISDecode):
(PAL::shiftJISEncode):
(PAL::eucKREncode):
(PAL::big5Encode):
(PAL::gb18030AsymmetricEncode):
(PAL::gbEncodeShared):
* Source/WebCore/PAL/pal/text/TextCodecICU.cpp:
(PAL::TextCodecICU::decodeToBuffer):
(PAL::TextCodecICU::decode):
(PAL::urlEscapedEntityCallback):
* Source/WebCore/PAL/pal/text/TextCodecICU.h:
* Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp:
(PAL::TextCodecLatin1::decode):
(PAL::TextCodecLatin1::encode const):
* Source/WebCore/PAL/pal/text/TextCodecSingleByte.cpp:
(PAL::decode):
* Source/WebCore/PAL/pal/text/TextCodecUTF16.cpp:
(PAL::TextCodecUTF16::decode):
* Source/WebCore/PAL/pal/text/TextCodecUTF16.h:
* Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp:
(PAL::appendCharacter):
(PAL::TextCodecUTF8::handlePartialSequence):
(PAL::TextCodecUTF8::decode):
* Source/WebCore/PAL/pal/text/TextCodecUTF8.h:
* Source/WebCore/PAL/pal/text/TextCodecUserDefined.cpp:
(PAL::TextCodecUserDefined::decode):
(PAL::TextCodecUserDefined::encode const):
* Source/WebCore/PAL/pal/text/TextEncoding.cpp:
(PAL::TextEncoding::backslashAsCurrencySymbol const):
* Source/WebCore/PAL/pal/text/TextEncoding.h:
* Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp:
(PAL::atomCanonicalTextEncodingName):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::secureContext):
(WebCore::AXObjectCache::nextBoundary):
(WebCore::AXObjectCache::previousBoundary):
* Source/WebCore/accessibility/AXTextRun.h:
(WebCore::AXTextRun::characterAt const):
* Source/WebCore/accessibility/AccessibilityMathMLElement.cpp:
(WebCore::AccessibilityMathMLElement::textUnderElement const):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::textRuns):
* Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h:
* Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::characterOffset const):
(WebCore::AccessibilityObjectAtspi::characterIndex const):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::write):
(WebCore::CloneDeserializer::readString):
* Source/WebCore/contentextensions/ContentExtensionParser.cpp:
(WebCore::ContentExtensions::getDomainList):
* Source/WebCore/contentextensions/DFAMinimizer.cpp:
* Source/WebCore/contentextensions/HashableActionList.h:
(WebCore::ContentExtensions::HashableActionList::HashableActionList):
* Source/WebCore/contentextensions/Term.h:
(WebCore::ContentExtensions::Term::CharacterSet::set):
(WebCore::ContentExtensions::Term::CharacterSet::get const):
(WebCore::ContentExtensions::Term::toString const):
(WebCore::ContentExtensions::Term::Term):
(WebCore::ContentExtensions::Term::addCharacter):
(WebCore::ContentExtensions::Term::generateSubgraphForAtom const):
* Source/WebCore/contentextensions/URLFilterParser.cpp:
(WebCore::ContentExtensions::PatternParser::atomPatternCharacter):
(WebCore::ContentExtensions::PatternParser::atomCharacterClassAtom):
(WebCore::ContentExtensions::PatternParser::atomCharacterClassRange):
* Source/WebCore/css/CSSCounterStyle.cpp:
(WebCore::counterForSystemCJK):
(WebCore::CSSCounterStyle::counterForSystemSimplifiedChineseInformal):
(WebCore::CSSCounterStyle::counterForSystemSimplifiedChineseFormal):
(WebCore::CSSCounterStyle::counterForSystemTraditionalChineseInformal):
(WebCore::CSSCounterStyle::counterForSystemTraditionalChineseFormal):
(WebCore::CSSCounterStyle::counterForSystemEthiopicNumeric):
* Source/WebCore/css/CSSProperty.h:
* Source/WebCore/css/CSSStyleProperties.cpp:
* Source/WebCore/css/CSSValueList.cpp:
(WebCore::CSSValueList::create):
* Source/WebCore/css/CSSValueList.h:
* Source/WebCore/css/CSSVariableData.cpp:
(WebCore::CSSVariableData::CSSVariableData):
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::attributeValueMatches):
* Source/WebCore/css/parser/CSSParserToken.cpp:
(WebCore::CSSParserToken::CSSParserToken):
(WebCore::CSSParserToken::delimiter const):
* Source/WebCore/css/parser/CSSParserToken.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+UnicodeRange.cpp:
(WebCore::CSSPropertyParserHelpers::consumeOptionalDelimiter):
(WebCore::CSSPropertyParserHelpers::consumeAndAppendOptionalDelimiter):
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::consumeCombinator):
* Source/WebCore/css/parser/CSSTokenizer.cpp:
(WebCore::CSSTokenizer::isNewline):
(WebCore::CSSTokenizer::newline):
(WebCore::twoCharsAreValidEscape):
(WebCore::CSSTokenizer::reconsume):
(WebCore::CSSTokenizer::consume):
(WebCore::CSSTokenizer::whitespace):
(WebCore::CSSTokenizer::leftParenthesis):
(WebCore::CSSTokenizer::rightParenthesis):
(WebCore::CSSTokenizer::leftBracket):
(WebCore::CSSTokenizer::rightBracket):
(WebCore::CSSTokenizer::leftBrace):
(WebCore::CSSTokenizer::rightBrace):
(WebCore::CSSTokenizer::plusOrFullStop):
(WebCore::CSSTokenizer::asterisk):
(WebCore::CSSTokenizer::lessThan):
(WebCore::CSSTokenizer::comma):
(WebCore::CSSTokenizer::hyphenMinus):
(WebCore::CSSTokenizer::solidus):
(WebCore::CSSTokenizer::colon):
(WebCore::CSSTokenizer::semiColon):
(WebCore::CSSTokenizer::hash):
(WebCore::CSSTokenizer::circumflexAccent):
(WebCore::CSSTokenizer::dollarSign):
(WebCore::CSSTokenizer::verticalLine):
(WebCore::CSSTokenizer::tilde):
(WebCore::CSSTokenizer::commercialAt):
(WebCore::CSSTokenizer::reverseSolidus):
(WebCore::CSSTokenizer::asciiDigit):
(WebCore::CSSTokenizer::nameStart):
(WebCore::CSSTokenizer::stringStart):
(WebCore::CSSTokenizer::endOfFile):
(WebCore::CSSTokenizer::nextToken):
(WebCore::CSSTokenizer::consumeNumber):
(WebCore::CSSTokenizer::consumeIdentLikeToken):
(WebCore::CSSTokenizer::consumeStringTokenUntil):
(WebCore::isNonPrintableCodePoint):
(WebCore::CSSTokenizer::consumeURLToken):
(WebCore::CSSTokenizer::consumeBadUrlRemnants):
(WebCore::CSSTokenizer::consumeSingleWhitespaceIfNext):
(WebCore::CSSTokenizer::consumeUntilCommentEndFound):
(WebCore::CSSTokenizer::consumeIfNext):
(WebCore::CSSTokenizer::consumeName):
(WebCore::CSSTokenizer::consumeEscape):
(WebCore::CSSTokenizer::nextCharsAreNumber):
(WebCore::CSSTokenizer::nextCharsAreIdentifier):
* Source/WebCore/css/parser/CSSTokenizer.h:
* Source/WebCore/css/parser/CSSTokenizerInputStream.h:
(WebCore::CSSTokenizerInputStream::nextInputChar const):
(WebCore::CSSTokenizerInputStream::peek const):
(WebCore::CSSTokenizerInputStream::pushBack):
(WebCore::CSSTokenizerInputStream::characterPredicate):
* Source/WebCore/css/parser/SizesCalcParser.cpp:
(WebCore::operatorPriority):
(WebCore::operateOnStack):
* Source/WebCore/css/parser/SizesCalcParser.h:
* Source/WebCore/css/scripts/process-css-properties.py:
(GenerateCSSPropertyNames):
* Source/WebCore/css/scripts/process-css-pseudo-selectors.py:
* Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSPropertyNames.gperf:
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::constructFragmentsInternal):
* Source/WebCore/dom/DatasetDOMStringMap.cpp:
(WebCore::convertAttributeNameToPropertyName):
(WebCore::convertPropertyNameToAttributeName):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setMarkupUnsafe):
(WebCore::isValidNameNonASCII):
* Source/WebCore/dom/Position.cpp:
(WebCore::Position::leadingWhitespacePosition const):
(WebCore::Position::trailingWhitespacePosition const):
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::requestClassicScript):
(WebCore::ScriptElement::requestModuleScript):
* Source/WebCore/dom/SpaceSplitString.cpp:
(WebCore::SpaceSplitString::spaceSplitStringContainsValue):
* Source/WebCore/dom/TextDecoder.cpp:
(WebCore::TextDecoder::create):
* Source/WebCore/dom/TextEncoderStreamEncoder.h:
* Source/WebCore/dom/make_names.pl:
(printTagNameHeaderFile):
(printTagNameCppFile):
(printNodeNameHeaderFile):
(printNodeNameCppFile):
* Source/WebCore/editing/CompositeEditCommand.cpp:
(WebCore::isWhitespaceForRebalance):
* Source/WebCore/editing/Editing.cpp:
(WebCore::isAmbiguousBoundaryCharacter):
* Source/WebCore/editing/Editing.h:
(WebCore::deprecatedIsEditingWhitespace):
(WebCore::deprecatedIsCollapsibleWhitespace):
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::characterInRelationToCaretSelection const):
(WebCore::FrameSelection::selectionAtWordStart const):
(WebCore::FrameSelection::wordSelectionContainingCaretSelection):
* Source/WebCore/editing/FrameSelection.h:
* Source/WebCore/editing/InsertTextCommand.cpp:
(WebCore::InsertTextCommand::performTrivialReplace):
* Source/WebCore/editing/MarkupAccumulator.cpp:
(WebCore::MarkupAccumulator::appendCharactersReplacingEntities):
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::TextIteratorCopyableText::set):
(WebCore::TextIterator::handleTextRun):
(WebCore::TextIterator::emitCharacter):
(WebCore::SimplifiedBackwardsTextIterator::emitCharacter):
(WebCore::foldQuoteMarkAndReplaceNoBreakSpace):
(WebCore::isKanaLetter):
(WebCore::isSmallKanaLetter):
(WebCore::composedVoicedSoundMark):
(WebCore::isCombiningVoicedSoundMark):
(WebCore::normalizeCharacters):
(WebCore::SearchBuffer::isBadMatch const):
(WebCore::SearchBuffer::append):
(WebCore::SearchBuffer::prependContext):
(WebCore::SearchBuffer::search):
* Source/WebCore/editing/TextIterator.h:
* Source/WebCore/editing/TextManipulationController.cpp:
(WebCore::isInPrivateUseArea):
(WebCore::isTokenDelimiter):
(WebCore::isNotSpace):
* Source/WebCore/editing/VisibleSelection.cpp:
(WebCore::VisibleSelection::appendTrailingWhitespace):
* Source/WebCore/editing/VisibleUnits.cpp:
(WebCore::wordBreakIteratorForMinOffsetBoundary):
(WebCore::wordBreakIteratorForMaxOffsetBoundary):
(WebCore::visualWordPosition):
(WebCore::prepend):
(WebCore::prependRepeatedCharacter):
(WebCore::appendRepeatedCharacter):
(WebCore::suffixLengthForRange):
(WebCore::prefixLengthForRange):
(WebCore::backwardSearchForBoundaryWithTextIterator):
(WebCore::forwardSearchForBoundaryWithTextIterator):
(WebCore::previousBoundary):
(WebCore::nextBoundary):
* Source/WebCore/editing/VisibleUnits.h:
* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(HTMLConverter::_processText):
* Source/WebCore/html/DOMTokenList.cpp:
(WebCore::tokenContainsHTMLSpace):
* Source/WebCore/html/EmailInputType.cpp:
(WebCore::EmailInputType::typeMismatchFor const):
* Source/WebCore/html/FTPDirectoryDocument.cpp:
(WebCore::FTPDirectoryDocumentParser::append):
* Source/WebCore/html/FormController.cpp:
(WebCore::FormController::SavedFormState::consumeSerializedState):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::textToFragment):
(WebCore::HTMLElement::setInnerText):
(WebCore::HTMLElement::setOuterText):
(WebCore::HTMLElement::parseLegacyColorValue):
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::extractMIMETypeFromTypeAttributeForLookup):
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::isRFC2616TokenCharacter):
(WebCore::parseAcceptAttribute):
(WebCore::HTMLInputElement::placeholder const):
* Source/WebCore/html/HTMLScriptElement.cpp:
(WebCore::HTMLScriptElement::isScriptPreventedByAttributes const):
* Source/WebCore/html/HTMLTablePartElement.cpp:
(WebCore::HTMLTablePartElement::collectPresentationalHintsForAttribute):
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::isNotLineBreak):
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::imageSourceURL const):
* Source/WebCore/html/NumberInputType.cpp:
(WebCore::isE):
* Source/WebCore/html/PermissionsPolicy.cpp:
(WebCore::readFeatureIdentifier):
(WebCore::splitOnAsciiWhiteSpace):
* Source/WebCore/html/TypeAhead.cpp:
(WebCore::TypeAhead::handleEvent):
* Source/WebCore/html/TypeAhead.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::isSpaceThatNeedsReplacing):
(WebCore::CanvasRenderingContext2DBase::normalizeSpaces):
* Source/WebCore/html/parser/AtomHTMLToken.h:
(WebCore::AtomHTMLToken::characters const):
* Source/WebCore/html/parser/CSSPreloadScanner.cpp:
(WebCore::CSSPreloadScanner::scan):
(WebCore::CSSPreloadScanner::tokenize):
(WebCore::parseCSSStringOrURL):
(WebCore::hasValidImportConditions):
* Source/WebCore/html/parser/CSSPreloadScanner.h:
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::scanHTMLCharacterReference):
* Source/WebCore/html/parser/HTMLEntityParser.cpp:
(WebCore::DecodedHTMLEntity::DecodedHTMLEntity):
(WebCore::makeEntity):
(WebCore::SegmentedStringSource::currentCharacter const):
(WebCore::StringParsingBufferSource::currentCharacter const):
(WebCore::consumeDecimalHTMLEntity):
(WebCore::consumeHexHTMLEntity):
(WebCore::consumeNamedHTMLEntity):
(WebCore::consumeHTMLEntity):
* Source/WebCore/html/parser/HTMLEntityParser.h:
* Source/WebCore/html/parser/HTMLEntitySearch.cpp:
(WebCore::HTMLEntitySearch::compare const):
(WebCore::HTMLEntitySearch::findFirst const):
(WebCore::HTMLEntitySearch::findLast const):
(WebCore::HTMLEntitySearch::advance):
* Source/WebCore/html/parser/HTMLEntitySearch.h:
* Source/WebCore/html/parser/HTMLEntityTable.h:
* Source/WebCore/html/parser/HTMLMetaCharsetParser.cpp:
(WebCore::extractCharset):
(WebCore::HTMLMetaCharsetParser::encodingFromMetaAttributes):
* Source/WebCore/html/parser/HTMLNameCache.h:
(WebCore::HTMLNameCache::makeAttributeQualifiedName):
(WebCore::HTMLNameCache::makeAttributeValue):
(WebCore::HTMLNameCache::slotIndex):
(WebCore::HTMLNameCache::atomStringCacheSlot):
(WebCore::HTMLNameCache::qualifiedNameCacheSlot):
* Source/WebCore/html/parser/HTMLParserIdioms.cpp:
(WebCore::parseToDecimalForNumberType):
(WebCore::parseToDoubleForNumberType):
(WebCore::isNumberStart):
* Source/WebCore/html/parser/HTMLParserIdioms.h:
(WebCore::isHTMLLineBreak):
(WebCore::containsHTMLLineBreak):
(WebCore::isHTMLSpaceButNotLineBreak):
* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
(WebCore::TokenPreloadScanner::StartTagScanner::processImageAndScriptAttribute):
(WebCore::TokenPreloadScanner::StartTagScanner::processVideoAttribute):
(WebCore::TokenPreloadScanner::StartTagScanner::processAttribute):
(WebCore::TokenPreloadScanner::StartTagScanner::setURLToLoadAllowingReplacement):
(WebCore::TokenPreloadScanner::scan):
(WebCore::TokenPreloadScanner::updatePredictedBaseURL):
* Source/WebCore/html/parser/HTMLSrcsetParser.cpp:
(WebCore::parseDescriptors):
(WebCore::parseImageCandidatesFromSrcsetAttribute):
* Source/WebCore/html/parser/HTMLToken.h:
(WebCore::HTMLToken::appendToName):
(WebCore::HTMLToken::beginDOCTYPE):
(WebCore::HTMLToken::appendToPublicIdentifier):
(WebCore::HTMLToken::appendToSystemIdentifier):
(WebCore::HTMLToken::appendToAttributeName):
(WebCore::HTMLToken::appendToAttributeValue):
(WebCore::HTMLToken::appendToCharacter):
(WebCore::HTMLToken::appendToComment):
(WebCore::findAttribute):
* Source/WebCore/html/parser/HTMLTokenizer.cpp:
(WebCore::convertASCIIAlphaToLower):
(WebCore::HTMLTokenizer::bufferASCIICharacter):
(WebCore::HTMLTokenizer::bufferCharacter):
(WebCore::HTMLTokenizer::commitToPartialEndTag):
(WebCore::HTMLTokenizer::processToken):
(WebCore::HTMLTokenizer::appendToTemporaryBuffer):
(WebCore::HTMLTokenizer::appendToPossibleEndTag):
* Source/WebCore/html/parser/HTMLTokenizer.h:
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::HTMLTreeBuilder::ExternalCharacterTokenBuffer::takeRemainingWhitespace):
(WebCore::HTMLTreeBuilder::ExternalCharacterTokenBuffer::characterPredicate):
* Source/WebCore/html/parser/InputStreamPreprocessor.h:
(WebCore::InputStreamPreprocessor::nextInputCharacter const):
(WebCore::InputStreamPreprocessor::peek):
* Source/WebCore/html/parser/create-html-entity-table:
* Source/WebCore/html/shadow/DateTimeNumericFieldElement.cpp:
(WebCore::DateTimeNumericFieldElement::handleKeyboardEvent):
* Source/WebCore/html/track/BufferedLineReader.cpp:
(WebCore::BufferedLineReader::nextLine):
* Source/WebCore/html/track/TrackBase.cpp:
(WebCore::isValidBCP47LanguageTag):
(WebCore::TrackBase::setLanguage):
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::isCueParagraphSeparator):
(WebCore::VTTCue::determineTextDirection):
* Source/WebCore/html/track/VTTRegion.cpp:
(WebCore::VTTRegion::setRegionSettings):
(WebCore::VTTRegion::parseSettingValue):
* Source/WebCore/html/track/VTTScanner.cpp:
(WebCore::VTTScanner::createRun const):
* Source/WebCore/html/track/VTTScanner.h:
(WebCore::VTTScanner::Run::Run):
(WebCore::VTTScanner::Run::span16 const):
(WebCore::characterPredicate):
(WebCore::VTTScanner::seekTo):
(WebCore::VTTScanner::currentChar const):
* Source/WebCore/html/track/WebVTTParser.cpp:
(WebCore::WebVTTParser::collectTimingsAndSettings):
* Source/WebCore/html/track/WebVTTTokenizer.cpp:
(WebCore::ProcessEntity):
(WebCore::WebVTTTokenizer::nextToken):
* Source/WebCore/inspector/InspectorOverlayLabel.cpp:
(WebCore::InspectorOverlayLabel::draw):
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::StyleSheetHandler::endRuleHeader):
(WebCore::StyleSheetHandler::fixUnparsedPropertyRanges):
(WebCore::isNotSpaceOrTab):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::TextUtil::mayBreakInBetween):
(WebCore::Layout::TextUtil::hasPositionDependentContentWidth):
* Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp:
(WebCore::LayoutIntegration::printTextForSubtree):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::extractContentLanguageFromHeader):
* Source/WebCore/loader/HTTPHeaderField.cpp:
(WebCore::HTTPHeaderField::create):
* Source/WebCore/loader/HeaderFieldTokenizer.cpp:
(WebCore::HeaderFieldTokenizer::consume):
(WebCore::HeaderFieldTokenizer::consumeBeforeAnyCharMatch):
* Source/WebCore/loader/HeaderFieldTokenizer.h:
* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::ImageLoader::updateFromElement):
(WebCore::ImageLoader::decode):
* Source/WebCore/loader/ResourceCryptographicDigest.cpp:
(WebCore::parseCryptographicDigest):
(WebCore::parseEncodedCryptographicDigest):
* Source/WebCore/loader/ResourceCryptographicDigest.h:
* Source/WebCore/loader/TextResourceDecoder.cpp:
* Source/WebCore/loader/appcache/ApplicationCacheResource.cpp:
(WebCore::ApplicationCacheResource::estimatedSizeInStorage):
* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::isUnreservedURICharacter):
(WebCore::getFileNameFromURIComponent):
* Source/WebCore/mathml/MathMLPresentationElement.cpp:
(WebCore::MathMLPresentationElement::parseNumberAndUnit):
(WebCore::MathMLPresentationElement::parseMathMLLength):
* Source/WebCore/mathml/MathMLTokenElement.cpp:
(WebCore::MathMLTokenElement::convertToSingleCodePoint):
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::insertUnicodeCharacter):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::isKeyEventAllowedInFullScreen const):
* Source/WebCore/page/EventSource.cpp:
(WebCore::EventSource::parseEventStreamLine):
* Source/WebCore/page/EventSource.h:
* Source/WebCore/page/LoginStatus.cpp:
(WebCore::LoginStatus::create):
* Source/WebCore/page/WindowFeatures.cpp:
(WebCore::isSeparator):
(WebCore::parseDisabledAdaptations):
(WebCore::parseDialogFeaturesMap):
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp:
(WebCore::ContentSecurityPolicyDirectiveList::parse):
* Source/WebCore/page/csp/ContentSecurityPolicyTrustedTypesDirective.cpp:
(WebCore::ContentSecurityPolicyTrustedTypesDirective::allows const):
* Source/WebCore/page/ios/FrameIOS.mm:
(WebCore::LocalFrame::wordsInCurrentParagraph const):
(WebCore::LocalFrame::interpretationsForCurrentRoot const):
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractRenderedTokens):
(WebCore::TextExtraction::extractAllTextAndRectsRecursive):
* Source/WebCore/platform/ContentType.cpp:
(WebCore::ContentType::parameter const):
(WebCore::splitParameters):
* Source/WebCore/platform/Length.cpp:
(WebCore::parseLength):
(WebCore::countCharacter):
* Source/WebCore/platform/MIMETypeRegistry.cpp:
(WebCore::isValidXMLMIMETypeChar):
* Source/WebCore/platform/ReferrerPolicy.cpp:
(WebCore::parseReferrerPolicy):
* Source/WebCore/platform/SharedStringHash.cpp:
(WebCore::computeSharedStringHash):
* Source/WebCore/platform/SharedStringHash.h:
* Source/WebCore/platform/TelephoneNumberDetector.h:
* Source/WebCore/platform/cocoa/KeyEventCocoa.mm:
(WebCore::keyForCharCode):
* Source/WebCore/platform/cocoa/TelephoneNumberDetectorCocoa.cpp:
(WebCore::TelephoneNumberDetector::find):
* Source/WebCore/platform/graphics/ComplexTextController.cpp:
(WebCore::ComplexTextController::enclosingGlyphBoundsForTextRun):
* Source/WebCore/platform/graphics/ComplexTextController.h:
(WebCore::ComplexTextController::ComplexTextRun::create):
(WebCore::ComplexTextController::ComplexTextRun::characters const):
* Source/WebCore/platform/graphics/ComposedCharacterClusterTextIterator.h:
(WebCore::ComposedCharacterClusterTextIterator::ComposedCharacterClusterTextIterator):
(WebCore::ComposedCharacterClusterTextIterator::remainingCharacters const):
(WebCore::ComposedCharacterClusterTextIterator::characters const):
* Source/WebCore/platform/graphics/Font.cpp:
(WebCore::fillGlyphPage):
(WebCore::overrideControlCharacters):
(WebCore::createAndFillGlyphPage):
* Source/WebCore/platform/graphics/FontCache.cpp:
(WebCore::FontCache::useBackslashAsYenSignForFamily):
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::normalizeSpaces):
(WebCore::FontCascade::characterRangeCodePath):
(WebCore::FontCascade::expansionOpportunityCountInternal):
* Source/WebCore/platform/graphics/FontCascade.h:
* Source/WebCore/platform/graphics/GlyphPage.h:
* Source/WebCore/platform/graphics/Latin1TextIterator.h:
* Source/WebCore/platform/graphics/StringTruncator.cpp:
(WebCore::centerTruncateToBuffer):
(WebCore::rightTruncateToBuffer):
(WebCore::rightClipToCharacterBuffer):
(WebCore::rightClipToWordBuffer):
(WebCore::leftTruncateToBuffer):
(WebCore::stringWidth):
(WebCore::truncateString):
* Source/WebCore/platform/graphics/SurrogatePairAwareTextIterator.h:
(WebCore::SurrogatePairAwareTextIterator::SurrogatePairAwareTextIterator):
(WebCore::SurrogatePairAwareTextIterator::remainingCharacters const):
(WebCore::SurrogatePairAwareTextIterator::characters const):
* Source/WebCore/platform/graphics/TextBoxIterator.h:
(WebCore::TextBoxIterator::current const):
* Source/WebCore/platform/graphics/TextRun.h:
* Source/WebCore/platform/graphics/WidthCache.h:
(WebCore::WidthCache::SmallStringKey::SmallStringKey):
(WebCore::WidthCache::SmallStringKey::characters const):
(WebCore::WidthCache::SmallStringKey::copySmallCharacters):
(WebCore::WidthCache::addSlowCase):
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp:
(WebCore::MediaPlayerPrivateAVFoundation::extractKeyURIKeyIDAndCertificateFromInitData):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::shouldWaitForLoadingOfResource):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::ensureStructuralLayer):
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
(WebCore::isArabicCharacter):
(WebCore::lookupFallbackFont):
(WebCore::FontCache::platformAlternateFamilyName):
* Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm:
(WebCore::ComplexTextController::ComplexTextRun::ComplexTextRun):
(WebCore::ComplexTextController::collectComplexTextRunsForCharacters):
* Source/WebCore/platform/graphics/coretext/GlyphPageCoreText.cpp:
(WebCore::shouldFillWithVerticalGlyphs):
(WebCore::GlyphPage::fill):
* Source/WebCore/platform/graphics/freetype/GlyphPageTreeNodeFreeType.cpp:
(WebCore::GlyphPage::fill):
* Source/WebCore/platform/graphics/harfbuzz/ComplexTextControllerHarfBuzz.cpp:
(WebCore::ComplexTextController::ComplexTextRun::ComplexTextRun):
(WebCore::findNextRun):
(WebCore::ComplexTextController::collectComplexTextRunsForCharacters):
* Source/WebCore/platform/graphics/opentype/OpenTypeUtilities.cpp:
(WebCore::EOTHeader::appendBigEndianString):
(WebCore::renameFont):
* Source/WebCore/platform/graphics/skia/ComplexTextControllerSkia.cpp:
(WebCore::ComplexTextController::ComplexTextRun::ComplexTextRun):
(WebCore::findNextRun):
(WebCore::ComplexTextController::collectComplexTextRunsForCharacters):
* Source/WebCore/platform/graphics/skia/GlyphPageSkia.cpp:
(WebCore::GlyphPage::fill):
* Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp:
(WebCore::shapeByUniscribe):
(WebCore::ComplexTextController::collectComplexTextRunsForCharacters):
* Source/WebCore/platform/graphics/win/FontCacheSkiaWin.cpp:
(WebCore::fontsPath):
* Source/WebCore/platform/graphics/win/FontCacheWin.cpp:
(WebCore::currentFontContainsCharacter):
(WebCore::createMLangFont):
(WebCore::FontCache::systemFallbackForCharacterCluster):
(WebCore::createGDIFont):
(WebCore::FontCache::getFontSelectionCapabilitiesInFamily):
* Source/WebCore/platform/graphics/win/GlyphPageTreeNodeWin.cpp:
(WebCore::GlyphPage::fill):
* Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp:
(WebCore::PlatformKeyboardEvent::singleCharacterString):
* Source/WebCore/platform/ios/KeyEventIOS.mm:
(WebCore::isFunctionKey):
* Source/WebCore/platform/mac/StringUtilities.mm:
(WebCore::wildcardRegexPatternString):
* Source/WebCore/platform/network/CacheValidation.cpp:
(WebCore::isCacheHeaderSeparator):
(WebCore::isControlCharacterOrSpace):
(WebCore::collectVaryingRequestHeadersInternal):
* Source/WebCore/platform/network/DataURLDecoder.cpp:
(WebCore::DataURLDecoder::DecodeTask::process):
* Source/WebCore/platform/network/HTTPParsers.cpp:
(WebCore::skipWhile):
(WebCore::skipWhiteSpace):
(WebCore::isValidReasonPhrase):
(WebCore::isValidHTTPHeaderValue):
(WebCore::isValidAcceptHeaderValue):
(WebCore::containsCORSUnsafeRequestHeaderBytes):
(WebCore::isValidLanguageHeaderValue):
(WebCore::isValidHTTPToken):
(WebCore::skipCharacter):
(WebCore::filenameFromHTTPContentDisposition):
(WebCore::extractMIMETypeFromMediaType):
(WebCore::parseContentTypeOptionsHeader):
(WebCore::parseXFrameOptionsHeader):
(WebCore::parseClearSiteDataHeader):
(WebCore::parseRange):
(WebCore::isForbiddenHeader):
(WebCore::parseCrossOriginResourcePolicyHeader):
* Source/WebCore/platform/network/MIMEHeader.cpp:
(WebCore::retrieveKeyValuePairs):
(WebCore::MIMEHeader::parseContentTransferEncoding):
* Source/WebCore/platform/network/ParsedContentType.cpp:
(WebCore::isQuotedStringTokenCharacter):
(WebCore::isTokenCharacter):
(WebCore::isNotQuoteOrBackslash):
(WebCore::collectHTTPQuotedString):
(WebCore::isNotForwardSlash):
(WebCore::isNotSemicolon):
(WebCore::isNotSemicolonOrEqualSign):
(WebCore::containsNewline):
(WebCore::ParsedContentType::create):
(WebCore::ParsedContentType::setContentType):
* Source/WebCore/platform/network/RFC7230.cpp:
(RFC7230::isTokenCharacter):
(RFC7230::isDelimiter):
(RFC7230::isVisibleCharacter):
(RFC7230::isInRange):
(RFC7230::isOBSText):
(RFC7230::isQuotedTextCharacter):
(RFC7230::isQuotedPairSecondOctet):
(RFC7230::isCommentText):
(RFC7230::isValidValue):
* Source/WebCore/platform/network/RFC7230.h:
* Source/WebCore/platform/network/ResourceResponseBase.cpp:
(WebCore::ResourceResponseBase::isAttachment const):
(WebCore::ResourceResponseBase::isAttachmentWithFilename const):
(WebCore::ResourceResponseBase::containsInvalidHTTPHeaders const):
* Source/WebCore/platform/network/TimingAllowOrigin.cpp:
(WebCore::passesTimingAllowOriginCheck):
* Source/WebCore/platform/network/soup/ResourceResponseSoup.cpp:
(WebCore::sanitizeFilename):
* Source/WebCore/platform/sql/SQLiteDatabase.cpp:
(WebCore::SQLiteDatabase::prepareStatementSlow):
(WebCore::SQLiteDatabase::prepareHeapStatementSlow):
* Source/WebCore/platform/sql/SQLiteStatement.cpp:
(WebCore::SQLiteStatement::bindBlob):
(WebCore::SQLiteStatement::columnBlobAsString):
* Source/WebCore/platform/text/DateTimeFormat.cpp:
(WebCore::mapCharacterToFieldType):
(WebCore::DateTimeFormat::parse):
(WebCore::isASCIIAlphabetOrQuote):
* Source/WebCore/platform/text/LocaleICU.cpp:
(WebCore::LocaleICU::decimalSymbol):
(WebCore::LocaleICU::decimalTextAttribute):
(WebCore::LocaleICU::openDateFormat const):
(WebCore::getDateFormatPattern):
(WebCore::LocaleICU::createLabelVector):
(WebCore::getFormatForSkeleton):
(WebCore::LocaleICU::monthFormat):
(WebCore::LocaleICU::shortMonthFormat):
* Source/WebCore/platform/text/PlatformLocale.cpp:
(WebCore::Locale::convertFromLocalizedNumber):
* Source/WebCore/platform/text/SegmentedString.cpp:
(WebCore::SegmentedString::advancePastSlowCase):
* Source/WebCore/platform/text/SegmentedString.h:
(WebCore::SegmentedString::currentCharacter const):
(WebCore::SegmentedString::Substring::currentCharacter const):
(WebCore::SegmentedString::Substring::currentCharacterPreIncrement):
* Source/WebCore/platform/text/SuffixTree.h:
(WebCore::UnicodeCodebook::codeWord):
(WebCore::ASCIICodebook::codeWord):
* Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp:
(WebCore::createGlobalData):
(WebCore::setFileDescriptorData):
(WebCore::getClipboardMap):
* Source/WebCore/platform/win/KeyEventWin.cpp:
(WebCore::singleCharacterString):
* Source/WebCore/platform/win/PasteboardWin.cpp:
(WebCore::fileSystemPathFromURLOrTitle):
(WebCore::Pasteboard::writeURLToDataObject):
(WebCore::createGlobalImageFileDescriptor):
* Source/WebCore/platform/win/WindowsKeyNames.cpp:
(WebCore::WindowsKeyNames::domKeyFromChar):
* Source/WebCore/platform/win/WindowsKeyNames.h:
* Source/WebCore/platform/xr/PlatformXR.h:
(PlatformXR::parseSessionFeatureDescriptor):
* Source/WebCore/rendering/BreakLines.h:
(WebCore::BreakLines::LineBreakTable::unsafeLookup):
(WebCore::BreakLines::isBreakableSpace):
(WebCore::BreakLines::nextBreakablePosition):
(WebCore::BreakLines::classify):
* Source/WebCore/rendering/LegacyInlineIterator.cpp:
(WebCore::LegacyInlineIterator::surrogateTextDirection const):
* Source/WebCore/rendering/LegacyInlineIterator.h:
(WebCore::LegacyInlineIterator::characterAt const):
(WebCore::LegacyInlineIterator::current const):
(WebCore::LegacyInlineIterator::previousInSameNode const):
(WebCore::LegacyInlineIterator::direction const):
* Source/WebCore/rendering/LegacyLineLayout.cpp:
(WebCore::determineDirectionality):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::constructTextRun):
(WebCore::RenderBlock::updateSecurityDiscCharacters):
* Source/WebCore/rendering/RenderBlock.h:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::stripTrailingSpace):
* Source/WebCore/rendering/RenderFileUploadControl.cpp:
(WebCore::RenderFileUploadControl::computeIntrinsicLogicalWidths const):
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::reversed):
* Source/WebCore/rendering/RenderQuote.cpp:
(WebCore::checkNumberOfDistinctQuoteCharacters):
(WebCore::quotesForLanguage):
(WebCore::stringForQuoteCharacter):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::convertNoBreakSpaceToSpace):
(WebCore::capitalizeCharacter):
(WebCore::capitalize):
(WebCore::isHangablePunctuationAtLineStart):
(WebCore::isHangablePunctuationAtLineEnd):
(WebCore::RenderText::isHangableStopOrComma):
(WebCore::isSpaceAccordingToStyle):
(WebCore::RenderText::computePreferredLogicalWidths):
(WebCore::RenderText::previousCharacter const):
(WebCore::convertToFullSizeKana):
(WebCore::applyTextTransform):
(WebCore::RenderText::secureText):
* Source/WebCore/rendering/RenderText.h:
(WebCore::RenderText::characterAt const):
* Source/WebCore/rendering/RenderTextControl.cpp:
(WebCore::RenderTextControl::getAverageCharWidth):
* Source/WebCore/rendering/RenderTextFragment.cpp:
(WebCore::RenderTextFragment::previousCharacter const):
* Source/WebCore/rendering/RenderTextFragment.h:
* Source/WebCore/rendering/RenderTreeAsText.cpp:
(WebCore::quoteAndEscapeNonPrintables):
* Source/WebCore/rendering/line/BreakingContext.h:
(WebCore::shouldSkipWhitespaceAfterStartObject):
(WebCore::nextCharacter):
(WebCore::BreakingContext::handleText):
* Source/WebCore/rendering/line/LineInlineHeaders.h:
(WebCore::requiresLineBox):
* Source/WebCore/rendering/mathml/MathOperator.cpp:
* Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::isCollapsibleWhiteSpace const):
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
(WebCore::TextStreamSeparator::TextStreamSeparator):
* Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp:
(WebCore::processRenderSVGInlineText):
* Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp:
(WebCore::dumpTextBoxes):
(WebCore::SVGTextLayoutEngine::layoutTextOnLineOrPath):
* Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp:
(WebCore::SVGTextLayoutEngineBaseline::calculateGlyphOrientationAngle const):
* Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.h:
* Source/WebCore/rendering/svg/SVGTextLayoutEngineSpacing.cpp:
(WebCore::SVGTextLayoutEngineSpacing::calculateCSSSpacing):
* Source/WebCore/rendering/svg/SVGTextLayoutEngineSpacing.h:
* Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp:
(WebCore::SVGTextMetricsBuilder::measureTextRenderer):
(WebCore::SVGTextMetricsBuilder::walkTree):
* Source/WebCore/rendering/svg/SVGTextMetricsBuilder.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderMathML.cpp:
(WebCore::RenderTreeBuilder::MathML::attach):
* Source/WebCore/svg/SVGAnimationElement.cpp:
(WebCore::parseKeyTimes):
(WebCore::SVGAnimationElement::attributeChanged):
* Source/WebCore/svg/SVGFitToViewBox.cpp:
(WebCore::SVGFitToViewBox::parseViewBox):
* Source/WebCore/svg/SVGFitToViewBox.h:
* Source/WebCore/svg/SVGParserUtilities.cpp:
(WebCore::parseNumber):
(WebCore::parseArcFlag):
(WebCore::parseFloatPoint):
* Source/WebCore/svg/SVGParserUtilities.h:
* Source/WebCore/svg/SVGPathStringViewSource.h:
* Source/WebCore/svg/SVGPreserveAspectRatioValue.cpp:
(WebCore::SVGPreserveAspectRatioValue::parse):
* Source/WebCore/svg/SVGPreserveAspectRatioValue.h:
* Source/WebCore/svg/SVGStringList.cpp:
(WebCore::SVGStringList::parse):
* Source/WebCore/svg/SVGStringList.h:
* Source/WebCore/svg/SVGToOTFFontConversion.cpp:
(WebCore::codepointToString):
* Source/WebCore/svg/SVGTransformList.cpp:
(WebCore::SVGTransformList::parse):
* Source/WebCore/svg/SVGTransformList.h:
* Source/WebCore/svg/SVGTransformable.cpp:
(WebCore::SVGTransformable::parseTransformType):
* Source/WebCore/svg/SVGTransformable.h:
* Source/WebCore/svg/SVGZoomAndPan.cpp:
(WebCore::SVGZoomAndPan::parseZoomAndPan):
* Source/WebCore/svg/SVGZoomAndPan.h:
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::parseOffsetValue):
(WebCore::SVGSMILElement::parseClockValue):
(WebCore::SVGSMILElement::parseCondition):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::setRequestHeader):
* Source/WebCore/xml/XPathFunctions.cpp:
(WebCore::XPath::isWhitespace):
(WebCore::XPath::FunNormalizeSpace::evaluate const):
(WebCore::XPath::FunTranslate::evaluate const):
* Source/WebCore/xml/XPathParser.cpp:
(WebCore::XPath::charCat):
(WebCore::XPath::Parser::peekAheadHelper):
(WebCore::XPath::Parser::peekCurHelper):
(WebCore::XPath::Parser::lexString):
(WebCore::XPath::Parser::lexNumber):
* Source/WebCore/xml/XPathValue.cpp:
(WebCore::XPath::Value::toNumber const):
* Source/WebCore/xml/XSLStyleSheetLibxslt.cpp:
(WebCore::XSLStyleSheet::parseString):
* Source/WebCore/xml/parser/MarkupTokenizerInlines.h:
(WebCore::isTokenizerWhitespace):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLDocumentParser::doWrite):
(WebCore::convertUTF16EntityToUTF8):
(WebCore::xmlDocPtrForString):
(WebCore::parseAttributes):

Canonical link: <a href="https://commits.webkit.org/297580@main">https://commits.webkit.org/297580@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ecd28daa12ecca0575b90ebb331dfc8447705f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112229 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31960 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22438 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118306 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62550 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114191 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32613 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40524 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85258 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/35937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115176 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26021 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100976 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65688 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25324 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19112 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62151 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95404 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19191 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121633 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39303 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29238 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94074 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39684 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97218 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93898 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24004 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39128 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16921 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35331 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39191 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44679 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38826 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42163 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40569 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->