### PR TITLE
WebDriver BiDi: support for locating DOM nodes via `browsingContext.locateNodes`

### DIFF
--- a/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp
@@ -324,6 +324,225 @@ void BidiBrowsingContextAgent::reload(const BrowsingContext& browsingContext, st
     });
 }
 
+void BidiBrowsingContextAgent::locateNodes(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext& context, Ref<JSON::Object>&& locatorObject, std::optional<double>&& optionalMaxNodeCount, RefPtr<JSON::Object>&& optionalSerializationOptionsObject, RefPtr<JSON::Array>&& optionalStartNodesArray, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::BidiScript::RemoteValue>>>&& callback)
+{
+    RefPtr<WebAutomationSession> session = m_session.get();
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+    auto page = session->webPageProxyForHandle(context);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!page, WindowNotFound);
+
+    String locateNodeFunction = R"(
+        (function (locator, contextNodes, maxNodeCount) {
+            "use strict";
+
+            if (!Array.isArray(contextNodes) || contextNodes.length === 0) {
+                contextNodes = [document.documentElement];
+            }
+
+            function validateLimit(maxCount) {
+                if (maxCount == null) return Infinity;
+                if (typeof maxCount !== "number" || !Number.isInteger(maxCount) || maxCount < 1) {
+                    throw { name: "InvalidArgument", message: "maxNodeCount must be an integer ≥ 1." };
+                }
+                return maxCount;
+            }
+
+            function findByCss(selector, roots, limit) {
+                try {
+                    document.createDocumentFragment().querySelector(selector);
+                } catch (error) {
+                    throw { name: "InvalidSelector", message: error.message };
+                }
+                const nodes = [];
+                for (const root of roots) {
+                    let matches;
+                    try {
+                        matches = root.querySelectorAll(selector);
+                    } catch (error) {
+                        throw { name: "InvalidSelector", message: error.message };
+                    }
+                    for (let i = 0; i < matches.length && nodes.length < limit; i++) {
+                        nodes.push(matches[i]);
+                    }
+                    if (nodes.length >= limit) break;
+                }
+                return nodes;
+            }
+
+            function findByXPath(expression, roots, limit) {
+                const nodes = [];
+                for (const root of roots) {
+                    let result;
+                    try {
+                        result = document.evaluate(expression, root, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
+                    } catch (e) {
+                        if (e instanceof DOMException && e.name === "SyntaxError") {
+                            throw { name: "InvalidSelector", message: e.message };
+                        }
+                        throw { name: "UnknownError", message: e.message };
+                    }
+                    for (let i = 0; i < result.snapshotLength && nodes.length < limit; i++) {
+                        const node = result.snapshotItem(i);
+                        nodes.push(node);
+                    }
+                }
+                return nodes;
+            }
+
+            function findByInnerText(selector, roots, maxDepth, matchType, ignoreCase, limit) {
+                if (typeof selector !== "string" || selector === "") {
+                    throw { name: "InvalidSelector", message: "Selector must be a non-empty string." };
+                }
+
+                const matches = [];
+                const searchText = ignoreCase ? selector.toUpperCase() : selector;
+
+                function recurse(nodes, depth) {
+                    for (const node of nodes) {
+                        if (node.nodeType !== 1) continue; // HTMLElement only
+                        let nodeText = node.innerText ?? "";
+                        if (ignoreCase) nodeText = nodeText.toUpperCase();
+
+                        const isMatch =
+                            matchType === "full" ? nodeText === searchText :
+                            matchType === "partial" ? nodeText.includes(searchText) : false;
+
+                        if (isMatch) {
+                            matches.push(node);
+                            if (matches.length >= limit) return;
+                        }
+
+                        if ((maxDepth === null || depth < maxDepth) && node.children.length > 0) {
+                            recurse(node.children, depth + 1);
+                            if (matches.length >= limit) return;
+                        }
+                    }
+                }
+
+                for (const root of roots) {
+                    recurse([root], 0);
+                    if (matches.length >= limit) break;
+                }
+
+                return matches;
+            }
+
+            function findByAccessibility(selector, roots, limit) {
+                const matches = [];
+
+                function getRole(el) {
+                    return el.getAttribute("role");
+                }
+
+                function getAccessibleName(el) {
+                    return el.getAttribute("aria-label") || el.getAttribute("aria-labelledby");
+                }
+
+                function recurse(nodes) {
+                    for (const node of nodes) {
+                        if (node.nodeType !== 1) continue;
+
+                        let match = true;
+                        if ("role" in selector) {
+                            match = getRole(node) === selector.role;
+                        }
+                        if (match && "name" in selector) {
+                            match = getAccessibleName(node) === selector.name;
+                        }
+
+                        if (match) {
+                            matches.push(node);
+                            if (matches.length >= limit) return;
+                        }
+
+                        if (node.children.length > 0) {
+                            recurse(Array.from(node.children));
+                            if (matches.length >= limit) return;
+                        }
+                    }
+                }
+
+                if (!("role" in selector || "name" in selector)) {
+                    throw { name: "InvalidSelector", message: "Accessibility selector must include 'role' or 'name'." };
+                }
+
+                for (const root of roots) {
+                    recurse([root]);
+                    if (matches.length >= limit) break;
+                }
+
+                return matches;
+            }
+
+            function findByContext(selector, roots, limit) {
+                return [];
+            }
+
+            const type = locator.type;
+            const value = locator.value;
+            const limit = validateLimit(maxNodeCount);
+
+            switch (type) {
+                case "css":
+                    return findByCss(value, contextNodes, limit);
+
+                case "xpath":
+                    return findByXPath(value, contextNodes, limit);
+
+                case "innerText":
+                    return findByInnerText(
+                        value,
+                        contextNodes,
+                        locator.maxDepth ?? null,
+                        locator.matchType || "full",
+                        !!locator.ignoreCase,
+                        limit
+                    );
+
+                case "accessibility":
+                    return findByAccessibility(value, contextNodes, limit);
+
+                case "context":
+                    return findByContext(value, contextNodes, limit);
+
+                default:
+                    throw { name: "InvalidArgument", message: `Unsupported locator type: ${type}.` };
+            }
+        })
+    )"_s;
+
+    RefPtr<JSON::Array> arguments = JSON::Array::create();
+
+    arguments->pushValue(WTFMove(locatorObject));
+
+    if (optionalStartNodesArray) {
+        Ref<JSON::Value> startNodesValue = *optionalStartNodesArray;
+        arguments->pushValue(WTFMove(startNodesValue));
+    } else {
+        Ref<JSON::Value> nullValue = JSON::Value::null();
+        arguments->pushValue(WTFMove(nullValue));
+    }
+
+    if (optionalMaxNodeCount) {
+        Ref<JSON::Value> numberValue = JSON::Value::create(*optionalMaxNodeCount);
+        arguments->pushValue(WTFMove(numberValue));
+    } else {
+        Ref<JSON::Value> nullValue = JSON::Value::null();
+        arguments->pushValue(WTFMove(nullValue));
+    }
+
+    std::optional<double> callbackTimeout = 250;
+
+    session->evaluateJavaScriptFunction(context, emptyString(), locateNodeFunction, *arguments, true, false, callbackTimeout.value(),
+    [callback = WTFMove(callback)](Inspector::CommandResult<String>&& result) mutable {
+
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!result, InternalError);
+
+        // FIXME: Await resolution of https://bugs.webkit.org/show_bug.cgi?id=294633 to implement a complete callback. Currently, we can't convert the result into objects due to uncertainty about its return format.
+    });
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(WEBDRIVER_BIDI)

