### PR TITLE
[iOS] _WKWarningView should stop using deprecated UITextItemInteraction API

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/_WKWarningView.mm
+++ b/Source/WebKit/UIProcess/Cocoa/_WKWarningView.mm
@@ -523,14 +523,18 @@ static RetainPtr<ViewType> makeLabel(NSAttributedString *attributedString)
     [self layoutText];
 }
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
-- (BOOL)textView:(UITextView *)textView shouldInteractWithURL:(NSURL *)URL inRange:(NSRange)characterRange interaction:(UITextItemInteraction)interaction
-ALLOW_DEPRECATED_IMPLEMENTATIONS_END
-ALLOW_DEPRECATED_DECLARATIONS_END
+- (UIAction *)textView:(UITextView *)textView primaryActionForTextItem:(UITextItem *)textItem defaultAction:(UIAction *)defaultAction
 {
-    [self clickedOnLink:URL];
-    return NO;
+    if (textItem.contentType == UITextItemContentTypeLink)
+        [self clickedOnLink:textItem.link];
+    return nil;
+}
+
+- (UITextItemMenuConfiguration *)textView:(UITextView *)textView menuConfigurationForTextItem:(UITextItem *)textItem defaultMenu:(UIMenu *)defaultMenu
+{
+    // We implement this delegate method because the text view requests a menu to be presented
+    // if a `nil` action is returned from `textView:primaryActionForTextItem:defaultAction:`.
+    return nil;
 }
 
 - (void)didMoveToWindow


### PR DESCRIPTION
#### 714c20614f9c5b0b72363255d0559b257fe30c07
<pre>
[iOS] _WKWarningView should stop using deprecated UITextItemInteraction API
<a href="https://bugs.webkit.org/show_bug.cgi?id=294828">https://bugs.webkit.org/show_bug.cgi?id=294828</a>
<a href="https://rdar.apple.com/106668003">rdar://106668003</a>

Reviewed by Wenson Hsieh and Megan Gardner.

This patch drops usage of the UITextItemInteraction API, which has been
deprecated since iOS 17, and instead adopts UITextView API
`-textView:primaryActionForTextItem:defaultAction:` and
`-textView:menuConfigurationForTextItem:defaultMenu:` instead.

No new tests since this does not change functionality. Test coverage in
the TestWebKitAPI.WebKit.SafeBrowsing suite suffices.

* Source/WebKit/UIProcess/Cocoa/_WKWarningView.mm:
(-[_WKWarningView textView:primaryActionForTextItem:defaultAction:]):
(-[_WKWarningView textView:menuConfigurationForTextItem:defaultMenu:]):
(-[_WKWarningView textView:shouldInteractWithURL:inRange:interaction:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/296522@main">https://commits.webkit.org/296522@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19c3d08620d7c0f0d43bfede0d1d0bf3ef57f9d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108744 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28405 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113955 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59128 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29094 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36968 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82618 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111692 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23112 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97949 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63055 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22532 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58655 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92482 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16135 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117076 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35798 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26429 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91638 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36171 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94216 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91444 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23290 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36342 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14098 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31680 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35698 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41232 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35408 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38755 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37086 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->