### PR TITLE
[WebDriver BiDi] browsingContext.create returns an empty browsing context handle

### DIFF
--- a/Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_backend_dispatcher_implementation.py
+++ b/Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_backend_dispatcher_implementation.py
@@ -311,7 +311,7 @@ class CppBackendDispatcherImplementationGenerator(CppGenerator):
                 parameter_value = parameter_value + '.releaseNonNull()'
             elif CppGenerator.should_dereference_argument(_type, parameter.is_optional):
                 parameter_value = '*' + parameter_value
-            elif CppGenerator.should_move_argument(_type, parameter.is_optional):
+            elif CppGenerator.should_move_argument(_type, parameter.is_optional) or _type.raw_name() == 'string':
                 parameter_value = 'WTFMove(%s)' % parameter_value
 
             param_args = {

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-async-attribute.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-async-attribute.json-result
@@ -336,7 +336,7 @@ void DatabaseBackendDispatcher::executeSQLSyncOptionalReturnValues(long protocol
     if (!!out_opt_columnNames)
         protocol_jsonMessage->setArray("columnNames"_s, out_opt_columnNames.releaseNonNull());
     if (!!out_opt_notes)
-        protocol_jsonMessage->setString("notes"_s, out_opt_notes);
+        protocol_jsonMessage->setString("notes"_s, WTFMove(out_opt_notes));
     if (!!out_opt_timestamp)
         protocol_jsonMessage->setDouble("timestamp"_s, *out_opt_timestamp);
     if (!!out_opt_values)
@@ -352,7 +352,7 @@ void DatabaseBackendDispatcher::executeSQLSyncOptionalReturnValues(long protocol
     if (!!out_opt_alternateColors)
         protocol_jsonMessage->setArray("alternateColors"_s, out_opt_alternateColors.releaseNonNull());
     if (!!out_opt_printColor)
-        protocol_jsonMessage->setString("printColor"_s, out_opt_printColor);
+        protocol_jsonMessage->setString("printColor"_s, WTFMove(out_opt_printColor));
     m_backendDispatcher->sendResponse(protocol_requestId, WTFMove(protocol_jsonMessage), false);
 }
 
@@ -385,7 +385,7 @@ void DatabaseBackendDispatcher::executeSQLAsyncOptionalReturnValues(long protoco
         if (!!out_opt_columnNames)
             protocol_jsonMessage->setArray("columnNames"_s, out_opt_columnNames.releaseNonNull());
         if (!!out_opt_notes)
-            protocol_jsonMessage->setString("notes"_s, out_opt_notes);
+            protocol_jsonMessage->setString("notes"_s, WTFMove(out_opt_notes));
         if (!!out_opt_timestamp)
             protocol_jsonMessage->setDouble("timestamp"_s, *out_opt_timestamp);
         if (!!out_opt_values)
@@ -401,7 +401,7 @@ void DatabaseBackendDispatcher::executeSQLAsyncOptionalReturnValues(long protoco
         if (!!out_opt_alternateColors)
             protocol_jsonMessage->setArray("alternateColors"_s, out_opt_alternateColors.releaseNonNull());
         if (!!out_opt_printColor)
-            protocol_jsonMessage->setString("printColor"_s, out_opt_printColor);
+            protocol_jsonMessage->setString("printColor"_s, WTFMove(out_opt_printColor));
         backendDispatcher->sendResponse(protocol_requestId, WTFMove(protocol_jsonMessage), false);
     });
 }
@@ -433,7 +433,7 @@ void DatabaseBackendDispatcher::executeSQLSync(long protocol_requestId, RefPtr<J
 
     auto protocol_jsonMessage = JSON::Object::create();
     protocol_jsonMessage->setArray("columnNames"_s, WTFMove(out_columnNames));
-    protocol_jsonMessage->setString("notes"_s, out_notes);
+    protocol_jsonMessage->setString("notes"_s, WTFMove(out_notes));
     protocol_jsonMessage->setDouble("timestamp"_s, out_timestamp);
     protocol_jsonMessage->setObject("values"_s, WTFMove(out_values));
     protocol_jsonMessage->setValue("payload"_s, WTFMove(out_payload));
@@ -441,7 +441,7 @@ void DatabaseBackendDispatcher::executeSQLSync(long protocol_requestId, RefPtr<J
     protocol_jsonMessage->setObject("sqlError"_s, WTFMove(out_sqlError));
     protocol_jsonMessage->setArray("alternateColors"_s, WTFMove(out_alternateColors));
     protocol_jsonMessage->setString("screenColor"_s, Protocol::TestHelpers::getEnumConstantValue(out_screenColor));
-    protocol_jsonMessage->setString("printColor"_s, out_printColor);
+    protocol_jsonMessage->setString("printColor"_s, WTFMove(out_printColor));
     m_backendDispatcher->sendResponse(protocol_requestId, WTFMove(protocol_jsonMessage), false);
 }
 
@@ -472,7 +472,7 @@ void DatabaseBackendDispatcher::executeSQLAsync(long protocol_requestId, RefPtr<
 
         auto protocol_jsonMessage = JSON::Object::create();
         protocol_jsonMessage->setArray("columnNames"_s, WTFMove(out_columnNames));
-        protocol_jsonMessage->setString("notes"_s, out_notes);
+        protocol_jsonMessage->setString("notes"_s, WTFMove(out_notes));
         protocol_jsonMessage->setDouble("timestamp"_s, out_timestamp);
         protocol_jsonMessage->setObject("values"_s, WTFMove(out_values));
         protocol_jsonMessage->setValue("payload"_s, WTFMove(out_payload));
@@ -480,7 +480,7 @@ void DatabaseBackendDispatcher::executeSQLAsync(long protocol_requestId, RefPtr<
         protocol_jsonMessage->setObject("sqlError"_s, WTFMove(out_sqlError));
         protocol_jsonMessage->setString("screenColor"_s, Protocol::TestHelpers::getEnumConstantValue(out_screenColor));
         protocol_jsonMessage->setArray("alternateColors"_s, WTFMove(out_alternateColors));
-        protocol_jsonMessage->setString("printColor"_s, out_printColor);
+        protocol_jsonMessage->setString("printColor"_s, WTFMove(out_printColor));
         backendDispatcher->sendResponse(protocol_requestId, WTFMove(protocol_jsonMessage), false);
     });
 }

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-optional-call-return-parameters.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-optional-call-return-parameters.json-result
@@ -326,7 +326,7 @@ void DatabaseBackendDispatcher::executeAllOptionalParameters(long protocol_reque
     if (!!out_opt_columnNames)
         protocol_jsonMessage->setArray("columnNames"_s, out_opt_columnNames.releaseNonNull());
     if (!!out_opt_notes)
-        protocol_jsonMessage->setString("notes"_s, out_opt_notes);
+        protocol_jsonMessage->setString("notes"_s, WTFMove(out_opt_notes));
     if (!!out_opt_timestamp)
         protocol_jsonMessage->setDouble("timestamp"_s, *out_opt_timestamp);
     if (!!out_opt_values)
@@ -342,7 +342,7 @@ void DatabaseBackendDispatcher::executeAllOptionalParameters(long protocol_reque
     if (!!out_opt_alternateColors)
         protocol_jsonMessage->setArray("alternateColors"_s, out_opt_alternateColors.releaseNonNull());
     if (!!out_opt_printColor)
-        protocol_jsonMessage->setString("printColor"_s, out_opt_printColor);
+        protocol_jsonMessage->setString("printColor"_s, WTFMove(out_opt_printColor));
     m_backendDispatcher->sendResponse(protocol_requestId, WTFMove(protocol_jsonMessage), false);
 }
 
@@ -387,7 +387,7 @@ void DatabaseBackendDispatcher::executeNoOptionalParameters(long protocol_reques
 
     auto protocol_jsonMessage = JSON::Object::create();
     protocol_jsonMessage->setArray("columnNames"_s, WTFMove(out_columnNames));
-    protocol_jsonMessage->setString("notes"_s, out_notes);
+    protocol_jsonMessage->setString("notes"_s, WTFMove(out_notes));
     protocol_jsonMessage->setDouble("timestamp"_s, out_timestamp);
     protocol_jsonMessage->setObject("values"_s, WTFMove(out_values));
     protocol_jsonMessage->setValue("payload"_s, WTFMove(out_payload));
@@ -395,7 +395,7 @@ void DatabaseBackendDispatcher::executeNoOptionalParameters(long protocol_reques
     protocol_jsonMessage->setObject("sqlError"_s, WTFMove(out_sqlError));
     protocol_jsonMessage->setString("screenColor"_s, Protocol::TestHelpers::getEnumConstantValue(out_screenColor));
     protocol_jsonMessage->setArray("alternateColors"_s, WTFMove(out_alternateColors));
-    protocol_jsonMessage->setString("printColor"_s, out_printColor);
+    protocol_jsonMessage->setString("printColor"_s, WTFMove(out_printColor));
     m_backendDispatcher->sendResponse(protocol_requestId, WTFMove(protocol_jsonMessage), false);
 }
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-exposed-as-other-name.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-exposed-as-other-name.json-result
@@ -338,7 +338,7 @@ void DatabaseBackendDispatcher::executeSQLSyncOptionalReturnValues(long protocol
     if (!!out_opt_columnNames)
         protocol_jsonMessage->setArray("columnNames"_s, out_opt_columnNames.releaseNonNull());
     if (!!out_opt_notes)
-        protocol_jsonMessage->setString("notes"_s, out_opt_notes);
+        protocol_jsonMessage->setString("notes"_s, WTFMove(out_opt_notes));
     if (!!out_opt_timestamp)
         protocol_jsonMessage->setDouble("timestamp"_s, *out_opt_timestamp);
     if (!!out_opt_values)
@@ -354,7 +354,7 @@ void DatabaseBackendDispatcher::executeSQLSyncOptionalReturnValues(long protocol
     if (!!out_opt_alternateColors)
         protocol_jsonMessage->setArray("alternateColors"_s, out_opt_alternateColors.releaseNonNull());
     if (!!out_opt_printColor)
-        protocol_jsonMessage->setString("printColor"_s, out_opt_printColor);
+        protocol_jsonMessage->setString("printColor"_s, WTFMove(out_opt_printColor));
     m_backendDispatcher->sendResponse(protocol_requestId, WTFMove(protocol_jsonMessage), false);
 }
 
@@ -387,7 +387,7 @@ void DatabaseBackendDispatcher::executeSQLAsyncOptionalReturnValues(long protoco
         if (!!out_opt_columnNames)
             protocol_jsonMessage->setArray("columnNames"_s, out_opt_columnNames.releaseNonNull());
         if (!!out_opt_notes)
-            protocol_jsonMessage->setString("notes"_s, out_opt_notes);
+            protocol_jsonMessage->setString("notes"_s, WTFMove(out_opt_notes));
         if (!!out_opt_timestamp)
             protocol_jsonMessage->setDouble("timestamp"_s, *out_opt_timestamp);
         if (!!out_opt_values)
@@ -403,7 +403,7 @@ void DatabaseBackendDispatcher::executeSQLAsyncOptionalReturnValues(long protoco
         if (!!out_opt_alternateColors)
             protocol_jsonMessage->setArray("alternateColors"_s, out_opt_alternateColors.releaseNonNull());
         if (!!out_opt_printColor)
-            protocol_jsonMessage->setString("printColor"_s, out_opt_printColor);
+            protocol_jsonMessage->setString("printColor"_s, WTFMove(out_opt_printColor));
         backendDispatcher->sendResponse(protocol_requestId, WTFMove(protocol_jsonMessage), false);
     });
 }
@@ -435,7 +435,7 @@ void DatabaseBackendDispatcher::executeSQLSync(long protocol_requestId, RefPtr<J
 
     auto protocol_jsonMessage = JSON::Object::create();
     protocol_jsonMessage->setArray("columnNames"_s, WTFMove(out_columnNames));
-    protocol_jsonMessage->setString("notes"_s, out_notes);
+    protocol_jsonMessage->setString("notes"_s, WTFMove(out_notes));
     protocol_jsonMessage->setDouble("timestamp"_s, out_timestamp);
     protocol_jsonMessage->setObject("values"_s, WTFMove(out_values));
     protocol_jsonMessage->setValue("payload"_s, WTFMove(out_payload));
@@ -443,7 +443,7 @@ void DatabaseBackendDispatcher::executeSQLSync(long protocol_requestId, RefPtr<J
     protocol_jsonMessage->setObject("sqlError"_s, WTFMove(out_sqlError));
     protocol_jsonMessage->setArray("alternateColors"_s, WTFMove(out_alternateColors));
     protocol_jsonMessage->setString("screenColor"_s, Protocol::TestHelpers::getEnumConstantValue(out_screenColor));
-    protocol_jsonMessage->setString("printColor"_s, out_printColor);
+    protocol_jsonMessage->setString("printColor"_s, WTFMove(out_printColor));
     m_backendDispatcher->sendResponse(protocol_requestId, WTFMove(protocol_jsonMessage), false);
 }
 
@@ -474,7 +474,7 @@ void DatabaseBackendDispatcher::executeSQLAsync(long protocol_requestId, RefPtr<
 
         auto protocol_jsonMessage = JSON::Object::create();
         protocol_jsonMessage->setArray("columnNames"_s, WTFMove(out_columnNames));
-        protocol_jsonMessage->setString("notes"_s, out_notes);
+        protocol_jsonMessage->setString("notes"_s, WTFMove(out_notes));
         protocol_jsonMessage->setDouble("timestamp"_s, out_timestamp);
         protocol_jsonMessage->setObject("values"_s, WTFMove(out_values));
         protocol_jsonMessage->setValue("payload"_s, WTFMove(out_payload));
@@ -482,7 +482,7 @@ void DatabaseBackendDispatcher::executeSQLAsync(long protocol_requestId, RefPtr<
         protocol_jsonMessage->setObject("sqlError"_s, WTFMove(out_sqlError));
         protocol_jsonMessage->setString("screenColor"_s, Protocol::TestHelpers::getEnumConstantValue(out_screenColor));
         protocol_jsonMessage->setArray("alternateColors"_s, WTFMove(out_alternateColors));
-        protocol_jsonMessage->setString("printColor"_s, out_printColor);
+        protocol_jsonMessage->setString("printColor"_s, WTFMove(out_printColor));
         backendDispatcher->sendResponse(protocol_requestId, WTFMove(protocol_jsonMessage), false);
     });
 }

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/enum-values.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/enum-values.json-result
@@ -341,9 +341,9 @@ void CommandDomainBackendDispatcher::command(long protocol_requestId, RefPtr<JSO
     protocol_jsonMessage->setString("enumRequired"_s, Protocol::TestHelpers::getEnumConstantValue(out_enumRequired));
     if (!!out_opt_enumOptional)
         protocol_jsonMessage->setString("enumOptional"_s, Protocol::TestHelpers::getEnumConstantValue(*out_opt_enumOptional));
-    protocol_jsonMessage->setString("returnRequired"_s, out_returnRequired);
+    protocol_jsonMessage->setString("returnRequired"_s, WTFMove(out_returnRequired));
     if (!!out_opt_returnOptional)
-        protocol_jsonMessage->setString("returnOptional"_s, out_opt_returnOptional);
+        protocol_jsonMessage->setString("returnOptional"_s, WTFMove(out_opt_returnOptional));
     m_backendDispatcher->sendResponse(protocol_requestId, WTFMove(protocol_jsonMessage), false);
 }
 


### PR DESCRIPTION
#### a29b25ef9b3fb17a5fe8ad070d39582fe52610e9
<pre>
[WebDriver BiDi] browsingContext.create returns an empty browsing context handle
<a href="https://bugs.webkit.org/show_bug.cgi?id=294633">https://bugs.webkit.org/show_bug.cgi?id=294633</a>
<a href="https://rdar.apple.com/153673940">rdar://153673940</a>

Reviewed by NOBODY (OOPS!).

This is ultimately caused by a bug introduced during modernization of generated async command code.

The code to convert each result parameter was changed to use destructuring assignment
and WTFMove in order to avoid writing out each parameter. However, this subtly shortened
the lifetime of any WTFString arguments held alive by the passed-in parameter to have the same
lifetime as the call stack. When other code later serializes the JSON::Object with a string value
the string itself becomes empty.

Fix this by selectively moving String out-parameters for async response parameters. This is safe
since we can guarantee in the generated code that each out-parameter is only used once.

* Source/JavaScriptCore/inspector/scripts/codegen/cpp_generator.py:
(CppGenerator):
(CppGenerator.should_copy_argument):
* Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_backend_dispatcher_implementation.py:
(CppBackendDispatcherImplementationGenerator._generate_dispatcher_implementation_for_command):
* Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-async-attribute.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-optional-call-return-parameters.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/domain-exposed-as-other-name.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/enum-values.json-result:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a29b25ef9b3fb17a5fe8ad070d39582fe52610e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110792 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30455 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20888 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116821 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61060 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31135 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39041 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84240 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113740 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24869 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99768 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64681 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24235 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17905 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60616 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/103284 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94262 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17965 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119640 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109346 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37837 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28120 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93221 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38213 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96036 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93046 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38062 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15816 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33811 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37730 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43200 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/133621 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37391 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36087 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40729 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39098 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->