### PR TITLE
Tools: replace UChar with char16_t

### DIFF
--- a/Tools/DumpRenderTree/TestRunner.cpp
+++ b/Tools/DumpRenderTree/TestRunner.cpp
@@ -2279,7 +2279,7 @@ void TestRunner::runUIScript(JSContextRef context, JSStringRef script, JSValueRe
     if (!m_UIScriptContext)
         m_UIScriptContext = WTR::UIScriptContext::create(*this, WTR::UIScriptController::create);
 
-    String scriptString({ reinterpret_cast<const UChar*>(JSStringGetCharactersPtr(script)), JSStringGetLength(script) });
+    String scriptString({ reinterpret_cast<const char16_t*>(JSStringGetCharactersPtr(script)), JSStringGetLength(script) });
     m_UIScriptContext->runUIScript(scriptString, callbackID);
 }
 

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptContext.cpp
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptContext.cpp
@@ -166,7 +166,7 @@ void UIScriptContext::tryToCompleteUIScriptForCurrentParentCallback()
         return;
 
     JSStringRef result = m_uiScriptResultsPendingCompletion.take(m_currentScriptCallbackID);
-    String scriptResult({ reinterpret_cast<const UChar*>(JSStringGetCharactersPtr(result)), JSStringGetLength(result) });
+    String scriptResult({ reinterpret_cast<const char16_t*>(JSStringGetCharactersPtr(result)), JSStringGetLength(result) });
     if (result)
         JSStringRelease(result);
 

--- a/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
@@ -999,8 +999,8 @@ TEST_F(FileSystemTest, isAncestor)
         EXPECT_EQ(
             input.second,
                 FileSystem::isAncestor(
-                    std::span<const UChar> { static_cast<const UChar *>(input.first.first), std::char_traits<char16_t>::length(input.first.first) },
-                    std::span<const UChar> { static_cast<const UChar*>(input.first.second), std::char_traits<char16_t>::length(input.first.second) }
+                    std::span<const char16_t> { static_cast<const char16_t *>(input.first.first), std::char_traits<char16_t>::length(input.first.first) },
+                    std::span<const char16_t> { static_cast<const char16_t*>(input.first.second), std::char_traits<char16_t>::length(input.first.second) }
                 )
             );
         }

--- a/Tools/TestWebKitAPI/Tests/WTF/HexNumber.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/HexNumber.cpp
@@ -38,7 +38,7 @@ namespace TestWebKitAPI {
         if (builder.is8Bit()) \
             EXPECT_EQ(String(expected), String(builder.span<LChar>())); \
         else \
-            EXPECT_EQ(String(expected), String(builder.span<UChar>())); \
+            EXPECT_EQ(String(expected), String(builder.span<char16_t>())); \
     } \
 
 TEST(WTF, HexNumber)

--- a/Tools/TestWebKitAPI/Tests/WTF/StringBuilder.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringBuilder.cpp
@@ -46,7 +46,7 @@ static String builderContent(const StringBuilder& builder)
     // change internal state of builder.
     if (builder.is8Bit())
         return builder.span<LChar>();
-    return builder.span<UChar>();
+    return builder.span<char16_t>();
 }
 
 void expectEmpty(const StringBuilder& builder)
@@ -102,13 +102,13 @@ TEST(StringBuilderTest, Append)
     EXPECT_EQ(2U, builderForUChar32Append.length());
     builderForUChar32Append.append(U'A');
     EXPECT_EQ(3U, builderForUChar32Append.length());
