### PR TITLE
DOMCacheStorage methods can assert in Debug

### DIFF
--- a/LayoutTests/http/tests/cache-storage/page-cache-domcache-pending-promise.html
+++ b/LayoutTests/http/tests/cache-storage/page-cache-domcache-pending-promise.html
@@ -24,6 +24,51 @@ window.addEventListener("pageshow", function(event) {
 
 function tryCache()
 {
+    caches.open("foo").then(() => {
+        setTimeout(tryCache2, 0);
+    }, (e) => {
+        setTimeout(tryCache, 0);
+    });
+}
+
+function tryCache2()
+{
+    caches.keys().then(() => {
+        setTimeout(tryCache3, 0);
+    }, (e) => {
+        setTimeout(tryCache2, 0);
+    });
+}
+
+function tryCache3()
+{
+    caches.delete("notfound").then(() => {
+        setTimeout(tryCache4, 0);
+    }, (e) => {
+        setTimeout(tryCache3, 0);
+    });
+}
+
+function tryCache4()
+{
+    caches.has("paage-cache-test").then(() => {
+        setTimeout(tryCache5, 0);
+    }, (e) => {
+        setTimeout(tryCache4, 0);
+    });
+}
+
+function tryCache5()
+{
+    caches.match("x").then((response) => {
+        setTimeout(tryCache6, 0);
+    }, (e) => {
+        setTimeout(tryCache5, 0);
+    });
+}
+
+function tryCache6()
+{
     cache.add('../navigation/resources/blank.txt').then(() => {
         if (!restoredFromPageCache) {
             setTimeout(tryCache, 0);
@@ -33,7 +78,7 @@ function tryCache()
         clearTimeout(handle2);
         finishJSTest();
     }, (e) => {
-        setTimeout(tryCache, 0);
+        setTimeout(tryCache6, 0);
     });
 }
 

--- a/Source/WebCore/Modules/cache/DOMCacheStorage.cpp
+++ b/Source/WebCore/Modules/cache/DOMCacheStorage.cpp
@@ -115,7 +115,9 @@ void DOMCacheStorage::match(DOMCache::RequestInfo&& info, MultiCacheQueryOptions
 {
     retrieveCaches([this, info = WTFMove(info), options = WTFMove(options), promise = WTFMove(promise)](std::optional<Exception>&& exception) mutable {
         if (exception) {
-            promise->reject(WTFMove(*exception));
+            queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [promise = WTFMove(promise), exception = WTFMove(exception.value())](auto&) mutable {
+                promise->reject(WTFMove(exception));
+            });
             return;
         }
 
@@ -137,7 +139,9 @@ void DOMCacheStorage::has(const String& name, DOMPromiseDeferred<IDLBoolean>&& p
 {
     retrieveCaches([this, name, promise = WTFMove(promise)](std::optional<Exception>&& exception) mutable {
         if (exception) {
-            promise.reject(WTFMove(exception.value()));
+            queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [promise = WTFMove(promise), exception = WTFMove(exception.value())](auto&) mutable {
+                promise.reject(WTFMove(exception));
+            });
             return;
         }
         promise.resolve(m_caches.findIf([&](auto& item) { return item->name() == name; }) != notFound);
@@ -225,7 +229,9 @@ void DOMCacheStorage::open(const String& name, DOMPromiseDeferred<IDLInterface<D
 {
     retrieveCaches([this, name, promise = WTFMove(promise)](std::optional<Exception>&& exception) mutable {
         if (exception) {
-            promise.reject(WTFMove(*exception));
+            queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [promise = WTFMove(promise), exception = WTFMove(exception.value())](auto&) mutable {
+                promise.reject(WTFMove(exception));
+            });
             return;
         }
         doOpen(name, WTFMove(promise));
@@ -269,7 +275,9 @@ void DOMCacheStorage::remove(const String& name, DOMPromiseDeferred<IDLBoolean>&
 {
     retrieveCaches([this, name, promise = WTFMove(promise)](std::optional<Exception>&& exception) mutable {
         if (exception) {
-            promise.reject(WTFMove(*exception));
+            queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [promise = WTFMove(promise), exception = WTFMove(exception.value())](auto&) mutable {
+                promise.reject(WTFMove(exception));
+            });
             return;
         }
         doRemove(name, WTFMove(promise));
@@ -296,7 +304,9 @@ void DOMCacheStorage::keys(KeysPromise&& promise)
 {
     retrieveCaches([this, promise = WTFMove(promise)](std::optional<Exception>&& exception) mutable {
         if (exception) {
-            promise.reject(WTFMove(exception.value()));
+            queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [promise = WTFMove(promise), exception = WTFMove(exception.value())](auto&) mutable {
+                promise.reject(WTFMove(exception));
+            });
             return;
         }
 


### PR DESCRIPTION
#### 314f2e989894f28574d87471da5fc40201781edc
<pre>
DOMCacheStorage methods can assert in Debug
<a href="https://bugs.webkit.org/show_bug.cgi?id=294839">https://bugs.webkit.org/show_bug.cgi?id=294839</a>

Reviewed by Chris Dumez.

DOMCacheStorage methods can assert in Debug when a DOMCacheStorage promise is rejected while
the page is suspended, use a similar solution like in r250786 to fix this.

* LayoutTests/http/tests/cache-storage/page-cache-domcache-pending-promise.html:
* Source/WebCore/Modules/cache/DOMCacheStorage.cpp:
(WebCore::DOMCacheStorage::match):
(WebCore::DOMCacheStorage::has):
(WebCore::DOMCacheStorage::open):
(WebCore::DOMCacheStorage::remove):
(WebCore::DOMCacheStorage::keys):

Canonical link: <a href="https://commits.webkit.org/297015@main">https://commits.webkit.org/297015@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac6d4a1394bab711ad7a05d7da287db4435a53ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28565 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114113 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59250 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110868 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37131 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82753 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111853 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23250 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98094 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63192 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22671 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16231 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58812 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92625 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16277 "Found 1 new test failure: fast/mediastream/play-newly-added-audio-track.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117233 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35955 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26567 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91766 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36327 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94358 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91573 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23608 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36480 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14237 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31816 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35854 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41380 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35555 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38897 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37240 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->