### PR TITLE
[view-transitions] Add `animation-delay: inherit` to UA stylesheet

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/style-inheritance.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/style-inheritance.html
@@ -16,6 +16,7 @@
   background-color: inherit;
   color: blue;
   animation-duration: 0.321s;
+  animation-delay: 0.05s;
 }
 
 ::view-transition-image-pair(*) {
@@ -39,15 +40,19 @@ promise_test(async () => {
   assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(root)").backgroundColor, "rgb(255, 0, 0)", "group");
   assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(root)").color, "rgb(0, 0, 255)", "group");
   assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(root)").animationDuration, "0.321s", "group");
+  assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(root)").animationDelay, "0.05s", "group");
 
   assert_equals(getComputedStyle(document.documentElement, "::view-transition-image-pair(root)").color, "rgb(0, 0, 255)", "wrapper");
   assert_equals(getComputedStyle(document.documentElement, "::view-transition-image-pair(root)").overflowX, "clip", "wrapper");
   assert_equals(getComputedStyle(document.documentElement, "::view-transition-image-pair(root)").animationDuration, "0.321s", "wrapper");
+  assert_equals(getComputedStyle(document.documentElement, "::view-transition-image-pair(root)").animationDelay, "0.05s", "wrapper");
 
   assert_equals(getComputedStyle(document.documentElement, "::view-transition-old(root)").overflowX, "clip", "outgoing");
   assert_equals(getComputedStyle(document.documentElement, "::view-transition-old(root)").animationDuration, "0.321s", "outgoing");
+  assert_equals(getComputedStyle(document.documentElement, "::view-transition-old(root)").animationDelay, "0.05s", "outgoing");
   assert_equals(getComputedStyle(document.documentElement, "::view-transition-new(root)").overflowX, "clip", "incoming");
   assert_equals(getComputedStyle(document.documentElement, "::view-transition-new(root)").animationDuration, "0.321s", "incoming");
+  assert_equals(getComputedStyle(document.documentElement, "::view-transition-new(root)").animationDelay, "0.05s", "incoming");
 
   await transition.finished;
 }, "style inheritance of pseudo elements");

--- a/Source/WebCore/css/viewTransitions.css
+++ b/Source/WebCore/css/viewTransitions.css
@@ -48,6 +48,7 @@
 
     animation-duration: inherit;
     animation-fill-mode: inherit;
+    animation-delay: inherit;
 }
 
 :root::view-transition-old(*),
@@ -59,6 +60,7 @@
 
     animation-duration: inherit;
     animation-fill-mode: inherit;
+    animation-delay: inherit;
 }
 
 /* Default cross-fade transition */


### PR DESCRIPTION
#### af260479bf09d66dbb948aa62caac366ce1e4cb6
<pre>
[view-transitions] Add `animation-delay: inherit` to UA stylesheet
<a href="https://bugs.webkit.org/show_bug.cgi?id=294812">https://bugs.webkit.org/show_bug.cgi?id=294812</a>
<a href="https://rdar.apple.com/154071965">rdar://154071965</a>

Reviewed by Anne van Kesteren.

Follow this spec change: <a href="https://github.com/w3c/csswg-drafts/commit/d1156bc0223b7eafb34167ae9cd0c8e72d6ea9d1">https://github.com/w3c/csswg-drafts/commit/d1156bc0223b7eafb34167ae9cd0c8e72d6ea9d1</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/style-inheritance.html:
* Source/WebCore/css/viewTransitions.css:
(:root::view-transition-image-pair(*)):
(:root::view-transition-old(*),):

Canonical link: <a href="https://commits.webkit.org/296501@main">https://commits.webkit.org/296501@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9468f1c004e8a76211ff72c9e50e2ddcc582d66

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108743 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28404 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18828 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113954 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59127 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110706 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29093 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36967 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82619 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111691 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23113 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97948 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63056 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22533 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16084 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58654 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92483 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16134 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117075 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35797 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26426 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91637 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36170 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94215 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91443 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23285 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36341 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14097 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31678 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35697 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41231 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35407 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38754 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37085 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->