### PR TITLE
WebGPU: Replace UChar with char16_t

### DIFF
--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -37,7 +37,7 @@
 
 namespace WGSL {
 
-static unsigned isIdentifierStart(UChar character, std::span<const UChar> code)
+static unsigned isIdentifierStart(char16_t character, std::span<const char16_t> code)
 {
     if (character == '_')
         return 1;
@@ -50,7 +50,7 @@ static unsigned isIdentifierStart(UChar character, std::span<const UChar> code)
     return 0;
 }
 
-static unsigned isIdentifierContinue(UChar character, std::span<const UChar> code)
+static unsigned isIdentifierContinue(char16_t character, std::span<const char16_t> code)
 {
     if (auto length = isIdentifierStart(character, code))
         return length;
@@ -1037,6 +1037,6 @@ Token Lexer<T>::lexNumber()
 }
 
 template class Lexer<LChar>;
-template class Lexer<UChar>;
+template class Lexer<char16_t>;
 
 }

--- a/Source/WebGPU/WGSL/Lexer.h
+++ b/Source/WebGPU/WGSL/Lexer.h
@@ -40,7 +40,7 @@ public:
         if constexpr (std::is_same<T, LChar>::value)
             m_code = wgsl.span8();
         else {
-            static_assert(std::is_same<T, UChar>::value, "The lexer expects its template parameter to be either LChar or UChar");
+            static_assert(std::is_same<T, char16_t>::value, "The lexer expects its template parameter to be either LChar or char16_t");
             m_code = wgsl.span16();
             ASSERT(!(wgsl.sizeInBytes() % 2));
         }

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -335,7 +335,7 @@ std::optional<FailedCheck> parse(ShaderModule& shaderModule)
 {
     if (shaderModule.source().is8Bit())
         return parse<Lexer<LChar>>(shaderModule);
-    return parse<Lexer<UChar>>(shaderModule);
+    return parse<Lexer<char16_t>>(shaderModule);
 }
 
 template<typename Lexer>


### PR DESCRIPTION
#### f3097d84b52785cb73b3f4a7301fe612b75200bd
<pre>
WebGPU: Replace UChar with char16_t
<a href="https://bugs.webkit.org/show_bug.cgi?id=294730">https://bugs.webkit.org/show_bug.cgi?id=294730</a>
<a href="https://rdar.apple.com/153822449">rdar://153822449</a>

Reviewed by Alex Christensen.

WebKit wishes to move from UChar to the standard C++ chat16_t. This PR makes
the change in Source/WebGPU; it&apos;s a simple textual replacement of \bUChar\b
with char16_t. These are typedef&apos;d to be the same so no functional differences
are expected.

* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::isIdentifierStart):
(WGSL::isIdentifierContinue):
* Source/WebGPU/WGSL/Lexer.h:
(WGSL::Lexer::Lexer):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::parse):

Canonical link: <a href="https://commits.webkit.org/296800@main">https://commits.webkit.org/296800@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f8fedb2c66fe622eaf9790af7a32bc478692aa2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108480 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28141 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113689 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58883 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28830 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36692 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82381 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111428 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22869 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97710 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62817 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22286 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58408 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92240 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15901 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116810 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35534 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26184 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91407 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35907 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93984 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91208 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36101 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13865 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31282 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17689 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35436 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40971 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35145 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38497 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36827 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->