-    const UChar resultArray[] = { U16_LEAD(frakturAChar), U16_TRAIL(frakturAChar), 'A' };
+    const char16_t resultArray[] = { U16_LEAD(frakturAChar), U16_TRAIL(frakturAChar), 'A' };
     EXPECT_EQ(String({ resultArray, std::size(resultArray) }), builderContent(builderForUChar32Append));
     {
         StringBuilder builder;
         StringBuilder builder2;
         char32_t frakturAChar = 0x1D504;
-        const UChar data[] = { U16_LEAD(frakturAChar), U16_TRAIL(frakturAChar) };
+        const char16_t data[] = { U16_LEAD(frakturAChar), U16_TRAIL(frakturAChar) };
         builder2.append(std::span { data });
         EXPECT_EQ(2U, builder2.length());
         String result2 = builder2.toString();
@@ -116,7 +116,7 @@ TEST(StringBuilderTest, Append)
         builder.append(builder2);
         builder.append(std::span { data });
         EXPECT_EQ(4U, builder.length());
-        const UChar resultArray[] = { U16_LEAD(frakturAChar), U16_TRAIL(frakturAChar), U16_LEAD(frakturAChar), U16_TRAIL(frakturAChar) };
+        const char16_t resultArray[] = { U16_LEAD(frakturAChar), U16_TRAIL(frakturAChar), U16_LEAD(frakturAChar), U16_TRAIL(frakturAChar) };
         EXPECT_EQ(String({ resultArray, std::size(resultArray) }), builderContent(builder));
     }
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp
@@ -70,7 +70,7 @@ TEST(WTF_StringCommon, Find8NonASCII)
 
 TEST(WTF_StringCommon, Find16NonASCII)
 {
-    Vector<UChar> vector(4096);
+    Vector<char16_t> vector(4096);
     vector.fill('a');
 
     EXPECT_FALSE(WTF::find16NonASCII(vector.subspan(0, 4096)));
@@ -247,67 +247,67 @@ TEST(WTF_StringCommon, CharactersContain8)
 TEST(WTF_StringCommon, CharactersContain16)
 {
     {
-        Vector<UChar> source;
-        EXPECT_FALSE((charactersContain<UChar, 0>(source.span())));
-        EXPECT_FALSE((charactersContain<UChar, 0, 1>(source.span())));
-        EXPECT_FALSE((charactersContain<UChar, 0, 1, 2>(source.span())));
+        Vector<char16_t> source;
+        EXPECT_FALSE((charactersContain<char16_t, 0>(source.span())));
+        EXPECT_FALSE((charactersContain<char16_t, 0, 1>(source.span())));
+        EXPECT_FALSE((charactersContain<char16_t, 0, 1, 2>(source.span())));
     }
 
     {
-        Vector<UChar> source;
+        Vector<char16_t> source;
         for (unsigned i = 0; i < 15; ++i)
             source.append(i);
-        EXPECT_TRUE((charactersContain<UChar, 0>(source.span())));
-        EXPECT_TRUE((charactersContain<UChar, 1>(source.span())));
-        EXPECT_TRUE((charactersContain<UChar, 2>(source.span())));
-        EXPECT_TRUE((charactersContain<UChar, 2, 3>(source.span())));
-        EXPECT_TRUE((charactersContain<UChar, 16, 14>(source.span())));
-        EXPECT_FALSE((charactersContain<UChar, 16>(source.span())));
-        EXPECT_FALSE((charactersContain<UChar, 16, 15>(source.span())));
-        EXPECT_FALSE((charactersContain<UChar, 16, 15, 17>(source.span())));
-        EXPECT_FALSE((charactersContain<UChar, 16, 15, 17, 18>(source.span())));
-        EXPECT_FALSE((charactersContain<UChar, 0x81>(source.span())));
-        EXPECT_FALSE((charactersContain<UChar, 0x81, 0x82>(source.span())));
+        EXPECT_TRUE((charactersContain<char16_t, 0>(source.span())));
+        EXPECT_TRUE((charactersContain<char16_t, 1>(source.span())));
+        EXPECT_TRUE((charactersContain<char16_t, 2>(source.span())));
+        EXPECT_TRUE((charactersContain<char16_t, 2, 3>(source.span())));
+        EXPECT_TRUE((charactersContain<char16_t, 16, 14>(source.span())));
+        EXPECT_FALSE((charactersContain<char16_t, 16>(source.span())));
+        EXPECT_FALSE((charactersContain<char16_t, 16, 15>(source.span())));
+        EXPECT_FALSE((charactersContain<char16_t, 16, 15, 17>(source.span())));
+        EXPECT_FALSE((charactersContain<char16_t, 16, 15, 17, 18>(source.span())));
+        EXPECT_FALSE((charactersContain<char16_t, 0x81>(source.span())));
+        EXPECT_FALSE((charactersContain<char16_t, 0x81, 0x82>(source.span())));
     }
 
     {
-        Vector<UChar> source;
+        Vector<char16_t> source;
         for (unsigned i = 0; i < 250; ++i) {
             if (i & 0x1)
                 source.append(i);
         }
-        EXPECT_FALSE((charactersContain<UChar, 0>(source.span())));
-        EXPECT_FALSE((charactersContain<UChar, 0xff>(source.span())));
-        EXPECT_TRUE((charactersContain<UChar, 0x81>(source.span())));
-        EXPECT_FALSE((charactersContain<UChar, 250>(source.span())));
-        EXPECT_TRUE((charactersContain<UChar, 249>(source.span())));
-        EXPECT_TRUE((charactersContain<UChar, 0, 249>(source.span())));
-        EXPECT_FALSE((charactersContain<UChar, 0x101>(source.span())));
-        EXPECT_FALSE((charactersContain<UChar, 0x1001>(source.span())));
-        EXPECT_FALSE((charactersContain<UChar, 0x1001, 0x1001>(source.span())));
+        EXPECT_FALSE((charactersContain<char16_t, 0>(source.span())));
+        EXPECT_FALSE((charactersContain<char16_t, 0xff>(source.span())));
+        EXPECT_TRUE((charactersContain<char16_t, 0x81>(source.span())));
+        EXPECT_FALSE((charactersContain<char16_t, 250>(source.span())));
+        EXPECT_TRUE((charactersContain<char16_t, 249>(source.span())));
+        EXPECT_TRUE((charactersContain<char16_t, 0, 249>(source.span())));
+        EXPECT_FALSE((charactersContain<char16_t, 0x101>(source.span())));
+        EXPECT_FALSE((charactersContain<char16_t, 0x1001>(source.span())));
+        EXPECT_FALSE((charactersContain<char16_t, 0x1001, 0x1001>(source.span())));
     }
 
     {
-        Vector<UChar> source;
+        Vector<char16_t> source;
         for (unsigned i = 0; i < 250; ++i) {
             if (i & 0x1)
                 source.append(i + 0x1000);
         }
-        EXPECT_FALSE((charactersContain<UChar, 0>(source.span())));
-        EXPECT_FALSE((charactersContain<UChar, 0>(source.span())));
-        EXPECT_FALSE((charactersContain<UChar, 0xff>(source.span())));
-        EXPECT_FALSE((charactersContain<UChar, 0x81>(source.span())));
-        EXPECT_FALSE((charactersContain<UChar, 250>(source.span())));
-        EXPECT_FALSE((charactersContain<UChar, 249>(source.span())));
-        EXPECT_FALSE((charactersContain<UChar, 0x101>(source.span())));
-        EXPECT_TRUE((charactersContain<UChar, 0x1001>(source.span())));
-        EXPECT_FALSE((charactersContain<UChar, 0x1000>(source.span())));
-        EXPECT_FALSE((charactersContain<UChar, 0x1100>(source.span())));
-        EXPECT_FALSE((charactersContain<UChar, 0x1000 + 256>(source.span())));
-        EXPECT_FALSE((charactersContain<UChar, 0x1000 + 250>(source.span())));
-        EXPECT_TRUE((charactersContain<UChar, 0x1000 + 249>(source.span())));
-        EXPECT_TRUE((charactersContain<UChar, 0x1000 + 249, 0>(source.span())));
-        EXPECT_FALSE((charactersContain<UChar, 0x1000 + 250, 0>(source.span())));
+        EXPECT_FALSE((charactersContain<char16_t, 0>(source.span())));
+        EXPECT_FALSE((charactersContain<char16_t, 0>(source.span())));
+        EXPECT_FALSE((charactersContain<char16_t, 0xff>(source.span())));
+        EXPECT_FALSE((charactersContain<char16_t, 0x81>(source.span())));
+        EXPECT_FALSE((charactersContain<char16_t, 250>(source.span())));
+        EXPECT_FALSE((charactersContain<char16_t, 249>(source.span())));
+        EXPECT_FALSE((charactersContain<char16_t, 0x101>(source.span())));
+        EXPECT_TRUE((charactersContain<char16_t, 0x1001>(source.span())));
+        EXPECT_FALSE((charactersContain<char16_t, 0x1000>(source.span())));
+        EXPECT_FALSE((charactersContain<char16_t, 0x1100>(source.span())));
+        EXPECT_FALSE((charactersContain<char16_t, 0x1000 + 256>(source.span())));
+        EXPECT_FALSE((charactersContain<char16_t, 0x1000 + 250>(source.span())));
+        EXPECT_TRUE((charactersContain<char16_t, 0x1000 + 249>(source.span())));
+        EXPECT_TRUE((charactersContain<char16_t, 0x1000 + 249, 0>(source.span())));
+        EXPECT_FALSE((charactersContain<char16_t, 0x1000 + 250, 0>(source.span())));
     }
 }
 
@@ -386,61 +386,61 @@ TEST(WTF_StringCommon, CountMatchedCharacters8)
 TEST(WTF_StringCommon, CountMatchedCharacters16)
 {
     {
-        Vector<UChar> source;
-        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 0)), 0U);
-        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 1)), 0U);
-        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 2)), 0U);
+        Vector<char16_t> source;
+        EXPECT_EQ((WTF::countMatchedCharacters<char16_t>(source.span(), 0)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<char16_t>(source.span(), 1)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<char16_t>(source.span(), 2)), 0U);
     }
 
     {
-        Vector<UChar> source;
+        Vector<char16_t> source;
         for (unsigned i = 0; i < 15; ++i)
             source.append(i);
-        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 0)), 1U);
-        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 1)), 1U);
-        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 2)), 1U);
-        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 3)), 1U);
-        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 14)), 1U);
-        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 15)), 0U);
-        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 16)), 0U);
-        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 17)), 0U);
-        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 18)), 0U);
-        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 0x81)), 0U);
-        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 0x82)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<char16_t>(source.span(), 0)), 1U);
+        EXPECT_EQ((WTF::countMatchedCharacters<char16_t>(source.span(), 1)), 1U);
+        EXPECT_EQ((WTF::countMatchedCharacters<char16_t>(source.span(), 2)), 1U);
+        EXPECT_EQ((WTF::countMatchedCharacters<char16_t>(source.span(), 3)), 1U);
+        EXPECT_EQ((WTF::countMatchedCharacters<char16_t>(source.span(), 14)), 1U);
+        EXPECT_EQ((WTF::countMatchedCharacters<char16_t>(source.span(), 15)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<char16_t>(source.span(), 16)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<char16_t>(source.span(), 17)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<char16_t>(source.span(), 18)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<char16_t>(source.span(), 0x81)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<char16_t>(source.span(), 0x82)), 0U);
     }
 
     {
-        Vector<UChar> source;
+        Vector<char16_t> source;
         for (unsigned i = 0; i < 250; ++i) {
             if (i & 0x1)
                 source.append(i);
         }
-        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 0)), 0U);
-        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 1)), 1U);
-        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 0xff)), 0U);
-        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 0x81)), 1U);
-        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 250)), 0U);
-        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 249)), 1U);
+        EXPECT_EQ((WTF::countMatchedCharacters<char16_t>(source.span(), 0)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<char16_t>(source.span(), 1)), 1U);
+        EXPECT_EQ((WTF::countMatchedCharacters<char16_t>(source.span(), 0xff)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<char16_t>(source.span(), 0x81)), 1U);
+        EXPECT_EQ((WTF::countMatchedCharacters<char16_t>(source.span(), 250)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<char16_t>(source.span(), 249)), 1U);
     }
 
     {
-        Vector<UChar> source;
+        Vector<char16_t> source;
         for (unsigned c = 0; c < 1024; ++c) {
             for (unsigned i = 0; i < 250; ++i) {
                 if (i & 0x1)
                     source.append(i);
             }
         }
-        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 0)), 0U);
-        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 1)), 1024U);
-        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 0xff)), 0U);
-        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 0x81)), 1024U);
-        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 250)), 0U);
-        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 249)), 1024U);
+        EXPECT_EQ((WTF::countMatchedCharacters<char16_t>(source.span(), 0)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<char16_t>(source.span(), 1)), 1024U);
+        EXPECT_EQ((WTF::countMatchedCharacters<char16_t>(source.span(), 0xff)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<char16_t>(source.span(), 0x81)), 1024U);
+        EXPECT_EQ((WTF::countMatchedCharacters<char16_t>(source.span(), 250)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<char16_t>(source.span(), 249)), 1024U);
     }
 
     {
-        Vector<UChar> source;
+        Vector<char16_t> source;
         for (unsigned c = 0; c < 0xffff; ++c) {
             for (unsigned i = 0; i < 250; ++i)
                 source.append(1);
@@ -449,9 +449,9 @@ TEST(WTF_StringCommon, CountMatchedCharacters16)
         source.append(1);
         source.append(1);
 
-        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 0)), 0U);
-        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 1)), source.size());
-        EXPECT_EQ((WTF::countMatchedCharacters<UChar>(source.span(), 0x81)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<char16_t>(source.span(), 0)), 0U);
+        EXPECT_EQ((WTF::countMatchedCharacters<char16_t>(source.span(), 1)), source.size());
+        EXPECT_EQ((WTF::countMatchedCharacters<char16_t>(source.span(), 0x81)), 0U);
     }
 }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/StringConcatenate.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringConcatenate.cpp
