### PR TITLE
REGRESSION(292342@main): [UnifiedPDF] [iOS] Keyboard scroll does not work after tapping on screen

### DIFF
--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -764,6 +764,8 @@ public:
     virtual void foreachRegionInDamageHistoryForTesting(Function<void(const Region&)>&&) const { }
 #endif
 
+    virtual bool usePluginRendererScrollableArea(LocalFrame&) const { return true; }
+
     WEBCORE_EXPORT virtual ~ChromeClient();
 
 protected:

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -2144,8 +2144,12 @@ ScrollableArea* EventHandler::enclosingScrollableArea(Node* node) const
         }
 
         if (RefPtr plugin = dynamicDowncast<RenderEmbeddedObject>(renderer)) {
-            if (auto* scrollableArea = plugin->scrollableArea())
-                return scrollableArea;
+            if (auto* scrollableArea = plugin->scrollableArea()) {
+                Ref frame = m_frame.get();
+                RefPtr page = frame->page();
+                if (!page || page->chrome().client().usePluginRendererScrollableArea(frame))
+                    return scrollableArea;
+            }
         }
 
         auto* layer = renderer->enclosingLayer();

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -340,6 +340,8 @@ public:
 
     virtual void frameViewLayoutOrVisualViewportChanged(const WebCore::IntRect&) { }
 
+    virtual bool delegatesScrollingToMainFrame() const { return false; }
+
 protected:
     virtual double contentScaleFactor() const = 0;
     virtual bool platformPopulateEditorStateIfNeeded(EditorState&) const { return false; }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -648,6 +648,8 @@ private:
 
     bool shouldUseInProcessBackingStore() const;
 
+    bool delegatesScrollingToMainFrame() const final;
+
     RefPtr<PDFPresentationController> m_presentationController;
 
     PDFDocumentLayout m_documentLayout;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -4738,6 +4738,11 @@ bool UnifiedPDFPlugin::layerNeedsPlatformContext(const GraphicsLayer* layer) con
     return shouldUseInProcessBackingStore() && (layer == layerForHorizontalScrollbar() || layer == layerForVerticalScrollbar() || layer == layerForScrollCorner());
 }
 
+bool UnifiedPDFPlugin::delegatesScrollingToMainFrame() const
+{
+    return !handlesPageScaleFactor() && isFullFramePlugin() && scrollingMode() == DelegatedScrollingMode::DelegatedToNativeScrollView;
+}
+
 ViewportConfiguration::Parameters UnifiedPDFPlugin::viewportParameters()
 {
     ViewportConfiguration::Parameters parameters;

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -1228,6 +1228,14 @@ bool PluginView::pluginHandlesPageScaleFactor() const
     return m_plugin->handlesPageScaleFactor();
 }
 
+bool PluginView::pluginDelegatesScrollingToMainFrame() const
+{
+    if (!m_isInitialized)
+        return false;
+
+    return m_plugin->delegatesScrollingToMainFrame();
+}
+
 } // namespace WebKit
 
 #endif

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -166,6 +166,8 @@ public:
 
     void frameViewLayoutOrVisualViewportChanged(const WebCore::IntRect& unobscuredContentRect);
 
+    bool pluginDelegatesScrollingToMainFrame() const;
+
 private:
     PluginView(WebCore::HTMLPlugInElement&, const URL&, const String& contentType, bool shouldUseManualLoader, WebPage&);
     virtual ~PluginView();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -2386,4 +2386,13 @@ void WebChromeClient::setNeedsFixedContainerEdgesUpdate()
     m_page->setNeedsFixedContainerEdgesUpdate();
 }
 
+bool WebChromeClient::usePluginRendererScrollableArea(LocalFrame& frame) const
+{
+#if ENABLE(PDF_PLUGIN)
+    if (RefPtr pluginView = WebPage::pluginViewForFrame(&frame))
+        return !pluginView->pluginDelegatesScrollingToMainFrame();
+#endif
+    return true;
+}
+
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -568,6 +568,8 @@ private:
 
     void setNeedsFixedContainerEdgesUpdate() final;
 
+    bool usePluginRendererScrollableArea(WebCore::LocalFrame&) const final;
+
     mutable bool m_cachedMainFrameHasHorizontalScrollbar { false };
     mutable bool m_cachedMainFrameHasVerticalScrollbar { false };
 


### PR DESCRIPTION
#### 4eaf1f7a6d30722f6c924f4649b5c85a1bd8df24
<pre>
REGRESSION(292342@main): [UnifiedPDF] [iOS] Keyboard scroll does not work after tapping on screen
<a href="https://bugs.webkit.org/show_bug.cgi?id=294773">https://bugs.webkit.org/show_bug.cgi?id=294773</a>
<a href="https://rdar.apple.com/153719019">rdar://153719019</a>

Reviewed by Wenson Hsieh.

To support keyboard scrolling over subscrollable regions, 292342@main
introduces the concept of &quot;last touched node&quot;, based on which we can
determine if the scrollable area to send scrolls to is some non-main
frame inner scroller.

Unfortunately, this change does not play well with how main frame PDF
plugins scroll on iOS today, because while UnifiedPDFPlugin is a
ScrollableArea of itself, we delegate scrolling to the main frame
instead. After 292342@main, this was no longer happening and scrolls
were being sent to the plugin, instead, which did not do the right
thing.

This patch introduces a workaround for RenderEmbeddedObjects and their
scrollable areas by first checking with ChromeClient if the plugin in
our local frame _wants_ to scroll using its own scrollable area. If not,
we fall back to the scrollable area of the local frame instead.

API tests:
- UnifiedPDF.MainFramePDFIsKeyboardScrollable
- UnifiedPDF.MainFramePDFIsKeyboardScrollableAfterTap

* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::usePluginRendererScrollableArea const):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::enclosingScrollableArea const):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::delegatesScrollingToMainFrame const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::delegatesScrollingToMainFrame const):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::pluginDelegatesScrollingToMainFrame const):
* Source/WebKit/WebProcess/Plugins/PluginView.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::usePluginRendererScrollableArea const):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm:
(TestWebKitAPI::checkKeyboardScrollability):
(TestWebKitAPI::UNIFIED_PDF_TEST):

Canonical link: <a href="https://commits.webkit.org/296474@main">https://commits.webkit.org/296474@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f7d5f2a48555ba61851423c43f895f34cff135f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108635 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28296 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18720 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113843 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/59020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110598 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28985 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36851 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/82519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/59020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111583 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/23015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/97857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/62956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/22432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/15994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/58554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/92385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/16045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116964 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35689 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/26319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/91541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36062 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/94126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/91345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/36248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/14009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17540 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35590 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/41123 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35300 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38646 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36977 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->