### PR TITLE
WebKit: convert UChar to char16_t

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -282,7 +282,7 @@ bool NetworkLoadChecker::checkTAO(const ResourceResponse& response)
     if (m_origin) {
         const auto& timingAllowOriginString = response.httpHeaderField(HTTPHeaderName::TimingAllowOrigin);
         for (auto originWithSpace : StringView(timingAllowOriginString).split(',')) {
-            auto origin = originWithSpace.trim(isASCIIWhitespaceWithoutFF<UChar>);
+            auto origin = originWithSpace.trim(isASCIIWhitespaceWithoutFF<char16_t>);
             if (origin == "*"_s || origin == protectedOrigin()->toString())
                 return true;
         }

--- a/Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.cpp
@@ -73,7 +73,7 @@ WebSocketTask::WebSocketTask(NetworkSocketChannel& channel, const WebCore::Resou
         protocols.reset(static_cast<char**>(g_new0(char*, protocolList.size() + 1)));
         unsigned i = 0;
         for (auto& subprotocol : protocolList)
-            protocols.get()[i++] = g_strdup(subprotocol.trim(isASCIIWhitespaceWithoutFF<UChar>).utf8().data());
+            protocols.get()[i++] = g_strdup(subprotocol.trim(isASCIIWhitespaceWithoutFF<char16_t>).utf8().data());
     }
     WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageRecord.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageRecord.cpp
@@ -50,7 +50,7 @@ void CacheStorageRecordInformation::updateVaryHeaders(const WebCore::ResourceReq
     }
 
     varyValue.split(',', [&](StringView view) {
-        if (!m_hasVaryStar && view.trim(isASCIIWhitespaceWithoutFF<UChar>) == "*"_s)
+        if (!m_hasVaryStar && view.trim(isASCIIWhitespaceWithoutFF<char16_t>) == "*"_s)
             m_hasVaryStar = true;
         m_varyHeaders.add(view.toString(), request.httpHeaderField(view));
     });

--- a/Source/WebKit/Platform/IPC/ArgumentCoders.cpp
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.cpp
@@ -84,7 +84,7 @@ WARN_UNUSED_RETURN std::optional<String> ArgumentCoder<String>::decode(Decoder& 
     
     if (*is8Bit)
         return decodeStringText<LChar>(decoder, *length);
-    return decodeStringText<UChar>(decoder, *length);
+    return decodeStringText<char16_t>(decoder, *length);
 }
 template
 std::optional<String> ArgumentCoder<String>::decode<Decoder>(Decoder&);

--- a/Source/WebKit/Platform/IPC/DaemonCoders.h
+++ b/Source/WebKit/Platform/IPC/DaemonCoders.h
@@ -186,7 +186,7 @@ template<> struct Coder<WTF::String> {
 
         if (*is8Bit)
             return decodeStringText<LChar>(decoder, *length);
-        return decodeStringText<UChar>(decoder, *length);
+        return decodeStringText<char16_t>(decoder, *length);
     }
 };
 

--- a/Source/WebKit/Shared/API/c/WKString.cpp
+++ b/Source/WebKit/Shared/API/c/WKString.cpp
@@ -61,12 +61,12 @@ size_t WKStringGetLength(WKStringRef stringRef)
 
 size_t WKStringGetCharacters(WKStringRef stringRef, WKChar* buffer, size_t bufferLength)
 {
-    static_assert(sizeof(WKChar) == sizeof(UChar), "Size of WKChar must match size of UChar");
+    static_assert(sizeof(WKChar) == sizeof(char16_t), "Size of WKChar must match size of char16_t");
 
     unsigned unsignedBufferLength = std::min<size_t>(bufferLength, std::numeric_limits<unsigned>::max());
     auto substring = WebKit::toProtectedImpl(stringRef)->stringView().left(unsignedBufferLength);
 
-    substring.getCharacters(unsafeMakeSpan(reinterpret_cast<UChar*>(buffer), bufferLength));
+    substring.getCharacters(unsafeMakeSpan(reinterpret_cast<char16_t*>(buffer), bufferLength));
     return substring.length();
 }
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionLocalization.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionLocalization.cpp
@@ -333,7 +333,7 @@ String WebExtensionLocalization::stringByReplacingPositionalPlaceholdersInString
         if (index < 0)
             break;
 