--- a/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.h
+++ b/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.h
@@ -58,7 +58,7 @@ public:
     void handleUserPrompt(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, std::optional<bool>&& optionalShouldAccept, const String& userText, Inspector::CommandCallback<void>&&) override;
     void navigate(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, const String& url, std::optional<Inspector::Protocol::BidiBrowsingContext::ReadinessState>&&, Inspector::CommandCallbackOf<String, Inspector::Protocol::BidiBrowsingContext::Navigation>&&) override;
     void reload(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, std::optional<bool>&& optionalIgnoreCache, std::optional<Inspector::Protocol::BidiBrowsingContext::ReadinessState>&& optionalWait, Inspector::CommandCallbackOf<String, String>&&) override;
-
+    void locateNodes(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, Ref<JSON::Object>&& locatorObject, std::optional<double>&& optionalMaxNodeCount, RefPtr<JSON::Object>&& optionalSerializationOptionsObject, RefPtr<JSON::Array>&& optionalStartNodesArray, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::BidiScript::RemoteValue>>>&&) override;
 private:
     enum class IncludeParentID: bool { No, Yes };
 

--- a/Source/WebKit/UIProcess/Automation/protocol/BidiBrowsingContext.json
+++ b/Source/WebKit/UIProcess/Automation/protocol/BidiBrowsingContext.json
@@ -53,6 +53,75 @@
             "spec": "https://w3c.github.io/webdriver-bidi/#type-browsingContext-UserPromptType",
             "type": "string",
             "enum": [ "alert", "beforeunload", "confirm", "prompt" ]