@@ -203,13 +203,13 @@ TEST(WTF, StringConcatenate_Tuple)
     EXPECT_STREQ("hello 42 world", makeString("hello"_s, ' ', std::make_tuple(unsigned(42), ' ', "world"_s)).utf8().data());
     EXPECT_STREQ("hello 42 world", makeString(std::make_tuple("hello"_s, ' ', unsigned(42), ' ', "world"_s)).utf8().data());
 
-    UChar checkmarkCodepoint = 0x2713;
+    char16_t checkmarkCodepoint = 0x2713;
     EXPECT_STREQ("hello \xE2\x9C\x93 world", makeString("hello"_s, ' ', checkmarkCodepoint, ' ', "world"_s).utf8().data());
     EXPECT_STREQ("hello \xE2\x9C\x93 world", makeString("hello"_s, ' ', std::make_tuple(checkmarkCodepoint), ' ', "world"_s).utf8().data());
     EXPECT_STREQ("hello \xE2\x9C\x93 world", makeString("hello"_s, ' ', std::make_tuple(checkmarkCodepoint, ' ', "world"_s)).utf8().data());
     EXPECT_STREQ("hello \xE2\x9C\x93 world", makeString(std::make_tuple("hello"_s, ' ', checkmarkCodepoint, ' ', "world"_s)).utf8().data());
 
-    const UChar helloCodepoints[] = { 'h', 'e', 'l', 'l', 'o', '\0' };
+    const char16_t helloCodepoints[] = { 'h', 'e', 'l', 'l', 'o', '\0' };
     EXPECT_STREQ("hello 42 world", makeString(helloCodepoints, ' ', unsigned(42), ' ', "world"_s).utf8().data());
     EXPECT_STREQ("hello 42 world", makeString(std::make_tuple(helloCodepoints), ' ', unsigned(42), ' ', "world"_s).utf8().data());
     EXPECT_STREQ("hello 42 world", makeString(std::make_tuple(helloCodepoints, ' ', unsigned(42)), ' ', "world"_s).utf8().data());

