### PR TITLE
[text-wrap-style] should not constrain single line content.

### DIFF
--- a/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-style-does-not-adjust-single-line-content-expected.html
+++ b/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-style-does-not-adjust-single-line-content-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<head>
+   <meta charset="utf-8">
+   <title>text-wrap-style single line</title>
+</head>
+<style>
+   .pretty {
+   display: flex;
+   }
+   .balance {
+   display: flex;
+   }
+   body {
+   font-family: "Ahem";
+   font-size: 12px;
+   }
+</style>
+<body>
+   <div class="pretty">
+      <div>This test passes if this line is one line</div>
+   </div>
+   <div class="balance">
+      <div>This test passes if this line is one line</div>
+   </div>
+</body>
+</html>

--- a/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-style-does-not-adjust-single-line-content.html
+++ b/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-style-does-not-adjust-single-line-content.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<head>
+   <meta charset="utf-8">
+   <title>text-wrap-style single line</title>
+</head>
+<style>
+   .pretty {
+   text-wrap: pretty;
+   display: flex;
+   }
+   .balance {
+   text-wrap: balance;
+   display: flex;
+   }
+   body {
+   font-family: "Ahem";
+   font-size: 12px;
+   }
+</style>
+<body>
+   <div class="pretty">
+      <div>This test passes if this line is one line</div>
+   </div>
+   <div class="balance">
+      <div>This test passes if this line is one line</div>
+   </div>
+</body>
+</html>

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp
@@ -245,7 +245,7 @@ void InlineContentConstrainer::initialize()
         return;
     }
 
-    // if we have a single line content, we don't have anything to be balanced.
+    // Do not adjust single line content.
     if (numberOfVisibleLinesAllowed == 1) {
         m_hasSingleLineVisibleContent = true;
         return;
@@ -294,6 +294,10 @@ void InlineContentConstrainer::initialize()
     // Cache inline item widths after laying out all inline content with LineBuilder.
     updateCachedWidths();
     m_numberOfLinesInOriginalLayout = lineIndex;
+
+    // Do not adjust single line content.
+    if (m_numberOfLinesInOriginalLayout == 1)
+        m_hasSingleLineVisibleContent = true;
 }
 
 std::optional<Vector<LayoutUnit>> InlineContentConstrainer::computeParagraphLevelConstraints(TextWrapStyle wrapStyle)


### PR DESCRIPTION
#### 6d56364f98c0c7b3f50d49c841249d82b9f09089
<pre>
[text-wrap-style] should not constrain single line content.
<a href="https://bugs.webkit.org/show_bug.cgi?id=294771">https://bugs.webkit.org/show_bug.cgi?id=294771</a>
&lt;<a href="https://rdar.apple.com/153755326">rdar://153755326</a>&gt;

Reviewed by Alan Baradlay.

The first fix addresses an issue where text-wrap-style did not properly
avoid setting bounds for single-line content.

Combined changes:
* LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-style-does-not-adjust-single-line-content-expected.html: Added.
* LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-style-does-not-adjust-single-line-content.html: Added.
* Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp:
(WebCore::Layout::InlineContentConstrainer::initialize):

Canonical link: <a href="https://commits.webkit.org/296471@main">https://commits.webkit.org/296471@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/425ca9f69446a34c0dd69fe17c55e8197a07366f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108628 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28289 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113836 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59013 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110591 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28978 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36844 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/82513 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111576 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23006 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97849 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62950 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22423 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15986 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58549 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92377 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16037 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116957 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35682 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26312 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/91534 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36055 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94118 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91338 "Found 2 new API test failures: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23271 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36238 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14001 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31499 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35583 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41116 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35293 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38639 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36970 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->