### PR TITLE
[EME][GStreamer][Thunder] Fix crash with garbage collected CDMInstance

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
@@ -501,7 +501,11 @@ void CDMInstanceSessionThunder::requestLicense(LicenseType licenseType, KeyGroup
 
     // FIXME: UUID or system ID?
     auto instance = cdmInstanceThunder();
-    ASSERT(instance);
+    if (!instance) {
+        GST_WARNING("no instance, bailing out");
+        callback(WTFMove(initDataSharedBuffer), { }, false, Failed);
+        return;
+    }
     m_initData = InitData(instance->keySystem(), WTFMove(initDataSharedBuffer));
 
     GST_TRACE("Going to request a new session id, init data size %zu", m_initData.payload()->size());


### PR DESCRIPTION
#### 3cd5b617ea439dd479ad9af8db7fda8806cae71e
<pre>
[EME][GStreamer][Thunder] Fix crash with garbage collected CDMInstance
<a href="https://bugs.webkit.org/show_bug.cgi?id=294833">https://bugs.webkit.org/show_bug.cgi?id=294833</a>

Reviewed by Philippe Normand.

There was a crash in certain situations where the CDMInstance got garbage collected, which made it crash as there was no
valid object. Now we just bail out and warn.

* Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp:
(WebCore::CDMInstanceSessionThunder::requestLicense):

Canonical link: <a href="https://commits.webkit.org/296608@main">https://commits.webkit.org/296608@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ee45d74c158d6dc585747bafc0706d943122beb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109048 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28709 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114259 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59361 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111011 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29391 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37275 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82870 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111996 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23376 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98218 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63312 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22780 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16357 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58947 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92746 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16403 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117377 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36097 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26682 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91882 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36468 "Hash 3ee45d74 for PR 47057 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94482 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91687 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23342 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14352 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31953 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35994 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41505 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35691 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39029 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37376 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->