### PR TITLE
[WPE] WPE Platform: use memcpySpan instead of memcpy to write in SHM pool

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
@@ -37,6 +37,7 @@
 #include <wtf/FastMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/GSpanExtras.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/glib/GWeakPtr.h>
 #include <wtf/glib/WTFGType.h>
@@ -300,8 +301,7 @@ static SharedMemoryBuffer* sharedMemoryBufferCreate(WPEView* view, GBytes* bytes
     if (offset < 0)
         return nullptr;
 
-    memcpy(reinterpret_cast<char*>(wlPool->data()) + offset, g_bytes_get_data(bytes, nullptr), size);
-
+    wlPool->write(WTF::span(bytes), offset);
     return new SharedMemoryBuffer(view, WTFMove(wlPool), offset, width, height, stride);
 }
 
@@ -309,7 +309,7 @@ static struct wl_buffer* createWaylandBufferSHM(WPEView* view, WPEBuffer* buffer
 {
     if (auto* sharedMemoryBuffer = static_cast<SharedMemoryBuffer*>(wpe_buffer_get_user_data(buffer))) {
         GBytes* bytes = wpe_buffer_shm_get_data(WPE_BUFFER_SHM(buffer));
-        memcpy(reinterpret_cast<char*>(sharedMemoryBuffer->wlPool()->data()), g_bytes_get_data(bytes, nullptr), sharedMemoryBuffer->wlPool()->size());
+        sharedMemoryBuffer->wlPool()->write(WTF::span(bytes));
         return sharedMemoryBuffer->wlBuffer();
     }
 

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandCursorTheme.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandCursorTheme.cpp
@@ -106,7 +106,7 @@ void WaylandCursorTheme::loadCursor(const char* name, double scale, std::optiona
 
         // FIXME: support upscaling cursor.
         if (effectiveScale == 1)
-            memcpy(reinterpret_cast<char*>(m_pool->data()) + offset, cursorImage.pixels.span().data(), sizeInBytes);
+            m_pool->write(cursorImage.pixels.span(), offset);
 
         image.buffer = m_pool->createBuffer(offset, image.width, image.height, image.width * 4);
         images.append(WTFMove(image));

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSHMPool.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSHMPool.cpp
@@ -156,4 +156,14 @@ struct wl_buffer* WaylandSHMPool::createBuffer(uint32_t offset, uint32_t width, 
     return wl_shm_pool_create_buffer(m_pool, offset, width, height, stride, WL_SHM_FORMAT_ARGB8888);
 }
 
+void WaylandSHMPool::write(std::span<const uint8_t> data, int offset)
+{
+    memcpySpan(mutableSpan().subspan(offset), data);
+}
+
+void WaylandSHMPool::write(std::span<const uint32_t> data, int offset)
+{
+    write(asBytes(data), offset);
+}
+
 } // namespace WPE

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSHMPool.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSHMPool.h
@@ -39,14 +39,14 @@ public:
     WaylandSHMPool(void*, size_t, WTF::UnixFileDescriptor&&, struct wl_shm*);
     ~WaylandSHMPool();
 
-    void* data() const { return m_data; }
-    size_t size() const { return m_size; }
-
     int allocate(size_t);
     struct wl_buffer* createBuffer(uint32_t offset, uint32_t width, uint32_t height, uint32_t stride);
+    void write(std::span<const uint8_t> data, int offset = 0);
+    void write(std::span<const uint32_t> data, int offset = 0);
 
 private:
     bool resize(size_t);
+    std::span<uint8_t> mutableSpan() LIFETIME_BOUND { return unsafeMakeSpan<uint8_t>(static_cast<uint8_t*>(m_data), m_size); }
 
     void* m_data { nullptr };
     size_t m_size { 0 };


### PR DESCRIPTION
#### 0510ca13e5289b78a74417d5b12cb8bfdadde57a
<pre>
[WPE] WPE Platform: use memcpySpan instead of memcpy to write in SHM pool
<a href="https://bugs.webkit.org/show_bug.cgi?id=294830">https://bugs.webkit.org/show_bug.cgi?id=294830</a>

Reviewed by Adrian Perez de Castro.

Canonical link: <a href="https://commits.webkit.org/297108@main">https://commits.webkit.org/297108@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dea0a43effa362577e77b93e22560dacc539689a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110590 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20682 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/116616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/60857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30928 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38838 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/116616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/60857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113538 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/24697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/99577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/116616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/24060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/60411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/94083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/17776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119406 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37630 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/27944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/93062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/38004 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/95848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/92884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/15637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/33605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17837 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37525 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42996 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37188 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/40527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38896 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->