### PR TITLE
[Liquid Glass] [iOS] Smart App Banner is not blurred by scroll edge effect when top fixed elements are present

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3063,6 +3063,7 @@ static WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::Fixe
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
     [self _updateFixedColorExtensionViews];
     [self _updateHiddenScrollPocketEdges];
+    [self _updateTopScrollPocketCaptureColor];
 #endif
 
 #if PLATFORM(MAC) && ENABLE(CONTENT_INSET_BACKGROUND_FILL)
@@ -3126,6 +3127,18 @@ static WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::Fixe
 {
 #if PLATFORM(MAC)
     _impl->updateTopScrollPocketCaptureColor();
+#else
+    if (!_needsTopScrollPocketDueToVisibleContentInset) {
+        // On iOS, overriding the top scroll pocket capture color is only necessary when:
+        //   1. The top content inset area is visible.
+        //   2. There's an element with a top fixed-position color.
+        // If either condition is false, the scroll pocket is either not visible in the first place,
+        // or it should match the scroll view background color anyways.
+        return;
+    }
+
+    if (RetainPtr color = [self _sampledTopFixedPositionContentColor] ?: [self underPageBackgroundColor])
+        [_scrollView _setPocketColor:color.get() forEdge:UIRectEdgeTop];
 #endif
 }
 
@@ -3244,7 +3257,7 @@ static WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::Fixe
 #if PLATFORM(IOS_FAMILY)
     [_scrollView _setHiddenPocketEdgesInternal:[&] {
         UIRectEdge edges = UIRectEdgeNone;
-        if (_reasonsToHideTopScrollPocket || [self _hasVisibleColorExtensionView:WebCore::BoxSide::Top])
+        if ([self _shouldHideTopScrollPocket])
             edges |= UIRectEdgeTop;
         if ([self _hasVisibleColorExtensionView:WebCore::BoxSide::Right])
             edges |= UIRectEdgeRight;
@@ -3270,10 +3283,9 @@ static WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::Fixe
     if (_reasonsToHideTopScrollPocket.contains(reason))
         return;
 
-    if (!_reasonsToHideTopScrollPocket)
-        [self _setTopScrollPocketHidden:YES];
-
     _reasonsToHideTopScrollPocket.add(reason);
+
+    [self _updateHiddenScrollPocketEdges];
 }
 
 - (void)_removeReasonToHideTopScrollPocket:(WebKit::HideScrollPocketReason)reason
@@ -3283,23 +3295,7 @@ static WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::Fixe
 
     _reasonsToHideTopScrollPocket.remove(reason);
 
-    if (!_reasonsToHideTopScrollPocket)
-        [self _setTopScrollPocketHidden:NO];
-}
-
-- (void)_setTopScrollPocketHidden:(BOOL)hidden
-{
-#if PLATFORM(IOS_FAMILY)
-    [_scrollView _setHiddenPocketEdgesInternal:[&] {
-        UIRectEdge hiddenEdges = [_scrollView _hiddenPocketEdges];
-        return hidden ? (hiddenEdges | UIRectEdgeTop) : (hiddenEdges & ~UIRectEdgeTop);
-    }()];
-#else
-    RetainPtr scrollPocket = _impl->topScrollPocket();
-    RetainPtr captureView = [scrollPocket captureView];
-    [scrollPocket setHidden:hidden];
-    [captureView setHidden:hidden];
-#endif
+    [self _updateHiddenScrollPocketEdges];
 }
 
 #pragma mark - WKColorExtensionViewDelegate

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -467,6 +467,7 @@ struct PerWebProcessState {
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
     WebCore::RectEdges<RetainPtr<WKColorExtensionView>> _fixedColorExtensionViews;
     OptionSet<WebKit::HideScrollPocketReason> _reasonsToHideTopScrollPocket;
+    BOOL _needsTopScrollPocketDueToVisibleContentInset;
 #endif
 }
 