--- a/Tools/TestWebKitAPI/Tests/WTF/StringHasher.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringHasher.cpp
@@ -44,7 +44,7 @@ TEST(WTF, StringHasher)
     };
 
     auto generateUCharArray = [&](size_t size) {
-        auto array = std::unique_ptr<UChar[]>(new UChar[size]);
+        auto array = std::unique_ptr<char16_t[]>(new char16_t[size]);
         for (size_t i = 0; i < size; i++)
             array[i] = i;
         return array;
@@ -54,7 +54,7 @@ TEST(WTF, StringHasher)
     unsigned max8Bit = std::numeric_limits<uint8_t>::max();
     for (size_t size = 0; size <= max8Bit; size++) {
         std::unique_ptr<const LChar[]> arr1 = generateLCharArray(size);
-        std::unique_ptr<const UChar[]> arr2 = generateUCharArray(size);
+        std::unique_ptr<const char16_t[]> arr2 = generateUCharArray(size);
         unsigned left = StringHasher::computeHashAndMaskTop8Bits(std::span { arr1.get(), size });
         unsigned right = StringHasher::computeHashAndMaskTop8Bits(std::span { arr2.get(), size });
         ASSERT_EQ(left, right);
@@ -72,9 +72,9 @@ TEST(WTF, StringHasher_SuperFastHash_VS_WYHash)
         return;
 
     size_t sum = 0;
-    dataLogLn("UChar");
+    dataLogLn("char16_t");
     for (size_t size = 2; size < (1 << 16); size *= 2) {
-        Vector<UChar> vector(size, [](size_t index) {
+        Vector<char16_t> vector(size, [](size_t index) {
             return index & 0x7f;
         });
         sum += SuperFastHash::computeHashAndMaskTop8Bits(vector.span());

--- a/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
@@ -88,17 +88,17 @@ TEST(WTF, StringImplReplaceWithLiteral)
     testStringImpl = testString.impl()->replace('2', "NotFound"_span);
     ASSERT_TRUE(equal(testStringImpl.get(), String::fromUTF8("résumé").impl()));
 
-    testStringImpl = testString.impl()->replace(UChar(0x00E9 /*U+00E9 is 'é'*/), "e"_span);
+    testStringImpl = testString.impl()->replace(char16_t(0x00E9 /*U+00E9 is 'é'*/), "e"_span);
     ASSERT_TRUE(equal(testStringImpl.get(), "resume"_s));
 
     testString = String::fromUTF8("résumé");
     ASSERT_FALSE(testString.impl()->is8Bit());
-    testStringImpl = testString.impl()->replace(UChar(0x00E9 /*U+00E9 is 'é'*/), ""_span);
+    testStringImpl = testString.impl()->replace(char16_t(0x00E9 /*U+00E9 is 'é'*/), ""_span);
     ASSERT_TRUE(equal(testStringImpl.get(), "rsum"_s));
 
     testString = String::fromUTF8("résumé");
     ASSERT_FALSE(testString.impl()->is8Bit());
-    testStringImpl = testString.impl()->replace(UChar(0x00E9 /*U+00E9 is 'é'*/), "555"_span);
+    testStringImpl = testString.impl()->replace(char16_t(0x00E9 /*U+00E9 is 'é'*/), "555"_span);
     ASSERT_TRUE(equal(testStringImpl.get(), "r555sum555"_s));
 }
 
@@ -775,8 +775,8 @@ TEST(WTF, ExternalStringImplCreate8bit)
 
 TEST(WTF, ExternalStringImplCreate16bit)
 {
-    constexpr UChar buffer[] = { L'h', L'e', L'l', L'l', L'o', L'\0' };
-    constexpr size_t bufferStringLength = (sizeof(buffer) - 1) / sizeof(UChar);
+    constexpr char16_t buffer[] = { L'h', L'e', L'l', L'l', L'o', L'\0' };
+    constexpr size_t bufferStringLength = (sizeof(buffer) - 1) / sizeof(char16_t);
     bool freeFunctionCalled = false;
 
     {

--- a/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
@@ -117,15 +117,15 @@ bool compareLoopIterations(StringView::CodePoints codePoints, std::vector<char32
     return actual == expected;
 }
 
-static bool compareLoopIterations(StringView::CodeUnits codeUnits, std::vector<UChar> expected)
+static bool compareLoopIterations(StringView::CodeUnits codeUnits, std::vector<char16_t> expected)
 {
-    std::vector<UChar> actual;
+    std::vector<char16_t> actual;
     for (auto codeUnit : codeUnits)
         actual.push_back(codeUnit);
     return actual == expected;
 }
 
-static void build(StringBuilder& builder, std::vector<UChar> input)
+static void build(StringBuilder& builder, std::vector<char16_t> input)
 {
     builder.clear();
     for (auto codeUnit : input)
@@ -187,7 +187,7 @@ TEST(WTF, StringViewIterators)
     build(b, {0xD800, 0xD801}); // Two leading surrogates
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).codePoints(), {0xD800, 0xD801}));
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).codeUnits(), {0xD800, 0xD801}));
-    EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).graphemeClusters(), { StringView(b.span<UChar>().subspan(0, 1)), StringView(b.span<UChar>().subspan(1, 1)) }));
+    EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).graphemeClusters(), { StringView(b.span<char16_t>().subspan(0, 1)), StringView(b.span<char16_t>().subspan(1, 1)) }));
 
     build(b, {0xDD55}); // Trailing surrogate only
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).codePoints(), {0xDD55}));
@@ -197,7 +197,7 @@ TEST(WTF, StringViewIterators)
     build(b, {0xD800, 'h'}); // Leading surrogate followed by non-surrogate
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).codePoints(), {0xD800, 'h'}));
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).codeUnits(), {0xD800, 'h'}));
-    EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).graphemeClusters(), { StringView(b.span<UChar>().subspan(0, 1)), StringView(b.span<UChar>().subspan(1, 1)) }));
+    EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).graphemeClusters(), { StringView(b.span<char16_t>().subspan(0, 1)), StringView(b.span<char16_t>().subspan(1, 1)) }));
 
     build(b, {0x0306}); // "COMBINING BREVE"
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).codePoints(), {0x0306}));
@@ -208,12 +208,12 @@ TEST(WTF, StringViewIterators)
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).codePoints(), {0x0306, 0x10155, 'h', 'e', 'l', 'o'}));
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).codeUnits(), {0x0306, 0xD800, 0xDD55, 'h', 'e', 'l', 'o'}));
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).graphemeClusters(), {
-        StringView(b.span<UChar>().subspan(0, 1)),
-        StringView(b.span<UChar>().subspan(1, 2)),
-        StringView(b.span<UChar>().subspan(3, 1)),
-        StringView(b.span<UChar>().subspan(4, 1)),
-        StringView(b.span<UChar>().subspan(5, 1)),
-        StringView(b.span<UChar>().subspan(6, 1)) }));
+        StringView(b.span<char16_t>().subspan(0, 1)),
+        StringView(b.span<char16_t>().subspan(1, 2)),
+        StringView(b.span<char16_t>().subspan(3, 1)),
+        StringView(b.span<char16_t>().subspan(4, 1)),
+        StringView(b.span<char16_t>().subspan(5, 1)),
+        StringView(b.span<char16_t>().subspan(6, 1)) }));
 
     build(b, {'e', 0x0301}); // "COMBINING ACUTE"
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).codePoints(), {'e', 0x0301}));
@@ -224,16 +224,16 @@ TEST(WTF, StringViewIterators)
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).codePoints(), {'e', 0x0301, 0x0306, 'a'}));
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).codeUnits(), {'e', 0x0301, 0x0306, 'a'}));
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).graphemeClusters(), {
-        StringView(b.span<UChar>().subspan(0, 3)),
-        StringView(b.span<UChar>().subspan(3, 1)),
+        StringView(b.span<char16_t>().subspan(0, 3)),
+        StringView(b.span<char16_t>().subspan(3, 1)),
         }));
 
     build(b, {0x1112, 0x116f, 0x11b6, 0x1107, 0x1161, 0x11B8}); // Korean combining Jamo
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).codePoints(), {0x1112, 0x116f, 0x11b6, 0x1107, 0x1161, 0x11B8}));
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).codeUnits(), {0x1112, 0x116f, 0x11b6, 0x1107, 0x1161, 0x11B8}));
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).graphemeClusters(), {
-        StringView(b.span<UChar>().subspan(0, 3)),
-        StringView(b.span<UChar>().subspan(3, 3)) }));
+        StringView(b.span<char16_t>().subspan(0, 3)),
+        StringView(b.span<char16_t>().subspan(3, 3)) }));
 }
 
 static Vector<String> vectorFromSplitResult(const StringView::SplitResult& substrings)
@@ -895,7 +895,7 @@ TEST(WTF, StringView8Bit)
     EXPECT_TRUE(emptyStringView().is8Bit());
 
     std::span<const LChar> lcharSpan;
-    std::span<const UChar> ucharSpan;
+    std::span<const char16_t> ucharSpan;
     EXPECT_TRUE(StringView(lcharSpan).is8Bit());
     EXPECT_FALSE(StringView(ucharSpan).is8Bit());
 
