### PR TITLE
[text-wrap-style] should be applied to text in narrower containing blocks.

### DIFF
--- a/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-pretty-line-break-1-expected.html
+++ b/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-pretty-line-break-1-expected.html
@@ -10,7 +10,7 @@
     </style>
 <body>
     <div id="text">
-        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor <br>incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis <br>nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. <br>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu <br>fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim <br>id est laborum.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor <br>incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis <br>nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. <br>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore <br>eu fugiat nulla pariatur. Excepteur sint <br>occaecat cupidatat non proident, sunt <br>in culpa qui officia deserunt mollit <br>anim id est laborum.</p>
     </div>
 </body>
 </html>

--- a/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-style-narrow-block-expected.html
+++ b/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-style-narrow-block-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en-US" class="theme-beta">
+   <head>
+      <meta charset="utf-8" />
+      <title>text-wrap-style short line with long words</title>
+   </head>
+   <style>
+      .auto {
+         text-wrap: auto;
+         width: 200px;
+      }
+      body {
+         font-family: "Ahem";
+         font-size: 12px;
+      }
+   </style>
+   <body>
+      <div class="auto">
+         <div>This test passes if textwrapstylepretty is applied</div>
+      </div>
+   </body>
+</html>

--- a/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-style-narrow-block.html
+++ b/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-style-narrow-block.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en-US" class="theme-beta">
+   <head>
+      <meta charset="utf-8" />
+      <title>text-wrap-style short line with long words</title>
+   </head>
+   <style>
+      .pretty {
+         text-wrap: pretty;
+         width: 200px;
+      }
+      body {
+         font-family: "Ahem";
+         font-size: 12px;
+      }
+   </style>
+   <body>
+      <div class="pretty">
+         <div>This test passes if textwrapstylepretty is applied</div>
+      </div>
+   </body>
+</html>

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp
@@ -65,7 +65,7 @@ static size_t lastLineBreakingPointOffset()
 // In these situations, text-wrap-pretty does very little of note other than take up time.
 static bool validIdealLineWidth(InlineLayoutUnit maxItemWidth, InlineLayoutUnit idealLineWidth, InlineLayoutUnit maxTextIndent)
 {
-    return idealLineWidth >= maxItemWidth * 3 + maxTextIndent;
+    return idealLineWidth >= maxItemWidth + maxTextIndent;
 }
 
 static bool validLineWidthPretty(InlineLayoutUnit candidateLineWidth, InlineLayoutUnit idealLineWidth)


### PR DESCRIPTION
#### 3b48c97ebba7b6d8780a6719e1cace8829b1a4cc
<pre>
[text-wrap-style] should be applied to text in narrower containing blocks.
<a href="https://bugs.webkit.org/show_bug.cgi?id=294777">https://bugs.webkit.org/show_bug.cgi?id=294777</a>
&lt;<a href="https://rdar.apple.com/153942653">rdar://153942653</a>&gt;

Reviewed by Alan Baradlay.

`text-wrap-style` pretty is currently only being applied if the line width is wide enough
to fit 3 words. This causes an issue where resizing the containing block of a piece of text
can cause `text-wrap-style` to suddenly be applied/unapplied. We should instead apply
`text-wrap-style` as soon as the containing block is wide enough to fit the widest inline item.

This PR also fixes a test that was not correctly testing for the correct line breaks.

Combined changes:
* LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-pretty-line-break-1-expected.html:
* LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-style-narrow-block-expected.html: Added.
* LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-style-narrow-block.html: Added.
* Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp:
(WebCore::Layout::validIdealLineWidth):

Canonical link: <a href="https://commits.webkit.org/296477@main">https://commits.webkit.org/296477@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a4125d2f90f96174b75663573fb69d5d83a3c9f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108637 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28298 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18722 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113845 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59022 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110600 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28987 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36853 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/82521 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111585 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23017 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97859 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62958 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22434 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/15996 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58556 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92387 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/16047 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116966 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35691 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/26321 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91543 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36064 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94128 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91347 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23274 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36250 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14011 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31514 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35592 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41125 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35302 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38648 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36979 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->