@@ -580,6 +581,10 @@ struct PerWebProcessState {
 - (void)_updatePDFPageNumberIndicatorIfNeeded;
 - (void)_removeAnyPDFPageNumberIndicator;
 
+#endif
+
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+- (void)_updateHiddenScrollPocketEdges;
 #endif
 
 @property (nonatomic, setter=_setHasActiveNowPlayingSession:) BOOL _hasActiveNowPlayingSession;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -242,6 +242,10 @@ enum class TapHandlingResult : uint8_t;
 
 - (UIEdgeInsets)currentlyVisibleContentInsetsWithScale:(CGFloat)scaleFactor obscuredInsets:(UIEdgeInsets)obscuredInsets;
 
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+@property (nonatomic, readonly) BOOL _shouldHideTopScrollPocket;
+#endif
+
 @end
 
 _WKTapHandlingResult wkTapHandlingResult(WebKit::TapHandlingResult);

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -2397,7 +2397,49 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [_scrollView insertSubview:topColorExtensionView.get() aboveSubview:_contentView.get()];
 }
 
+- (void)_updateNeedsTopScrollPocketDueToVisibleContentInset
+{
+    BOOL value = [&] -> BOOL {
+        if ([_scrollView adjustedContentInset].top <= self._computedObscuredInset.top + CGFLOAT_EPSILON)
+            return NO;
+
+        if ([_scrollView _wk_isScrolledBeyondTopExtent])
+            return NO;
+
+        if ([[_scrollView topEdgeEffect].style isEqual:UIScrollEdgeEffectStyle.hardStyle])
+            return NO;
+
+        return [_scrollView contentOffset].y < 0;
+    }();
+
+    if (_needsTopScrollPocketDueToVisibleContentInset == value)
+        return;
+
+    _needsTopScrollPocketDueToVisibleContentInset = value;
+
+    [self _updateHiddenScrollPocketEdges];
+    [self _updateTopScrollPocketCaptureColor];
+}
+
+- (BOOL)_shouldHideTopScrollPocket
+{
+    if (_reasonsToHideTopScrollPocket)
+        return YES;
+
+    if (_needsTopScrollPocketDueToVisibleContentInset)
+        return NO;
+
+    return [self _hasVisibleColorExtensionView:WebCore::BoxSide::Top];
+}
+
 #endif // ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+
+- (void)scrollViewDidChangeAdjustedContentInset:(UIScrollView *)scrollView
+{
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+    [self _updateNeedsTopScrollPocketDueToVisibleContentInset];
+#endif
+}
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView
 {
@@ -2406,6 +2448,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
         [self _updateFixedColorExtensionViewFrames];
         [self _reinsertTopFixedColorExtensionViewIfNeeded];
+        [self _updateNeedsTopScrollPocketDueToVisibleContentInset];
 #endif
     }
 

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -572,12 +572,23 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     _cachedHasCustomTintColor = std::nullopt;
 
-    if (self.window) {
-        [self setUpInteraction];
-        _page->setScreenIsBeingCaptured([self screenIsBeingCaptured]);
-    }
-    else
+    if (!self.window) {
         [self cleanUpInteractionPreviewContainers];
+        return;
+    }
+
+    [self setUpInteraction];
+    _page->setScreenIsBeingCaptured([self screenIsBeingCaptured]);
+
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+    RunLoop::protectedMain()->dispatch([strongSelf = retainPtr(self)] {
+        if (![strongSelf window])
+            return;
+
+        // FIXME: This is only necessary to work around rdar://153991882.
+        [strongSelf->_webView _updateHiddenScrollPocketEdges];
+    });
+#endif // ENABLE(CONTENT_INSET_BACKGROUND_FILL)
 }
 
 - (WKPageRef)_pageRef

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -6943,7 +6943,10 @@ void WebViewImpl::updateScrollPocket()
 
     RetainPtr view = m_view.get();
     CGFloat topContentInset = obscuredContentInsets().top();