@@ -956,7 +956,7 @@ TEST(WTF, StringViewReverseFindBasic)
 
 TEST(WTF, StringViewTrim)
 {
-    auto isA = [] (UChar c) { 
+    auto isA = [] (char16_t c) { 
         return c == 'A';
     };
 
@@ -983,7 +983,7 @@ TEST(WTF, StringViewContainsOnlyASCII)
     EXPECT_FALSE(StringView(String::fromLatin1("📱")).containsOnlyASCII());
     EXPECT_FALSE(StringView(String::fromLatin1("\u0080")).containsOnlyASCII());
     constexpr size_t zeroLength = 0;
-    EXPECT_TRUE(StringView(String({ reinterpret_cast<const UChar*>(u"Hello"), zeroLength })).containsOnlyASCII());
+    EXPECT_TRUE(StringView(String({ reinterpret_cast<const char16_t*>(u"Hello"), zeroLength })).containsOnlyASCII());
 }
 
 TEST(WTF, StringViewUpconvert)

--- a/Tools/TestWebKitAPI/Tests/WTF/SuperFastHash.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/SuperFastHash.cpp
@@ -29,14 +29,14 @@
 namespace TestWebKitAPI {
 
 static const LChar nullLChars[2] = { 0, 0 };
-static const UChar nullUChars[2] = { 0, 0 };
+static const char16_t nullUChars[2] = { 0, 0 };
 
 static const unsigned emptyStringHash = 0x4EC889EU;
 static const unsigned singleNullCharacterHash = 0x3D3ABF44U;
 
 static const LChar testALChars[6] = { 0x41, 0x95, 0xFF, 0x50, 0x01, 0 };
-static const UChar testAUChars[6] = { 0x41, 0x95, 0xFF, 0x50, 0x01, 0 };
-static const UChar testBUChars[6] = { 0x41, 0x95, 0xFFFF, 0x1080, 0x01, 0 };
+static const char16_t testAUChars[6] = { 0x41, 0x95, 0xFF, 0x50, 0x01, 0 };
+static const char16_t testBUChars[6] = { 0x41, 0x95, 0xFFFF, 0x1080, 0x01, 0 };
 
 static const unsigned testAHash1 = 0xEA32B004;
 static const unsigned testAHash2 = 0x93F0F71E;
@@ -124,7 +124,7 @@ TEST(WTF, SuperFastHash_addCharacters)
     ASSERT_EQ(emptyStringHash, hasher.hash());
     ASSERT_EQ(emptyStringHash & 0xFFFFFF, hasher.hashWithTop8BitsMasked());
     hasher = SuperFastHash();
-    hasher.addCharacters(static_cast<UChar*>(0), 0);
+    hasher.addCharacters(static_cast<char16_t*>(0), 0);
     ASSERT_EQ(emptyStringHash, hasher.hash());
     ASSERT_EQ(emptyStringHash & 0xFFFFFF, hasher.hashWithTop8BitsMasked());
     hasher = SuperFastHash();
@@ -316,7 +316,7 @@ TEST(WTF, SuperFastHash_addCharactersAssumingAligned)
     ASSERT_EQ(emptyStringHash, hasher.hash());
     ASSERT_EQ(emptyStringHash & 0xFFFFFF, hasher.hashWithTop8BitsMasked());
     hasher = SuperFastHash();
-    hasher.addCharactersAssumingAligned(static_cast<UChar*>(0), 0);
+    hasher.addCharactersAssumingAligned(static_cast<char16_t*>(0), 0);
     ASSERT_EQ(emptyStringHash, hasher.hash());
     ASSERT_EQ(emptyStringHash & 0xFFFFFF, hasher.hashWithTop8BitsMasked());
     hasher = SuperFastHash();
@@ -439,7 +439,7 @@ TEST(WTF, SuperFastHash_computeHash)
     static constexpr size_t zeroLength = 0;
     ASSERT_EQ(emptyStringHash, SuperFastHash::computeHash(std::span { static_cast<const LChar*>(0), zeroLength }));
     ASSERT_EQ(emptyStringHash, SuperFastHash::computeHash(std::span { nullLChars, zeroLength }));
-    ASSERT_EQ(emptyStringHash, SuperFastHash::computeHash(std::span { static_cast<const UChar*>(0), zeroLength }));
+    ASSERT_EQ(emptyStringHash, SuperFastHash::computeHash(std::span { static_cast<const char16_t*>(0), zeroLength }));
     ASSERT_EQ(emptyStringHash, SuperFastHash::computeHash(std::span { nullUChars, zeroLength }));
 
     ASSERT_EQ(singleNullCharacterHash, SuperFastHash::computeHash(std::span { nullLChars, 1 }));
@@ -458,7 +458,7 @@ TEST(WTF, SuperFastHash_computeHashAndMaskTop8Bits)
     static constexpr size_t zeroLength = 0;
     ASSERT_EQ(emptyStringHash & 0xFFFFFF, SuperFastHash::computeHashAndMaskTop8Bits(std::span { static_cast<const LChar*>(0), zeroLength }));
     ASSERT_EQ(emptyStringHash & 0xFFFFFF, SuperFastHash::computeHashAndMaskTop8Bits(std::span { nullLChars, zeroLength }));
-    ASSERT_EQ(emptyStringHash & 0xFFFFFF, SuperFastHash::computeHashAndMaskTop8Bits(std::span { static_cast<const UChar*>(0), zeroLength }));
+    ASSERT_EQ(emptyStringHash & 0xFFFFFF, SuperFastHash::computeHashAndMaskTop8Bits(std::span { static_cast<const char16_t*>(0), zeroLength }));
     ASSERT_EQ(emptyStringHash & 0xFFFFFF, SuperFastHash::computeHashAndMaskTop8Bits(std::span { nullUChars, zeroLength }));
 
     ASSERT_EQ(singleNullCharacterHash & 0xFFFFFF, SuperFastHash::computeHashAndMaskTop8Bits(std::span { nullLChars, 1 }));

--- a/Tools/TestWebKitAPI/Tests/WTF/TextBreakIterator.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/TextBreakIterator.cpp
@@ -33,9 +33,9 @@
 
 namespace TestWebKitAPI {
 
-static String makeUTF16(std::vector<UChar> input)
+static String makeUTF16(std::vector<char16_t> input)
 {
-    return std::span<const UChar> { input };
+    return std::span<const char16_t> { input };
 }
 
 TEST(WTF_TextBreakIterator, NumGraphemeClusters)

--- a/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
@@ -353,7 +353,7 @@ TEST(WTF_Vector, CopyFromOtherMinCapacity)
 
 TEST(WTF_Vector, ConstructorOtherRawPointerTypeAndLength)
 {
-    const UChar uchars[] = { 'b', 'a', 'r' };
+    const char16_t uchars[] = { 'b', 'a', 'r' };
     Vector<LChar> vector(std::span(uchars, static_cast<size_t>(3)));
     EXPECT_EQ(vector.size(), 3U);
     EXPECT_EQ(vector[0], 'b');

--- a/Tools/TestWebKitAPI/Tests/WTF/WTFString.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WTFString.cpp
@@ -262,12 +262,12 @@ TEST(WTF, StringReplaceWithLiteral)
     // Cases for 16Bit source.
     testString = String::fromUTF8("résumé");
     EXPECT_FALSE(testString.is8Bit());
-    testString = makeStringByReplacingAll(testString, UChar(0x00E9 /*U+00E9 is 'é'*/), "e"_s);
+    testString = makeStringByReplacingAll(testString, char16_t(0x00E9 /*U+00E9 is 'é'*/), "e"_s);
     EXPECT_STREQ("resume", testString.utf8().data());
 
     testString = String::fromUTF8("résumé");
     EXPECT_FALSE(testString.is8Bit());
-    testString = makeStringByReplacingAll(testString, UChar(0x00E9 /*U+00E9 is 'é'*/), ""_s);
+    testString = makeStringByReplacingAll(testString, char16_t(0x00E9 /*U+00E9 is 'é'*/), ""_s);
     EXPECT_STREQ("rsum", testString.utf8().data());
 
     testString = String::fromUTF8("résumé");
@@ -368,10 +368,10 @@ TEST(WTF, StringUnicodeEqualUCharArray)
     String string1("abc"_s);
     EXPECT_FALSE(string1.isNull());
     EXPECT_TRUE(string1.is8Bit());
-    UChar ab[] = { 'a', 'b' };
-    UChar abc[] = { 'a', 'b', 'c' };
-    UChar abcd[] = { 'a', 'b', 'c', 'd' };
-    UChar aBc[] = { 'a', 'B', 'c' };
+    char16_t ab[] = { 'a', 'b' };
+    char16_t abc[] = { 'a', 'b', 'c' };
+    char16_t abcd[] = { 'a', 'b', 'c', 'd' };
+    char16_t aBc[] = { 'a', 'B', 'c' };
     EXPECT_FALSE(equal(string1, ab));
     EXPECT_TRUE(equal(string1, abc));
     EXPECT_FALSE(equal(string1, abcd));

--- a/Tools/TestWebKitAPI/Tests/WTF/WYHash.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WYHash.cpp
@@ -61,7 +61,7 @@ TEST(WTF, WYHasher)
     };
 
     auto generateUCharArray = [&](size_t size) {
-        auto array = std::unique_ptr<UChar[]>(new UChar[size]);
+        auto array = std::unique_ptr<char16_t[]>(new char16_t[size]);
         for (size_t i = 0; i < size; i++)
             array[i] = i;
         return array;
@@ -70,7 +70,7 @@ TEST(WTF, WYHasher)
     unsigned max8Bit = std::numeric_limits<uint8_t>::max();
     for (size_t size = 0; size <= max8Bit; size++) {
         std::unique_ptr<const LChar[]> arr1 = generateLCharArray(size);
-        std::unique_ptr<const UChar[]> arr2 = generateUCharArray(size);
+        std::unique_ptr<const char16_t[]> arr2 = generateUCharArray(size);
         unsigned left = WYHash::computeHashAndMaskTop8Bits(std::span { arr1.get(), size });
         unsigned right = WYHash::computeHashAndMaskTop8Bits(std::span { arr2.get(), size });
         ASSERT_EQ(left, right);

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
@@ -307,7 +307,7 @@ TEST(URLExtras, URLExtras_ParsingError)
     WTF::URL url2 { utf16String(u"http://\u2267\u222E\uFE63\u0661\u06F1") };
     EXPECT_NULL([url2.createNSURL() absoluteString]);
 
-    std::array<UChar, 2> utf16 { 0xC2, 0xB6 };
+    std::array<char16_t, 2> utf16 { 0xC2, 0xB6 };
     WTF::URL url3 { String(utf16) };
     EXPECT_FALSE(url3.string().is8Bit());
     EXPECT_FALSE(url3.isValid());

--- a/Tools/TestWebKitAPI/Tests/WebCore/ComplexTextController.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ComplexTextController.cpp
@@ -58,7 +58,7 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceWithLeftRunInRTL)
 
     FloatSize initialAdvance = FloatSize(-15.15625, 18.046875);
 
-    std::array<UChar, 6> characters { 0x644, 0x637, 0x641, 0x627, 0x64b, 0x20 };
+    std::array<char16_t, 6> characters { 0x644, 0x637, 0x641, 0x627, 0x64b, 0x20 };
     TextRun textRun { StringView(characters) };
     auto run1 = ComplexTextController::ComplexTextRun::create({ FloatSize(21.875, 0) }, { FloatPoint() }, { 5 }, { 5 }, FloatSize(), font.primaryFont(), std::span { characters }, 0, 5, 6, false);
     auto run2 = ComplexTextController::ComplexTextRun::create(advances, origins, { 193, 377, 447, 431, 458 }, { 4, 3, 2, 1, 0 }, initialAdvance, font.primaryFont(), std::span { characters }, 0, 0, 5, false);
@@ -103,7 +103,7 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceInRTL)
 
     FloatSize initialAdvance = FloatSize(-15.15625, 18.046875);
 
-    std::array<UChar, 5> characters { 0x644, 0x637, 0x641, 0x627, 0x64b };
+    std::array<char16_t, 5> characters { 0x644, 0x637, 0x641, 0x627, 0x64b };
     TextRun textRun { StringView(characters) };
     auto run = ComplexTextController::ComplexTextRun::create(advances, origins, { 193, 377, 447, 431, 458 }, { 4, 3, 2, 1, 0 }, initialAdvance, font.primaryFont(), std::span { characters }, 0, 0, 5, false);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
@@ -147,7 +147,7 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceWithLeftRunInLTR)
 
     FloatSize initialAdvance = FloatSize(28.144531, 0);
 
-    std::array<UChar, 3> characters { 0x20, 0x61, 0x20e3 };
+    std::array<char16_t, 3> characters { 0x20, 0x61, 0x20e3 };
     TextRun textRun { StringView(characters) };
     auto run1 = ComplexTextController::ComplexTextRun::create({ FloatSize(spaceWidth, 0) }, { FloatPoint() }, { 5 }, { 0 }, FloatSize(), font.primaryFont(), std::span { characters }, 0, 0, 1, true);
     auto run2 = ComplexTextController::ComplexTextRun::create(advances, origins, { 68, 1471 }, { 1, 2 }, initialAdvance, font.primaryFont(), std::span { characters }, 0, 1, 3, true);
@@ -188,7 +188,7 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceInLTR)
 
     FloatSize initialAdvance = FloatSize(28.144531, 0);
 
-    std::array<UChar, 2> characters { 0x61, 0x20e3 };
+    std::array<char16_t, 2> characters { 0x61, 0x20e3 };
     TextRun textRun { StringView(characters) };
     auto run = ComplexTextController::ComplexTextRun::create(advances, origins, { 68, 1471 }, { 0, 1 }, initialAdvance, font.primaryFont(), std::span { characters }, 0, 0, 2, true);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
@@ -221,7 +221,7 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceInRTLNoOrigins)
 
     FloatSize initialAdvance = FloatSize(4.33996383363472, 12.368896925859);
 
