### PR TITLE
[Calc] Clamp the result of progress() between 0 and 1

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/progress-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/progress-computed-expected.txt
@@ -1,22 +1,22 @@
 
 PASS progress(1, 0, 1) should be used-value-equivalent to 1
 PASS progress(progress(1, 0, 1), progress(0px, 0px, 1px), progress(1deg, 0deg, 1deg)) should be used-value-equivalent to 1
-PASS progress(sign(-10px) * 10px, (10px - 10px), 10px * progress(1deg, 0deg, 1deg)) should be used-value-equivalent to -1
-PASS calc(progress(100px, 0px, 50px) * 10px + 100px) should be used-value-equivalent to 120px
-PASS calc(progress(100, 0, sign(50px))) should be used-value-equivalent to 100
+PASS progress(sign(-10px) * 10px, (10px - 10px), 10px * progress(1deg, 0deg, 1deg)) should be used-value-equivalent to 0
+PASS calc(progress(100px, 0px, 50px) * 10px + 100px) should be used-value-equivalent to 110px
+PASS calc(progress(100, 0, sign(50px))) should be used-value-equivalent to 1
 PASS calc(progress(abs(5%), hypot(3%, 4%), 10%)) should be used-value-equivalent to 0
-PASS progress(1000em, 10em, 110em) should be used-value-equivalent to 9.9
-PASS scale(progress(1000em, 10rem, 110em)) should be used-value-equivalent to scale(9.9)
+PASS progress(1000em, 10em, 110em) should be used-value-equivalent to 1
+PASS scale(progress(1000em, 10rem, 110em)) should be used-value-equivalent to scale(1)
 PASS scale(progress(0em, 0rem, 0em)) should be used-value-equivalent to scale(0)
 PASS scale(progress(sign(1em - 1rem) * 1ex, 0rem, 0em)) should be used-value-equivalent to scale(0)
 PASS calc(progress(1, 0, 1) * 10px) should be used-value-equivalent to 10px
 PASS calc(progress(1, 0, 1) * 1s) should be used-value-equivalent to 1s
 PASS calc(progress(1, 0, 1) * 1deg) should be used-value-equivalent to 1deg
 PASS calc(progress(sign(1001em - 10lh * progress(100px, 2rex, 10ex)) * 10em, 2rem, 12em) / 2) should be used-value-equivalent to 0.4
-PASS calc(progress(sign(1001em - 10lh * progress(100px, 2rex, 10ex)) * 20em, 2rem, 12em) * 10) should be used-value-equivalent to 18
-PASS calc(progress(sign(1001em - 10lh * progress(100px, 2rex, 10ex)) * 20em, 2rem, 12em) * 30) should be used-value-equivalent to 54
-PASS calc(progress(sign(1001em - 10lh * progress(100px, 2rex, 10ex)) * 20em, 2rem, 12em) / 4) should be used-value-equivalent to 0.45
-PASS calc(progress(sign(1001em - 10lh * progress(100px, 2rex, 10ex)) * 20em, 2rem, 12em) * 4) should be used-value-equivalent to 7
-PASS calc(progress(sign(1001em - 10lh * progress(100px, 2rex, 10ex)) * 20em, 2rem, 12em) * 2) should be used-value-equivalent to 3.6
+PASS calc(progress(sign(1001em - 10lh * progress(100px, 2rex, 10ex)) * 20em, 2rem, 12em) * 10) should be used-value-equivalent to 10
+PASS calc(progress(sign(1001em - 10lh * progress(100px, 2rex, 10ex)) * 20em, 2rem, 12em) * 30) should be used-value-equivalent to 30
+PASS calc(progress(sign(1001em - 10lh * progress(100px, 2rex, 10ex)) * 20em, 2rem, 12em) / 4) should be used-value-equivalent to 0.25
+PASS calc(progress(sign(1001em - 10lh * progress(100px, 2rex, 10ex)) * 20em, 2rem, 12em) * 4) should be used-value-equivalent to 4
+PASS calc(progress(sign(1001em - 10lh * progress(100px, 2rex, 10ex)) * 20em, 2rem, 12em) * 2) should be used-value-equivalent to 2
 PASS rotate3d(progress(21em, 1rem, 11em), progress(21em, 1rem, 11em), progress(21em, 1rem, 11em), calc(progress(11em, 1rem, 11em) * 2deg)) should be used-value-equivalent to rotate3d(2, 2, 2, 2deg)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/progress-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/progress-computed.html
