### PR TITLE
AX: Optimize AXIsolatedObject::boolAttributeValue by matching AXProperty order with AXPropertyFlag order

### DIFF
--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -796,63 +796,17 @@ unsigned AXIsolatedObject::unsignedAttributeValue(AXProperty property) const
 
 bool AXIsolatedObject::boolAttributeValue(AXProperty property) const
 {
-    switch (property) {
-    case AXProperty::CanSetFocusAttribute:
-        return hasPropertyFlag(AXPropertyFlag::CanSetFocusAttribute);
-    case AXProperty::CanSetSelectedAttribute:
-        return hasPropertyFlag(AXPropertyFlag::CanSetSelectedAttribute);
-    case AXProperty::CanSetValueAttribute:
-        return hasPropertyFlag(AXPropertyFlag::CanSetValueAttribute);
-    case AXProperty::HasBoldFont:
-        return hasPropertyFlag(AXPropertyFlag::HasBoldFont);
-    case AXProperty::HasClickHandler:
-        return hasPropertyFlag(AXPropertyFlag::HasClickHandler);
-    case AXProperty::HasItalicFont:
-        return hasPropertyFlag(AXPropertyFlag::HasItalicFont);
-    case AXProperty::HasPlainText:
-        return hasPropertyFlag(AXPropertyFlag::HasPlainText);
-    case AXProperty::IsEnabled:
-        return hasPropertyFlag(AXPropertyFlag::IsEnabled);
-    case AXProperty::IsExposedTableCell:
-        return hasPropertyFlag(AXPropertyFlag::IsExposedTableCell);
-    case AXProperty::IsGrabbed:
-        return hasPropertyFlag(AXPropertyFlag::IsGrabbed);
-    case AXProperty::IsIgnored:
-        return hasPropertyFlag(AXPropertyFlag::IsIgnored);
-    case AXProperty::IsInlineText:
-        return hasPropertyFlag(AXPropertyFlag::IsInlineText);
-    case AXProperty::IsKeyboardFocusable:
-        return hasPropertyFlag(AXPropertyFlag::IsKeyboardFocusable);
-    case AXProperty::IsNonLayerSVGObject:
-        return hasPropertyFlag(AXPropertyFlag::IsNonLayerSVGObject);
-    case AXProperty::IsTableRow:
-        return hasPropertyFlag(AXPropertyFlag::IsTableRow);
-    case AXProperty::IsVisited:
-        return hasPropertyFlag(AXPropertyFlag::IsVisited);
-    case AXProperty::SupportsCheckedState:
-        return hasPropertyFlag(AXPropertyFlag::SupportsCheckedState);
-    case AXProperty::SupportsDragging:
-        return hasPropertyFlag(AXPropertyFlag::SupportsDragging);
-    case AXProperty::SupportsExpanded:
-        return hasPropertyFlag(AXPropertyFlag::SupportsExpanded);
-    case AXProperty::SupportsPath:
-        return hasPropertyFlag(AXPropertyFlag::SupportsPath);
-    case AXProperty::SupportsPosInSet:
-        return hasPropertyFlag(AXPropertyFlag::SupportsPosInSet);
-    case AXProperty::SupportsSetSize:
-        return hasPropertyFlag(AXPropertyFlag::SupportsSetSize);
-    default:
-        break;
+    uint16_t propertyIndex = static_cast<uint16_t>(property);
+    if (propertyIndex > lastPropertyFlagIndex) {
+        size_t index = indexOfProperty(property);
+        if (index == notFound)
+            return false;
+        return WTF::switchOn(m_properties[index].second,
+            [] (const bool& typedValue) { return typedValue; },
+            [] (auto&) { return false; }
+        );
     }
-
-    size_t index = indexOfProperty(property);
-    if (index == notFound)
-        return false;
-
-    return WTF::switchOn(m_properties[index].second,
-        [] (const bool& typedValue) { return typedValue; },
-        [] (auto&) { return false; }
-    );
+    return hasPropertyFlag(static_cast<AXPropertyFlag>(1 << propertyIndex));
 }
 
 String AXIsolatedObject::stringAttributeValue(AXProperty property) const

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -55,8 +55,10 @@ class AccessibilityObject;
 class Page;
 enum class AXStreamOptions : uint8_t;
 
+static constexpr uint16_t lastPropertyFlagIndex = 21;
 // The most common boolean properties are stored in a bitfield rather than in a HashMap.
-// If you edit these, update AXIsolatedObject::boolAttributeValue and AXIsolatedObject::setProperty.
+// If you edit these, make sure the corresponding AXProperty is ordered correctly in that
+// enum, and update lastPropertyFlagIndex above.
 enum class AXPropertyFlag : uint32_t {
     CanSetFocusAttribute                          = 1 << 0,
     CanSetSelectedAttribute                       = 1 << 1,
@@ -79,10 +81,34 @@ enum class AXPropertyFlag : uint32_t {
     SupportsExpanded                              = 1 << 18,
     SupportsPath                                  = 1 << 19,
     SupportsPosInSet                              = 1 << 20,
-    SupportsSetSize                               = 1 << 21
+    SupportsSetSize                               = 1 << lastPropertyFlagIndex
 };
 
 enum class AXProperty : uint16_t {
+    CanSetFocusAttribute = 0,
+    CanSetSelectedAttribute = 1,
+    CanSetValueAttribute = 2,
+    HasBoldFont = 3,
+    HasClickHandler = 4,
+    HasItalicFont = 5,
+    HasPlainText = 6,
+    IsEnabled = 7,
+    IsExposedTableCell = 8,
+    IsGrabbed = 9,
+    IsIgnored = 10,
+    IsInlineText = 11,
+    IsKeyboardFocusable = 12,
+    IsNonLayerSVGObject = 13,
+    IsTableRow = 14,
+    IsVisited = 15,
+    SupportsCheckedState = 16,
+    SupportsDragging = 17,
+    SupportsExpanded = 18,
+    SupportsPath = 19,
+    SupportsPosInSet = 20,
+    SupportsSetSize = lastPropertyFlagIndex,
+    // End bool attributes that are matched in order by AXPropertyFlag.
+
     ARIALevel,
     ARIARoleDescription,
 #if !ENABLE(AX_THREAD_TEXT_APIS)
@@ -102,9 +128,6 @@ enum class AXProperty : uint16_t {
     BrailleRoleDescription,
     ButtonState,
     CanBeMultilineTextField,
-    CanSetFocusAttribute,
-    CanSetSelectedAttribute,
-    CanSetValueAttribute,
 #if PLATFORM(MAC)
     CaretBrowsingEnabled,
 #endif
@@ -142,11 +165,7 @@ enum class AXProperty : uint16_t {
 #endif
     TextColor,
     HasApplePDFAnnotationAttribute,
-    HasBoldFont,
-    HasClickHandler,
-    HasItalicFont,
     HasLinethrough,
-    HasPlainText,
     HasRemoteFrameChild,
     InputType,
     IsEditableWebArea,
@@ -160,7 +179,6 @@ enum class AXProperty : uint16_t {
     InitialFrameRect,
     InnerHTML,
     InternalLinkElement,
-    IsGrabbed,
     IsARIAGridRow,
     IsARIATreeGridRow,
     IsAnonymousMathOperator,
@@ -168,15 +186,10 @@ enum class AXProperty : uint16_t {
     IsBusy,
     IsChecked,
     IsColumnHeader,
-    IsEnabled,
     IsExpanded,
     IsExposable,
-    IsExposedTableCell,
     IsFieldset,
-    IsIgnored,
     IsIndeterminate,
-    IsInlineText,
-    IsKeyboardFocusable,
     IsMathElement,
     IsMathFraction,
     IsMathFenced,
@@ -191,7 +204,6 @@ enum class AXProperty : uint16_t {
     IsMathMultiscript,
     IsMathToken,
     IsMultiSelectable,
-    IsNonLayerSVGObject,
     IsPlugin,
     IsPressed,
     IsRequired,
@@ -200,12 +212,10 @@ enum class AXProperty : uint16_t {
     IsSelected,
     IsSelectedOptionActive,
     IsTable,
-    IsTableRow,
     IsTree,
     IsTreeItem,
     IsValueAutofillAvailable,
     IsVisible,
-    IsVisited,
     IsWidget,
     KeyShortcuts,
     Language,
@@ -260,18 +270,12 @@ enum class AXProperty : uint16_t {
     SpeakAs,
     StringValue,
     SubrolePlatformString,
-    SupportsDragging,
     SupportsDropping,
     SupportsARIAOwns,
-    SupportsCheckedState,
     SupportsCurrent,
     SupportsDatetimeAttribute,
-    SupportsExpanded,
     SupportsExpandedTextValue,
     SupportsKeyShortcuts,
-    SupportsPath,
-    SupportsPosInSet,
-    SupportsSetSize,
     TextContentPrefixFromListMarker,
 #if !ENABLE(AX_THREAD_TEXT_APIS)
     // Rather than caching text content as property when ENABLE(AX_THREAD_TEXT_APIS), we should


### PR DESCRIPTION
#### 280d982bb70fc0a69ed208fd5a45514ca8554dd3
<pre>
AX: Optimize AXIsolatedObject::boolAttributeValue by matching AXProperty order with AXPropertyFlag order
<a href="https://bugs.webkit.org/show_bug.cgi?id=294743">https://bugs.webkit.org/show_bug.cgi?id=294743</a>
<a href="https://rdar.apple.com/153866597">rdar://153866597</a>

Reviewed by Joshua Hoffman.

Prior to this commit, AXIsolatedObject::boolAttributeValue had 21 branches to map the given AXProperty to an AXPropertyFlag.
With this commit, we avoid all of these branches by making the property ordering in AXProperty and AXPropertyFlag match,
meaning we can cast between them, and quickly determine whether it is a property that has a corresponding flag (static_cast(property) &lt;= lastPropertyFlagIndex).

boolAttributeValue is one of our most called functions. Here is the before and after runtimes of boolAttributeValue
while holding VO-Right on the HTML spec page for ~2.5 mins.

Before: 398665000 calls, mean duration: 0.000023ms, total duration: 9177.080922ms
After: 398665000 calls, mean duration: 0.000012ms, total duration: 4964.236194ms

* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::boolAttributeValue const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:

Canonical link: <a href="https://commits.webkit.org/296447@main">https://commits.webkit.org/296447@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/637037d6eb0cb3c1bbdfca626a537eb27735190e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108530 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28191 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18615 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113739 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58928 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110493 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28880 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36743 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82425 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111478 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22915 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97757 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62861 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22332 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15897 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58454 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92285 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15948 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116860 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35584 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26229 "Found 7 new test failures: http/tests/media/hls/hls-audio-tracks-language.html http/tests/media/hls/hls-webvtt-default.html http/tests/media/hls/hls-webvtt-style.html http/tests/media/hls/range-request-cross-origin.html http/tests/media/hls/track-in-band-multiple-cues.html http/tests/media/hls/track-webvtt-multitracks.html platform/mac/media/encrypted-media/fps-generateRequest.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91450 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35957 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94029 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91251 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23257 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36144 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13912 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31340 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35486 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41021 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35197 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38547 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36876 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->