### PR TITLE
[JSC] Optimize `Array#toSpliced` for an array contains hole

### DIFF
--- a/JSTests/microbenchmarks/array-prototype-toSpliced-hole-contiguous.js
+++ b/JSTests/microbenchmarks/array-prototype-toSpliced-hole-contiguous.js
@@ -1,0 +1,14 @@
+const arr = [];
+for (let i = 0; i < 1024; i++) {
+    arr.push({ i });
+}
+delete arr[512];
+
+function test(deleteCount) {
+    arr.toSpliced(400, deleteCount, { i: 9999 }, { i: 8888 });
+}
+noInline(test);
+
+for (let i = 0; i < 1e4; i++) {
+    test(i % 100);
+}

--- a/JSTests/microbenchmarks/array-prototype-toSpliced-hole-double.js
+++ b/JSTests/microbenchmarks/array-prototype-toSpliced-hole-double.js
@@ -1,0 +1,14 @@
+const arr = [];
+for (let i = 0; i < 1024; i++) {
+    arr.push(i + 0.1);
+}
+delete arr[512];
+
+function test(deleteCount) {
+    arr.toSpliced(400, deleteCount, 9999.9, 8888.8);
+}
+noInline(test);
+
+for (let i = 0; i < 1e4; i++) {
+    test(i % 100);
+}

--- a/JSTests/microbenchmarks/array-prototype-toSpliced-hole-int32.js
+++ b/JSTests/microbenchmarks/array-prototype-toSpliced-hole-int32.js
@@ -1,0 +1,14 @@
+const arr = [];
+for (let i = 0; i < 1024; i++) {
+    arr.push(i);
+}
+delete arr[512];
+
+function test(deleteCount) {
+    arr.toSpliced(400, deleteCount, 9999, 8888);
+}
+noInline(test);
+
+for (let i = 0; i < 1e4; i++) {
+    test(i % 100);
+}

--- a/JSTests/stress/array-prototype-toSpliced-hole-contiguous.js
+++ b/JSTests/stress/array-prototype-toSpliced-hole-contiguous.js
@@ -1,0 +1,20 @@
+function sameArray(a, b) {
+    if (a.length !== b.length)
+        throw new Error(`Expected array length ${b.length} but got ${a.length}`);
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i])
+            throw new Error(`Expected ${b[i]} but got ${a[i]} (${i})`);
+    }
+}
+
+
+const arr = [];
+for (let i = 0; i < 10; i++) {
+    arr.push({ i });
+}
+delete arr[5];
+
+const newValue1 = { i: 777 };
+const newValue2 = { i: 888 };
+const result = arr.toSpliced(2, 3, newValue1, newValue2);
+sameArray(result, [arr[0], arr[1], newValue1, newValue2, undefined, arr[6], arr[7], arr[8], arr[9]]);

--- a/JSTests/stress/array-prototype-toSpliced-hole-double.js
+++ b/JSTests/stress/array-prototype-toSpliced-hole-double.js
@@ -1,0 +1,17 @@
+function sameArray(a, b) {
+    if (a.length !== b.length)
+        throw new Error(`Expected array length ${b.length} but got ${a.length}`);
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i])
+            throw new Error(`Expected ${b[i]} but got ${a[i]} (${i})`);
+    }
+}
+
+
+const arr = [];
+for (let i = 0; i < 10; i++) {
+    arr.push(i + 0.1);
+}
+delete arr[5];
+const result = arr.toSpliced(2, 3, 777.7, 888.8);
+sameArray(result, [0.1, 1.1, 777.7, 888.8, undefined, 6.1, 7.1, 8.1, 9.1]);

--- a/JSTests/stress/array-prototype-toSpliced-hole-int32.js
+++ b/JSTests/stress/array-prototype-toSpliced-hole-int32.js
@@ -1,0 +1,17 @@
+function sameArray(a, b) {
+    if (a.length !== b.length)
+        throw new Error(`Expected array length ${b.length} but got ${a.length}`);
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i])
+            throw new Error(`Expected ${b[i]} but got ${a[i]} (${i})`);
+    }
+}
+
+
+const arr = [];
+for (let i = 0; i < 10; i++) {
+    arr.push(i);
+}
+delete arr[5];
+const result = arr.toSpliced(2, 3, 777, 888);
+sameArray(result, [0, 1, 777, 888, undefined, 6, 7, 8, 9]);