@@ -12,14 +12,14 @@ test_math_used('progress(1, 0, 1)', '1', {type:'number'});
 
 // Nestings
 test_math_used('progress(progress(1, 0, 1), progress(0px, 0px, 1px), progress(1deg, 0deg, 1deg))', '1', {type:'number'});
-test_math_used('progress(sign(-10px) * 10px, (10px - 10px), 10px * progress(1deg, 0deg, 1deg))', '-1', {type:'number'});
+test_math_used('progress(sign(-10px) * 10px, (10px - 10px), 10px * progress(1deg, 0deg, 1deg))', '0', {type:'number'});
 
 // General calculations
-test_math_used('calc(progress(100px, 0px, 50px) * 10px + 100px)', '120px');
-test_math_used('calc(progress(100, 0, sign(50px)))', '100', {type:'number'});
+test_math_used('calc(progress(100px, 0px, 50px) * 10px + 100px)', '110px');
+test_math_used('calc(progress(100, 0, sign(50px)))', '1', {type:'number'});
 test_math_used('calc(progress(abs(5%), hypot(3%, 4%), 10%))', '0', {type:'number', approx:0.001});
-test_math_used('progress(1000em, 10em, 110em)', '9.9', {type:'number', approx:0.1});
-test_math_used('scale(progress(1000em, 10rem, 110em))', 'scale(9.9)', {prop:'transform', type:'number', approx:0.1});
+test_math_used('progress(1000em, 10em, 110em)', '1', {type:'number', approx:0.1});
+test_math_used('scale(progress(1000em, 10rem, 110em))', 'scale(1)', {prop:'transform', type:'number', approx:0.1});
 test_math_used('scale(progress(0em, 0rem, 0em))', 'scale(0)', {prop:'transform', type:'number'});
 test_math_used('scale(progress(sign(1em - 1rem) * 1ex, 0rem, 0em))', 'scale(0)', {prop:'transform', type:'number'});
 
