### PR TITLE
[css-pseudo] Allow more animation properties for ::marker after scroll-animations

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/parsing/marker-supported-properties-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/parsing/marker-supported-properties-expected.txt
@@ -35,6 +35,10 @@ PASS Property animation-name value 'anim' in ::marker
 PASS Property animation-play-state value 'paused' in ::marker
 PASS Property animation-timing-function value 'linear' in ::marker
 PASS Property animation-composition value 'add' in ::marker
+PASS Property animation-range value 'contain 10px cover 20px' in ::marker
+PASS Property animation-range-start value 'contain 10px' in ::marker
+PASS Property animation-range-end value 'cover 20px' in ::marker
+PASS Property animation-timeline value 'scroll()' in ::marker
 PASS Property transition value 'display 1s linear 2s' in ::marker
 PASS Property transition-delay value '1s' in ::marker
 PASS Property transition-duration value '2s' in ::marker

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/parsing/marker-supported-properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/parsing/marker-supported-properties.html
@@ -63,6 +63,11 @@ test_pseudo_computed_value("::marker", "animation-play-state", "paused");
 test_pseudo_computed_value("::marker", "animation-timing-function", "linear");
 test_pseudo_computed_value("::marker", "animation-composition", "add");
 
+test_pseudo_computed_value("::marker", "animation-range", "contain 10px cover 20px");
+test_pseudo_computed_value("::marker", "animation-range-start", "contain 10px");
+test_pseudo_computed_value("::marker", "animation-range-end", "cover 20px");
+test_pseudo_computed_value("::marker", "animation-timeline", "scroll()");
+
 // ::marker supports transition properties.
 test_pseudo_computed_value("::marker", "transition", "display 1s linear 2s");
 test_pseudo_computed_value("::marker", "transition-delay", "1s");

--- a/Source/WebCore/style/PropertyAllowlist.cpp
+++ b/Source/WebCore/style/PropertyAllowlist.cpp
@@ -103,6 +103,9 @@ bool isValidMarkerStyleProperty(CSSPropertyID id)
     case CSSPropertyAnimationPlayState:
     case CSSPropertyAnimationComposition:
     case CSSPropertyAnimationName:
+    case CSSPropertyAnimationRangeEnd:
+    case CSSPropertyAnimationRangeStart:
+    case CSSPropertyAnimationTimeline:
     case CSSPropertyTransitionBehavior:
     case CSSPropertyTransitionDuration:
     case CSSPropertyTransitionTimingFunction:


### PR DESCRIPTION
#### 45f6a6da1ae2826cb2ff8372447de7e9403a7cea
<pre>
[css-pseudo] Allow more animation properties for ::marker after scroll-animations
<a href="https://bugs.webkit.org/show_bug.cgi?id=294523">https://bugs.webkit.org/show_bug.cgi?id=294523</a>
&lt;<a href="https://rdar.apple.com/problem/154021467">rdar://problem/154021467</a>&gt;

Reviewed by Tim Nguyen.

The CSS Lists and Counters Module Level 3 spec section for &quot;Properties Applying to ::marker&quot; states [0]
that &quot;all animation and transition properties&quot; apply to a marker box. So we make sure the more recently
added CSS Animations properties added for Scroll-driven Animations are part of our allow list.

[0] <a href="https://drafts.csswg.org/css-lists-3/#marker-properties">https://drafts.csswg.org/css-lists-3/#marker-properties</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/parsing/marker-supported-properties-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/parsing/marker-supported-properties.html:
* Source/WebCore/style/PropertyAllowlist.cpp:
(WebCore::Style::isValidMarkerStyleProperty):

Canonical link: <a href="https://commits.webkit.org/296488@main">https://commits.webkit.org/296488@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17d05bdd4446e3a39c2312e546bfc09fe5f382c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108691 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18776 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113902 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59076 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110654 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36911 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82572 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111639 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23067 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97913 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63009 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22486 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16049 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58607 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92437 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16099 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117023 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35745 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26377 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91592 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36118 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94180 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91399 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36300 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14063 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31602 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17547 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35646 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41179 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35355 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38702 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37033 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->