### PR TITLE
[GStreamer] isContentTypeSupported() fails for av1,vp8,vp9 codec strings

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -851,7 +851,17 @@ MediaPlayerEnums::SupportsType GStreamerRegistryScanner::isContentTypeSupported(
             return SupportsType::IsNotSupported;
 
 #if GST_CHECK_VERSION(1, 22, 0)
-        for (const auto& mimeCodec : codecs) {
+        for (const auto& codec : codecs) {
+            // gst_codec_utils_caps_from_mime_codec() expects a four characters string. See also RFC 6381 section 3.3.
+            auto mimeCodec = codec;
+            if (mimeCodec.length() < 4) {
+                if (mimeCodec == "vp8"_s)
+                    mimeCodec = "vp08"_s;
+                else if (mimeCodec == "vp9"_s)
+                    mimeCodec = "vp09"_s;
+                else if (mimeCodec == "av1"_s)
+                    mimeCodec = "av01"_s;
+            }
             auto codecCaps = adoptGRef(gst_codec_utils_caps_from_mime_codec(mimeCodec.ascii().data()));
             if (!codecCaps) {
                 GST_WARNING("Unable to convert codec %s to caps", mimeCodec.ascii().data());


### PR DESCRIPTION
#### 0dcec8c2bd96c4d1da1513de6f1d52e3d31fe748
<pre>
[GStreamer] isContentTypeSupported() fails for av1,vp8,vp9 codec strings
<a href="https://bugs.webkit.org/show_bug.cgi?id=294791">https://bugs.webkit.org/show_bug.cgi?id=294791</a>

Reviewed by Xabier Rodriguez-Calvar.

gst_codec_utils_caps_from_mime_codec() expects a four characters string. See also RFC 6381 section
3.3.

Canonical link: <a href="https://commits.webkit.org/296500@main">https://commits.webkit.org/296500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4acb89c698088f2da4dba18b4b088e1e5ee10a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108646 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18731 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113857 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59031 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110609 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36862 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82532 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111594 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23024 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97867 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62969 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22441 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16004 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58565 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92394 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16055 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116978 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35700 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26330 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91554 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36073 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94136 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91358 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23284 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36258 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14019 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31527 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35601 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41134 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35311 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38657 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36988 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->