@@ -30,10 +30,10 @@ test_math_used('calc(progress(1, 0, 1) * 1deg)', '1deg', {type:'angle', approx:0
 
 // Test different number accepting properties
 test_math_used('calc(progress(sign(1001em - 10lh * progress(100px, 2rex, 10ex)) * 10em, 2rem, 12em) / 2)', '0.4', {prop:'opacity', type:'number'});
-test_math_used('calc(progress(sign(1001em - 10lh * progress(100px, 2rex, 10ex)) * 20em, 2rem, 12em) * 10)', '18', {prop:'order', type:'number'});
-test_math_used('calc(progress(sign(1001em - 10lh * progress(100px, 2rex, 10ex)) * 20em, 2rem, 12em) * 30)', '54', {prop:'flex-grow', type:'number'});
-test_math_used('calc(progress(sign(1001em - 10lh * progress(100px, 2rex, 10ex)) * 20em, 2rem, 12em) / 4)', '0.45', {prop:'flex-grow', type:'number'});
-test_math_used('calc(progress(sign(1001em - 10lh * progress(100px, 2rex, 10ex)) * 20em, 2rem, 12em) * 4)', '7', {prop:'column-count', type:'number'});
-test_math_used('calc(progress(sign(1001em - 10lh * progress(100px, 2rex, 10ex)) * 20em, 2rem, 12em) * 2)', '3.6', {prop:'scale'});
+test_math_used('calc(progress(sign(1001em - 10lh * progress(100px, 2rex, 10ex)) * 20em, 2rem, 12em) * 10)', '10', {prop:'order', type:'number'});
+test_math_used('calc(progress(sign(1001em - 10lh * progress(100px, 2rex, 10ex)) * 20em, 2rem, 12em) * 30)', '30', {prop:'flex-grow', type:'number'});
+test_math_used('calc(progress(sign(1001em - 10lh * progress(100px, 2rex, 10ex)) * 20em, 2rem, 12em) / 4)', '0.25', {prop:'flex-grow', type:'number'});
+test_math_used('calc(progress(sign(1001em - 10lh * progress(100px, 2rex, 10ex)) * 20em, 2rem, 12em) * 4)', '4', {prop:'column-count', type:'number'});
+test_math_used('calc(progress(sign(1001em - 10lh * progress(100px, 2rex, 10ex)) * 20em, 2rem, 12em) * 2)', '2', {prop:'scale'});
 test_math_used('rotate3d(progress(21em, 1rem, 11em), progress(21em, 1rem, 11em), progress(21em, 1rem, 11em), calc(progress(11em, 1rem, 11em) * 2deg))', 'rotate3d(2, 2, 2, 2deg)', {prop:'transform'});
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/progress-serialize-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/progress-serialize-expected.txt
@@ -23,6 +23,14 @@ PASS 'calc(0.5 * progress(100px, 0px, 100px))' as a specified value should seria
 PASS 'scale(calc(0.5 * progress(100px, 0px, 100px)))' as a specified value should serialize as 'scale(calc(0.5))'.
 PASS 'calc(0.5 * progress(100px, 0px, 100px))' as a computed value should serialize as '0.5'.
 PASS 'scale(calc(0.5 * progress(100px, 0px, 100px)))' as a computed value should serialize as 'matrix(0.5, 0, 0, 0.5, 0, 0)'.
+PASS 'calc(0.5 * progress(200px, 0px, 100px))' as a specified value should serialize as 'calc(0.5)'.
+PASS 'scale(calc(0.5 * progress(200px, 0px, 100px)))' as a specified value should serialize as 'scale(calc(0.5))'.
+PASS 'calc(0.5 * progress(200px, 0px, 100px))' as a computed value should serialize as '0.5'.
+PASS 'scale(calc(0.5 * progress(200px, 0px, 100px)))' as a computed value should serialize as 'matrix(0.5, 0, 0, 0.5, 0, 0)'.
+PASS 'calc(0.5 * progress(-100px, 0px, 100px))' as a specified value should serialize as 'calc(0)'.
+PASS 'scale(calc(0.5 * progress(-100px, 0px, 100px)))' as a specified value should serialize as 'scale(calc(0))'.
+PASS 'calc(0.5 * progress(-100px, 0px, 100px))' as a computed value should serialize as '0'.
+PASS 'scale(calc(0.5 * progress(-100px, 0px, 100px)))' as a computed value should serialize as 'matrix(0, 0, 0, 0, 0, 0)'.
 PASS 'calc(50px * progress(100px, 0px, 100px))' as a specified value should serialize as 'calc(50px)'.
 PASS 'calc(1px * progress(abs(10%), (10% - 10%), 100% / 10))' as a computed value should serialize as '1px'.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/progress-serialize.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/progress-serialize.html
@@ -43,6 +43,16 @@ test_serialization(
     'calc(0.5)',
     '0.5'
 );
+test_serialization(
+    'calc(0.5 * progress(200px, 0px, 100px))',
+    'calc(0.5)',
+    '0.5'
+);
+test_serialization(
+    'calc(0.5 * progress(-100px, 0px, 100px))',
+    'calc(0)',
+    '0'
+);
 test_specified_serialization(
     'width',
     'calc(50px * progress(100px, 0px, 100px))',

--- a/Source/WebCore/platform/calc/CalculationExecutor.h
+++ b/Source/WebCore/platform/calc/CalculationExecutor.h
@@ -485,7 +485,7 @@ template<> struct OperatorExecutor<Progress> {
     double operator()(double progress, double from, double to)
     {
         // (progress value - start value) / (end value - start value)
-        return (progress - from) / (to - from);
+        return executeOperation<Clamp>(0.0, (progress - from) / (to - from), 1.0);
     }
 };
 


### PR DESCRIPTION
#### 6ce3acb4af5de5bd18d37e7ecab007551c9f8af9
<pre>
[Calc] Clamp the result of progress() between 0 and 1
<a href="https://bugs.webkit.org/show_bug.cgi?id=294735">https://bugs.webkit.org/show_bug.cgi?id=294735</a>

Reviewed by Darin Adler.

Update CSS progress() function to clamp result between 0 and 1 matching latest CSSWG resolution:

    <a href="https://github.com/w3c/csswg-drafts/issues/11825#issuecomment-2984969769">https://github.com/w3c/csswg-drafts/issues/11825#issuecomment-2984969769</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/progress-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/progress-computed.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/progress-serialize-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/progress-serialize.html:
    - Update tests to test clamping behavior.

* Source/WebCore/platform/calc/CalculationExecutor.h:
(WebCore::Calculation::OperatorExecutor&lt;Progress&gt;::operator()):
    - Apply clamp to execution.

Canonical link: <a href="https://commits.webkit.org/296440@main">https://commits.webkit.org/296440@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d298266dc230f6eb7d0994a79516b01f0d4eedb0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108522 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28183 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18607 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113731 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58920 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110485 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28872 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36735 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82415 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111470 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97748 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62851 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22323 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15888 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58446 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92276 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15939 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116852 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35576 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26220 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91440 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35949 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94020 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91241 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23250 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36137 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13903 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31325 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35478 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41013 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35188 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38539 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36868 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->