### PR TITLE
[JSC] Ensure `Date.prototype.setMonth` and `Date.prototype.setUTCMonth` Respects TimeClip Range by Guarding months of GregorianDateTime Overflow

### DIFF
--- a/JSTests/stress/date-timeClip-large-values.js
+++ b/JSTests/stress/date-timeClip-large-values.js
@@ -56,8 +56,8 @@ shouldBe(new Date(8.64e15).setDate(new Date(8.64e15).getDate() + 1).valueOf(), N
 
 // Testing setMonth()
 shouldBe(new Date(0).setMonth(Infinity).valueOf(), NaN);
-// shouldBe(new Date(0).setMonth(1.79769e+308).valueOf(), NaN);
-// shouldBe(new Date(0).setMonth(-1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(0).setMonth(1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(0).setMonth(-1.79769e+308).valueOf(), NaN);
 shouldBe(new Date(8.64e15).setMonth(new Date(8.64e15).getMonth()).valueOf(), 8.64e15);
 shouldBe(new Date(8.64e15).setMonth(new Date(8.64e15).getMonth() + 1).valueOf(), NaN);
 
@@ -113,8 +113,8 @@ shouldBe(new Date(8.64e15).setUTCDate(new Date(8.64e15).getUTCDate() + 1).valueO
 
 // Testing setUTCMonth()
 shouldBe(new Date(0).setUTCMonth(Infinity).valueOf(), NaN);
-// shouldBe(new Date(0).setUTCMonth(1.79769e+308).valueOf(), NaN);
-// shouldBe(new Date(0).setUTCMonth(-1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(0).setUTCMonth(1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(0).setUTCMonth(-1.79769e+308).valueOf(), NaN);
 shouldBe(new Date(8.64e15).setUTCMonth(new Date(8.64e15).getUTCMonth()).valueOf(), 8.64e15);
 shouldBe(new Date(8.64e15).setUTCMonth(new Date(8.64e15).getUTCMonth() + 1).valueOf(), NaN);
 

--- a/LayoutTests/js/date-timeClip-large-values-expected.txt
+++ b/LayoutTests/js/date-timeClip-large-values-expected.txt
@@ -46,8 +46,8 @@ PASS new Date(8.64e15).setDate(new Date(8.64e15).getDate()).valueOf() is 8.64e15
 PASS new Date(8.64e15).setDate(new Date(8.64e15).getDate() + 1).valueOf() is NaN
 Testing setMonth()
 PASS new Date(0).setMonth(Infinity).valueOf() is NaN
-FAIL new Date(0).setMonth(1.79769e+308).valueOf() should be NaN. Was -28857600000.
-FAIL new Date(0).setMonth(-1.79769e+308).valueOf() should be NaN. Was -28857600000.
+PASS new Date(0).setMonth(1.79769e+308).valueOf() is NaN
+PASS new Date(0).setMonth(-1.79769e+308).valueOf() is NaN
 PASS new Date(8.64e15).setMonth(new Date(8.64e15).getMonth()).valueOf() is 8.64e15
 PASS new Date(8.64e15).setMonth(new Date(8.64e15).getMonth() + 1).valueOf() is NaN
 Testing setYear()
@@ -95,8 +95,8 @@ PASS new Date(8.64e15).setUTCDate(new Date(8.64e15).getUTCDate()).valueOf() is 8
 PASS new Date(8.64e15).setUTCDate(new Date(8.64e15).getUTCDate() + 1).valueOf() is NaN
 Testing setUTCMonth()
 PASS new Date(0).setUTCMonth(Infinity).valueOf() is NaN
-FAIL new Date(0).setUTCMonth(1.79769e+308).valueOf() should be NaN. Was 0.
-FAIL new Date(0).setUTCMonth(-1.79769e+308).valueOf() should be NaN. Was 0.
+PASS new Date(0).setUTCMonth(1.79769e+308).valueOf() is NaN
+PASS new Date(0).setUTCMonth(-1.79769e+308).valueOf() is NaN
 PASS new Date(8.64e15).setUTCMonth(new Date(8.64e15).getUTCMonth()).valueOf() is 8.64e15
 PASS new Date(8.64e15).setUTCMonth(new Date(8.64e15).getUTCMonth() + 1).valueOf() is NaN
 Testing setUTCFullYear()

--- a/Source/JavaScriptCore/runtime/DatePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/DatePrototype.cpp
@@ -205,7 +205,8 @@ static bool fillStructuresUsingDateArgs(JSGlobalObject* globalObject, CallFrame*
     if (maxArgs >= 2 && idx < numArgs) {
         double months = callFrame->uncheckedArgument(idx++).toIntegerPreserveNaN(globalObject);
         RETURN_IF_EXCEPTION(scope, false);
-        ok = ok && std::isfinite(months);
+        double years = months / 12;
+        ok = ok && std::isfinite(months) && std::abs(years) <= msToYear(WTF::maxECMAScriptTime);
         t->setMonth(toInt32(months));
     }
     // days


### PR DESCRIPTION
#### 7d717f937dacbd898dc653acdc01c6aa9905a2af
<pre>
[JSC] Ensure `Date.prototype.setMonth` and `Date.prototype.setUTCMonth` Respects TimeClip Range by Guarding months of GregorianDateTime Overflow
<a href="https://bugs.webkit.org/show_bug.cgi?id=294815">https://bugs.webkit.org/show_bug.cgi?id=294815</a>

Reviewed by Sosuke Suzuki.

TimeClip[1] function, as referenced in Date.prototype.setMonth[2] and
Date.prototype.setUTCMonth[3], mentions that absolute value of time must not
exceed 8.64E15 in milliseconds, otherwise returns NaN.
However, the current GregorianDateTime class represents months member variable as int.
Therefore, if the months exceeds the maximum representable int,
date calculations may produce incorrect results.
This patch adds a safeguard to ensure that such overflows are prevented
to align the behavior with the TC39 spec.

[1]: <a href="https://tc39.es/ecma262/#sec-timeclip">https://tc39.es/ecma262/#sec-timeclip</a>
[2]: <a href="https://tc39.es/ecma262/#sec-date.prototype.setmonth">https://tc39.es/ecma262/#sec-date.prototype.setmonth</a>
[3]: <a href="https://tc39.es/ecma262/#sec-date.prototype.setutcmonth">https://tc39.es/ecma262/#sec-date.prototype.setutcmonth</a>

* JSTests/stress/date-timeClip-large-values.js:
* LayoutTests/js/date-timeClip-large-values-expected.txt:
* Source/JavaScriptCore/runtime/DatePrototype.cpp:
(JSC::fillStructuresUsingDateArgs):

Canonical link: <a href="https://commits.webkit.org/296644@main">https://commits.webkit.org/296644@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63c38665129e23dc96d491bbabb5c650b82431f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108706 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28367 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18791 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113917 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59091 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29056 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36928 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82583 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111654 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23078 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97920 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63020 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22498 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16056 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58619 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/101255 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92448 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16106 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117038 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/107265 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35760 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26432 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91603 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36133 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94187 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91409 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23370 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36311 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14070 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31624 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35661 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41194 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/131543 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35370 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35671 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38717 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37048 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->