-    bool needsTopView = m_page->preferences().contentInsetBackgroundFillEnabled() && view && topContentInset > 0;
+    bool needsTopView = m_page->preferences().contentInsetBackgroundFillEnabled()
+        && view
+        && !view->_reasonsToHideTopScrollPocket
+        && topContentInset > 0;
 
     if (!needsTopView) {
         if (RetainPtr scrollPocket = std::exchange(m_topScrollPocket, nil)) {


### PR DESCRIPTION
#### a5cbd2d8d08741dd5f1ef7aabca077f136db12b7
<pre>
[Liquid Glass] [iOS] Smart App Banner is not blurred by scroll edge effect when top fixed elements are present
<a href="https://bugs.webkit.org/show_bug.cgi?id=294805">https://bugs.webkit.org/show_bug.cgi?id=294805</a>
<a href="https://rdar.apple.com/151640309">rdar://151640309</a>

Reviewed by Richard Robinson.

Currently, on iOS, the presence of a viewport-constrained element near one of the viewport edges
causes the scroll edge effect (i.e. scroll pocket) to be hidden, so that we get a solid color fill
in the inset area on that edge, instead of a blur / filter effect that blends the scroll view
background color. However, in the case where Safari shows a Smart App Banner or Tab Group banner (or
any other non-pinned banner UI), this policy causes the banner to not get blurred with the magic
pocket effect as the user scrolls, causing it to make text in the status bar illegible.

To fix this, we add logic to detect when the web view&apos;s scroll view is scrolled but the content
inset area above the top of the unobscured content rect is still visible, and force the magic pocket
to show in this case, even if there&apos;s a top fixed-position element.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _updateFixedContainerEdges:]):
(-[WKWebView _updateTopScrollPocketCaptureColor]):

Note that we also need to explicitly override the capture color of the scroll pocket in the case
where there&apos;s a visible app banner in the content inset area. This is necessary because the capture
color defaults to the scroll view&apos;s background color, which may differ from the fixed element color
extension. For example, this avoids an issue on iPhone when visiting <a href="https://www.goodreads.com">https://www.goodreads.com</a>
where the fixed element color is orange, but the page background is white. If we don&apos;t update the
capture color to orange, we end up with a weird crossfade from orange to white in the magic pocket
under the smart app banner when scrolling.

(-[WKWebView _updateHiddenScrollPocketEdges]):
(-[WKWebView _addReasonToHideTopScrollPocket:]):
(-[WKWebView _removeReasonToHideTopScrollPocket:]):
(-[WKWebView _setTopScrollPocketHidden:]): Deleted.

Remove this separate method for hiding or showing the scroll pocket, and instead consolidate all the
logic into `-_updateHiddenScrollPocketEdges`, which is idempotent. This makes the logic a lot easier
to follow since we only need the `_shouldHideTopScrollPocket` check in one place, instead of having
to keep logic in `-_setTopScrollPocketHidden:` in sync with `-_updateHiddenScrollPocketEdges`.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _updateNeedsTopScrollPocketDueToVisibleContentInset]):

See description above for more details.

(-[WKWebView _shouldHideTopScrollPocket]):

Consolidate the policy for determining whether to show the top scroll pocket into this helper
method. In short, `_reasonsToHideTopScrollPocket` (i.e. &quot;are we in element fullscreen?&quot;) takes
precedence over `_needsTopScrollPocketDueToVisibleContentInset` (&quot;is the app banner UI showing in
the content inset area?&quot;), which in turn takes precedence over whether or not there&apos;s a top fixed-
position element color extension.

(-[WKWebView scrollViewDidChangeAdjustedContentInset:]):
(-[WKWebView scrollViewDidScroll:]):
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView didMoveToWindow]):

Additionally work around an existing Safari bug, <a href="https://rdar.apple.com/153991882">rdar://153991882</a>, which causes the scroll edge
effect to incorrectly disappear or appear when switching tabs. This is a necessary change alongside
the rest of the patch, because without it, there would be more cases where we end up with stale
hidden pocket edges state (causing the magic pocket to not appear when it should).

* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::updateScrollPocket):

Canonical link: <a href="https://commits.webkit.org/296485@main">https://commits.webkit.org/296485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9502c66f05452b2c2dc4fe943868a76b1be18503

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108677 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28338 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18762 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113888 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59062 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29027 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36895 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82559 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111625 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23055 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97897 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62996 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22474 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58593 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92425 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16085 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117009 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35731 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/26362 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91579 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36104 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94166 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91383 "Found 2 new API test failures: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23278 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36288 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14049 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31580 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35632 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41165 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35341 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38688 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37019 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->