### PR TITLE
[WPE] run-minibrowser should run MiniBrowser by default instead of cog

### DIFF
--- a/Tools/Scripts/webkitpy/port/wpe.py
+++ b/Tools/Scripts/webkitpy/port/wpe.py
@@ -124,10 +124,8 @@ class WPEPort(GLibPort):
             return browser
 
         if browser:
-            _log.warning("Unknown browser {}. Defaulting to Cog and MiniBrowser selection".format(browser))
+            _log.warning("Unknown browser {}. Defaulting to MiniBrowser".format(browser))
 
-        if self._filesystem.isfile(self.cog_path_to('launcher', 'cog')):
-            return "cog"
         return "minibrowser"
 
     def setup_environ_for_minibrowser(self):
@@ -152,7 +150,7 @@ class WPEPort(GLibPort):
         if self.browser_name() == "cog":
             miniBrowser = self.get_browser_path("cog")
             if not self._filesystem.isfile(miniBrowser):
-                _log.warning("Cog not found 😢. If you wish to enable it, rebuild with `-DENABLE_COG=ON`. Falling back to good old MiniBrowser")
+                _log.warning("Cog not found 😢. If you wish to enable it, rebuild with `-DENABLE_COG=ON`. Falling back to MiniBrowser")
                 miniBrowser = None
             else:
                 print("Using Cog as MiniBrowser")

--- a/Tools/Scripts/webkitpy/port/wpe_unittest.py
+++ b/Tools/Scripts/webkitpy/port/wpe_unittest.py
@@ -90,7 +90,7 @@ class WPEPortTest(port_testcase.PortTestCase):
         port = self.make_port()
         self._mock_port_cog_is_built(port)
         with patch('os.environ', {}):
-            self.assertEqual(port.browser_name(), "cog")
+            self.assertEqual(port.browser_name(), "minibrowser")
 
     def test_browser_name_override_minibrowser_with_cog_built(self):
         with patch('os.environ', {'WPE_BROWSER': 'MiniBrowser'}):
@@ -112,7 +112,7 @@ class WPEPortTest(port_testcase.PortTestCase):
         with patch('os.environ', {'WPE_BROWSER': 'Mosaic'}):
             port = self.make_port()
             self._mock_port_cog_is_built(port)
-            self.assertEqual(port.browser_name(), "cog")
+            self.assertEqual(port.browser_name(), "minibrowser")
 
     def test_browser_cog_parameters_platform_default(self):
         with patch('os.environ', {'WPE_BROWSER': 'cog'}):


### PR DESCRIPTION
#### daaeb5dee246d8bb15e1cea46cd978413720cc5f
<pre>
[WPE] run-minibrowser should run MiniBrowser by default instead of cog
<a href="https://bugs.webkit.org/show_bug.cgi?id=294748">https://bugs.webkit.org/show_bug.cgi?id=294748</a>

Reviewed by Patrick Griffis and Adrian Perez de Castro.

Now that WPE Platform API is used by default in all other tools,
run-minibrowser should run MiniBrowser by default too.

Canonical link: <a href="https://commits.webkit.org/296496@main">https://commits.webkit.org/296496@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c2f60491cc8030e8d6cd55fede357bbed2d63d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108546 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28207 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18631 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113755 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58945 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110509 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28896 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36761 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82440 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111494 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22927 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97770 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62877 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/107978 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22344 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15910 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58471 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92297 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15961 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116876 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35600 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26244 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91465 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35973 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94042 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91266 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36159 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13925 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31358 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17552 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35502 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35214 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38563 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36892 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->