### PR TITLE
[JSC] Implement `Intl.Locale.prototype.variants` getter

### DIFF
--- a/JSTests/stress/intl-locale-prototype-variants.js
+++ b/JSTests/stress/intl-locale-prototype-variants.js
@@ -1,0 +1,144 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function shouldThrow(func, expectedError) {
+    let error = null;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+    
+    if (!error)
+        throw new Error('Expected function to throw');
+    
+    if (!(error instanceof expectedError))
+        throw new Error(`Expected ${expectedError.name} but got ${error.constructor.name}`);
+}
+
+let descriptor = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, 'variants');
+shouldBe(typeof descriptor.get, 'function');
+shouldBe(descriptor.set, undefined);
+shouldBe(descriptor.enumerable, false);
+shouldBe(descriptor.configurable, true);
+
+{
+    let locale = new Intl.Locale('en');
+    shouldBe(locale.variants, undefined);
+}
+{
+    let locale = new Intl.Locale('en-1996');
+    shouldBe(locale.variants, '1996');
+}
+{
+    let locale = new Intl.Locale('de-1901-emodeng');
+    shouldBe(locale.variants, '1901-emodeng');
+}
+
+{
+    let locale = new Intl.Locale('en-oxendict-spanglis');
+    shouldBe(locale.variants, 'oxendict-spanglis');
+}
+
+{
+    let locale = new Intl.Locale('de-latn-de-fonipa-1996-u-ca-gregory');
+    shouldBe(locale.variants, '1996-fonipa');
+}
+
+// Test constructor options
+{
+    let locale = new Intl.Locale('en', { variants: 'emodeng' });
+    shouldBe(locale.variants, 'emodeng');
+}
+
+{
+    let locale = new Intl.Locale('en', { variants: 'spanglis-oxendict' });
+    shouldBe(locale.variants, 'oxendict-spanglis');
+}
+
+{
+    let locale = new Intl.Locale('en-1996', { variants: 'emodeng' });
+    shouldBe(locale.variants, 'emodeng');
+}
+
+{
+    let locale = new Intl.Locale('xx', { variants: '1xyz-1234-abcde-12345678' });
+    shouldBe(locale.variants, '1234-12345678-1xyz-abcde');
+}
+
+{
+    let locale = new Intl.Locale('ja', { variants: undefined });
+    shouldBe(locale.variants, undefined);
+}
+
+{
+    // valid variants
+    shouldBe(new Intl.Locale('en', { variants: 'spanglis' }).variants, 'spanglis');
+    shouldBe(new Intl.Locale('en', { variants: '1234' }).variants, '1234');
+    shouldBe(new Intl.Locale('en', { variants: 'abcde' }).variants, 'abcde');
+    shouldBe(new Intl.Locale('en', { variants: '12345678' }).variants, '12345678');
+
+    // invalid variants
+    shouldThrow(() => new Intl.Locale('en', { variants: '' }), RangeError);
+    shouldThrow(() => new Intl.Locale('en', { variants: 'abc' }), RangeError);
+    shouldThrow(() => new Intl.Locale('en', { variants: '123456789' }), RangeError);
+    shouldThrow(() => new Intl.Locale('en', { variants: 'abc@' }), RangeError);
+    shouldThrow(() => new Intl.Locale('en', { variants: 'abc-def' }), RangeError);
+    shouldThrow(() => new Intl.Locale('en', { variants: 'fonipa-fonipa' }), RangeError);
+    shouldThrow(() => new Intl.Locale('en', { variants: 'fonipa-valencia-Fonipa' }), RangeError);
+    shouldThrow(() => new Intl.Locale('en', { variants: '-spanglis' }), RangeError);
+    shouldThrow(() => new Intl.Locale('en', { variants: 'spanglis-' }), RangeError);
+    shouldThrow(() => new Intl.Locale('en', { variants: 'spanglis--oxendict' }), RangeError);
+}
+
+{
+    let locale = new Intl.Locale('en', { variants: 'spanglis-oxendict' });
+    shouldBe(locale.toString(), 'en-oxendict-spanglis');
+    shouldBe(locale.baseName, 'en-oxendict-spanglis');
+    shouldBe(locale.variants, 'oxendict-spanglis'); // Alphabetical order
+}
+
+{
+    let locale = new Intl.Locale('xx', { variants: '1xyz-1234-abcde-12345678' });
+    shouldBe(locale.toString(), 'xx-1234-12345678-1xyz-abcde');
+    shouldBe(locale.baseName, 'xx-1234-12345678-1xyz-abcde');
+    shouldBe(locale.variants, '1234-12345678-1xyz-abcde'); // Canonical order
+}
+
+{
+    let locale = new Intl.Locale('en-spanglis-oxendict');
+    shouldBe(locale.variants, 'oxendict-spanglis');
+}
+
+{
+    let locale = new Intl.Locale('en', { variants: 'EMODENG' });
+    shouldBe(locale.variants, 'emodeng');
+}
+
+{
+    let locale = new Intl.Locale('en', { variants: 'SpAnGlIs-OxEnDiCt' });
+    shouldBe(locale.variants, 'oxendict-spanglis');
+}
+
+{
+    let variantsGetter = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, 'variants').get;
+
+    shouldThrow(() => variantsGetter.call(undefined), TypeError);
+    shouldThrow(() => variantsGetter.call(null), TypeError);
+    shouldThrow(() => variantsGetter.call(true), TypeError);
+    shouldThrow(() => variantsGetter.call('string'), TypeError);
+    shouldThrow(() => variantsGetter.call(123), TypeError);
+    shouldThrow(() => variantsGetter.call({}), TypeError);
+    shouldThrow(() => variantsGetter.call([]), TypeError);
+    shouldThrow(() => variantsGetter.call(Symbol()), TypeError);
+
+    shouldThrow(() => variantsGetter.call(Intl.Locale.prototype), TypeError);
+}
+
+{
+    let variantsGetter = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, 'variants').get;
+    let locale = new Intl.Locale('en-1996');
+    shouldBe(variantsGetter.call(locale), '1996');
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1153,33 +1153,12 @@ test/intl402/Intl/supportedValuesOf/calendars.js:
 test/intl402/Intl/supportedValuesOf/timeZones-include-non-continental.js:
   default: 'Test262Error: non-continental timezone Etc/GMT+1 is not supported'
   strict mode: 'Test262Error: non-continental timezone Etc/GMT+1 is not supported'