+        },
+        {
+            "id": "AccessibilityLocator",
+            "description": "Locator for accessibility attributes (name and/or role).",
+            "type": "object",
+            "properties": [
+                { "name": "type", "type": "string", "enum": ["accessibility"], "description": "The locator strategy type." },
+                {
+                    "name": "value",
+                    "type": "object",
+                    "description": "The accessibility attributes to match.",
+                    "properties": [
+                        { "name": "name", "type": "string", "optional": true, "description": "The accessible name to match." },
+                        { "name": "role", "type": "string", "optional": true, "description": "The computed role to match." }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "CssLocator",
+            "description": "Locator for CSS selectors.",
+            "type": "object",
+            "properties": [
+                { "name": "type", "type": "string", "enum": ["css"], "description": "The locator strategy type." },
+                { "name": "value", "type": "string", "description": "The CSS selector string." }
+            ],
+            "required": ["type", "value"]
+        },
+        {
+            "id": "ContextLocator",
+            "description": "Locator for a child browsing context's container element.",
+            "type": "object",
+            "properties": [
+                { "name": "type", "type": "string", "enum": ["context"], "description": "The locator strategy type." },
+                { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "description": "The ID of the child browsing context." }
+            ]
+        },
+        {
+            "id": "InnerTextLocator",
+            "description": "Locator for inner text content.",
+            "type": "object",
+            "properties": [
+                { "name": "type", "type": "string", "enum": ["innerText"], "description": "The locator strategy type." },
+                { "name": "value", "type": "string", "description": "The text string to search for." },
+                { "name": "ignoreCase", "type": "boolean", "optional": true, "description": "Whether the search should be case-insensitive. Defaults to false." },
+                { "name": "matchType", "type": "string", "enum": ["full", "partial"], "optional": true, "description": "How the text should match. 'full' for exact match, 'partial' for substring. Defaults to 'full'." },
+                { "name": "maxDepth", "type": "number", "optional": true, "description": "Maximum depth to traverse the DOM tree. Null for no limit. 0 means only the context node itself." }
+            ]
+        },
+        {
+            "id": "XPathLocator",
+            "description": "Locator for XPath expressions.",
+            "type": "object",
+            "properties": [
+                { "name": "type", "type": "string", "enum": ["xpath"], "description": "The locator strategy type." },
+                { "name": "value", "type": "string", "description": "The XPath expression string." }
+            ]
+        },
+        {
+            "id": "Locator",
+            "description": "General Locator Object",
+            "type": "object",
+            "properties": [
+                {"name": "type", "type": "string", "enum": ["accessibility", "css", "context", "innerText", "xpath"]},
+                { "name": "value", "type": "any" },
+                { "name": "ignoreCase", "type": "boolean", "optional": true, "description": "Whether the search should be case-insensitive. Defaults to false." },
+                { "name": "matchType", "type": "string", "enum": ["full", "partial"], "optional": true, "description": "How the text should match. 'full' for exact match, 'partial' for substring. Defaults to 'full'." },
+                { "name": "maxDepth", "type": "number", "optional": true, "description": "Maximum depth to traverse the DOM tree. Null for no limit. 0 means only the context node itself." }
+            ]
         }
     ],
     "commands": [
@@ -149,6 +218,23 @@
             "returns": [
                 { "name": "url", "type": "string", "description": "The URL the browsing context navigated to." },
                 { "name": "navigation", "$ref": "BidiBrowsingContext.Navigation", "optional": true, "description": "The navigation ID, or null if not applicable." }
+            ]
+        },
+        {
+            "name": "locateNodes",
+            "description": "The browsingContext.locateNodes command returns a list of all nodes matching the specified locator.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-browsingContext-locateNodes",
+            "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/browsing_context/locate_nodes",
+            "async": true,
+            "parameters": [
+                { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "description": "The identifier of the browsing context to search within." },
+                { "name": "locator", "$ref": "BidiBrowsingContext.Locator", "description": "The strategy and value for locating nodes." },
+                { "name": "maxNodeCount", "type": "number", "optional": true, "description": "Maximum number of nodes to return. Must be >= 1." },
+                { "name": "serializationOptions", "$ref": "BidiScript.SerializationOptions", "optional": true, "description": "Options for serializing the returned nodes." },
+                { "name": "startNodes", "type": "array", "items": { "$ref": "BidiScript.SharedReference" }, "optional": true, "description": "An array of nodes from which to start the search. If not provided, the search starts from the document root." }
+            ],
+            "returns": [
+                { "name": "nodes", "type": "array", "items": { "$ref": "BidiScript.RemoteValue" }, "description": "A list of found nodes." }
             ]
         }
     ],

--- a/Source/WebKit/UIProcess/Automation/protocol/BidiScript.json
+++ b/Source/WebKit/UIProcess/Automation/protocol/BidiScript.json
@@ -126,6 +126,22 @@
             ]
         },
         {
+            "id": "SharedReference",
+            "description": "Represents a reference to a JavaScript object with the shared object cache.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#cddl-type-scriptsharedreference",
+            "type": "object",
+            "properties": [
+                { "name": "sharedId", "type": "number"},
+                { "name": "handle", "type": "number", "optional": true }
+            ]
+        },
+        {
+            "id": "SharedId",
+            "description": "A unique identifier assigned to a JavaScript object.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#cddl-type-scriptsharedid",
+            "type": "string"
+        },
+        {
             "id": "StackFrame",
             "description": "Represents a single call frame within a <code>BidiScript.StackTrace</code>.",
             "spec": "https://w3c.github.io/webdriver-bidi/#type-script-StackFrame",


### PR DESCRIPTION
#### 373034cf88c32e49f694474f3d6bc26f2da74a7c
<pre>
WebDriver BiDi: support for locating DOM nodes via `browsingContext.locateNodes`
<a href="https://rdar.apple.com/137019465">rdar://137019465</a>

Reviewed by NOBODY (OOPS!).

Adding the majority of work for the locateNodes endpoint. The main focus is a need for a new JS
script as the classic implementation found as an atom couldn&apos;t be modified for the BIDI
specification. A current bug with the dispatcher <a href="https://bugs.webkit.org/show_bug.cgi?id=294633">https://bugs.webkit.org/show_bug.cgi?id=294633</a>
has blocked end-to-end testing. The new script was individually tested against a test site,
ensuring each type of locator worked. Currently, the callback from evaluateJavaScriptFunction
is bare as it&apos;s difficult to create a thorough solution without testing.

* Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp:
(WebKit::BidiBrowsingContextAgent::locateNodes):
* Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.h:
* Source/WebKit/UIProcess/Automation/protocol/BidiBrowsingContext.json:
* Source/WebKit/UIProcess/Automation/protocol/BidiScript.json:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/373034cf88c32e49f694474f3d6bc26f2da74a7c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108539 "43 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28200 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18624 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113748 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58937 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36754 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82434 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111487 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22923 "Found 2 new test failures: fast/filter-image/clipped-filter.html http/tests/security/cached-svg-image-with-css-cross-domain.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97767 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62871 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22340 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58463 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92293 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15958 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116869 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35593 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26239 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91460 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35966 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94039 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91261 "Found 2 new API test failures: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36153 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13922 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31350 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35495 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41030 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35207 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38556 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36885 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->