-    std::array<UChar, 4> characters { 0x633, 0x20, 0x627, 0x650 };
+    std::array<char16_t, 4> characters { 0x633, 0x20, 0x627, 0x650 };
     TextRun textRun { StringView(characters) };
     auto run1 = ComplexTextController::ComplexTextRun::create({ FloatSize(-4.33996383363472, -12.368896925859), FloatSize(14.0397830018083, 0) }, { }, { 884, 240 }, { 3, 2 }, initialAdvance, font.primaryFont(), std::span { characters }, 0, 2, 4, false);
     auto run2 = ComplexTextController::ComplexTextRun::create({ FloatSize(12.0, 0) }, { }, { 3 }, { 1 }, FloatSize(), font.primaryFont(), std::span { characters }, 0, 1, 2, false);
@@ -264,7 +264,7 @@ TEST_F(ComplexTextControllerTest, LeftExpansion)
     FontCascade font(WTFMove(description));
     font.update();
 
-    std::array<UChar, 1> characters { 'a' };
+    std::array<char16_t, 1> characters { 'a' };
     TextRun textRun(StringView(characters), 0, 100, ExpansionBehavior::forceLeftOnly());
     auto run = ComplexTextController::ComplexTextRun::create({ FloatSize(24, 0) }, { }, { 16 }, { 0 }, FloatSize(), font.primaryFont(), std::span { characters }, 0, 0, 1, true);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
@@ -293,7 +293,7 @@ TEST_F(ComplexTextControllerTest, VerticalAdvances)
     FontCascade font(WTFMove(description));
     font.update();
 
