### PR TITLE
Enforce adoption of Dispatched(From|To) across message receivers

### DIFF
--- a/Source/WebKit/GPUProcess/RemoteSharedResourceCache.messages.in
+++ b/Source/WebKit/GPUProcess/RemoteSharedResourceCache.messages.in
@@ -22,7 +22,11 @@
 
 #if ENABLE(GPU_PROCESS)
 
-[ExceptionForEnabledBy]
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=GPU,
+    ExceptionForEnabledBy
+]
 messages -> RemoteSharedResourceCache {
     void ReleaseSerializedImageBuffer(WebKit::RemoteSerializedImageBufferIdentifier identifier)
 }

--- a/Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.messages.in
@@ -22,7 +22,11 @@
 
 #if USE(GRAPHICS_LAYER_WC)
 
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> RemoteWCLayerTreeHost {
     Update(struct WebKit::WCUpdateInfo updateInfo) -> (std::optional<WebKit::UpdateInfo> updateInfo)
 }

--- a/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.messages.in
+++ b/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.messages.in
@@ -26,6 +26,7 @@
 // rdar://140690546 - Can currently be dispatchedTo UI & GPU
 [
     DispatchedFrom=WebContent,
+    ExceptionForDispatchedTo,
     ExceptionForEnabledBy
 ]
 messages -> UserMediaCaptureManagerProxy {

--- a/Source/WebKit/Scripts/generate-derived-log-sources.py
+++ b/Source/WebKit/Scripts/generate-derived-log-sources.py
@@ -12,7 +12,11 @@ def generate_messages_file(log_messages, log_messages_receiver_input_file, strea
 
     with open(log_messages_receiver_input_file, 'w') as file:
         file.write("#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)\n")
-        file.write("[ExceptionForEnabledBy]\n")
+        file.write("[\n")
+        file.write("    DispatchedFrom=WebContent,\n")
+        file.write("    DispatchedTo=UI,\n")
+        file.write("    ExceptionForEnabledBy\n")
+        file.write("]\n")
         file.write("messages -> LogStream ")
         if streaming_ipc:
             file.write("Stream ")

--- a/Source/WebKit/Scripts/generate-message-receiver.py
+++ b/Source/WebKit/Scripts/generate-message-receiver.py
@@ -56,6 +56,8 @@ def main(argv):
             with open('%s/%s.messages.in' % (base_dir, message_receiver)) as source_file:
                 receiver = webkit.parser.parse(source_file)
 
+        receiver.enforce_attribute_constraints()
+
         receivers.append(receiver)
         if receiver_name != receiver.name:
             sys.stderr.write("Error: %s defined in file %s/%s.messages.in instead of %s.messages.in\n" % (receiver.name, base_dir, message_receiver, receiver.name))

--- a/Source/WebKit/Scripts/webkit/model_unittest.py
+++ b/Source/WebKit/Scripts/webkit/model_unittest.py
@@ -39,18 +39,26 @@ class ModelCheckTest(unittest.TestCase):
 
     def test_duplicate_receivers(self):
         contents = """
-messages -> WebPage {
-    LoadURL(String url)
-}"""
+        [
+            ExceptionForDispatchedFrom,
+            ExceptionForDispatchedTo
+        ]
+        messages -> WebPage {
+            LoadURL(String url)
+        }"""
         receiver = parser.parse(StringIO(contents))
         self.assertEqual(receiver.name, 'WebPage')
         self.assertEqual(receiver.messages[0].name, 'LoadURL')
 
         other_contents = """
-    messages -> WebPage {
-        LoadURL(String url)
-        LoadURL2(String url)
-    }"""
+        [
+            ExceptionForDispatchedFrom,
+            ExceptionForDispatchedTo
+        ]
+        messages -> WebPage {
+            LoadURL(String url)
+            LoadURL2(String url)
+        }"""
 
         other_receiver = parser.parse(StringIO(other_contents))
         self.assertEqual(other_receiver.name, 'WebPage')
@@ -62,14 +70,18 @@ messages -> WebPage {
 
     def test_mismatch_message_attribute_sync(self):
         contents = """
-messages -> WebPage {
-#if USE(COCOA)
-    LoadURL(String url) Synchronous
-#endif
-#if USE(GTK)
-    LoadURL(String url)
-#endif
-}"""
+        [
+            ExceptionForDispatchedFrom,
+            ExceptionForDispatchedTo
+        ]
+        messages -> WebPage {
+        #if USE(COCOA)
+            LoadURL(String url) Synchronous
+        #endif
+        #if USE(GTK)
+            LoadURL(String url)
+        #endif
+        }"""
         receiver = parser.parse(StringIO(contents))
         self.assertEqual(receiver.name, 'WebPage')
         self.assertEqual(receiver.messages[0].name, 'LoadURL')

--- a/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBuffer.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBuffer.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> TestWithCVPixelBuffer {
 #if USE(AVFOUNDATION)
     void SendCVPixelBuffer(RetainPtr<CVPixelBufferRef> s0)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithDeferSendingOption.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithDeferSendingOption.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[EnabledBy=SomeFeature]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    EnabledBy=SomeFeature
+]
 messages -> TestWithDeferSendingOption {
     NoOptions(String url)
     [DeferSendingIfSuspended] NoIndices(String url)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithEnabledBy.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithEnabledBy.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[SharedPreferencesNeedsConnection]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    SharedPreferencesNeedsConnection
+]
 messages -> TestWithEnabledBy {
     [ExceptionForEnabledBy] AlwaysEnabled(String url)
     [EnabledBy=SomeFeature] ConditionallyEnabled(String url)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithEnabledByAndConjunction.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithEnabledByAndConjunction.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[EnabledBy=SomeFeature && OtherFeature]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    EnabledBy=SomeFeature && OtherFeature
+]
 messages -> TestWithEnabledByAndConjunction {
     AlwaysEnabled(String url)
 }

--- a/Source/WebKit/Scripts/webkit/tests/TestWithEnabledByOrConjunction.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithEnabledByOrConjunction.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[EnabledBy=SomeFeature || OtherFeature]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    EnabledBy=SomeFeature || OtherFeature
+]
 messages -> TestWithEnabledByOrConjunction {
     AlwaysEnabled(String url)
 }

--- a/Source/WebKit/Scripts/webkit/tests/TestWithIfMessage.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithIfMessage.messages.in
@@ -22,7 +22,11 @@
 
 # Tests scenario where #if'ed message should generate isValidMessageName() == true for
 # both cases.
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> TestWithIfMessage {
 #if PLATFORM(COCOA)
     void LoadURL(String url)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithIfReceiver.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithIfReceiver.messages.in
@@ -24,6 +24,10 @@
 // top-level #if, avoiding generic #include for ApplePayPaymentAuthorizationResult.
 
 #if ENABLE(APPLE_PAY)
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo
+]
 messages -> TestWithIfReceiver {
     CompletePaymentSession(struct WebCore::ApplePayPaymentAuthorizationResult result)
 }

--- a/Source/WebKit/Scripts/webkit/tests/TestWithImageData.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithImageData.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> TestWithImageData {
     void SendImageData(RefPtr<WebCore::ImageData> s0)
     void ReceiveImageData() -> (RefPtr<WebCore::ImageData> r0)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiver.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiver.messages.in
@@ -23,7 +23,11 @@
 #if ENABLE(WEBKIT2)
 #if NESTED_MASTER_CONDITION || MASTER_OR && MASTER_AND
 
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> TestWithLegacyReceiver {
     LoadURL(String url)
 #if ENABLE(TOUCH_EVENTS)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSemaphore.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSemaphore.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> TestWithSemaphore {
     void SendSemaphore(IPC::Semaphore s0)
     void ReceiveSemaphore() -> (IPC::Semaphore r0)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSpanOfConst.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSpanOfConst.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> TestWithSpanOfConst {
     TestSpanOfConstFloat(std::span<const float> floats);
     TestSpanOfConstFloatSegments(std::span<const WebCore::FloatSegment> floatSegments);

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStream.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStream.messages.in
@@ -21,7 +21,11 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # Tests Stream receiver attribute.
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> TestWithStream Stream {
     void SendString(String url)
     void SendStringAsync(String url) -> (int64_t returnValue)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatched.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatched.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 # Tests StreamBatched message attribute.
 messages -> TestWithStreamBatched Stream {
     void SendString(String url) StreamBatched

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBuffer.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBuffer.messages.in
@@ -21,7 +21,11 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # Tests Stream receiver attribute.
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> TestWithStreamBuffer  {
     void SendStreamBuffer(IPC::StreamConnectionBuffer stream)
 }

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandle.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandle.messages.in
@@ -21,7 +21,11 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # Tests Stream receiver attribute.
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> TestWithStreamServerConnectionHandle  {
     void SendStreamServerConnection(IPC::StreamServerConnectionHandle handle)
 }

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclass.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclass.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> TestWithSuperclass : WebPageBase {
     LoadURL(String url)
 #if ENABLE(TEST_FEATURE)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassAndWantsAsyncDispatch.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassAndWantsAsyncDispatch.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> TestWithSuperclassAndWantsAsyncDispatch : WebPageBase WantsAsyncDispatchMessage {
     LoadURL(String url)
     TestSyncMessage(uint32_t param) -> (uint8_t reply) Synchronous

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassAndWantsDispatch.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassAndWantsDispatch.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> TestWithSuperclassAndWantsDispatch : WebPageBase WantsDispatchMessage {
     LoadURL(String url)
     TestSyncMessage(uint32_t param) -> (uint8_t reply) Synchronous

--- a/Source/WebKit/Scripts/webkit/tests/TestWithValidator.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithValidator.messages.in
@@ -21,6 +21,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 [
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
     WantsSendCancelReply,
     EnabledBy=SomeOtherFeature
 ]

--- a/Source/WebKit/Scripts/webkit/tests/TestWithWantsAsyncDispatch.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithWantsAsyncDispatch.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> TestWithWantsAsyncDispatch WantsAsyncDispatchMessage {
     TestMessage(String url)
     TestSyncMessage(uint32_t param) -> (uint8_t reply) Synchronous

--- a/Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatch.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatch.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> TestWithWantsDispatch WantsDispatchMessage {
     TestMessage(String url)
     TestSyncMessage(uint32_t param) -> (uint8_t reply) Synchronous

--- a/Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatchNoSyncMessages.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatchNoSyncMessages.messages.in
@@ -22,7 +22,11 @@
 
 // Tests that WantsDispatchMessage generates sync message handing even though 
 // the message list does not have sync messages.
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> TestWithWantsDispatchNoSyncMessages WantsDispatchMessage {
     TestMessage(String url)
 }

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributes.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributes.messages.in
@@ -30,7 +30,11 @@
     #FakeLoadURLC(String url)
     # FakeLoadURLD(String url)
 
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> TestWithoutAttributes {
     LoadURL(String url)
 #if ENABLE(TOUCH_EVENTS)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnection.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnection.messages.in
@@ -22,7 +22,11 @@
 
 # Tests various parts of generating message handlers that work with custom transport (e.g. not an IPC Conneciton)
 
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> TestWithoutUsingIPCConnection NotUsingIPCConnection {
     void MessageWithoutArgument()
     void MessageWithoutArgumentAndEmptyReply() -> ()

--- a/Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.messages.in
+++ b/Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> RemoteObjectRegistry {
     InvokeMethod(WebKit::RemoteObjectInvocation invocation)
     CallReplyBlock(uint64_t replyID, WebKit::UserData blockInvocation);

--- a/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.messages.in
+++ b/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.messages.in
@@ -27,6 +27,7 @@
 // Currently DispatchedTo=Networking when APPLE_PAY_REMOTE_UI and DispatchedTo=UI when !APPLE_PAY_REMOTE_UI
 [
     DispatchedFrom=WebContent,
+    ExceptionForDispatchedTo,
     EnabledBy=ApplePayEnabled
 ]
 messages -> WebPaymentCoordinatorProxy {

--- a/Source/WebKit/Shared/AuxiliaryProcess.messages.in
+++ b/Source/WebKit/Shared/AuxiliaryProcess.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> AuxiliaryProcess WantsDispatchMessage {
     ShutDown()
     SetProcessSuppressionEnabled(bool flag)

--- a/Source/WebKit/Shared/IPCConnectionTester.messages.in
+++ b/Source/WebKit/Shared/IPCConnectionTester.messages.in
@@ -22,7 +22,11 @@
 
 #if ENABLE(IPC_TESTING_API)
 
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> IPCConnectionTester {
     AsyncMessage(uint32_t value)
     SyncMessage(uint32_t value) -> (uint32_t sameValue) Synchronous

--- a/Source/WebKit/Shared/IPCStreamTester.messages.in
+++ b/Source/WebKit/Shared/IPCStreamTester.messages.in
@@ -22,7 +22,11 @@
 
 #if ENABLE(IPC_TESTING_API)
 
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> IPCStreamTester Stream {
     SyncMessage(uint32_t value) -> (uint32_t sameValue) Synchronous
     SyncMessageNotStreamEncodableReply(uint32_t value) -> (uint32_t sameValue) Synchronous NotStreamEncodableReply

--- a/Source/WebKit/Shared/IPCStreamTesterProxy.messages.in
+++ b/Source/WebKit/Shared/IPCStreamTesterProxy.messages.in
@@ -22,7 +22,11 @@
 
 #if ENABLE(IPC_TESTING_API)
 
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> IPCStreamTesterProxy {
     void WasCreated(IPC::Semaphore streamWakeUpSemaphore, IPC::Semaphore streamClientWaitSemaphore)
 }

--- a/Source/WebKit/Shared/IPCTester.messages.in
+++ b/Source/WebKit/Shared/IPCTester.messages.in
@@ -22,7 +22,11 @@
 
 #if ENABLE(IPC_TESTING_API)
 
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> IPCTester {
     StartMessageTesting(String driverName)
     StopMessageTesting() -> () Synchronous

--- a/Source/WebKit/Shared/IPCTesterReceiver.messages.in
+++ b/Source/WebKit/Shared/IPCTesterReceiver.messages.in
@@ -22,7 +22,11 @@
 
 #if ENABLE(IPC_TESTING_API)
 
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> IPCTesterReceiver {
     void AsyncMessage(uint32_t arg1) -> (uint32_t reply) Asynchronous
 }

--- a/Source/WebKit/Shared/LogStream.messages.in
+++ b/Source/WebKit/Shared/LogStream.messages.in
@@ -23,7 +23,11 @@
 
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
 
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> LogStream Stream {
     LogOnBehalfOfWebContent(std::span<const uint8_t> logChannel, std::span<const uint8_t> logCategory, std::span<const uint8_t> logString, uint8_t logType)
 }

--- a/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.messages.in
+++ b/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[SharedPreferencesNeedsConnection]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    SharedPreferencesNeedsConnection
+]
 messages -> NotificationManagerMessageHandler {
 #if ENABLE(NOTIFICATIONS)
     [EnabledBy=NotificationsEnabled] ShowNotification(struct WebCore::NotificationData notificationData, RefPtr<WebCore::NotificationResources> notificationResources) -> ()

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.messages.in
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[ExceptionForEnabledBy]
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=UI,
+    ExceptionForEnabledBy
+]
 messages -> WebAutomationSession {
     LogEntryAdded(enum:uint8_t JSC::MessageSource messageSource, enum:uint8_t JSC::MessageLevel messageLevel, String messageText, enum:uint8_t JSC::MessageType messageType, WallTime timestamp)
 }

--- a/Source/WebKit/UIProcess/glib/AcceleratedBackingStore.messages.in
+++ b/Source/WebKit/UIProcess/glib/AcceleratedBackingStore.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> AcceleratedBackingStore {
     DidCreateDMABufBuffer(uint64_t id, WebCore::IntSize size, uint32_t format, Vector<UnixFileDescriptor> fds, Vector<uint32_t> offsets, Vector<uint32_t> strides, uint64_t modifier, WebKit::RendererBufferFormat::Usage usage)
     DidCreateSHMBuffer(uint64_t id, WebCore::ShareableBitmapHandle handle)

--- a/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.messages.in
+++ b/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.messages.in
@@ -26,6 +26,7 @@
 
 // Currently DispatchedFrom=Networking when APPLE_PAY_REMOTE_UI and DispatchedFrom=UI when !APPLE_PAY_REMOTE_UI
 [
+    ExceptionForDispatchedFrom,
     DispatchedTo=WebContent
 ]
 messages -> WebPaymentCoordinator {

--- a/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS) && PLATFORM(IOS_FAMILY)
 
 [
+    DispatchedFrom=GPU,
     DispatchedTo=WebContent
 ]
 messages -> RemoteMediaSessionHelper {

--- a/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.messages.in
+++ b/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[ExceptionForEnabledBy]
+[
+    DispatchedFrom=UI,
+    DispatchedTo=WebContent,
+    ExceptionForEnabledBy
+]
 messages -> WebGeolocationManager {
     DidChangePosition(WebCore::RegistrableDomain registrableDomain, WebCore::GeolocationPositionData position);
     DidFailToDeterminePosition(WebCore::RegistrableDomain registrableDomain, String errorMessage);

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.messages.in
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.messages.in
@@ -21,6 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 [
+    ExceptionForDispatchedFrom,
     DispatchedTo=WebContent
 ]
 messages -> WebInspectorUI {

--- a/Source/WebKit/WebProcess/Notifications/WebNotificationManager.messages.in
+++ b/Source/WebKit/WebProcess/Notifications/WebNotificationManager.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> WebNotificationManager {
     DidShowNotification(WTF::UUID notificationID);
     DidClickNotification(WTF::UUID notificationID);

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.messages.in
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.messages.in
@@ -22,6 +22,7 @@
 
 // Currently being DispatchedFrom both the UI and Networking Process
 [
+    ExceptionForDispatchedFrom,
     DispatchedTo=WebContent
 ]
 messages -> WebSWContextManagerConnection {

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.messages.in
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.messages.in
@@ -22,6 +22,7 @@
 
 // Currently DispatchedFrom both the UI and Network Process
 [
+    ExceptionForDispatchedFrom,
     DispatchedTo=WebContent
 ]
 messages -> WebSharedWorkerContextManagerConnection {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.messages.in
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.messages.in
@@ -23,7 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
  
- [
+[
     DispatchedFrom=UI,
     DispatchedTo=WebContent
 ]

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.messages.in
@@ -20,7 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> AcceleratedSurface {
     ReleaseBuffer(uint64_t id, UnixFileDescriptor releaseFence)
     FrameDone()

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -22,6 +22,7 @@
 
 // Currently DispatchedFrom both the Networking and UI process
 [
+    ExceptionForDispatchedFrom,
     DispatchedTo=WebContent
 ]
 messages -> WebPage WantsAsyncDispatchMessage {

--- a/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.messages.in
+++ b/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.messages.in
@@ -25,6 +25,7 @@
 
 // rdar://140690546 - Can currently be dispatchedFrom UI & GPU
 [
+    ExceptionForDispatchedFrom,
     DispatchedTo=WebContent
 ]
 messages -> RemoteCaptureSampleManager {

--- a/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.messages.in
+++ b/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.messages.in
@@ -25,6 +25,7 @@
 
 // rdar://140690546 - Can currently be dispatchedFrom UI & GPU
 [
+    ExceptionForDispatchedFrom,
     DispatchedTo=WebContent
 ]
 messages -> UserMediaCaptureManager {

--- a/Source/WebKit/WebProcess/glib/SystemSettingsManager.messages.in
+++ b/Source/WebKit/WebProcess/glib/SystemSettingsManager.messages.in
@@ -21,7 +21,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> SystemSettingsManager {
     DidChange(struct WebCore::SystemSettings::State state)
 }

--- a/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.messages.in
+++ b/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.messages.in
@@ -23,7 +23,11 @@
 
 #if ENABLE(MEDIA_STREAM)
 
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> UserMediaCaptureManager {
     ValidateUserMediaRequestConstraints(struct WebCore::MediaStreamRequest request, struct WebCore::MediaDeviceHashSalts mediaDeviceIdentifierHashSalts) -> (Expected<WebCore::RealtimeMediaSourceCenter::ValidDevices, WebCore::MediaConstraintType> result)
     GetMediaStreamDevices(bool revealIdsAndLabels) -> (Vector<WebCore::CaptureDeviceWithCapabilities> devices)

--- a/Source/WebKit/webpushd/PushClientConnection.messages.in
+++ b/Source/WebKit/webpushd/PushClientConnection.messages.in
@@ -22,7 +22,11 @@
 
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
 
-[ExceptionForEnabledBy]
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
+    ExceptionForEnabledBy
+]
 messages -> WebPushD::PushClientConnection NotUsingIPCConnection {
     SetPushAndNotificationsEnabledForOrigin(String originString, bool enabled) -> ()
     GetPendingPushMessage() -> (struct std::optional<WebKit::WebPushMessage> message)

--- a/Tools/Scripts/webkitpy/style/checkers/messagesin_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/messagesin_unittest.py
@@ -33,7 +33,10 @@ class MessagesInCheckerStyleTestCase(unittest.TestCase):
     """Test MessagesInChecker style checking issues."""
 
     test_file_content = """#if ENABLE(SOME_GUARD)
-
+[
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo
+]
 messages -> GoodName {
     # BadHandler contains WTF:: prefix that should raise an error
 \tBadHandler(Vector<WTF::String> list) -> (bool result)
@@ -46,8 +49,8 @@ messages -> GoodName {
 """
 
     expected_errors = set([
-        (5, 'whitespace/tab', 5, 'Line contains tab character.'),
-        (5, 'build/messagesin/wtf', 5, 'Line contains WTF:: prefix.'),
+        (8, 'whitespace/tab', 5, 'Line contains tab character.'),
+        (8, 'build/messagesin/wtf', 5, 'Line contains WTF:: prefix.'),
     ])
 
     def test_checker(self):


### PR DESCRIPTION
#### c6389c6268ff2ccb00c3ee1479fefb10e38b8405
<pre>
Enforce adoption of Dispatched(From|To) across message receivers
<a href="https://bugs.webkit.org/show_bug.cgi?id=294835">https://bugs.webkit.org/show_bug.cgi?id=294835</a>
<a href="https://rdar.apple.com/problem/154096608">rdar://problem/154096608</a>

Reviewed by Alex Christensen.

This PR enforces adoption of Dispatched(From|To) across our IPC receivers.
It introduces a pair of new ExceptionForDispatched(From|To) which can be
used in places where we still rely on multiple processes interacting
with a single receiver. The intention is to burn these down for all but
explcitly shared receivers.

* Source/WebKit/GPUProcess/RemoteSharedResourceCache.messages.in:
* Source/WebKit/GPUProcess/media/RemoteMediaRecorderPrivateWriterManager.messages.in:
* Source/WebKit/Scripts/generate-derived-log-sources.py:
(generate_messages_file):
* Source/WebKit/Scripts/webkit/parser.py:
(parse):
* Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBuffer.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithEnabledBy.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithEnabledByAndConjunction.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithEnabledByOrConjunction.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithIfMessage.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithIfReceiver.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithImageData.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiver.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithSemaphore.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithSpanOfConst.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithStream.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBatched.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBuffer.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandle.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclass.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclassAndWantsAsyncDispatch.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclassAndWantsDispatch.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithWantsAsyncDispatch.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatch.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatchNoSyncMessages.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithoutAttributes.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnection.messages.in:
* Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.messages.in:
* Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.messages.in:
* Source/WebKit/Shared/AuxiliaryProcess.messages.in:
* Source/WebKit/Shared/IPCConnectionTester.messages.in:
* Source/WebKit/Shared/IPCStreamTester.messages.in:
* Source/WebKit/Shared/IPCStreamTesterProxy.messages.in:
* Source/WebKit/Shared/IPCTester.messages.in:
* Source/WebKit/Shared/IPCTesterReceiver.messages.in:
* Source/WebKit/Shared/LogStream.messages.in:
* Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.messages.in:
* Source/WebKit/UIProcess/Automation/WebAutomationSession.messages.in:
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.messages.in:
* Source/WebKit/UIProcess/dmabuf/AcceleratedBackingStoreDMABuf.messages.in:
* Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.messages.in:
* Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.messages.in:
* Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.messages.in:
* Source/WebKit/WebProcess/Inspector/WebInspectorUI.messages.in:
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.messages.in:
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.messages.in:
* Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.messages.in:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.messages.in:
* Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.messages.in:
* Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.messages.in:
* Source/WebKit/WebProcess/glib/SystemSettingsManager.messages.in:
* Source/WebKit/WebProcess/glib/UserMediaCaptureManager.messages.in:
* Source/WebKit/webpushd/PushClientConnection.messages.in:

Canonical link: <a href="https://commits.webkit.org/298555@main">https://commits.webkit.org/298555@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a01a4a48be71d49c98ef724aff73966d532b6f48

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115751 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35414 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25937 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121799 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66286 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e1638480-9f06-4997-9cfb-55c2b59600d5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117640 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36095 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43997 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87924 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/90d2dbcf-0ad2-439a-933f-d6ad3f9d6c50) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118699 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28794 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103867 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68325 "Passed tests") | | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/115125 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27933 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21982 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65470 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98182 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22103 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124949 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42646 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31980 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96682 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43013 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100056 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96468 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24566 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41734 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19587 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38579 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42537 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48109 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42010 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45340 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43718 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->