### PR DESCRIPTION
#### eb9e8b7f4c8c4099e7fe8f51afe7cdd2c76beed0
<pre>
[JSC] Optimize `Array#toSpliced` for an array contains hole
<a href="https://bugs.webkit.org/show_bug.cgi?id=294794">https://bugs.webkit.org/show_bug.cgi?id=294794</a>

Reviewed by NOBODY (OOPS!).

This patch changes to optimize `Array#with` in the same way as
<a href="https://commits.webkit.org/296030@main">https://commits.webkit.org/296030@main</a> and <a href="https://commits.webkit.org/296436@main">https://commits.webkit.org/296436@main</a>

                                                  TipOfTree                  Patched

array-prototype-toSpliced-hole-contiguous
                                               42.4100+-1.7082     ^      3.3318+-0.0742        ^ definitely 12.7289x faster
array-prototype-toSpliced-hole-int32           36.4897+-1.6700     ^      4.0341+-0.4615        ^ definitely 9.0454x faster
array-prototype-toSpliced-hole-double          38.7956+-0.1567     ^      4.4470+-0.1238        ^ definitely 8.7240x faster

* JSTests/microbenchmarks/array-prototype-toSpliced-hole-contiguous.js: Added.
(test):
* JSTests/microbenchmarks/array-prototype-toSpliced-hole-double.js: Added.
(test):
* JSTests/microbenchmarks/array-prototype-toSpliced-hole-int32.js: Added.
(test):
* JSTests/stress/array-prototype-toSpliced-hole-contiguous.js: Added.
(sameArray):
* JSTests/stress/array-prototype-toSpliced-hole-double.js: Added.
(sameArray):
* JSTests/stress/array-prototype-toSpliced-hole-int32.js: Added.
(sameArray):
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::fastToSpliced):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb9e8b7f4c8c4099e7fe8f51afe7cdd2c76beed0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110587 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30246 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116613 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60854 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30925 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38835 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84093 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113535 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24694 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99580 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64534 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24057 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17720 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60408 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/103078 "Found 18 new JSC stress test failures: stress/change-array-by-copy.js.bytecode-cache, stress/change-array-by-copy.js.default, stress/change-array-by-copy.js.dfg-eager, stress/change-array-by-copy.js.dfg-eager-no-cjit-validate, stress/change-array-by-copy.js.eager-jettison-no-cjit, stress/change-array-by-copy.js.ftl-eager, stress/change-array-by-copy.js.ftl-eager-no-cjit, stress/change-array-by-copy.js.ftl-eager-no-cjit-b3o1, stress/change-array-by-copy.js.ftl-no-cjit-b3o0, stress/change-array-by-copy.js.ftl-no-cjit-no-inline-validate ... (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94079 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17779 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119403 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109141 "Found 18 new JSC stress test failures: stress/change-array-by-copy.js.bytecode-cache, stress/change-array-by-copy.js.default, stress/change-array-by-copy.js.dfg-eager, stress/change-array-by-copy.js.dfg-eager-no-cjit-validate, stress/change-array-by-copy.js.eager-jettison-no-cjit, stress/change-array-by-copy.js.ftl-eager, stress/change-array-by-copy.js.ftl-eager-no-cjit, stress/change-array-by-copy.js.ftl-eager-no-cjit-b3o1, stress/change-array-by-copy.js.ftl-no-cjit-b3o0, stress/change-array-by-copy.js.ftl-no-cjit-no-inline-validate ... (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37627 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27942 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93059 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38001 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95851 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92881 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37899 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15640 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33602 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37522 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42993 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/133416 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37185 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36051 "Found 9 new JSC stress test failures: stress/change-array-by-copy.js.bytecode-cache, stress/change-array-by-copy.js.default, stress/change-array-by-copy.js.dfg-eager, stress/change-array-by-copy.js.dfg-eager-no-cjit-validate, stress/change-array-by-copy.js.eager-jettison-no-cjit, stress/change-array-by-copy.js.mini-mode, stress/change-array-by-copy.js.no-cjit-collect-continuously, stress/change-array-by-copy.js.no-cjit-validate-phases, stress/change-array-by-copy.js.no-llint (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40524 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38893 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->