### PR TITLE
[Style] Add a shared base class for Style WebCore::Length wrappers to reduce code duplication

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2780,6 +2780,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     style/values/position/StyleInset.h
 
+    style/values/primitives/StyleLengthWrapper.h
     style/values/primitives/StylePosition.h
     style/values/primitives/StylePrimitiveNumeric.h
     style/values/primitives/StylePrimitiveNumericAdaptors.h

--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -130,15 +130,7 @@ rendering/style/StyleCachedImage.cpp
 rendering/svg/SVGRenderingContext.h
 style/StyleExtractorState.h
 style/StyleScope.h
-style/values/box/StyleMargin.h
-style/values/box/StylePadding.h
-style/values/flexbox/StyleFlexBasis.h
-style/values/motion/StyleOffsetDistance.h
-style/values/position/StyleInset.h
-style/values/scroll-snap/StyleScrollPadding.h
-style/values/sizing/StyleMaximumSize.h
-style/values/sizing/StyleMinimumSize.h
-style/values/sizing/StylePreferredSize.h
+style/values/primitives/StyleLengthWrapper.h
 testing/Internals.cpp
 workers/DedicatedWorkerThread.cpp
 workers/Worker.h

--- a/Source/WebCore/platform/Length.cpp
+++ b/Source/WebCore/platform/Length.cpp
@@ -413,7 +413,7 @@ static Length blendMixedTypes(const Length& from, const Length& to, const Blendi
     if (context.compositeOperation != CompositeOperation::Replace)
         return makeLength(Calculation::add(lengthCalculation(from), lengthCalculation(to)));
 
-    if (from.isIntrinsicOrLegacyIntrinsicOrAuto() || to.isIntrinsicOrLegacyIntrinsicOrAuto()) {
+    if ((!from.isSpecified() && !from.isRelative()) || (!to.isSpecified() && !to.isRelative())) {
         ASSERT(context.isDiscrete);
         ASSERT(!context.progress || context.progress == 1);
         return context.progress ? to : from;

--- a/Source/WebCore/platform/Length.h
+++ b/Source/WebCore/platform/Length.h
@@ -140,11 +140,6 @@ public:
 
     ~Length();
 
-    void setValue(LengthType, int value);
-    void setValue(LengthType, float value);
-    void setValue(LengthType, LayoutUnit value);
-    Length& operator*=(float);
-
     bool operator==(const Length&) const;
 
     float value() const;
@@ -162,19 +157,19 @@ public:
     LengthType type() const;
     WEBCORE_EXPORT IPCData ipcData() const;
 
-    bool isAuto() const;
-    bool isCalculated() const;
     bool isFixed() const;
+    bool isCalculated() const;
+    bool isPercent() const;
+    bool isPercentOrCalculated() const; // Returns true for both Percent and Calculated.
+    bool isSpecified() const;
+
+    bool isRelative() const;
+
+    bool isAuto() const;
     bool isMaxContent() const;
     bool isMinContent() const;
     bool isNormal() const;
-    bool isPercent() const;
-    bool isRelative() const;
     bool isUndefined() const;
-    bool isFillAvailable() const;
-    bool isFitContent() const;
-    bool isMinIntrinsic() const;
-    bool isContent() const;
 
     bool isEmptyValue() const { return m_isEmptyValue; }
 
@@ -189,19 +184,7 @@ public:
     bool isPositive() const;
     bool isNegative() const;
 
-    bool isFloat() const;
-
-    bool isPercentOrCalculated() const; // Returns true for both Percent and Calculated.
-
-    bool isIntrinsic() const;
-    bool isIntrinsicOrLegacyIntrinsic() const;
-    bool isIntrinsicOrLegacyIntrinsicOrAuto() const;
-    bool isSpecified() const;
-    bool isSpecifiedOrIntrinsic() const;
-
     WEBCORE_EXPORT float nonNanCalculatedValue(float maxValue) const;
-
-    bool isLegacyIntrinsic() const;
 
     struct MarkableTraits {
         static bool isEmptyValue(const Length& length) { return length.isEmptyValue(); }
@@ -415,20 +398,6 @@ inline bool Length::operator==(const Length& other) const
     return value() == other.value();
 }
 
-inline Length& Length::operator*=(float value)
-{
-    ASSERT(!isCalculated());
-    if (isCalculated())
-        return *this;
-
-    if (m_isFloat)
-        m_floatValue *= value;
-    else
-        m_intValue *= value;
-
-    return *this;
-}
-
 inline float Length::value() const
 {
     ASSERT(!isUndefined());
@@ -463,41 +432,39 @@ inline bool Length::hasQuirk() const
     return m_hasQuirk;
 }
 
-inline bool Length::isFloat() const
-{
-    return m_isFloat;
-}
-
 inline void Length::setHasQuirk(bool hasQuirk)
 {
     m_hasQuirk = hasQuirk;
 }
 
-inline void Length::setValue(LengthType type, int value)
+inline bool Length::isFixed() const
 {
-    ASSERT(!isCalculated());
-    ASSERT(type != LengthType::Calculated);
-    m_type = type;
-    m_intValue = value;
-    m_isFloat = false;
+    return type() == LengthType::Fixed;
 }
 
-inline void Length::setValue(LengthType type, float value)
+inline bool Length::isPercent() const
 {
-    ASSERT(!isCalculated());
-    ASSERT(type != LengthType::Calculated);
-    m_type = type;
-    m_floatValue = value;
-    m_isFloat = true;
+    return type() == LengthType::Percent;
 }
 
-inline void Length::setValue(LengthType type, LayoutUnit value)
+inline bool Length::isCalculated() const
 {
-    ASSERT(!isCalculated());
-    ASSERT(type != LengthType::Calculated);
-    m_type = type;
-    m_floatValue = value;
-    m_isFloat = true;
+    return type() == LengthType::Calculated;
+}
+
+inline bool Length::isPercentOrCalculated() const
+{
+    return isPercent() || isCalculated();
+}
+
+inline bool Length::isSpecified() const
+{
+    return isFixed() || isPercentOrCalculated();
+}
+
+inline bool Length::isRelative() const
+{
+    return type() == LengthType::Relative;
 }
 
 inline bool Length::isNormal() const
@@ -510,11 +477,6 @@ inline bool Length::isAuto() const
     return type() == LengthType::Auto;
 }
 
-inline bool Length::isFixed() const
-{
-    return type() == LengthType::Fixed;
-}
-
 inline bool Length::isMaxContent() const
 {
     return type() == LengthType::MaxContent;
@@ -525,32 +487,9 @@ inline bool Length::isMinContent() const
     return type() == LengthType::MinContent;
 }
 
-inline bool Length::isNegative() const
-{
-    ASSERT(!isEmptyValue());
-    if (isUndefined() || isCalculated())
-        return false;
-    return m_isFloat ? (m_floatValue < 0) : (m_intValue < 0);
-}
-
-inline bool Length::isPercent() const
-{
-    return type() == LengthType::Percent;
-}
-
-inline bool Length::isRelative() const
-{
-    return type() == LengthType::Relative;
-}
-
 inline bool Length::isUndefined() const
 {
     return type() == LengthType::Undefined;
-}
-
-inline bool Length::isPercentOrCalculated() const
-{
-    return isPercent() || isCalculated();
 }
 
 inline bool Length::isPositive() const
@@ -563,6 +502,14 @@ inline bool Length::isPositive() const
     return m_isFloat ? (m_floatValue > 0) : (m_intValue > 0);
 }
 
+inline bool Length::isNegative() const
+{
+    ASSERT(!isEmptyValue());
+    if (isUndefined() || isCalculated())
+        return false;
+    return m_isFloat ? (m_floatValue < 0) : (m_intValue < 0);
+}
+
 inline bool Length::isZero() const
 {
     ASSERT(!isUndefined());
@@ -570,62 +517,6 @@ inline bool Length::isZero() const
     if (isCalculated() || isAuto())
         return false;
     return m_isFloat ? !m_floatValue : !m_intValue;
-}
-
-inline bool Length::isCalculated() const
-{
-    return type() == LengthType::Calculated;
-}
-
-inline bool Length::isLegacyIntrinsic() const
-{
-    return type() == LengthType::Intrinsic || type() == LengthType::MinIntrinsic;
-}
-
-inline bool Length::isIntrinsic() const
-{
-    // FIXME: This is misleadingly named. One would expect this function does "return type() == LengthType::Intrinsic;".
-    return type() == LengthType::MinContent || type() == LengthType::MaxContent || type() == LengthType::FillAvailable || type() == LengthType::FitContent;
-}
-
-inline bool Length::isIntrinsicOrLegacyIntrinsic() const
-{
-    return isIntrinsic() || isLegacyIntrinsic();
-}
-
-inline bool Length::isIntrinsicOrLegacyIntrinsicOrAuto() const
-{
-    return isAuto() || isIntrinsicOrLegacyIntrinsic();
-}
-
-inline bool Length::isSpecified() const
-{
-    return isFixed() || isPercentOrCalculated();
-}
-
-inline bool Length::isSpecifiedOrIntrinsic() const
-{
-    return isSpecified() || isIntrinsic();
-}
-
-inline bool Length::isFillAvailable() const
-{
-    return type() == LengthType::FillAvailable;
-}
-
-inline bool Length::isFitContent() const
-{
-    return type() == LengthType::FitContent;
-}
-
-inline bool Length::isMinIntrinsic() const
-{
-    return type() == LengthType::MinIntrinsic;
-}
-
-inline bool Length::isContent() const
-{
-    return type() == LengthType::Content;
 }
 
 Length convertTo100PercentMinusLength(const Length&);

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -1647,7 +1647,7 @@ std::pair<LayoutUnit, LayoutUnit> RenderFlexibleBox::computeFlexItemMinMaxSizes(
 {
     auto max = maxMainSizeLengthForFlexItem(flexItem);
     std::optional<LayoutUnit> maxExtent = std::nullopt;
-    if (max.isSpecifiedOrIntrinsic())
+    if (max.isSpecified() || max.isIntrinsic())
         maxExtent = computeMainAxisExtentForFlexItem(flexItem, max);
 
     auto min = minMainSizeLengthForFlexItem(flexItem);

--- a/Source/WebCore/rendering/RenderScrollbarPart.cpp
+++ b/Source/WebCore/rendering/RenderScrollbarPart.cpp
@@ -100,7 +100,7 @@ static int calcScrollbarThicknessUsing(const Style::MinimumSize& minimumSize)
 
 static int calcScrollbarThicknessUsing(const Style::MaximumSize& maximumSize)
 {
-    if (!maximumSize.isPercentOrCalculated() && !maximumSize.isIntrinsicOrLegacyIntrinsic())
+    if (!maximumSize.isPercentOrCalculated() && !maximumSize.isIntrinsic() && !maximumSize.isLegacyIntrinsic())
         return Style::evaluateMinimum(maximumSize, { });
     return ScrollbarTheme::theme().scrollbarThickness();
 }
@@ -115,8 +115,8 @@ void RenderScrollbarPart::computeScrollbarWidth()
     setWidth(std::max(minWidth, std::min(maxWidth, width)));
     
     // Buttons and track pieces can all have margins along the axis of the scrollbar. 
-    m_marginBox.setLeft(Style::evaluateMinimum(style().marginLeft(), { }));
-    m_marginBox.setRight(Style::evaluateMinimum(style().marginRight(), { }));
+    m_marginBox.setLeft(Style::evaluateMinimum(style().marginLeft(), 0_lu));
+    m_marginBox.setRight(Style::evaluateMinimum(style().marginRight(), 0_lu));
 }
 
 void RenderScrollbarPart::computeScrollbarHeight()
@@ -129,8 +129,8 @@ void RenderScrollbarPart::computeScrollbarHeight()
     setHeight(std::max(minHeight, std::min(maxHeight, height)));
 
     // Buttons and track pieces can all have margins along the axis of the scrollbar. 
-    m_marginBox.setTop(Style::evaluateMinimum(style().marginTop(), { }));
-    m_marginBox.setBottom(Style::evaluateMinimum(style().marginBottom(), { }));
+    m_marginBox.setTop(Style::evaluateMinimum(style().marginTop(), 0_lu));
+    m_marginBox.setBottom(Style::evaluateMinimum(style().marginBottom(), 0_lu));
 }
 
 void RenderScrollbarPart::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)

--- a/Source/WebCore/rendering/RenderTextInlines.h
+++ b/Source/WebCore/rendering/RenderTextInlines.h
@@ -26,8 +26,8 @@
 
 namespace WebCore {
 
-inline LayoutUnit RenderText::marginLeft() const { return Style::evaluateMinimum(style().marginLeft(), 0); }
-inline LayoutUnit RenderText::marginRight() const { return Style::evaluateMinimum(style().marginRight(), 0); }
+inline LayoutUnit RenderText::marginLeft() const { return Style::evaluateMinimum(style().marginLeft(), 0_lu); }
+inline LayoutUnit RenderText::marginRight() const { return Style::evaluateMinimum(style().marginRight(), 0_lu); }
 
 template <typename MeasureTextCallback>
 float RenderText::measureTextConsideringPossibleTrailingSpace(bool currentCharacterIsSpace, unsigned startIndex, unsigned wordLength, WordTrailingSpace& wordTrailingSpace, SingleThreadWeakHashSet<const Font>& fallbackFonts, MeasureTextCallback&& callback)

--- a/Source/WebCore/rendering/style/StyleFlexibleBoxData.cpp
+++ b/Source/WebCore/rendering/style/StyleFlexibleBoxData.cpp
@@ -28,6 +28,7 @@
 
 #include "RenderStyleDifference.h"
 #include "RenderStyleInlines.h"
+#include "StylePrimitiveNumericTypes+Logging.h"
 
 namespace WebCore {
 
@@ -78,4 +79,4 @@ void StyleFlexibleBoxData::dumpDifferences(TextStream& ts, const StyleFlexibleBo
 }
 #endif // !LOG_DISABLED
 
-}
+} // namespace WebCore

--- a/Source/WebCore/style/values/box/StyleMargin.cpp
+++ b/Source/WebCore/style/values/box/StyleMargin.cpp
@@ -27,7 +27,6 @@
 
 #include "StyleBuilderConverter.h"
 #include "StyleBuilderState.h"