-    std::array<UChar, 4> characters { 'a', 'b', 'c', 'd' };
+    std::array<char16_t, 4> characters { 'a', 'b', 'c', 'd' };
     TextRun textRun { StringView(characters) };
     auto run1 = ComplexTextController::ComplexTextRun::create({ FloatSize(0, 1), FloatSize(0, 2) }, { FloatPoint(0, 4), FloatPoint(0, 8) }, { 16, 17 }, { 0, 1 }, FloatSize(0, 16), font.primaryFont(), std::span { characters }, 0, 0, 2, true);
     auto run2 = ComplexTextController::ComplexTextRun::create({ FloatSize(0, 32), FloatSize(0, 64) }, { FloatPoint(0, 128), FloatPoint(0, 256) }, { 18, 19 }, { 2, 3 }, FloatSize(0, 512), font.primaryFont(), std::span { characters }, 0, 2, 4, true);
@@ -341,7 +341,7 @@ TEST_F(ComplexTextControllerTest, TotalWidthWithJustification)
 
     FloatSize initialAdvance = FloatSize();
 
-    std::array<UChar, 5> characters { 0x644, ' ', 0x644, ' ', 0x644 };
+    std::array<char16_t, 5> characters { 0x644, ' ', 0x644, ' ', 0x644 };
     TextRun textRun(StringView(characters), 0, 14, ExpansionBehavior::defaultBehavior(), TextDirection::RTL);
     auto run = ComplexTextController::ComplexTextRun::create(advances, origins, { 5, 6, 7, 8, 9 }, { 4, 3, 2, 1, 0 }, initialAdvance, font.primaryFont(), std::span { characters }, 0, 0, 5, false);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;