-test/intl402/Locale/constructor-getter-order.js:
-  default: 'Test262Error: Actual [tag toString, get language, toString language, get script, toString script, get region, toString region, get calendar, toString calendar, get collation, toString collation, get hourCycle, toString hourCycle, get caseFirst, toString caseFirst, get numeric, get numberingSystem, toString numberingSystem] and expected [tag toString, get language, toString language, get script, toString script, get region, toString region, get variants, toString variants, get calendar, toString calendar, get collation, toString collation, get hourCycle, toString hourCycle, get caseFirst, toString caseFirst, get numeric, get numberingSystem, toString numberingSystem] should have the same contents. '
-  strict mode: 'Test262Error: Actual [tag toString, get language, toString language, get script, toString script, get region, toString region, get calendar, toString calendar, get collation, toString collation, get hourCycle, toString hourCycle, get caseFirst, toString caseFirst, get numeric, get numberingSystem, toString numberingSystem] and expected [tag toString, get language, toString language, get script, toString script, get region, toString region, get variants, toString variants, get calendar, toString calendar, get collation, toString collation, get hourCycle, toString hourCycle, get caseFirst, toString caseFirst, get numeric, get numberingSystem, toString numberingSystem] should have the same contents. '
-test/intl402/Locale/constructor-options-throwing-getters.js:
-  default: 'Test262Error: new Intl.Locale("en", {get variants() {throw new CustomError();}}) throws CustomError Expected a CustomError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: new Intl.Locale("en", {get variants() {throw new CustomError();}}) throws CustomError Expected a CustomError to be thrown but no exception was thrown at all'
-test/intl402/Locale/constructor-options-variants-invalid.js:
-  default: 'Test262Error: new Intl.Locale("en", {variants: ""}) throws RangeError Expected a RangeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: new Intl.Locale("en", {variants: ""}) throws RangeError Expected a RangeError to be thrown but no exception was thrown at all'
-test/intl402/Locale/constructor-options-variants-valid.js:
-  default: 'Test262Error: new Intl.Locale("en", {variants: "spanglis"}).toString() returns "en-spanglis" Expected SameValue(«"en"», «"en-spanglis"») to be true'
-  strict mode: 'Test262Error: new Intl.Locale("en", {variants: "spanglis"}).toString() returns "en-spanglis" Expected SameValue(«"en"», «"en-spanglis"») to be true'
 test/intl402/Locale/extensions-grandfathered.js:
   default: 'Test262Error: Expected SameValue(«"fr-Cyrl-FR-gaulish-u-nu-latn"», «"fr-Cyrl-FR-u-nu-latn"») to be true'
   strict mode: 'Test262Error: Expected SameValue(«"fr-Cyrl-FR-gaulish-u-nu-latn"», «"fr-Cyrl-FR-u-nu-latn"») to be true'
-test/intl402/Locale/getters-missing.js:
-  default: 'Test262Error: Expected SameValue(«undefined», «"1901"») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«undefined», «"1901"») to be true'
 test/intl402/Locale/getters.js:
-  default: 'Test262Error: Expected SameValue(«undefined», «"1996-fonipa"») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«undefined», «"1996-fonipa"») to be true'
-test/intl402/Locale/prototype/variants/name.js:
-  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(Intl.Locale.prototype, \"variants\").get')"
-  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(Intl.Locale.prototype, \"variants\").get')"
-test/intl402/Locale/prototype/variants/prop-desc.js:
-  default: "TypeError: undefined is not an object (evaluating 'propdesc.set')"
-  strict mode: "TypeError: undefined is not an object (evaluating 'propdesc.set')"
+  default: 'Test262Error: Expected SameValue(«undefined», «"und"») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «"und"») to be true'
 test/intl402/NumberFormat/currency-digits-nonstandard-notation.js:
   default: "Test262Error: Didn't get correct maximumFractionDigits for JPY in engineering notation. Expected SameValue(«0», «3») to be true"
   strict mode: "Test262Error: Didn't get correct maximumFractionDigits for JPY in engineering notation. Expected SameValue(«0», «3») to be true"

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.h
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.h
@@ -248,6 +248,7 @@
     macro(read) \
     macro(region) \
     macro(replace) \
+    macro(variants) \
     macro(resizable) \
     macro(resize) \
     macro(resolve) \

--- a/Source/JavaScriptCore/runtime/IntlLocale.h
+++ b/Source/JavaScriptCore/runtime/IntlLocale.h
@@ -61,6 +61,7 @@ public:
     const String& language();
     const String& script();
     const String& region();
+    const String& variants();
 
     const String& calendar();
     const String& caseFirst();
@@ -94,6 +95,7 @@ private:
     String m_language;
     String m_script;
     String m_region;
+    String m_variants;
     std::optional<String> m_calendar;
     std::optional<String> m_caseFirst;
     std::optional<String> m_collation;

--- a/Source/JavaScriptCore/runtime/IntlLocalePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlLocalePrototype.cpp
@@ -54,6 +54,7 @@ static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterNumberingSystem);
 static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterLanguage);
 static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterScript);
 static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterRegion);
+static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterVariants);
 
 }
 
@@ -86,6 +87,7 @@ const ClassInfo IntlLocalePrototype::s_info = { "Intl.Locale"_s, &Base::s_info, 
   language            intlLocalePrototypeGetterLanguage          DontEnum|ReadOnly|CustomAccessor
   script              intlLocalePrototypeGetterScript            DontEnum|ReadOnly|CustomAccessor
   region              intlLocalePrototypeGetterRegion            DontEnum|ReadOnly|CustomAccessor
+  variants            intlLocalePrototypeGetterVariants          DontEnum|ReadOnly|CustomAccessor
 @end
 */
 
@@ -362,6 +364,20 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterRegion, (JSGlobalObject* globa
 
     const String& region = locale->region();
     RELEASE_AND_RETURN(scope, JSValue::encode(region.isEmpty() ? jsUndefined() : jsString(vm, region)));
+}
+
+// https://tc39.es/ecma402/#sec-Intl.Locale.prototype.variants
+JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterVariants, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
+    if (!locale) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.variants called on value that's not a Locale"_s);
+
+    const String& variants = locale->variants();
+    RELEASE_AND_RETURN(scope, JSValue::encode(variants.isEmpty() ? jsUndefined() : jsString(vm, variants)));
 }
 
 // https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getTimezones


### PR DESCRIPTION
#### b8b32fe6a3c5cdaf94eab51e0dfef07620ac170e
<pre>
[JSC] Implement `Intl.Locale.prototype.variants` getter
<a href="https://bugs.webkit.org/show_bug.cgi?id=294755">https://bugs.webkit.org/show_bug.cgi?id=294755</a>

Reviewed by Yusuke Suzuki.

<a href="https://github.com/tc39/ecma402/pull/960">https://github.com/tc39/ecma402/pull/960</a> added `Intl.Locale.prototype.variants`
to the ECMAScript specification. The test262 test suite has also been updated [1].

This patch implements `Intl.Locale.prototype.variants` for JSC.

[1]: <a href="https://github.com/tc39/test262/pull/4474">https://github.com/tc39/test262/pull/4474</a>

* JSTests/stress/intl-locale-prototype-variants.js: Added.
(shouldBe):
(shouldThrow):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/CommonIdentifiers.h:
* Source/JavaScriptCore/runtime/IntlLocale.cpp:
(JSC::LocaleIDBuilder::overrideLanguageScriptRegionVariants):
(JSC::IntlLocale::initializeLocale):
(JSC::IntlLocale::variants):
(JSC::LocaleIDBuilder::overrideLanguageScriptRegion): Deleted.
* Source/JavaScriptCore/runtime/IntlLocale.h:
* Source/JavaScriptCore/runtime/IntlLocalePrototype.cpp:
(JSC::JSC_DEFINE_CUSTOM_GETTER):

Canonical link: <a href="https://commits.webkit.org/296467@main">https://commits.webkit.org/296467@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6bde4d8ffd39d005fe6fbdfd79e7c5f89db0e2e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108571 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113780 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58967 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28921 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36786 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82470 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111519 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22955 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97795 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62906 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22374 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15934 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58494 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/101128 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92325 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15985 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116900 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/107130 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35625 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26264 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91490 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35998 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94066 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91291 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23267 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36183 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13949 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31388 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35527 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41062 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/131412 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35239 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35648 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38587 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36916 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->