### PR TITLE
[DRT] UIScriptController::doAsyncTask() implementation can be shared between Cocoa platforms

### DIFF
--- a/Tools/DumpRenderTree/cocoa/UIScriptControllerCocoa.h
+++ b/Tools/DumpRenderTree/cocoa/UIScriptControllerCocoa.h
@@ -38,6 +38,7 @@ public:
 
 protected:
     explicit UIScriptControllerCocoa(UIScriptContext&);
+    void doAsyncTask(JSValueRef) override;
 };
 
 } // namespace WTR

--- a/Tools/DumpRenderTree/ios/UIScriptControllerIOS.h
+++ b/Tools/DumpRenderTree/ios/UIScriptControllerIOS.h
@@ -38,7 +38,6 @@ public:
     {
     }
 
-    void doAsyncTask(JSValueRef callback) override;
     void zoomToScale(double scale, JSValueRef callback) override;
     double zoomScale() const override;
     double contentOffsetX() const override;

--- a/Tools/DumpRenderTree/ios/UIScriptControllerIOS.mm
+++ b/Tools/DumpRenderTree/ios/UIScriptControllerIOS.mm
@@ -46,17 +46,6 @@ Ref<UIScriptController> UIScriptController::create(UIScriptContext& context)
     return adoptRef(*new UIScriptControllerIOS(context));
 }
 
-void UIScriptControllerIOS::doAsyncTask(JSValueRef callback)
-{
-    unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
-
-    WorkQueue::protectedMain()->dispatch([this, protectedThis = Ref { *this }, callbackID] {
-        if (!m_context)
-            return;
-        m_context->asyncTaskComplete(callbackID);
-    });
-}
-
 void UIScriptControllerIOS::zoomToScale(double scale, JSValueRef callback)
 {
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);

--- a/Tools/DumpRenderTree/mac/UIScriptControllerMac.h
+++ b/Tools/DumpRenderTree/mac/UIScriptControllerMac.h
@@ -38,7 +38,6 @@ public:
     {
     }
 
-    void doAsyncTask(JSValueRef) override;
     void replaceTextAtRange(JSStringRef, int, int) override;
     void zoomToScale(double, JSValueRef) override;
     double zoomScale() const override;

--- a/Tools/DumpRenderTree/mac/UIScriptControllerMac.mm
+++ b/Tools/DumpRenderTree/mac/UIScriptControllerMac.mm
@@ -50,17 +50,6 @@ Ref<UIScriptController> UIScriptController::create(UIScriptContext& context)
     return adoptRef(*new UIScriptControllerMac(context));
 }
 
-void UIScriptControllerMac::doAsyncTask(JSValueRef callback)
-{
-    unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
-
-    WorkQueue::protectedMain()->dispatch([this, protectedThis = Ref { *this }, callbackID] {
-        if (!m_context)
-            return;
-        m_context->asyncTaskComplete(callbackID);
-    });
-}
-
 void UIScriptControllerMac::replaceTextAtRange(JSStringRef text, int location, int length)
 {
     auto textToInsert = adoptCF(JSStringCopyCFString(kCFAllocatorDefault, text));


### PR DESCRIPTION
#### 5822d58ad2eaa7cb53e12687c13a8a818f65c1fc
<pre>
[DRT] UIScriptController::doAsyncTask() implementation can be shared between Cocoa platforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=294781">https://bugs.webkit.org/show_bug.cgi?id=294781</a>
<a href="https://rdar.apple.com/153957170">rdar://153957170</a>

Reviewed by Richard Robinson.

This is a mechanical patch pushing the `doAsyncTask()` implementation a
level higher in the inheritance tree. This helps with unnecessary code
duplication in DumpRenderTree.

* Tools/DumpRenderTree/cocoa/UIScriptControllerCocoa.h:
* Tools/DumpRenderTree/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::doAsyncTask):
* Tools/DumpRenderTree/ios/UIScriptControllerIOS.h:
* Tools/DumpRenderTree/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::doAsyncTask): Deleted.
* Tools/DumpRenderTree/mac/UIScriptControllerMac.h:
* Tools/DumpRenderTree/mac/UIScriptControllerMac.mm:
(WTR::UIScriptControllerMac::doAsyncTask): Deleted.

Canonical link: <a href="https://commits.webkit.org/296482@main">https://commits.webkit.org/296482@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3c3bc38027143007308195431a69b8fb1032a00

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18726 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113850 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59026 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110604 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36857 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82526 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111589 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23019 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97862 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62963 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22436 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15999 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58560 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92389 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16050 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116971 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35695 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26325 "Found 1 new test failure: compositing/hdr/iframe-with-hdr-image.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91548 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36068 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94131 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91352 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23277 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36253 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14014 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31518 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35596 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35306 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38652 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36983 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->