--- a/Tools/TestWebKitAPI/Tests/WebCore/FontCascade.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FontCascade.cpp
@@ -32,15 +32,15 @@ namespace TestWebKitAPI {
 using namespace WebCore;
 using CodePath = FontCascade::CodePath;
 
-static void testCodePath(UChar codePoint, CodePath codePath)
+static void testCodePath(char16_t codePoint, CodePath codePath)
 {
-    std::array<UChar, 1> target = { codePoint };
-    EXPECT_EQ(codePath, FontCascade::characterRangeCodePath(std::span<UChar>(target))) << "target: " << static_cast<int>(target[0]);
+    std::array<char16_t, 1> target = { codePoint };
+    EXPECT_EQ(codePath, FontCascade::characterRangeCodePath(std::span<char16_t>(target))) << "target: " << static_cast<int>(target[0]);
 }
 
 struct CodePathRange {
-    UChar start;
-    UChar end;
+    char16_t start;
+    char16_t end;
     CodePath path;
     CodePath belowPath { CodePath::Simple };
     CodePath abovePath { CodePath::Simple };
@@ -48,17 +48,17 @@ struct CodePathRange {
 
 static void testCodePathRange(CodePathRange range)
 {
-    std::array<UChar, 1> below = { static_cast<UChar>(range.start - 1) };
-    std::array<UChar, 1> start = { range.start };
-    std::array<UChar, 1> middle = { static_cast<UChar>((range.start + range.end) / 2) };
-    std::array<UChar, 1> end = { range.end };
-    std::array<UChar, 1> above = { static_cast<UChar>(range.end + 1) };
+    std::array<char16_t, 1> below = { static_cast<char16_t>(range.start - 1) };
+    std::array<char16_t, 1> start = { range.start };
+    std::array<char16_t, 1> middle = { static_cast<char16_t>((range.start + range.end) / 2) };
+    std::array<char16_t, 1> end = { range.end };
+    std::array<char16_t, 1> above = { static_cast<char16_t>(range.end + 1) };
 
-    EXPECT_EQ(range.belowPath, FontCascade::characterRangeCodePath(std::span<UChar>(below))) << "below: " << std::hex << static_cast<int>(below[0]);
-    EXPECT_EQ(range.path, FontCascade::characterRangeCodePath(std::span<UChar>(start))) << "start: " << std::hex << static_cast<int>(start[0]);
-    EXPECT_EQ(range.path, FontCascade::characterRangeCodePath(std::span<UChar>(middle))) << "middle: " << std::hex << static_cast<int>(middle[0]);
-    EXPECT_EQ(range.path, FontCascade::characterRangeCodePath(std::span<UChar>(end))) << "end: " << std::hex << static_cast<int>(end[0]);
-    EXPECT_EQ(range.abovePath, FontCascade::characterRangeCodePath(std::span<UChar>(above))) << "above: " << std::hex << static_cast<int>(above[0]);
+    EXPECT_EQ(range.belowPath, FontCascade::characterRangeCodePath(std::span<char16_t>(below))) << "below: " << std::hex << static_cast<int>(below[0]);
+    EXPECT_EQ(range.path, FontCascade::characterRangeCodePath(std::span<char16_t>(start))) << "start: " << std::hex << static_cast<int>(start[0]);
+    EXPECT_EQ(range.path, FontCascade::characterRangeCodePath(std::span<char16_t>(middle))) << "middle: " << std::hex << static_cast<int>(middle[0]);
+    EXPECT_EQ(range.path, FontCascade::characterRangeCodePath(std::span<char16_t>(end))) << "end: " << std::hex << static_cast<int>(end[0]);
+    EXPECT_EQ(range.abovePath, FontCascade::characterRangeCodePath(std::span<char16_t>(above))) << "above: " << std::hex << static_cast<int>(above[0]);
 }
 
 // Testing characterRangeCodePath for non-surrogate codepoints

--- a/Tools/TestWebKitAPI/Tests/WebCore/LineBreaking.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/LineBreaking.mm
@@ -52,7 +52,7 @@ Vector<unsigned> breakingLocationsFromICU(const Vector<UInt16>& testString, cons
     uloc_setKeywordValue("lb", icuValue.data(), buffer, bufferSize, &status);
     ASSERT(U_SUCCESS(status));
 
-    UBreakIterator* iterator = ubrk_open(UBRK_LINE, buffer.data(), reinterpret_cast<const UChar*>(testString.data()), testString.size(), &status);
+    UBreakIterator* iterator = ubrk_open(UBRK_LINE, buffer.data(), reinterpret_cast<const char16_t*>(testString.data()), testString.size(), &status);
     ASSERT(U_SUCCESS(status));
     ASSERT(iterator);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -282,7 +282,7 @@ template<> struct TestArgumentCoder<String> {
             return std::nullopt;
         if (*is8Bit)
             return decodeStringText<LChar>(decoder, *length);
-        return decodeStringText<UChar>(decoder, *length);
+        return decodeStringText<char16_t>(decoder, *length);
     }
 };
 

--- a/Tools/TestWebKitAPI/WTFTestUtilities.h
+++ b/Tools/TestWebKitAPI/WTFTestUtilities.h
@@ -42,7 +42,7 @@ String utf16String(const char16_t (&url)[length])
     StringBuilder builder;
     builder.reserveCapacity(length - 1);
     for (size_t i = 0; i < length - 1; ++i)
-        builder.append(static_cast<UChar>(url[i]));
+        builder.append(static_cast<char16_t>(url[i]));
     return builder.toString();
 }
 

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
@@ -81,7 +81,7 @@ template<> inline void StringTypeAdapter<WKStringRef>::writeTo<LChar>(std::span<
 {
 }
 
-template<> inline void StringTypeAdapter<WKStringRef>::writeTo<UChar>(std::span<UChar> destination) const
+template<> inline void StringTypeAdapter<WKStringRef>::writeTo<char16_t>(std::span<char16_t> destination) const
 {
     if (m_string)
         WKStringGetCharacters(m_string, reinterpret_cast<WKChar*>(destination.data()), WKStringGetLength(m_string));

--- a/Tools/gdb/webkit.py
+++ b/Tools/gdb/webkit.py
@@ -95,7 +95,7 @@ class StringPrinter(object):
 
 
 class UCharStringPrinter(StringPrinter):
-    "Print a UChar*; we must guess at the length"
+    "Print a char16_t*; we must guess at the length"
     def to_string(self):
         return ustring_to_string(self.val)
 
@@ -323,7 +323,7 @@ def add_pretty_printers():
 
         if type.code == gdb.TYPE_CODE_PTR:
             name = str(type.target().unqualified())
-            if name == 'UChar':
+            if name == 'char16_t':
                 return UCharStringPrinter(val)
             if name == 'LChar':
                 return LCharStringPrinter(val)

--- a/Tools/lldb/lldbWebKitTester/main.cpp
+++ b/Tools/lldb/lldbWebKitTester/main.cpp
@@ -43,7 +43,7 @@ static String utf16String(const char16_t (&string)[length])
     StringBuilder builder;
     builder.reserveCapacity(length - 1);
     for (auto c : string)
-        builder.append(static_cast<UChar>(c));
+        builder.append(static_cast<char16_t>(c));
     return builder.toString();
 }
 


### PR DESCRIPTION
#### 29d7763e4506f7a857e56f4039cf6277840d44ab
<pre>
Tools: replace UChar with char16_t
<a href="https://bugs.webkit.org/show_bug.cgi?id=294732">https://bugs.webkit.org/show_bug.cgi?id=294732</a>
<a href="https://rdar.apple.com/153822948">rdar://153822948</a>

Reviewed by Alex Christensen.

WebKit wishes to move from UChar to the C++ standard char16_t. This PR makes
that change for the Tools subdirectory. It&apos;s a plain textual substitution of
\bUChar\b for char16_t. These types are identical due to typedef so no
functional changes are expected.

This is one of a series of PRs making this change for each part of WebKit.

* Tools/DumpRenderTree/TestRunner.cpp:
(TestRunner::runUIScript):
* Tools/TestRunnerShared/UIScriptContext/UIScriptContext.cpp:
(UIScriptContext::tryToCompleteUIScriptForCurrentParentCallback):
* Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp:
(TestWebKitAPI::TEST_F(FileSystemTest, isAncestor)):
* Tools/TestWebKitAPI/Tests/WTF/HexNumber.cpp:
* Tools/TestWebKitAPI/Tests/WTF/StringBuilder.cpp:
(TestWebKitAPI::builderContent):
(TestWebKitAPI::TEST(StringBuilderTest, Append)):
* Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp:
(TestWebKitAPI::TEST(WTF_StringCommon, Find16NonASCII)):
(TestWebKitAPI::TEST(WTF_StringCommon, CharactersContain16)):
(TestWebKitAPI::TEST(WTF_StringCommon, CountMatchedCharacters16)):
* Tools/TestWebKitAPI/Tests/WTF/StringConcatenate.cpp:
(TestWebKitAPI::TEST(WTF, StringConcatenate_Tuple)):
* Tools/TestWebKitAPI/Tests/WTF/StringHasher.cpp:
(TestWebKitAPI::TEST(WTF, StringHasher)):
(TestWebKitAPI::TEST(WTF, StringHasher_SuperFastHash_VS_WYHash)):
* Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp:
(TestWebKitAPI::TEST(WTF, StringImplReplaceWithLiteral)):
(TestWebKitAPI::TEST(WTF, ExternalStringImplCreate16bit)):
* Tools/TestWebKitAPI/Tests/WTF/StringView.cpp:
(TestWebKitAPI::compareLoopIterations):
(TestWebKitAPI::build):
(TestWebKitAPI::TEST(WTF, StringViewIterators)):
(TestWebKitAPI::TEST(WTF, StringView8Bit)):
(TestWebKitAPI::TEST(WTF, StringViewTrim)):
(TestWebKitAPI::TEST(WTF, StringViewContainsOnlyASCII)):
* Tools/TestWebKitAPI/Tests/WTF/SuperFastHash.cpp:
(TestWebKitAPI::TEST(WTF, SuperFastHash_addCharacters)):
(TestWebKitAPI::TEST(WTF, SuperFastHash_addCharactersAssumingAligned)):
(TestWebKitAPI::TEST(WTF, SuperFastHash_computeHash)):
(TestWebKitAPI::TEST(WTF, SuperFastHash_computeHashAndMaskTop8Bits)):
* Tools/TestWebKitAPI/Tests/WTF/TextBreakIterator.cpp:
(TestWebKitAPI::makeUTF16):
* Tools/TestWebKitAPI/Tests/WTF/Vector.cpp:
(TestWebKitAPI::TEST(WTF_Vector, ConstructorOtherRawPointerTypeAndLength)):
* Tools/TestWebKitAPI/Tests/WTF/WTFString.cpp:
(TestWebKitAPI::TEST(WTF, StringReplaceWithLiteral)):
(TestWebKitAPI::TEST(WTF, StringUnicodeEqualUCharArray)):
* Tools/TestWebKitAPI/Tests/WTF/WYHash.cpp:
(TestWebKitAPI::TEST(WTF, WYHasher)):
* Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm:
(TestWebKitAPI::TEST(URLExtras, URLExtras_ParsingError)):
* Tools/TestWebKitAPI/Tests/WebCore/ComplexTextController.cpp:
(TestWebKitAPI::TEST_F(ComplexTextControllerTest, InitialAdvanceWithLeftRunInRTL)):
(TestWebKitAPI::TEST_F(ComplexTextControllerTest, InitialAdvanceInRTL)):
(TestWebKitAPI::TEST_F(ComplexTextControllerTest, InitialAdvanceWithLeftRunInLTR)):
(TestWebKitAPI::TEST_F(ComplexTextControllerTest, InitialAdvanceInLTR)):
(TestWebKitAPI::TEST_F(ComplexTextControllerTest, InitialAdvanceInRTLNoOrigins)):
(TestWebKitAPI::TEST_F(ComplexTextControllerTest, LeftExpansion)):
(TestWebKitAPI::TEST_F(ComplexTextControllerTest, VerticalAdvances)):
(TestWebKitAPI::TEST_F(ComplexTextControllerTest, TotalWidthWithJustification)):
* Tools/TestWebKitAPI/Tests/WebCore/FontCascade.cpp:
(TestWebKitAPI::testCodePath):
(TestWebKitAPI::testCodePathRange):
* Tools/TestWebKitAPI/Tests/WebCore/LineBreaking.mm:
(breakingLocationsFromICU):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(TestWebKitAPI::TestArgumentCoder&lt;String&gt;::decode):
* Tools/TestWebKitAPI/WTFTestUtilities.h:
(TestWebKitAPI::utf16String):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp:
(WTF::StringTypeAdapter&lt;WKStringRef&gt;::writeTo&lt;char16_t&gt; const):
(WTF::StringTypeAdapter&lt;WKStringRef&gt;::writeTo&lt;UChar&gt; const): Deleted.
* Tools/gdb/webkit.py:
(UCharStringPrinter):
(add_pretty_printers.lookup_function):
* Tools/lldb/lldbWebKitTester/main.cpp:
(utf16String):

Canonical link: <a href="https://commits.webkit.org/296802@main">https://commits.webkit.org/296802@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abcef230e0942c3e5163ff2c48285235647e280b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108483 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28144 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18568 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113692 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58886 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110446 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28833 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36695 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82385 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111431 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22871 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97711 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62821 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22288 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15848 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58411 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92242 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15902 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116813 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35537 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26186 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91410 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35910 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93985 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91210 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36103 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13866 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31285 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17690 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35439 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35148 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38500 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36830 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->