### PR TITLE
[WPE] On wayland fallback to libdrm for device detection if other methods are unsupported

### DIFF
--- a/Source/WebKit/WPEPlatform/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/CMakeLists.txt
@@ -10,7 +10,7 @@ configure_file(wpe-platform-uninstalled.pc.in ${CMAKE_BINARY_DIR}/wpe-platform-$
 configure_file(wpe/WPEConfig.h.in ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/WPEConfig.h)
 configure_file(wpe/WPEVersion.h.in ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/WPEVersion.h)
 
-set(WPEPlatform_SOURCES
+set(WPEPlatform_SOURCES_FOR_INTROSPECTION
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBuffer.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBufferDMABuf.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBufferDMABufFormats.cpp
@@ -41,6 +41,11 @@ set(WPEPlatform_SOURCES
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEView.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEViewAccessible.cpp
     ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/WPEEnumTypes.cpp
+)
+
+set(WPEPlatform_SOURCES
+    ${WPEPlatform_SOURCES_FOR_INTROSPECTION}
+    ${WEBKIT_DIR}/WPEPlatform/wpe/LibDRMUtilities.cpp
 )
 
 set(WPEPlatform_INSTALLED_HEADERS
@@ -196,7 +201,7 @@ GI_INTROSPECT(WPEPlatform ${WPE_API_VERSION} wpe/wpe-platform.h
         -I${WPEPlatform_DERIVED_SOURCES_DIR}
     SOURCES
         ${WPEPlatform_INSTALLED_HEADERS}
-        ${WPEPlatform_SOURCES}
+        ${WPEPlatform_SOURCES_FOR_INTROSPECTION}
     NO_IMPLICIT_SOURCES
 )
 

--- a/Source/WebKit/WPEPlatform/wpe/LibDRMUtilities.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/LibDRMUtilities.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "LibDRMUtilities.h"
+
+#if USE(LIBDRM)
+
+#include <glib.h>
+#include <wtf/StdLibExtras.h>
+#include <xf86drm.h>
+
+std::pair<CString, CString> lookupNodesWithLibDRM()
+{
+    std::array<drmDevicePtr, 64> devices { };
+
+    int numDevices = drmGetDevices2(0, devices.data(), std::size(devices));
+    if (numDevices <= 0)
+        return { };
+
+    CString devicePath;
+    CString renderNodePath;
+    for (int i = 0; i < numDevices; ++i) {
+        drmDevice* device = devices[i];
+        if (!(device->available_nodes & (1 << DRM_NODE_PRIMARY | 1 << DRM_NODE_RENDER)))
+            continue;
+
+        if (!devicePath.isNull()) {
+            g_warning("Infered DRM device (%s) using libdrm but multiple were found, you can override this with WPE_DRM_DEVICE and WPE_DRM_RENDER_NODE", devicePath.data());
+            break;
+        }
+
+        if (device->available_nodes & (1 << DRM_NODE_RENDER))
+            renderNodePath = CString(device->nodes[DRM_NODE_RENDER]);
+        if (device->available_nodes & (1 << DRM_NODE_PRIMARY))
+            devicePath = CString(device->nodes[DRM_NODE_PRIMARY]);
+    }
+    drmFreeDevices(devices.data(), numDevices);
+
+    return { WTFMove(devicePath), WTFMove(renderNodePath) };
+}
+
+#endif /* USE(LIBDRM) */

--- a/Source/WebKit/WPEPlatform/wpe/LibDRMUtilities.h
+++ b/Source/WebKit/WPEPlatform/wpe/LibDRMUtilities.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#pragma once
+
+#if USE(LIBDRM)
+
+#include <wtf/text/CString.h>
+
+std::pair<CString, CString> lookupNodesWithLibDRM();
+
+#endif /* USE(LIBDRM) */

--- a/Source/WebKit/glib/environment-variables.md.in
+++ b/Source/WebKit/glib/environment-variables.md.in
@@ -24,7 +24,7 @@ Defines a comma-separated list of logging channels and their levels for WebKit's
 
 - `WPE_DRM_DEVICE`
 Specifies the primary device that WebKit will use for gpu buffer allocation when it needs access to the main device. It is interesting for DRM backend. You need to specify a file path.
-Example: `dev/dri/card0`
+Example: `/dev/dri/card0`
 
 - `WPE_DRM_RENDER_NODE`:
 Specifies the render device that WebKit will use for buffer allocation, this is the one used for allocating general gpu buffers. You need to specify a file path.


### PR DESCRIPTION
#### ee58a81908dac32282180157ab9992af9955ae2f
<pre>
[WPE] On wayland fallback to libdrm for device detection if other methods are unsupported
<a href="https://bugs.webkit.org/show_bug.cgi?id=294737">https://bugs.webkit.org/show_bug.cgi?id=294737</a>

Reviewed by Carlos Garcia Campos.

Older compositors will not support zwp_linux_dmabuf_v1_get_default_feedback.

Some drivers, specifically libmali, do not support EGL_EXT_device_query.

In such a case we can at least try the first device from libdrm.

Canonical link: <a href="https://commits.webkit.org/296563@main">https://commits.webkit.org/296563@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a356d3e403a4ad200d3b0ed2319f876234077d1f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108704 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113915 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59089 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29054 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36926 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82582 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111652 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23077 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97919 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63019 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22497 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58617 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92447 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16105 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117036 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35758 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26388 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91602 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36131 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94186 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91408 "Found 2 new API test failures: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36309 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14069 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31621 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17582 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35659 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41192 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35368 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38715 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37046 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->