### PR TITLE
[JSC] Use ErrorInstance's stack information in Exception

### DIFF
--- a/JSTests/stress/error-stack-first-entry.js
+++ b/JSTests/stress/error-stack-first-entry.js
@@ -1,0 +1,19 @@
+function test2() {
+    return new Error("Hey");
+}
+
+function test1() {
+    return test2();
+}
+noInline(test1);
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+for (let i = 0; i < testLoopCount; ++i) {
+    let error = test1();
+    shouldBe(error.line, 2);
+    shouldBe(error.column, 21);
+}

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -991,6 +991,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/DeferredWorkTimerInlines.h
     runtime/DefinePropertyAttributes.h
     runtime/DeletePropertySlot.h
+    runtime/DestructibleException.h
     runtime/DirectArguments.h
     runtime/DirectArgumentsOffset.h
     runtime/DirectEvalExecutable.h
@@ -1014,6 +1015,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/ExceptionExpectation.h
     runtime/ExceptionHelpers.h
     runtime/ExceptionScope.h
+    runtime/ExceptionStack.h
     runtime/ExecutableBase.h
     runtime/ExecutableBaseInlines.h
     runtime/Float16Array.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2022,6 +2022,7 @@
 		E355D38F22446877008F1AD6 /* GlobalExecutable.h in Headers */ = {isa = PBXBuildFile; fileRef = E355D38D2244686B008F1AD6 /* GlobalExecutable.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E356987222841187008CDCCB /* PackedCellPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = E356987122841183008CDCCB /* PackedCellPtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E35A0B9D220AD87A00AC4474 /* ExecutableBaseInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E35A0B9C220AD87A00AC4474 /* ExecutableBaseInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E35A90B42E0624E1008AB6F1 /* ExceptionStack.h in Headers */ = {isa = PBXBuildFile; fileRef = E35A90B22E0624E1008AB6F1 /* ExceptionStack.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E35B36072A2E981E004EC264 /* StringReplaceCacheInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E35B36052A2E981E004EC264 /* StringReplaceCacheInlines.h */; };
 		E35B36082A2E981E004EC264 /* StringReplaceCache.h in Headers */ = {isa = PBXBuildFile; fileRef = E35B36062A2E981E004EC264 /* StringReplaceCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E35CA1541DBC3A5C00F83516 /* DOMJITHeapRange.h in Headers */ = {isa = PBXBuildFile; fileRef = E35CA1521DBC3A5600F83516 /* DOMJITHeapRange.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2029,6 +2030,7 @@
 		E35E89FD25C50F870071EE1E /* BigInt64Array.h in Headers */ = {isa = PBXBuildFile; fileRef = E35E89FB25C50F860071EE1E /* BigInt64Array.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E35E89FE25C50F870071EE1E /* BigUint64Array.h in Headers */ = {isa = PBXBuildFile; fileRef = E35E89FC25C50F870071EE1E /* BigUint64Array.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3637EE9236E56B00096BD0A /* LinkTimeConstant.h in Headers */ = {isa = PBXBuildFile; fileRef = E3637EE7236E56B00096BD0A /* LinkTimeConstant.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E364BE2F2E06242E00DA218E /* DestructibleException.h in Headers */ = {isa = PBXBuildFile; fileRef = E364BE2D2E06242E00DA218E /* DestructibleException.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E366441E254409B30001876F /* IntlListFormat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E318CA69254406B5004DC129 /* IntlListFormat.cpp */; };
 		E367062A2A2705DB00CF892F /* StringSplitCacheInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E36706282A2705DB00CF892F /* StringSplitCacheInlines.h */; };
 		E367062B2A2705DB00CF892F /* StringSplitCache.h in Headers */ = {isa = PBXBuildFile; fileRef = E36706292A2705DB00CF892F /* StringSplitCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5790,6 +5792,8 @@
 		E355D38E2244686C008F1AD6 /* GlobalExecutable.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = GlobalExecutable.cpp; sourceTree = "<group>"; };
 		E356987122841183008CDCCB /* PackedCellPtr.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PackedCellPtr.h; sourceTree = "<group>"; };
 		E35A0B9C220AD87A00AC4474 /* ExecutableBaseInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExecutableBaseInlines.h; sourceTree = "<group>"; };
+		E35A90B22E0624E1008AB6F1 /* ExceptionStack.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExceptionStack.h; sourceTree = "<group>"; };
+		E35A90B32E0624E1008AB6F1 /* ExceptionStack.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ExceptionStack.cpp; sourceTree = "<group>"; };
 		E35B36052A2E981E004EC264 /* StringReplaceCacheInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringReplaceCacheInlines.h; sourceTree = "<group>"; };
 		E35B36062A2E981E004EC264 /* StringReplaceCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringReplaceCache.h; sourceTree = "<group>"; };
 		E35CA14F1DBC3A5600F83516 /* DOMJITAbstractHeap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DOMJITAbstractHeap.cpp; sourceTree = "<group>"; };
@@ -5800,6 +5804,8 @@
 		E35E89FC25C50F870071EE1E /* BigUint64Array.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BigUint64Array.h; sourceTree = "<group>"; };
 		E3637EE7236E56B00096BD0A /* LinkTimeConstant.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LinkTimeConstant.h; sourceTree = "<group>"; };
 		E3637EE8236E56B00096BD0A /* LinkTimeConstant.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LinkTimeConstant.cpp; sourceTree = "<group>"; };
+		E364BE2D2E06242E00DA218E /* DestructibleException.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DestructibleException.h; sourceTree = "<group>"; };
+		E364BE2E2E06242E00DA218E /* DestructibleException.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DestructibleException.cpp; sourceTree = "<group>"; };
 		E365F33824AA621100C991B2 /* IntlDisplayNamesPrototype.lut.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IntlDisplayNamesPrototype.lut.h; sourceTree = "<group>"; };
 		E365F33924AA621200C991B2 /* IntlDisplayNamesConstructor.lut.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IntlDisplayNamesConstructor.lut.h; sourceTree = "<group>"; };
 		E36706282A2705DB00CF892F /* StringSplitCacheInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringSplitCacheInlines.h; sourceTree = "<group>"; };
@@ -8281,6 +8287,8 @@
 				FE9F3FC626163CA90069E89F /* DeferTermination.h */,
 				169948EDE68D4054B01EF797 /* DefinePropertyAttributes.h */,
 				734B655423F4A33100A069D1 /* DeletePropertySlot.h */,
+				E364BE2E2E06242E00DA218E /* DestructibleException.cpp */,
+				E364BE2D2E06242E00DA218E /* DestructibleException.h */,
 				0FE0500F1AA9091100D33B33 /* DirectArguments.cpp */,
 				0FE050101AA9091100D33B33 /* DirectArguments.h */,
 				0FE0500D1AA9091100D33B33 /* DirectArgumentsOffset.cpp */,
@@ -8335,6 +8343,8 @@
 				A72701B30DADE94900E548D7 /* ExceptionHelpers.h */,
 				FE6491381D78F3A300A694D4 /* ExceptionScope.cpp */,
 				FE6491361D78F01300A694D4 /* ExceptionScope.h */,
+				E35A90B32E0624E1008AB6F1 /* ExceptionStack.cpp */,
+				E35A90B22E0624E1008AB6F1 /* ExceptionStack.h */,
 				147341E91DC2CF2500AA29BA /* ExecutableBase.cpp */,
 				147341CB1DC02D7200AA29BA /* ExecutableBase.h */,
 				E35A0B9C220AD87A00AC4474 /* ExecutableBaseInlines.h */,
@@ -10814,6 +10824,7 @@
 				73AD062923FF662600F53593 /* DeleteByStatus.h in Headers */,
 				7311FA32240DB1D3003D48DB /* DeleteByVariant.h in Headers */,
 				734B655523F5C10400A069D1 /* DeletePropertySlot.h in Headers */,
+				E364BE2F2E06242E00DA218E /* DestructibleException.h in Headers */,
 				0F96303C1D4192CD005609D9 /* DestructionMode.h in Headers */,
 				A77A423E17A0BBFD00A8DB81 /* DFGAbstractHeap.h in Headers */,
 				A704D90317A0BAA8006BA554 /* DFGAbstractInterpreter.h in Headers */,
@@ -11037,6 +11048,7 @@
 				0F12DE101979D5FD0006FF4E /* ExceptionFuzz.h in Headers */,
 				BC18C4000E16F5CD00B34460 /* ExceptionHelpers.h in Headers */,
 				FE6491371D78F01D00A694D4 /* ExceptionScope.h in Headers */,
+				E35A90B42E0624E1008AB6F1 /* ExceptionStack.h in Headers */,
 				0FF054FA1AC35B4400E5BE57 /* ExecutableAllocationFuzz.h in Headers */,
 				A766B44F0EE8DCD1009518CA /* ExecutableAllocator.h in Headers */,
 				147341CC1DC02D7200AA29BA /* ExecutableBase.h in Headers */,

--- a/Source/JavaScriptCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -64,7 +64,6 @@ runtime/DateInstance.h
 runtime/DirectArguments.cpp
 runtime/ErrorInstance.h
 runtime/EvalExecutable.cpp
-runtime/Exception.cpp
 runtime/ExecutableBase.cpp
 runtime/FunctionExecutable.cpp
 runtime/FunctionRareData.cpp

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -789,6 +789,7 @@ runtime/DateConversion.cpp
 runtime/DateInstance.cpp
 runtime/DatePrototype.cpp
 runtime/DeferredWorkTimer.cpp
+runtime/DestructibleException.cpp
 runtime/DirectArguments.cpp
 runtime/DirectArgumentsOffset.cpp
 runtime/DirectEvalExecutable.cpp
@@ -809,6 +810,7 @@ runtime/ExceptionEventLocation.cpp
 runtime/ExceptionFuzz.cpp
 runtime/ExceptionHelpers.cpp
 runtime/ExceptionScope.cpp
+runtime/ExceptionStack.cpp
 runtime/ExecutableBase.cpp
 runtime/FileBasedFuzzerAgent.cpp
 runtime/FileBasedFuzzerAgentBase.cpp

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -3393,6 +3393,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         break;
 
     case Throw:
+    case ThrowWithAdjustment:
     case ThrowStaticError:
     case TailCall:
     case DirectTailCall:
@@ -3635,6 +3636,12 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
 
         clobberWorld();
         makeHeapTopForNode(node);
+        break;
+    }
+
+    case NewError: {
+        clobberWorld();
+        setTypeForNode(node, SpecObjectOther);
         break;
     }
 

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -54,6 +54,7 @@
 #include "DFGLiveCatchVariablePreservationPhase.h"
 #include "DOMJITGetterSetter.h"
 #include "DeleteByStatus.h"
+#include "ErrorConstructor.h"
 #include "FunctionCodeBlock.h"
 #include "GetByStatus.h"
 #include "GetterSetter.h"
@@ -5076,7 +5077,6 @@ bool ByteCodeParser::handleConstantFunction(
     int argumentCountIncludingThis, CodeSpecializationKind kind, SpeculatedType prediction, Node* newTarget, const ChecksFunctor& insertChecks)
 {
     VERBOSE_LOG("    Handling constant function ", JSValue(function), "\n");
-    UNUSED_PARAM(newTarget);
     
     // It so happens that the code below assumes that the result operand is valid. It's extremely
     // unlikely that the result operand would be invalid - you'd have to call this via a setter call.
@@ -5183,6 +5183,53 @@ bool ByteCodeParser::handleConstantFunction(
                 set(result, resultNode);
                 return true;
             }
+        }
+    }
+
+    if (function->classInfo() == ErrorConstructor::info() && kind == CodeSpecializationKind::CodeForConstruct) {
+        Node* newTargetNode = get(virtualRegisterForArgumentIncludingThis(0, registerOffset));
+        JSGlobalObject* globalObject = function->globalObject();
+        Structure* structure = nullptr;
+        if (newTargetNode != callTargetNode) {
+            JSFunction* derived = nullptr;
+            if (newTargetNode)
+                derived = newTargetNode->dynamicCastConstant<JSFunction*>();
+            if (!derived && newTarget)
+                derived = newTarget->dynamicCastConstant<JSFunction*>();
+
+            if (derived && derived->globalObject() == globalObject) {
+                if (FunctionRareData* rareData = derived->rareData()) {
+                    if (rareData->allocationProfileWatchpointSet().isStillValid() && globalObject->structureCacheClearedWatchpointSet().isStillValid()) {
+                        Structure* newStructure = rareData->internalFunctionAllocationStructure();
+                        if (newStructure
+                            && newStructure->classInfoForCells() == ErrorInstance::info()
+                            && newStructure->globalObject() == globalObject) {
+                            m_graph.freeze(rareData);
+                            m_graph.watchpoints().addLazily(rareData->allocationProfileWatchpointSet());
+                            m_graph.freeze(globalObject);
+                            m_graph.watchpoints().addLazily(globalObject->structureCacheClearedWatchpointSet());
+                            structure = newStructure;
+                        }
+                    }
+                }
+            }
+
+            if (!structure)
+                return false;
+        }
+
+        if (!structure)
+            structure = globalObject->errorStructureConcurrently();
+        if (structure) {
+            insertChecks();
+            Node* message = jsConstant(jsUndefined());
+            Node* options = jsConstant(jsUndefined());
+            if (argumentCountIncludingThis > 1)
+                message = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
+            if (argumentCountIncludingThis > 2)
+                options = get(virtualRegisterForArgumentIncludingThis(2, registerOffset));
+            set(result, addToGraph(NewError, OpInfo(m_graph.registerStructure(structure)), message, options));
+            return true;
         }
     }
 

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -921,6 +921,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     }
 
     case Throw:
+    case ThrowWithAdjustment:
     case ThrowStaticError:
     case TailCall:
     case DirectTailCall:
@@ -2132,6 +2133,10 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
             write(HeapObjectCount);
         } else
             clobberTop();
+        return;
+
+    case NewError:
+        clobberTop();
         return;
 
     case NewObject:

--- a/Source/JavaScriptCore/dfg/DFGCloneHelper.h
+++ b/Source/JavaScriptCore/dfg/DFGCloneHelper.h
@@ -297,6 +297,7 @@ BasicBlock* CloneHelper::cloneBlock(BasicBlock* const block, const CustomizeSucc
     CLONE_STATUS(NewObject, Common) \
     CLONE_STATUS(NewRegExp, Common) \
     CLONE_STATUS(NewRegExpUntyped, Common) \
+    CLONE_STATUS(NewError, Common) \
     CLONE_STATUS(NewSet, Common) \
     CLONE_STATUS(NormalizeMapKey, Common) \
     CLONE_STATUS(NumberToStringWithValidRadixConstant, Common) \

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -382,6 +382,7 @@ bool doesGC(Graph& graph, Node* node)
     case TailCallVarargs:
     case TailCallVarargsInlinedCaller:
     case Throw:
+    case ThrowWithAdjustment:
     case ToNumber:
     case ToNumeric:
     case ToObject:
@@ -419,6 +420,7 @@ bool doesGC(Graph& graph, Node* node)
     case NewArrayBuffer:
     case NewRegExp:
     case NewRegExpUntyped:
+    case NewError:
     case NewStringObject:
     case NewMap:
     case NewSet:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -3551,6 +3551,8 @@ private:
         case CallCustomAccessorSetter:
         case MultiGetByVal:
         case MultiPutByVal:
+        case NewError:
+        case ThrowWithAdjustment:
             break;
 #else // not ASSERT_ENABLED
         default:

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -397,6 +397,8 @@ void Graph::dump(PrintStream& out, const char* prefixStr, Node* node, DumpContex
         out.print(comma, *node->putByStatus());
     if (node->hasEnumeratorMetadata())
         out.print(comma, "enumeratorModes = "_s, node->enumeratorMetadata().toRaw());
+    if (node->hasCallDepth())
+        out.print(comma, "callDepth = "_s, node->callDepth());
     if (node->hasExtractOffset())
         out.print(comma, "<<"_s, node->extractOffset());
     if (node->isJump())

--- a/Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.cpp
+++ b/Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.cpp
@@ -454,6 +454,7 @@ inline bool InPlaceAbstractState::mergeToSuccessors(BasicBlock* basicBlock)
     case TailCallForwardVarargs:
     case Unreachable:
     case Throw:
+    case ThrowWithAdjustment:
     case ThrowStaticError:
         ASSERT(basicBlock->cfaBranchDirection == InvalidBranchDirection);
         return false;

--- a/Source/JavaScriptCore/dfg/DFGMayExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGMayExit.cpp
@@ -206,6 +206,9 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
         return Exits;
     }
 
+    case NewError:
+        return Exits;
+
     case SetRegExpObjectLastIndex:
         if (node->ignoreLastIndexIsWritable())
             break;

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -540,6 +540,13 @@ public:
     void convertToPutByIdMaybeMegamorphic(Graph&, CacheableIdentifier);
     void convertToInByIdMaybeMegamorphic(Graph&, CacheableIdentifier);
 
+    void convertToThrowWithAdjustment(unsigned depth)
+    {
+        setOp(ThrowWithAdjustment);
+        child1().setUseKind(KnownCellUse);
+        m_opInfo = depth;
+    }
+
     bool mustGenerate() const
     {
         return m_flags & NodeMustGenerate;
@@ -1850,6 +1857,7 @@ public:
         case Unreachable:
         case Throw:
         case ThrowStaticError:
+        case ThrowWithAdjustment:
             return true;
         default:
             return false;
@@ -2412,6 +2420,7 @@ public:
         case NewSet:
         case NewArrayWithSizeAndStructure:
         case NewTypedArrayBuffer:
+        case NewError:
             return true;
         default:
             return false;
@@ -3802,6 +3811,17 @@ public:
             RELEASE_ASSERT_NOT_REACHED();
             break;
         }
+    }
+
+    bool hasCallDepth() const
+    {
+        return op() == ThrowWithAdjustment;
+    }
+
+    unsigned callDepth()
+    {
+        ASSERT(hasCallDepth());
+        return m_opInfo.as<unsigned>();
     }
 
     void resetOpInfo()

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -414,6 +414,7 @@ namespace JSC { namespace DFG {
     macro(NewTypedArrayBuffer, NodeResultJS | NodeMustGenerate) \
     macro(NewRegExp, NodeResultJS) \
     macro(NewRegExpUntyped, NodeResultJS | NodeMustGenerate) \
+    macro(NewError, NodeResultJS | NodeMustGenerate) \
     macro(NewSymbol, NodeResultJS | NodeMustGenerate) \
     macro(NewStringObject, NodeResultJS) \
     macro(NewMap, NodeResultJS) \
@@ -538,6 +539,7 @@ namespace JSC { namespace DFG {
     macro(TailCallForwardVarargs, NodeMustGenerate) \
     macro(Unreachable, NodeMustGenerate) \
     macro(Throw, NodeMustGenerate) \
+    macro(ThrowWithAdjustment, NodeMustGenerate) \
     macro(ThrowStaticError, NodeMustGenerate) \
     \
     /* Count execution. */\

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -2857,6 +2857,20 @@ JSC_DEFINE_JIT_OPERATION(operationNewRegExpString, JSObject*, (JSGlobalObject* g
     OPERATION_RETURN(scope, constructRegExp(globalObject, ArgList { args, 2 }, globalObject->regExpConstructor()));
 }
 
+JSC_DEFINE_JIT_OPERATION(operationNewError, JSObject*, (JSGlobalObject* globalObject, Structure* structure, EncodedJSValue encodedMessage, EncodedJSValue encodedOptions))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue message = JSValue::decode(encodedMessage);
+    JSValue options = JSValue::decode(encodedOptions);
+
+    // Since this is just an operation, we should use `useCurrentFrame = true`.
+    OPERATION_RETURN(scope, ErrorInstance::create(globalObject, structure, message, options, nullptr, TypeNothing, ErrorType::Error, /* useCurrentFrame */ true));
+}
+
 JSC_DEFINE_JIT_OPERATION(operationStringValueOf, JSString*, (JSGlobalObject* globalObject, EncodedJSValue encodedArgument))
 {
     VM& vm = globalObject->vm();
@@ -5213,6 +5227,19 @@ JSC_DEFINE_JIT_OPERATION(operationThrowDFG, void, (JSGlobalObject* globalObject,
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
     scope.throwException(globalObject, JSValue::decode(valueToThrow));
+    OPERATION_RETURN(scope);
+}
+
+JSC_DEFINE_JIT_OPERATION(operationThrowWithAdjustment, void, (JSGlobalObject* globalObject, ErrorInstance* error, uint32_t callDepth))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    CodeBlock* codeBlock = callFrame->codeBlock();
+    LineColumn lineColumn = StackFrame::lineAndColumnForBytecodeIndex(codeBlock, callFrame->codeOrigin());
+    scope.throwException(globalObject, Exception::createWithFrameAdjustment(vm, error, lineColumn, callDepth));
     OPERATION_RETURN(scope);
 }
 

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -40,6 +40,7 @@ namespace JSC {
 class ConcatKeyAtomStringCache;
 class DateInstance;
 class DirectCallLinkInfo;
+class ErrorInstance;
 class JSBigInt;
 class JSBoundFunction;
 class JSPropertyNameEnumerator;
@@ -140,6 +141,7 @@ JSC_DECLARE_JIT_OPERATION(operationEnumeratorRecoverNameAndPutByVal, void, (JSGl
 JSC_DECLARE_JIT_OPERATION(operationNewRegExpWithLastIndex, JSCell*, (JSGlobalObject*, JSCell*, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationNewRegExpUntyped, JSObject*, (JSGlobalObject*, EncodedJSValue, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationNewRegExpString, JSObject*, (JSGlobalObject*, JSString*, JSString*));
+JSC_DECLARE_JIT_OPERATION(operationNewError, JSObject*, (JSGlobalObject*, Structure*, EncodedJSValue, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationNewArray, char*, (JSGlobalObject*, Structure*, void*, size_t));
 JSC_DECLARE_JIT_OPERATION(operationNewEmptyArray, char*, (VM*, Structure*));
 JSC_DECLARE_JIT_OPERATION(operationNewArrayWithSize, char*, (JSGlobalObject*, Structure*, int32_t, Butterfly*));
@@ -377,6 +379,7 @@ JSC_DECLARE_JIT_OPERATION(operationThrowStackOverflowForVarargs, void, (JSGlobal
 JSC_DECLARE_JIT_OPERATION(operationSizeOfVarargs, UCPUStrictInt32, (JSGlobalObject*, EncodedJSValue arguments, uint32_t firstVarArgOffset));
 JSC_DECLARE_JIT_OPERATION(operationLoadVarargs, void, (JSGlobalObject*, int32_t firstElementDest, EncodedJSValue arguments, uint32_t offset, uint32_t length, uint32_t mandatoryMinimum));
 JSC_DECLARE_JIT_OPERATION(operationThrowDFG, void, (JSGlobalObject*, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationThrowWithAdjustment, void, (JSGlobalObject*, ErrorInstance*, uint32_t));
 JSC_DECLARE_JIT_OPERATION(operationThrowStaticError, void, (JSGlobalObject*, JSString*, uint32_t));
 
 JSC_DECLARE_JIT_OPERATION(operationHasOwnProperty, size_t, (JSGlobalObject*, JSObject*, EncodedJSValue));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1415,6 +1415,10 @@ private:
             setPrediction(SpecRegExpObject);
             break;
         }
+        case NewError: {
+            setPrediction(SpecObjectOther);
+            break;
+        }
         case NewSymbol: {
             setPrediction(SpecSymbol);
             break;
@@ -1660,6 +1664,7 @@ private:
         case PutToArguments:
         case Return:
         case Throw:
+        case ThrowWithAdjustment:
         case ThrowStaticError:
         case TailCall:
         case DirectTailCall:

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -679,6 +679,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case SetFunctionName:
     case NewStringObject:
     case NewRegExpUntyped:
+    case NewError:
     case InByVal:
     case InByValMegamorphic:
     case InById:
@@ -709,6 +710,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case TailCallVarargs:
     case TailCallForwardVarargs:
     case Throw:
+    case ThrowWithAdjustment:
     case ThrowStaticError:
     case CountExecution:
     case SuperSamplerBegin:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -11434,6 +11434,21 @@ void SpeculativeJIT::compileNewRegExpUntyped(Node* node)
     cellResult(resultGPR, node);
 }
 
+void SpeculativeJIT::compileNewError(Node* node)
+{
+    JSValueOperand message(this, node->child1());
+    JSValueOperand options(this, node->child2());
+
+    JSValueRegs messageRegs = message.jsValueRegs();
+    JSValueRegs optionsRegs = options.jsValueRegs();
+
+    flushRegisters();
+    GPRFlushedCallResult result(this);
+    GPRReg resultGPR = result.gpr();
+    callOperation(operationNewError, resultGPR, LinkableConstant::globalObject(*this, node), TrustedImmPtr(node->structure()), messageRegs, optionsRegs);
+    cellResult(resultGPR, node);
+}
+
 void SpeculativeJIT::compileNewTypedArrayWithSize(Node* node)
 {
     JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
@@ -14283,6 +14298,16 @@ void SpeculativeJIT::compileThrow(Node* node)
     JSValueRegs valueRegs = value.jsValueRegs();
     flushRegisters();
     callOperation(operationThrowDFG, LinkableConstant::globalObject(*this, node), valueRegs);
+    breakpoint();
+    noResult(node);
+}
+
+void SpeculativeJIT::compileThrowWithAdjustment(Node* node)
+{
+    SpeculateCellOperand error(this, node->child1());
+    GPRReg errorGPR = error.gpr();
+    flushRegisters();
+    callOperation(operationThrowWithAdjustment, LinkableConstant::globalObject(*this, node), errorGPR, TrustedImm32(node->callDepth()));
     breakpoint();
     noResult(node);
 }

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1454,6 +1454,7 @@ public:
     void compileNewMap(Node*);
     void compileNewSet(Node*);
     void compileNewRegExpUntyped(Node*);
+    void compileNewError(Node*);
 
     void emitNewTypedArrayWithSizeInRegister(Node*, TypedArrayType, RegisteredStructure, GPRReg sizeGPR);
     void compileNewTypedArrayWithSize(Node*);
@@ -1732,6 +1733,7 @@ public:
     void compileStringSubstring(Node*);
     void compileToLowerCase(Node*);
     void compileThrow(Node*);
+    void compileThrowWithAdjustment(Node*);
     void compileThrowStaticError(Node*);
 
     void compileExtractFromTuple(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -3001,6 +3001,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case ThrowWithAdjustment: {
+        compileThrowWithAdjustment(node);
+        break;
+    }
+
     case ThrowStaticError: {
         compileThrowStaticError(node);
         break;
@@ -3163,6 +3168,11 @@ void SpeculativeJIT::compile(Node* node)
 
     case NewRegExpUntyped: {
         compileNewRegExpUntyped(node);
+        break;
+    }
+
+    case NewError: {
+        compileNewError(node);
         break;
     }
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -4373,6 +4373,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case ThrowWithAdjustment: {
+        compileThrowWithAdjustment(node);
+        break;
+    }
+
     case ThrowStaticError: {
         compileThrowStaticError(node);
         break;
@@ -4525,6 +4530,11 @@ void SpeculativeJIT::compile(Node* node)
 
     case NewRegExpUntyped: {
         compileNewRegExpUntyped(node);
+        break;
+    }
+
+    case NewError: {
+        compileNewError(node);
         break;
     }
 

--- a/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
@@ -388,7 +388,6 @@ private:
             case NewTypedArray:
             case NewTypedArrayBuffer:
             case NewRegExp:
-            case NewRegExpUntyped:
             case NewStringObject:
             case NewMap:
             case NewSet:

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -1747,6 +1747,27 @@ private:
             break;
         }
 
+        case Throw: {
+            if (m_node->child1()->op() == NewError) {
+                auto* throwingInlineCallFrame = m_node->origin.semantic.inlineCallFrame();
+                CodeOrigin codeOrigin = m_node->child1()->origin.semantic;
+                unsigned depth = 0;
+                while (true) {
+                    auto* inlineCallFrame = codeOrigin.inlineCallFrame();
+                    if (inlineCallFrame == throwingInlineCallFrame) {
+                        m_node->convertToThrowWithAdjustment(depth);
+                        m_changed = true;
+                        break;
+                    }
+                    if (!inlineCallFrame)
+                        break;
+                    codeOrigin = inlineCallFrame->directCaller;
+                    ++depth;
+                }
+            }
+            break;
+        }
+
         default:
             break;
         }

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -79,6 +79,7 @@ inline CapabilityLevel canCompile(Node* node)
     case NewAsyncGenerator:
     case NewStringObject:
     case NewRegExpUntyped:
+    case NewError:
     case NewSymbol:
     case NewArray:
     case NewArrayWithSpread:
@@ -269,6 +270,7 @@ inline CapabilityLevel canCompile(Node* node)
     case ToPropertyKey:
     case ToPropertyKeyOrNumber:
     case Throw:
+    case ThrowWithAdjustment:
     case ThrowStaticError:
     case Unreachable:
     case InByVal:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1228,6 +1228,9 @@ private:
         case NewRegExpUntyped:
             compileNewRegExpUntyped();
             break;
+        case NewError:
+            compileNewError();
+            break;
         case NewSymbol:
             compileNewSymbol();
             break;
@@ -1542,6 +1545,9 @@ private:
             break;
         case Throw:
             compileThrow();
+            break;
+        case ThrowWithAdjustment:
+            compileThrowWithAdjustment();
             break;
         case ThrowStaticError:
             compileThrowStaticError();
@@ -9443,6 +9449,12 @@ IGNORE_CLANG_WARNINGS_END
         setJSValue(vmCall(pointerType(), operationNewRegExpUntyped, weakPointer(globalObject), lowJSValue(m_node->child1()), lowJSValue(m_node->child2())));
     }
 
+    void compileNewError()
+    {
+        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+        setJSValue(vmCall(pointerType(), operationNewError, weakPointer(globalObject), weakStructure(m_node->structure()), lowJSValue(m_node->child1()), lowJSValue(m_node->child2())));
+    }
+
     void compileNewSymbol()
     {
         JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
@@ -14469,6 +14481,15 @@ IGNORE_CLANG_WARNINGS_END
         JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
         LValue error = lowJSValue(m_node->child1());
         vmCall(Void, operationThrowDFG, weakPointer(globalObject), error);
+        // vmCall() does an exception check so we should never reach this.
+        m_out.unreachable();
+    }
+
+    void compileThrowWithAdjustment()
+    {
+        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+        LValue error = lowCell(m_node->child1());
+        vmCall(Void, operationThrowWithAdjustment, weakPointer(globalObject), error, m_out.constInt32(m_node->callDepth()));
         // vmCall() does an exception check so we should never reach this.
         m_out.unreachable();
     }

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -26,6 +26,7 @@
 #include "CodeBlockSetInlines.h"
 #include "CollectingScope.h"
 #include "ConservativeRoots.h"
+#include "DestructibleException.h"
 #include "EdenGCActivityCallback.h"
 #include "Exception.h"
 #include "FastMallocAlignedMemoryAllocator.h"

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -127,8 +127,9 @@ class Heap;
     v(clonedArgumentsSpace, cellHeapCellType, ClonedArguments) \
     v(customGetterSetterSpace, cellHeapCellType, CustomGetterSetter) \
     v(dateInstanceSpace, dateInstanceHeapCellType, DateInstance) \
+    v(destructibleExceptionSpace, destructibleCellHeapCellType, DestructibleException) \
     v(domAttributeGetterSetterSpace, cellHeapCellType, DOMAttributeGetterSetter) \
-    v(exceptionSpace, destructibleCellHeapCellType, Exception) \
+    v(exceptionSpace, cellHeapCellType, Exception) \
     v(functionSpace, cellHeapCellType, JSFunction) \
     v(getterSetterSpace, cellHeapCellType, GetterSetter) \
     v(globalLexicalEnvironmentSpace, globalLexicalEnvironmentHeapCellType, JSGlobalLexicalEnvironment) \

--- a/Source/JavaScriptCore/inspector/InjectedScriptManager.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScriptManager.cpp
@@ -182,13 +182,13 @@ InjectedScript InjectedScriptManager::injectedScriptFor(JSGlobalObject* globalOb
         auto& error = createResult.error();
         ASSERT(error);
 
-        if (globalObject->vm().isTerminationException(error))
+        VM& vm = globalObject->vm();
+        if (vm.isTerminationException(error))
             return InjectedScript();
 
         LineColumn lineColumn;
-        auto& stack = error->stack();
-        if (stack.size() > 0)
-            lineColumn = stack[0].computeLineAndColumn();
+        if (auto stack = error->stack(); !stack.isEmpty())
+            lineColumn = stack.computeLineAndColumn(vm);
         WTFLogAlways("Error when creating injected script: %s (%d:%d)\n", error->value().toWTFString(globalObject).utf8().data(), lineColumn.line, lineColumn.column);
         RELEASE_ASSERT_NOT_REACHED();
     }

--- a/Source/JavaScriptCore/inspector/InjectedScriptModule.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScriptModule.cpp
@@ -59,6 +59,7 @@ void InjectedScriptModule::ensureInjected(InjectedScriptManager* injectedScriptM
 
     // FIXME: Make the InjectedScript a module itself.
     JSC::JSLockHolder locker(injectedScript.globalObject());
+    JSC::VM& vm = injectedScript.globalObject()->vm();
     ScriptFunctionCall function(injectedScript.globalObject(), injectedScript.injectedScriptObject(), "hasInjectedModule"_s, injectedScriptManager->inspectorEnvironment().functionCallHandler());
     function.appendArgument(name());
     auto hasInjectedModuleResult = injectedScript.callFunctionWithEvalEnabled(function);
@@ -67,9 +68,8 @@ void InjectedScriptModule::ensureInjected(InjectedScriptManager* injectedScriptM
         auto& error = hasInjectedModuleResult.error();
         ASSERT(error);
         JSC::LineColumn lineColumn;
-        auto& stack = error->stack();
-        if (stack.size() > 0)
-            lineColumn = stack[0].computeLineAndColumn();
+        if (auto stack = error->stack(); !stack.isEmpty())
+            lineColumn = stack.computeLineAndColumn(vm);
         WTFLogAlways("Error when calling 'hasInjectedModule' for '%s': %s (%d:%d)\n", name().utf8().data(), error->value().toWTFString(injectedScript.globalObject()).utf8().data(), lineColumn.line, lineColumn.column);
         RELEASE_ASSERT_NOT_REACHED();
     }
@@ -87,9 +87,8 @@ void InjectedScriptModule::ensureInjected(InjectedScriptManager* injectedScriptM
             auto& error = injectModuleResult.error();
             ASSERT(error);
             JSC::LineColumn lineColumn;
-            auto& stack = error->stack();
-            if (stack.size() > 0)
-                lineColumn = stack[0].computeLineAndColumn();
+            if (auto stack = error->stack(); !stack.isEmpty())
+                lineColumn = stack.computeLineAndColumn(vm);
             WTFLogAlways("Error when calling 'injectModule' for '%s': %s (%d:%d)\n", name().utf8().data(), error->value().toWTFString(injectedScript.globalObject()).utf8().data(), lineColumn.line, lineColumn.column);
             RELEASE_ASSERT_NOT_REACHED();
         }

--- a/Source/JavaScriptCore/inspector/ScriptCallStackFactory.cpp
+++ b/Source/JavaScriptCore/inspector/ScriptCallStackFactory.cpp
@@ -158,8 +158,16 @@ static bool extractSourceInformationFromException(JSC::JSGlobalObject* globalObj
         lineColumn->column = columnValue && columnValue.isNumber() ? int(columnValue.toNumber(globalObject)) : 0;
         *sourceURL = sourceURLValue.toWTFString(globalObject);
         result = true;
-    } else if (ErrorInstance* error = jsDynamicCast<ErrorInstance*>(exceptionObject))
-        result = getLineColumnAndSource(vm, error->stackTrace(), *lineColumn, *sourceURL);
+    } else if (ErrorInstance* error = jsDynamicCast<ErrorInstance*>(exceptionObject)) {
+        if (auto stack = error->stackTrace(); !stack.isEmpty()) {
+            stack.computeErrorInfo(vm);
+            if (stack.lineColumn() != LineColumn { }) {
+                *lineColumn = stack.stack()->lineColumn();
+                *sourceURL = stack.stack()->sourceURL();
+                result = true;
+            }
+        }
+    }
 
     if (sourceURL->isEmpty())
         *sourceURL = "undefined"_s;
@@ -171,12 +179,17 @@ static bool extractSourceInformationFromException(JSC::JSGlobalObject* globalObj
 Ref<ScriptCallStack> createScriptCallStackFromException(JSC::JSGlobalObject* globalObject, JSC::Exception* exception, size_t maxStackSize)
 {
     Vector<ScriptCallFrame> frames;
-    auto& stackTrace = exception->stack();
     VM& vm = globalObject->vm();
-    for (size_t i = 0; i < stackTrace.size() && i < maxStackSize; i++) {
-        auto lineColumn = stackTrace[i].computeLineAndColumn();
-        String functionName = stackTrace[i].functionName(vm);
-        frames.append(ScriptCallFrame(functionName, stackTrace[i].sourceURL(vm), stackTrace[i].sourceID(), lineColumn));
+    size_t stackSize = 0;
+    if (auto stackTrace = exception->stack(); !stackTrace.isEmpty()) {
+        stackTrace.computeErrorInfo(vm);
+        stackSize = stackTrace.size();
+        for (size_t i = 0; i < stackSize && i < maxStackSize; i++) {
+            auto frame = stackTrace.computedAt(i);
+            auto lineColumn = frame.m_lineColumn;
+            String functionName = frame.m_functionName;
+            frames.append(ScriptCallFrame(functionName, frame.m_sourceURL, frame.m_sourceID, lineColumn));
+        }
     }
 
     // Fallback to getting at least the line and sourceURL from the exception object if it has values and the exceptionStack doesn't.
@@ -194,10 +207,14 @@ Ref<ScriptCallStack> createScriptCallStackFromException(JSC::JSGlobalObject* glo
             // example - it uses firstNonNativeCallFrame). This looks like it splats something else
             // over it. That something else is probably already at stackTrace[1].
             // https://bugs.webkit.org/show_bug.cgi?id=176663
-            if (!stackTrace[0].hasLineAndColumnInfo() || stackTrace[0].sourceURL(vm).isEmpty()) {
-                const ScriptCallFrame& firstCallFrame = frames.first();
-                if (extractSourceInformationFromException(globalObject, exceptionObject, &lineColumn, &exceptionSourceURL))
-                    frames[0] = ScriptCallFrame(firstCallFrame.functionName(), exceptionSourceURL, stackTrace[0].sourceID(), lineColumn);
+            if (auto stackTrace = exception->stack(); !stackTrace.isEmpty()) {
+                stackTrace.computeErrorInfo(vm);
+                auto frame = stackTrace.computedAt(0);
+                if (frame.m_lineColumn != LineColumn { } || frame.m_sourceURL.isEmpty()) {
+                    const ScriptCallFrame& firstCallFrame = frames.first();
+                    if (extractSourceInformationFromException(globalObject, exceptionObject, &lineColumn, &exceptionSourceURL))
+                        frames[0] = ScriptCallFrame(firstCallFrame.functionName(), exceptionSourceURL, frame.m_sourceID, lineColumn);
+                }
             }
         }
     }
@@ -207,7 +224,7 @@ Ref<ScriptCallStack> createScriptCallStackFromException(JSC::JSGlobalObject* glo
         if (auto* debuggerAgent = dynamicDowncast<InspectorDebuggerAgent>(debugger->client()))
             parentStackTrace = debuggerAgent->currentParentStackTrace();
     }
-    return ScriptCallStack::create(WTFMove(frames), stackTrace.size() > maxStackSize, parentStackTrace);
+    return ScriptCallStack::create(WTFMove(frames), stackSize > maxStackSize, parentStackTrace);
 }
 
 Ref<ScriptArguments> createScriptArguments(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callFrame, unsigned skipArgumentCount)

--- a/Source/JavaScriptCore/runtime/DestructibleException.cpp
+++ b/Source/JavaScriptCore/runtime/DestructibleException.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DestructibleException.h"
+
+#include "Interpreter.h"
+#include "JSCJSValueInlines.h"
+#include "JSObjectInlines.h"
+#include "StructureInlines.h"
+#include "JSWebAssemblyException.h"
+#include "WasmTag.h"
+
+namespace JSC {
+
+const ClassInfo DestructibleException::s_info = { "DestructibleException"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(DestructibleException) };
+
+DestructibleException* DestructibleException::create(VM& vm, JSValue thrownValue)
+{
+    DestructibleException* result = new (NotNull, allocateCell<DestructibleException>(vm)) DestructibleException(vm, thrownValue);
+    result->finishCreation(vm);
+    return result;
+}
+
+void DestructibleException::destroy(JSCell* cell)
+{
+    static_cast<DestructibleException*>(cell)->~DestructibleException();
+}
+
+Structure* DestructibleException::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
+{
+    return Structure::create(vm, globalObject, prototype, TypeInfo(CellType, StructureFlags), info());
+}
+
+template<typename Visitor>
+void DestructibleException::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+{
+    DestructibleException* thisObject = jsCast<DestructibleException*>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+    Base::visitChildren(thisObject, visitor);
+    if (SUPPRESS_UNCOUNTED_LOCAL auto* stack = thisObject->m_stack.get())
+        stack->visitAggregate(visitor);
+}
+
+DEFINE_VISIT_CHILDREN(DestructibleException);
+
+DestructibleException::DestructibleException(VM& vm, JSValue thrownValue)
+    : Base(vm, vm.destructibleExceptionStructure.get(), thrownValue)
+{
+}
+
+DestructibleException::~DestructibleException() = default;
+
+void DestructibleException::finishCreation(VM& vm)
+{
+    Base::finishCreation(vm);
+
+    auto stackTrace = makeUnique<Vector<StackFrame>>();
+    vm.interpreter.getStackTrace(this, *stackTrace, 0, Options::exceptionStackTraceLimit());
+    auto stack = ExceptionStackContent::create(WTFMove(stackTrace));
+    size_t sizeInBytes = stack->sizeInBytes();
+    WTF::storeStoreFence();
+    m_stack = WTFMove(stack);
+    vm.writeBarrier(this);
+    vm.heap.reportExtraMemoryAllocated(this, sizeInBytes);
+}
+
+ExceptionStack DestructibleException::stack() const
+{
+    return ExceptionStack { m_stack, m_replacedLineColumn, m_callDepth };
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/DestructibleException.h
+++ b/Source/JavaScriptCore/runtime/DestructibleException.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,19 +25,43 @@
 
 #pragma once
 
+#include "Exception.h"
+#include "ExceptionStack.h"
+#include <wtf/Vector.h>
+
 namespace JSC {
 
-struct LineColumn {
-    bool operator==(const LineColumn& other) const
+class DestructibleException final : public Exception {
+public:
+    using Base = Exception;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
+
+    template<typename CellType, SubspaceAccess mode>
+    static GCClient::IsoSubspace* subspaceFor(VM& vm)
     {
-        return line == other.line && column == other.column;
+        return &vm.destructibleExceptionSpace();
     }
 
-    explicit operator bool() const { return !!line; }
+    JS_EXPORT_PRIVATE static DestructibleException* create(VM&, JSValue thrownValue);
 
-    unsigned line { 0 };
-    unsigned column { 0 };
+    static Structure* createStructure(VM&, JSGlobalObject*, JSValue prototype);
+
+    DECLARE_VISIT_CHILDREN;
+
+    DECLARE_EXPORT_INFO;
+
+    ~DestructibleException();
+
+    ExceptionStack stack() const;
+
+private:
+    DestructibleException(VM&, JSValue thrownValue);
+    void finishCreation(VM&);
+    static void destroy(JSCell*);
+
+    RefPtr<ExceptionStackContent> m_stack;
+
+    friend class LLIntOffsetsExtractor;
 };
 
 } // namespace JSC
-

--- a/Source/JavaScriptCore/runtime/Error.cpp
+++ b/Source/JavaScriptCore/runtime/Error.cpp
@@ -34,59 +34,59 @@
 
 namespace JSC {
 
-JSObject* createError(JSGlobalObject* globalObject, const String& message, ErrorInstance::SourceAppender appender)
+ErrorInstance* createError(JSGlobalObject* globalObject, const String& message, ErrorInstance::SourceAppender appender)
 {
     ASSERT(!message.isEmpty());
     return ErrorInstance::create(globalObject->vm(), globalObject->errorStructure(), message, JSValue(), appender, TypeNothing, ErrorType::Error, true);
 }
 
-JSObject* createEvalError(JSGlobalObject* globalObject, const String& message, ErrorInstance::SourceAppender appender)
+ErrorInstance* createEvalError(JSGlobalObject* globalObject, const String& message, ErrorInstance::SourceAppender appender)
 {
     ASSERT(!message.isEmpty());
     return ErrorInstance::create(globalObject->vm(), globalObject->errorStructure(ErrorType::EvalError), message, JSValue(), appender, TypeNothing, ErrorType::EvalError, true);
 }
 
-JSObject* createRangeError(JSGlobalObject* globalObject, const String& message, ErrorInstance::SourceAppender appender)
+ErrorInstance* createRangeError(JSGlobalObject* globalObject, const String& message, ErrorInstance::SourceAppender appender)
 {
     ASSERT(!message.isEmpty());
     return ErrorInstance::create(globalObject->vm(), globalObject->errorStructure(ErrorType::RangeError), message, JSValue(), appender, TypeNothing, ErrorType::RangeError, true);
 }
 
-JSObject* createReferenceError(JSGlobalObject* globalObject, const String& message, ErrorInstance::SourceAppender appender)
+ErrorInstance* createReferenceError(JSGlobalObject* globalObject, const String& message, ErrorInstance::SourceAppender appender)
 {
     ASSERT(!message.isEmpty());
     return ErrorInstance::create(globalObject->vm(), globalObject->errorStructure(ErrorType::ReferenceError), message, JSValue(), appender, TypeNothing, ErrorType::ReferenceError, true);
 }
 
-JSObject* createSyntaxError(JSGlobalObject* globalObject, const String& message, ErrorInstance::SourceAppender appender)
+ErrorInstance* createSyntaxError(JSGlobalObject* globalObject, const String& message, ErrorInstance::SourceAppender appender)
 {
     ASSERT(!message.isEmpty());
     return ErrorInstance::create(globalObject->vm(), globalObject->errorStructure(ErrorType::SyntaxError), message, JSValue(), appender, TypeNothing, ErrorType::SyntaxError, true);
 }
 
-JSObject* createTypeError(JSGlobalObject* globalObject, const String& message, ErrorInstance::SourceAppender appender, RuntimeType type)
+ErrorInstance* createTypeError(JSGlobalObject* globalObject, const String& message, ErrorInstance::SourceAppender appender, RuntimeType type)
 {
     ASSERT(!message.isEmpty());
     return ErrorInstance::create(globalObject->vm(), globalObject->errorStructure(ErrorType::TypeError), message, JSValue(), appender, type, ErrorType::TypeError, true);
 }
 
-JSObject* createNotEnoughArgumentsError(JSGlobalObject* globalObject, ErrorInstance::SourceAppender appender)
+ErrorInstance* createNotEnoughArgumentsError(JSGlobalObject* globalObject, ErrorInstance::SourceAppender appender)
 {
     return createTypeError(globalObject, "Not enough arguments"_s, appender, TypeNothing);
 }
 
-JSObject* createURIError(JSGlobalObject* globalObject, const String& message, ErrorInstance::SourceAppender appender)
+ErrorInstance* createURIError(JSGlobalObject* globalObject, const String& message, ErrorInstance::SourceAppender appender)
 {
     ASSERT(!message.isEmpty());
     return ErrorInstance::create(globalObject->vm(), globalObject->errorStructure(ErrorType::URIError), message, JSValue(), appender, TypeNothing, ErrorType::URIError, true);
 }
 
-JSObject* createError(JSGlobalObject* globalObject, ErrorType errorType, const String& message)
+ErrorInstance* createError(JSGlobalObject* globalObject, ErrorType errorType, const String& message)
 {
     return createError(globalObject, static_cast<ErrorTypeWithExtension>(errorType), message);
 }
 
-JSObject* createError(JSGlobalObject* globalObject, ErrorTypeWithExtension errorType, const String& message)
+ErrorInstance* createError(JSGlobalObject* globalObject, ErrorTypeWithExtension errorType, const String& message)
 {
     switch (errorType) {
     case ErrorTypeWithExtension::Error:
@@ -114,7 +114,7 @@ JSObject* createError(JSGlobalObject* globalObject, ErrorTypeWithExtension error
     return nullptr;
 }
 
-static JSObject* createGetterTypeError(JSGlobalObject* globalObject, const String& message)
+static ErrorInstance* createGetterTypeError(JSGlobalObject* globalObject, const String& message)
 {
     ASSERT(!message.isEmpty());
     auto* error = ErrorInstance::create(globalObject->vm(), globalObject->errorStructure(ErrorType::TypeError), message, JSValue(), nullptr, TypeNothing, ErrorType::TypeError);
@@ -188,41 +188,21 @@ std::tuple<CodeBlock*, BytecodeIndex> getBytecodeIndex(VM& vm, CallFrame* startC
     return { functor.codeBlock(), functor.bytecodeIndex() };
 }
 
-bool getLineColumnAndSource(VM& vm, Vector<StackFrame>* stackTrace, LineColumn& lineColumn, String& sourceURL)
-{
-    lineColumn = { };
-    sourceURL = String();
-    
-    if (!stackTrace)
-        return false;
-    
-    for (unsigned i = 0 ; i < stackTrace->size(); ++i) {
-        StackFrame& frame = stackTrace->at(i);
-        if (frame.hasLineAndColumnInfo()) {
-            lineColumn = frame.computeLineAndColumn();
-            sourceURL = frame.sourceURLStripped(vm);
-            return true;
-        }
-    }
-    
-    return false;
-}
-
-bool addErrorInfo(VM& vm, Vector<StackFrame>* stackTrace, JSObject* obj)
+bool addErrorInfo(VM& vm, RefPtr<ExceptionStackContent> stackTrace, JSObject* obj)
 {
     if (!stackTrace)
         return false;
 
     if (!stackTrace->isEmpty()) {
-        LineColumn lineColumn;
-        String sourceURL;
-        getLineColumnAndSource(vm, stackTrace, lineColumn, sourceURL);
+        stackTrace->computeErrorInfo(vm);
+        LineColumn lineColumn = stackTrace->lineColumn();
+        String sourceURL = stackTrace->sourceURL();
         obj->putDirect(vm, vm.propertyNames->line, jsNumber(lineColumn.line));
         obj->putDirect(vm, vm.propertyNames->column, jsNumber(lineColumn.column));
         if (!sourceURL.isEmpty())
             obj->putDirect(vm, vm.propertyNames->sourceURL, jsString(vm, WTFMove(sourceURL)));
 
-        obj->putDirect(vm, vm.propertyNames->stack, jsString(vm, Interpreter::stackTraceAsString(vm, *stackTrace)), static_cast<unsigned>(PropertyAttribute::DontEnum));
+        obj->putDirect(vm, vm.propertyNames->stack, jsString(vm, stackTrace->stackString()), static_cast<unsigned>(PropertyAttribute::DontEnum));
 
         return true;
     }
@@ -234,8 +214,7 @@ bool addErrorInfo(VM& vm, Vector<StackFrame>* stackTrace, JSObject* obj)
 void addErrorInfo(JSGlobalObject* globalObject, JSObject* obj, bool useCurrentFrame)
 {
     VM& vm = globalObject->vm();
-    std::unique_ptr<Vector<StackFrame>> stackTrace = getStackTrace(vm, obj, useCurrentFrame);
-    addErrorInfo(vm, stackTrace.get(), obj);
+    addErrorInfo(vm, ExceptionStackContent::create(getStackTrace(vm, obj, useCurrentFrame)), obj);
 }
 
 JSObject* addErrorInfo(VM& vm, JSObject* error, int line, const SourceCode& source)
@@ -262,7 +241,7 @@ JSObject* addErrorInfo(VM& vm, JSObject* error, int line, const SourceCode& sour
     return error;
 }
 
-JSObject* createTypeErrorCopy(JSGlobalObject* globalObject, JSValue error)
+ErrorInstance* createTypeErrorCopy(JSGlobalObject* globalObject, JSValue error)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_CATCH_SCOPE(vm);
@@ -310,7 +289,7 @@ Exception* throwConstructorCannotBeCalledAsFunctionTypeError(JSGlobalObject* glo
 
 Exception* throwTypeError(JSGlobalObject* globalObject, ThrowScope& scope)
 {
-    return throwException(globalObject, scope, createTypeError(globalObject));
+    return throwException(globalObject, scope, Exception::createWithStackFromError(globalObject->vm(), createTypeError(globalObject)));
 }
 
 Exception* throwTypeError(JSGlobalObject* globalObject, ThrowScope& scope, ASCIILiteral errorMessage)
@@ -320,87 +299,87 @@ Exception* throwTypeError(JSGlobalObject* globalObject, ThrowScope& scope, ASCII
 
 Exception* throwTypeError(JSGlobalObject* globalObject, ThrowScope& scope, const String& message)
 {
-    return throwException(globalObject, scope, createTypeError(globalObject, message));
+    return throwException(globalObject, scope, Exception::createWithStackFromError(globalObject->vm(), createTypeError(globalObject, message)));
 }
 
 Exception* throwSyntaxError(JSGlobalObject* globalObject, ThrowScope& scope)
 {
-    return throwException(globalObject, scope, createSyntaxError(globalObject));
+    return throwException(globalObject, scope, Exception::createWithStackFromError(globalObject->vm(), createSyntaxError(globalObject)));
 }
 
 Exception* throwSyntaxError(JSGlobalObject* globalObject, ThrowScope& scope, const String& message)
 {
-    return throwException(globalObject, scope, createSyntaxError(globalObject, message));
+    return throwException(globalObject, scope, Exception::createWithStackFromError(globalObject->vm(), createSyntaxError(globalObject, message)));
 }
 
 JSValue throwDOMAttributeGetterTypeError(JSGlobalObject* globalObject, ThrowScope& scope, const ClassInfo* classInfo, PropertyName propertyName)
 {
-    return throwException(globalObject, scope, createGetterTypeError(globalObject, makeDOMAttributeGetterTypeErrorMessage(classInfo->className, String(propertyName.uid()))));
+    return throwException(globalObject, scope, Exception::createWithStackFromError(globalObject->vm(), createGetterTypeError(globalObject, makeDOMAttributeGetterTypeErrorMessage(classInfo->className, String(propertyName.uid())))));
 }
 
 JSValue throwDOMAttributeSetterTypeError(JSGlobalObject* globalObject, ThrowScope& scope, const ClassInfo* classInfo, PropertyName propertyName)
 {
-    return throwException(globalObject, scope, createTypeError(globalObject, makeDOMAttributeSetterTypeErrorMessage(classInfo->className, String(propertyName.uid()))));
+    return throwException(globalObject, scope, Exception::createWithStackFromError(globalObject->vm(), createTypeError(globalObject, makeDOMAttributeSetterTypeErrorMessage(classInfo->className, String(propertyName.uid())))));
 }
 
-JSObject* createError(JSGlobalObject* globalObject, const String& message)
+ErrorInstance* createError(JSGlobalObject* globalObject, const String& message)
 {
     return createError(globalObject, message, nullptr);
 }
 
-JSObject* createEvalError(JSGlobalObject* globalObject, const String& message)
+ErrorInstance* createEvalError(JSGlobalObject* globalObject, const String& message)
 {
     return createEvalError(globalObject, message, nullptr);
 }
 
-JSObject* createRangeError(JSGlobalObject* globalObject, const String& message)
+ErrorInstance* createRangeError(JSGlobalObject* globalObject, const String& message)
 {
     return createRangeError(globalObject, message, nullptr);
 }
 
-JSObject* createReferenceError(JSGlobalObject* globalObject, const String& message)
+ErrorInstance* createReferenceError(JSGlobalObject* globalObject, const String& message)
 {
     return createReferenceError(globalObject, message, nullptr);
 }
 
-JSObject* createSyntaxError(JSGlobalObject* globalObject, const String& message)
+ErrorInstance* createSyntaxError(JSGlobalObject* globalObject, const String& message)
 {
     return createSyntaxError(globalObject, message, nullptr);
 }
 
-JSObject* createSyntaxError(JSGlobalObject* globalObject)
+ErrorInstance* createSyntaxError(JSGlobalObject* globalObject)
 {
     return createSyntaxError(globalObject, "Syntax error"_s, nullptr);
 }
 
-JSObject* createTypeError(JSGlobalObject* globalObject)
+ErrorInstance* createTypeError(JSGlobalObject* globalObject)
 {
     return createTypeError(globalObject, "Type error"_s);
 }
 
-JSObject* createTypeError(JSGlobalObject* globalObject, const String& message)
+ErrorInstance* createTypeError(JSGlobalObject* globalObject, const String& message)
 {
     return createTypeError(globalObject, message, nullptr, TypeNothing);
 }
 
-JSObject* createNotEnoughArgumentsError(JSGlobalObject* globalObject)
+ErrorInstance* createNotEnoughArgumentsError(JSGlobalObject* globalObject)
 {
     return createNotEnoughArgumentsError(globalObject, nullptr);
 }
 
-JSObject* createURIError(JSGlobalObject* globalObject, const String& message)
+ErrorInstance* createURIError(JSGlobalObject* globalObject, const String& message)
 {
     return createURIError(globalObject, message, nullptr);
 }
 
-JSObject* createOutOfMemoryError(JSGlobalObject* globalObject)
+ErrorInstance* createOutOfMemoryError(JSGlobalObject* globalObject)
 {
     auto* error = createRangeError(globalObject, "Out of memory"_s, nullptr);
     jsCast<ErrorInstance*>(error)->setOutOfMemoryError();
     return error;
 }
 
-JSObject* createOutOfMemoryError(JSGlobalObject* globalObject, const String& message)
+ErrorInstance* createOutOfMemoryError(JSGlobalObject* globalObject, const String& message)
 {
     if (message.isEmpty())
         return createOutOfMemoryError(globalObject);

--- a/Source/JavaScriptCore/runtime/Error.h
+++ b/Source/JavaScriptCore/runtime/Error.h
@@ -41,35 +41,34 @@ class JSObject;
 class SourceCode;
 class Structure;
 
-JSObject* createError(JSGlobalObject*, const String&, ErrorInstance::SourceAppender);
-JSObject* createEvalError(JSGlobalObject*, const String&, ErrorInstance::SourceAppender);
-JSObject* createRangeError(JSGlobalObject*, const String&, ErrorInstance::SourceAppender);
-JSObject* createReferenceError(JSGlobalObject*, const String&, ErrorInstance::SourceAppender);
-JSObject* createSyntaxError(JSGlobalObject*, const String&, ErrorInstance::SourceAppender);
-JSObject* createTypeError(JSGlobalObject*, const String&, ErrorInstance::SourceAppender, RuntimeType);
-JSObject* createNotEnoughArgumentsError(JSGlobalObject*, ErrorInstance::SourceAppender);
-JSObject* createURIError(JSGlobalObject*, const String&, ErrorInstance::SourceAppender);
+ErrorInstance* createError(JSGlobalObject*, const String&, ErrorInstance::SourceAppender);
+ErrorInstance* createEvalError(JSGlobalObject*, const String&, ErrorInstance::SourceAppender);
+ErrorInstance* createRangeError(JSGlobalObject*, const String&, ErrorInstance::SourceAppender);
+ErrorInstance* createReferenceError(JSGlobalObject*, const String&, ErrorInstance::SourceAppender);
+ErrorInstance* createSyntaxError(JSGlobalObject*, const String&, ErrorInstance::SourceAppender);
+ErrorInstance* createTypeError(JSGlobalObject*, const String&, ErrorInstance::SourceAppender, RuntimeType);
+ErrorInstance* createNotEnoughArgumentsError(JSGlobalObject*, ErrorInstance::SourceAppender);
+ErrorInstance* createURIError(JSGlobalObject*, const String&, ErrorInstance::SourceAppender);
 
-JS_EXPORT_PRIVATE JSObject* createError(JSGlobalObject*, const String&);
-JS_EXPORT_PRIVATE JSObject* createEvalError(JSGlobalObject*, const String&);
-JS_EXPORT_PRIVATE JSObject* createRangeError(JSGlobalObject*, const String&);
-JS_EXPORT_PRIVATE JSObject* createReferenceError(JSGlobalObject*, const String&);
-JS_EXPORT_PRIVATE JSObject* createSyntaxError(JSGlobalObject*, const String&);
-JS_EXPORT_PRIVATE JSObject* createSyntaxError(JSGlobalObject*);
-JS_EXPORT_PRIVATE JSObject* createTypeError(JSGlobalObject*);
-JS_EXPORT_PRIVATE JSObject* createTypeError(JSGlobalObject*, const String&);
-JS_EXPORT_PRIVATE JSObject* createNotEnoughArgumentsError(JSGlobalObject*);
-JS_EXPORT_PRIVATE JSObject* createURIError(JSGlobalObject*, const String&);
-JS_EXPORT_PRIVATE JSObject* createOutOfMemoryError(JSGlobalObject*);
-JS_EXPORT_PRIVATE JSObject* createOutOfMemoryError(JSGlobalObject*, const String&);
+JS_EXPORT_PRIVATE ErrorInstance* createError(JSGlobalObject*, const String&);
+JS_EXPORT_PRIVATE ErrorInstance* createEvalError(JSGlobalObject*, const String&);
+JS_EXPORT_PRIVATE ErrorInstance* createRangeError(JSGlobalObject*, const String&);
+JS_EXPORT_PRIVATE ErrorInstance* createReferenceError(JSGlobalObject*, const String&);
+JS_EXPORT_PRIVATE ErrorInstance* createSyntaxError(JSGlobalObject*, const String&);
+JS_EXPORT_PRIVATE ErrorInstance* createSyntaxError(JSGlobalObject*);
+JS_EXPORT_PRIVATE ErrorInstance* createTypeError(JSGlobalObject*);
+JS_EXPORT_PRIVATE ErrorInstance* createTypeError(JSGlobalObject*, const String&);
+JS_EXPORT_PRIVATE ErrorInstance* createNotEnoughArgumentsError(JSGlobalObject*);
+JS_EXPORT_PRIVATE ErrorInstance* createURIError(JSGlobalObject*, const String&);
+JS_EXPORT_PRIVATE ErrorInstance* createOutOfMemoryError(JSGlobalObject*);
+JS_EXPORT_PRIVATE ErrorInstance* createOutOfMemoryError(JSGlobalObject*, const String&);
 
-JS_EXPORT_PRIVATE JSObject* createError(JSGlobalObject*, ErrorType, const String&);
-JS_EXPORT_PRIVATE JSObject* createError(JSGlobalObject*, ErrorTypeWithExtension, const String&);
+JS_EXPORT_PRIVATE ErrorInstance* createError(JSGlobalObject*, ErrorType, const String&);
+JS_EXPORT_PRIVATE ErrorInstance* createError(JSGlobalObject*, ErrorTypeWithExtension, const String&);
 
 std::unique_ptr<Vector<StackFrame>> getStackTrace(VM&, JSObject*, bool useCurrentFrame, JSCell* ownerOfCallLinkInfo = nullptr, CallLinkInfo* = nullptr);
 std::tuple<CodeBlock*, BytecodeIndex> getBytecodeIndex(VM&, CallFrame*);
-bool getLineColumnAndSource(VM&, Vector<StackFrame>* stackTrace, LineColumn&, String& sourceURL);
-bool addErrorInfo(VM&, Vector<StackFrame>*, JSObject*);
+bool addErrorInfo(VM&, RefPtr<ExceptionStackContent>, JSObject*);
 JS_EXPORT_PRIVATE void addErrorInfo(JSGlobalObject*, JSObject*, bool);
 JSObject* addErrorInfo(VM&, JSObject* error, int line, const SourceCode&);
 
@@ -79,7 +78,7 @@ JSObject* addErrorInfo(VM&, JSObject* error, int line, const SourceCode&);
 // without invoking any observable operations. It attempts to maintain the
 // error message of the original error, if possible, and may include additional
 // information.
-JSObject* createTypeErrorCopy(JSGlobalObject*, JSValue error);
+ErrorInstance* createTypeErrorCopy(JSGlobalObject*, JSValue error);
 
 // Methods to throw Errors.
 

--- a/Source/JavaScriptCore/runtime/ErrorInstance.cpp
+++ b/Source/JavaScriptCore/runtime/ErrorInstance.cpp
@@ -22,6 +22,7 @@
 #include "ErrorInstance.h"
 
 #include "CodeBlock.h"
+#include "ExceptionStack.h"
 #include "InlineCallFrame.h"
 #include "IntegrityInlines.h"
 #include "Interpreter.h"
@@ -112,22 +113,17 @@ void ErrorInstance::finishCreation(VM& vm, const String& message, JSValue cause,
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
 
-    m_sourceAppender = appender;
     m_runtimeTypeForCause = type;
-
-    std::unique_ptr<Vector<StackFrame>> stackTrace = getStackTrace(vm, this, useCurrentFrame);
-    {
-        Locker locker { cellLock() };
-        m_stackTrace = WTFMove(stackTrace);
-    }
+    auto stack = ExceptionStackContent::create(getStackTrace(vm, this, useCurrentFrame));
+    WTF::storeStoreFence();
+    m_stackTrace = WTFMove(stack);
     vm.writeBarrier(this);
+    vm.heap.reportExtraMemoryAllocated(this, m_stackTrace->sizeInBytes());
 
     String messageWithSource = message;
-    if (m_stackTrace && !m_stackTrace->isEmpty() && hasSourceAppender()) {
+    if (!m_stackTrace->isEmpty() && appender) {
         auto [codeBlock, bytecodeIndex] = getBytecodeIndex(vm, vm.topCallFrame);
         if (codeBlock) {
-            ErrorInstance::SourceAppender appender = sourceAppender();
-            clearSourceAppender();
             RuntimeType type = runtimeTypeForCause();
             clearRuntimeTypeForCause();
             messageWithSource = appendSourceToErrorMessage(codeBlock, bytecodeIndex, message, type, appender);
@@ -145,13 +141,11 @@ void ErrorInstance::finishCreation(VM& vm, const String& message, JSValue cause,
 {
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
-
-    std::unique_ptr<Vector<StackFrame>> stackTrace = getStackTrace(vm, this, /* useCurrentFrame */ true, owner, callLinkInfo);
-    {
-        Locker locker { cellLock() };
-        m_stackTrace = WTFMove(stackTrace);
-    }
+    auto stack = ExceptionStackContent::create(getStackTrace(vm, this, /* useCurrentFrame */ true, owner, callLinkInfo));
+    WTF::storeStoreFence();
+    m_stackTrace = WTFMove(stack);
     vm.writeBarrier(this);
+    vm.heap.reportExtraMemoryAllocated(this, m_stackTrace->sizeInBytes());
     if (!message.isNull())
         putDirect(vm, vm.propertyNames->message, jsString(vm, message), static_cast<unsigned>(PropertyAttribute::DontEnum));
 
@@ -163,10 +157,10 @@ void ErrorInstance::finishCreation(VM& vm, String&& message, LineColumn lineColu
 {
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
-
-    m_lineColumn = lineColumn;
-    m_sourceURL = WTFMove(sourceURL);
-    m_stackString = WTFMove(stackString);
+    auto stack = ExceptionStackContent::create(lineColumn, WTFMove(stackString), WTFMove(sourceURL));
+    WTF::storeStoreFence();
+    m_stackTrace = WTFMove(stack);
+    vm.heap.reportExtraMemoryAllocated(this, m_stackTrace->sizeInBytes());
     if (!message.isNull())
         putDirect(vm, vm.propertyNames->message, jsString(vm, WTFMove(message)), static_cast<unsigned>(PropertyAttribute::DontEnum));
     if (!cause.isNull())
@@ -256,34 +250,10 @@ String ErrorInstance::tryGetMessageForDebugging()
     return emptyString();
 }
 
-void ErrorInstance::finalizeUnconditionally(VM& vm, CollectionScope)
+void ErrorInstance::finalizeUnconditionally(VM& vm, CollectionScope scope)
 {
-    if (!m_stackTrace)
-        return;
-
-    // We don't want to keep our stack traces alive forever if the user doesn't access the stack trace.
-    // If we did, we might end up keeping functions (and their global objects) alive that happened to
-    // get caught in a trace.
-    for (const auto& frame : *m_stackTrace.get()) {
-        if (!frame.isMarked(vm)) {
-            computeErrorInfo(vm);
-            return;
-        }
-    }
-}
-
-void ErrorInstance::computeErrorInfo(VM& vm)
-{
-    ASSERT(!m_errorInfoMaterialized);
-    // Here we use DeferGCForAWhile instead of DeferGC since GC's Heap::runEndPhase can trigger this function. In
-    // that case, DeferGC's destructor might trigger another GC cycle which is unexpected.
-    DeferGCForAWhile deferGC(vm);
-
-    if (m_stackTrace && !m_stackTrace->isEmpty()) {
-        getLineColumnAndSource(vm, m_stackTrace.get(), m_lineColumn, m_sourceURL);
-        m_stackString = Interpreter::stackTraceAsString(vm, *m_stackTrace.get());
-        m_stackTrace = nullptr;
-    }
+    if (m_stackTrace)
+        m_stackTrace->finalizeUnconditionally(vm, scope);
 }
 
 bool ErrorInstance::materializeErrorInfoIfNeeded(VM& vm)
@@ -291,17 +261,19 @@ bool ErrorInstance::materializeErrorInfoIfNeeded(VM& vm)
     if (m_errorInfoMaterialized)
         return false;
 
-    computeErrorInfo(vm);
+    if (m_stackTrace) {
+        m_stackTrace->computeErrorInfo(vm);
 
-    if (!m_stackString.isNull()) {
-        auto attributes = static_cast<unsigned>(PropertyAttribute::DontEnum);
+        if (!m_stackTrace->stackString().isNull()) {
+            auto attributes = static_cast<unsigned>(PropertyAttribute::DontEnum);
 
-        putDirect(vm, vm.propertyNames->line, jsNumber(m_lineColumn.line), attributes);
-        putDirect(vm, vm.propertyNames->column, jsNumber(m_lineColumn.column), attributes);
-        if (!m_sourceURL.isEmpty())
-            putDirect(vm, vm.propertyNames->sourceURL, jsString(vm, WTFMove(m_sourceURL)), attributes);
+            putDirect(vm, vm.propertyNames->line, jsNumber(m_stackTrace->lineColumn().line), attributes);
+            putDirect(vm, vm.propertyNames->column, jsNumber(m_stackTrace->lineColumn().column), attributes);
+            if (!m_stackTrace->sourceURL().isEmpty())
+                putDirect(vm, vm.propertyNames->sourceURL, jsString(vm, m_stackTrace->sourceURL()), attributes);
 
-        putDirect(vm, vm.propertyNames->stack, jsString(vm, WTFMove(m_stackString)), attributes);
+            putDirect(vm, vm.propertyNames->stack, jsString(vm, m_stackTrace->stackString()), attributes);
+        }
     }
 
     m_errorInfoMaterialized = true;

--- a/Source/JavaScriptCore/runtime/ErrorInstance.h
+++ b/Source/JavaScriptCore/runtime/ErrorInstance.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "ErrorType.h"
+#include "ExceptionStack.h"
 #include "JSObject.h"
 #include "RuntimeType.h"
 #include "StackFrame.h"
@@ -71,10 +72,6 @@ public:
     JS_EXPORT_PRIVATE static ErrorInstance* create(JSGlobalObject*, String&& message, ErrorType, LineColumn, String&& sourceURL, String&& stackString, String&& cause = { });
     static ErrorInstance* create(JSGlobalObject*, Structure*, JSValue message, JSValue options, SourceAppender = nullptr, RuntimeType = TypeNothing, ErrorType = ErrorType::Error, bool useCurrentFrame = true);
 
-    bool hasSourceAppender() const { return !!m_sourceAppender; }
-    SourceAppender sourceAppender() const { return m_sourceAppender; }
-    void setSourceAppender(SourceAppender appender) { m_sourceAppender = appender; }
-    void clearSourceAppender() { m_sourceAppender = nullptr; }
     void setRuntimeTypeForCause(RuntimeType type) { m_runtimeTypeForCause = type; }
     RuntimeType runtimeTypeForCause() const { return m_runtimeTypeForCause; }
     void clearRuntimeTypeForCause() { m_runtimeTypeForCause = TypeNothing; }
@@ -111,7 +108,7 @@ public:
     
     JS_EXPORT_PRIVATE String tryGetMessageForDebugging();
 
-    Vector<StackFrame>* stackTrace() { return m_stackTrace.get(); }
+    ExceptionStack stackTrace() { return ExceptionStack { m_stackTrace }; }
 
     bool materializeErrorInfoIfNeeded(VM&);
     bool materializeErrorInfoIfNeeded(VM&, PropertyName);
@@ -131,13 +128,7 @@ protected:
     static bool put(JSCell*, JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
     static bool deleteProperty(JSCell*, JSGlobalObject*, PropertyName, DeletePropertySlot&);
 
-    void computeErrorInfo(VM&);
-
-    SourceAppender m_sourceAppender { nullptr };
-    std::unique_ptr<Vector<StackFrame>> m_stackTrace;
-    LineColumn m_lineColumn;
-    String m_sourceURL;
-    String m_stackString;
+    RefPtr<ExceptionStackContent> m_stackTrace;
     RuntimeType m_runtimeTypeForCause { TypeNothing };
     ErrorType m_errorType { ErrorType::Error };
     bool m_stackOverflowError : 1;

--- a/Source/JavaScriptCore/runtime/Exception.cpp
+++ b/Source/JavaScriptCore/runtime/Exception.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "Exception.h"
 
+#include "DestructibleException.h"
 #include "Interpreter.h"
 #include "JSCJSValueInlines.h"
 #include "JSObjectInlines.h"
@@ -39,15 +40,27 @@ const ClassInfo Exception::s_info = { "Exception"_s, nullptr, nullptr, nullptr, 
 
 Exception* Exception::create(VM& vm, JSValue thrownValue, StackCaptureAction action)
 {
-    Exception* result = new (NotNull, allocateCell<Exception>(vm)) Exception(vm, thrownValue);
-    result->finishCreation(vm, action);
+    if (action == CaptureStack)
+        return DestructibleException::create(vm, thrownValue);
+    Exception* result = new (NotNull, allocateCell<Exception>(vm)) Exception(vm, vm.exceptionStructure.get(), thrownValue);
+    result->finishCreation(vm);
     return result;
 }
 
-void Exception::destroy(JSCell* cell)
+Exception* Exception::createWithStackFromError(VM& vm, ErrorInstance* error)
 {
-    Exception* exception = static_cast<Exception*>(cell);
-    exception->~Exception();
+    Exception* result = new (NotNull, allocateCell<Exception>(vm)) Exception(vm, vm.exceptionStructure.get(), error);
+    result->finishCreation(vm);
+    return result;
+}
+
+Exception* Exception::createWithFrameAdjustment(VM& vm, ErrorInstance* error, LineColumn lineColumn, unsigned callDepth)
+{
+    Exception* result = new (NotNull, allocateCell<Exception>(vm)) Exception(vm, vm.exceptionStructure.get(), error);
+    result->finishCreation(vm);
+    result->m_replacedLineColumn = lineColumn;
+    result->m_callDepth = callDepth;
+    return result;
 }
 
 Structure* Exception::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
@@ -61,32 +74,26 @@ void Exception::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     Exception* thisObject = jsCast<Exception*>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-
     visitor.append(thisObject->m_value);
-    for (StackFrame& frame : thisObject->m_stack)
-        frame.visitAggregate(visitor);
-    visitor.reportExtraMemoryVisited(thisObject->m_stack.sizeInBytes());
 }
 
 DEFINE_VISIT_CHILDREN(Exception);
 
-Exception::Exception(VM& vm, JSValue thrownValue)
-    : Base(vm, vm.exceptionStructure.get())
+Exception::Exception(VM& vm, Structure* structure, JSValue thrownValue)
+    : Base(vm, structure)
     , m_value(thrownValue, WriteBarrierEarlyInit)
 {
 }
 
 Exception::~Exception() = default;
 
-void Exception::finishCreation(VM& vm, StackCaptureAction action)
+ExceptionStack Exception::stack() const
 {
-    Base::finishCreation(vm);
-
-    Vector<StackFrame> stackTrace;
-    if (action == StackCaptureAction::CaptureStack)
-        vm.interpreter.getStackTrace(this, stackTrace, 0, Options::exceptionStackTraceLimit());
-    m_stack = WTFMove(stackTrace);
-    vm.heap.reportExtraMemoryAllocated(this, m_stack.sizeInBytes());
+    if (auto* derived = jsDynamicCast<const DestructibleException*>(this))
+        return derived->stack();
+    if (auto* error = jsDynamicCast<ErrorInstance*>(m_value.get()))
+        return ExceptionStack { error->stackTrace().stack(), m_replacedLineColumn, m_callDepth };
+    return ExceptionStack { nullptr, m_replacedLineColumn, m_callDepth };
 }
 
 #if ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/runtime/Exception.h
+++ b/Source/JavaScriptCore/runtime/Exception.h
@@ -25,17 +25,18 @@
 
 #pragma once
 
-#include "JSDestructibleObject.h"
-#include "StackFrame.h"
+#include "ExceptionStack.h"
+#include "JSObject.h"
 #include <wtf/Vector.h>
 
 namespace JSC {
-    
-class Exception final : public JSCell {
+
+class ErrorInstance;
+
+class Exception : public JSCell {
 public:
     using Base = JSCell;
     static constexpr unsigned StructureFlags = Base::StructureFlags | StructureIsImmortal;
-    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     template<typename CellType, SubspaceAccess mode>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)
@@ -43,11 +44,13 @@ public:
         return &vm.exceptionSpace();
     }
 
-    enum StackCaptureAction {
+    enum StackCaptureAction : uint8_t {
         CaptureStack,
         DoNotCaptureStack
     };
     JS_EXPORT_PRIVATE static Exception* create(VM&, JSValue thrownValue, StackCaptureAction = CaptureStack);
+    JS_EXPORT_PRIVATE static Exception* createWithStackFromError(VM&, ErrorInstance*);
+    JS_EXPORT_PRIVATE static Exception* createWithFrameAdjustment(VM&, ErrorInstance*, LineColumn, unsigned callDepth);
 
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue prototype);
 
@@ -61,10 +64,9 @@ public:
     }
 
     JSValue value() const { return m_value.get(); }
-    const Vector<StackFrame>& stack() const { return m_stack; }
 
-    bool didNotifyInspectorOfThrow() const { return m_didNotifyInspectorOfThrow; }
-    void setDidNotifyInspectorOfThrow() { m_didNotifyInspectorOfThrow = true; }
+    bool didNotifyInspectorOfThrow() const { return perCellBit(); }
+    void setDidNotifyInspectorOfThrow() { setPerCellBit(true); }
 
 #if ENABLE(WEBASSEMBLY)
     void wrapValueForJSTag(JSGlobalObject*);
@@ -72,14 +74,14 @@ public:
 
     ~Exception();
 
-private:
-    Exception(VM&, JSValue thrownValue);
-    void finishCreation(VM&, StackCaptureAction);
-    static void destroy(JSCell*);
+    ExceptionStack stack() const;
+
+protected:
+    Exception(VM&, Structure*, JSValue thrownValue);
 
     WriteBarrier<Unknown> m_value;
-    Vector<StackFrame> m_stack;
-    bool m_didNotifyInspectorOfThrow { false };
+    LineColumn m_replacedLineColumn { };
+    unsigned m_callDepth { };
 
     friend class LLIntOffsetsExtractor;
 };

--- a/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
+++ b/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
@@ -40,14 +40,14 @@
 
 namespace JSC {
 
-JSObject* createStackOverflowError(JSGlobalObject* globalObject)
+ErrorInstance* createStackOverflowError(JSGlobalObject* globalObject)
 {
     auto* error = createRangeError(globalObject, "Maximum call stack size exceeded."_s);
     jsCast<ErrorInstance*>(error)->setStackOverflowError();
     return error;
 }
 
-JSObject* createUndefinedVariableError(JSGlobalObject* globalObject, const Identifier& ident)
+ErrorInstance* createUndefinedVariableError(JSGlobalObject* globalObject, const Identifier& ident)
 {
     if (ident.isPrivateName())
         return createReferenceError(globalObject, makeString("Can't find private variable: PrivateSymbol."_s, ident.string()));
@@ -265,7 +265,7 @@ String constructErrorMessage(JSGlobalObject* globalObject, JSValue value, const 
     return tryMakeString(valueDescription, ' ', message);
 }
 
-JSObject* createError(JSGlobalObject* globalObject, JSValue value, const String& message, ErrorInstance::SourceAppender appender)
+ErrorInstance* createError(JSGlobalObject* globalObject, JSValue value, const String& message, ErrorInstance::SourceAppender appender)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_CATCH_SCOPE(vm);
@@ -280,87 +280,87 @@ JSObject* createError(JSGlobalObject* globalObject, JSValue value, const String&
         return createOutOfMemoryError(globalObject);
     }
     scope.assertNoException();
-    JSObject* exception = createTypeError(globalObject, errorMessage, appender, runtimeTypeForValue(value));
+    ErrorInstance* exception = createTypeError(globalObject, errorMessage, appender, runtimeTypeForValue(value));
     ASSERT(exception->isErrorInstance());
     return exception;
 }
 
-JSObject* createInvalidFunctionApplyParameterError(JSGlobalObject* globalObject, JSValue value)
+ErrorInstance* createInvalidFunctionApplyParameterError(JSGlobalObject* globalObject, JSValue value)
 {
     return createTypeError(globalObject, "second argument to Function.prototype.apply must be an Array-like object"_s, defaultSourceAppender, runtimeTypeForValue(value));
 }
 
-JSObject* createInvalidInParameterError(JSGlobalObject* globalObject, JSValue value)
+ErrorInstance* createInvalidInParameterError(JSGlobalObject* globalObject, JSValue value)
 {
     return createError(globalObject, value, "is not an Object."_s, invalidParameterInSourceAppender);
 }
 
-JSObject* createInvalidInstanceofParameterErrorNotFunction(JSGlobalObject* globalObject, JSValue value)
+ErrorInstance* createInvalidInstanceofParameterErrorNotFunction(JSGlobalObject* globalObject, JSValue value)
 {
     return createError(globalObject, value, " is not a function"_s, invalidParameterInstanceofNotFunctionSourceAppender);
 }
 
-JSObject* createInvalidInstanceofParameterErrorHasInstanceValueNotFunction(JSGlobalObject* globalObject, JSValue value)
+ErrorInstance* createInvalidInstanceofParameterErrorHasInstanceValueNotFunction(JSGlobalObject* globalObject, JSValue value)
 {
     return createError(globalObject, value, "[Symbol.hasInstance] is not a function, undefined, or null"_s, invalidParameterInstanceofhasInstanceValueNotFunctionSourceAppender);
 }
 
-JSObject* createNotAConstructorError(JSGlobalObject* globalObject, JSValue value)
+ErrorInstance* createNotAConstructorError(JSGlobalObject* globalObject, JSValue value)
 {
     return createError(globalObject, value, "is not a constructor"_s, defaultSourceAppender);
 }
 
-JSObject* createNotAFunctionError(JSGlobalObject* globalObject, JSValue value)
+ErrorInstance* createNotAFunctionError(JSGlobalObject* globalObject, JSValue value)
 {
     return createError(globalObject, value, "is not a function"_s, notAFunctionSourceAppender);
 }
 
-JSObject* createNotAnObjectError(JSGlobalObject* globalObject, JSValue value)
+ErrorInstance* createNotAnObjectError(JSGlobalObject* globalObject, JSValue value)
 {
     return createError(globalObject, value, "is not an object"_s, defaultSourceAppender);
 }
 
-JSObject* createInvalidPrototypeError(JSGlobalObject* globalObject, JSValue value)
+ErrorInstance* createInvalidPrototypeError(JSGlobalObject* globalObject, JSValue value)
 {
     return createError(globalObject, value, "is not an object or null"_s, invalidPrototypeSourceAppender);
 }
 
-JSObject* createErrorForDuplicateGlobalVariableDeclaration(JSGlobalObject* globalObject, UniquedStringImpl* key)
+ErrorInstance* createErrorForDuplicateGlobalVariableDeclaration(JSGlobalObject* globalObject, UniquedStringImpl* key)
 {
     return createSyntaxError(globalObject, makeString("Can't create duplicate variable: '"_s, StringView(key), '\''));
 }
 
-JSObject* createErrorForInvalidGlobalFunctionDeclaration(JSGlobalObject* globalObject, const Identifier& ident)
+ErrorInstance* createErrorForInvalidGlobalFunctionDeclaration(JSGlobalObject* globalObject, const Identifier& ident)
 {
     return createTypeError(globalObject, makeString("Can't declare global function '"_s, ident.string(), "': property must be either configurable or both writable and enumerable"_s));
 }
 
-JSObject* createErrorForInvalidGlobalVarDeclaration(JSGlobalObject* globalObject, const Identifier& ident)
+ErrorInstance* createErrorForInvalidGlobalVarDeclaration(JSGlobalObject* globalObject, const Identifier& ident)
 {
     return createTypeError(globalObject, makeString("Can't declare global variable '"_s, ident.string(), "': global object must be extensible"_s));
 }
 
-JSObject* createTDZError(JSGlobalObject* globalObject)
+ErrorInstance* createTDZError(JSGlobalObject* globalObject)
 {
     return createReferenceError(globalObject, "Cannot access uninitialized variable."_s);
 }
 
-JSObject* createInvalidPrivateNameError(JSGlobalObject* globalObject)
+ErrorInstance* createInvalidPrivateNameError(JSGlobalObject* globalObject)
 {
     return createTypeError(globalObject, "Cannot access invalid private field"_s, defaultSourceAppender, TypeNothing);
 }
 
-JSObject* createRedefinedPrivateNameError(JSGlobalObject* globalObject)
+ErrorInstance* createRedefinedPrivateNameError(JSGlobalObject* globalObject)
 {
     return createTypeError(globalObject, "Cannot redefine existing private field"_s, defaultSourceAppender, TypeNothing);
 }
 
-JSObject* createPrivateMethodAccessError(JSGlobalObject* globalObject)
+ErrorInstance* createPrivateMethodAccessError(JSGlobalObject* globalObject)
 {
     return createTypeError(globalObject, "Cannot access private method or acessor"_s, defaultSourceAppender, TypeNothing);
 }
 
-JSObject* createReinstallPrivateMethodError(JSGlobalObject* globalObject)
+ErrorInstance* createReinstallPrivateMethodError(JSGlobalObject* globalObject)
 {
     return createTypeError(globalObject, "Cannot install same private methods on object more than once"_s, defaultSourceAppender, TypeNothing);
 }

--- a/Source/JavaScriptCore/runtime/ExceptionHelpers.h
+++ b/Source/JavaScriptCore/runtime/ExceptionHelpers.h
@@ -36,29 +36,27 @@
 
 namespace JSC {
 
-typedef JSObject* (*ErrorFactory)(JSGlobalObject*, const String&, ErrorInstance::SourceAppender);
-
 String defaultSourceAppender(const String&, StringView, RuntimeType, ErrorInstance::SourceTextWhereErrorOccurred);
 String notAFunctionSourceAppender(const String&, StringView, RuntimeType, ErrorInstance::SourceTextWhereErrorOccurred);
 
 String constructErrorMessage(JSGlobalObject*, JSValue, const String&);
-JS_EXPORT_PRIVATE JSObject* createError(JSGlobalObject*, JSValue, const String&, ErrorInstance::SourceAppender);
-JS_EXPORT_PRIVATE JSObject* createStackOverflowError(JSGlobalObject*);
-JSObject* createUndefinedVariableError(JSGlobalObject*, const Identifier&);
-JSObject* createTDZError(JSGlobalObject*);
-JSObject* createNotAnObjectError(JSGlobalObject*, JSValue);
-JSObject* createInvalidFunctionApplyParameterError(JSGlobalObject*, JSValue);
-JSObject* createInvalidInParameterError(JSGlobalObject*, JSValue);
-JSObject* createInvalidInstanceofParameterErrorNotFunction(JSGlobalObject*, JSValue);
-JSObject* createInvalidInstanceofParameterErrorHasInstanceValueNotFunction(JSGlobalObject*, JSValue);
-JSObject* createNotAConstructorError(JSGlobalObject*, JSValue);
-JSObject* createNotAFunctionError(JSGlobalObject*, JSValue);
-JSObject* createInvalidPrototypeError(JSGlobalObject*, JSValue);
-JSObject* createErrorForDuplicateGlobalVariableDeclaration(JSGlobalObject*, UniquedStringImpl*);
-JSObject* createErrorForInvalidGlobalFunctionDeclaration(JSGlobalObject*, const Identifier&);
-JSObject* createErrorForInvalidGlobalVarDeclaration(JSGlobalObject*, const Identifier&);
-JSObject* createInvalidPrivateNameError(JSGlobalObject*);
-JSObject* createRedefinedPrivateNameError(JSGlobalObject*);
+JS_EXPORT_PRIVATE ErrorInstance* createError(JSGlobalObject*, JSValue, const String&, ErrorInstance::SourceAppender);
+JS_EXPORT_PRIVATE ErrorInstance* createStackOverflowError(JSGlobalObject*);
+ErrorInstance* createUndefinedVariableError(JSGlobalObject*, const Identifier&);
+ErrorInstance* createTDZError(JSGlobalObject*);
+ErrorInstance* createNotAnObjectError(JSGlobalObject*, JSValue);
+ErrorInstance* createInvalidFunctionApplyParameterError(JSGlobalObject*, JSValue);
+ErrorInstance* createInvalidInParameterError(JSGlobalObject*, JSValue);
+ErrorInstance* createInvalidInstanceofParameterErrorNotFunction(JSGlobalObject*, JSValue);
+ErrorInstance* createInvalidInstanceofParameterErrorHasInstanceValueNotFunction(JSGlobalObject*, JSValue);
+ErrorInstance* createNotAConstructorError(JSGlobalObject*, JSValue);
+ErrorInstance* createNotAFunctionError(JSGlobalObject*, JSValue);
+ErrorInstance* createInvalidPrototypeError(JSGlobalObject*, JSValue);
+ErrorInstance* createErrorForDuplicateGlobalVariableDeclaration(JSGlobalObject*, UniquedStringImpl*);
+ErrorInstance* createErrorForInvalidGlobalFunctionDeclaration(JSGlobalObject*, const Identifier&);
+ErrorInstance* createErrorForInvalidGlobalVarDeclaration(JSGlobalObject*, const Identifier&);
+ErrorInstance* createInvalidPrivateNameError(JSGlobalObject*);
+ErrorInstance* createRedefinedPrivateNameError(JSGlobalObject*);
 String errorDescriptionForValue(JSGlobalObject*, JSValue);
 
 JS_EXPORT_PRIVATE Exception* throwOutOfMemoryError(JSGlobalObject*, ThrowScope&);

--- a/Source/JavaScriptCore/runtime/ExceptionStack.cpp
+++ b/Source/JavaScriptCore/runtime/ExceptionStack.cpp
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ExceptionStack.h"
+
+#include "Error.h"
+#include <wtf/FixedVector.h>
+#include <wtf/TZoneMallocInlines.h>
+
+namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ExceptionStackContent);
+
+ExceptionStackContent::ExceptionStackContent(std::unique_ptr<Vector<StackFrame>>&& stack)
+    : m_stack(WTFMove(stack))
+{
+}
+
+ExceptionStackContent::ExceptionStackContent(LineColumn lineColumn, String&& stackString, String&& sourceURL)
+    : m_lineColumn(lineColumn)
+    , m_stackString(WTFMove(stackString))
+    , m_sourceURL(WTFMove(sourceURL))
+{
+}
+
+template<typename Visitor>
+void ExceptionStackContent::visitAggregateImpl(Visitor& visitor)
+{
+    {
+        Locker locker { m_lock };
+        if (m_stack) {
+            for (StackFrame& frame : *m_stack)
+                frame.visitAggregate(visitor);
+            visitor.reportExtraMemoryVisited(m_stack->sizeInBytes());
+        }
+    }
+}
+
+DEFINE_VISIT_AGGREGATE(ExceptionStackContent);
+
+bool ExceptionStackContent::isEmpty() const
+{
+    if (m_stack)
+        return m_stack->isEmpty();
+    return m_computed.isEmpty();
+}
+
+void ExceptionStackContent::computeErrorInfo(VM& vm)
+{
+    if (m_stack) {
+        // Here we use DeferGCForAWhile instead of DeferGC since GC's Heap::runEndPhase can trigger this function. In
+        // that case, DeferGC's destructor might trigger another GC cycle which is unexpected.
+        DeferGCForAWhile deferGC(vm);
+        if (!m_stack->isEmpty()) {
+            for (auto& frame : *m_stack) {
+                if (frame.hasLineAndColumnInfo()) {
+                    m_lineColumn = frame.computeLineAndColumn();
+                    m_sourceURL = frame.sourceURLStripped(vm);
+                    break;
+                }
+            }
+            m_stackString = Interpreter::stackTraceAsString(vm, *m_stack);
+            m_computed = FixedVector<StackFrame::ComputedStackFrame>::map(m_stack->span(), [&](const StackFrame& frame) {
+                return frame.computed(vm);
+            });
+        }
+        {
+            Locker locker { m_lock };
+            m_stack = nullptr;
+        }
+    }
+}
+
+void ExceptionStackContent::finalizeUnconditionally(VM& vm, CollectionScope)
+{
+    if (!m_stack)
+        return;
+
+    // We don't want to keep our stack traces alive forever if the user doesn't access the stack trace.
+    // If we did, we might end up keeping functions (and their global objects) alive that happened to
+    // get caught in a trace.
+    for (const auto& frame : *m_stack) {
+        if (!frame.isMarked(vm)) {
+            computeErrorInfo(vm);
+            return;
+        }
+    }
+}
+
+size_t ExceptionStackContent::sizeInBytes() const
+{
+    Locker locker { m_lock };
+    if (m_stack)
+        return m_stack->sizeInBytes();
+    return 0;
+}
+
+LineColumn ExceptionStackContent::computeLineAndColumn(VM& vm)
+{
+    computeErrorInfo(vm);
+    return m_lineColumn;
+}
+
+
+void ExceptionStack::computeErrorInfo(VM& vm)
+{
+    if (m_stack)
+        m_stack->computeErrorInfo(vm);
+}
+
+LineColumn ExceptionStack::computeLineAndColumn(VM& vm)
+{
+    LineColumn result { };
+    if (m_stack)
+        result = m_stack->computeLineAndColumn(vm);
+    if (m_replacedLineColumn)
+        return m_replacedLineColumn;
+    return result;
+}
+
+StackFrame::ComputedStackFrame ExceptionStack::computedAt(size_t index)
+{
+    auto computed = m_stack->computed();
+    index += m_callDepth;
+    if (index < computed.size()) {
+        auto frame = computed[index];
+        if (m_replacedLineColumn)
+            frame.m_lineColumn = m_replacedLineColumn;
+        return frame;
+    }
+    return { };
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/ExceptionStack.h
+++ b/Source/JavaScriptCore/runtime/ExceptionStack.h
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "JSDestructibleObject.h"
+#include "StackFrame.h"
+#include <wtf/Lock.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/Vector.h>
+
+namespace JSC {
+
+class ExceptionStackContent final : public RefCounted<ExceptionStackContent> {
+    WTF_MAKE_TZONE_ALLOCATED(ExceptionStackContent);
+public:
+    static Ref<ExceptionStackContent> create(std::unique_ptr<Vector<StackFrame>>&& stack)
+    {
+        return adoptRef(*new ExceptionStackContent(WTFMove(stack)));
+    }
+
+    static Ref<ExceptionStackContent> create(LineColumn lineColumn, String&& stackString, String&& sourceURL)
+    {
+        return adoptRef(*new ExceptionStackContent(lineColumn, WTFMove(stackString), WTFMove(sourceURL)));
+    }
+
+    bool isEmpty() const;
+
+    DECLARE_VISIT_AGGREGATE;
+
+    void computeErrorInfo(VM&);
+    void finalizeUnconditionally(VM&, CollectionScope);
+
+    const String& sourceURL() const { return m_sourceURL; }
+    const String& stackString() const { return m_stackString; }
+    LineColumn lineColumn() const { return m_lineColumn; }
+    const FixedVector<StackFrame::ComputedStackFrame>& computed() { return m_computed; }
+
+    size_t sizeInBytes() const;
+
+    LineColumn computeLineAndColumn(VM&);
+
+private:
+    ExceptionStackContent(std::unique_ptr<Vector<StackFrame>>&&);
+    ExceptionStackContent(LineColumn, String&&, String&&);
+
+    mutable Lock m_lock;
+    LineColumn m_lineColumn;
+    String m_stackString;
+    String m_sourceURL;
+    std::unique_ptr<Vector<StackFrame>> m_stack;
+    FixedVector<StackFrame::ComputedStackFrame> m_computed;
+};
+
+class ExceptionStack {
+public:
+    ExceptionStack(RefPtr<ExceptionStackContent> stack)
+        : m_stack(WTFMove(stack))
+    {
+    }
+
+    ExceptionStack(RefPtr<ExceptionStackContent> stack, LineColumn replacedLineColumn, unsigned callDepth)
+        : m_stack(WTFMove(stack))
+        , m_replacedLineColumn(replacedLineColumn)
+        , m_callDepth(callDepth)
+    {
+    }
+
+    LineColumn lineColumn() const
+    {
+        if (m_replacedLineColumn)
+            return m_replacedLineColumn;
+        if (m_stack)
+            return m_stack->lineColumn();
+        return { };
+    }
+
+    size_t sizeInBytes() const
+    {
+        if (m_stack)
+            return m_stack->sizeInBytes();
+        return 0;
+    }
+
+    bool isEmpty() const
+    {
+        return !size();
+    }
+
+    size_t size() const
+    {
+        if (!m_stack)
+            return 0;
+        size_t originalSize = m_stack->computed().size();
+        if (originalSize >= m_callDepth)
+            return originalSize - m_callDepth;
+        return 0;
+    }
+
+    RefPtr<ExceptionStackContent> stack() const { return m_stack; }
+
+    void computeErrorInfo(VM&);
+    LineColumn computeLineAndColumn(VM&);
+    StackFrame::ComputedStackFrame computedAt(size_t);
+
+private:
+    const RefPtr<ExceptionStackContent> m_stack;
+    LineColumn m_replacedLineColumn { };
+    unsigned m_callDepth { };
+};
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -847,6 +847,7 @@ public:
     Structure* dateStructure() const { return m_dateStructure.get(this); }
     Structure* nullPrototypeObjectStructure() const { return m_nullPrototypeObjectStructure.get(); }
     Structure* errorStructure() const { return m_errorStructure.get(this); }
+    Structure* errorStructureConcurrently() const { return m_errorStructure.getConcurrently(); }
     inline Structure* errorStructure(ErrorType) const;
     template<ErrorType errorType> Structure* errorStructureWithErrorType() const { return errorStructure(errorType); }
 

--- a/Source/JavaScriptCore/runtime/JSObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSObjectInlines.h
@@ -793,10 +793,10 @@ inline JSValue JSObject::get(JSGlobalObject* globalObject, uint64_t propertyName
     return get(globalObject, Identifier::from(globalObject->vm(), propertyName));
 }
 
-JSObject* createInvalidPrivateNameError(JSGlobalObject*);
-JSObject* createRedefinedPrivateNameError(JSGlobalObject*);
-JSObject* createReinstallPrivateMethodError(JSGlobalObject*);
-JSObject* createPrivateMethodAccessError(JSGlobalObject*);
+ErrorInstance* createInvalidPrivateNameError(JSGlobalObject*);
+ErrorInstance* createRedefinedPrivateNameError(JSGlobalObject*);
+ErrorInstance* createReinstallPrivateMethodError(JSGlobalObject*);
+ErrorInstance* createPrivateMethodAccessError(JSGlobalObject*);
 
 ALWAYS_INLINE bool JSObject::getPrivateFieldSlot(JSObject* object, JSGlobalObject* globalObject, PropertyName propertyName, PropertySlot& slot)
 {

--- a/Source/JavaScriptCore/runtime/StackFrame.cpp
+++ b/Source/JavaScriptCore/runtime/StackFrame.cpp
@@ -28,6 +28,7 @@
 
 #include "CodeBlock.h"
 #include "DebuggerPrimitives.h"
+#include "InlineCallFrame.h"
 #include "JSCellInlines.h"
 #include <wtf/text/MakeString.h>
 
@@ -148,18 +149,30 @@ String StackFrame::functionName(VM& vm) const
     return name.isNull() ? emptyString() : name;
 }
 
+LineColumn StackFrame::lineAndColumnForBytecodeIndex(CodeBlock* codeBlock, CodeOrigin codeOrigin)
+{
+    if (!codeBlock)
+        return { };
+
+    CodeBlock* owner = codeBlock;
+    if (auto* inlineCallFrame = codeOrigin.inlineCallFrame())
+        owner = baselineCodeBlockForInlineCallFrame(inlineCallFrame);
+
+    auto lineColumn = owner->lineColumnForBytecodeIndex(codeOrigin.bytecodeIndex());
+
+    ScriptExecutable* executable = owner->ownerExecutable();
+    if (std::optional<int> overrideLineNumber = executable->overrideLineNumber(owner->vm()))
+        lineColumn.line = overrideLineNumber.value();
+
+    return lineColumn;
+}
+
 LineColumn StackFrame::computeLineAndColumn() const
 {
     if (!m_codeBlock)
         return { };
 
-    auto lineColumn = m_codeBlock->lineColumnForBytecodeIndex(m_bytecodeIndex);
-
-    ScriptExecutable* executable = m_codeBlock->ownerExecutable();
-    if (std::optional<int> overrideLineNumber = executable->overrideLineNumber(m_codeBlock->vm()))
-        lineColumn.line = overrideLineNumber.value();
-
-    return lineColumn;
+    return lineAndColumnForBytecodeIndex(m_codeBlock.get(), CodeOrigin(m_bytecodeIndex));
 }
 
 String StackFrame::toString(VM& vm) const
@@ -172,6 +185,16 @@ String StackFrame::toString(VM& vm) const
 
     auto lineColumn = computeLineAndColumn();
     return makeString(functionName, '@', sourceURL, ':', lineColumn.line, ':', lineColumn.column);
+}
+
+StackFrame::ComputedStackFrame StackFrame::computed(VM& vm) const
+{
+    return ComputedStackFrame {
+        functionName(vm),
+        sourceURL(vm),
+        sourceID(),
+        computeLineAndColumn(),
+    };
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/StackFrame.h
+++ b/Source/JavaScriptCore/runtime/StackFrame.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "BytecodeIndex.h"
+#include "CodeOrigin.h"
 #include "Heap.h"
 #include "LineColumn.h"
 #include "SlotVisitorMacros.h"
@@ -41,6 +42,13 @@ class JSObject;
 
 class StackFrame {
 public:
+    struct ComputedStackFrame {
+        String m_functionName;
+        String m_sourceURL;
+        SourceID m_sourceID;
+        LineColumn m_lineColumn;
+    };
+
     StackFrame(VM&, JSCell* owner, JSCell* callee);
     StackFrame(VM&, JSCell* owner, JSCell* callee, CodeBlock*, BytecodeIndex);
     StackFrame(VM&, JSCell* owner, CodeBlock*, BytecodeIndex);
@@ -50,6 +58,8 @@ public:
 
     bool hasLineAndColumnInfo() const { return !!m_codeBlock; }
     CodeBlock* codeBlock() const { return m_codeBlock.get(); }
+
+    static LineColumn lineAndColumnForBytecodeIndex(CodeBlock*, CodeOrigin);
 
     LineColumn computeLineAndColumn() const;
     String functionName(VM&) const;
@@ -75,6 +85,8 @@ public:
     }
 
     bool isMarked(VM& vm) const { return (!m_callee || vm.heap.isMarked(m_callee.get())) && (!m_codeBlock || vm.heap.isMarked(m_codeBlock.get())); }
+
+    ComputedStackFrame computed(VM&) const;
 
 private:
     WriteBarrier<JSCell> m_callee { };

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -44,6 +44,7 @@
 #include "DOMAttributeGetterSetterInlines.h"
 #include "Debugger.h"
 #include "DeferredWorkTimer.h"
+#include "DestructibleException.h"
 #include "Disassembler.h"
 #include "DoublePredictionFuzzerAgent.h"
 #include "ErrorInstance.h"
@@ -333,6 +334,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     propertyTableStructure.setWithoutWriteBarrier(PropertyTable::createStructure(*this, nullptr, jsNull()));
     functionRareDataStructure.setWithoutWriteBarrier(FunctionRareData::createStructure(*this, nullptr, jsNull()));
     exceptionStructure.setWithoutWriteBarrier(Exception::createStructure(*this, nullptr, jsNull()));
+    destructibleExceptionStructure.setWithoutWriteBarrier(DestructibleException::createStructure(*this, nullptr, jsNull()));
     programCodeBlockStructure.setWithoutWriteBarrier(ProgramCodeBlock::createStructure(*this, nullptr, jsNull()));
     moduleProgramCodeBlockStructure.setWithoutWriteBarrier(ModuleProgramCodeBlock::createStructure(*this, nullptr, jsNull()));
     evalCodeBlockStructure.setWithoutWriteBarrier(EvalCodeBlock::createStructure(*this, nullptr, jsNull()));
@@ -1687,6 +1689,7 @@ void VM::visitAggregateImpl(Visitor& visitor)
     visitor.append(propertyTableStructure);
     visitor.append(functionRareDataStructure);
     visitor.append(exceptionStructure);
+    visitor.append(destructibleExceptionStructure);
     visitor.append(programCodeBlockStructure);
     visitor.append(moduleProgramCodeBlockStructure);
     visitor.append(evalCodeBlockStructure);

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -491,6 +491,7 @@ public:
     WriteBarrier<Structure> propertyTableStructure;
     WriteBarrier<Structure> functionRareDataStructure;
     WriteBarrier<Structure> exceptionStructure;
+    WriteBarrier<Structure> destructibleExceptionStructure;
     WriteBarrier<Structure> programCodeBlockStructure;
     WriteBarrier<Structure> moduleProgramCodeBlockStructure;
     WriteBarrier<Structure> evalCodeBlockStructure;

--- a/Source/WTF/wtf/CagedPtr.h
+++ b/Source/WTF/wtf/CagedPtr.h
@@ -36,6 +36,8 @@
 #include <mach/vm_param.h>
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WTF {
 
 template<Gigacage::Kind passedKind, typename T, typename PtrTraits = RawPtrTraits<T>>
@@ -125,6 +127,8 @@ protected:
 };
 
 } // namespace WTF
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 using WTF::CagedPtr;
 


### PR DESCRIPTION
#### 38cc7731f00671074034d0423a2d7742d3e596f2
<pre>
[JSC] Use ErrorInstance&apos;s stack information in Exception
<a href="https://bugs.webkit.org/show_bug.cgi?id=294774">https://bugs.webkit.org/show_bug.cgi?id=294774</a>
<a href="https://rdar.apple.com/153938109">rdar://153938109</a>

Reviewed by NOBODY (OOPS!).

Exception should use ErrorInstance&apos;s error stack information as it is
intended behavior. But right now, we are separately collecting and erorr
and some of reports are using different values. That&apos;s not so great.
This patch adds ExceptionStack and DestructibleException. And using
ExceptionStack from ErrorInstance when possible. And
DestructibleException is used only when given value is not an error
instance. (For example, throwing a string). We also remove
sourceAppender member field since passed argument is enough.

By doing this, we got improvement in error reporting since now Error&apos;s
stack and reported error stack matches correctly. Previously they were
slightly different.

* JSTests/stress/error-stack-first-entry.js: Added.
(test2):
(test1):
(shouldBe):
* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/bytecode/LineColumn.h:
(JSC::LineColumn::operator bool const):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleConstantFunction):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGCloneHelper.h:
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::dump):
* Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.cpp:
(JSC::DFG::InPlaceAbstractState::mergeToSuccessors):
* Source/JavaScriptCore/dfg/DFGMayExit.cpp:
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::convertToThrowWithAdjustment):
(JSC::DFG::Node::isTerminal):
(JSC::DFG::Node::hasStructure):
(JSC::DFG::Node::hasCallDepth const):
(JSC::DFG::Node::callDepth):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp:
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileNewError):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/heap/Heap.cpp:
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/inspector/InjectedScriptManager.cpp:
(Inspector::InjectedScriptManager::injectedScriptFor):
* Source/JavaScriptCore/inspector/InjectedScriptModule.cpp:
(Inspector::InjectedScriptModule::ensureInjected):
* Source/JavaScriptCore/inspector/ScriptCallStackFactory.cpp:
(Inspector::extractSourceInformationFromException):
(Inspector::createScriptCallStackFromException):
* Source/JavaScriptCore/runtime/DestructibleException.cpp: Added.
(JSC::DestructibleException::create):
(JSC::DestructibleException::destroy):
(JSC::DestructibleException::createStructure):
(JSC::DestructibleException::visitChildrenImpl):
(JSC::DestructibleException::DestructibleException):
(JSC::DestructibleException::finishCreation):
(JSC::DestructibleException::stack const):
* Source/JavaScriptCore/runtime/DestructibleException.h: Copied from Source/JavaScriptCore/runtime/Exception.h.
* Source/JavaScriptCore/runtime/Error.cpp:
(JSC::createError):
(JSC::createEvalError):
(JSC::createRangeError):
(JSC::createReferenceError):
(JSC::createSyntaxError):
(JSC::createTypeError):
(JSC::createNotEnoughArgumentsError):
(JSC::createURIError):
(JSC::createGetterTypeError):
(JSC::addErrorInfo):
(JSC::createTypeErrorCopy):
(JSC::throwTypeError):
(JSC::throwSyntaxError):
(JSC::throwDOMAttributeGetterTypeError):
(JSC::throwDOMAttributeSetterTypeError):
(JSC::createOutOfMemoryError):
(JSC::getLineColumnAndSource): Deleted.
* Source/JavaScriptCore/runtime/Error.h:
* Source/JavaScriptCore/runtime/ErrorInstance.cpp:
(JSC::ErrorInstance::finishCreation):
(JSC::ErrorInstance::finalizeUnconditionally):
(JSC::ErrorInstance::materializeErrorInfoIfNeeded):
(JSC::ErrorInstance::computeErrorInfo): Deleted.
* Source/JavaScriptCore/runtime/ErrorInstance.h:
(JSC::ErrorInstance::stackTrace):
(JSC::ErrorInstance::hasSourceAppender const): Deleted.
(JSC::ErrorInstance::sourceAppender const): Deleted.
(JSC::ErrorInstance::setSourceAppender): Deleted.
(JSC::ErrorInstance::clearSourceAppender): Deleted.
* Source/JavaScriptCore/runtime/Exception.cpp:
(JSC::Exception::create):
(JSC::Exception::createWithStackFromError):
(JSC::Exception::createWithFrameAdjustment):
(JSC::Exception::visitChildrenImpl):
(JSC::Exception::Exception):
(JSC::Exception::stack const):
(JSC::Exception::destroy): Deleted.
(JSC::Exception::finishCreation): Deleted.
* Source/JavaScriptCore/runtime/Exception.h:
(JSC::Exception::value const):
(JSC::Exception::didNotifyInspectorOfThrow const):
(JSC::Exception::setDidNotifyInspectorOfThrow):
* Source/JavaScriptCore/runtime/ExceptionHelpers.cpp:
(JSC::createStackOverflowError):
(JSC::createUndefinedVariableError):
(JSC::createError):
(JSC::createInvalidFunctionApplyParameterError):
(JSC::createInvalidInParameterError):
(JSC::createInvalidInstanceofParameterErrorNotFunction):
(JSC::createInvalidInstanceofParameterErrorHasInstanceValueNotFunction):
(JSC::createNotAConstructorError):
(JSC::createNotAFunctionError):
(JSC::createNotAnObjectError):
(JSC::createInvalidPrototypeError):
(JSC::createErrorForDuplicateGlobalVariableDeclaration):
(JSC::createErrorForInvalidGlobalFunctionDeclaration):
(JSC::createErrorForInvalidGlobalVarDeclaration):
(JSC::createTDZError):
(JSC::createInvalidPrivateNameError):
(JSC::createRedefinedPrivateNameError):
(JSC::createPrivateMethodAccessError):
(JSC::createReinstallPrivateMethodError):
* Source/JavaScriptCore/runtime/ExceptionHelpers.h:
* Source/JavaScriptCore/runtime/ExceptionStack.cpp: Added.
(JSC::ExceptionStackContent::ExceptionStackContent):
(JSC::ExceptionStackContent::visitAggregateImpl):
(JSC::ExceptionStackContent::isEmpty const):
(JSC::ExceptionStackContent::computeErrorInfo):
(JSC::ExceptionStackContent::finalizeUnconditionally):
(JSC::ExceptionStackContent::sizeInBytes const):
(JSC::ExceptionStackContent::computeLineAndColumn):
(JSC::ExceptionStack::computeErrorInfo):
(JSC::ExceptionStack::computeLineAndColumn):
(JSC::ExceptionStack::computedAt):
* Source/JavaScriptCore/runtime/ExceptionStack.h: Added.
(JSC::ExceptionStack::ExceptionStack):
(JSC::ExceptionStack::lineColumn const):
(JSC::ExceptionStack::sizeInBytes const):
(JSC::ExceptionStack::isEmpty const):
(JSC::ExceptionStack::size const):
(JSC::ExceptionStack::stack const):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::errorStructureConcurrently const):
* Source/JavaScriptCore/runtime/JSObjectInlines.h:
* Source/JavaScriptCore/runtime/StackFrame.cpp:
(JSC::StackFrame::lineAndColumnForBytecodeIndex):
(JSC::StackFrame::computeLineAndColumn const):
(JSC::StackFrame::computed const):
* Source/JavaScriptCore/runtime/StackFrame.h:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::VM):
(JSC::VM::visitAggregateImpl):
* Source/JavaScriptCore/runtime/VM.h:
* Source/WTF/wtf/CagedPtr.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38cc7731f00671074034d0423a2d7742d3e596f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114981 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34697 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25178 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121101 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65634 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5fac7ce5-306b-493a-b4d1-14932f0cd244) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35342 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43258 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87370 "Found 97 new test failures: fast/events/window-onerror-exception-in-attr.html fast/events/window-onerror1.html fast/events/window-onerror10.html fast/events/window-onerror11.html fast/events/window-onerror2.html fast/events/window-onerror3.html fast/events/window-onerror4.html fast/events/window-onerror5.html fast/events/window-onerror7.html fast/events/window-onerror8.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42199 "Too many flaky failures: fast/dom/normalize-doesnt-check-string-length.html, fast/events/window-onerror-exception-in-attr.html, fast/events/window-onerror1.html, fast/events/window-onerror10.html, fast/events/window-onerror11.html, fast/events/window-onerror2.html, fast/events/window-onerror3.html, fast/events/window-onerror4.html, fast/events/window-onerror5.html, fast/events/window-onerror7.html, fast/events/window-onerror8.html, fast/events/window-onerror9.html, fast/forms/change-input-type-during-setSelectionRange-crash.html, fast/forms/radio/radio_checked.html, fast/workers/worker-script-error.html, http/tests/security/regress-52192.html, http/tests/security/script-crossorigin-error-event-information.html, http/tests/security/script-crossorigin-onerror-information.html, http/tests/security/script-with-dataurl.html, http/tests/security/window-onerror-exception-in-iframe.html, imported/w3c/web-platform-tests/css/css-page/cssom/margin-002.html, imported/w3c/web-platform-tests/event-timing/interaction-count-tap.html, js/arrowfunction-block-2.html, js/call-apply-crash.html, js/dom/call-link-info-recursion.html, js/dom/exception-line-number.html, js/dom/null-char-in-string.html, resize-observer/element-leak.html, storage/indexeddb/intversion-persistence-private.html, streams/readable-stream-lock-after-worker-terminates-crash.html, streams/shadowing-defineProperty.html, webgl/2.0.y/conformance/extensions/webgl-compressed-texture-size-limit.html, webgl/2.0.y/conformance/glsl/constructors/glsl-construct-bvec2.html, webgl/2.0.y/conformance2/extensions/ext-disjoint-timer-query-webgl2.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a5a3e3c9-5389-42c8-b861-f3fff74806f6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117929 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28163 "Found 18 new test failures: fast/events/window-onerror-exception-in-attr.html fast/events/window-onerror1.html fast/events/window-onerror10.html fast/events/window-onerror11.html fast/events/window-onerror2.html fast/events/window-onerror3.html fast/events/window-onerror4.html fast/events/window-onerror5.html fast/events/window-onerror7.html fast/events/window-onerror8.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103230 "Found 1 new API test failure: TestWebKitAPI.WKWebView.EvaluateJavaScriptErrorCases (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67766 "Found 2 new API test failures: /WPE/TestConsoleMessage:/webkit/WebKitConsoleMessage/js-exception, /WPE/TestWebKitWebView:/webkit/WebKitWebView/run-javascript (failure)") | | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27335 "Found 60 new test failures: imported/w3c/web-platform-tests/content-security-policy/unsafe-eval/tentative/eval-allowed-by-hash.sub.html imported/w3c/web-platform-tests/credential-management/federatedcredential-framed-get.sub.https.html imported/w3c/web-platform-tests/credential-management/passwordcredential-framed-get.sub.https.html imported/w3c/web-platform-tests/css/css-page/cssom/margin-002.html imported/w3c/web-platform-tests/css/css-syntax/non-ascii-codepoints.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-position.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/object-position.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-anchor.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-position.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/perspective-origin.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21349 "Found 60 new test failures: fast/editing/document-leak-altered-text-field.html fast/events/window-onerror-exception-in-attr.html fast/events/window-onerror1.html fast/events/window-onerror10.html fast/events/window-onerror11.html fast/events/window-onerror2.html fast/events/window-onerror3.html fast/events/window-onerror4.html fast/events/window-onerror5.html fast/events/window-onerror7.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64753 "Built successfully") | | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/107265 "Found 9 new JSC stress test failures: stress/recursive-try-catch.js.dfg-eager-no-cjit-validate, stress/recursive-try-catch.js.ftl-eager-no-cjit-b3o1, stress/sampling-profiler-basic.js.ftl-eager-no-cjit-b3o1, stress/sampling-profiler-basic.js.ftl-no-cjit-b3o0, stress/sampling-profiler-basic.js.ftl-no-cjit-no-inline-validate, stress/sampling-profiler-basic.js.ftl-no-cjit-no-put-stack-validate, stress/sampling-profiler-basic.js.ftl-no-cjit-validate-sampling-profiler, stress/sampling-profiler-basic.js.no-cjit-validate-phases, stress/sampling-profiler-internal-function-name.js.ftl-eager-no-cjit-b3o1 (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97544 "Found 1 new API test failure: TestWebKitAPI.WKWebView.EvaluateJavaScriptErrorCases (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21466 "Found 60 new test failures: accessibility/aria-modal-with-text-crash.html accessibility/mac/attributed-string-for-text-marker-range-using-webarea.html animations/animation-direction-reverse.html compositing/backing/replaced-child-no-backing.html compositing/backing/solid-color-with-paints-into-ancestor.html compositing/clipping/preserve3d-flatten-assertion-nested.html compositing/geometry/fixed-inside-overflow-scroll.html compositing/hidpi-absolute-subpixel-positioned-transformed-elements.html compositing/iframes/hidpi-iframe-subpixel-compositing.html compositing/layer-creation/fixed-position-no-content-scroll-reason.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124291 "Built successfully") | | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/113527 "Found 23 new JSC stress test failures: stress/recursive-try-catch.js.dfg-eager-no-cjit-validate, stress/recursive-try-catch.js.ftl-eager-no-cjit-b3o1, stress/sampling-profiler-basic.js.bytecode-cache, stress/sampling-profiler-basic.js.default, stress/sampling-profiler-basic.js.dfg-eager, stress/sampling-profiler-basic.js.dfg-eager-no-cjit-validate, stress/sampling-profiler-basic.js.eager-jettison-no-cjit, stress/sampling-profiler-basic.js.ftl-eager-no-cjit, stress/sampling-profiler-basic.js.ftl-eager-no-cjit-b3o1, stress/sampling-profiler-basic.js.ftl-no-cjit-b3o0 ... (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41954 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31361 "Found 60 new test failures: fast/events/window-onerror-exception-in-attr.html fast/events/window-onerror1.html fast/events/window-onerror10.html fast/events/window-onerror11.html fast/events/window-onerror2.html fast/events/window-onerror3.html fast/events/window-onerror4.html fast/events/window-onerror5.html fast/events/window-onerror7.html fast/events/window-onerror8.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96167 "Found 113 new test failures: fast/events/window-onerror-exception-in-attr.html fast/events/window-onerror1.html fast/events/window-onerror10.html fast/events/window-onerror11.html fast/events/window-onerror2.html fast/events/window-onerror3.html fast/events/window-onerror4.html fast/events/window-onerror5.html fast/events/window-onerror7.html fast/events/window-onerror8.html ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42326 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99420 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95953 "Found 2 new API test failures: /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/js-exception, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/run-javascript (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41153 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18992 "Found 60 new test failures: fast/canvas/canvas-size-change-after-layout.html fast/events/window-onerror-exception-in-attr.html fast/events/window-onerror1.html fast/events/window-onerror10.html fast/events/window-onerror11.html fast/events/window-onerror2.html fast/events/window-onerror3.html fast/events/window-onerror4.html fast/events/window-onerror5.html fast/events/window-onerror7.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37978 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41829 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47364 "Found 1 new failure in runtime/DestructibleException.cpp and found 1 fixed file: bindings/js/JSDOMPromiseDeferred.cpp") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/137733 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41373 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36817 "Found 5 new JSC stress test failures: stress/recursive-try-catch.js.dfg-eager-no-cjit-validate, stress/sampling-profiler-basic.js.bytecode-cache, stress/sampling-profiler-basic.js.dfg-eager-no-cjit-validate, stress/sampling-profiler-basic.js.no-cjit-validate-phases, stress/sampling-profiler-internal-function-name.js.dfg-eager-no-cjit-validate (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44690 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43111 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->