-        auto originalKey = localizedString.substring(index, matchLength).trim(isASCIIWhitespace<UChar>);
+        auto originalKey = localizedString.substring(index, matchLength).trim(isASCIIWhitespace<char16_t>);
         auto key = originalKey.substring(1, originalKey.length());
         auto keyInteger = parseInteger<size_t>(key);
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp
@@ -180,7 +180,7 @@ String toErrorString(const String& callingAPIName, const String& sourceKey, Stri
     va_start(arguments, underlyingErrorString);
 
 ALLOW_NONLITERAL_FORMAT_BEGIN
-    String formattedUnderlyingErrorString = formatString(underlyingErrorString.utf8().data(), arguments).trim([](UChar character) -> bool {
+    String formattedUnderlyingErrorString = formatString(underlyingErrorString.utf8().data(), arguments).trim([](char16_t character) -> bool {
         return character == '.';
     });
 ALLOW_NONLITERAL_FORMAT_END

--- a/Source/WebKit/Shared/win/WebEventFactory.cpp
+++ b/Source/WebKit/Shared/win/WebEventFactory.cpp
@@ -215,7 +215,7 @@ static String textFromEvent(WPARAM wparam, WebEventType type)
     if (type != WebEventType::Char)
         return String();
 
-    UChar c = static_cast<UChar>(wparam);
+    char16_t c = static_cast<char16_t>(wparam);
     return span(c);
 }
 
@@ -224,7 +224,7 @@ static String unmodifiedTextFromEvent(WPARAM wparam, WebEventType type)
     if (type != WebEventType::Char)
         return String();
 
-    UChar c = static_cast<UChar>(wparam);
+    char16_t c = static_cast<char16_t>(wparam);
     return span(c);
 }
 

--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
@@ -308,7 +308,7 @@ static Expected<MappedData, std::error_code> compiledToFile(WTF::String&& json, 
                 m_sourceWritten += sourceJSON.length();
             } else {
                 writeToFile(WebKit::NetworkCache::Data(asBytes(sourceJSON.span16())));
-                m_sourceWritten += sourceJSON.length() * sizeof(UChar);
+                m_sourceWritten += sourceJSON.length() * sizeof(char16_t);
             }
         }
 
