### PR TITLE
[GTK][WPE][OpenXR] Add a mechanism to exit an immersive experience

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -32,6 +32,7 @@
 #include "JavaScriptEvaluationResult.h"
 #include "NotificationService.h"
 #include "PageLoadState.h"
+#include "PlatformXRSystem.h"
 #include "ProcessTerminationReason.h"
 #include "ProvisionalPageProxy.h"
 #include "RunJavaScriptParameters.h"
@@ -5842,4 +5843,27 @@ webkit_web_view_get_default_content_security_policy(WebKitWebView* webView)
         return nullptr;
 
     return webView->priv->defaultContentSecurityPolicy.data();
+}
+
+/**
+ * webkit_web_view_end_immersive_session:
+ * @web_view: a #WebKitWebView
+ *
+ * Requests the immersive session associated to this #WebKitWebView to end.
+ *
+ * Since: 2.50
+ */
+void
+webkit_web_view_end_immersive_session(WebKitWebView* webView)
+{
+    g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));
+
+#if ENABLE(WEBXR)
+    Ref page = getPage(webView);
+    if (auto xrSystem = page->xrSystem()) {
+        // This asks the xr coordinator to end the session for the page it's invoked on,
+        // going through the sessionDidEnd message
+        xrSystem->invalidate(PlatformXRSystem::InvalidationReason::Client);
+    }
+#endif
 }

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -920,6 +920,9 @@ webkit_web_view_get_theme_color                      (WebKitWebView             
                                                       GdkRGBA                   *rgba);
 #endif
 
+WEBKIT_API void
+webkit_web_view_end_immersive_session                (WebKitWebView             *web_view);
+
 #if USE(GI_FINISH_FUNC_ANNOTATION)
 /**
  * webkit_web_view_run_async_javascript_function_in_world: (finish-func webkit_web_view_run_javascript_in_world_finish)

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
@@ -64,7 +64,7 @@ std::optional<SharedPreferencesForWebProcess> PlatformXRSystem::sharedPreference
     return WebProcessProxy::fromConnection(connection)->sharedPreferencesForWebProcess();
 }
 
-void PlatformXRSystem::invalidate()
+void PlatformXRSystem::invalidate(InvalidationReason reason)
 {
     ASSERT(RunLoop::isMain());
     RefPtr page = m_page.get();
@@ -77,7 +77,7 @@ void PlatformXRSystem::invalidate()
     if (xrCoordinator())
         xrCoordinator()->endSessionIfExists(*page);
 
-    invalidateImmersiveSessionState();
+    invalidateImmersiveSessionState(reason == InvalidationReason::Client ? ImmersiveSessionState::SessionEndingFromSystem : ImmersiveSessionState::Idle);
 }
 
 void PlatformXRSystem::ensureImmersiveSessionActivity()

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
@@ -64,7 +64,11 @@ public:
 
     USING_CAN_MAKE_WEAKPTR(PlatformXRCoordinatorSessionEventClient);
 
-    void invalidate();
+    enum class InvalidationReason : uint8_t {
+        Client,
+        State
+    };
+    void invalidate(InvalidationReason invalidateReason = InvalidationReason::State);
 
     bool hasActiveSession() const { return !!m_immersiveSessionActivity; }
     void ensureImmersiveSessionActivity();

--- a/Tools/MiniBrowser/wpe/main.cpp
+++ b/Tools/MiniBrowser/wpe/main.cpp
@@ -237,6 +237,11 @@ static gboolean wpeViewEventCallback(WPEView* view, WPEEvent* event, WebKitWebVi
         }
     }
 
+    if (keyval == WPE_KEY_Escape) {
+        webkit_web_view_end_immersive_session(webView);
+        return TRUE;
+    }
+
     return FALSE;
 }
 


### PR DESCRIPTION
#### 893ce1bec46e7283563a27396c9cab154770dfbd
<pre>
[GTK][WPE][OpenXR] Add a mechanism to exit an immersive experience
<a href="https://bugs.webkit.org/show_bug.cgi?id=294752">https://bugs.webkit.org/show_bug.cgi?id=294752</a>

Reviewed by Adrian Perez de Castro.

This exposes a mechanism to exit an immersive experience using
PlatformXRSystem::invalidate.

* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp: implement
  webkit_web_view_end_immersive_session by retrieving the XR system, if
any, and invoking invalidate.
* Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in: declare a new
  webkit_web_view_end_immersive_session method.
* Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp:
(WebKit::PlatformXRSystem::invalidate): use a new InvalidationReason to
decide the next state when invoking invalidateImmersiveSessionState.
* Source/WebKit/UIProcess/XR/PlatformXRSystem.h: add a new
  InvalidationReason enum parameter to invalidate.
* Tools/MiniBrowser/wpe/main.cpp: validate the logic by hooking the
  Escape key with ending an immersive session.

Canonical link: <a href="https://commits.webkit.org/298279@main">https://commits.webkit.org/298279@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a9c83c5b565d2c806c528919606edf3d1d108a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114784 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34529 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24993 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120946 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65469 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116673 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35158 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43087 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87241 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42114 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; layout-tests (exception)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117732 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28010 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103070 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67631 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27195 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21192 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64614 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97394 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21306 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124147 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41788 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31217 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96047 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42166 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99260 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95832 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24419 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41014 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18855 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37843 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41669 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47183 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41231 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44546 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42975 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->