-#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 namespace Style {
@@ -37,30 +36,6 @@ namespace Style {
 auto CSSValueConversion<MarginEdge>::operator()(BuilderState& state, const CSSValue& value) -> MarginEdge
 {
     return MarginEdge { BuilderConverter::convertLengthOrAuto(state, value) };
-}
-
-// MARK: - Blending
-
-auto Blending<MarginEdge>::canBlend(const MarginEdge& a, const MarginEdge& b) -> bool
-{
-    return WebCore::canInterpolateLengths(a.m_value, b.m_value, true);
-}
-
-auto Blending<MarginEdge>::requiresInterpolationForAccumulativeIteration(const MarginEdge& a, const MarginEdge& b) -> bool
-{
-    return WebCore::lengthsRequireInterpolationForAccumulativeIteration(a.m_value, b.m_value);
-}
-
-auto Blending<MarginEdge>::blend(const MarginEdge& a, const MarginEdge& b, const BlendingContext& context) -> MarginEdge
-{
-    return MarginEdge { WebCore::blend(a.m_value, b.m_value, context, ValueRange::All) };
-}
-
-// MARK: - Logging
-
-WTF::TextStream& operator<<(WTF::TextStream& ts, const MarginEdge& value)
-{
-    return ts << value.m_value;
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/box/StyleMargin.h
+++ b/Source/WebCore/style/values/box/StyleMargin.h
@@ -24,128 +24,17 @@
 
 #pragma once
 
-#include "Length.h"
-#include "LengthFunctions.h"
-#include "StylePrimitiveNumericTypes.h"
-#include "StyleValueTypes.h"
+#include "StyleLengthWrapper.h"
 
 namespace WebCore {
-
-class CSSValue;
-class RenderStyle;
-
 namespace Style {
-
-class BuilderState;
 
 // <'margin-*'> = auto | <length-percentage>
 // https://drafts.csswg.org/css-box/#margin-physical
-struct MarginEdge {
-    using Specified = LengthPercentage<>;
-    using Fixed = typename Specified::Dimension;
-    using Percentage = typename Specified::Percentage;
-    using Calc = typename Specified::Calc;
-
-    MarginEdge(CSS::Keyword::Auto) : m_value(WebCore::LengthType::Auto) { }
-
-    MarginEdge(Fixed&& fixed) : m_value(fixed.value, WebCore::LengthType::Fixed) { }
-    MarginEdge(const Fixed& fixed) : m_value(fixed.value, WebCore::LengthType::Fixed) { }
-    MarginEdge(Percentage&& percent) : m_value(percent.value, WebCore::LengthType::Percent) { }
-    MarginEdge(const Percentage& percent) : m_value(percent.value, WebCore::LengthType::Percent) { }
-
-    MarginEdge(CSS::ValueLiteral<CSS::LengthUnit::Px> literal) : m_value(static_cast<float>(literal.value), WebCore::LengthType::Fixed) { }
-    MarginEdge(CSS::ValueLiteral<CSS::PercentageUnit::Percentage> literal) : m_value(static_cast<float>(literal.value), WebCore::LengthType::Percent) { }
-
-    explicit MarginEdge(WebCore::Length&& other) : m_value(WTFMove(other)) { RELEASE_ASSERT(isValid(m_value)); }
-    explicit MarginEdge(const WebCore::Length& other) : m_value(other) { RELEASE_ASSERT(isValid(m_value)); }
+struct MarginEdge : LengthWrapperBase<LengthPercentage<>, CSS::Keyword::Auto> {
+    using Base::Base;
 
     ALWAYS_INLINE bool hasQuirk() const { return m_value.hasQuirk(); }
-
-    ALWAYS_INLINE bool isAuto() const { return m_value.isAuto(); }
-    ALWAYS_INLINE bool isFixed() const { return m_value.isFixed(); }
-    ALWAYS_INLINE bool isPercent() const { return m_value.isPercent(); }
-    ALWAYS_INLINE bool isCalculated() const { return m_value.isCalculated(); }
-    ALWAYS_INLINE bool isPercentOrCalculated() const { return m_value.isPercentOrCalculated(); }
-    ALWAYS_INLINE bool isSpecified() const { return m_value.isSpecified(); }
-
-    ALWAYS_INLINE bool isZero() const { return m_value.isZero(); }
-    ALWAYS_INLINE bool isPositive() const { return m_value.isPositive(); }
-    ALWAYS_INLINE bool isNegative() const { return m_value.isNegative(); }
-
-    std::optional<Fixed> tryFixed() const { return isFixed() ? std::make_optional(Fixed { m_value.value() }) : std::nullopt; }
-    std::optional<Percentage> tryPercentage() const { return isPercent() ? std::make_optional(Percentage { m_value.value() }) : std::nullopt; }
-    std::optional<Calc> tryCalc() const { return isCalculated() ? std::make_optional(Calc { m_value.calculationValue() }) : std::nullopt; }
-
-    template<typename T> bool holdsAlternative() const
-    {
-             if constexpr (std::same_as<T, Fixed>)              return isFixed();
-        else if constexpr (std::same_as<T, Percentage>)         return isPercent();
-        else if constexpr (std::same_as<T, Calc>)               return isCalculated();
-        else if constexpr (std::same_as<T, CSS::Keyword::Auto>) return isAuto();
-    }
-
-    template<typename... F> decltype(auto) switchOn(F&&... f) const
-    {
-        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
-
-        switch (m_value.type()) {
-        case WebCore::LengthType::Fixed:            return visitor(Fixed { m_value.value() });
-        case WebCore::LengthType::Percent:          return visitor(Percentage { m_value.value() });
-        case WebCore::LengthType::Calculated:       return visitor(Calc { m_value.calculationValue() });
-        case WebCore::LengthType::Auto:             return visitor(CSS::Keyword::Auto { });
-
-        case WebCore::LengthType::Intrinsic:
-        case WebCore::LengthType::MinIntrinsic:
-        case WebCore::LengthType::MinContent:
-        case WebCore::LengthType::MaxContent:
-        case WebCore::LengthType::FillAvailable:
-        case WebCore::LengthType::FitContent:
-        case WebCore::LengthType::Content:
-        case WebCore::LengthType::Normal:
-        case WebCore::LengthType::Relative:
-        case WebCore::LengthType::Undefined:
-            break;
-        }
-        RELEASE_ASSERT_NOT_REACHED();
-    }
-
-    bool hasSameType(const MarginEdge& other) const { return m_value.type() == other.m_value.type(); }
-
-    bool operator==(const MarginEdge&) const = default;
-
-private:
-    friend struct Blending<MarginEdge>;
-    friend struct Evaluation<MarginEdge>;
-    friend LayoutUnit evaluateMinimum(const MarginEdge&, NOESCAPE const Invocable<LayoutUnit()> auto&);
-    friend LayoutUnit evaluateMinimum(const MarginEdge&, LayoutUnit);
-    friend WTF::TextStream& operator<<(WTF::TextStream&, const MarginEdge&);
-
-    static bool isValid(const WebCore::Length& length)
-    {
-        switch (length.type()) {
-        case WebCore::LengthType::Fixed:
-            return CSS::isWithinRange<Fixed::range>(length.value());
-        case WebCore::LengthType::Percent:
-            return CSS::isWithinRange<Percentage::range>(length.value());
-        case WebCore::LengthType::Calculated:
-        case WebCore::LengthType::Auto:
-            return true;
-        case WebCore::LengthType::Intrinsic:
-        case WebCore::LengthType::MinIntrinsic:
-        case WebCore::LengthType::MinContent:
-        case WebCore::LengthType::MaxContent:
-        case WebCore::LengthType::FillAvailable:
-        case WebCore::LengthType::FitContent:
-        case WebCore::LengthType::Content:
-        case WebCore::LengthType::Normal:
-        case WebCore::LengthType::Relative:
-        case WebCore::LengthType::Undefined:
-            break;
-        }
-        return false;
-    }
-
-    WebCore::Length m_value;
 };
 
 // <'margin'> = <'margin-top'>{1,4}
@@ -155,42 +44,6 @@ using MarginBox = MinimallySerializingSpaceSeparatedRectEdges<MarginEdge>;
 // MARK: - Conversion
 
 template<> struct CSSValueConversion<MarginEdge> { auto operator()(BuilderState&, const CSSValue&) -> MarginEdge; };
-
-// MARK: - Evaluation
-
-template<> struct Evaluation<MarginEdge> {
-    auto operator()(const MarginEdge& edge, LayoutUnit referenceLength) -> LayoutUnit
-    {
-        return valueForLength(edge.m_value, referenceLength);
-    }
-
-    auto operator()(const MarginEdge& edge, float referenceLength) -> float
-    {
-        return floatValueForLength(edge.m_value, referenceLength);
-    }
-};
-
-inline LayoutUnit evaluateMinimum(const MarginEdge& edge, NOESCAPE const Invocable<LayoutUnit()> auto& lazyMaximumValueFunctor)
-{
-    return minimumValueForLengthWithLazyMaximum<LayoutUnit, LayoutUnit>(edge.m_value, lazyMaximumValueFunctor);
-}
-
-inline LayoutUnit evaluateMinimum(const MarginEdge& edge, LayoutUnit maximumValue)
-{
-    return minimumValueForLength(edge.m_value, maximumValue);
-}
-
-// MARK: - Blending
-
-template<> struct Blending<MarginEdge> {
-    auto canBlend(const MarginEdge&, const MarginEdge&) -> bool;
-    auto requiresInterpolationForAccumulativeIteration(const MarginEdge&, const MarginEdge&) -> bool;
-    auto blend(const MarginEdge&, const MarginEdge&, const BlendingContext&) -> MarginEdge;
-};
-
-// MARK: - Logging
-
-WTF::TextStream& operator<<(WTF::TextStream&, const MarginEdge&);
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/box/StylePadding.cpp
+++ b/Source/WebCore/style/values/box/StylePadding.cpp
@@ -27,7 +27,6 @@
 
 #include "StyleBuilderConverter.h"
 #include "StyleBuilderState.h"
-#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 namespace Style {
@@ -37,30 +36,6 @@ namespace Style {
 auto CSSValueConversion<PaddingEdge>::operator()(BuilderState& state, const CSSValue& value) -> PaddingEdge
 {
     return PaddingEdge { BuilderConverter::convertLength(state, value) };
-}
-
-// MARK: - Blending
-
-auto Blending<PaddingEdge>::canBlend(const PaddingEdge& a, const PaddingEdge& b) -> bool
-{
-    return WebCore::canInterpolateLengths(a.m_value, b.m_value, true);
-}
-
-auto Blending<PaddingEdge>::requiresInterpolationForAccumulativeIteration(const PaddingEdge& a, const PaddingEdge& b) -> bool
-{
-    return WebCore::lengthsRequireInterpolationForAccumulativeIteration(a.m_value, b.m_value);
-}
-
-auto Blending<PaddingEdge>::blend(const PaddingEdge& a, const PaddingEdge& b, const BlendingContext& context) -> PaddingEdge
-{
-    return PaddingEdge { WebCore::blend(a.m_value, b.m_value, context, ValueRange::NonNegative) };
-}
-
-// MARK: - Logging
-
-WTF::TextStream& operator<<(WTF::TextStream& ts, const PaddingEdge& value)
-{
-    return ts << value.m_value;
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/box/StylePadding.h
+++ b/Source/WebCore/style/values/box/StylePadding.h
@@ -24,122 +24,15 @@
 
 #pragma once
 
-#include "Length.h"
-#include "LengthFunctions.h"
-#include "StylePrimitiveNumericTypes.h"
-#include "StyleValueTypes.h"
+#include "StyleLengthWrapper.h"
 
 namespace WebCore {
-
-class CSSValue;
-class RenderStyle;
-
 namespace Style {
-
-class BuilderState;
 
 // <'padding-*'> = <length-percentage [0,∞]>
 // https://drafts.csswg.org/css-box/#padding-physical
-struct PaddingEdge {
-    using Specified = LengthPercentage<CSS::Nonnegative>;
-    using Fixed = typename Specified::Dimension;
-    using Percentage = typename Specified::Percentage;
-    using Calc = typename Specified::Calc;
-
-    PaddingEdge(Fixed&& fixed) : m_value(fixed.value, WebCore::LengthType::Fixed) { }
-    PaddingEdge(const Fixed& fixed) : m_value(fixed.value, WebCore::LengthType::Fixed) { }
-    PaddingEdge(Percentage&& percent) : m_value(percent.value, WebCore::LengthType::Percent) { }
-    PaddingEdge(const Percentage& percent) : m_value(percent.value, WebCore::LengthType::Percent) { }
-
-    PaddingEdge(CSS::ValueLiteral<CSS::LengthUnit::Px> literal) : m_value(static_cast<float>(literal.value), WebCore::LengthType::Fixed) { }
-    PaddingEdge(CSS::ValueLiteral<CSS::PercentageUnit::Percentage> literal) : m_value(static_cast<float>(literal.value), WebCore::LengthType::Percent) { }
-
-    explicit PaddingEdge(WebCore::Length&& other) : m_value(WTFMove(other)) { RELEASE_ASSERT(isValid(m_value)); }
-    explicit PaddingEdge(const WebCore::Length& other) : m_value(other) { RELEASE_ASSERT(isValid(m_value)); }
-
-    ALWAYS_INLINE bool isFixed() const { return m_value.isFixed(); }
-    ALWAYS_INLINE bool isPercent() const { return m_value.isPercent(); }
-    ALWAYS_INLINE bool isCalculated() const { return m_value.isCalculated(); }
-    ALWAYS_INLINE bool isPercentOrCalculated() const { return m_value.isPercentOrCalculated(); }
-    ALWAYS_INLINE bool isSpecified() const { return m_value.isSpecified(); }
-
-    ALWAYS_INLINE bool isZero() const { return m_value.isZero(); }
-    ALWAYS_INLINE bool isPositive() const { return m_value.isPositive(); }
-    ALWAYS_INLINE bool isNegative() const { return m_value.isNegative(); }
-
-    std::optional<Fixed> tryFixed() const { return isFixed() ? std::make_optional(Fixed { m_value.value() }) : std::nullopt; }
-    std::optional<Percentage> tryPercentage() const { return isPercent() ? std::make_optional(Percentage { m_value.value() }) : std::nullopt; }
-    std::optional<Calc> tryCalc() const { return isCalculated() ? std::make_optional(Calc { m_value.calculationValue() }) : std::nullopt; }
-
-    template<typename T> bool holdsAlternative() const
-    {
-             if constexpr (std::same_as<T, Fixed>)              return isFixed();
-        else if constexpr (std::same_as<T, Percentage>)         return isPercent();
-        else if constexpr (std::same_as<T, Calc>)               return isCalculated();
-    }
-
-    template<typename... F> decltype(auto) switchOn(F&&... f) const
-    {
-        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
-
-        switch (m_value.type()) {
-        case WebCore::LengthType::Fixed:            return visitor(Fixed { m_value.value() });
-        case WebCore::LengthType::Percent:          return visitor(Percentage { m_value.value() });
-        case WebCore::LengthType::Calculated:       return visitor(Calc { m_value.calculationValue() });
-
-        case WebCore::LengthType::Auto:
-        case WebCore::LengthType::Intrinsic:
-        case WebCore::LengthType::MinIntrinsic:
-        case WebCore::LengthType::MinContent:
-        case WebCore::LengthType::MaxContent:
-        case WebCore::LengthType::FillAvailable:
-        case WebCore::LengthType::FitContent:
-        case WebCore::LengthType::Content:
-        case WebCore::LengthType::Normal:
-        case WebCore::LengthType::Relative:
-        case WebCore::LengthType::Undefined:
-            break;
-        }
-        RELEASE_ASSERT_NOT_REACHED();
-    }
-
-    bool hasSameType(const PaddingEdge& other) const { return m_value.type() == other.m_value.type(); }
-
-    bool operator==(const PaddingEdge&) const = default;
-
-private:
-    friend struct Blending<PaddingEdge>;
-    friend struct Evaluation<PaddingEdge>;
-    friend LayoutUnit evaluateMinimum(const PaddingEdge&, NOESCAPE const Invocable<LayoutUnit()> auto&);
-    friend LayoutUnit evaluateMinimum(const PaddingEdge&, LayoutUnit);
-    friend WTF::TextStream& operator<<(WTF::TextStream&, const PaddingEdge&);
-
-    static bool isValid(const WebCore::Length& length)
-    {
-        switch (length.type()) {
-        case WebCore::LengthType::Fixed:
-            return CSS::isWithinRange<Fixed::range>(length.value());
-        case WebCore::LengthType::Percent:
-            return CSS::isWithinRange<Percentage::range>(length.value());
-        case WebCore::LengthType::Calculated:
-        case WebCore::LengthType::Auto:
-            return true;
-        case WebCore::LengthType::Intrinsic:
-        case WebCore::LengthType::MinIntrinsic:
-        case WebCore::LengthType::MinContent:
-        case WebCore::LengthType::MaxContent:
-        case WebCore::LengthType::FillAvailable:
-        case WebCore::LengthType::FitContent:
-        case WebCore::LengthType::Content:
-        case WebCore::LengthType::Normal:
-        case WebCore::LengthType::Relative:
-        case WebCore::LengthType::Undefined:
-            break;
-        }
-        return false;
-    }
-
-    WebCore::Length m_value;
+struct PaddingEdge : LengthWrapperBase<LengthPercentage<CSS::Nonnegative>> {
+    using Base::Base;
 };
 
 // <'padding'> = <'padding-top'>{1,4}
@@ -149,42 +42,6 @@ using PaddingBox = MinimallySerializingSpaceSeparatedRectEdges<PaddingEdge>;
 // MARK: - Conversion
 
 template<> struct CSSValueConversion<PaddingEdge> { auto operator()(BuilderState&, const CSSValue&) -> PaddingEdge; };
-
-// MARK: - Evaluation
-
-template<> struct Evaluation<PaddingEdge> {
-    auto operator()(const PaddingEdge& edge, LayoutUnit referenceLength) -> LayoutUnit
-    {
-        return valueForLength(edge.m_value, referenceLength);
-    }
-
-    auto operator()(const PaddingEdge& edge, float referenceLength) -> float
-    {
-        return floatValueForLength(edge.m_value, referenceLength);
-    }
-};
-
-inline LayoutUnit evaluateMinimum(const PaddingEdge& edge, NOESCAPE const Invocable<LayoutUnit()> auto& lazyMaximumValueFunctor)
-{
-    return minimumValueForLengthWithLazyMaximum<LayoutUnit, LayoutUnit>(edge.m_value, lazyMaximumValueFunctor);
-}
-
-inline LayoutUnit evaluateMinimum(const PaddingEdge& edge, LayoutUnit maximumValue)
-{
-    return minimumValueForLength(edge.m_value, maximumValue);
-}
-
-// MARK: - Blending
-
-template<> struct Blending<PaddingEdge> {
-    auto canBlend(const PaddingEdge&, const PaddingEdge&) -> bool;
-    auto requiresInterpolationForAccumulativeIteration(const PaddingEdge&, const PaddingEdge&) -> bool;
-    auto blend(const PaddingEdge&, const PaddingEdge&, const BlendingContext&) -> PaddingEdge;
-};
-
-// MARK: - Logging
-
-WTF::TextStream& operator<<(WTF::TextStream&, const PaddingEdge&);
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/flexbox/StyleFlexBasis.cpp
+++ b/Source/WebCore/style/values/flexbox/StyleFlexBasis.cpp
@@ -27,14 +27,13 @@
 
 #include "StyleBuilderConverter.h"
 #include "StyleBuilderState.h"
-#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 namespace Style {
 
 std::optional<PreferredSize> FlexBasis::tryPreferredSize() const
 {
-    if (m_value.isContent())
+    if (isContent())
         return { };
     return PreferredSize { WebCore::Length { m_value } };
 }
@@ -44,30 +43,6 @@ std::optional<PreferredSize> FlexBasis::tryPreferredSize() const
 auto CSSValueConversion<FlexBasis>::operator()(BuilderState& state, const CSSValue& value) -> FlexBasis
 {
     return FlexBasis { BuilderConverter::convertLengthSizing(state, value) };
-}
-
-// MARK: - Blending
-
-auto Blending<FlexBasis>::canBlend(const FlexBasis& a, const FlexBasis& b) -> bool
-{
-    return WebCore::canInterpolateLengths(a.m_value, b.m_value, true);
-}
-
-auto Blending<FlexBasis>::requiresInterpolationForAccumulativeIteration(const FlexBasis& a, const FlexBasis& b) -> bool
-{
-    return WebCore::lengthsRequireInterpolationForAccumulativeIteration(a.m_value, b.m_value);
-}
-
-auto Blending<FlexBasis>::blend(const FlexBasis& a, const FlexBasis& b, const BlendingContext& context) -> FlexBasis
-{
-    return FlexBasis { WebCore::blend(a.m_value, b.m_value, context, ValueRange::NonNegative) };
-}
-
-// MARK: - Logging
-
-WTF::TextStream& operator<<(WTF::TextStream& ts, const FlexBasis& value)
-{
-    return ts << value.m_value;
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/flexbox/StyleFlexBasis.h
+++ b/Source/WebCore/style/values/flexbox/StyleFlexBasis.h
@@ -24,206 +24,25 @@
 
 #pragma once
 
-#include "Length.h"
-#include "LengthFunctions.h"
-#include "StylePrimitiveNumericTypes.h"
-#include "StyleValueTypes.h"
+#include "StyleLengthWrapper.h"
 
 namespace WebCore {
-
-class CSSValue;
-class RenderStyle;
-
 namespace Style {
 
-class BuilderState;
 struct PreferredSize;
 
 // <'flex-basis'> = content | <‘width’>
 // https://drafts.csswg.org/css-flexbox/#propdef-flex-basis
-struct FlexBasis {
-    using Specified = LengthPercentage<CSS::Nonnegative>;
-    using Fixed = typename Specified::Dimension;
-    using Percentage = typename Specified::Percentage;
-    using Calc = typename Specified::Calc;
-
-    FlexBasis(CSS::Keyword::Content) : m_value(WebCore::LengthType::Content) { }
-    FlexBasis(CSS::Keyword::Auto) : m_value(WebCore::LengthType::Auto) { }
-    FlexBasis(CSS::Keyword::MinContent) : m_value(WebCore::LengthType::MinContent) { }
-    FlexBasis(CSS::Keyword::MaxContent) : m_value(WebCore::LengthType::MaxContent) { }
-    FlexBasis(CSS::Keyword::FitContent) : m_value(WebCore::LengthType::FitContent) { }
-    FlexBasis(CSS::Keyword::WebkitFillAvailable) : m_value(WebCore::LengthType::FillAvailable) { }
-    FlexBasis(CSS::Keyword::Intrinsic) : m_value(WebCore::LengthType::Intrinsic) { }
-    FlexBasis(CSS::Keyword::MinIntrinsic) : m_value(WebCore::LengthType::MinIntrinsic) { }
-
-    FlexBasis(Fixed&& fixed) : m_value(fixed.value, WebCore::LengthType::Fixed) { }
-    FlexBasis(const Fixed& fixed) : m_value(fixed.value, WebCore::LengthType::Fixed) { }
-    FlexBasis(Percentage&& percent) : m_value(percent.value, WebCore::LengthType::Percent) { }
-    FlexBasis(const Percentage& percent) : m_value(percent.value, WebCore::LengthType::Percent) { }
-
-    FlexBasis(CSS::ValueLiteral<CSS::LengthUnit::Px> literal) : m_value(static_cast<float>(literal.value), WebCore::LengthType::Fixed) { }
-    FlexBasis(CSS::ValueLiteral<CSS::PercentageUnit::Percentage> literal) : m_value(static_cast<float>(literal.value), WebCore::LengthType::Percent) { }
-
-    explicit FlexBasis(WebCore::Length&& other) : m_value(WTFMove(other)) { RELEASE_ASSERT(isValid(m_value)); }
-    explicit FlexBasis(const WebCore::Length& other) : m_value(other) { RELEASE_ASSERT(isValid(m_value)); }
-
-    ALWAYS_INLINE bool isFixed() const { return m_value.isFixed(); }
-    ALWAYS_INLINE bool isDimension() const { return m_value.isFixed(); }
-    ALWAYS_INLINE bool isPercent() const { return m_value.isPercent(); }
-    ALWAYS_INLINE bool isCalculated() const { return m_value.isCalculated(); }
-    ALWAYS_INLINE bool isPercentOrCalculated() const { return m_value.isPercentOrCalculated(); }
-    ALWAYS_INLINE bool isSpecified() const { return m_value.isSpecified(); }
-
-    // `content` is a `FlexBasis` specific value.
-    ALWAYS_INLINE bool isContent() const { return m_value.isContent(); }
-    ALWAYS_INLINE bool isAuto() const { return m_value.isAuto(); }
-    ALWAYS_INLINE bool isMinContent() const { return m_value.isMinContent(); }
-    ALWAYS_INLINE bool isMaxContent() const { return m_value.isMaxContent(); }
-    ALWAYS_INLINE bool isFitContent() const { return m_value.isFitContent(); }
-    ALWAYS_INLINE bool isFillAvailable() const { return m_value.isFillAvailable(); }
-    ALWAYS_INLINE bool isMinIntrinsic() const { return m_value.isMinIntrinsic(); }
-    ALWAYS_INLINE bool isIntrinsicKeyword() const { return m_value.type() == LengthType::Intrinsic; }
-
-    // FIXME: This is misleadingly named. One would expect this function checks `type == LengthType::Intrinsic` but instead it checks `type = LengthType::MinContent || type == LengthType::MaxContent || type == LengthType::FillAvailable || type == LengthType::FitContent`.
-    ALWAYS_INLINE bool isIntrinsic() const { return m_value.isIntrinsic(); }
-    ALWAYS_INLINE bool isLegacyIntrinsic() const { return m_value.isLegacyIntrinsic(); }
-    ALWAYS_INLINE bool isIntrinsicOrLegacyIntrinsic() const { return isIntrinsic() || isLegacyIntrinsic(); }
-    ALWAYS_INLINE bool isIntrinsicOrLegacyIntrinsicOrAuto() const { return m_value.isIntrinsicOrLegacyIntrinsicOrAuto(); }
-    ALWAYS_INLINE bool isSpecifiedOrIntrinsic() const { return m_value.isSpecifiedOrIntrinsic(); }
-
-    ALWAYS_INLINE bool isZero() const { return m_value.isZero(); }
-    ALWAYS_INLINE bool isPositive() const { return m_value.isPositive(); }
-    ALWAYS_INLINE bool isNegative() const { return m_value.isNegative(); }
-
-    // FIXME: Remove this when RenderBox's adjust*Box functions no longer need it.
-    ALWAYS_INLINE WebCore::LengthType type() const { return m_value.type(); }
-
-    ALWAYS_INLINE std::optional<Fixed> tryFixed() const { return isFixed() ? std::make_optional(Fixed { m_value.value() }) : std::nullopt; }
-    ALWAYS_INLINE std::optional<Percentage> tryPercentage() const { return isPercent() ? std::make_optional(Percentage { m_value.value() }) : std::nullopt; }
-    std::optional<Calc> tryCalc() const { return isCalculated() ? std::make_optional(Calc { m_value.calculationValue() }) : std::nullopt; }
+struct FlexBasis  : LengthWrapperBase<LengthPercentage<CSS::Nonnegative>, CSS::Keyword::Content, CSS::Keyword::Auto, CSS::Keyword::MinContent, CSS::Keyword::MaxContent, CSS::Keyword::FitContent, CSS::Keyword::WebkitFillAvailable, CSS::Keyword::Intrinsic, CSS::Keyword::MinIntrinsic> {
+    using Base::Base;
 
     // `FlexBasis` is a superset of `PreferredSize` and therefore this conversion can fail when type is `content`.
     std::optional<PreferredSize> tryPreferredSize() const;
-
-    template<typename T> bool holdsAlternative() const
-    {
-             if constexpr (std::same_as<T, Fixed>)                              return isFixed();
-        else if constexpr (std::same_as<T, Percentage>)                         return isPercent();
-        else if constexpr (std::same_as<T, Calc>)                               return isCalculated();
-        else if constexpr (std::same_as<T, CSS::Keyword::Content>)              return isContent();
-        else if constexpr (std::same_as<T, CSS::Keyword::Auto>)                 return isAuto();
-        else if constexpr (std::same_as<T, CSS::Keyword::Intrinsic>)            return isIntrinsicKeyword();
-        else if constexpr (std::same_as<T, CSS::Keyword::MinIntrinsic>)         return isMinIntrinsic();
-        else if constexpr (std::same_as<T, CSS::Keyword::MinContent>)           return isMinContent();
-        else if constexpr (std::same_as<T, CSS::Keyword::MaxContent>)           return isMaxContent();
-        else if constexpr (std::same_as<T, CSS::Keyword::WebkitFillAvailable>)  return isFillAvailable();
-        else if constexpr (std::same_as<T, CSS::Keyword::FitContent>)           return isFitContent();
-    }
-
-    template<typename... F> decltype(auto) switchOn(F&&... f) const
-    {
-        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
-
-        switch (m_value.type()) {
-        case WebCore::LengthType::Fixed:            return visitor(Fixed { m_value.value() });
-        case WebCore::LengthType::Percent:          return visitor(Percentage { m_value.value() });
-        case WebCore::LengthType::Calculated:       return visitor(Calc { m_value.calculationValue() });
-        case WebCore::LengthType::Content:          return visitor(CSS::Keyword::Content { });
-        case WebCore::LengthType::Auto:             return visitor(CSS::Keyword::Auto { });
-        case WebCore::LengthType::Intrinsic:        return visitor(CSS::Keyword::Intrinsic { });
-        case WebCore::LengthType::MinIntrinsic:     return visitor(CSS::Keyword::MinIntrinsic { });
-        case WebCore::LengthType::MinContent:       return visitor(CSS::Keyword::MinContent { });
-        case WebCore::LengthType::MaxContent:       return visitor(CSS::Keyword::MaxContent { });
-        case WebCore::LengthType::FillAvailable:    return visitor(CSS::Keyword::WebkitFillAvailable { });
-        case WebCore::LengthType::FitContent:       return visitor(CSS::Keyword::FitContent { });
-
-        case WebCore::LengthType::Normal:
-        case WebCore::LengthType::Relative:
-        case WebCore::LengthType::Undefined:
-            break;
-        }
-
-        RELEASE_ASSERT_NOT_REACHED();
-    }
-
-    bool hasSameType(const FlexBasis& other) const { return m_value.type() == other.m_value.type(); }
-
-    bool operator==(const FlexBasis&) const = default;
-
-private:
-    friend struct Blending<FlexBasis>;
-    friend struct Evaluation<FlexBasis>;
-    friend LayoutUnit evaluateMinimum(const FlexBasis&, NOESCAPE const Invocable<LayoutUnit()> auto&);
-    friend LayoutUnit evaluateMinimum(const FlexBasis&, LayoutUnit);
-    friend WTF::TextStream& operator<<(WTF::TextStream&, const FlexBasis&);
-
-    static bool isValid(const WebCore::Length& length)
-    {
-        switch (length.type()) {
-        case WebCore::LengthType::Fixed:
-            return CSS::isWithinRange<Fixed::range>(length.value());
-        case WebCore::LengthType::Percent:
-            return CSS::isWithinRange<Percentage::range>(length.value());
-        case WebCore::LengthType::Content:
-        case WebCore::LengthType::Auto:
-        case WebCore::LengthType::Intrinsic:
-        case WebCore::LengthType::MinIntrinsic:
-        case WebCore::LengthType::MinContent:
-        case WebCore::LengthType::MaxContent:
-        case WebCore::LengthType::FillAvailable:
-        case WebCore::LengthType::FitContent:
-        case WebCore::LengthType::Calculated:
-            return true;
-        case WebCore::LengthType::Normal:
-        case WebCore::LengthType::Relative:
-        case WebCore::LengthType::Undefined:
-            break;
-        }
-        return false;
-    }
-
-    WebCore::Length m_value;
 };
 
 // MARK: - Conversion
 
 template<> struct CSSValueConversion<FlexBasis> { auto operator()(BuilderState&, const CSSValue&) -> FlexBasis; };
-
-// MARK: - Evaluation
-
-template<> struct Evaluation<FlexBasis> {
-    auto operator()(const FlexBasis& edge, LayoutUnit referenceLength) -> LayoutUnit
-    {
-        return valueForLength(edge.m_value, referenceLength);
-    }
-
-    auto operator()(const FlexBasis& edge, float referenceLength) -> float
-    {
-        return floatValueForLength(edge.m_value, referenceLength);
-    }
-};
-
-inline LayoutUnit evaluateMinimum(const FlexBasis& edge, NOESCAPE const Invocable<LayoutUnit()> auto& lazyMaximumValueFunctor)
-{
-    return minimumValueForLengthWithLazyMaximum<LayoutUnit, LayoutUnit>(edge.m_value, lazyMaximumValueFunctor);
-}
-
-inline LayoutUnit evaluateMinimum(const FlexBasis& edge, LayoutUnit maximumValue)
-{
-    return minimumValueForLength(edge.m_value, maximumValue);
-}
-
-// MARK: - Blending
-
-template<> struct Blending<FlexBasis> {
-    auto canBlend(const FlexBasis&, const FlexBasis&) -> bool;
-    auto requiresInterpolationForAccumulativeIteration(const FlexBasis&, const FlexBasis&) -> bool;
-    auto blend(const FlexBasis&, const FlexBasis&, const BlendingContext&) -> FlexBasis;
-};
-
-// MARK: - Logging
-
-WTF::TextStream& operator<<(WTF::TextStream&, const FlexBasis&);
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/motion/StyleOffsetDistance.cpp
+++ b/Source/WebCore/style/values/motion/StyleOffsetDistance.cpp
@@ -27,7 +27,6 @@
 
 #include "StyleBuilderConverter.h"
 #include "StyleBuilderState.h"
-#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 namespace Style {
@@ -37,32 +36,6 @@ namespace Style {
 auto CSSValueConversion<OffsetDistance>::operator()(BuilderState& state, const CSSValue& value) -> OffsetDistance
 {
     return OffsetDistance { BuilderConverter::convertLength(state, value) };
-}
-
-// MARK: - Blending
-
-auto Blending<OffsetDistance>::requiresInterpolationForAccumulativeIteration(const OffsetDistance& a, const OffsetDistance& b) -> bool
-{
-    return WebCore::lengthsRequireInterpolationForAccumulativeIteration(a.m_value, b.m_value);
-}
-
-auto Blending<OffsetDistance>::blend(const OffsetDistance& a, const OffsetDistance& b, const BlendingContext& context) -> OffsetDistance
-{
-    return OffsetDistance { WebCore::blend(a.m_value, b.m_value, context, ValueRange::All) };
-}
-
-// MARK: - Logging
-
-WTF::TextStream& operator<<(WTF::TextStream& ts, const OffsetDistance& value)
-{
-    return ts << value.m_value;
-}
-
-// MARK: - Platform
-
-auto ToPlatform<OffsetDistance>::operator()(const OffsetDistance& value) -> WebCore::Length
-{
-    return value.m_value;
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/motion/StyleOffsetDistance.h
+++ b/Source/WebCore/style/values/motion/StyleOffsetDistance.h
@@ -24,162 +24,20 @@
 
 #pragma once
 
-#include "Length.h"
-#include "LengthFunctions.h"
-#include "StylePrimitiveNumericTypes.h"
-#include "StyleValueTypes.h"
+#include "StyleLengthWrapper.h"
 
 namespace WebCore {
 namespace Style {
 
 // <'offset-distance'> = <length-percentage>
 // https://drafts.fxtf.org/motion/#propdef-offset-distance
-struct OffsetDistance {
-    using Specified = LengthPercentage<>;
-    using Fixed = typename Specified::Dimension;
-    using Percentage = typename Specified::Percentage;
-    using Calc = typename Specified::Calc;
-
-    OffsetDistance(Fixed&& fixed) : m_value(fixed.value, WebCore::LengthType::Fixed) { }
-    OffsetDistance(const Fixed& fixed) : m_value(fixed.value, WebCore::LengthType::Fixed) { }
-    OffsetDistance(Percentage&& percent) : m_value(percent.value, WebCore::LengthType::Percent) { }
-    OffsetDistance(const Percentage& percent) : m_value(percent.value, WebCore::LengthType::Percent) { }
-
-    OffsetDistance(CSS::ValueLiteral<CSS::LengthUnit::Px> literal) : m_value(static_cast<float>(literal.value), WebCore::LengthType::Fixed) { }
-    OffsetDistance(CSS::ValueLiteral<CSS::PercentageUnit::Percentage> literal) : m_value(static_cast<float>(literal.value), WebCore::LengthType::Percent) { }
-
-    explicit OffsetDistance(WebCore::Length&& other) : m_value(WTFMove(other)) { RELEASE_ASSERT(isValid(m_value)); }
-    explicit OffsetDistance(const WebCore::Length& other) : m_value(other) { RELEASE_ASSERT(isValid(m_value)); }
-
-    ALWAYS_INLINE bool isFixed() const { return m_value.isFixed(); }
-    ALWAYS_INLINE bool isDimension() const { return m_value.isFixed(); }
-    ALWAYS_INLINE bool isPercent() const { return m_value.isPercent(); }
-    ALWAYS_INLINE bool isCalculated() const { return m_value.isCalculated(); }
-    ALWAYS_INLINE bool isPercentOrCalculated() const { return m_value.isPercentOrCalculated(); }
-
-    ALWAYS_INLINE bool isZero() const { return m_value.isZero(); }
-    ALWAYS_INLINE bool isPositive() const { return m_value.isPositive(); }
-    ALWAYS_INLINE bool isNegative() const { return m_value.isNegative(); }
-
-    ALWAYS_INLINE std::optional<Fixed> tryFixed() const { return isFixed() ? std::make_optional(Fixed { m_value.value() }) : std::nullopt; }
-    ALWAYS_INLINE std::optional<Percentage> tryPercentage() const { return isPercent() ? std::make_optional(Percentage { m_value.value() }) : std::nullopt; }
-    std::optional<Calc> tryCalc() const { return isCalculated() ? std::make_optional(Calc { m_value.calculationValue() }) : std::nullopt; }
-
-    template<typename T> bool holdsAlternative() const
-    {
-             if constexpr (std::same_as<T, Fixed>)      return isFixed();
-        else if constexpr (std::same_as<T, Percentage>) return isPercent();
-        else if constexpr (std::same_as<T, Calc>)       return isCalculated();
-    }
-
-    template<typename... F> decltype(auto) switchOn(F&&... f) const
-    {
-        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
-
-        switch (m_value.type()) {
-        case WebCore::LengthType::Fixed:                return visitor(Fixed { m_value.value() });
-        case WebCore::LengthType::Percent:              return visitor(Percentage { m_value.value() });
-        case WebCore::LengthType::Calculated:           return visitor(Calc { m_value.calculationValue() });
-
-        case WebCore::LengthType::Auto:
-        case WebCore::LengthType::Intrinsic:
-        case WebCore::LengthType::MinIntrinsic:
-        case WebCore::LengthType::MinContent:
-        case WebCore::LengthType::MaxContent:
-        case WebCore::LengthType::FillAvailable:
-        case WebCore::LengthType::FitContent:
-        case WebCore::LengthType::Content:
-        case WebCore::LengthType::Normal:
-        case WebCore::LengthType::Relative:
-        case WebCore::LengthType::Undefined:
-            break;
-        }
-
-        RELEASE_ASSERT_NOT_REACHED();
-    }
-
-    bool hasSameType(const OffsetDistance& other) const { return m_value.type() == other.m_value.type(); }
-
-    bool operator==(const OffsetDistance&) const = default;
-
-private:
-    friend struct Blending<OffsetDistance>;
-    friend struct Evaluation<OffsetDistance>;
-    friend struct ToPlatform<OffsetDistance>;
-    friend LayoutUnit evaluateMinimum(const OffsetDistance&, NOESCAPE const Invocable<LayoutUnit()> auto&);
-    friend LayoutUnit evaluateMinimum(const OffsetDistance&, LayoutUnit);
-    friend WTF::TextStream& operator<<(WTF::TextStream&, const OffsetDistance&);
-
-    static bool isValid(const WebCore::Length& length)
-    {
-        switch (length.type()) {
-        case WebCore::LengthType::Fixed:
-            return CSS::isWithinRange<Fixed::range>(length.value());
-        case WebCore::LengthType::Percent:
-            return CSS::isWithinRange<Percentage::range>(length.value());
-        case WebCore::LengthType::Calculated:
-            return true;
-        case WebCore::LengthType::Auto:
-        case WebCore::LengthType::Intrinsic:
-        case WebCore::LengthType::MinIntrinsic:
-        case WebCore::LengthType::MinContent:
-        case WebCore::LengthType::MaxContent:
-        case WebCore::LengthType::FillAvailable:
-        case WebCore::LengthType::FitContent:
-        case WebCore::LengthType::Content:
-        case WebCore::LengthType::Normal:
-        case WebCore::LengthType::Relative:
-        case WebCore::LengthType::Undefined:
-            break;
-        }
-        return false;
-    }
-
-    WebCore::Length m_value;
+struct OffsetDistance : LengthWrapperBase<LengthPercentage<>> {
+    using Base::Base;
 };
 
 // MARK: - Conversion
 
 template<> struct CSSValueConversion<OffsetDistance> { auto operator()(BuilderState&, const CSSValue&) -> OffsetDistance; };
-
-// MARK: - Evaluation
-
-template<> struct Evaluation<OffsetDistance> {
-    auto operator()(const OffsetDistance& edge, LayoutUnit referenceLength) -> LayoutUnit
-    {
-        return valueForLength(edge.m_value, referenceLength);
-    }
-
-    auto operator()(const OffsetDistance& edge, float referenceLength) -> float
-    {
-        return floatValueForLength(edge.m_value, referenceLength);
-    }
-};
-
-inline LayoutUnit evaluateMinimum(const OffsetDistance& edge, NOESCAPE const Invocable<LayoutUnit()> auto& lazyMaximumValueFunctor)
-{
-    return minimumValueForLengthWithLazyMaximum<LayoutUnit, LayoutUnit>(edge.m_value, lazyMaximumValueFunctor);
-}
-
-inline LayoutUnit evaluateMinimum(const OffsetDistance& edge, LayoutUnit maximumValue)
-{
-    return minimumValueForLength(edge.m_value, maximumValue);
-}
-
-// MARK: - Blending
-
-template<> struct Blending<OffsetDistance> {
-    auto requiresInterpolationForAccumulativeIteration(const OffsetDistance&, const OffsetDistance&) -> bool;
-    auto blend(const OffsetDistance&, const OffsetDistance&, const BlendingContext&) -> OffsetDistance;
-};
-
-// MARK: - Logging
-
-WTF::TextStream& operator<<(WTF::TextStream&, const OffsetDistance&);
-
-// MARK: - Platform
-
-template<> struct ToPlatform<OffsetDistance> { auto operator()(const OffsetDistance&) -> WebCore::Length; };
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/position/StyleInset.cpp
+++ b/Source/WebCore/style/values/position/StyleInset.cpp
@@ -27,7 +27,6 @@
 
 #include "StyleBuilderConverter.h"
 #include "StyleBuilderState.h"
-#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 namespace Style {
@@ -37,30 +36,6 @@ namespace Style {
 auto CSSValueConversion<InsetEdge>::operator()(BuilderState& state, const CSSValue& value) -> InsetEdge
 {
     return InsetEdge { BuilderConverter::convertLengthOrAuto(state, value) };
-}
-
-// MARK: - Blending
-
-auto Blending<InsetEdge>::canBlend(const InsetEdge& a, const InsetEdge& b) -> bool
-{
-    return WebCore::canInterpolateLengths(a.m_value, b.m_value, true);
-}
-
-auto Blending<InsetEdge>::requiresInterpolationForAccumulativeIteration(const InsetEdge& a, const InsetEdge& b) -> bool
-{
-    return WebCore::lengthsRequireInterpolationForAccumulativeIteration(a.m_value, b.m_value);
-}
-
-auto Blending<InsetEdge>::blend(const InsetEdge& a, const InsetEdge& b, const BlendingContext& context) -> InsetEdge
-{
-    return InsetEdge { WebCore::blend(a.m_value, b.m_value, context, ValueRange::All) };
-}
-
-// MARK: - Logging
-
-WTF::TextStream& operator<<(WTF::TextStream& ts, const InsetEdge& value)
-{
-    return ts << value.m_value;
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/position/StyleInset.h
+++ b/Source/WebCore/style/values/position/StyleInset.h
@@ -24,126 +24,15 @@
 
 #pragma once
 
-#include "Length.h"
-#include "LengthFunctions.h"
-#include "StylePrimitiveNumericTypes.h"
-#include "StyleValueTypes.h"
+#include "StyleLengthWrapper.h"
 
 namespace WebCore {
-
-class CSSValue;
-class RenderStyle;
-
 namespace Style {
-
-class BuilderState;
 
 // <'top'>/<'right'>/<'bottom'>/<'left'> = auto | <length-percentage>
 // https://drafts.csswg.org/css-position/#insets
-struct InsetEdge {
-    using Specified = LengthPercentage<>;
-    using Fixed = typename Specified::Dimension;
-    using Percentage = typename Specified::Percentage;
-    using Calc = typename Specified::Calc;
-
-    InsetEdge(CSS::Keyword::Auto) : m_value(WebCore::LengthType::Auto) { }
-
-    InsetEdge(Fixed&& fixed) : m_value(fixed.value, WebCore::LengthType::Fixed) { }
-    InsetEdge(const Fixed& fixed) : m_value(fixed.value, WebCore::LengthType::Fixed) { }
-    InsetEdge(Percentage&& percent) : m_value(percent.value, WebCore::LengthType::Percent) { }
-    InsetEdge(const Percentage& percent) : m_value(percent.value, WebCore::LengthType::Percent) { }
-
-    InsetEdge(CSS::ValueLiteral<CSS::LengthUnit::Px> literal) : m_value(static_cast<float>(literal.value), WebCore::LengthType::Fixed) { }
-    InsetEdge(CSS::ValueLiteral<CSS::PercentageUnit::Percentage> literal) : m_value(static_cast<float>(literal.value), WebCore::LengthType::Percent) { }
-
-    explicit InsetEdge(WebCore::Length&& other) : m_value(WTFMove(other)) { RELEASE_ASSERT(isValid(m_value)); }
-    explicit InsetEdge(const WebCore::Length& other) : m_value(other) { RELEASE_ASSERT(isValid(m_value)); }
-
-    ALWAYS_INLINE bool isAuto() const { return m_value.isAuto(); }
-    ALWAYS_INLINE bool isFixed() const { return m_value.isFixed(); }
-    ALWAYS_INLINE bool isPercent() const { return m_value.isPercent(); }
-    ALWAYS_INLINE bool isCalculated() const { return m_value.isCalculated(); }
-    ALWAYS_INLINE bool isPercentOrCalculated() const { return m_value.isPercentOrCalculated(); }
-    ALWAYS_INLINE bool isSpecified() const { return m_value.isSpecified(); }
-
-    ALWAYS_INLINE bool isZero() const { return m_value.isZero(); }
-    ALWAYS_INLINE bool isPositive() const { return m_value.isPositive(); }
-    ALWAYS_INLINE bool isNegative() const { return m_value.isNegative(); }
-
-    std::optional<Fixed> tryFixed() const { return isFixed() ? std::make_optional(Fixed { m_value.value() }) : std::nullopt; }
-    std::optional<Percentage> tryPercentage() const { return isPercent() ? std::make_optional(Percentage { m_value.value() }) : std::nullopt; }
-    std::optional<Calc> tryCalc() const { return isCalculated() ? std::make_optional(Calc { m_value.calculationValue() }) : std::nullopt; }
-
-    template<typename T> bool holdsAlternative() const
-    {
-             if constexpr (std::same_as<T, Fixed>)              return isFixed();
-        else if constexpr (std::same_as<T, Percentage>)         return isPercent();
-        else if constexpr (std::same_as<T, Calc>)               return isCalculated();
-        else if constexpr (std::same_as<T, CSS::Keyword::Auto>) return isAuto();
-    }
-
-    template<typename... F> decltype(auto) switchOn(F&&... f) const
-    {
-        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
-
-        switch (m_value.type()) {
-        case WebCore::LengthType::Fixed:            return visitor(Fixed { m_value.value() });
-        case WebCore::LengthType::Percent:          return visitor(Percentage { m_value.value() });
-        case WebCore::LengthType::Calculated:       return visitor(Calc { m_value.calculationValue() });
-        case WebCore::LengthType::Auto:             return visitor(CSS::Keyword::Auto { });
-
-        case WebCore::LengthType::Intrinsic:
-        case WebCore::LengthType::MinIntrinsic:
-        case WebCore::LengthType::MinContent:
-        case WebCore::LengthType::MaxContent:
-        case WebCore::LengthType::FillAvailable:
-        case WebCore::LengthType::FitContent:
-        case WebCore::LengthType::Content:
-        case WebCore::LengthType::Normal:
-        case WebCore::LengthType::Relative:
-        case WebCore::LengthType::Undefined:
-            break;
-        }
-        RELEASE_ASSERT_NOT_REACHED();
-    }
-
-    bool hasSameType(const InsetEdge& other) const { return m_value.type() == other.m_value.type(); }
-
-    bool operator==(const InsetEdge&) const = default;
-
-private:
-    friend struct Blending<InsetEdge>;
-    friend struct Evaluation<InsetEdge>;
-    friend LayoutUnit evaluateMinimum(const InsetEdge&, NOESCAPE const Invocable<LayoutUnit()> auto&);
-    friend LayoutUnit evaluateMinimum(const InsetEdge&, LayoutUnit);
-    friend WTF::TextStream& operator<<(WTF::TextStream&, const InsetEdge&);
-
-    static bool isValid(const WebCore::Length& length)
-    {
-        switch (length.type()) {
-        case WebCore::LengthType::Fixed:
-            return CSS::isWithinRange<Fixed::range>(length.value());
-        case WebCore::LengthType::Percent:
-            return CSS::isWithinRange<Percentage::range>(length.value());
-        case WebCore::LengthType::Calculated:
-        case WebCore::LengthType::Auto:
-            return true;
-        case WebCore::LengthType::Intrinsic:
-        case WebCore::LengthType::MinIntrinsic:
-        case WebCore::LengthType::MinContent:
-        case WebCore::LengthType::MaxContent:
-        case WebCore::LengthType::FillAvailable:
-        case WebCore::LengthType::FitContent:
-        case WebCore::LengthType::Content:
-        case WebCore::LengthType::Normal:
-        case WebCore::LengthType::Relative:
-        case WebCore::LengthType::Undefined:
-            break;
-        }
-        return false;
-    }
-
-    WebCore::Length m_value;
+struct InsetEdge : LengthWrapperBase<LengthPercentage<>, CSS::Keyword::Auto> {
+    using Base::Base;
 };
 
 // <'inset'> = <'top'>{1,4}
@@ -153,42 +42,6 @@ using InsetBox = MinimallySerializingSpaceSeparatedRectEdges<InsetEdge>;
 // MARK: - Conversion
 
 template<> struct CSSValueConversion<InsetEdge> { auto operator()(BuilderState&, const CSSValue&) -> InsetEdge; };
-
-// MARK: - Evaluation
-
-template<> struct Evaluation<InsetEdge> {
-    auto operator()(const InsetEdge& edge, LayoutUnit referenceLength) -> LayoutUnit
-    {
-        return valueForLength(edge.m_value, referenceLength);
-    }
-
-    auto operator()(const InsetEdge& edge, float referenceLength) -> float
-    {
-        return floatValueForLength(edge.m_value, referenceLength);
-    }
-};
-
-inline LayoutUnit evaluateMinimum(const InsetEdge& edge, NOESCAPE const Invocable<LayoutUnit()> auto& lazyMaximumValueFunctor)
-{
-    return minimumValueForLengthWithLazyMaximum<LayoutUnit, LayoutUnit>(edge.m_value, lazyMaximumValueFunctor);
-}
-
-inline LayoutUnit evaluateMinimum(const InsetEdge& edge, LayoutUnit maximumValue)
-{
-    return minimumValueForLength(edge.m_value, maximumValue);
-}
-
-// MARK: - Blending
-
-template<> struct Blending<InsetEdge> {
-    auto canBlend(const InsetEdge&, const InsetEdge&) -> bool;
-    auto requiresInterpolationForAccumulativeIteration(const InsetEdge&, const InsetEdge&) -> bool;
-    auto blend(const InsetEdge&, const InsetEdge&, const BlendingContext&) -> InsetEdge;
-};
-
-// MARK: - Logging
-
-WTF::TextStream& operator<<(WTF::TextStream&, const InsetEdge&);
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
@@ -1,0 +1,280 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSPrimitiveKeywordList.h"
+#include "Length.h"
+#include "LengthFunctions.h"
+#include "StylePrimitiveNumericTypes.h"
+#include "StyleValueTypes.h"
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+namespace Style {
+
+template<typename Numeric, CSS::PrimitiveKeyword... Ks> struct LengthWrapperBase;
+
+// Transitionary type acting as a `Style::PrimitiveNumericOrKeyword<...>` but implemented by wrapping a `WebCore::Length`.
+template<typename Numeric, CSS::PrimitiveKeyword... Ks> struct LengthWrapperBase {
+    using Base = LengthWrapperBase<Numeric, Ks...>;
+    using Keywords = CSS::PrimitiveKeywordList<Ks...>;
+
+    using Specified = Numeric;
+    using Fixed = typename Specified::Dimension;
+    using Percentage = typename Specified::Percentage;
+    using Calc = typename Specified::Calc;
+
+    static constexpr bool SupportsAuto = Keywords::isValidKeyword(CSS::Keyword::Auto { });
+    static constexpr bool SupportsNormal = Keywords::isValidKeyword(CSS::Keyword::Normal { });
+    static constexpr bool SupportsIntrinsic = Keywords::isValidKeyword(CSS::Keyword::Intrinsic { });
+    static constexpr bool SupportsMinIntrinsic = Keywords::isValidKeyword(CSS::Keyword::MinIntrinsic { });
+    static constexpr bool SupportsMinContent = Keywords::isValidKeyword(CSS::Keyword::MinContent { });
+    static constexpr bool SupportsMaxContent = Keywords::isValidKeyword(CSS::Keyword::MaxContent { });
+    static constexpr bool SupportsWebkitFillAvailable = Keywords::isValidKeyword(CSS::Keyword::WebkitFillAvailable { });
+    static constexpr bool SupportsFitContent = Keywords::isValidKeyword(CSS::Keyword::FitContent { });
+    static constexpr bool SupportsContent = Keywords::isValidKeyword(CSS::Keyword::Content { });
+    static constexpr bool SupportsNone = Keywords::isValidKeyword(CSS::Keyword::None { });
+
+    LengthWrapperBase(CSS::Keyword::Auto) requires (SupportsAuto) : m_value(WebCore::LengthType::Auto) { }
+    LengthWrapperBase(CSS::Keyword::Normal) requires (SupportsNormal) : m_value(WebCore::LengthType::Normal) { }
+    LengthWrapperBase(CSS::Keyword::Intrinsic) requires (SupportsIntrinsic) : m_value(WebCore::LengthType::Intrinsic) { }
+    LengthWrapperBase(CSS::Keyword::MinIntrinsic) requires (SupportsMinIntrinsic) : m_value(WebCore::LengthType::MinIntrinsic) { }
+    LengthWrapperBase(CSS::Keyword::MinContent) requires (SupportsMinContent) : m_value(WebCore::LengthType::MinContent) { }
+    LengthWrapperBase(CSS::Keyword::MaxContent) requires (SupportsMaxContent) : m_value(WebCore::LengthType::MaxContent) { }
+    LengthWrapperBase(CSS::Keyword::WebkitFillAvailable) requires (SupportsWebkitFillAvailable) : m_value(WebCore::LengthType::FillAvailable) { }
+    LengthWrapperBase(CSS::Keyword::FitContent) requires (SupportsFitContent) : m_value(WebCore::LengthType::FitContent) { }
+    LengthWrapperBase(CSS::Keyword::Content) requires (SupportsContent) : m_value(WebCore::LengthType::Content) { }
+    LengthWrapperBase(CSS::Keyword::None) requires (SupportsNone) : m_value(WebCore::LengthType::Undefined) { }
+
+    LengthWrapperBase(Fixed fixed) : m_value(fixed.value, WebCore::LengthType::Fixed) { }
+    LengthWrapperBase(Percentage percent) : m_value(percent.value, WebCore::LengthType::Percent) { }
+
+    LengthWrapperBase(CSS::ValueLiteral<CSS::LengthUnit::Px> literal) : m_value(static_cast<float>(literal.value), WebCore::LengthType::Fixed) { }
+    LengthWrapperBase(CSS::ValueLiteral<CSS::PercentageUnit::Percentage> literal) : m_value(static_cast<float>(literal.value), WebCore::LengthType::Percent) { }
+
+    explicit LengthWrapperBase(WebCore::Length&& other) : m_value(WTFMove(other)) { RELEASE_ASSERT(isValid(m_value)); }
+    explicit LengthWrapperBase(const WebCore::Length& other) : m_value(other) { RELEASE_ASSERT(isValid(m_value)); }
+
+    explicit LengthWrapperBase(WTF::HashTableEmptyValueType token) : m_value(token) { }
+
+    ALWAYS_INLINE bool isFixed() const { return m_value.type() == WebCore::LengthType::Fixed; }
+    ALWAYS_INLINE bool isPercent() const { return m_value.type() == WebCore::LengthType::Percent; }
+    ALWAYS_INLINE bool isCalculated() const { return m_value.type() == WebCore::LengthType::Calculated; }
+    ALWAYS_INLINE bool isPercentOrCalculated() const { return isPercent() || isCalculated(); }
+    ALWAYS_INLINE bool isSpecified() const { return isFixed() || isPercent() || isCalculated(); }
+
+    ALWAYS_INLINE bool isAuto() const requires (SupportsAuto) { return m_value.type() == WebCore::LengthType::Auto; }
+    ALWAYS_INLINE bool isNormal() const requires (SupportsNormal) { return m_value.type() == WebCore::LengthType::Normal; }
+    ALWAYS_INLINE bool isIntrinsicKeyword() const requires (SupportsIntrinsic) { return m_value.type() == WebCore::LengthType::Intrinsic; }
+    ALWAYS_INLINE bool isMinIntrinsic() const requires (SupportsMinIntrinsic) { return m_value.type() == WebCore::LengthType::MinIntrinsic; }
+    ALWAYS_INLINE bool isMinContent() const requires (SupportsMinContent) { return m_value.type() == WebCore::LengthType::MinContent; }
+    ALWAYS_INLINE bool isMaxContent() const requires (SupportsMaxContent) { return m_value.type() == WebCore::LengthType::MaxContent; }
+    ALWAYS_INLINE bool isFillAvailable() const requires (SupportsWebkitFillAvailable) { return m_value.type() == WebCore::LengthType::FillAvailable; }
+    ALWAYS_INLINE bool isFitContent() const requires (SupportsFitContent) { return m_value.type() == WebCore::LengthType::FitContent; }
+    ALWAYS_INLINE bool isContent() const requires (SupportsContent) { return m_value.type() == WebCore::LengthType::Content; }
+    ALWAYS_INLINE bool isNone() const requires (SupportsNone) { return m_value.type() == WebCore::LengthType::Undefined; }
+
+    // FIXME: This is misleadingly named. One would expect this function checks `type == LengthType::Intrinsic` but instead it checks `type = LengthType::MinContent || type == LengthType::MaxContent || type == LengthType::FillAvailable || type == LengthType::FitContent`.
+
+    static constexpr bool SupportsIsIntrinsic = SupportsMinContent || SupportsMaxContent || SupportsWebkitFillAvailable || SupportsFitContent;
+    static constexpr bool SupportsIsLegacyIntrinsic = SupportsIntrinsic || SupportsMinIntrinsic;
+
+    ALWAYS_INLINE bool isIntrinsic() const
+        requires (SupportsIsIntrinsic)
+    {
+        return (SupportsMinContent && m_value.type() == WebCore::LengthType::MinContent)
+            || (SupportsMinContent && m_value.type() == WebCore::LengthType::MaxContent)
+            || (SupportsWebkitFillAvailable && m_value.type() == WebCore::LengthType::FillAvailable)
+            || (SupportsFitContent && m_value.type() == WebCore::LengthType::FitContent);
+    }
+    ALWAYS_INLINE bool isLegacyIntrinsic() const
+        requires (SupportsIsLegacyIntrinsic)
+    {
+        return (SupportsIntrinsic && m_value.type() == WebCore::LengthType::Intrinsic)
+            || (SupportsMinIntrinsic && m_value.type() == WebCore::LengthType::MinIntrinsic);
+    }
+    ALWAYS_INLINE bool isIntrinsicOrLegacyIntrinsicOrAuto() const
+        requires (SupportsIsIntrinsic || SupportsIsLegacyIntrinsic || SupportsAuto)
+    {
+        return (SupportsMinContent && m_value.type() == WebCore::LengthType::MinContent)
+            || (SupportsMinContent && m_value.type() == WebCore::LengthType::MaxContent)
+            || (SupportsWebkitFillAvailable && m_value.type() == WebCore::LengthType::FillAvailable)
+            || (SupportsFitContent && m_value.type() == WebCore::LengthType::FitContent)
+            || (SupportsIntrinsic && m_value.type() == WebCore::LengthType::Intrinsic)
+            || (SupportsMinIntrinsic && m_value.type() == WebCore::LengthType::MinIntrinsic)
+            || (SupportsAuto && m_value.type() == WebCore::LengthType::Auto);
+    }
+
+    ALWAYS_INLINE bool isZero() const { return m_value.isZero(); }
+    ALWAYS_INLINE bool isPositive() const { return m_value.isPositive(); }
+    ALWAYS_INLINE bool isNegative() const { return m_value.isNegative(); }
+
+    // FIXME: Remove this when RenderBox's adjust*Box functions no longer need it.
+    ALWAYS_INLINE WebCore::LengthType type() const { return m_value.type(); }
+
+    std::optional<Fixed> tryFixed() const { return isFixed() ? std::make_optional(Fixed { m_value.value() }) : std::nullopt; }
+    std::optional<Percentage> tryPercentage() const { return isPercent() ? std::make_optional(Percentage { m_value.value() }) : std::nullopt; }
+    std::optional<Calc> tryCalc() const { return isCalculated() ? std::make_optional(Calc { m_value.calculationValue() }) : std::nullopt; }
+
+    template<typename T> bool holdsAlternative() const
+    {
+             if constexpr (std::same_as<T, Fixed>)                                                              return isFixed();
+        else if constexpr (std::same_as<T, Percentage>)                                                         return isPercent();
+        else if constexpr (std::same_as<T, Calc>)                                                               return isCalculated();
+        else if constexpr (std::same_as<T, CSS::Keyword::Auto> && SupportsAuto)                                 return isAuto();
+        else if constexpr (std::same_as<T, CSS::Keyword::Normal> && SupportsNormal)                             return isNormal();
+        else if constexpr (std::same_as<T, CSS::Keyword::Intrinsic> && SupportsIntrinsic)                       return isIntrinsicKeyword();
+        else if constexpr (std::same_as<T, CSS::Keyword::MinIntrinsic> && SupportsMinIntrinsic)                 return isMinIntrinsic();
+        else if constexpr (std::same_as<T, CSS::Keyword::MinContent> && SupportsMinContent)                     return isMinContent();
+        else if constexpr (std::same_as<T, CSS::Keyword::MaxContent> && SupportsMaxContent)                     return isMaxContent();
+        else if constexpr (std::same_as<T, CSS::Keyword::WebkitFillAvailable> && SupportsWebkitFillAvailable)   return isFillAvailable();
+        else if constexpr (std::same_as<T, CSS::Keyword::FitContent> && SupportsFitContent)                     return isFitContent();
+        else if constexpr (std::same_as<T, CSS::Keyword::Content> && SupportsContent)                           return isContent();
+        else if constexpr (std::same_as<T, CSS::Keyword::None> && SupportsNone)                                 return isNone();
+    }
+
+    template<typename... F> decltype(auto) switchOn(F&&... f) const
+    {
+        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
+
+        switch (m_value.type()) {
+        case WebCore::LengthType::Fixed:            return visitor(Fixed { m_value.value() });
+        case WebCore::LengthType::Percent:          return visitor(Percentage { m_value.value() });
+        case WebCore::LengthType::Calculated:       return visitor(Calc { m_value.calculationValue() });
+        case WebCore::LengthType::Auto:             if constexpr (SupportsAuto) { return visitor(CSS::Keyword::Auto { }); } else { break; }
+        case WebCore::LengthType::Intrinsic:        if constexpr (SupportsIntrinsic) { return visitor(CSS::Keyword::Intrinsic { }); } else { break; }
+        case WebCore::LengthType::MinIntrinsic:     if constexpr (SupportsMinIntrinsic) { return visitor(CSS::Keyword::MinIntrinsic { }); } else { break; }
+        case WebCore::LengthType::MinContent:       if constexpr (SupportsMinContent) { return visitor(CSS::Keyword::MinContent { }); } else { break; }
+        case WebCore::LengthType::MaxContent:       if constexpr (SupportsMaxContent) { return visitor(CSS::Keyword::MaxContent { }); } else { break; }
+        case WebCore::LengthType::FillAvailable:    if constexpr (SupportsWebkitFillAvailable) { return visitor(CSS::Keyword::WebkitFillAvailable { }); } else { break; }
+        case WebCore::LengthType::FitContent:       if constexpr (SupportsFitContent) { return visitor(CSS::Keyword::FitContent { }); } else { break; }
+        case WebCore::LengthType::Content:          if constexpr (SupportsContent) { return visitor(CSS::Keyword::Content { }); } else { break; }
+        case WebCore::LengthType::Normal:           if constexpr (SupportsNormal) { return visitor(CSS::Keyword::Normal { }); } else { break; }
+        case WebCore::LengthType::Undefined:        if constexpr (SupportsNone) { return visitor(CSS::Keyword::None { }); } else { break; }
+        case WebCore::LengthType::Relative:
+            break;
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
+    bool hasSameType(const LengthWrapperBase& other) const { return m_value.type() == other.m_value.type(); }
+
+    bool operator==(const LengthWrapperBase&) const = default;
+
+protected:
+    template<typename> friend struct ToPlatform;
+
+    static bool isValid(const WebCore::Length& length)
+    {
+        switch (length.type()) {
+        case WebCore::LengthType::Fixed:            return CSS::isWithinRange<Fixed::range>(length.value());
+        case WebCore::LengthType::Percent:          return CSS::isWithinRange<Percentage::range>(length.value());
+        case WebCore::LengthType::Calculated:       return true;
+        case WebCore::LengthType::Auto:             return SupportsAuto;
+        case WebCore::LengthType::Intrinsic:        return SupportsIntrinsic;
+        case WebCore::LengthType::MinIntrinsic:     return SupportsMinIntrinsic;
+        case WebCore::LengthType::MinContent:       return SupportsMinContent;
+        case WebCore::LengthType::MaxContent:       return SupportsMaxContent;
+        case WebCore::LengthType::FillAvailable:    return SupportsWebkitFillAvailable;
+        case WebCore::LengthType::FitContent:       return SupportsFitContent;
+        case WebCore::LengthType::Content:          return SupportsContent;
+        case WebCore::LengthType::Normal:           return SupportsNormal;
+        case WebCore::LengthType::Undefined:        return SupportsNone;
+        case WebCore::LengthType::Relative:
+            break;
+        }
+        return false;
+    }
+
+    WebCore::Length m_value;
+};
+
+// MARK: - Concepts
+
+template<typename T> concept LengthWrapperBaseDerived = WTF::IsBaseOfTemplate<LengthWrapperBase, T>::value && VariantLike<T>;
+
+// MARK: - Platform
+
+template<LengthWrapperBaseDerived T> struct ToPlatform<T> {
+    auto operator()(const T& value) -> WebCore::Length
+    {
+        return value.m_value;
+    }
+};
+
+// MARK: - Evaluation
+
+template<LengthWrapperBaseDerived T> struct Evaluation<T> {
+    auto operator()(const T& value, LayoutUnit referenceLength) -> LayoutUnit
+    {
+        return valueForLength(toPlatform(value), referenceLength);
+    }
+    auto operator()(const T& value, float referenceLength) -> float
+    {
+        return floatValueForLength(toPlatform(value), referenceLength);
+    }
+};
+
+template<LengthWrapperBaseDerived T> inline LayoutUnit evaluateMinimum(const T& value, NOESCAPE const Invocable<LayoutUnit()> auto& lazyMaximumValueFunctor)
+{
+    return minimumValueForLengthWithLazyMaximum<LayoutUnit, LayoutUnit>(toPlatform(value), lazyMaximumValueFunctor);
+}
+
+template<LengthWrapperBaseDerived T> inline LayoutUnit evaluateMinimum(const T& value, LayoutUnit maximumValue)
+{
+    return minimumValueForLength(toPlatform(value), maximumValue);
+}
+
+template<LengthWrapperBaseDerived T> inline float evaluateMinimum(const T& value, float maximumValue)
+{
+    return minimumValueForLength(toPlatform(value), maximumValue);
+}
+
+// MARK: - Blending
+
+template<LengthWrapperBaseDerived T> struct Blending<T> {
+    auto canBlend(const T& a, const T& b) -> bool
+    {
+        return WebCore::canInterpolateLengths(toPlatform(a), toPlatform(b), true);
+    }
+    auto requiresInterpolationForAccumulativeIteration(const T& a, const T& b) -> bool
+    {
+        return WebCore::lengthsRequireInterpolationForAccumulativeIteration(toPlatform(a), toPlatform(b));
+    }
+    auto blend(const T& a, const T& b, const BlendingContext& context) -> T
+    {
+        return T { WebCore::blend(toPlatform(a), toPlatform(b), context, T::Fixed::range == CSS::Nonnegative ? ValueRange::NonNegative : ValueRange::All) };
+    }
+};
+
+// MARK: - Logging
+
+template<LengthWrapperBaseDerived T> WTF::TextStream& operator<<(WTF::TextStream& ts, const T& value)
+{
+    return ts << toPlatform(value);
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.cpp
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.cpp
@@ -28,11 +28,14 @@
 #include "LayoutRect.h"
 #include "StyleBuilderConverter.h"
 #include "StyleBuilderState.h"
-#include "StyleExtractorConverter.h"
-#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 namespace Style {
+
+auto CSSValueConversion<ScrollPaddingEdge>::operator()(BuilderState& state, const CSSValue& value) -> ScrollPaddingEdge
+{
+    return ScrollPaddingEdge { BuilderConverter::convertLengthOrAuto(state, value) };
+}
 
 LayoutUnit Evaluation<ScrollPaddingEdge>::operator()(const ScrollPaddingEdge& edge, LayoutUnit referenceLength)
 {
@@ -96,10 +99,6 @@ float Evaluation<ScrollPaddingEdge>::operator()(const ScrollPaddingEdge& edge, f
     return 0;
 }
 
-auto CSSValueConversion<ScrollPaddingEdge>::operator()(BuilderState& state, const CSSValue& value) -> ScrollPaddingEdge
-{
-    return ScrollPaddingEdge { BuilderConverter::convertLengthOrAuto(state, value) };
-}
 
 LayoutBoxExtent extentForRect(const ScrollPaddingBox& padding, const LayoutRect& rect)
 {
@@ -109,11 +108,6 @@ LayoutBoxExtent extentForRect(const ScrollPaddingBox& padding, const LayoutRect&
         Style::evaluate(padding.bottom(), rect.height()),
         Style::evaluate(padding.left(), rect.width()),
     };
-}
-
-WTF::TextStream& operator<<(WTF::TextStream& ts, const ScrollPaddingEdge& value)
-{
-    return ts << value.m_value;
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h
@@ -25,125 +25,21 @@
 #pragma once
 
 #include "BoxExtents.h"
-#include "Length.h"
-#include "StylePrimitiveNumericTypes.h"
-#include "StyleValueTypes.h"
+#include "StyleLengthWrapper.h"
 
 namespace WebCore {
 
-class CSSValue;
 class LayoutRect;
-class LayoutUnit;
-class RenderStyle;
 
 namespace Style {
 
-class BuilderState;
-struct ExtractorState;
-
 // <'scroll-padding-*'> = auto | <length-percentage [0,∞]>
 // https://drafts.csswg.org/css-scroll-snap-1/#padding-longhands-physical
-struct ScrollPaddingEdge {
-    using Specified = LengthPercentage<CSS::Nonnegative>;
-    using Fixed = typename Specified::Dimension;
-    using Percentage = typename Specified::Percentage;
-    using Calc = typename Specified::Calc;
-
-    ScrollPaddingEdge(CSS::Keyword::Auto) : m_value(WebCore::LengthType::Auto) { }
-
-    ScrollPaddingEdge(Fixed&& fixed) : m_value(fixed.value, WebCore::LengthType::Fixed) { }
-    ScrollPaddingEdge(const Fixed& fixed) : m_value(fixed.value, WebCore::LengthType::Fixed) { }
-    ScrollPaddingEdge(Percentage&& percent) : m_value(percent.value, WebCore::LengthType::Percent) { }
-    ScrollPaddingEdge(const Percentage& percent) : m_value(percent.value, WebCore::LengthType::Percent) { }
-
-    ScrollPaddingEdge(CSS::ValueLiteral<CSS::LengthUnit::Px> literal) : m_value(static_cast<float>(literal.value), WebCore::LengthType::Fixed) { }
-    ScrollPaddingEdge(CSS::ValueLiteral<CSS::PercentageUnit::Percentage> literal) : m_value(static_cast<float>(literal.value), WebCore::LengthType::Percent) { }
-
-    explicit ScrollPaddingEdge(WebCore::Length&& other) : m_value(WTFMove(other)) { RELEASE_ASSERT(isValid(m_value)); }
-    explicit ScrollPaddingEdge(const WebCore::Length& other) : m_value(other) { RELEASE_ASSERT(isValid(m_value)); }
-
-    ALWAYS_INLINE bool isAuto() const { return m_value.isAuto(); }
-    ALWAYS_INLINE bool isFixed() const { return m_value.isFixed(); }
-    ALWAYS_INLINE bool isPercent() const { return m_value.isPercent(); }
-    ALWAYS_INLINE bool isCalculated() const { return m_value.isCalculated(); }
-    ALWAYS_INLINE bool isPercentOrCalculated() const { return m_value.isPercentOrCalculated(); }
-    ALWAYS_INLINE bool isSpecified() const { return m_value.isSpecified(); }
-
-    ALWAYS_INLINE bool isZero() const { return m_value.isZero(); }
-    ALWAYS_INLINE bool isPositive() const { return m_value.isPositive(); }
-    ALWAYS_INLINE bool isNegative() const { return m_value.isNegative(); }
-
-    std::optional<Fixed> tryFixed() const { return isFixed() ? std::make_optional(Fixed { m_value.value() }) : std::nullopt; }
-    std::optional<Percentage> tryPercentage() const { return isPercent() ? std::make_optional(Percentage { m_value.value() }) : std::nullopt; }
-    std::optional<Calc> tryCalc() const { return isCalculated() ? std::make_optional(Calc { m_value.calculationValue() }) : std::nullopt; }
-
-    template<typename T> bool holdsAlternative() const
-    {
-             if constexpr (std::same_as<T, Fixed>)              return isFixed();
-        else if constexpr (std::same_as<T, Percentage>)         return isPercent();
-        else if constexpr (std::same_as<T, Calc>)               return isCalculated();
-        else if constexpr (std::same_as<T, CSS::Keyword::Auto>) return isAuto();
-    }
-
-    template<typename... F> decltype(auto) switchOn(F&&... f) const
-    {
-        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
-
-        switch (m_value.type()) {
-        case WebCore::LengthType::Fixed:            return visitor(Fixed { m_value.value() });
-        case WebCore::LengthType::Percent:          return visitor(Percentage { m_value.value() });
-        case WebCore::LengthType::Calculated:       return visitor(Calc { m_value.calculationValue() });
-        case WebCore::LengthType::Auto:             return visitor(CSS::Keyword::Auto { });
-
-        case WebCore::LengthType::Intrinsic:
-        case WebCore::LengthType::MinIntrinsic:
-        case WebCore::LengthType::MinContent:
-        case WebCore::LengthType::MaxContent:
-        case WebCore::LengthType::FillAvailable:
-        case WebCore::LengthType::FitContent:
-        case WebCore::LengthType::Content:
-        case WebCore::LengthType::Normal:
-        case WebCore::LengthType::Relative:
-        case WebCore::LengthType::Undefined:
-            break;
-        }
-        RELEASE_ASSERT_NOT_REACHED();
-    }
-
-    bool hasSameType(const ScrollPaddingEdge& other) const { return m_value.type() == other.m_value.type(); }
-
-    bool operator==(const ScrollPaddingEdge&) const = default;
+struct ScrollPaddingEdge : LengthWrapperBase<LengthPercentage<CSS::Nonnegative>, CSS::Keyword::Auto> {
+    using Base::Base;
 
 private:
     friend struct Evaluation<ScrollPaddingEdge>;
-    friend WTF::TextStream& operator<<(WTF::TextStream&, const ScrollPaddingEdge&);
-
-    static bool isValid(const WebCore::Length& length)
-    {
-        switch (length.type()) {
-        case WebCore::LengthType::Fixed:
-            return CSS::isWithinRange<Fixed::range>(length.value());
-        case WebCore::LengthType::Percent:
-            return CSS::isWithinRange<Percentage::range>(length.value());
-        case WebCore::LengthType::Calculated:
-        case WebCore::LengthType::Auto:
-            return true;
-        case WebCore::LengthType::Intrinsic:
-        case WebCore::LengthType::MinIntrinsic:
-        case WebCore::LengthType::MinContent:
-        case WebCore::LengthType::MaxContent:
-        case WebCore::LengthType::FillAvailable:
-        case WebCore::LengthType::FitContent:
-        case WebCore::LengthType::Content:
-        case WebCore::LengthType::Normal:
-        case WebCore::LengthType::Relative:
-        case WebCore::LengthType::Undefined:
-            break;
-        }
-        return false;
-    }
-
-    WebCore::Length m_value;
 };
 
 // <'scroll-padding'> = [ auto | <length-percentage [0,∞]> ]{1,4}
@@ -164,10 +60,6 @@ template<> struct Evaluation<ScrollPaddingEdge> {
 // MARK: - Extent
 
 LayoutBoxExtent extentForRect(const ScrollPaddingBox&, const LayoutRect&);
-
-// MARK: - Logging
-
-WTF::TextStream& operator<<(WTF::TextStream&, const ScrollPaddingEdge&);
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/sizing/StyleMaximumSize.cpp
+++ b/Source/WebCore/style/values/sizing/StyleMaximumSize.cpp
@@ -27,7 +27,6 @@
 
 #include "StyleBuilderConverter.h"
 #include "StyleBuilderState.h"
-#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 namespace Style {
@@ -39,30 +38,6 @@ auto CSSValueConversion<MaximumSize>::operator()(BuilderState& state, const CSSV
     if (value.valueID() == CSSValueNone)
         return MaximumSize { CSS::Keyword::None { } };
     return MaximumSize { BuilderConverter::convertLengthSizing(state, value) };
-}
-
-// MARK: - Blending
-
-auto Blending<MaximumSize>::canBlend(const MaximumSize& a, const MaximumSize& b) -> bool
-{
-    return WebCore::canInterpolateLengths(a.m_value, b.m_value, true);
-}
-
-auto Blending<MaximumSize>::requiresInterpolationForAccumulativeIteration(const MaximumSize& a, const MaximumSize& b) -> bool
-{
-    return WebCore::lengthsRequireInterpolationForAccumulativeIteration(a.m_value, b.m_value);
-}
-
-auto Blending<MaximumSize>::blend(const MaximumSize& a, const MaximumSize& b, const BlendingContext& context) -> MaximumSize
-{
-    return MaximumSize { WebCore::blend(a.m_value, b.m_value, context, ValueRange::NonNegative) };
-}
-
-// MARK: - Logging
-
-WTF::TextStream& operator<<(WTF::TextStream& ts, const MaximumSize& value)
-{
-    return ts << value.m_value;
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/sizing/StyleMaximumSize.h
+++ b/Source/WebCore/style/values/sizing/StyleMaximumSize.h
@@ -24,19 +24,10 @@
 
 #pragma once
 
-#include "Length.h"
-#include "LengthFunctions.h"
-#include "StylePrimitiveNumericTypes.h"
-#include "StyleValueTypes.h"
+#include "StyleLengthWrapper.h"
 
 namespace WebCore {
-
-class CSSValue;
-class RenderStyle;
-
 namespace Style {
-
-class BuilderState;
 
 // <'max-width'>/<'max-height'> = none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain
 //
@@ -57,140 +48,8 @@ class BuilderState;
 //
 // https://drafts.csswg.org/css-sizing-3/#max-size-properties
 // https://drafts.csswg.org/css-sizing-4/#sizing-values (additional values added)
-struct MaximumSize {
-    using Specified = LengthPercentage<CSS::Nonnegative>;
-    using Fixed = typename Specified::Dimension;
-    using Percentage = typename Specified::Percentage;
-    using Calc = typename Specified::Calc;
-
-    MaximumSize(CSS::Keyword::None) : m_value(WebCore::LengthType::Undefined) { }
-    MaximumSize(CSS::Keyword::MinContent) : m_value(WebCore::LengthType::MinContent) { }
-    MaximumSize(CSS::Keyword::MaxContent) : m_value(WebCore::LengthType::MaxContent) { }
-    MaximumSize(CSS::Keyword::FitContent) : m_value(WebCore::LengthType::FitContent) { }
-    MaximumSize(CSS::Keyword::WebkitFillAvailable) : m_value(WebCore::LengthType::FillAvailable) { }
-    MaximumSize(CSS::Keyword::Intrinsic) : m_value(WebCore::LengthType::Intrinsic) { }
-    MaximumSize(CSS::Keyword::MinIntrinsic) : m_value(WebCore::LengthType::MinIntrinsic) { }
-
-    MaximumSize(Fixed&& fixed) : m_value(fixed.value, WebCore::LengthType::Fixed) { }
-    MaximumSize(const Fixed& fixed) : m_value(fixed.value, WebCore::LengthType::Fixed) { }
-    MaximumSize(Percentage&& percent) : m_value(percent.value, WebCore::LengthType::Percent) { }
-    MaximumSize(const Percentage& percent) : m_value(percent.value, WebCore::LengthType::Percent) { }
-
-    MaximumSize(CSS::ValueLiteral<CSS::LengthUnit::Px> literal) : m_value(static_cast<float>(literal.value), WebCore::LengthType::Fixed) { }
-    MaximumSize(CSS::ValueLiteral<CSS::PercentageUnit::Percentage> literal) : m_value(static_cast<float>(literal.value), WebCore::LengthType::Percent) { }
-
-    explicit MaximumSize(WebCore::Length&& other) : m_value(WTFMove(other)) { RELEASE_ASSERT(isValid(m_value)); }
-    explicit MaximumSize(const WebCore::Length& other) : m_value(other) { RELEASE_ASSERT(isValid(m_value)); }
-
-    ALWAYS_INLINE bool isFixed() const { return m_value.isFixed(); }
-    ALWAYS_INLINE bool isPercent() const { return m_value.isPercent(); }
-    ALWAYS_INLINE bool isCalculated() const { return m_value.isCalculated(); }
-    ALWAYS_INLINE bool isPercentOrCalculated() const { return m_value.isPercentOrCalculated(); }
-    ALWAYS_INLINE bool isSpecified() const { return m_value.isSpecified(); }
-
-    ALWAYS_INLINE bool isNone() const { return m_value.isUndefined(); }
-    ALWAYS_INLINE bool isMinContent() const { return m_value.isMinContent(); }
-    ALWAYS_INLINE bool isMaxContent() const { return m_value.isMaxContent(); }
-    ALWAYS_INLINE bool isFitContent() const { return m_value.isFitContent(); }
-    ALWAYS_INLINE bool isFillAvailable() const { return m_value.isFillAvailable(); }
-    ALWAYS_INLINE bool isMinIntrinsic() const { return m_value.isMinIntrinsic(); }
-    ALWAYS_INLINE bool isIntrinsicKeyword() const { return m_value.type() == LengthType::Intrinsic; }
-
-    // FIXME: This is misleadingly named. One would expect this function checks `type == LengthType::Intrinsic` but instead it checks `type = LengthType::MinContent || type == LengthType::MaxContent || type == LengthType::FillAvailable || type == LengthType::FitContent`.
-    ALWAYS_INLINE bool isIntrinsic() const { return m_value.isIntrinsic(); }
-    ALWAYS_INLINE bool isLegacyIntrinsic() const { return m_value.isLegacyIntrinsic(); }
-    ALWAYS_INLINE bool isIntrinsicOrLegacyIntrinsic() const { return isIntrinsic() || isLegacyIntrinsic(); }
-    ALWAYS_INLINE bool isIntrinsicOrLegacyIntrinsicOrAuto() const { return isIntrinsic() || isLegacyIntrinsic(); } // NOTE: it is never `auto` for MaximumSize, but this function is implemented for use in generic contexts.
-    ALWAYS_INLINE bool isSpecifiedOrIntrinsic() const { return m_value.isSpecifiedOrIntrinsic(); }
-
-    ALWAYS_INLINE bool isZero() const { return m_value.isZero(); }
-    ALWAYS_INLINE bool isPositive() const { return m_value.isPositive(); }
-    ALWAYS_INLINE bool isNegative() const { return m_value.isNegative(); }
-
-    // FIXME: Remove this when RenderBox's adjust*Box functions no longer need it.
-    ALWAYS_INLINE WebCore::LengthType type() const { return m_value.type(); }
-
-    std::optional<Fixed> tryFixed() const { return isFixed() ? std::make_optional(Fixed { m_value.value() }) : std::nullopt; }
-    std::optional<Percentage> tryPercentage() const { return isPercent() ? std::make_optional(Percentage { m_value.value() }) : std::nullopt; }
-    std::optional<Calc> tryCalc() const { return isCalculated() ? std::make_optional(Calc { m_value.calculationValue() }) : std::nullopt; }
-
-    template<typename T> bool holdsAlternative() const
-    {
-             if constexpr (std::same_as<T, Fixed>)                              return isFixed();
-        else if constexpr (std::same_as<T, Percentage>)                         return isPercent();
-        else if constexpr (std::same_as<T, Calc>)                               return isCalculated();
-        else if constexpr (std::same_as<T, CSS::Keyword::None>)                 return isNone();
-        else if constexpr (std::same_as<T, CSS::Keyword::Intrinsic>)            return isIntrinsicKeyword();
-        else if constexpr (std::same_as<T, CSS::Keyword::MinIntrinsic>)         return isMinIntrinsic();
-        else if constexpr (std::same_as<T, CSS::Keyword::MinContent>)           return isMinContent();
-        else if constexpr (std::same_as<T, CSS::Keyword::MaxContent>)           return isMaxContent();
-        else if constexpr (std::same_as<T, CSS::Keyword::WebkitFillAvailable>)  return isFillAvailable();
-        else if constexpr (std::same_as<T, CSS::Keyword::FitContent>)           return isFitContent();
-    }
-
-    template<typename... F> decltype(auto) switchOn(F&&... f) const
-    {
-        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
-
-        switch (m_value.type()) {
-        case WebCore::LengthType::Fixed:            return visitor(Fixed { m_value.value() });
-        case WebCore::LengthType::Percent:          return visitor(Percentage { m_value.value() });
-        case WebCore::LengthType::Calculated:       return visitor(Calc { m_value.calculationValue() });
-        case WebCore::LengthType::Undefined:        return visitor(CSS::Keyword::None { });
-        case WebCore::LengthType::Intrinsic:        return visitor(CSS::Keyword::Intrinsic { });
-        case WebCore::LengthType::MinIntrinsic:     return visitor(CSS::Keyword::MinIntrinsic { });
-        case WebCore::LengthType::MinContent:       return visitor(CSS::Keyword::MinContent { });
-        case WebCore::LengthType::MaxContent:       return visitor(CSS::Keyword::MaxContent { });
-        case WebCore::LengthType::FillAvailable:    return visitor(CSS::Keyword::WebkitFillAvailable { });
-        case WebCore::LengthType::FitContent:       return visitor(CSS::Keyword::FitContent { });
-
-        case WebCore::LengthType::Auto:
-        case WebCore::LengthType::Content:
-        case WebCore::LengthType::Normal:
-        case WebCore::LengthType::Relative:
-            break;
-        }
-
-        RELEASE_ASSERT_NOT_REACHED();
-    }
-
-    bool hasSameType(const MaximumSize& other) const { return m_value.type() == other.m_value.type(); }
-
-    bool operator==(const MaximumSize&) const = default;
-
-private:
-    friend struct Blending<MaximumSize>;
-    friend struct Evaluation<MaximumSize>;
-    friend LayoutUnit evaluateMinimum(const MaximumSize&, NOESCAPE const Invocable<LayoutUnit()> auto&);
-    friend LayoutUnit evaluateMinimum(const MaximumSize&, LayoutUnit);
-    friend WTF::TextStream& operator<<(WTF::TextStream&, const MaximumSize&);
-
-    static bool isValid(const WebCore::Length& length)
-    {
-        switch (length.type()) {
-        case WebCore::LengthType::Fixed:
-            return CSS::isWithinRange<Fixed::range>(length.value());
-        case WebCore::LengthType::Percent:
-            return CSS::isWithinRange<Percentage::range>(length.value());
-        case WebCore::LengthType::Undefined:
-        case WebCore::LengthType::Intrinsic:
-        case WebCore::LengthType::MinIntrinsic:
-        case WebCore::LengthType::MinContent:
-        case WebCore::LengthType::MaxContent:
-        case WebCore::LengthType::FillAvailable:
-        case WebCore::LengthType::FitContent:
-        case WebCore::LengthType::Calculated:
-            return true;
-        case WebCore::LengthType::Auto:
-        case WebCore::LengthType::Content:
-        case WebCore::LengthType::Normal:
-        case WebCore::LengthType::Relative:
-            break;
-        }
-        return false;
-    }
-
-    WebCore::Length m_value;
+struct MaximumSize : LengthWrapperBase<LengthPercentage<CSS::Nonnegative>, CSS::Keyword::None, CSS::Keyword::MinContent, CSS::Keyword::MaxContent, CSS::Keyword::FitContent, CSS::Keyword::WebkitFillAvailable, CSS::Keyword::Intrinsic, CSS::Keyword::MinIntrinsic> {
+    using Base::Base;
 };
 
 using MaximumSizePair = SpaceSeparatedSize<MaximumSize>;
@@ -198,42 +57,6 @@ using MaximumSizePair = SpaceSeparatedSize<MaximumSize>;
 // MARK: - Conversion
 
 template<> struct CSSValueConversion<MaximumSize> { auto operator()(BuilderState&, const CSSValue&) -> MaximumSize; };
-
-// MARK: - Evaluation
-
-template<> struct Evaluation<MaximumSize> {
-    auto operator()(const MaximumSize& edge, LayoutUnit referenceLength) -> LayoutUnit
-    {
-        return valueForLength(edge.m_value, referenceLength);
-    }
-
-    auto operator()(const MaximumSize& edge, float referenceLength) -> float
-    {
-        return floatValueForLength(edge.m_value, referenceLength);
-    }
-};
-
-inline LayoutUnit evaluateMinimum(const MaximumSize& edge, NOESCAPE const Invocable<LayoutUnit()> auto& lazyMaximumValueFunctor)
-{
-    return minimumValueForLengthWithLazyMaximum<LayoutUnit, LayoutUnit>(edge.m_value, lazyMaximumValueFunctor);
-}
-
-inline LayoutUnit evaluateMinimum(const MaximumSize& edge, LayoutUnit maximumValue)
-{
-    return minimumValueForLength(edge.m_value, maximumValue);
-}
-
-// MARK: - Blending
-
-template<> struct Blending<MaximumSize> {
-    auto canBlend(const MaximumSize&, const MaximumSize&) -> bool;
-    auto requiresInterpolationForAccumulativeIteration(const MaximumSize&, const MaximumSize&) -> bool;
-    auto blend(const MaximumSize&, const MaximumSize&, const BlendingContext&) -> MaximumSize;
-};
-
-// MARK: - Logging
-
-WTF::TextStream& operator<<(WTF::TextStream&, const MaximumSize&);
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/sizing/StyleMinimumSize.cpp
+++ b/Source/WebCore/style/values/sizing/StyleMinimumSize.cpp
@@ -28,18 +28,17 @@
 #include "StyleBuilderConverter.h"
 #include "StyleBuilderState.h"
 #include "StylePreferredSize.h"
-#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 namespace Style {
 
 MinimumSize::MinimumSize(PreferredSize&& other)
-    : m_value(WTFMove(other.m_value))
+    : Base(WTFMove(other.m_value))
 {
 }
 
 MinimumSize::MinimumSize(const PreferredSize& other)
-    : m_value(other.m_value)
+    : Base(other.m_value)
 {
 }
 
@@ -48,30 +47,6 @@ MinimumSize::MinimumSize(const PreferredSize& other)
 auto CSSValueConversion<MinimumSize>::operator()(BuilderState& state, const CSSValue& value) -> MinimumSize
 {
     return MinimumSize { BuilderConverter::convertLengthSizing(state, value) };
-}
-
-// MARK: - Blending
-
-auto Blending<MinimumSize>::canBlend(const MinimumSize& a, const MinimumSize& b) -> bool
-{
-    return WebCore::canInterpolateLengths(a.m_value, b.m_value, true);
-}
-
-auto Blending<MinimumSize>::requiresInterpolationForAccumulativeIteration(const MinimumSize& a, const MinimumSize& b) -> bool
-{
-    return WebCore::lengthsRequireInterpolationForAccumulativeIteration(a.m_value, b.m_value);
-}
-
-auto Blending<MinimumSize>::blend(const MinimumSize& a, const MinimumSize& b, const BlendingContext& context) -> MinimumSize
-{
-    return MinimumSize { WebCore::blend(a.m_value, b.m_value, context, ValueRange::NonNegative) };
-}
-
-// MARK: - Logging
-
-WTF::TextStream& operator<<(WTF::TextStream& ts, const MinimumSize& value)
-{
-    return ts << value.m_value;
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/sizing/StyleMinimumSize.h
+++ b/Source/WebCore/style/values/sizing/StyleMinimumSize.h
@@ -24,19 +24,10 @@
 
 #pragma once
 
-#include "Length.h"
-#include "LengthFunctions.h"
-#include "StylePrimitiveNumericTypes.h"
-#include "StyleValueTypes.h"
+#include "StyleLengthWrapper.h"
 
 namespace WebCore {
-
-class CSSValue;
-class RenderStyle;
-
 namespace Style {
-
-class BuilderState;
 
 struct PreferredSize;
 
@@ -59,145 +50,15 @@ struct PreferredSize;
 //
 // https://drafts.csswg.org/css-sizing-3/#min-size-properties
 // https://drafts.csswg.org/css-sizing-4/#sizing-values (additional values added)
-struct MinimumSize {
-    using Specified = LengthPercentage<CSS::Nonnegative>;
-    using Fixed = typename Specified::Dimension;
-    using Percentage = typename Specified::Percentage;
-    using Calc = typename Specified::Calc;
-
-    MinimumSize(CSS::Keyword::Auto) : m_value(WebCore::LengthType::Auto) { }
-    MinimumSize(CSS::Keyword::MinContent) : m_value(WebCore::LengthType::MinContent) { }
-    MinimumSize(CSS::Keyword::MaxContent) : m_value(WebCore::LengthType::MaxContent) { }
-    MinimumSize(CSS::Keyword::FitContent) : m_value(WebCore::LengthType::FitContent) { }
-    MinimumSize(CSS::Keyword::WebkitFillAvailable) : m_value(WebCore::LengthType::FillAvailable) { }
-    MinimumSize(CSS::Keyword::Intrinsic) : m_value(WebCore::LengthType::Intrinsic) { }
-    MinimumSize(CSS::Keyword::MinIntrinsic) : m_value(WebCore::LengthType::MinIntrinsic) { }
-
-    MinimumSize(Fixed&& fixed) : m_value(fixed.value, WebCore::LengthType::Fixed) { }
-    MinimumSize(const Fixed& fixed) : m_value(fixed.value, WebCore::LengthType::Fixed) { }
-    MinimumSize(Percentage&& percent) : m_value(percent.value, WebCore::LengthType::Percent) { }
-    MinimumSize(const Percentage& percent) : m_value(percent.value, WebCore::LengthType::Percent) { }
-
-    MinimumSize(CSS::ValueLiteral<CSS::LengthUnit::Px> literal) : m_value(static_cast<float>(literal.value), WebCore::LengthType::Fixed) { }
-    MinimumSize(CSS::ValueLiteral<CSS::PercentageUnit::Percentage> literal) : m_value(static_cast<float>(literal.value), WebCore::LengthType::Percent) { }
-
-    explicit MinimumSize(WebCore::Length&& other) : m_value(WTFMove(other)) { RELEASE_ASSERT(isValid(m_value)); }
-    explicit MinimumSize(const WebCore::Length& other) : m_value(other) { RELEASE_ASSERT(isValid(m_value)); }
+struct MinimumSize : LengthWrapperBase<LengthPercentage<CSS::Nonnegative>, CSS::Keyword::Auto, CSS::Keyword::MinContent, CSS::Keyword::MaxContent, CSS::Keyword::FitContent, CSS::Keyword::WebkitFillAvailable, CSS::Keyword::Intrinsic, CSS::Keyword::MinIntrinsic> {
+    using Base::Base;
 
     // `MinimumSize` is a structural twin of `PreferredSize` so `MinimumSize` can always be constructed from one.
     explicit MinimumSize(PreferredSize&&);
     explicit MinimumSize(const PreferredSize&);
 
-    ALWAYS_INLINE bool isFixed() const { return m_value.isFixed(); }
-    ALWAYS_INLINE bool isPercent() const { return m_value.isPercent(); }
-    ALWAYS_INLINE bool isCalculated() const { return m_value.isCalculated(); }
-    ALWAYS_INLINE bool isPercentOrCalculated() const { return m_value.isPercentOrCalculated(); }
-    ALWAYS_INLINE bool isSpecified() const { return m_value.isSpecified(); }
-
-    ALWAYS_INLINE bool isAuto() const { return m_value.isAuto(); }
-    ALWAYS_INLINE bool isMinContent() const { return m_value.isMinContent(); }
-    ALWAYS_INLINE bool isMaxContent() const { return m_value.isMaxContent(); }
-    ALWAYS_INLINE bool isFitContent() const { return m_value.isFitContent(); }
-    ALWAYS_INLINE bool isFillAvailable() const { return m_value.isFillAvailable(); }
-    ALWAYS_INLINE bool isMinIntrinsic() const { return m_value.isMinIntrinsic(); }
-    ALWAYS_INLINE bool isIntrinsicKeyword() const { return m_value.type() == LengthType::Intrinsic; }
-
-    // FIXME: This is misleadingly named. One would expect this function checks `type == LengthType::Intrinsic` but instead it checks `type = LengthType::MinContent || type == LengthType::MaxContent || type == LengthType::FillAvailable || type == LengthType::FitContent`.
-    ALWAYS_INLINE bool isIntrinsic() const { return m_value.isIntrinsic(); }
-    ALWAYS_INLINE bool isLegacyIntrinsic() const { return m_value.isLegacyIntrinsic(); }
-    ALWAYS_INLINE bool isIntrinsicOrLegacyIntrinsic() const { return isIntrinsic() || isLegacyIntrinsic(); }
-    ALWAYS_INLINE bool isIntrinsicOrLegacyIntrinsicOrAuto() const { return m_value.isIntrinsicOrLegacyIntrinsicOrAuto(); }
-    ALWAYS_INLINE bool isSpecifiedOrIntrinsic() const { return m_value.isSpecifiedOrIntrinsic(); }
-
-    ALWAYS_INLINE bool isZero() const { return m_value.isZero(); }
-    ALWAYS_INLINE bool isPositive() const { return m_value.isPositive(); }
-    ALWAYS_INLINE bool isNegative() const { return m_value.isNegative(); }
-
-    // FIXME: Remove this when RenderBox's adjust*Box functions no longer need it.
-    ALWAYS_INLINE WebCore::LengthType type() const { return m_value.type(); }
-
-    std::optional<Fixed> tryFixed() const { return isFixed() ? std::make_optional(Fixed { m_value.value() }) : std::nullopt; }
-    std::optional<Percentage> tryPercentage() const { return isPercent() ? std::make_optional(Percentage { m_value.value() }) : std::nullopt; }
-    std::optional<Calc> tryCalc() const { return isCalculated() ? std::make_optional(Calc { m_value.calculationValue() }) : std::nullopt; }
-
-    template<typename T> bool holdsAlternative() const
-    {
-             if constexpr (std::same_as<T, Fixed>)                              return isFixed();
-        else if constexpr (std::same_as<T, Percentage>)                         return isPercent();
-        else if constexpr (std::same_as<T, Calc>)                               return isCalculated();
-        else if constexpr (std::same_as<T, CSS::Keyword::Auto>)                 return isAuto();
-        else if constexpr (std::same_as<T, CSS::Keyword::Intrinsic>)            return isIntrinsicKeyword();
-        else if constexpr (std::same_as<T, CSS::Keyword::MinIntrinsic>)         return isMinIntrinsic();
-        else if constexpr (std::same_as<T, CSS::Keyword::MinContent>)           return isMinContent();
-        else if constexpr (std::same_as<T, CSS::Keyword::MaxContent>)           return isMaxContent();
-        else if constexpr (std::same_as<T, CSS::Keyword::WebkitFillAvailable>)  return isFillAvailable();
-        else if constexpr (std::same_as<T, CSS::Keyword::FitContent>)           return isFitContent();
-    }
-
-    template<typename... F> decltype(auto) switchOn(F&&... f) const
-    {
-        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
-
-        switch (m_value.type()) {
-        case WebCore::LengthType::Fixed:            return visitor(Fixed { m_value.value() });
-        case WebCore::LengthType::Percent:          return visitor(Percentage { m_value.value() });
-        case WebCore::LengthType::Calculated:       return visitor(Calc { m_value.calculationValue() });
-        case WebCore::LengthType::Auto:             return visitor(CSS::Keyword::Auto { });
-        case WebCore::LengthType::Intrinsic:        return visitor(CSS::Keyword::Intrinsic { });
-        case WebCore::LengthType::MinIntrinsic:     return visitor(CSS::Keyword::MinIntrinsic { });
-        case WebCore::LengthType::MinContent:       return visitor(CSS::Keyword::MinContent { });
-        case WebCore::LengthType::MaxContent:       return visitor(CSS::Keyword::MaxContent { });
-        case WebCore::LengthType::FillAvailable:    return visitor(CSS::Keyword::WebkitFillAvailable { });
-        case WebCore::LengthType::FitContent:       return visitor(CSS::Keyword::FitContent { });
-
-        case WebCore::LengthType::Content:
-        case WebCore::LengthType::Normal:
-        case WebCore::LengthType::Relative:
-        case WebCore::LengthType::Undefined:
-            break;
-        }
-
-        RELEASE_ASSERT_NOT_REACHED();
-    }
-
-    bool hasSameType(const MinimumSize& other) const { return m_value.type() == other.m_value.type(); }
-
-    bool operator==(const MinimumSize&) const = default;
-
 private:
     friend struct PreferredSize;
-    friend struct Blending<MinimumSize>;
-    friend struct Evaluation<MinimumSize>;
-    friend LayoutUnit evaluateMinimum(const MinimumSize&, NOESCAPE const Invocable<LayoutUnit()> auto&);
-    friend LayoutUnit evaluateMinimum(const MinimumSize&, LayoutUnit);
-    friend WTF::TextStream& operator<<(WTF::TextStream&, const MinimumSize&);
-
-    static bool isValid(const WebCore::Length& length)
-    {
-        switch (length.type()) {
-        case WebCore::LengthType::Fixed:
-            return CSS::isWithinRange<Fixed::range>(length.value());
-        case WebCore::LengthType::Percent:
-            return CSS::isWithinRange<Percentage::range>(length.value());
-        case WebCore::LengthType::Auto:
-        case WebCore::LengthType::Intrinsic:
-        case WebCore::LengthType::MinIntrinsic:
-        case WebCore::LengthType::MinContent:
-        case WebCore::LengthType::MaxContent:
-        case WebCore::LengthType::FillAvailable:
-        case WebCore::LengthType::FitContent:
-        case WebCore::LengthType::Calculated:
-            return true;
-        case WebCore::LengthType::Content:
-        case WebCore::LengthType::Normal:
-        case WebCore::LengthType::Relative:
-        case WebCore::LengthType::Undefined:
-            break;
-        }
-        return false;
-    }
-
-    WebCore::Length m_value;
 };
 
 using MinimumSizePair = SpaceSeparatedSize<MinimumSize>;
@@ -205,42 +66,6 @@ using MinimumSizePair = SpaceSeparatedSize<MinimumSize>;
 // MARK: - Conversion
 
 template<> struct CSSValueConversion<MinimumSize> { auto operator()(BuilderState&, const CSSValue&) -> MinimumSize; };
-
-// MARK: - Evaluation
-
-template<> struct Evaluation<MinimumSize> {
-    auto operator()(const MinimumSize& edge, LayoutUnit referenceLength) -> LayoutUnit
-    {
-        return valueForLength(edge.m_value, referenceLength);
-    }
-
-    auto operator()(const MinimumSize& edge, float referenceLength) -> float
-    {
-        return floatValueForLength(edge.m_value, referenceLength);
-    }
-};
-
-inline LayoutUnit evaluateMinimum(const MinimumSize& edge, NOESCAPE const Invocable<LayoutUnit()> auto& lazyMaximumValueFunctor)
-{
-    return minimumValueForLengthWithLazyMaximum<LayoutUnit, LayoutUnit>(edge.m_value, lazyMaximumValueFunctor);
-}
-
-inline LayoutUnit evaluateMinimum(const MinimumSize& edge, LayoutUnit maximumValue)
-{
-    return minimumValueForLength(edge.m_value, maximumValue);
-}
-
-// MARK: - Blending
-
-template<> struct Blending<MinimumSize> {
-    auto canBlend(const MinimumSize&, const MinimumSize&) -> bool;
-    auto requiresInterpolationForAccumulativeIteration(const MinimumSize&, const MinimumSize&) -> bool;
-    auto blend(const MinimumSize&, const MinimumSize&, const BlendingContext&) -> MinimumSize;
-};
-
-// MARK: - Logging
-
-WTF::TextStream& operator<<(WTF::TextStream&, const MinimumSize&);
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/sizing/StylePreferredSize.cpp
+++ b/Source/WebCore/style/values/sizing/StylePreferredSize.cpp
@@ -28,7 +28,6 @@
 #include "StyleBuilderConverter.h"
 #include "StyleBuilderState.h"
 #include "StyleFlexBasis.h"
-#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 namespace Style {
@@ -43,30 +42,6 @@ FlexBasis PreferredSize::asFlexBasis() const
 auto CSSValueConversion<PreferredSize>::operator()(BuilderState& state, const CSSValue& value) -> PreferredSize
 {
     return PreferredSize { BuilderConverter::convertLengthSizing(state, value) };
-}
-
-// MARK: - Blending
-
-auto Blending<PreferredSize>::canBlend(const PreferredSize& a, const PreferredSize& b) -> bool
-{
-    return WebCore::canInterpolateLengths(a.m_value, b.m_value, true);
-}
-
-auto Blending<PreferredSize>::requiresInterpolationForAccumulativeIteration(const PreferredSize& a, const PreferredSize& b) -> bool
-{
-    return WebCore::lengthsRequireInterpolationForAccumulativeIteration(a.m_value, b.m_value);
-}
-
-auto Blending<PreferredSize>::blend(const PreferredSize& a, const PreferredSize& b, const BlendingContext& context) -> PreferredSize
-{
-    return PreferredSize { WebCore::blend(a.m_value, b.m_value, context, ValueRange::NonNegative) };
-}
-
-// MARK: - Logging
-
-WTF::TextStream& operator<<(WTF::TextStream& ts, const PreferredSize& value)
-{
-    return ts << value.m_value;
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/sizing/StylePreferredSize.h
+++ b/Source/WebCore/style/values/sizing/StylePreferredSize.h
@@ -24,19 +24,11 @@
 
 #pragma once
 
-#include "Length.h"
-#include "LengthFunctions.h"
-#include "StylePrimitiveNumericTypes.h"
-#include "StyleValueTypes.h"
+#include "StyleLengthWrapper.h"
 
 namespace WebCore {
-
-class CSSValue;
-class RenderStyle;
-
 namespace Style {
 
-class BuilderState;
 struct FlexBasis;
 struct MinimumSize;
 
@@ -59,147 +51,15 @@ struct MinimumSize;
 //
 // https://drafts.csswg.org/css-sizing-3/#preferred-size-properties
 // https://drafts.csswg.org/css-sizing-4/#sizing-values (additional values added)
-struct PreferredSize {
-    using Specified = LengthPercentage<CSS::Nonnegative>;
-    using Fixed = typename Specified::Dimension;
-    using Percentage = typename Specified::Percentage;
-    using Calc = typename Specified::Calc;
-
-    PreferredSize(CSS::Keyword::Auto) : m_value(WebCore::LengthType::Auto) { }
-    PreferredSize(CSS::Keyword::MinContent) : m_value(WebCore::LengthType::MinContent) { }
-    PreferredSize(CSS::Keyword::MaxContent) : m_value(WebCore::LengthType::MaxContent) { }
-    PreferredSize(CSS::Keyword::FitContent) : m_value(WebCore::LengthType::FitContent) { }
-    PreferredSize(CSS::Keyword::WebkitFillAvailable) : m_value(WebCore::LengthType::FillAvailable) { }
-    PreferredSize(CSS::Keyword::Intrinsic) : m_value(WebCore::LengthType::Intrinsic) { }
-    PreferredSize(CSS::Keyword::MinIntrinsic) : m_value(WebCore::LengthType::MinIntrinsic) { }
-
-    PreferredSize(Fixed&& fixed) : m_value(fixed.value, WebCore::LengthType::Fixed) { }
-    PreferredSize(const Fixed& fixed) : m_value(fixed.value, WebCore::LengthType::Fixed) { }
-    PreferredSize(Percentage&& percent) : m_value(percent.value, WebCore::LengthType::Percent) { }
-    PreferredSize(const Percentage& percent) : m_value(percent.value, WebCore::LengthType::Percent) { }
-
-    PreferredSize(CSS::ValueLiteral<CSS::LengthUnit::Px> literal) : m_value(static_cast<float>(literal.value), WebCore::LengthType::Fixed) { }
-    PreferredSize(CSS::ValueLiteral<CSS::PercentageUnit::Percentage> literal) : m_value(static_cast<float>(literal.value), WebCore::LengthType::Percent) { }
-
-    explicit PreferredSize(WebCore::Length&& other) : m_value(WTFMove(other)) { RELEASE_ASSERT(isValid(m_value)); }
-    explicit PreferredSize(const WebCore::Length& other) : m_value(other) { RELEASE_ASSERT(isValid(m_value)); }
-
-    explicit PreferredSize(WTF::HashTableEmptyValueType token) : m_value(token) { }
-
-    ALWAYS_INLINE bool isFixed() const { return m_value.isFixed(); }
-    ALWAYS_INLINE bool isPercent() const { return m_value.isPercent(); }
-    ALWAYS_INLINE bool isCalculated() const { return m_value.isCalculated(); }
-    ALWAYS_INLINE bool isPercentOrCalculated() const { return m_value.isPercentOrCalculated(); }
-    ALWAYS_INLINE bool isSpecified() const { return m_value.isSpecified(); }
-
-    ALWAYS_INLINE bool isAuto() const { return m_value.isAuto(); }
-    ALWAYS_INLINE bool isMinContent() const { return m_value.isMinContent(); }
-    ALWAYS_INLINE bool isMaxContent() const { return m_value.isMaxContent(); }
-    ALWAYS_INLINE bool isFitContent() const { return m_value.isFitContent(); }
-    ALWAYS_INLINE bool isFillAvailable() const { return m_value.isFillAvailable(); }
-    ALWAYS_INLINE bool isMinIntrinsic() const { return m_value.isMinIntrinsic(); }
-    ALWAYS_INLINE bool isIntrinsicKeyword() const { return m_value.type() == LengthType::Intrinsic; }
-
-    // FIXME: This is misleadingly named. One would expect this function checks `type == LengthType::Intrinsic` but instead it checks `type = LengthType::MinContent || type == LengthType::MaxContent || type == LengthType::FillAvailable || type == LengthType::FitContent`.
-    ALWAYS_INLINE bool isIntrinsic() const { return m_value.isIntrinsic(); }
-    ALWAYS_INLINE bool isLegacyIntrinsic() const { return m_value.isLegacyIntrinsic(); }
-    ALWAYS_INLINE bool isIntrinsicOrLegacyIntrinsic() const { return isIntrinsic() || isLegacyIntrinsic(); }
-    ALWAYS_INLINE bool isIntrinsicOrLegacyIntrinsicOrAuto() const { return m_value.isIntrinsicOrLegacyIntrinsicOrAuto(); }
-    ALWAYS_INLINE bool isSpecifiedOrIntrinsic() const { return m_value.isSpecifiedOrIntrinsic(); }
-
-    ALWAYS_INLINE bool isZero() const { return m_value.isZero(); }
-    ALWAYS_INLINE bool isPositive() const { return m_value.isPositive(); }
-    ALWAYS_INLINE bool isNegative() const { return m_value.isNegative(); }
-
-    // FIXME: Remove this when RenderBox's adjust*Box functions no longer need it.
-    ALWAYS_INLINE WebCore::LengthType type() const { return m_value.type(); }
-
-    std::optional<Fixed> tryFixed() const { return isFixed() ? std::make_optional(Fixed { m_value.value() }) : std::nullopt; }
-    std::optional<Percentage> tryPercentage() const { return isPercent() ? std::make_optional(Percentage { m_value.value() }) : std::nullopt; }
-    std::optional<Calc> tryCalc() const { return isCalculated() ? std::make_optional(Calc { m_value.calculationValue() }) : std::nullopt; }
+struct PreferredSize : LengthWrapperBase<LengthPercentage<CSS::Nonnegative>, CSS::Keyword::Auto, CSS::Keyword::MinContent, CSS::Keyword::MaxContent, CSS::Keyword::FitContent, CSS::Keyword::WebkitFillAvailable, CSS::Keyword::Intrinsic, CSS::Keyword::MinIntrinsic> {
+    using Base::Base;
 
     // `PreferredSize` is a subset of `FlexBasis` and therefore can be losslessly converted.
     FlexBasis asFlexBasis() const;
 
-    template<typename T> bool holdsAlternative() const
-    {
-             if constexpr (std::same_as<T, Fixed>)                              return isFixed();
-        else if constexpr (std::same_as<T, Percentage>)                         return isPercent();
-        else if constexpr (std::same_as<T, Calc>)                               return isCalculated();
-        else if constexpr (std::same_as<T, CSS::Keyword::Auto>)                 return isAuto();
-        else if constexpr (std::same_as<T, CSS::Keyword::Intrinsic>)            return isIntrinsicKeyword();
-        else if constexpr (std::same_as<T, CSS::Keyword::MinIntrinsic>)         return isMinIntrinsic();
-        else if constexpr (std::same_as<T, CSS::Keyword::MinContent>)           return isMinContent();
-        else if constexpr (std::same_as<T, CSS::Keyword::MaxContent>)           return isMaxContent();
-        else if constexpr (std::same_as<T, CSS::Keyword::WebkitFillAvailable>)  return isFillAvailable();
-        else if constexpr (std::same_as<T, CSS::Keyword::FitContent>)           return isFitContent();
-    }
-
-    template<typename... F> decltype(auto) switchOn(F&&... f) const
-    {
-        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
-
-        switch (m_value.type()) {
-        case WebCore::LengthType::Fixed:            return visitor(Fixed { m_value.value() });
-        case WebCore::LengthType::Percent:          return visitor(Percentage { m_value.value() });
-        case WebCore::LengthType::Calculated:       return visitor(Calc { m_value.calculationValue() });
-        case WebCore::LengthType::Auto:             return visitor(CSS::Keyword::Auto { });
-        case WebCore::LengthType::Intrinsic:        return visitor(CSS::Keyword::Intrinsic { });
-        case WebCore::LengthType::MinIntrinsic:     return visitor(CSS::Keyword::MinIntrinsic { });
-        case WebCore::LengthType::MinContent:       return visitor(CSS::Keyword::MinContent { });
-        case WebCore::LengthType::MaxContent:       return visitor(CSS::Keyword::MaxContent { });
-        case WebCore::LengthType::FillAvailable:    return visitor(CSS::Keyword::WebkitFillAvailable { });
-        case WebCore::LengthType::FitContent:       return visitor(CSS::Keyword::FitContent { });
-
-        case WebCore::LengthType::Content:
-        case WebCore::LengthType::Normal:
-        case WebCore::LengthType::Relative:
-        case WebCore::LengthType::Undefined:
-            break;
-        }
-        RELEASE_ASSERT_NOT_REACHED();
-    }
-
-    bool hasSameType(const PreferredSize& other) const { return m_value.type() == other.m_value.type(); }
-
-    bool operator==(const PreferredSize&) const = default;
-
 private:
     friend struct FlexBasis;
     friend struct MinimumSize;
-    friend struct Blending<PreferredSize>;
-    friend struct Evaluation<PreferredSize>;
-    friend LayoutUnit evaluateMinimum(const PreferredSize&, NOESCAPE const Invocable<LayoutUnit()> auto&);
-    friend LayoutUnit evaluateMinimum(const PreferredSize&, LayoutUnit);
-    friend float evaluateMinimum(const PreferredSize&, float);
-    friend WTF::TextStream& operator<<(WTF::TextStream&, const PreferredSize&);
-
-    static bool isValid(const WebCore::Length& length)
-    {
-        switch (length.type()) {
-        case WebCore::LengthType::Fixed:
-            return CSS::isWithinRange<Fixed::range>(length.value());
-        case WebCore::LengthType::Percent:
-            return CSS::isWithinRange<Percentage::range>(length.value());
-        case WebCore::LengthType::Auto:
-        case WebCore::LengthType::Intrinsic:
-        case WebCore::LengthType::MinIntrinsic:
-        case WebCore::LengthType::MinContent:
-        case WebCore::LengthType::MaxContent:
-        case WebCore::LengthType::FillAvailable:
-        case WebCore::LengthType::FitContent:
-        case WebCore::LengthType::Calculated:
-            return true;
-        case WebCore::LengthType::Content:
-        case WebCore::LengthType::Normal:
-        case WebCore::LengthType::Relative:
-        case WebCore::LengthType::Undefined:
-            break;
-        }
-        return false;
-    }
-
-    WebCore::Length m_value;
 };
 
 using PreferredSizePair = SpaceSeparatedSize<PreferredSize>;
@@ -207,47 +67,6 @@ using PreferredSizePair = SpaceSeparatedSize<PreferredSize>;
 // MARK: - Conversion
 
 template<> struct CSSValueConversion<PreferredSize> { auto operator()(BuilderState&, const CSSValue&) -> PreferredSize; };
-
-// MARK: - Evaluation
-
-template<> struct Evaluation<PreferredSize> {
-    auto operator()(const PreferredSize& edge, LayoutUnit referenceLength) -> LayoutUnit
-    {
-        return valueForLength(edge.m_value, referenceLength);
-    }
-
-    auto operator()(const PreferredSize& edge, float referenceLength) -> float
-    {
-        return floatValueForLength(edge.m_value, referenceLength);
-    }
-};
-
-inline LayoutUnit evaluateMinimum(const PreferredSize& edge, NOESCAPE const Invocable<LayoutUnit()> auto& lazyMaximumValueFunctor)
-{
-    return minimumValueForLengthWithLazyMaximum<LayoutUnit, LayoutUnit>(edge.m_value, lazyMaximumValueFunctor);
-}
-
-inline LayoutUnit evaluateMinimum(const PreferredSize& edge, LayoutUnit maximumValue)
-{
-    return minimumValueForLength(edge.m_value, maximumValue);
-}
-
-inline float evaluateMinimum(const PreferredSize& edge, float maximumValue)
-{
-    return minimumValueForLength(edge.m_value, maximumValue);
-}
-
-// MARK: - Blending
-
-template<> struct Blending<PreferredSize> {
-    auto canBlend(const PreferredSize&, const PreferredSize&) -> bool;
-    auto requiresInterpolationForAccumulativeIteration(const PreferredSize&, const PreferredSize&) -> bool;
-    auto blend(const PreferredSize&, const PreferredSize&, const BlendingContext&) -> PreferredSize;
-};
-
-// MARK: - Logging
-
-WTF::TextStream& operator<<(WTF::TextStream&, const PreferredSize&);
 
 } // namespace Style
 } // namespace WebCore


### PR DESCRIPTION
#### 7832e782324e1abbf200594249833acf672cea5c
<pre>
[Style] Add a shared base class for Style WebCore::Length wrappers to reduce code duplication
<a href="https://bugs.webkit.org/show_bug.cgi?id=294811">https://bugs.webkit.org/show_bug.cgi?id=294811</a>

Reviewed by Darin Adler.

Adds a shared base class for strong Style types that wrap WebCore::Length
that is customizable via template parameters allowing for a nice reduction
in code duplication.

Eventually, these should all use Style::PrimitiveNumericOrKeyword&lt;&gt;, but
to ensure we have no performance regressions, we are first moving to
&quot;zero-cost&quot; wrappers of the existing type, WebCore::Length, to enforce
the type safety without any memory layout changes.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/Length.h:
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
* Source/WebCore/rendering/RenderScrollbarPart.cpp:
* Source/WebCore/rendering/RenderTextInlines.h:
* Source/WebCore/rendering/style/StyleFlexibleBoxData.cpp:
* Source/WebCore/style/values/box/StyleMargin.cpp:
* Source/WebCore/style/values/box/StyleMargin.h:
* Source/WebCore/style/values/box/StylePadding.cpp:
* Source/WebCore/style/values/box/StylePadding.h:
* Source/WebCore/style/values/flexbox/StyleFlexBasis.cpp:
* Source/WebCore/style/values/flexbox/StyleFlexBasis.h:
* Source/WebCore/style/values/motion/StyleOffsetDistance.cpp:
* Source/WebCore/style/values/motion/StyleOffsetDistance.h:
* Source/WebCore/style/values/position/StyleInset.cpp:
* Source/WebCore/style/values/position/StyleInset.h:
* Source/WebCore/style/values/primitives/StyleLengthWrapper.h: Added.
* Source/WebCore/style/values/scroll-snap/StyleScrollPadding.cpp:
* Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h:
* Source/WebCore/style/values/sizing/StyleMaximumSize.cpp:
* Source/WebCore/style/values/sizing/StyleMaximumSize.h:
* Source/WebCore/style/values/sizing/StyleMinimumSize.cpp:
* Source/WebCore/style/values/sizing/StyleMinimumSize.h:
* Source/WebCore/style/values/sizing/StylePreferredSize.cpp:
* Source/WebCore/style/values/sizing/StylePreferredSize.h:

Canonical link: <a href="https://commits.webkit.org/296527@main">https://commits.webkit.org/296527@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c408bdd5a0509b31df1bec2970bf9e2831fb5ce8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108797 "16 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18882 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114007 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59166 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110760 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37022 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82670 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111745 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23158 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97996 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63109 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22581 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16134 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58709 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92529 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16182 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117129 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35850 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26476 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/91682 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36223 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94263 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91492 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23295 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36388 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14144 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31727 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35749 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41283 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35455 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38800 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37138 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->