@@ -511,13 +511,13 @@ static WTF::String getContentRuleListSourceFromMappedFile(const MappedData& mapp
     if (is8Bit)
         return dataSpan.subspan(start, length);
 
-    if (length % sizeof(UChar)) {
+    if (length % sizeof(char16_t)) {
         ASSERT_NOT_REACHED();
-        WTFLogAlways("Content Rule List source recovery failed: Length is not a multiple of UChar size; data is corrupted.");
+        WTFLogAlways("Content Rule List source recovery failed: Length is not a multiple of char16_t size; data is corrupted.");
         return { };
     }
 
-    return spanReinterpretCast<const UChar>(dataSpan.subspan(start, length));
+    return spanReinterpretCast<const char16_t>(dataSpan.subspan(start, length));
 }
 
 void ContentRuleListStore::lookupContentRuleList(WTF::String&& identifier, CompletionHandler<void(RefPtr<API::ContentRuleList>, std::error_code)> completionHandler)

--- a/Source/WebKit/UIProcess/API/gtk/DropTargetGtk3.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/DropTargetGtk3.cpp
@@ -185,8 +185,8 @@ void DropTarget::dataReceived(IntPoint&& position, GtkSelectionData* data, unsig
         const auto* markupData = gtk_selection_data_get_data_with_length(data, &length);
         if (length > 0) {
             // If data starts with UTF-16 BOM assume it's UTF-16, otherwise assume UTF-8.
-            if (length >= 2 && reinterpret_cast<const UChar*>(markupData)[0] == 0xFEFF)
-                m_selectionData->setMarkup(String({ reinterpret_cast<const UChar*>(markupData) + 1, static_cast<size_t>((length / 2) - 1) }));
+            if (length >= 2 && reinterpret_cast<const char16_t*>(markupData)[0] == 0xFEFF)
+                m_selectionData->setMarkup(String({ reinterpret_cast<const char16_t*>(markupData) + 1, static_cast<size_t>((length / 2) - 1) }));
             else
                 m_selectionData->setMarkup(String::fromUTF8(std::span(markupData, length)));
         }

--- a/Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp
@@ -192,8 +192,8 @@ void DropTarget::accept(GdkDrop* drop, std::optional<WebCore::IntPoint> position
                 if (length) {
                     WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GTK port
                     // If data starts with UTF-16 BOM assume it's UTF-16, otherwise assume UTF-8.
-                    if (length >= 2 && reinterpret_cast<const UChar*>(markupData)[0] == 0xFEFF)
-                        m_selectionData->setMarkup(String({ reinterpret_cast<const UChar*>(markupData) + 1, (length / 2) - 1 }));
+                    if (length >= 2 && reinterpret_cast<const char16_t*>(markupData)[0] == 0xFEFF)
+                        m_selectionData->setMarkup(String({ reinterpret_cast<const char16_t*>(markupData) + 1, (length / 2) - 1 }));
                     else
                         m_selectionData->setMarkup(String::fromUTF8(std::span(static_cast<const char*>(markupData), length)));
                     WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
+++ b/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
@@ -133,8 +133,8 @@ public:
         uint32_t length = value.length();
         *this << length;
 
-        *this << static_cast<uint64_t>(length * sizeof(UChar));
-        encodeFixedLengthData(asBytes(StringView(value).upconvertedCharacters().span()), alignof(UChar));
+        *this << static_cast<uint64_t>(length * sizeof(char16_t));
+        encodeFixedLengthData(asBytes(StringView(value).upconvertedCharacters().span()), alignof(char16_t));
 
         return *this;
     }
@@ -594,19 +594,19 @@ public:
         uint64_t lengthInBytes;
         *this >> lengthInBytes;
 
-        if (lengthInBytes % sizeof(UChar) || lengthInBytes / sizeof(UChar) != length) {
+        if (lengthInBytes % sizeof(char16_t) || lengthInBytes / sizeof(char16_t) != length) {
             markInvalid();
             return *this;
         }
 
-        if (!bufferIsLargeEnoughToContain<UChar>(length)) {
+        if (!bufferIsLargeEnoughToContain<char16_t>(length)) {
             markInvalid();
             return *this;
         }
 
-        std::span<UChar> buffer;
+        std::span<char16_t> buffer;
         auto string = String::createUninitialized(length, buffer);
-        decodeFixedLengthData(asMutableByteSpan(buffer), alignof(UChar));
+        decodeFixedLengthData(asMutableByteSpan(buffer), alignof(char16_t));
 
         value = string;
         return *this;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -2312,7 +2312,7 @@ void UnifiedPDFPlugin::revealFragmentIfNeeded()
         fragmentView = fragmentView.left(endOfFirstComponentLocation);
 
     // Ignore leading hashes.
-    auto isNotHash = [](UChar character) {
+    auto isNotHash = [](char16_t character) {
         return character != '#';
     };
     if (auto firstNonHashLocation = fragmentView.find(isNotHash); firstNonHashLocation != notFound)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9780,7 +9780,7 @@ bool WebPage::shouldSkipDecidePolicyForResponse(const WebCore::ResourceResponse&
     if (response.url().protocolIsFile())
         return false;
 
-    if (auto components = response.httpHeaderField(HTTPHeaderName::ContentDisposition).split(';'); !components.isEmpty() && equalIgnoringASCIICase(components[0].trim(isASCIIWhitespaceWithoutFF<UChar>), "attachment"_s))
+    if (auto components = response.httpHeaderField(HTTPHeaderName::ContentDisposition).split(';'); !components.isEmpty() && equalIgnoringASCIICase(components[0].trim(isASCIIWhitespaceWithoutFF<char16_t>), "attachment"_s))
         return false;
 
     return true;

--- a/Source/WebKit/webpushd/PushClientConnection.mm
+++ b/Source/WebKit/webpushd/PushClientConnection.mm
@@ -116,7 +116,7 @@ static bool isValidPushPartition(String partition)
         return true;
 
     // On iOS, the push partition is expected to match the format of a web clip identifier.
-    auto isASCIIDigitOrUpper = [](UChar character) {
+    auto isASCIIDigitOrUpper = [](char16_t character) {
         return isASCIIDigit(character) || isASCIIUpper(character);
     };
     return partition.length() == 32 && partition.containsOnly<isASCIIDigitOrUpper>();

--- a/Source/WebKitLegacy/ios/Misc/WebUIKitSupport.mm
+++ b/Source/WebKitLegacy/ios/Misc/WebUIKitSupport.mm
@@ -88,7 +88,7 @@ float WebKitGetMinimumZoomFontSize(void)
     return DEFAULT_VALUE_FOR_MinimumZoomFontSize;
 }
 
-int WebKitGetLastLineBreakInBuffer(UChar *characters, int position, int length)
+int WebKitGetLastLineBreakInBuffer(char16_t *characters, int position, int length)
 {
     unsigned lastBreakPos = position;
     unsigned breakPos = 0;

--- a/Source/WebKitLegacy/mac/Misc/WebKitNSStringExtras.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebKitNSStringExtras.mm
@@ -69,7 +69,7 @@ static bool canUseFastRenderer(std::span<const UniChar> buffer)
 
     if (canUseFastRenderer(buffer)) {
         FontCascade webCoreFont(FontPlatformData((__bridge CTFontRef)font, [font pointSize]));
-        TextRun run(StringView(spanReinterpretCast<const UChar>(std::span { buffer })));
+        TextRun run(StringView(spanReinterpretCast<const char16_t>(std::span { buffer })));
 
         // The following is a half-assed attempt to match AppKit's rounding rules for drawAtPoint.
         // If you change it, be sure to test all the text drawn this way in Safari, including
@@ -109,7 +109,7 @@ static bool canUseFastRenderer(std::span<const UniChar> buffer)
 
     if (canUseFastRenderer(buffer)) {
         FontCascade webCoreFont(FontPlatformData((__bridge CTFontRef)font, [font pointSize]));
-        TextRun run(StringView(spanReinterpretCast<const UChar>(std::span { buffer })));
+        TextRun run(StringView(spanReinterpretCast<const char16_t>(std::span { buffer })));
         return webCoreFont.width(run);
     }
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.mm
@@ -86,14 +86,14 @@ void WebVisitedLinkStore::addVisitedLink(NSString *urlString)
     size_t length = urlString.length;
 
     if (auto characters = CFStringGetCharactersPtr((__bridge CFStringRef)urlString)) {
-        addVisitedLinkHash(computeSharedStringHash(std::span { reinterpret_cast<const UChar*>(characters), length }));
+        addVisitedLinkHash(computeSharedStringHash(std::span { reinterpret_cast<const char16_t*>(characters), length }));
         return;
     }
 
     Vector<UniChar, 512> buffer(length);
     [urlString getCharacters:buffer.mutableSpan().data()];
 
-    addVisitedLinkHash(computeSharedStringHash(spanReinterpretCast<const UChar>(buffer.span())));
+    addVisitedLinkHash(computeSharedStringHash(spanReinterpretCast<const char16_t>(buffer.span())));
 }
 
 void WebVisitedLinkStore::removeVisitedLink(NSString *urlString)

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -2006,13 +2006,13 @@ static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
 
     bool addLeadingSpace = start.deepEquivalent().leadingWhitespacePosition(WebCore::VisiblePosition::defaultAffinity, true).isNull() && !isStartOfParagraph(start);
     if (addLeadingSpace) {
-        if (UChar previousCharacter = start.previous().characterAfter())
+        if (char16_t previousCharacter = start.previous().characterAfter())
             addLeadingSpace = !WebCore::isCharacterSmartReplaceExempt(previousCharacter, true);
     }
     
     bool addTrailingSpace = end.deepEquivalent().trailingWhitespacePosition(WebCore::VisiblePosition::defaultAffinity, true).isNull() && !isEndOfParagraph(end);
     if (addTrailingSpace) {
-        if (UChar followingCharacter = end.characterAfter())
+        if (char16_t followingCharacter = end.characterAfter())
             addTrailingSpace = !WebCore::isCharacterSmartReplaceExempt(followingCharacter, false);
     }
 


### PR DESCRIPTION
#### 4de95e21619d9d595a106e7f608ceba22611bcd7
<pre>
WebKit: convert UChar to char16_t
<a href="https://bugs.webkit.org/show_bug.cgi?id=294733">https://bugs.webkit.org/show_bug.cgi?id=294733</a>
<a href="https://rdar.apple.com/153823213">rdar://153823213</a>

Reviewed by Alex Christensen.

WebKit would like to switch from UChar to the C++ standard char16_t. This PR
makes the change for the Source/WebKit and Source/WebKitLegacy directories.
This is a simple textual substitution of \bUChar\b to char16_t. As these types
are currently typedefed to be identical, no functional changes are expected.

One file was excluded from this:
Source/WebKitLegacy/ios/Misc/WebUIKitSupport.h
because this file is included in plain [objective-C] code as well as C++ code,
where char16_t does not exist (it&apos;s a C++ type).

* Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp:
(WebKit::NetworkLoadChecker::checkTAO):
* Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.cpp:
(WebKit::WebSocketTask::WebSocketTask):
* Source/WebKit/NetworkProcess/storage/CacheStorageRecord.cpp:
(WebKit::CacheStorageRecordInformation::updateVaryHeaders):
* Source/WebKit/Platform/IPC/ArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;String&gt;::decode):
* Source/WebKit/Platform/IPC/DaemonCoders.h:
(WebKit::Daemon::Coder&lt;WTF::String&gt;::decode):
* Source/WebKit/Shared/API/c/WKString.cpp:
(WKStringGetCharacters):
* Source/WebKit/Shared/Extensions/WebExtensionLocalization.cpp:
(WebKit::WebExtensionLocalization::stringByReplacingPositionalPlaceholdersInString):
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp:
(WebKit::toErrorString):
* Source/WebKit/Shared/win/WebEventFactory.cpp:
(WebKit::textFromEvent):
(WebKit::unmodifiedTextFromEvent):
* Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp:
(API::compiledToFile):
(API::getContentRuleListSourceFromMappedFile):
* Source/WebKit/UIProcess/API/gtk/DropTargetGtk3.cpp:
(WebKit::DropTarget::dataReceived):
* Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp:
(WebKit::DropTarget::accept):
* Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp:
(WebKit::HistoryEntryDataEncoder::operator&lt;&lt;):
(WebKit::HistoryEntryDataDecoder::operator&gt;&gt;):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::revealFragmentIfNeeded):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::shouldSkipDecidePolicyForResponse const):
* Source/WebKit/webpushd/PushClientConnection.mm:
(WebPushD::isValidPushPartition):
* Source/WebKitLegacy/ios/Misc/WebUIKitSupport.mm:
(WebKitGetLastLineBreakInBuffer):
* Source/WebKitLegacy/mac/Misc/WebKitNSStringExtras.mm:
(-[NSString _web_drawAtPoint:font:textColor:]):
(-[NSString _web_widthWithFont:]):
* Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.mm:
(WebVisitedLinkStore::addVisitedLink):
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame _smartInsertForString:replacingRange:beforeString:afterString:]):

Canonical link: <a href="https://commits.webkit.org/296864@main">https://commits.webkit.org/296864@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b01ddaa056cfba5e91cb057395847cfffe74fc0c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109805 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29463 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19893 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115826 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60042 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30141 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38051 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83445 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112753 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24019 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98883 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63908 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23398 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17031 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59620 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93389 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17074 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118618 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36844 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27295 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92447 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37217 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95150 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92270 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37238 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14986 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/32683 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17719 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36739 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42209 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36399 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39741 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38108 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->