### PR TITLE
Stop using UncheckedKey containers in WebCore/layout

### DIFF
--- a/Source/WebCore/layout/FormattingState.h
+++ b/Source/WebCore/layout/FormattingState.h
@@ -62,7 +62,7 @@ protected:
 
 private:
     LayoutState& m_layoutState;
-    UncheckedKeyHashMap<const Box*, IntrinsicWidthConstraints> m_intrinsicWidthConstraintsForBoxes;
+    HashMap<const Box*, IntrinsicWidthConstraints> m_intrinsicWidthConstraintsForBoxes;
     std::optional<IntrinsicWidthConstraints> m_intrinsicWidthConstraints;
     Type m_type;
 };

--- a/Source/WebCore/layout/LayoutState.h
+++ b/Source/WebCore/layout/LayoutState.h
@@ -122,15 +122,15 @@ private:
 
     const Type m_type;
 
-    UncheckedKeyHashMap<const ElementBox*, std::unique_ptr<InlineContentCache>> m_inlineContentCaches;
+    HashMap<const ElementBox*, std::unique_ptr<InlineContentCache>> m_inlineContentCaches;
 
-    UncheckedKeyHashMap<const ElementBox*, std::unique_ptr<BlockFormattingState>> m_blockFormattingStates;
-    UncheckedKeyHashMap<const ElementBox*, std::unique_ptr<TableFormattingState>> m_tableFormattingStates;
+    HashMap<const ElementBox*, std::unique_ptr<BlockFormattingState>> m_blockFormattingStates;
+    HashMap<const ElementBox*, std::unique_ptr<TableFormattingState>> m_tableFormattingStates;
 
 #ifndef NDEBUG
-    UncheckedKeyHashSet<const FormattingContext*> m_formattingContextList;
+    HashSet<const FormattingContext*> m_formattingContextList;
 #endif
-    UncheckedKeyHashMap<const Box*, std::unique_ptr<BoxGeometry>> m_layoutBoxToBoxGeometry;
+    HashMap<const Box*, std::unique_ptr<BoxGeometry>> m_layoutBoxToBoxGeometry;
     QuirksMode m_quirksMode { QuirksMode::No };
 
     const CheckedRef<const ElementBox> m_rootContainer;

--- a/Source/WebCore/layout/formattingContexts/block/BlockFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/block/BlockFormattingContext.h
@@ -97,7 +97,7 @@ protected:
 
 private:
 #if ASSERT_ENABLED
-    UncheckedKeyHashMap<const ElementBox*, PrecomputedMarginBefore> m_precomputedMarginBeforeList;
+    HashMap<const ElementBox*, PrecomputedMarginBefore> m_precomputedMarginBeforeList;
 #endif
     BlockFormattingState& m_blockFormattingState;
     const BlockFormattingGeometry m_blockFormattingGeometry;

--- a/Source/WebCore/layout/formattingContexts/block/BlockFormattingState.h
+++ b/Source/WebCore/layout/formattingContexts/block/BlockFormattingState.h
@@ -62,8 +62,8 @@ public:
 private:
     PlacedFloats m_placedFloats;
     OutOfFlowBoxList m_outOfFlowBoxes;
-    UncheckedKeyHashMap<CheckedRef<const Box>, UsedVerticalMargin> m_usedVerticalMargins;
-    UncheckedKeyHashSet<CheckedRef<const Box>> m_clearanceSet;
+    HashMap<CheckedRef<const Box>, UsedVerticalMargin> m_usedVerticalMargins;
+    HashSet<CheckedRef<const Box>> m_clearanceSet;
 };
 
 }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentAligner.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentAligner.cpp
@@ -73,7 +73,7 @@ struct InlineBoxIndexAndExpansion {
     size_t index { 0 };
     InlineLayoutUnit expansion { 0.f };
 };
