### PR TITLE
Rename domWindow() to window()

### DIFF
--- a/Source/WebCore/Modules/applepay/ApplePaySession.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePaySession.cpp
@@ -643,7 +643,7 @@ ExceptionOr<void> ApplePaySession::completeMerchantValidation(JSC::JSGlobalObjec
         return Exception { ExceptionCode::TypeError };
 
     auto& document = *downcast<Document>(scriptExecutionContext());
-    auto& window = *document.domWindow();
+    auto& window = *document.window();
 
     String errorMessage;
     auto merchantSession = PaymentMerchantSession::fromJS(state, asObject(merchantSessionValue), errorMessage);

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemController.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemController.cpp
@@ -67,7 +67,7 @@ void provideMediaKeySystemTo(Page& page, MediaKeySystemClient& client)
 
 void MediaKeySystemController::logRequestMediaKeySystemDenial(Document& document)
 {
-    if (RefPtr window = document.domWindow())
+    if (RefPtr window = document.window())
         window->printErrorMessage("Not allowed to access MediaKeySystem."_str);
 }
 

--- a/Source/WebCore/Modules/identity/DigitalCredential.cpp
+++ b/Source/WebCore/Modules/identity/DigitalCredential.cpp
@@ -119,7 +119,7 @@ void DigitalCredential::discoverFromExternalSource(const Document& document, Cre
     }
 
     RefPtr frame = document.frame();
-    RefPtr window = document.domWindow();
+    RefPtr window = document.window();
     if (!frame || !window) {
         LOG(DigitalCredentials, "Preconditions for DigitalCredential.get() are not met");
         promise.reject(ExceptionCode::InvalidStateError, "Preconditions for calling .get() are not met."_s);

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -909,7 +909,7 @@ RefPtr<MediaSession> MediaControlsHost::mediaSession() const
     if (!mediaElement)
         return { };
 
-    RefPtr window = mediaElement->document().domWindow();
+    RefPtr window = mediaElement->document().window();
     if (!window)
         return { };
 

--- a/Source/WebCore/Modules/mediastream/UserMediaController.cpp
+++ b/Source/WebCore/Modules/mediastream/UserMediaController.cpp
@@ -62,13 +62,13 @@ void provideUserMediaTo(Page* page, UserMediaClient* client)
 
 void UserMediaController::logGetUserMediaDenial(Document& document)
 {
-    if (RefPtr window = document.domWindow())
+    if (RefPtr window = document.window())
         window->printErrorMessage("Not allowed to call getUserMedia."_s);
 }
 
 void UserMediaController::logGetDisplayMediaDenial(Document& document)
 {
-    if (RefPtr window = document.domWindow())
+    if (RefPtr window = document.window())
         window->printErrorMessage("Not allowed to call getDisplayMedia."_s);
 }
 
@@ -77,7 +77,7 @@ void UserMediaController::logEnumerateDevicesDenial(Document& document)
     // We redo the check to print to the console log.
     PermissionsPolicy::isFeatureEnabled(PermissionsPolicy::Feature::Camera, document);
     PermissionsPolicy::isFeatureEnabled(PermissionsPolicy::Feature::Microphone, document);
-    if (RefPtr window = document.domWindow())
+    if (RefPtr window = document.window())
         window->printErrorMessage("Not allowed to call enumerateDevices."_s);
 }
 

--- a/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
+++ b/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
@@ -164,7 +164,7 @@ void UserMediaRequest::allow(CaptureDevice&& audioDevice, CaptureDevice&& videoD
     RELEASE_LOG(MediaStream, "UserMediaRequest::allow %s %s", audioDevice ? audioDevice.persistentId().utf8().data() : "", videoDevice ? videoDevice.persistentId().utf8().data() : "");
 
     Ref document = downcast<Document>(*scriptExecutionContext());
-    RefPtr localWindow = document->domWindow();
+    RefPtr localWindow = document->window();
     RefPtr mediaDevices = localWindow ? NavigatorMediaDevices::mediaDevices(localWindow->protectedNavigator()) : nullptr;
     if (mediaDevices)
         mediaDevices->willStartMediaCapture(!!audioDevice, !!videoDevice);

--- a/Source/WebCore/Modules/permissions/Permissions.cpp
+++ b/Source/WebCore/Modules/permissions/Permissions.cpp
@@ -240,11 +240,11 @@ void Permissions::query(JSC::Strong<JSC::JSObject> permissionDescriptorValue, DO
 
 static std::optional<PermissionState> determineGeolocationPermissionState(PermissionState permissionState, const Document& document)
 {
-    RefPtr domWindow = document.domWindow();
-    if (!domWindow)
+    RefPtr window = document.window();
+    if (!window)
         return std::nullopt;
 
-    RefPtr geolocation = NavigatorGeolocation::optionalGeolocation(domWindow->protectedNavigator());
+    RefPtr geolocation = NavigatorGeolocation::optionalGeolocation(window->protectedNavigator());
 
     switch (permissionState) {
     case PermissionState::Granted:

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp
@@ -67,7 +67,7 @@ void WakeLock::request(WakeLockType lockType, Ref<DeferredPromise>&& promise)
 
     // FIXME: The permission check can likely be dropped once the specification gets updated to only
     // require transient activation (https://github.com/w3c/screen-wake-lock/pull/326).
-    bool hasTransientActivation = document->domWindow() && document->domWindow()->hasTransientActivation();
+    bool hasTransientActivation = document->window() && document->window()->hasTransientActivation();
     PermissionController::shared().query(document->clientOrigin(), PermissionDescriptor { PermissionName::ScreenWakeLock }, *document->page(), PermissionQuerySource::Window, [this, protectedThis = Ref { *this }, document = Ref { *document }, hasTransientActivation, promise = WTFMove(promise), lockType](std::optional<PermissionState> permission) mutable {
         if (!permission || *permission == PermissionState::Prompt) {
             if (hasTransientActivation || m_wasPreviouslyAuthorizedDueToTransientActivation) {

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -94,7 +94,7 @@ static bool shouldDocumentAllowWebAudioToAutoPlay(const Document& document)
     RefPtr mainDocument = document.mainFrameDocument();
     if (document.quirks().shouldAutoplayWebAudioForArbitraryUserGesture() && mainDocument && mainDocument->hasHadUserInteraction())
         return true;
-    RefPtr window = document.domWindow();
+    RefPtr window = document.window();
     return window && window->hasTransientActivation();
 }
 
@@ -213,8 +213,8 @@ AudioTimestamp AudioContext::getOutputTimestamp()
 
     DOMHighResTimeStamp performanceTime = 0.0;
     RefPtr document = this->document();
-    if (document && document->domWindow())
-        performanceTime = std::max(document->domWindow()->protectedPerformance()->relativeTimeFromTimeOriginInReducedResolution(position.timestamp), 0.0);
+    if (document && document->window())
+        performanceTime = std::max(document->window()->protectedPerformance()->relativeTimeFromTimeOriginInReducedResolution(position.timestamp), 0.0);
 
     return { position.position.seconds(), performanceTime };
 }
@@ -521,7 +521,7 @@ std::optional<MediaSessionGroupIdentifier> AudioContext::mediaSessionGroupIdenti
 static bool hasPlayBackAudioSession(Document* document)
 {
 #if ENABLE(DOM_AUDIO_SESSION)
-    RefPtr window = document ? document->domWindow() : nullptr;
+    RefPtr window = document ? document->window() : nullptr;
 
     RefPtr navigator = window ? window->optionalNavigator() : nullptr;
     RefPtr audioSession = navigator ? NavigatorAudioSession::audioSession(*navigator) : nullptr;
@@ -557,7 +557,7 @@ std::optional<NowPlayingInfo> AudioContext::nowPlayingInfo() const
 
     RefPtr document = this->document();
     RefPtr page = document ? document->page() : nullptr;
-    RefPtr window = document ? document->domWindow() : nullptr;
+    RefPtr window = document ? document->window() : nullptr;
     if (!page || !window)
         return { };
 

--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -714,7 +714,7 @@ bool WebXRSession::posesCanBeReported(const Document& document) const
 {
     // 1. If session’s relevant global object is not the current global object, return false.
     RefPtr sessionDocument = downcast<Document>(scriptExecutionContext());
-    if (!sessionDocument || sessionDocument->domWindow() != document.domWindow())
+    if (!sessionDocument || sessionDocument->window() != document.window())
         return false;
 
     // 2. If session's visibilityState is "hidden", return false.

--- a/Source/WebCore/Modules/webxr/WebXRSystem.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.cpp
@@ -489,7 +489,7 @@ void WebXRSystem::requestSession(Document& document, XRSessionMode mode, const X
     // 3. Let global object be the relevant Global object for the XRSystem on which this method was invoked.
     bool immersive = isImmersive(mode);
     Ref protectedDocument { document };
-    RefPtr globalObject = protectedDocument->domWindow();
+    RefPtr globalObject = protectedDocument->window();
     if (!globalObject) {
         promise.reject(Exception { ExceptionCode::InvalidAccessError });
         return;

--- a/Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp
+++ b/Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp
@@ -46,8 +46,8 @@ AcceleratedEffectStackUpdater::AcceleratedEffectStackUpdater(Document& document)
 {
     auto now = MonotonicTime::now();
     m_timeOrigin = now.secondsSinceEpoch();
-    if (RefPtr domWindow = document.domWindow())
-        m_timeOrigin -= Seconds::fromMilliseconds(domWindow->performance().relativeTimeFromTimeOriginInReducedResolution(now));
+    if (RefPtr window = document.window())
+        m_timeOrigin -= Seconds::fromMilliseconds(window->performance().relativeTimeFromTimeOriginInReducedResolution(now));
 }
 
 void AcceleratedEffectStackUpdater::updateEffectStacks()

--- a/Source/WebCore/animation/AnimationTimelinesController.cpp
+++ b/Source/WebCore/animation/AnimationTimelinesController.cpp
@@ -292,12 +292,12 @@ void AnimationTimelinesController::resumeAnimations()
 
 ReducedResolutionSeconds AnimationTimelinesController::liveCurrentTime() const
 {
-    return m_document->domWindow()->nowTimestamp();
+    return m_document->window()->nowTimestamp();
 }
 
 std::optional<Seconds> AnimationTimelinesController::currentTime()
 {
-    if (!m_document->domWindow())
+    if (!m_document->window())
         return std::nullopt;
 
     if (!m_cachedCurrentTime)

--- a/Source/WebCore/bindings/js/JSDOMBindingSecurity.cpp
+++ b/Source/WebCore/bindings/js/JSDOMBindingSecurity.cpp
@@ -40,7 +40,7 @@ void printErrorMessageForFrame(LocalFrame* frame, const String& message)
 {
     if (!frame)
         return;
-    frame->document()->domWindow()->printErrorMessage(message);
+    frame->document()->window()->printErrorMessage(message);
 }
 
 // FIXME: Refactor to share code with LocalDOMWindow::crossDomainAccessErrorMessage.
@@ -86,11 +86,11 @@ static inline bool canAccessDocument(JSC::JSGlobalObject* lexicalGlobalObject, D
     case ThrowSecurityError: {
         VM& vm = lexicalGlobalObject->vm();
         auto scope = DECLARE_THROW_SCOPE(vm);
-        throwSecurityError(*lexicalGlobalObject, scope, targetDocument->domWindow()->crossDomainAccessErrorMessage(active, IncludeTargetOrigin::No));
+        throwSecurityError(*lexicalGlobalObject, scope, targetDocument->window()->crossDomainAccessErrorMessage(active, IncludeTargetOrigin::No));
         break;
     }
     case LogSecurityError:
-        printErrorMessageForFrame(targetDocument->frame(), targetDocument->domWindow()->crossDomainAccessErrorMessage(active, IncludeTargetOrigin::Yes));
+        printErrorMessageForFrame(targetDocument->frame(), targetDocument->window()->crossDomainAccessErrorMessage(active, IncludeTargetOrigin::Yes));
         break;
     case DoNotReportSecurityError:
         break;
@@ -103,7 +103,7 @@ bool BindingSecurity::shouldAllowAccessToFrame(JSGlobalObject& lexicalGlobalObje
 {
     if (BindingSecurity::shouldAllowAccessToFrame(&lexicalGlobalObject, &frame, DoNotReportSecurityError))
         return true;
-    message = frame.document()->domWindow()->crossDomainAccessErrorMessage(activeDOMWindow(lexicalGlobalObject), IncludeTargetOrigin::No);
+    message = frame.document()->window()->crossDomainAccessErrorMessage(activeDOMWindow(lexicalGlobalObject), IncludeTargetOrigin::No);
     return false;
 }
 

--- a/Source/WebCore/bindings/js/JSDocumentCustom.cpp
+++ b/Source/WebCore/bindings/js/JSDocumentCustom.cpp
@@ -56,7 +56,7 @@ JSObject* cachedDocumentWrapper(JSGlobalObject& lexicalGlobalObject, JSDOMGlobal
     if (auto* wrapper = getCachedWrapper(globalObject.world(), document))
         return wrapper;
 
-    RefPtr window = document.domWindow();
+    RefPtr window = document.window();
     if (!window)
         return nullptr;
 

--- a/Source/WebCore/bindings/js/JSEventListener.h
+++ b/Source/WebCore/bindings/js/JSEventListener.h
@@ -113,8 +113,8 @@ inline JSC::JSValue windowEventHandlerAttribute(DOMWindow& window, const AtomStr
 
 inline JSC::JSValue windowEventHandlerAttribute(HTMLElement& element, const AtomString& eventType, DOMWrapperWorld& isolatedWorld)
 {
-    if (RefPtr domWindow = element.document().domWindow())
-        return eventHandlerAttribute(*domWindow, eventType, isolatedWorld);
+    if (RefPtr window = element.document().window())
+        return eventHandlerAttribute(*window, eventType, isolatedWorld);
     return JSC::jsNull();
 }
 
@@ -127,8 +127,8 @@ inline void setWindowEventHandlerAttribute(DOMWindow& window, const AtomString& 
 template<typename JSMaybeErrorEventListener>
 inline void setWindowEventHandlerAttribute(HTMLElement& element, const AtomString& eventType, JSC::JSValue listener, JSC::JSObject& jsEventTarget)
 {
-    if (RefPtr domWindow = element.document().domWindow())
-        domWindow->setAttributeEventListener<JSMaybeErrorEventListener>(eventType, listener, *jsEventTarget.globalObject());
+    if (RefPtr window = element.document().window())
+        window->setAttributeEventListener<JSMaybeErrorEventListener>(eventType, listener, *jsEventTarget.globalObject());
 }
 
 inline JSC::JSObject* JSEventListener::ensureJSFunction(ScriptExecutionContext& scriptExecutionContext) const

--- a/Source/WebCore/bindings/js/JSHTMLElementCustom.cpp
+++ b/Source/WebCore/bindings/js/JSHTMLElementCustom.cpp
@@ -69,7 +69,7 @@ EncodedJSValue constructJSHTMLElement(JSGlobalObject* lexicalGlobalObject, CallF
 
     RefPtr registry = document->activeCustomElementRegistry();
     if (!registry) {
-        RefPtr window = document->domWindow();
+        RefPtr window = document->window();
         if (!window)
             return throwVMTypeError(lexicalGlobalObject, scope, "new.target is not a valid custom element constructor"_s);
 

--- a/Source/WebCore/bindings/js/ScriptCachedFrameData.cpp
+++ b/Source/WebCore/bindings/js/ScriptCachedFrameData.cpp
@@ -81,8 +81,8 @@ void ScriptCachedFrameData::restore(LocalFrame& frame)
         if (auto* window = m_windows.get(world).get())
             windowProxy->setWindow(window->vm(), *window);
         else {
-            ASSERT(frame.document()->domWindow());
-            auto& domWindow = *frame.document()->domWindow();
+            ASSERT(frame.document()->window());
+            auto& domWindow = *frame.document()->window();
             if (&windowProxy->wrapped() == &domWindow)
                 continue;
 

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -633,7 +633,7 @@ ValueOrException ScriptController::executeScriptInWorld(DOMWrapperWorld& world, 
     if (parameters.forceUserGesture == ForceUserGesture::Yes && UserGestureIndicator::currentUserGesture() && parameters.removeTransientActivation == RemoveTransientActivation::Yes) {
         UserGestureIndicator::currentUserGesture()->addDestructionObserver([](UserGestureToken& token) {
             token.forEachImpactedDocument([](Document& document) {
-                if (RefPtr window = document.domWindow())
+                if (RefPtr window = document.window())
                     window->consumeTransientActivation();
             });
         });

--- a/Source/WebCore/dom/DOMImplementation.cpp
+++ b/Source/WebCore/dom/DOMImplementation.cpp
@@ -113,7 +113,7 @@ ExceptionOr<Ref<XMLDocument>> DOMImplementation::createDocument(const AtomString
 
     RefPtr<Element> documentElement;
     if (!qualifiedName.isEmpty()) {
-        ASSERT(!document->domWindow()); // If domWindow is not null, createElementNS could find CustomElementRegistry and arbitrary scripts.
+        ASSERT(!document->window()); // If domWindow is not null, createElementNS could find CustomElementRegistry and arbitrary scripts.
         auto result = document->createElementNS(namespaceURI, qualifiedName);
         if (result.hasException())
             return result.releaseException();

--- a/Source/WebCore/dom/DeviceMotionEvent.cpp
+++ b/Source/WebCore/dom/DeviceMotionEvent.cpp
@@ -139,7 +139,7 @@ void DeviceMotionEvent::initDeviceMotionEvent(const AtomString& type, bool bubbl
 #if ENABLE(DEVICE_ORIENTATION)
 void DeviceMotionEvent::requestPermission(Document& document, PermissionPromise&& promise)
 {
-    RefPtr window = document.domWindow();
+    RefPtr window = document.window();
     if (!window || !document.page())
         return promise.reject(Exception { ExceptionCode::InvalidStateError, "No browsing context"_s });
 

--- a/Source/WebCore/dom/DeviceOrientationEvent.cpp
+++ b/Source/WebCore/dom/DeviceOrientationEvent.cpp
@@ -123,7 +123,7 @@ void DeviceOrientationEvent::initDeviceOrientationEvent(const AtomString& type, 
 #if ENABLE(DEVICE_ORIENTATION)
 void DeviceOrientationEvent::requestPermission(Document& document, PermissionPromise&& promise)
 {
-    RefPtr window = document.domWindow();
+    RefPtr window = document.window();
     if (!window || !document.page())
         return promise.reject(Exception { ExceptionCode::InvalidStateError, "No browsing context"_s });
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1012,8 +1012,7 @@ public:
     void createDOMWindow();
     void takeDOMWindowFrom(Document&);
 
-    // FIXME: Consider renaming to window().
-    LocalDOMWindow* domWindow() const { return m_domWindow.get(); }
+    LocalDOMWindow* window() const { return m_domWindow.get(); }
     inline RefPtr<LocalDOMWindow> protectedWindow() const; // Defined in DocumentInlines.h.
 
     // In DOM Level 2, the Document's LocalDOMWindow is called the defaultView.

--- a/Source/WebCore/dom/DocumentFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentFullscreen.cpp
@@ -172,7 +172,7 @@ void DocumentFullscreen::requestFullscreen(Ref<Element>&& element, FullscreenChe
     if (auto error = fullscreenElementReadyCheck(checkType, element))
         return handleError(error, EmitErrorEvent::Yes, WTFMove(completionHandler));
 
-    if (RefPtr window = document().domWindow(); !window || !window->consumeTransientActivation())
+    if (RefPtr window = document().window(); !window || !window->consumeTransientActivation())
         return handleError("Cannot request fullscreen without transient activation."_s, EmitErrorEvent::Yes, WTFMove(completionHandler));
 
     if (UserGestureIndicator::processingUserGesture() && UserGestureIndicator::currentUserGesture()->gestureType() == UserGestureType::EscapeKey)

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1299,7 +1299,7 @@ void Element::scrollTo(const ScrollToOptions& options, ScrollClamping clamping, 
         // If the element is the scrolling element and is not potentially scrollable,
         // invoke scroll() on window with options as the only argument, and terminate these steps.
         // FIXME: Scrolling an independently scrollable body is broken: webkit.org/b/161612.
-        RefPtr window = document->domWindow();
+        RefPtr window = document->window();
         if (!window)
             return;
 
@@ -3286,7 +3286,7 @@ static bool canAttachAuthorShadowRoot(const Element& element)
     }
 
     if (auto localName = element.localName(); Document::validateCustomElementName(localName) == CustomElementNameValidationStatus::Valid) {
-        if (RefPtr window = element.document().domWindow()) {
+        if (RefPtr window = element.document().window()) {
             RefPtr registry = window->customElementRegistry();
             if (registry && registry->isShadowDisabled(localName))
                 return false;
@@ -3508,7 +3508,7 @@ CustomElementReactionQueue* Element::reactionQueue() const
 
 CustomElementRegistry* Element::customElementRegistry() const
 {
-    if (RefPtr window = document().domWindow())
+    if (RefPtr window = document().window())
         window->ensureCustomElementRegistry(); // Create the global registry before querying since registryForElement doesn't ensure it.
     return CustomElementRegistry::registryForElement(*this);
 }

--- a/Source/WebCore/dom/Event.cpp
+++ b/Source/WebCore/dom/Event.cpp
@@ -185,7 +185,7 @@ DOMHighResTimeStamp Event::timeStampForBindings(ScriptExecutionContext& context)
     RefPtr<Performance> performance;
     if (auto* globalScope = dynamicDowncast<WorkerGlobalScope>(context))
         performance = globalScope->performance();
-    else if (RefPtr window = downcast<Document>(context).domWindow())
+    else if (RefPtr window = downcast<Document>(context).window())
         performance = window->performance();
 
     if (!performance)

--- a/Source/WebCore/dom/EventPath.cpp
+++ b/Source/WebCore/dom/EventPath.cpp
@@ -118,7 +118,7 @@ void EventPath::buildPath(Node& originalTarget, Event& event)
                 if (auto* document = dynamicDowncast<Document>(*node); document && event.type() != eventNames().loadEvent) {
                     ASSERT(target);
                     if (target) {
-                        if (RefPtr window = document->domWindow())
+                        if (RefPtr window = document->window())
                             m_path.append(EventContext { EventContext::Type::Window, node.get(), window.get(), target.get(), closedShadowDepth });
                     }
                 }

--- a/Source/WebCore/dom/IdleDeadline.cpp
+++ b/Source/WebCore/dom/IdleDeadline.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 
 DOMHighResTimeStamp IdleDeadline::timeRemaining(Document& document) const
 {
-    RefPtr window { document.domWindow() };
+    RefPtr window { document.window() };
     if (!window || m_didTimeout == DidTimeout::Yes)
         return 0;
     Ref performance = window->performance();

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -2460,7 +2460,7 @@ static inline bool tryAddEventListener(Node* targetNode, const AtomString& event
 
 #if PLATFORM(IOS_FAMILY)
     if (targetNode == document.ptr() && typeInfo.type() == EventType::scroll) {
-        if (RefPtr window = document->domWindow())
+        if (RefPtr window = document->window())
             window->incrementScrollEventListenersCount();
     }
 
@@ -2512,7 +2512,7 @@ static inline bool didRemoveEventListenerOfType(Node& targetNode, const AtomStri
 
 #if PLATFORM(IOS_FAMILY)
     if (&targetNode == document.ptr() && typeInfo.type() == EventType::scroll) {
-        if (RefPtr window = document->domWindow())
+        if (RefPtr window = document->window())
             window->decrementScrollEventListenersCount();
     }
 

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -1138,7 +1138,7 @@ void Range::updateFromSelection(const SimpleRange& value)
 
 LocalDOMWindow* Range::window() const
 {
-    return m_isAssociatedWithSelection ? m_ownerDocument->domWindow() : nullptr;
+    return m_isAssociatedWithSelection ? m_ownerDocument->window() : nullptr;
 }
 
 SimpleRange makeSimpleRange(const Range& range)

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -715,7 +715,7 @@ ServiceWorkerContainer* ScriptExecutionContext::serviceWorkerContainer()
 {
     NavigatorBase* navigator = nullptr;
     if (auto* document = dynamicDowncast<Document>(*this)) {
-        if (auto* window = document->domWindow())
+        if (auto* window = document->window())
             navigator = window->optionalNavigator();
     } else
         navigator = downcast<WorkerGlobalScope>(*this).optionalNavigator();
@@ -727,7 +727,7 @@ ServiceWorkerContainer* ScriptExecutionContext::ensureServiceWorkerContainer()
 {
     NavigatorBase* navigator = nullptr;
     if (auto* document = dynamicDowncast<Document>(*this)) {
-        if (auto* window = document->domWindow())
+        if (auto* window = document->window())
             navigator = &window->navigator();
     } else
         navigator = &downcast<WorkerGlobalScope>(*this).navigator();

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -214,7 +214,7 @@ CustomElementRegistry* ShadowRoot::registryForBindings() const
     if (usesNullCustomElementRegistry())
         return nullptr;
     auto* registry = customElementRegistry();
-    if (RefPtr window = document().domWindow(); window && !registry)
+    if (RefPtr window = document().window(); window && !registry)
         registry = &window->ensureCustomElementRegistry();
     return registry;
 }

--- a/Source/WebCore/dom/TrustedType.cpp
+++ b/Source/WebCore/dom/TrustedType.cpp
@@ -121,7 +121,7 @@ Variant<std::monostate, Exception, Ref<TrustedHTML>, Ref<TrustedScript>, Ref<Tru
 {
     RefPtr<TrustedTypePolicy> protectedPolicy;
     if (RefPtr document = dynamicDowncast<Document>(scriptExecutionContext)) {
-        if (RefPtr window = document->domWindow())
+        if (RefPtr window = document->window())
             protectedPolicy = WindowOrWorkerGlobalScopeTrustedTypes::trustedTypes(*window)->defaultPolicy();
     } else if (RefPtr workerGlobalScope = dynamicDowncast<WorkerGlobalScope>(scriptExecutionContext))
         protectedPolicy = WindowOrWorkerGlobalScopeTrustedTypes::trustedTypes(*workerGlobalScope)->defaultPolicy();

--- a/Source/WebCore/dom/UserGestureIndicator.cpp
+++ b/Source/WebCore/dom/UserGestureIndicator.cpp
@@ -145,7 +145,7 @@ UserGestureIndicator::UserGestureIndicator(std::optional<IsProcessingUserGesture
         // https://html.spec.whatwg.org/multipage/interaction.html#user-activation-processing-model
         // When a user interaction causes firing of an activation triggering input event in a Document...
         // NOTE: Only activate the relevent DOMWindow when the gestureType is an ActivationTriggering one
-        RefPtr window = document->domWindow();
+        RefPtr window = document->window();
         if (window && gestureType == UserGestureType::ActivationTriggering)
             window->notifyActivated(currentToken()->startTime());
     }

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -2381,7 +2381,7 @@ void FrameSelection::updateAppearance()
     // Start blinking with a black caret. Be sure not to restart if we're
     // already blinking in the right location.
     if (shouldBlink && !caretAnimator().isActive()) {
-        if (document && document->domWindow())
+        if (document && document->window())
             caretAnimator().start();
 
         caretAnimator().setVisible(true);

--- a/Source/WebCore/history/CachedFrame.cpp
+++ b/Source/WebCore/history/CachedFrame.cpp
@@ -151,7 +151,7 @@ void CachedFrameBase::restore()
     if (m_isMainFrame && localFrame) {
         localFrame->loader().client().didRestoreFrameHierarchyForCachedFrame();
 
-        if (RefPtr domWindow = m_document->domWindow(); domWindow && domWindow->scrollEventListenerCount()) {
+        if (RefPtr window = m_document->window(); window && window->scrollEventListenerCount()) {
             // FIXME: Use Document::hasListenerType(). See <rdar://problem/9615482>.
             if (RefPtr page = frame->page())
                 page->chrome().client().setNeedsScrollNotifications(*localFrame, true);
@@ -180,8 +180,8 @@ CachedFrame::CachedFrame(Frame& frame)
         m_childFrames.append(makeUniqueRef<CachedFrame>(*child));
 
     if (document) {
-        RELEASE_ASSERT(document->domWindow());
-        RELEASE_ASSERT(document->domWindow()->frame());
+        RELEASE_ASSERT(document->window());
+        RELEASE_ASSERT(document->window()->frame());
 
         // Active DOM objects must be suspended before we cache the frame script data.
         document->suspend(ReasonForSuspension::BackForwardCache);
@@ -229,7 +229,7 @@ CachedFrame::CachedFrame(Frame& frame)
 
 #if PLATFORM(IOS_FAMILY)
     if (m_isMainFrame && localFrame) {
-        if (RefPtr domWindow = document->domWindow(); domWindow && domWindow->scrollEventListenerCount()) {
+        if (RefPtr window = document->window(); window && window->scrollEventListenerCount()) {
             if (RefPtr page = frame.page())
                 page->chrome().client().setNeedsScrollNotifications(*localFrame, false);
         }

--- a/Source/WebCore/history/CachedPage.cpp
+++ b/Source/WebCore/history/CachedPage.cpp
@@ -185,10 +185,10 @@ void CachedPage::restore(Page& page)
             frameView->updateContentsSize();
     }
 
-    if (CheckedRef backForwardController = page.backForward(); page.settings().navigationAPIEnabled() && focusedDocument->domWindow() && backForwardController->currentItem()) {
+    if (CheckedRef backForwardController = page.backForward(); page.settings().navigationAPIEnabled() && focusedDocument->window() && backForwardController->currentItem()) {
         Ref currentItem = *backForwardController->currentItem();
         auto allItems = backForwardController->allItems();
-        focusedDocument->domWindow()->navigation().updateForReactivation(allItems, currentItem);
+        focusedDocument->window()->navigation().updateForReactivation(allItems, currentItem);
     }
 
     firePageShowEvent(page);

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -322,7 +322,7 @@ ExceptionOr<std::optional<RenderingContext>> HTMLCanvasElement::getContext(JSC::
 
     if (isWebGPUType(contextId)) {
         RefPtr<GPU> gpu;
-        if (RefPtr window = document().domWindow()) {
+        if (RefPtr window = document().window()) {
             // FIXME: Should we be instead getting this through jsDynamicCast<JSDOMWindow*>(state)->wrapped().navigator().gpu()?
             gpu = window->protectedNavigator()->gpu();
         }
@@ -445,7 +445,7 @@ WebGLRenderingContextBase* HTMLCanvasElement::createContextWebGL(WebGLVersion ty
 #if ENABLE(WEBXR)
     // https://immersive-web.github.io/webxr/#xr-compatible
     if (attrs.xrCompatible) {
-        if (RefPtr window = document().domWindow()) {
+        if (RefPtr window = document().window()) {
             // FIXME: how to make this sync without blocking the main thread?
             // For reference: https://immersive-web.github.io/webxr/#ref-for-dom-webglcontextattributes-xrcompatible
             NavigatorWebXR::xr(window->navigator()).ensureImmersiveXRDeviceIsSelected([]() { });

--- a/Source/WebCore/html/HTMLDocument.cpp
+++ b/Source/WebCore/html/HTMLDocument.cpp
@@ -123,8 +123,8 @@ std::optional<Variant<RefPtr<WindowProxy>, RefPtr<Element>, RefPtr<HTMLCollectio
 
     Ref element = *documentNamedItem(name);
     if (auto* iframe = dynamicDowncast<HTMLIFrameElement>(element.get()); iframe) [[unlikely]] {
-        if (RefPtr domWindow = iframe->contentWindow())
-            return Variant<RefPtr<WindowProxy>, RefPtr<Element>, RefPtr<HTMLCollection>> { WTFMove(domWindow) };
+        if (RefPtr window = iframe->contentWindow())
+            return Variant<RefPtr<WindowProxy>, RefPtr<Element>, RefPtr<HTMLCollection>> { WTFMove(window) };
     }
 
     return Variant<RefPtr<WindowProxy>, RefPtr<Element>, RefPtr<HTMLCollection>> { RefPtr<Element> { WTFMove(element) } };

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -3775,7 +3775,7 @@ void HTMLMediaElement::fastSeek(const MediaTime& time)
 #if ENABLE(MEDIA_STREAM)
 void HTMLMediaElement::setAudioOutputDevice(String&& deviceId, DOMPromiseDeferred<void>&& promise)
 {
-    RefPtr window = document().domWindow();
+    RefPtr window = document().window();
     RefPtr mediaDevices = window ? NavigatorMediaDevices::mediaDevices(window->navigator()) : nullptr;
     if (!mediaDevices) {
         promise.reject(Exception { ExceptionCode::NotAllowedError });
@@ -7396,7 +7396,7 @@ void HTMLMediaElement::setPlayerIdentifierForVideoElement()
     if (!page || page->mediaPlaybackIsSuspended())
         return;
 
-    RefPtr window = document().domWindow();
+    RefPtr window = document().window();
     if (!window)
         return;
 
@@ -7415,7 +7415,7 @@ void HTMLMediaElement::enterFullscreen(VideoFullscreenMode mode)
     if (!page || page->mediaPlaybackIsSuspended())
         return;
 
-    RefPtr window = document().domWindow();
+    RefPtr window = document().window();
     if (!window)
         return;
 
@@ -8708,8 +8708,8 @@ void HTMLMediaElement::updateRateChangeRestrictions()
 
 RefPtr<VideoPlaybackQuality> HTMLMediaElement::getVideoPlaybackQuality() const
 {
-    RefPtr domWindow = document().domWindow();
-    double timestamp = domWindow ? domWindow->nowTimestamp().milliseconds() : 0;
+    RefPtr window = document().window();
+    double timestamp = window ? window->nowTimestamp().milliseconds() : 0;
 
     VideoPlaybackQualityMetrics currentVideoPlaybackQuality;
 #if ENABLE(MEDIA_SOURCE)

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -754,10 +754,10 @@ void HTMLVideoElement::serviceRequestVideoFrameCallbacks(ReducedResolutionSecond
         return;
 
     auto videoFrameMetadata = player()->videoFrameMetadata();
-    if (!videoFrameMetadata || !document().domWindow())
+    if (!videoFrameMetadata || !document().window())
         return;
 
-    processVideoFrameMetadataTimestamps(*videoFrameMetadata, document().domWindow()->protectedPerformance());
+    processVideoFrameMetadataTimestamps(*videoFrameMetadata, document().window()->protectedPerformance());
 
     Ref protectedThis { *this };
 

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -1592,7 +1592,7 @@ MediaSession* MediaElementSession::mediaSession() const
     if (!element)
         return nullptr;
 
-    auto* window = element->document().domWindow();
+    auto* window = element->document().window();
     if (!window)
         return nullptr;
     return &NavigatorMediaSession::mediaSession(window->protectedNavigator());

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -234,8 +234,8 @@ ExceptionOr<std::optional<OffscreenRenderingContext>> OffscreenCanvas::getContex
                 if (auto* gpu = globalScope->protectedNavigator()->gpu())
                     m_context = GPUCanvasContext::create(*this, *gpu);
             } else if (RefPtr document = dynamicDowncast<Document>(scriptExecutionContext)) {
-                if (RefPtr domWindow = document->domWindow()) {
-                    if (auto* gpu = domWindow->protectedNavigator()->gpu())
+                if (RefPtr window = document->window()) {
+                    if (auto* gpu = window->protectedNavigator()->gpu())
                         m_context = GPUCanvasContext::create(*this, *gpu);
                 }
             }

--- a/Source/WebCore/html/PermissionsPolicy.cpp
+++ b/Source/WebCore/html/PermissionsPolicy.cpp
@@ -305,7 +305,7 @@ static bool computeFeatureEnabled(PermissionsPolicy::Feature feature, const Docu
     bool enabled = checkPermissionsPolicy(document.permissionsPolicy(), feature, origin, document.securityOrigin().data());
     // FIXME: Spec suggests generating violation report for Reporting API but we only add log now.
     if (!enabled && shouldReportViolation == PermissionsPolicy::ShouldReportViolation::Yes) {
-        if (RefPtr window = document.domWindow())
+        if (RefPtr window = document.window())
             window->printErrorMessage(makeString("Permission policy '"_s, toFeatureNameForLogging(feature), "' check failed for document with origin '"_s, origin.toString(), "'."_s));
     }
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -2845,7 +2845,7 @@ void WebGLRenderingContextBase::makeXRCompatible(MakeXRCompatiblePromise&& promi
         return;
     }
 
-    auto* window = canvas->document().domWindow();
+    auto* window = canvas->document().window();
     if (!window) {
         m_attributes.xrCompatible = false;
         promise.reject(Exception { ExceptionCode::InvalidStateError });

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -1061,7 +1061,7 @@ Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::E
     if (includeAncestors.value_or(true)) {
         for (RefPtr ancestor = node->parentOrShadowHostNode(); ancestor; ancestor = ancestor->parentOrShadowHostNode())
             ancestors.append(ancestor.get());
-        if (auto* window = node->document().domWindow())
+        if (auto* window = node->document().window())
             ancestors.append(window);
     }
 
@@ -3228,7 +3228,7 @@ Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::DOM::MediaStats>> In
         .release();
     stats->setViewport(WTFMove(viewportJSON));
 
-    if (RefPtr window = mediaElement->document().domWindow())
+    if (RefPtr window = mediaElement->document().window())
         stats->setDevicePixelRatio(window->devicePixelRatio());
 
     if (videoTrack) {

--- a/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.cpp
@@ -167,7 +167,7 @@ String InspectorDOMStorageAgent::storageId(Storage& storage)
 {
     auto* document = storage.frame()->document();
     ASSERT(document);
-    auto* window = document->domWindow();
+    auto* window = document->window();
     ASSERT(window);
     Ref<SecurityOrigin> securityOrigin = document->securityOrigin();
     bool isLocalStorage = window->optionalLocalStorage() == &storage;

--- a/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
@@ -540,11 +540,11 @@ static Inspector::Protocol::ErrorStringOr<Document*> documentFromFrame(LocalFram
 
 static Inspector::Protocol::ErrorStringOr<IDBFactory*> IDBFactoryFromDocument(Document* document)
 {
-    RefPtr domWindow = document->domWindow();
-    if (!domWindow)
+    RefPtr window = document->window();
+    if (!window)
         return makeUnexpected("Missing window for given document"_s);
 
-    IDBFactory* idbFactory = WindowOrWorkerGlobalScopeIndexedDatabase::indexedDB(*domWindow);
+    IDBFactory* idbFactory = WindowOrWorkerGlobalScopeIndexedDatabase::indexedDB(*window);
     if (!idbFactory)
         makeUnexpected("Missing IndexedDB factory of window for given document"_s);
     

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -448,8 +448,8 @@ void DocumentLoader::notifyFinished(CachedResource& resource, const NetworkLoadM
 #endif
 
     if (RefPtr document = this->document()) {
-        if (RefPtr domWindow = document->domWindow())
-            domWindow->protectedPerformance()->navigationFinished(metrics);
+        if (RefPtr window = document->window())
+            window->protectedPerformance()->navigationFinished(metrics);
     }
 
     ASSERT_UNUSED(resource, m_mainResource == &resource);
@@ -1364,7 +1364,7 @@ void DocumentLoader::commitData(const SharedBuffer& data)
         if (!isLoading())
             return;
 
-        if (RefPtr window = document->domWindow()) {
+        if (RefPtr window = document->window()) {
             window->prewarmLocalStorageIfNecessary();
 
             if (m_mainResource) {

--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -683,7 +683,7 @@ void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCh
     if (options().initiatorContext == InitiatorContext::Worker)
         finishedTimingForWorkerLoad(resourceTiming);
     else {
-        if (RefPtr window = document().domWindow())
+        if (RefPtr window = document().window())
             window->protectedPerformance()->addResourceTiming(WTFMove(resourceTiming));
     }
 

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -583,7 +583,7 @@ void ImageLoader::decode(Ref<DeferredPromise>&& promise)
 {
     m_decodingPromises.append(WTFMove(promise));
 
-    if (!element().document().domWindow()) {
+    if (!element().document().window()) {
         rejectDecodePromises("Inactive document."_s);
         return;
     }
@@ -602,7 +602,7 @@ void ImageLoader::decode()
 {
     ASSERT(hasPendingDecodePromises());
     
-    if (!element().document().domWindow()) {
+    if (!element().document().window()) {
         rejectDecodePromises("Inactive document."_s);
         return;
     }

--- a/Source/WebCore/loader/PolicyChecker.cpp
+++ b/Source/WebCore/loader/PolicyChecker.cpp
@@ -216,8 +216,8 @@ void PolicyChecker::checkNavigationPolicy(ResourceRequest&& request, const Resou
     if (!action.downloadAttribute().isNull()) {
         RefPtr document = frame->document();
         if (document && document->settings().navigationAPIEnabled()) {
-            if (RefPtr domWindow = document->domWindow()) {
-                if (!domWindow->protectedNavigation()->dispatchDownloadNavigateEvent(request.url(), action.downloadAttribute()))
+            if (RefPtr window = document->window()) {
+                if (!window->protectedNavigation()->dispatchDownloadNavigateEvent(request.url(), action.downloadAttribute()))
                     return function({ }, nullptr, NavigationPolicyDecision::IgnoreLoad);
             }
         }

--- a/Source/WebCore/loader/ResourceTimingInformation.cpp
+++ b/Source/WebCore/loader/ResourceTimingInformation.cpp
@@ -68,7 +68,7 @@ void ResourceTimingInformation::addResourceTiming(CachedResource& resource, Docu
     if (!initiatorDocument)
         return;
 
-    RefPtr initiatorWindow = initiatorDocument->domWindow();
+    RefPtr initiatorWindow = initiatorDocument->window();
     if (!initiatorWindow)
         return;
 

--- a/Source/WebCore/page/DOMWindowExtension.cpp
+++ b/Source/WebCore/page/DOMWindowExtension.cpp
@@ -78,7 +78,7 @@ void DOMWindowExtension::resumeFromBackForwardCache()
 {
     ASSERT(frame());
     ASSERT(m_disconnectedFrame == frame());
-    ASSERT(frame()->document()->domWindow() == m_window);
+    ASSERT(frame()->document()->window() == m_window);
 
     m_disconnectedFrame = nullptr;
 

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -4233,7 +4233,7 @@ void EventHandler::defaultKeyboardEventHandler(KeyboardEvent& event)
 
         if (event.key() == "Escape"_s) {
             if (frame->settings().closeWatcherEnabled())
-                frame->document()->domWindow()->closeWatcherManager().escapeKeyHandler(event);
+                frame->document()->window()->closeWatcherManager().escapeKeyHandler(event);
             if (RefPtr activeModalDialog = frame->document()->activeModalDialog())
                 activeModalDialog->queueCancelTask();
             if (RefPtr topmostAutoPopover = frame->document()->topmostAutoPopover())

--- a/Source/WebCore/page/History.cpp
+++ b/Source/WebCore/page/History.cpp
@@ -303,7 +303,7 @@ ExceptionOr<void> History::stateObjectAdded(RefPtr<SerializedScriptValue>&& data
         return result.releaseException();
 
     if (document->settings().navigationAPIEnabled()) {
-        Ref navigation = document->domWindow()->navigation();
+        Ref navigation = document->window()->navigation();
         if (!navigation->dispatchPushReplaceReloadNavigateEvent(fullURL, historyBehavior == NavigationHistoryBehavior::Push ? NavigationNavigationType::Push : NavigationNavigationType::Replace, true, nullptr, data.get()))
             return { };
     }

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -578,7 +578,7 @@ std::optional<ReducedResolutionSeconds> IntersectionObserver::nowTimestamp() con
         if (!context)
             return std::nullopt;
         auto& document = downcast<Document>(*context);
-        window = document.domWindow();
+        window = document.window();
         if (!window)
             return std::nullopt;
     }

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -400,7 +400,7 @@ bool LocalDOMWindow::canShowModalDialog(const LocalFrame& frame)
 {
     // Override support for layout testing purposes.
     if (RefPtr document = frame.document()) {
-        if (RefPtr window = document->domWindow()) {
+        if (RefPtr window = document->window()) {
             if (window->m_canShowModalDialogOverride)
                 return window->m_canShowModalDialogOverride.value();
         }
@@ -613,7 +613,7 @@ void LocalDOMWindow::resumeFromBackForwardCache()
 bool LocalDOMWindow::isCurrentlyDisplayedInFrame() const
 {
     RefPtr frame = localFrame();
-    return frame && frame->document()->domWindow() == this;
+    return frame && frame->document()->window() == this;
 }
 
 CustomElementRegistry& LocalDOMWindow::ensureCustomElementRegistry()
@@ -2212,7 +2212,7 @@ void LocalDOMWindow::failedToRegisterDeviceMotionEventListener()
     if (RegistrableDomain::uncheckedCreateFromRegistrableDomainString("chase.com"_s).matches(document()->url())) {
         // Fire a fake DeviceMotionEvent with acceleration data to unblock the site's login flow.
         protectedDocument()->postTask([](auto& context) {
-            if (RefPtr window = downcast<Document>(context).domWindow()) {
+            if (RefPtr window = downcast<Document>(context).window()) {
                 auto acceleration = DeviceMotionData::Acceleration::create();
                 window->dispatchEvent(DeviceMotionEvent::create(eventNames().devicemotionEvent, DeviceMotionData::create(acceleration.copyRef(), acceleration.copyRef(), DeviceMotionData::RotationRate::create(), std::nullopt).ptr()));
             }

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -339,8 +339,8 @@ void LocalFrame::setDocument(RefPtr<Document>&& newDocument)
     }
 
     m_doc = newDocument.copyRef();
-    ASSERT(!m_doc || m_doc->domWindow());
-    ASSERT(!m_doc || m_doc->domWindow()->frame() == this);
+    ASSERT(!m_doc || m_doc->window());
+    ASSERT(!m_doc || m_doc->window()->frame() == this);
 
     // Don't use m_doc because it can be overwritten and we want to guarantee
     // that the document is not destroyed during this function call.
@@ -974,7 +974,7 @@ void LocalFrame::createView(const IntSize& viewportSize, const std::optional<Col
 
 LocalDOMWindow* LocalFrame::window() const
 {
-    return document() ? document()->domWindow() : nullptr;
+    return document() ? document()->window() : nullptr;
 }
 
 RefPtr<LocalDOMWindow> LocalFrame::protectedWindow() const
@@ -1297,7 +1297,7 @@ void LocalFrame::frameWasDisconnectedFromOwner() const
     if (!m_doc)
         return;
 
-    if (RefPtr window = m_doc->domWindow())
+    if (RefPtr window = m_doc->window())
         window->willDetachDocumentFromFrame();
 
     protectedDocument()->detachFromFrame();

--- a/Source/WebCore/page/Location.cpp
+++ b/Source/WebCore/page/Location.cpp
@@ -270,7 +270,7 @@ void Location::reload(LocalDOMWindow& activeWindow)
 
     ASSERT(activeWindow.document());
     ASSERT(localFrame->document());
-    ASSERT(localFrame->document()->domWindow());
+    ASSERT(localFrame->document()->window());
 
     Ref activeDocument = *activeWindow.document();
     Ref targetDocument = *localFrame->document();
@@ -279,7 +279,7 @@ void Location::reload(LocalDOMWindow& activeWindow)
     // We allow one page to change the location of another. Why block attempts to reload?
     // Other location operations simply block use of JavaScript URLs cross origin.
     if (!activeDocument->protectedSecurityOrigin()->isSameOriginDomain(targetDocument->protectedSecurityOrigin())) {
-        Ref targetWindow = *targetDocument->domWindow();
+        Ref targetWindow = *targetDocument->window();
         targetWindow->printErrorMessage(targetWindow->crossDomainAccessErrorMessage(activeWindow, IncludeTargetOrigin::Yes));
         return;
     }
@@ -310,7 +310,7 @@ ExceptionOr<void> Location::setLocation(LocalDOMWindow& incumbentWindow, LocalDO
 
     // https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-location-interface:location-object-navigate
     auto historyHandling = NavigationHistoryBehavior::Auto;
-    if (!firstFrame->loader().isComplete() && firstFrame->document() && !firstFrame->document()->domWindow()->hasTransientActivation())
+    if (!firstFrame->loader().isComplete() && firstFrame->document() && !firstFrame->document()->window()->hasTransientActivation())
         historyHandling = NavigationHistoryBehavior::Replace;
 
     ASSERT(frame->window());

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2250,7 +2250,7 @@ void Page::updateRendering()
     });
 
     for (auto& document : initialDocuments) {
-        if (document && document->domWindow())
+        if (document && document->window())
             document->protectedWindow()->unfreezeNowTimestamp();
     }
 
@@ -2765,7 +2765,7 @@ const String& Page::userStyleSheet() const
 void Page::userAgentChanged()
 {
     forEachDocument([] (Document& document) {
-        if (RefPtr window = document.domWindow()) {
+        if (RefPtr window = document.window()) {
             if (RefPtr navigator = window->optionalNavigator())
                 navigator->userAgentChanged();
         }

--- a/Source/WebCore/page/Performance.cpp
+++ b/Source/WebCore/page/Performance.cpp
@@ -142,7 +142,7 @@ PerformanceNavigation* Performance::navigation()
 
     ASSERT(isMainThread());
     if (!m_navigation)
-        m_navigation = PerformanceNavigation::create(downcast<Document>(*scriptExecutionContext()).domWindow());
+        m_navigation = PerformanceNavigation::create(downcast<Document>(*scriptExecutionContext()).window());
     return m_navigation.get();
 }
 
@@ -153,7 +153,7 @@ PerformanceTiming* Performance::timing()
 
     ASSERT(isMainThread());
     if (!m_timing)
-        m_timing = PerformanceTiming::create(downcast<Document>(*scriptExecutionContext()).domWindow());
+        m_timing = PerformanceTiming::create(downcast<Document>(*scriptExecutionContext()).window());
     return m_timing.get();
 }
 

--- a/Source/WebCore/page/PerformanceMark.cpp
+++ b/Source/WebCore/page/PerformanceMark.cpp
@@ -46,7 +46,7 @@ static double performanceNow(ScriptExecutionContext& scriptExecutionContext)
     // the ScriptExecutionContext to avoid this.
 
     if (RefPtr document = dynamicDowncast<Document>(scriptExecutionContext)) {
-        if (auto window = document->domWindow())
+        if (auto window = document->window())
             return window->performance().now();
     } else if (RefPtr workerGlobal = dynamicDowncast<WorkerGlobalScope>(scriptExecutionContext))
         return workerGlobal->performance().now();

--- a/Source/WebCore/page/PerformanceObserver.cpp
+++ b/Source/WebCore/page/PerformanceObserver.cpp
@@ -39,7 +39,7 @@ PerformanceObserver::PerformanceObserver(ScriptExecutionContext& scriptExecution
     : m_callback(WTFMove(callback))
 {
     if (RefPtr document = dynamicDowncast<Document>(scriptExecutionContext)) {
-        if (auto* window = document->domWindow())
+        if (auto* window = document->window())
             m_performance = window->performance();
     } else if (RefPtr workerGlobalScope = dynamicDowncast<WorkerGlobalScope>(scriptExecutionContext))
         m_performance = workerGlobalScope->performance();

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -820,7 +820,7 @@ bool Quirks::shouldBypassBackForwardCache() const
 
     // Login issue on bankofamerica.com (rdar://104938789).
     if (m_quirksData.isBankOfAmerica) {
-        if (RefPtr window = document->domWindow()) {
+        if (RefPtr window = document->window()) {
             if (window->hasEventListeners(eventNames().unloadEvent)) {
                 static MainThreadNeverDestroyed<const AtomString> signInId("signIn"_s);
                 static MainThreadNeverDestroyed<const AtomString> loadingClass("loading"_s);
@@ -1123,11 +1123,11 @@ Quirks::StorageAccessResult Quirks::triggerOptionalStorageAccessQuirk(Element& e
                 return Quirks::StorageAccessResult::ShouldNotCancelEvent;
             }
 
-            RefPtr domWindow = document->domWindow();
-            if (!domWindow)
+            RefPtr window = document->window();
+            if (!window)
                 return Quirks::StorageAccessResult::ShouldNotCancelEvent;
 
-            ExceptionOr<RefPtr<WindowProxy>> proxyOrException =  domWindow->open(*domWindow, *domWindow, kinjaURL->string(), emptyAtom(), loginPopupWindowFeatureString);
+            ExceptionOr<RefPtr<WindowProxy>> proxyOrException =  window->open(*window, *window, kinjaURL->string(), emptyAtom(), loginPopupWindowFeatureString);
             if (proxyOrException.hasException())
                 return Quirks::StorageAccessResult::ShouldNotCancelEvent;
             auto proxy = proxyOrException.releaseReturnValue();

--- a/Source/WebCore/page/ios/FrameIOS.mm
+++ b/Source/WebCore/page/ios/FrameIOS.mm
@@ -839,8 +839,8 @@ void LocalFrame::overflowScrollPositionChangedForNode(const IntPoint& position, 
 
 void LocalFrame::resetAllGeolocationPermission()
 {
-    if (document()->domWindow())
-        document()->domWindow()->resetAllGeolocationPermission();
+    if (document()->window())
+        document()->window()->resetAllGeolocationPermission();
 
     for (RefPtr child = tree().firstChild(); child; child = child->tree().nextSibling()) {
         auto* localChild = dynamicDowncast<LocalFrame>(child.get());

--- a/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm
@@ -295,7 +295,7 @@ void VideoPresentationModelVideoElement::requestFullscreenMode(HTMLMediaElementE
 
     if (finishedWithMedia && mode == MediaPlayer::VideoFullscreenModeNone) {
         if (videoElement->document().isMediaDocument()) {
-            if (auto* window = videoElement->document().domWindow())
+            if (auto* window = videoElement->document().window())
                 window->history().back();
         }
     }

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -303,7 +303,7 @@ static OptionSet<TouchAction> computeUsedTouchActions(const RenderStyle& style, 
 bool Adjuster::adjustEventListenerRegionTypesForRootStyle(RenderStyle& rootStyle, const Document& document)
 {
     auto regionTypes = computeEventListenerRegionTypes(document, rootStyle, document, { });
-    if (RefPtr window = document.domWindow())
+    if (RefPtr window = document.window())
         regionTypes.add(computeEventListenerRegionTypes(document, rootStyle, *window, { }));
 
     bool changed = regionTypes != rootStyle.eventListenerRegionTypes();

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -801,7 +801,7 @@ unsigned Internals::inflightBeaconsCount() const
     if (!document)
         return 0;
 
-    auto* window = document->domWindow();
+    auto* window = document->window();
     if (!window)
         return 0;
 
@@ -1009,10 +1009,10 @@ void Internals::setOverrideCachePolicy(CachePolicy policy)
 
 ExceptionOr<void> Internals::setCanShowModalDialogOverride(bool allow)
 {
-    if (!contextDocument() || !contextDocument()->domWindow())
+    if (!contextDocument() || !contextDocument()->window())
         return Exception { ExceptionCode::InvalidAccessError };
 
-    contextDocument()->domWindow()->setCanShowModalDialogOverride(allow);
+    contextDocument()->window()->setCanShowModalDialogOverride(allow);
     return { };
 }
 
@@ -1721,19 +1721,19 @@ void Internals::simulateSpeechSynthesizerVoiceListChange()
     }
 
     RefPtr document = contextDocument();
-    if (!document || !document->domWindow())
+    if (!document || !document->window())
         return;
 
-    if (RefPtr synthesis = LocalDOMWindowSpeechSynthesis::speechSynthesis(*document->domWindow()))
+    if (RefPtr synthesis = LocalDOMWindowSpeechSynthesis::speechSynthesis(*document->window()))
         synthesis->simulateVoicesListChange();
 }
 
 void Internals::enableMockSpeechSynthesizer()
 {
     auto document = contextDocument();
-    if (!document || !document->domWindow())
+    if (!document || !document->window())
         return;
-    auto synthesis = LocalDOMWindowSpeechSynthesis::speechSynthesis(*document->domWindow());
+    auto synthesis = LocalDOMWindowSpeechSynthesis::speechSynthesis(*document->window());
     if (!synthesis)
         return;
 
@@ -3272,7 +3272,7 @@ RefPtr<WindowProxy> Internals::openDummyInspectorFrontend(const String& url)
     if (!localMainFrame)
         return nullptr;
 
-    RefPtr window = localMainFrame->document()->domWindow();
+    RefPtr window = localMainFrame->document()->window();
     if (!window)
         return nullptr;
 
@@ -5892,7 +5892,7 @@ bool Internals::userIsInteracting()
 bool Internals::hasTransientActivation()
 {
     if (auto* document = contextDocument()) {
-        if (auto* window = document->domWindow())
+        if (auto* window = document->window())
             return window->hasTransientActivation();
     }
     return false;
@@ -5901,7 +5901,7 @@ bool Internals::hasTransientActivation()
 bool Internals::consumeTransientActivation()
 {
     if (auto* document = contextDocument()) {
-        if (auto* window = document->domWindow())
+        if (auto* window = document->window())
             return window->consumeTransientActivation();
     }
     return false;
@@ -5919,7 +5919,7 @@ double Internals::lastHandledUserGestureTimestamp()
 bool Internals::hasHistoryActionActivation()
 {
     if (auto* document = contextDocument()) {
-        if (auto* window = document->domWindow())
+        if (auto* window = document->window())
             return window->hasHistoryActionActivation();
     }
     return false;
@@ -5928,7 +5928,7 @@ bool Internals::hasHistoryActionActivation()
 bool Internals::consumeHistoryActionUserActivation()
 {
     if (auto* document = contextDocument()) {
-        if (auto* window = document->domWindow())
+        if (auto* window = document->window())
             return window->consumeHistoryActionUserActivation();
     }
     return false;
@@ -7339,11 +7339,11 @@ bool Internals::destroySleepDisabler(unsigned identifier)
 ExceptionOr<RefPtr<WebXRTest>> Internals::xrTest()
 {
     auto* document = contextDocument();
-    if (!document || !document->domWindow() || !document->settings().webXREnabled())
+    if (!document || !document->window() || !document->settings().webXREnabled())
         return Exception { ExceptionCode::InvalidAccessError };
 
     if (!m_xrTest) {
-        auto* navigator = contextDocument()->domWindow()->optionalNavigator();
+        auto* navigator = contextDocument()->window()->optionalNavigator();
         if (!navigator)
             return Exception { ExceptionCode::InvalidAccessError };
 
@@ -7462,13 +7462,13 @@ ExceptionOr<void> Internals::registerMockMediaSessionCoordinator(ScriptExecution
         return { };
 
     auto* document = contextDocument();
-    if (!document || !document->domWindow())
+    if (!document || !document->window())
         return Exception { ExceptionCode::InvalidAccessError };
 
     if (!document->settings().mediaSessionCoordinatorEnabled())
         return Exception { ExceptionCode::InvalidAccessError };
 
-    auto& session = NavigatorMediaSession::mediaSession(document->domWindow()->navigator());
+    auto& session = NavigatorMediaSession::mediaSession(document->window()->navigator());
     auto mock = MockMediaSessionCoordinator::create(context, WTFMove(listener));
     m_mockMediaSessionCoordinator = mock.ptr();
     session.coordinator().setMediaSessionCoordinatorPrivate(WTFMove(mock));
@@ -7549,7 +7549,7 @@ bool Internals::rangeIntersectsRange(const AbstractRange& a, const AbstractRange
 String Internals::dumpStyleResolvers()
 {
     auto* document = contextDocument();
-    if (!document || !document->domWindow())
+    if (!document || !document->window())
         return { };
 
     document->updateStyleIfNeeded();
@@ -7719,7 +7719,7 @@ bool Internals::hasScopeBreakingHasSelectors() const
 
 void Internals::setHistoryTotalStateObjectPayloadLimitOverride(uint32_t limit)
 {
-    RefPtr window = contextDocument() ? contextDocument()->domWindow() : nullptr;
+    RefPtr window = contextDocument() ? contextDocument()->window() : nullptr;
     if (!window)
         return;
     window->history().setTotalStateObjectPayloadLimitOverride(limit);

--- a/Source/WebCore/workers/service/ServiceWorkerClientData.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerClientData.cpp
@@ -49,7 +49,7 @@ static ServiceWorkerClientFrameType toServiceWorkerClientFrameType(ScriptExecuti
         return ServiceWorkerClientFrameType::None;
 
     if (frame->isMainFrame()) {
-        if (RefPtr window = document->domWindow()) {
+        if (RefPtr window = document->window()) {
             if (window->opener())
                 return ServiceWorkerClientFrameType::Auxiliary;
         }

--- a/Source/WebCore/worklets/PaintWorkletGlobalScope.cpp
+++ b/Source/WebCore/worklets/PaintWorkletGlobalScope.cpp
@@ -56,9 +56,9 @@ PaintWorkletGlobalScope::PaintWorkletGlobalScope(Document& document, Ref<VM>&& v
 
 double PaintWorkletGlobalScope::devicePixelRatio() const
 {
-    if (!responsibleDocument() || !responsibleDocument()->domWindow())
+    if (!responsibleDocument() || !responsibleDocument()->window())
         return 1.0;
-    return responsibleDocument()->domWindow()->devicePixelRatio();
+    return responsibleDocument()->window()->devicePixelRatio();
 }
 
 PaintDefinition::PaintDefinition(const AtomString& name, JSC::JSObject* paintConstructor, Ref<CSSPaintCallback>&& paintCallback, Vector<AtomString>&& inputProperties, Vector<String>&& inputArguments)

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -903,7 +903,7 @@ void XMLHttpRequest::didFail(std::optional<ScriptExecutionContextIdentifier>, co
 
     bool wasAbortedByClient = false;
     if (auto* document = this->document()) {
-        if (auto* window = document->domWindow())
+        if (auto* window = document->window())
             wasAbortedByClient = window->isStopping();
     }
 

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -815,7 +815,7 @@ void XMLDocumentParser::startElementNs(const xmlChar* xmlLocalName, const xmlCha
 
     bool willConstructCustomElement = false;
     if (!m_parsingFragment) {
-        if (RefPtr window = m_currentNode->document().domWindow()) {
+        if (RefPtr window = m_currentNode->document().window()) {
             if (RefPtr registry = window->customElementRegistry(); registry) [[unlikely]]
                 willConstructCustomElement = registry->findInterface(qName);
         }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/DOM/DOMObjectCache.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/DOM/DOMObjectCache.cpp
@@ -97,11 +97,11 @@ public:
     {
         ASSERT(!m_objects.contains(&data));
 
-        auto* domWindow = m_frame->document()->domWindow();
-        if (domWindow && (!m_domWindowObserver || m_domWindowObserver->window() != domWindow)) {
+        auto* window = m_frame->document()->window();
+        if (window && (!m_domWindowObserver || m_domWindowObserver->window() != window)) {
             // New LocalDOMWindow, clear the cache and create a new DOMWindowObserver.
             clear();
-            m_domWindowObserver = makeUnique<DOMWindowObserver>(*domWindow, *this);
+            m_domWindowObserver = makeUnique<DOMWindowObserver>(*window, *this);
         }
 
         m_objects.append(&data);

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMDOMWindow.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMDOMWindow.cpp
@@ -1055,11 +1055,11 @@ gboolean webkit_dom_dom_window_webkit_message_handlers_post_message(WebKitDOMDOM
     g_return_val_if_fail(message, FALSE);
 
 #if ENABLE(USER_MESSAGE_HANDLERS)
-    WebCore::LocalDOMWindow* domWindow = WebKit::core(window);
-    if (!domWindow->shouldHaveWebKitNamespaceForWorld(WebCore::mainThreadNormalWorldSingleton()))
+    auto* window = WebKit::core(window);
+    if (!window->shouldHaveWebKitNamespaceForWorld(WebCore::mainThreadNormalWorldSingleton()))
         return FALSE;
 
-    auto webkitNamespace = domWindow->webkitNamespace();
+    auto webkitNamespace = window->webkitNamespace();
     if (!webkitNamespace)
         return FALSE;
 
@@ -1067,7 +1067,7 @@ gboolean webkit_dom_dom_window_webkit_message_handlers_post_message(WebKitDOMDOM
     if (!handler)
         return FALSE;
     
-    auto* scriptExecutionContext = ((WebCore::ContextDestructionObserver*)domWindow)->scriptExecutionContext();
+    auto* scriptExecutionContext = ((WebCore::ContextDestructionObserver*)window)->scriptExecutionContext();
     if (!scriptExecutionContext)
         return FALSE;
     

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9512,7 +9512,7 @@ void WebPage::setAppHighlightsVisibility(WebCore::HighlightVisibility appHighlig
 void WebPage::createMediaSessionCoordinator(const String& identifier, CompletionHandler<void(bool)>&& completionHandler)
 {
     RefPtr document = m_mainFrame->coreLocalFrame()->document();
-    if (!document || !document->domWindow()) {
+    if (!document || !document->window()) {
         completionHandler(false);
         return;
     }

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
@@ -587,7 +587,7 @@ void PlaybackSessionManager::setMediaSessionAndRegisterAsObserver()
         return;
     }
 
-    RefPtr window = mediaElement->document().domWindow();
+    RefPtr window = mediaElement->document().window();
     if (!window) {
         m_mediaSession = nullptr;
         return;

--- a/Source/WebKitLegacy/mac/DOM/DOMAbstractView.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMAbstractView.mm
@@ -74,7 +74,7 @@ WebCore::LocalDOMWindow* core(DOMAbstractView *wrapper)
         return 0;
     if (!wrapper->_internal)
         return 0;
-    return reinterpret_cast<WebCore::LocalFrame*>(wrapper->_internal)->document()->domWindow();
+    return reinterpret_cast<WebCore::LocalFrame*>(wrapper->_internal)->document()->window();
 }
 
 DOMAbstractView *kit(WebCore::LocalDOMWindow* value)

--- a/Source/WebKitLegacy/mac/DOM/DOMDocument.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMDocument.mm
@@ -694,7 +694,7 @@ static RefPtr<WebCore::XPathNSResolver> wrap(id <DOMXPathNSResolver> resolver)
     WebCore::JSMainThreadNullState state;
     if (!element)
         raiseTypeErrorException();
-    auto* dv = IMPL->domWindow();
+    auto* dv = IMPL->window();
     if (!dv)
         return nil;
     return kit(WTF::getPtr(dv->getComputedStyle(*core(element), pseudoElement)));
@@ -708,7 +708,7 @@ static RefPtr<WebCore::XPathNSResolver> wrap(id <DOMXPathNSResolver> resolver)
 - (DOMCSSRuleList *)getMatchedCSSRules:(DOMElement *)element pseudoElement:(NSString *)pseudoElement authorOnly:(BOOL)authorOnly
 {
     WebCore::JSMainThreadNullState state;
-    auto* dv = IMPL->domWindow();
+    auto* dv = IMPL->window();
     if (!dv)
         return nil;
     return kit(WTF::getPtr(dv->getMatchedCSSRules(core(element), pseudoElement, authorOnly)));

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -1154,7 +1154,7 @@ static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
 
 - (unsigned)_pendingFrameUnloadEventCount
 {
-    return _private->coreFrame->document()->domWindow()->pendingUnloadEventListeners();
+    return _private->coreFrame->document()->window()->pendingUnloadEventListeners();
 }
 
 #if PLATFORM(IOS_FAMILY)
@@ -2049,8 +2049,8 @@ static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
     if (frameLoader.subframeLoader().containsPlugins())
         [result setObject:@YES forKey:WebFrameHasPlugins];
     
-    if (auto* domWindow = _private->coreFrame->document()->domWindow()) {
-        if (domWindow->hasEventListeners(WebCore::eventNames().unloadEvent))
+    if (auto* window = _private->coreFrame->document()->window()) {
+        if (window->hasEventListeners(WebCore::eventNames().unloadEvent))
             [result setObject:@YES forKey:WebFrameHasUnloadListener];
     }
     


### PR DESCRIPTION
#### 20bc4d8a29552f695efcfae8f4f459954dbc2855
<pre>
Rename domWindow() to window()
<a href="https://bugs.webkit.org/show_bug.cgi?id=294750">https://bugs.webkit.org/show_bug.cgi?id=294750</a>

Reviewed by Tyler Wilcock.

Addresses an existing FIXME and makes the name consistent with
protectedWindow().

Except for ScriptCachedFrameData.cpp where it created a conflict, local
variables have been renamed as well.

Canonical link: <a href="https://commits.webkit.org/296441@main">https://commits.webkit.org/296441@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb8651b8a91f3510d73bc1c6cd88e51f45dab1e4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108550 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28211 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113759 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58949 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110513 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28900 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36765 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82445 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111498 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22932 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97774 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62881 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22349 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15914 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58474 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92302 "Found 1 new API test failure: TestWebKitAPI.WKWebsiteDataStoreConfiguration.TotalQuotaRatioWithPersistedDomain (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15965 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116880 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35604 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26247 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91469 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35977 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94046 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91270 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36163 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13929 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31366 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17526 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35506 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41041 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35218 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38567 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36896 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->