### PR TITLE
[WebDriver][BiDi] Fix error forwarding for errors with detail string

### DIFF
--- a/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp
@@ -181,8 +181,18 @@ void WebDriverBidiProcessor::sendBidiMessage(const String& message)
             auto bidiErrorObj = JSON::Object::create();
             bidiErrorObj->setString("type"_s, "error"_s);
             auto internalMsg = internalErrorObj->getString("message"_s);
-            bidiErrorObj->setString("message"_s, internalMsg);
-            bidiErrorObj->setString("error"_s, toBidiErrorCode(*codeField, internalMsg));
+            auto divot = internalMsg.find(';');
+            if (divot != notFound) {
+                auto errorName = internalMsg.substring(0, divot);
+                auto errorDetail = internalMsg.substring(divot + 1);
+                if (errorDetail.isEmpty())
+                    errorDetail = "An error occurred."_s;
+                bidiErrorObj->setString("message"_s, errorDetail);
+                bidiErrorObj->setString("error"_s, toBidiErrorCode(*codeField, errorName));
+            } else {
+                bidiErrorObj->setString("message"_s, internalMsg);
+                bidiErrorObj->setString("error"_s, toBidiErrorCode(*codeField, internalMsg));
+            }
             if (auto commandId = msgObj->getInteger("id"_s))
                 bidiErrorObj->setInteger("id"_s, *commandId);
 


### PR DESCRIPTION
#### f8c41ac3bcf68b7e720b52430b9a4301ebd978c3
<pre>
[WebDriver][BiDi] Fix error forwarding for errors with detail string
<a href="https://bugs.webkit.org/show_bug.cgi?id=294824">https://bugs.webkit.org/show_bug.cgi?id=294824</a>

Reviewed by BJ Burg.

Ensure we check if we&apos;re getting an error message with a detail string,
using it for the &quot;message&quot; field in the outgoing BiDi error message.

This avoids getting generic &quot;Unknown Error&quot; with messages
&quot;InvalidParameter;The parameter foo is invalid&quot; if using the
&quot;...AND_DETAILS&quot; macros.

* Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp:
(WebKit::WebDriverBidiProcessor::sendBidiMessage):

Canonical link: <a href="https://commits.webkit.org/299108@main">https://commits.webkit.org/299108@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f59145c617e1bc94e8cd2f2c3d3610f07a88ee45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117909 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37587 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28220 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124054 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69943 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38280 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46169 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/89475 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120861 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30483 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105726 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69971 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29547 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67718 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99903 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24021 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127136 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44812 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33753 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98144 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45173 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101951 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97932 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24908 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43327 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21306 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41241 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44684 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50358 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44144 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47489 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45833 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->