### PR TITLE
Fix editable element in an iframe doesn't scroll into view on second focusing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/focus/focus-contenteditable-element-in-iframe-scroll-into-view-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/focus/focus-contenteditable-element-in-iframe-scroll-into-view-expected.txt
@@ -1,5 +1,5 @@
 focusable 1
 
 
-FAIL Check contenteditable element in an iframe scroll into view on second focusing assert_approx_equals: scroll X is within +/- 1 of a element in an iframe expected 0 +/- 1 but got 1519
+PASS Check contenteditable element in an iframe scroll into view on second focusing
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4137,8 +4137,10 @@ void Element::updateFocusAppearance(SelectionRestorationMode, SelectionRevealMod
             return;
         
         // When focusing an editable element in an iframe, don't reset the selection if it already contains a selection.
-        if (this == frame->selection().selection().rootEditableElement())
+        if (this == frame->selection().selection().rootEditableElement()) {
+            frame->selection().revealSelection();
             return;
+        }
 
         // FIXME: We should restore the previous selection if there is one.
         VisibleSelection newSelection = VisibleSelection(firstPositionInOrBeforeNode(this));


### PR DESCRIPTION
#### 894c1182b3fac77af919c6b60cdacf4d3f4c6b5c
<pre>
Fix editable element in an iframe doesn&apos;t scroll into view on second focusing
<a href="https://bugs.webkit.org/show_bug.cgi?id=292062">https://bugs.webkit.org/show_bug.cgi?id=292062</a>
<a href="https://rdar.apple.com/150521759">rdar://150521759</a>

Reviewed by Simon Fraser.

Merge: <a href="https://source.chromium.org/chromium/chromium/src/+/6ddd475c4898322459bcc843a175b72f0b975994">https://source.chromium.org/chromium/chromium/src/+/6ddd475c4898322459bcc843a175b72f0b975994</a>

When focusing an editable element in an iframe, scrolling into view
cannot be called if it already contains a selection. This patch adds the
call for this case.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::updateFocusAppearance):
* LayoutTests/imported/w3c/web-platform-tests/focus/focus-contenteditable-element-in-iframe-scroll-into-view-expected.txt: Progression

Canonical link: <a href="https://commits.webkit.org/296523@main">https://commits.webkit.org/296523@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b965b1aac10c76234b57e0f06b635dfdddf2654

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28346 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18770 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113896 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59070 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110648 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29035 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36903 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82567 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111633 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23062 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97906 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63004 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22481 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16043 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58601 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92432 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16093 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117017 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35739 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26370 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91587 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36112 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94174 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91391 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23289 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36294 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14057 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31591 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35640 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41173 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35349 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38696 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37027 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->