-static InlineBoxIndexAndExpansion expandInlineBoxWithDescendants(size_t inlineBoxIndex, InlineDisplay::Boxes& displayBoxes, const UncheckedKeyHashMap<const Box*, InlineLayoutUnit>& alignmentOffsetList,  InlineFormattingContext& inlineFormattingContext)
+static InlineBoxIndexAndExpansion expandInlineBoxWithDescendants(size_t inlineBoxIndex, InlineDisplay::Boxes& displayBoxes, const HashMap<const Box*, InlineLayoutUnit>& alignmentOffsetList,  InlineFormattingContext& inlineFormattingContext)
 {
     if (inlineBoxIndex >= displayBoxes.size() || !displayBoxes[inlineBoxIndex].isInlineBox()) {
         ASSERT_NOT_REACHED();
@@ -103,7 +103,7 @@ struct BaseIndexAndOffset {
     size_t index { 0 };
     InlineLayoutUnit offset { 0.f };
 };
-static BaseIndexAndOffset shiftRubyBaseContentByAlignmentOffset(BaseIndexAndOffset baseIndexAndOffset, InlineDisplay::Boxes& displayBoxes, const UncheckedKeyHashMap<const Box*, InlineLayoutUnit>& alignmentOffsetList, InlineContentAligner::AdjustContentOnlyInsideRubyBase adjustContentOnlyInsideRubyBase, InlineFormattingContext& inlineFormattingContext)
+static BaseIndexAndOffset shiftRubyBaseContentByAlignmentOffset(BaseIndexAndOffset baseIndexAndOffset, InlineDisplay::Boxes& displayBoxes, const HashMap<const Box*, InlineLayoutUnit>& alignmentOffsetList, InlineContentAligner::AdjustContentOnlyInsideRubyBase adjustContentOnlyInsideRubyBase, InlineFormattingContext& inlineFormattingContext)
 {
     auto baseIndex = baseIndexAndOffset.index;
     if (baseIndex >= displayBoxes.size() || !displayBoxes[baseIndex].layoutBox().isRubyBase()) {
@@ -342,7 +342,7 @@ InlineLayoutUnit InlineContentAligner::applyRubyAlign(RubyAlign rubyAlign, Line:
     }
 }
 
-void InlineContentAligner::applyRubyBaseAlignmentOffset(InlineDisplay::Boxes& displayBoxes, const UncheckedKeyHashMap<const Box*, InlineLayoutUnit>& alignmentOffsetList, AdjustContentOnlyInsideRubyBase adjustContentOnlyInsideRubyBase, InlineFormattingContext& inlineFormattingContext)
+void InlineContentAligner::applyRubyBaseAlignmentOffset(InlineDisplay::Boxes& displayBoxes, const HashMap<const Box*, InlineLayoutUnit>& alignmentOffsetList, AdjustContentOnlyInsideRubyBase adjustContentOnlyInsideRubyBase, InlineFormattingContext& inlineFormattingContext)
 {
     ASSERT(!alignmentOffsetList.isEmpty());
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentAligner.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentAligner.h
@@ -39,7 +39,7 @@ public:
     static InlineLayoutUnit applyRubyAlign(RubyAlign, Line::RunList&, WTF::Range<size_t>, InlineLayoutUnit spaceToDistribute);
 
     enum class AdjustContentOnlyInsideRubyBase : bool { No, Yes };
-    static void applyRubyBaseAlignmentOffset(InlineDisplay::Boxes&, const UncheckedKeyHashMap<const Box*, InlineLayoutUnit>& alignmentOffsetList, AdjustContentOnlyInsideRubyBase, InlineFormattingContext&);
+    static void applyRubyBaseAlignmentOffset(InlineDisplay::Boxes&, const HashMap<const Box*, InlineLayoutUnit>& alignmentOffsetList, AdjustContentOnlyInsideRubyBase, InlineFormattingContext&);
     static void applyRubyAnnotationAlignmentOffset(InlineDisplay::Boxes&, InlineLayoutUnit alignmentOffset, InlineFormattingContext&);
 
 private:

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
@@ -386,7 +386,7 @@ static inline const ElementBox& nearestCommonAncestor(const Box& first, const Bo
     if (&firstParent != &rootBox && &secondParent != &rootBox && &firstParent.parent() == &secondParent.parent())
         return firstParent.parent();
 
-    UncheckedKeyHashSet<const ElementBox*> descendantsSet;
+    HashSet<const ElementBox*> descendantsSet;
     for (auto* descendant = &firstParent; descendant != &rootBox; descendant = &descendant->parent())
         descendantsSet.add(descendant);
     for (auto* descendant = &secondParent; descendant != &rootBox; descendant = &descendant->parent()) {

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
@@ -113,7 +113,7 @@ void InlineItemsBuilder::build(InlineItemPosition startPosition)
     // Check if we've got matching inline box start/end pairs and unique inline level items (non-text, non-inline box items).
     size_t inlineBoxStart = 0;
     size_t inlineBoxEnd = 0;
-    auto inlineLevelItems = UncheckedKeyHashSet<const Box*> { };
+    auto inlineLevelItems = HashSet<const Box*> { };
     for (auto& inlineItem : inlineContentCache().inlineItems().content()) {
         if (inlineItem.isInlineBoxStart())
             ++inlineBoxStart;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLayoutState.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLayoutState.h
@@ -65,7 +65,7 @@ public:
     bool inStandardsMode() const { return m_inStandardsMode; }
 
     // Integration codepath
-    void setNestedListMarkerOffsets(UncheckedKeyHashMap<const ElementBox*, LayoutUnit>&& nestedListMarkerOffsets) { m_nestedListMarkerOffsets = WTFMove(nestedListMarkerOffsets); }
+    void setNestedListMarkerOffsets(HashMap<const ElementBox*, LayoutUnit>&& nestedListMarkerOffsets) { m_nestedListMarkerOffsets = WTFMove(nestedListMarkerOffsets); }
     LayoutUnit nestedListMarkerOffset(const ElementBox& listMarkerBox) const { return m_nestedListMarkerOffsets.get(&listMarkerBox); }
     void setShouldNotSynthesizeInlineBlockBaseline() { m_shouldNotSynthesizeInlineBlockBaseline = true; }
     bool shouldNotSynthesizeInlineBlockBaseline() const { return m_shouldNotSynthesizeInlineBlockBaseline; }
@@ -79,7 +79,7 @@ private:
     std::optional<size_t> m_hyphenationLimitLines { };
     size_t m_successiveHyphenatedLineCount { 0 };
     // FIXME: This is required by the integaration codepath.
-    UncheckedKeyHashMap<const ElementBox*, LayoutUnit> m_nestedListMarkerOffsets;
+    HashMap<const ElementBox*, LayoutUnit> m_nestedListMarkerOffsets;
     AvailableLineWidthOverride m_availableLineWidthOverride;
     bool m_shouldNotSynthesizeInlineBlockBaseline { false };
     bool m_inStandardsMode { false };

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBox.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBox.h
@@ -123,7 +123,7 @@ private:
     InlineLevelBox m_rootInlineBox;
     InlineLevelBoxList m_nonRootInlineLevelBoxList;
 
-    UncheckedKeyHashMap<const Box*, size_t> m_nonRootInlineLevelBoxMap;
+    HashMap<const Box*, size_t> m_nonRootInlineLevelBoxMap;
 };
 
 inline InlineLevelBox* LineBox::inlineLevelBoxFor(const Box& layoutBox)

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
@@ -508,7 +508,7 @@ void LineBoxBuilder::adjustInlineBoxHeightsForLineBoxContainIfApplicable(LineBox
     // font and Glyphs values affect the "size" of the associated inline boxes (which then affect the line box height).
     auto lineBoxContain = rootBox().style().lineBoxContain();
     // Collect layout bounds based on the contain property and set them on the inline boxes when they are applicable.
-    UncheckedKeyHashMap<InlineLevelBox*, TextUtil::EnclosingAscentDescent> inlineBoxBoundsMap;
+    HashMap<InlineLevelBox*, TextUtil::EnclosingAscentDescent> inlineBoxBoundsMap;
 
     if (lineBoxContain.contains(Style::LineBoxContain::InlineBox)) {
         for (auto& inlineLevelBox : lineBox.nonRootInlineLevelBoxes()) {

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.h
@@ -73,7 +73,7 @@ private:
     LineLayoutResult& m_lineLayoutResult;
     bool m_fallbackFontRequiresIdeographicBaseline { false };
     bool m_lineHasNonLineSpanningRubyContent { false };
-    UncheckedKeyHashMap<const InlineLevelBox*, TextUtil::FallbackFontList> m_fallbackFontsForInlineBoxes;
+    HashMap<const InlineLevelBox*, TextUtil::FallbackFontList> m_fallbackFontsForInlineBoxes;
     Vector<size_t> m_outsideListMarkers;
 };
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxVerticalAligner.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxVerticalAligner.cpp
@@ -183,7 +183,7 @@ LineBoxVerticalAligner::LineBoxAlignmentContent LineBoxVerticalAligner::computeL
         InlineLayoutUnit top { 0 };
         InlineLayoutUnit bottom { 0 };
     };
-    UncheckedKeyHashMap<const InlineLevelBox*, AbsoluteTopAndBottom> inlineLevelBoxAbsoluteTopAndBottomMap;
+    HashMap<const InlineLevelBox*, AbsoluteTopAndBottom> inlineLevelBoxAbsoluteTopAndBottomMap;
 
     auto minimumLogicalTop = std::optional<InlineLayoutUnit> { };
     auto maximumLogicalBottom = std::optional<InlineLayoutUnit> { };
@@ -248,7 +248,7 @@ void LineBoxVerticalAligner::computeRootInlineBoxVerticalPosition(LineBox& lineB
     auto& formattingUtils = this->formattingUtils();
     auto hasTopAlignedInlineLevelBox = false;
 
-    UncheckedKeyHashMap<const InlineLevelBox*, InlineLayoutUnit> inlineLevelBoxAbsoluteBaselineOffsetMap;
+    HashMap<const InlineLevelBox*, InlineLayoutUnit> inlineLevelBoxAbsoluteBaselineOffsetMap;
     inlineLevelBoxAbsoluteBaselineOffsetMap.add(&rootInlineBox, InlineLayoutUnit { });
 
     auto maximumTopOffsetFromRootInlineBoxBaseline = std::optional<InlineLayoutUnit> { };

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -50,7 +50,7 @@ struct LineContent {
     bool endsWithHyphen { false };
     size_t partialTrailingContentLength { 0 };
     std::optional<InlineLayoutUnit> overflowLogicalWidth { };
-    UncheckedKeyHashMap<const Box*, InlineLayoutUnit> rubyBaseAlignmentOffsetList { };
+    HashMap<const Box*, InlineLayoutUnit> rubyBaseAlignmentOffsetList { };
     InlineLayoutUnit rubyAnnotationOffset { 0.f };
 };
 
@@ -1090,7 +1090,7 @@ InlineLayoutUnit LineBuilder::placedClonedDecorationWidth(const InlineContentBre
     // At [4</span></span>] all inline boxes are closed.
     auto& formattingContext = this->formattingContext();
 
-    UncheckedKeyHashSet<const Box*> clonedInlineBoxes;
+    HashSet<const Box*> clonedInlineBoxes;
     auto clonedDecorationEndWidth = InlineLayoutUnit { };
     for (auto* box : m_line.inlineBoxListWithClonedDecorationEnd()) {
         clonedDecorationEndWidth += formattingContext.geometryForBox(*box).borderAndPaddingEnd();

--- a/Source/WebCore/layout/formattingContexts/inline/LineLayoutResult.h
+++ b/Source/WebCore/layout/formattingContexts/inline/LineLayoutResult.h
@@ -88,7 +88,7 @@ struct LineLayoutResult {
     IsFirstLast isFirstLast { };
 
     struct Ruby {
-        UncheckedKeyHashMap<const Box*, InlineLayoutUnit> baseAlignmentOffsetList { };
+        HashMap<const Box*, InlineLayoutUnit> baseAlignmentOffsetList { };
         InlineLayoutUnit annotationAlignmentOffset { 0.f };
     };
     Ruby ruby { };

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
@@ -603,7 +603,7 @@ struct IsFirstLastIndex {
     std::optional<size_t> first;
     std::optional<size_t> last;
 };
-using IsFirstLastIndexesMap = UncheckedKeyHashMap<const Box*, IsFirstLastIndex>;
+using IsFirstLastIndexesMap = HashMap<const Box*, IsFirstLastIndex>;
 void InlineDisplayContentBuilder::adjustVisualGeometryForDisplayBox(size_t displayBoxNodeIndex, InlineLayoutUnit& contentLineRightEdge, InlineLayoutUnit lineBoxLogicalTop, const DisplayBoxTree& displayBoxTree, InlineDisplay::Boxes& boxes, const IsFirstLastIndexesMap& isFirstLastIndexesMap)
 {
     auto rootWritingMode = root().writingMode();
@@ -1168,7 +1168,7 @@ void InlineDisplayContentBuilder::processRubyContent(InlineDisplay::Boxes& displ
     if (!m_hasSeenRubyBase)
         return;
 
-    UncheckedKeyHashSet<CheckedPtr<const Box>> lineSpanningRubyBaseList;
+    HashSet<CheckedPtr<const Box>> lineSpanningRubyBaseList;
     for (auto& lineRun : lineLayoutResult.inlineContent) {
         if (lineRun.isLineSpanningInlineBoxStart() && lineRun.layoutBox().isRubyBase())
             lineSpanningRubyBaseList.add(&lineRun.layoutBox());

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.h
@@ -67,7 +67,7 @@ private:
     inline InlineRect mapInlineRectLogicalToVisual(const InlineRect& logicalRect, const InlineRect& containerLogicalRect, WritingMode);
 
     void setInlineBoxGeometry(const Box& inlineBox, Layout::BoxGeometry&, const InlineRect&, bool isFirstInlineBoxFragment);
-    void adjustVisualGeometryForDisplayBox(size_t displayBoxNodeIndex, InlineLayoutUnit& accumulatedOffset, InlineLayoutUnit lineBoxLogicalTop, const DisplayBoxTree&, InlineDisplay::Boxes&, const UncheckedKeyHashMap<const Box*, IsFirstLastIndex>&);
+    void adjustVisualGeometryForDisplayBox(size_t displayBoxNodeIndex, InlineLayoutUnit& accumulatedOffset, InlineLayoutUnit lineBoxLogicalTop, const DisplayBoxTree&, InlineDisplay::Boxes&, const HashMap<const Box*, IsFirstLastIndex>&);
     size_t ensureDisplayBoxForContainer(const ElementBox&, DisplayBoxTree&, AncestorStack&, InlineDisplay::Boxes&);
 
     template <typename BoxType, typename LayoutUnitType>

--- a/Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.cpp
@@ -138,7 +138,7 @@ InlineLayoutUnit RubyFormattingContext::baseEndAdditionalLogicalWidth(const Box&
     return annotationBoxLogicalWidth(rubyBaseLayoutBox, inlineFormattingContext);
 }
 
-size_t RubyFormattingContext::applyRubyAlignOnBaseContent(size_t rubyBaseStart, Line& line, UncheckedKeyHashMap<const Box*, InlineLayoutUnit>& alignmentOffsetList, InlineFormattingContext& inlineFormattingContext)
+size_t RubyFormattingContext::applyRubyAlignOnBaseContent(size_t rubyBaseStart, Line& line, HashMap<const Box*, InlineLayoutUnit>& alignmentOffsetList, InlineFormattingContext& inlineFormattingContext)
 {
     auto& runs = line.runs();
     if (runs.isEmpty()) {
@@ -184,9 +184,9 @@ size_t RubyFormattingContext::applyRubyAlignOnBaseContent(size_t rubyBaseStart, 
     return rubyBaseEnd.value_or(runs.size());
 }
 
-UncheckedKeyHashMap<const Box*, InlineLayoutUnit> RubyFormattingContext::applyRubyAlign(Line& line, InlineFormattingContext& inlineFormattingContext)
+HashMap<const Box*, InlineLayoutUnit> RubyFormattingContext::applyRubyAlign(Line& line, InlineFormattingContext& inlineFormattingContext)
 {
-    UncheckedKeyHashMap<const Box*, InlineLayoutUnit> alignmentOffsetList;
+    HashMap<const Box*, InlineLayoutUnit> alignmentOffsetList;
     // https://drafts.csswg.org/css-ruby/#interlinear-inline
     // Within each base and annotation box, how the extra space is distributed when its content is narrower than
     // the measure of the box is specified by its ruby-align property.
@@ -204,7 +204,7 @@ InlineLayoutUnit RubyFormattingContext::applyRubyAlignOnAnnotationBox(Line& line
     return InlineContentAligner::applyRubyAlign(inlineFormattingContext.root().style().rubyAlign(), line.runs(), { 0, line.runs().size() }, spaceToDistribute);
 }
 
-void RubyFormattingContext::applyAlignmentOffsetList(InlineDisplay::Boxes& displayBoxes, const UncheckedKeyHashMap<const Box*, InlineLayoutUnit>& alignmentOffsetList, RubyBasesMayNeedResizing rubyBasesMayNeedResizing, InlineFormattingContext& inlineFormattingContext)
+void RubyFormattingContext::applyAlignmentOffsetList(InlineDisplay::Boxes& displayBoxes, const HashMap<const Box*, InlineLayoutUnit>& alignmentOffsetList, RubyBasesMayNeedResizing rubyBasesMayNeedResizing, InlineFormattingContext& inlineFormattingContext)
 {
     if (alignmentOffsetList.isEmpty())
         return;

--- a/Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.h
@@ -43,7 +43,7 @@ public:
     // Line building
     static InlineLayoutUnit annotationBoxLogicalWidth(const Box& rubyBaseLayoutBox, InlineFormattingContext&);
     static InlineLayoutUnit baseEndAdditionalLogicalWidth(const Box& rubyBaseLayoutBox, const Line::RunList&, const InlineContentBreaker::ContinuousContent::RunList&, InlineFormattingContext&);
-    static UncheckedKeyHashMap<const Box*, InlineLayoutUnit> applyRubyAlign(Line&, InlineFormattingContext&);
+    static HashMap<const Box*, InlineLayoutUnit> applyRubyAlign(Line&, InlineFormattingContext&);
     static InlineLayoutUnit applyRubyAlignOnAnnotationBox(Line&, InlineLayoutUnit spaceToDistribute, InlineFormattingContext&);
 
     // Line box building
@@ -57,7 +57,7 @@ public:
     static void applyRubyOverhang(InlineFormattingContext& parentFormattingContext, InlineLayoutUnit lineLogicalHeight, InlineDisplay::Boxes&, const Vector<WTF::Range<size_t>>& interlinearRubyColumnRangeList);
 
     enum class RubyBasesMayNeedResizing : bool { No, Yes };
-    static void applyAlignmentOffsetList(InlineDisplay::Boxes&, const UncheckedKeyHashMap<const Box*, InlineLayoutUnit>& alignmentOffsetList, RubyBasesMayNeedResizing, InlineFormattingContext&);
+    static void applyAlignmentOffsetList(InlineDisplay::Boxes&, const HashMap<const Box*, InlineLayoutUnit>& alignmentOffsetList, RubyBasesMayNeedResizing, InlineFormattingContext&);
     static void applyAnnotationAlignmentOffset(InlineDisplay::Boxes&, InlineLayoutUnit alignmentOffset, InlineFormattingContext&);
 
     // Miscellaneous helpers
@@ -65,10 +65,10 @@ public:
     static bool hasInterCharacterAnnotation(const Box& rubyBaseLayoutBox);
 
 private:
-    using MaximumLayoutBoundsStretchMap = UncheckedKeyHashMap<const InlineLevelBox*, InlineLevelBox::AscentAndDescent>;
+    using MaximumLayoutBoundsStretchMap = HashMap<const InlineLevelBox*, InlineLevelBox::AscentAndDescent>;
     static void adjustLayoutBoundsAndStretchAncestorRubyBase(LineBox&, InlineLevelBox& rubyBaseInlineBox, MaximumLayoutBoundsStretchMap&, const InlineFormattingContext&);
 
-    static size_t applyRubyAlignOnBaseContent(size_t rubyBaseStart, Line&, UncheckedKeyHashMap<const Box*, InlineLayoutUnit>& alignmentOffsetList, InlineFormattingContext&);
+    static size_t applyRubyAlignOnBaseContent(size_t rubyBaseStart, Line&, HashMap<const Box*, InlineLayoutUnit>& alignmentOffsetList, InlineFormattingContext&);
     static InlineLayoutUnit overhangForAnnotationBefore(const Box& rubyBaseLayoutBox, size_t rubyBaseStart, const InlineDisplay::Boxes&, InlineLayoutUnit lineLogicalHeight, InlineFormattingContext&);
     static InlineLayoutUnit overhangForAnnotationAfter(const Box& rubyBaseLayoutBox, WTF::Range<size_t> rubyBaseRange, const InlineDisplay::Boxes&, InlineLayoutUnit lineLogicalHeight, InlineFormattingContext&);
 };

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextBreakingPositionCache.h
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextBreakingPositionCache.h
@@ -56,7 +56,7 @@ private:
     void evict();
 
 private:
-    using TextBreakingPositionMap = UncheckedKeyHashMap<Key, List>;
+    using TextBreakingPositionMap = HashMap<Key, List>;
     TextBreakingPositionMap m_breakingPositionMap;
     size_t m_cachedContentSize { 0 };
     Timer m_delayedEvictionTimer;

--- a/Source/WebCore/layout/formattingContexts/table/TableGrid.h
+++ b/Source/WebCore/layout/formattingContexts/table/TableGrid.h
@@ -225,7 +225,7 @@ public:
     bool isSpanned(SlotPosition);
 
 private:
-    using SlotMap = UncheckedKeyHashMap<SlotPosition, std::unique_ptr<Slot>>;
+    using SlotMap = HashMap<SlotPosition, std::unique_ptr<Slot>>;
 
     Columns m_columns;
     Rows m_rows;

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.h
@@ -55,7 +55,7 @@ public:
 
     Layout::ConstraintsForInlineContent formattingContextConstraints(LayoutUnit availableWidth);
 
-    UncheckedKeyHashMap<const Layout::ElementBox*, LayoutUnit> takeNestedListMarkerOffsets() { return WTFMove(m_nestedListMarkerOffsets); }
+    HashMap<const Layout::ElementBox*, LayoutUnit> takeNestedListMarkerOffsets() { return WTFMove(m_nestedListMarkerOffsets); }
 
 private:
     void updateBoxGeometry(const RenderElement&, std::optional<LayoutUnit> availableWidth, std::optional<Layout::IntrinsicWidthMode>);
@@ -79,7 +79,7 @@ private:
 private:
     WeakPtr<Layout::LayoutState> m_layoutState;
     CheckedPtr<const Layout::ElementBox> m_rootLayoutBox;
-    UncheckedKeyHashMap<const Layout::ElementBox*, LayoutUnit> m_nestedListMarkerOffsets;
+    HashMap<const Layout::ElementBox*, LayoutUnit> m_nestedListMarkerOffsets;
 };
 
 }

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h
@@ -112,10 +112,10 @@ private:
     CheckedRef<const RenderBlockFlow> m_formattingContextRoot;
 
     InlineDisplay::Content m_displayContent;
-    using FirstBoxIndexCache = UncheckedKeyHashMap<CheckedRef<const Layout::Box>, size_t>;
+    using FirstBoxIndexCache = HashMap<CheckedRef<const Layout::Box>, size_t>;
     mutable std::unique_ptr<FirstBoxIndexCache> m_firstBoxIndexCache;
 
-    using InlineBoxIndexCache = UncheckedKeyHashMap<CheckedRef<const Layout::Box>, Vector<size_t>>;
+    using InlineBoxIndexCache = HashMap<CheckedRef<const Layout::Box>, Vector<size_t>>;
     mutable std::unique_ptr<InlineBoxIndexCache> m_inlineBoxIndexCache;
     FloatRect m_scrollableOverflow;
     FloatRect m_inkOverflow;

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
@@ -237,7 +237,7 @@ void InlineContentBuilder::computeIsFirstIsLastBoxAndBidiReorderingForInlineCont
         return;
     }
 
-    UncheckedKeyHashMap<const Layout::Box*, size_t> lastDisplayBoxForLayoutBoxIndexes;
+    HashMap<const Layout::Box*, size_t> lastDisplayBoxForLayoutBoxIndexes;
     lastDisplayBoxForLayoutBoxIndexes.reserveInitialCapacity(boxes.size() - 1);
 
     ASSERT(boxes[0].isRootInlineBox());

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -589,7 +589,7 @@ void LineLayout::updateRenderTreePositions(const Vector<LineAdjustment>& lineAdj
         }
     }
 
-    UncheckedKeyHashMap<CheckedRef<const Layout::Box>, LayoutSize> floatPaginationOffsetMap;
+    HashMap<CheckedRef<const Layout::Box>, LayoutSize> floatPaginationOffsetMap;
     if (!lineAdjustments.isEmpty()) {
         for (auto& floatItem : m_blockFormattingState.placedFloats().list()) {
             if (!floatItem.layoutBox() || !floatItem.placedByLine())

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.cpp
@@ -56,7 +56,7 @@ std::pair<Vector<LineAdjustment>, std::optional<LayoutRestartLine>> computeAdjus
     auto lineCount = inlineContent.displayContent().lines.size();
     Vector<LineAdjustment> adjustments { lineCount };
 
-    UncheckedKeyHashMap<size_t, LayoutUnit, DefaultHash<size_t>, WTF::UnsignedWithZeroKeyHashTraits<size_t>>  lineFloatBottomMap;
+    HashMap<size_t, LayoutUnit, DefaultHash<size_t>, WTF::UnsignedWithZeroKeyHashTraits<size_t>>  lineFloatBottomMap;
     for (auto& floatBox : placedFloats.list()) {
         if (!floatBox.layoutBox())
             continue;

--- a/Source/WebCore/layout/layouttree/LayoutBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutBox.h
@@ -231,7 +231,7 @@ private:
     
     OptionSet<BaseTypeFlag> baseTypeFlags() const { return OptionSet<BaseTypeFlag>::fromRaw(m_baseTypeFlags); }
 
-    typedef UncheckedKeyHashMap<const Box*, std::unique_ptr<BoxRareData>> RareDataMap;
+    typedef HashMap<const Box*, std::unique_ptr<BoxRareData>> RareDataMap;
 
     static RareDataMap& rareDataMap();
 


### PR DESCRIPTION
#### 3756dd8e1a2d41306ed5f27062d36ffbc4963236
<pre>
Stop using UncheckedKey containers in WebCore/layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=294761">https://bugs.webkit.org/show_bug.cgi?id=294761</a>

Reviewed by Alan Baradlay.

This tested as performance neutral on Speedometer and PLT.

* Source/WebCore/layout/FormattingState.h:
* Source/WebCore/layout/LayoutState.h:
* Source/WebCore/layout/formattingContexts/block/BlockFormattingContext.h:
* Source/WebCore/layout/formattingContexts/block/BlockFormattingState.h:
* Source/WebCore/layout/formattingContexts/inline/InlineContentAligner.cpp:
(WebCore::Layout::expandInlineBoxWithDescendants):
(WebCore::Layout::shiftRubyBaseContentByAlignmentOffset):
(WebCore::Layout::InlineContentAligner::applyRubyBaseAlignmentOffset):
* Source/WebCore/layout/formattingContexts/inline/InlineContentAligner.h:
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp:
(WebCore::Layout::nearestCommonAncestor):
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::InlineItemsBuilder::build):
* Source/WebCore/layout/formattingContexts/inline/InlineLayoutState.h:
(WebCore::Layout::InlineLayoutState::setNestedListMarkerOffsets):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBox.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp:
(WebCore::Layout::LineBoxBuilder::adjustInlineBoxHeightsForLineBoxContainIfApplicable):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxVerticalAligner.cpp:
(WebCore::Layout::LineBoxVerticalAligner::computeLineBoxLogicalHeight const):
(WebCore::Layout::LineBoxVerticalAligner::computeRootInlineBoxVerticalPosition const):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
(WebCore::Layout::LineBuilder::placedClonedDecorationWidth const):
* Source/WebCore/layout/formattingContexts/inline/LineLayoutResult.h:
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
(WebCore::Layout::InlineDisplayContentBuilder::processRubyContent):
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.h:
* Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.cpp:
(WebCore::Layout::RubyFormattingContext::applyRubyAlignOnBaseContent):
(WebCore::Layout::RubyFormattingContext::applyRubyAlign):
(WebCore::Layout::RubyFormattingContext::applyAlignmentOffsetList):
* Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.h:
* Source/WebCore/layout/formattingContexts/inline/text/TextBreakingPositionCache.h:
* Source/WebCore/layout/formattingContexts/table/TableGrid.h:
* Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.h:
(WebCore::LayoutIntegration::BoxGeometryUpdater::takeNestedListMarkerOffsets):
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp:
(WebCore::LayoutIntegration::InlineContentBuilder::computeIsFirstIsLastBoxAndBidiReorderingForInlineContent const):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::updateRenderTreePositions):
* Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.cpp:
(WebCore::LayoutIntegration::computeAdjustmentsForPagination):
* Source/WebCore/layout/layouttree/LayoutBox.h:

Canonical link: <a href="https://commits.webkit.org/296462@main">https://commits.webkit.org/296462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/406b4890d02048ccfe83270454e93ee0226fac77

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108595 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18680 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113803 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58985 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110558 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28945 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36810 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82482 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111543 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22974 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97816 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62919 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22390 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15953 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58517 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92343 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16004 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116924 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35649 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26282 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91505 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/fractional-translation-from-position.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36022 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94085 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91309 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23265 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36207 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13968 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31464 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35550 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41083 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35260 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38606 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36938 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->