### PR TITLE
Let WKSeparatedImageView override `layoutSubviews` without breaking the Swift + WKA setup

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WKSeparatedImageView.h
+++ b/Source/WebKit/UIProcess/Cocoa/WKSeparatedImageView.h
@@ -40,6 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithCoder:(NSCoder *)coder NS_UNAVAILABLE;
 
 - (void)setSurface:(nullable IOSurfaceRef)surface;
+- (void)layoutCustomSubtree;
 
 @end
 

--- a/Source/WebKit/UIProcess/Cocoa/WKSeparatedImageView.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKSeparatedImageView.mm
@@ -40,6 +40,12 @@
     return [WKObservingLayer class];
 }
 
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+    [self layoutCustomSubtree];
+}
+
 @end
 
 @implementation WKObservingLayer
@@ -82,6 +88,10 @@
 }
 
 - (void)setSurface:(nullable IOSurfaceRef)surface
+{
+}
+
+- (void)layoutCustomSubtree
 {
 }
 


### PR DESCRIPTION
#### 45c78daba7a17f9285212c2d059c5207f706db5f
<pre>
Let WKSeparatedImageView override `layoutSubviews` without breaking the Swift + WKA setup
<a href="https://bugs.webkit.org/show_bug.cgi?id=294764">https://bugs.webkit.org/show_bug.cgi?id=294764</a>
&lt;<a href="https://rdar.apple.com/152278969">rdar://152278969</a>&gt;

Reviewed by Aditya Keerthi.

We can&apos;t override a public method from the WKA
`@objc @implementation extension` because `WebKit_Internal` is imported
as internal.

Add a new `layoutCustomSubtree` method which serves as an extension
point instead, and call it from an objc `layoutSubview` override.

* Source/WebKit/UIProcess/Cocoa/WKSeparatedImageView.h:
* Source/WebKit/UIProcess/Cocoa/WKSeparatedImageView.mm:
(-[WKSeparatedImageView layoutSubviews]):
(-[WKSeparatedImageView layoutCustomSubtree]):

Canonical link: <a href="https://commits.webkit.org/296633@main">https://commits.webkit.org/296633@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fa69f990e23b269f723e71ccc13de0cebcf40d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108601 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28262 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18686 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113809 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58991 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28951 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36816 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82488 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111549 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22980 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97822 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62925 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22398 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58523 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92349 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16011 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116930 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35655 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26287 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91510 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36028 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94092 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91314 "Found 2 new API test failures: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23360 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36211 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13975 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31470 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35556 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41089 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35266 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38612 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36944 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->