### PR TITLE
Re-land [SwiftUI] Expose an async sequence for navigations instead of using Observation

### DIFF
--- a/Source/WebKit/UIProcess/API/Swift/WebPage+Navigation.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+Navigation.swift
@@ -26,10 +26,8 @@
 import Foundation
 
 extension WebPage {
-    /// An opaque identifier which can be used to uniquely identify a load request for a web page.
-    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
-    @available(watchOS, unavailable)
-    @available(tvOS, unavailable)
+    @available(*, deprecated, message: "Navigations are now observed using async sequences directly.")
+    @_spi(_)
     public struct NavigationID: Sendable, Hashable, Equatable {
         let rawValue: ObjectIdentifier
 
@@ -39,49 +37,37 @@ extension WebPage {
     }
 
     /// A particular state that occurs during the progression of a navigation.
+    public enum NavigationEvent: Hashable, Sendable {
+        /// This event occurs when the page receives provisional approval to process a navigation request,
+        /// but before it receives a response to that request.
+        case startedProvisionalNavigation
+
+        /// This event occurs when the page received a server redirect for a request.
+        case receivedServerRedirect
+
+        /// This event occurs when the page has started to receive content for the main frame.
+        ///
+        /// This happens immediately before the page starts to update the main frame.
+        case committed
+
+        /// This event occurs once the navigation is complete.
+        case finished
+    }
+
+    /// A specific error that caused a navigation to fail.
     @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
-    public struct NavigationEvent: Sendable {
-        /// A set of values representing the possible types a NavigationEvent can represent.
-        public enum Kind: Sendable {
-            /// This event occurs when the web page receives provisional approval to process a navigation request,
-            /// but before it receives a response to that request.
-            case startedProvisionalNavigation
+    public enum NavigationError: Error {
+        /// An error occurred during the early navigation process.
+        case failedProvisionalNavigation(any Error)
 
-            /// This event occurs when the web page received a server redirect for a request.
-            case receivedServerRedirect
+        /// The navigation could not begin because the page has been closed.
+        case pageClosed
 
-            /// This event occurs when the web page has started to receive content for the main frame.
-            /// This happens immediately before the web page starts to update the main frame.
-            case committed
-
-            /// This event occurs once the navigation is complete.
-            case finished
-
-            /// This event indicates an error occurs during the early navigation process.
-            case failedProvisionalNavigation(underlyingError: any Error)
-
-            /// This event indicates an error occurred during navigation.
-            case failed(underlyingError: any Error)
-        }
-
-        // SPI for testing.
-        // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-        @_spi(Testing)
-        public init(kind: Kind, navigationID: NavigationID) {
-            self.kind = kind
-            self.navigationID = navigationID
-        }
-
-        /// The type of this navigation event.
-        public let kind: Kind
-
-        /// The ID of the navigation that triggered this event.
-        ///
-        /// Multiple sequential events will have the same navigation identifier.
-        public let navigationID: NavigationID
+        /// The process for the web content of this page was terminated for any reason.
+        case webContentProcessTerminated
     }
 }
 
-#endif
+#endif // ENABLE_SWIFTUI && compiler(>=6.0)

--- a/Source/WebKit/UIProcess/API/Swift/WebPage.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage.swift
@@ -152,18 +152,28 @@ final public class WebPage {
 
     // MARK: Properties
 
-    /// The current navigation event, or `nil` if there have been no navigations so far.
-    ///
-    /// This property may be used to observe changes to both an individual navigation, and across navigations.
-    ///
-    /// A new navigation begins when a `NavigationEvent` has a type of `startedProvisionalNavigation`, and is finished once a
-    /// navigation event with a type of `.finished`, `.failedProvisionalNavigation`, or `.failed`.
-    public internal(set) var currentNavigationEvent: WebPage.NavigationEvent? = nil
-
     let configuration: Configuration
 
     /// The webpage's back-forward list.
     public internal(set) var backForwardList: BackForwardList = BackForwardList()
+
+    /// A sequence of all the navigation events that occur throughout the webpage, including both user navigation
+    /// and programmatic navigation.
+    ///
+    /// A specific navigation is comprised of a sequential set of ``NavigationEvent``s; a new navigation begins when an
+    /// event is ``NavigationEvent/startedProvisionalNavigation``.
+    ///
+    /// This property produces a new sequence each time it is called, and starts tracking events as soon as it is created.
+    /// The sequence is indefinite, but may be terminated under several circumstances:
+    ///
+    /// * The owning ``WebPage``'s lifetime ends.
+    /// * An error occurs during navigation, at which point the sequence will throw the error and terminate.
+    /// * The ``Task`` enclosing iteration of the sequence is cancelled.
+    ///
+    /// To track a specific programmatic navigation, use the return value of one of the loading APIs.
+    public var navigations: some AsyncSequence<NavigationEvent, any Error> {
+        createIndefiniteNavigationSequence()
+    }
 
     /// The URL for the current webpage.
     ///
@@ -316,6 +326,12 @@ final public class WebPage {
     }()
 
     // MARK: Loading functions
+    
+    @ObservationIgnored
+    private var scopedNavigations: [ObjectIdentifier : AsyncThrowingStream<NavigationEvent, any Error>.Continuation] = [:]
+
+    @ObservationIgnored
+    private var indefiniteNavigations: [UUID : AsyncThrowingStream<NavigationEvent, any Error>.Continuation] = [:]
 
     /// Loads the web content that the specified URL request object references and navigates to that content.
     ///
@@ -325,10 +341,10 @@ final public class WebPage {
     /// Provide the source of this load request for app activity data by setting the attribution parameter on your request.
     ///
     /// - Parameter request: A URL request that specifies the resource to display.
-    /// - Returns: A navigation identifier you use to track the loading progress of the request.
+    /// - Returns: An async sequence you use to track the loading progress of the navigation. If the `Task` enclosing the sequence is cancelled, the page will stop loading all resources.
     @discardableResult
-    public func load(_ request: URLRequest) -> NavigationID? {
-        backingWebView.load(request).map(NavigationID.init(_:))
+    public func load(_ request: URLRequest) -> some AsyncSequence<NavigationEvent, any Error> {
+        toNavigationSequence { $0.load(request) }
     }
 
     /// Loads the content of the specified data object and navigates to it.
@@ -341,9 +357,9 @@ final public class WebPage {
     ///   - mimeType: The MIME type of the information in the data parameter. This parameter must not contain an empty string.
     ///   - characterEncoding: The data's character encoding.
     ///   - baseURL: A URL that you use to resolve relative URLs within the document.
-    /// - Returns: A navigation identifier you use to track the loading progress of the request.
+    /// - Returns: An async sequence you use to track the loading progress of the navigation. If the `Task` enclosing the sequence is cancelled, the page will stop loading all resources.
     @discardableResult
-    public func load(_ data: Data, mimeType: String, characterEncoding: String.Encoding, baseURL: URL) -> NavigationID? {
+    public func load(_ data: Data, mimeType: String, characterEncoding: String.Encoding, baseURL: URL) -> some AsyncSequence<NavigationEvent, any Error> {
         let cfEncoding = CFStringConvertNSStringEncodingToEncoding(characterEncoding.rawValue)
         guard cfEncoding != kCFStringEncodingInvalidId else {
             preconditionFailure("\(characterEncoding) is not a valid character encoding")
@@ -352,9 +368,10 @@ final public class WebPage {
         guard let convertedEncoding = CFStringConvertEncodingToIANACharSetName(cfEncoding) as? String else {
             preconditionFailure("\(characterEncoding) is not a valid character encoding")
         }
-
-        return backingWebView.load(data, mimeType: mimeType, characterEncodingName: convertedEncoding, baseURL: baseURL)
-            .map(NavigationID.init(_:))
+        
+        return toNavigationSequence {
+            $0.load(data, mimeType: mimeType, characterEncodingName: convertedEncoding, baseURL: baseURL)
+        }
     }
 
     /// Loads the contents of the specified HTML string and navigates to it.
@@ -367,7 +384,17 @@ final public class WebPage {
     /// - Parameters:
     ///   - html: The string to use as the contents of the webpage.
     ///   - baseURL: The base URL to use when the system resolves relative URLs within the HTML string.
-    /// - Returns: A navigation identifier you use to track the loading progress of the request.
+    /// - Returns: An async sequence you use to track the loading progress of the navigation. If the `Task` enclosing the sequence is cancelled, the page will stop loading all resources.
+    @discardableResult
+    public func load(html: String, baseURL: URL) -> some AsyncSequence<NavigationEvent, any Error> {
+        toNavigationSequence {
+            $0.loadHTMLString(html, baseURL: baseURL)
+        }
+    }
+
+    @available(*, deprecated, message: "Navigations are now observed using async sequences directly.")
+    @_spi(_)
+    @_disfavoredOverload
     @discardableResult
     public func load(html: String, baseURL: URL) -> NavigationID? {
         backingWebView.loadHTMLString(html, baseURL: baseURL).map(NavigationID.init(_:))
@@ -379,13 +406,13 @@ final public class WebPage {
     ///   - request: A URL request that specifies the base URL and other loading details the system uses to interpret the data you provide.
     ///   - response: A response the system uses to interpret the data you provide.
     ///   - responseData: The data to use as the contents of the webpage.
-    /// - Returns: A navigation identifier you use to track the loading progress of the request.
+    /// - Returns: An async sequence you use to track the loading progress of the navigation. If the `Task` enclosing the sequence is cancelled, the page will stop loading all resources.
     @discardableResult
-    public func load(simulatedRequest request: URLRequest, response: URLResponse, responseData: Data) -> NavigationID? {
-        // `WKWebView` annotates this method as returning non-nil, but it may return nil.
-
-        let navigation = backingWebView.loadSimulatedRequest(request, response: response, responseData: responseData) as WKNavigation?
-        return navigation.map(NavigationID.init(_:))
+    public func load(simulatedRequest request: URLRequest, response: URLResponse, responseData: Data) -> some AsyncSequence<NavigationEvent, any Error> {
+        toNavigationSequence {
+            // `WKWebView` annotates this method as returning non-nil, but it may return nil.
+            $0.loadSimulatedRequest(request, response: response, responseData: responseData) as WKNavigation?
+        }
     }
 
     /// Loads the web content from the HTML you provide as if the HTML were the response to the request.
@@ -393,33 +420,36 @@ final public class WebPage {
     /// - Parameters:
     ///   - request: A URL request that specifies the base URL and other loading details the system uses to interpret the HTML you provide.
     ///   - htmlString: The HTML code you provide in a string to use as the contents of the webpage.
-    /// - Returns: A navigation identifier you use to track the loading progress of the request.
+    /// - Returns: An async sequence you use to track the loading progress of the navigation. If the `Task` enclosing the sequence is cancelled, the page will stop loading all resources.
     @discardableResult
-    public func load(simulatedRequest request: URLRequest, responseHTML htmlString: String) -> NavigationID? {
-        // `WKWebView` annotates this method as returning non-nil, but it may return nil.
-
-        let navigation = backingWebView.loadSimulatedRequest(request, responseHTML: htmlString) as WKNavigation?
-        return navigation.map(NavigationID.init(_:))
+    public func load(simulatedRequest request: URLRequest, responseHTML htmlString: String) -> some AsyncSequence<NavigationEvent, any Error> {
+        toNavigationSequence {
+            // `WKWebView` annotates this method as returning non-nil, but it may return nil.
+            $0.loadSimulatedRequest(request, responseHTML: htmlString) as WKNavigation?
+        }
     }
 
     /// Navigates to an item from the back-forward list and sets it as the current item.
     ///
     /// - Parameter item: The item to navigate to. The item must be in the webpage's back-forward list.
-    /// - Returns: A navigation identifier you use to track the loading progress of the request.
+    /// - Returns: An async sequence you use to track the loading progress of the navigation. If the `Task` enclosing the sequence is cancelled, the page will stop loading all resources.
     @discardableResult
-    public func load(_ item: BackForwardList.Item) -> NavigationID? {
-        backingWebView.go(to: item.wrapped).map(NavigationID.init(_:))
+    public func load(_ item: BackForwardList.Item) -> some AsyncSequence<NavigationEvent, any Error> {
+        toNavigationSequence {
+            $0.go(to: item.wrapped)
+        }
     }
 
     /// Reloads the current webpage.
     ///
     /// - Parameter fromOrigin: If `true`, end-to-end revalidation of the content using cache-validating conditionals
     /// is performed, if possible.
-    /// - Returns: A navigation identifier you use to track the loading progress of the request.
+    /// - Returns: An async sequence you use to track the loading progress of the navigation. If the `Task` enclosing the sequence is cancelled, the page will stop loading all resources.
     @discardableResult
-    public func reload(fromOrigin: Bool = false) -> NavigationID? {
-        let navigation = fromOrigin ? backingWebView.reloadFromOrigin() : backingWebView.reload()
-        return navigation.map(NavigationID.init(_:))
+    public func reload(fromOrigin: Bool = false) -> some AsyncSequence<NavigationEvent, any Error> {
+        toNavigationSequence {
+            fromOrigin ? $0.reloadFromOrigin() : $0.reload()
+        }
     }
 
     /// Stops loading all resources on the current page.
@@ -532,7 +562,62 @@ final public class WebPage {
         await backingWebView.setMicrophoneCaptureState(state)
     }
 
-    // MARK: Private helper functions
+    // MARK: Helper functions
+
+    func addNavigationEvent(_ event: Result<NavigationEvent, any Error>, for cocoaNavigation: WKNavigation) {
+        scopedNavigations[ObjectIdentifier(cocoaNavigation)]?.yield(with: event)
+
+        if case .success(.finished) = event {
+            scopedNavigations[ObjectIdentifier(cocoaNavigation)]?.finish()
+        }
+
+        for continuation in indefiniteNavigations.values {
+            continuation.yield(with: event)
+        }
+    }
+
+    private func createIndefiniteNavigationSequence() -> some AsyncSequence<NavigationEvent, any Error> {
+        let id = UUID()
+
+        let (stream, continuation) = AsyncThrowingStream.makeStream(of: NavigationEvent.self, throwing: (any Error).self)
+        continuation.onTermination = { [weak self] termination in
+            guard let self else {
+                return
+            }
+            Task { @MainActor in
+                // `stopLoading` is intentionally not called here because the semantics of doing
+                // so would not be well-defined in the case of multiple navigation sequences.
+                indefiniteNavigations[id] = nil
+            }
+        }
+
+        indefiniteNavigations[id] = continuation
+        return stream
+    }
+
+    private func toNavigationSequence(_ load: (WKWebView) -> WKNavigation?) -> some AsyncSequence<NavigationEvent, any Error> {
+        guard let id = load(backingWebView) else {
+            return AsyncThrowingStream { continuation in
+                continuation.finish(throwing: NavigationError.pageClosed)
+            }
+        }
+
+        let (stream, continuation) = AsyncThrowingStream.makeStream(of: NavigationEvent.self, throwing: (any Error).self)
+        continuation.onTermination = { [weak self] termination in
+            guard let self else {
+                return
+            }
+            Task { @MainActor in
+                if case .cancelled = termination {
+                    stopLoading()
+                }
+                scopedNavigations[ObjectIdentifier(id)] = nil
+            }
+        }
+
+        scopedNavigations[ObjectIdentifier(id)] = continuation
+        return stream
+    }
 
     private func createObservation<Value, BackingValue>(
         for keyPath: KeyPath<WebPage, Value>,

--- a/Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift
+++ b/Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift
@@ -135,9 +135,9 @@ final class BrowserViewModel {
     }
 
     func didReceiveNavigationEvent(_ event: WebPage.NavigationEvent) {
-        Self.logger.info("Did receive navigation event \(String(describing: event.kind)) for navigation \(String(describing: event.navigationID))")
+        Self.logger.info("Did receive navigation event \(String(describing: event))")
 
-        if case .committed = event.kind {
+        if event == .committed {
             displayedURL = page.url?.absoluteString ?? ""
         }
     }

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		07C02FD22D6D6FBC0004ED97 /* rtl-sideways-scrolling.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 07C02FD12D6D6FBC0004ED97 /* rtl-sideways-scrolling.html */; };
 		07C046CA1E4262A8007201E7 /* CARingBufferTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 07C046C91E42573E007201E7 /* CARingBufferTest.cpp */; };
 		07CE1CF31F06A7E000BF89F5 /* GetUserMediaNavigation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 07CE1CF21F06A7E000BF89F5 /* GetUserMediaNavigation.mm */; };
+		07DF05182E0531AD00007A1B /* WebPageNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07DF05172E0531AD00007A1B /* WebPageNavigationTests.swift */; };
 		07E499911F9E56DF002F1EF3 /* GetUserMediaReprompt.mm in Sources */ = {isa = PBXBuildFile; fileRef = 07E499901F9E56A1002F1EF3 /* GetUserMediaReprompt.mm */; };
 		07FAA74D2CE95E3200128360 /* WebPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07FAA74C2CE95E3200128360 /* WebPageTests.swift */; };
 		0DE559ED2A6B0AAF009AA320 /* WKWebViewResize.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0DE559E52A6B0AAF009AA320 /* WKWebViewResize.mm */; };
@@ -2280,6 +2281,7 @@
 		07CD32F52065B5420064A4BE /* AVFoundationPreference.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AVFoundationPreference.mm; sourceTree = "<group>"; };
 		07CD32F72065B72A0064A4BE /* video.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = video.html; sourceTree = "<group>"; };
 		07CE1CF21F06A7E000BF89F5 /* GetUserMediaNavigation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = GetUserMediaNavigation.mm; sourceTree = "<group>"; };
+		07DF05172E0531AD00007A1B /* WebPageNavigationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPageNavigationTests.swift; sourceTree = "<group>"; };
 		07E1F6A01FFC3A080096C7EC /* GetDisplayMedia.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = GetDisplayMedia.mm; sourceTree = "<group>"; };
 		07E1F6A11FFC44F90096C7EC /* getDisplayMedia.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = getDisplayMedia.html; path = ../WebKit/getDisplayMedia.html; sourceTree = "<group>"; };
 		07E499901F9E56A1002F1EF3 /* GetUserMediaReprompt.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = GetUserMediaReprompt.mm; sourceTree = "<group>"; };
@@ -4210,6 +4212,7 @@
 				078F21282DD99E6300E87858 /* RunLoopQueueTests.swift */,
 				070721102CE2F4B8004D9EC8 /* TestWebKitAPIBundle-Bridging-Header.h */,
 				078B04472CF118BD00B453A6 /* URLSchemeHandlerTests.swift */,
+				07DF05172E0531AD00007A1B /* WebPageNavigationTests.swift */,
 				07FAA74C2CE95E3200128360 /* WebPageTests.swift */,
 				071467792DFE8DEA00F77867 /* WebPageTransferableTests.swift */,
 				070721142CE2F5F6004D9EC8 /* WKWebViewSwiftOverlayTests.swift */,
@@ -7808,6 +7811,7 @@
 				078F21302DD99E6A00E87858 /* RunLoopQueueTests.swift in Sources */,
 				078B0CA92DF656BD00B3E569 /* TestPDFDocument.swift in Sources */,
 				078B04482CF118BD00B453A6 /* URLSchemeHandlerTests.swift in Sources */,
+				07DF05182E0531AD00007A1B /* WebPageNavigationTests.swift in Sources */,
 				07FAA74D2CE95E3200128360 /* WebPageTests.swift in Sources */,
 				0714677A2DFE8DEA00F77867 /* WebPageTransferableTests.swift in Sources */,
 				077489CC2CE4061A00133938 /* WKWebViewSwiftOverlayTests.swift in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageNavigationTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageNavigationTests.swift
@@ -1,0 +1,148 @@
+// Copyright (C) 2025 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.0)
+
+import Testing
+import WebKit
+
+extension RangeReplaceableCollection {
+    fileprivate init<Failure>(
+        _ sequence: some AsyncSequence<Element, Failure>,
+        isolation: isolated (any Actor)? = #isolation
+    ) async throws(Failure) where Failure: Error {
+        self.init()
+
+        for try await element in sequence {
+            append(element)
+        }
+    }
+}
+
+private struct NeverLoadingSchemeHandler: URLSchemeHandler {
+    @MainActor
+    static let scheme = URLScheme("never-loading")!
+
+    nonisolated func reply(for request: URLRequest) -> some AsyncSequence<URLSchemeTaskResult, any Error> {
+        AsyncThrowingStream { _ in }
+    }
+}
+
+@MainActor
+struct WebPageNavigationTests {
+    @Test
+    func basicNavigationProducesExpectedNavigationEvents() async throws {
+        let page = WebPage()
+
+        let html = "<html><div>Hello</div></html>"
+        let sequence = page.load(html: html, baseURL: .aboutBlank)
+
+        let expected: [WebPage.NavigationEvent] = [.startedProvisionalNavigation, .committed, .finished]
+        let actual = try await Array(sequence)
+
+        #expect(actual == expected)
+    }
+
+    @Test
+    func failedNavigationProducesExpectedNavigationError() async throws {
+        let page = WebPage()
+
+        let request = URLRequest(url: URL(string: "about:foo")!)
+        let sequence = page.load(request)
+
+        var actual: [WebPage.NavigationEvent] = []
+        let expected: [WebPage.NavigationEvent] = [.startedProvisionalNavigation]
+
+        await #expect(throws: (any Error).self) {
+            for try await event in sequence {
+                actual.append(event)
+            }
+        }
+
+        #expect(actual == expected)
+    }
+
+    @Test
+    func explicitlyStopLoadingProgrammaticNavigation() async throws {
+        var configuration = WebPage.Configuration()
+        configuration.urlSchemeHandlers[NeverLoadingSchemeHandler.scheme] = NeverLoadingSchemeHandler()
+
+        let page = WebPage(configuration: configuration)
+        let sequence = page.load(URLRequest(url: URL(string: "never-loading:///index.html")!))
+
+        // FIXME: `#expect` should work here, but due to a Swift Testing issue causes the test to hang.
+        do {
+            for try await event in sequence {
+                if event == .startedProvisionalNavigation {
+                    page.stopLoading()
+                }
+            }
+            Issue.record("Stopping page load should trigger an error and therefore the loop should never finish.")
+        } catch {
+            #expect(error is WebPage.NavigationError)
+        }
+    }
+
+    @Test
+    func stopLoadingProgrammaticNavigationViaTaskCancellation() async throws {
+        var configuration = WebPage.Configuration()
+        configuration.urlSchemeHandlers[NeverLoadingSchemeHandler.scheme] = NeverLoadingSchemeHandler()
+        let page = WebPage(configuration: configuration)
+
+        let allNavigations = page.navigations
+        let sequence = page.load(URLRequest(url: URL(string: "never-loading:///index.html")!))
+
+        var task: Task<Void, any Error>? = nil
+
+        await withCheckedContinuation { continuation in
+            task = Task {
+                for try await event in sequence {
+                    if event == .startedProvisionalNavigation {
+                        continuation.resume()
+                    } else {
+                        Issue.record("No other event should occur since the load is indefinite.")
+                    }
+                }
+            }
+        }
+
+        try #require(task).cancel()
+
+        let expectedEvents: [WebPage.NavigationEvent] = [.startedProvisionalNavigation]
+        var actualEvents: [WebPage.NavigationEvent] = []
+
+        // FIXME: `#expect` should work here, but due to a Swift Testing issue causes the test to hang.
+        do {
+            for try await event in allNavigations {
+                actualEvents.append(event)
+            }
+            Issue.record("The stream is indefinite and therefore should never reach here.")
+        } catch {
+            #expect(error is WebPage.NavigationError)
+        }
+
+        #expect(actualEvents == expectedEvents)
+    }
+}
+
+#endif // ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.0)

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTests.swift
@@ -29,33 +29,6 @@ import Testing
 @_spi(Private) @_spi(Testing) import WebKit
 @_spi(Private) import _WebKit_SwiftUI
 
-extension WebPage.NavigationEvent.Kind: @retroactive Equatable {
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-        switch (lhs, rhs) {
-        case (.startedProvisionalNavigation, .startedProvisionalNavigation):
-            true
-        case (.receivedServerRedirect, .receivedServerRedirect):
-            true
-        case (.committed, .committed):
-            true
-        case (.finished, .finished):
-            true
-        case (.failedProvisionalNavigation(_), .failedProvisionalNavigation(_)):
-            true
-        case (.failed(_), .failed(_)):
-            true
-        default:
-            false
-        }
-    }
-}
-
-extension WebPage.NavigationEvent: @retroactive Equatable {
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.kind == rhs.kind && lhs.navigationID == rhs.navigationID
-    }
-}
-
 // MARK: Supporting test types
 
 @MainActor


### PR DESCRIPTION
#### 4203492397b80e376ff463ddbb8074bdc7f0b855
<pre>
Re-land [SwiftUI] Expose an async sequence for navigations instead of using Observation
<a href="https://bugs.webkit.org/show_bug.cgi?id=294807">https://bugs.webkit.org/show_bug.cgi?id=294807</a>
<a href="https://rdar.apple.com/154001239">rdar://154001239</a>

Unreviewed re-landing/build fix.

This includes 296461@main, the followup build fix 296464@main, and an additional build fix.

* Source/WebKit/UIProcess/API/Swift/WebPage+Navigation.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage.swift:
(navigations):
(scopedNavigations):
(indefiniteNavigations):
(load(_:)):
(load(_:mimeType:characterEncoding:baseURL:)):
(load(_:baseURL:)):
(load(simulatedRequest:response:responseData:)):
(load(simulatedRequest:responseHTML:)):
(reload(_:)):
(addNavigationEvent(_:any:for:)):
(createIndefiniteNavigationSequence):
(toNavigationSequence(_:)):
(currentNavigationEvent): Deleted.
* Source/WebKit/UIProcess/Cocoa/WKNavigationDelegateAdapter.swift:
(WKNavigationDelegateAdapter.yieldNavigationProgress(_:cocoaNavigation:)):
(WKNavigationDelegateAdapter.failNavigationProgress(_:cocoaNavigation:)):
(WKNavigationDelegateAdapter.webView(_:didFailProvisionalNavigation:withError:)):
(WKNavigationDelegateAdapter.webView(_:didFail:withError:)):
* Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift:
(BrowserViewModel.didReceiveNavigationEvent(_:)):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageNavigationTests.swift: Added.
(NeverLoadingSchemeHandler.reply(for:)):
(WebPageNavigationTests.basicNavigationProducesExpectedNavigationEvents):
(WebPageNavigationTests.failedNavigationProducesExpectedNavigationError):
(WebPageNavigationTests.explicitlyStopLoadingProgrammaticNavigation):
(WebPageNavigationTests.stopLoadingProgrammaticNavigationViaTaskCancellation):
* Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTests.swift:

Canonical link: <a href="https://commits.webkit.org/296486@main">https://commits.webkit.org/296486@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7ab78d42f48a3e7927469533a455db04ae43d89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108684 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28345 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18769 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113895 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59069 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110647 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29034 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36902 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82566 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111632 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23060 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97903 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63003 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22479 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16039 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58600 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92430 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16090 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117016 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35738 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26367 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91585 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36111 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94171 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91389 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36293 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14054 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31590 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17546 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35639 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41172 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35348 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38695 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37026 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->