### PR TITLE
SWServer is being registered a client with a potentially wrong origin in case of load transfer

### DIFF
--- a/LayoutTests/http/tests/workers/service/resultingClientId.https.html
+++ b/LayoutTests/http/tests/workers/service/resultingClientId.https.html
@@ -38,6 +38,11 @@ async function setup()
     await waitForState(activeWorker, "activating");
 }
 
+function computeRedirectURL(path)
+{
+    return "http://127.0.0.1:8080/resources/redirect.py?url=http://localhost:8080/workers/service/" + path
+}
+
 async function checkIds()
 {
     activeWorker.postMessage("getResultingClientId");
@@ -49,7 +54,7 @@ async function checkIds()
     if (!self.step) {
         self.step = 1;
         self.withoutCoopResult = clientId === resultingClientId ? "PASS without coop" : "ids are not matching without coop: " + clientId + " vs. " + resultingClientId;
-        window.location = "resources/with-coop";
+        window.location = computeRedirectURL("resources/with-coop");
         return;
     }
 
@@ -59,11 +64,15 @@ async function checkIds()
         testRunner.notifyDone();
 }
 
-setup().then(async () => {
-    self.step = 0;
-    window.addEventListener("pageshow", checkIds);
-    window.location = "resources/without-coop";
-});
+if (window.location.host != "localhost:8080")
+    window.location = "http://localhost:8080" + window.location.pathname;
+else {
+    setup().then(async () => {
+        self.step = 0;
+        window.addEventListener("pageshow", checkIds);
+        window.location = computeRedirectURL("resources/without-coop");
+    });
+}
 </script>
 </body>
 </html>

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -673,7 +673,7 @@ void NetworkResourceLoader::transferToNewWebProcess(NetworkConnectionToWebProces
     ASSERT(m_responseCompletionHandler || m_cacheEntryWaitingForContinueDidReceiveResponse || m_serviceWorkerFetchTask);
     if (RefPtr serviceWorkerRegistration = m_serviceWorkerRegistration.get()) {
         if (RefPtr swConnection = newConnection.swConnection())
-            swConnection->transferServiceWorkerLoadToNewWebProcess(*this, *serviceWorkerRegistration, m_connection->webProcessIdentifier());
+            swConnection->transferServiceWorkerLoadToNewWebProcess(*this, *serviceWorkerRegistration, parameters.request);
     }
     if (m_workerStart)
         send(Messages::WebResourceLoader::SetWorkerStart { m_workerStart }, coreIdentifier());

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
@@ -866,9 +866,9 @@ void WebSWServerConnection::focusServiceWorkerClient(WebCore::ScriptExecutionCon
     sendWithAsyncReply(Messages::WebSWClientConnection::FocusServiceWorkerClient { clientIdentifier }, WTFMove(callback));
 }
 
-void WebSWServerConnection::transferServiceWorkerLoadToNewWebProcess(NetworkResourceLoader& loader, WebCore::SWServerRegistration& registration, WebCore::ProcessIdentifier webProcessIdentifier)
+void WebSWServerConnection::transferServiceWorkerLoadToNewWebProcess(NetworkResourceLoader& loader, WebCore::SWServerRegistration& registration, const WebCore::ResourceRequest& request)
 {
-    controlClient(loader.parameters(), registration, loader.originalRequest(), webProcessIdentifier);
+    controlClient(loader.parameters(), registration, request, loader.connectionToWebProcess().webProcessIdentifier());
 }
 
 std::optional<SWServer::GatheredClientData> WebSWServerConnection::gatherClientData(ScriptExecutionContextIdentifier clientIdentifier)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
@@ -97,7 +97,7 @@ public:
     RefPtr<ServiceWorkerFetchTask> createFetchTask(NetworkResourceLoader&, const WebCore::ResourceRequest&);
     void fetchTaskTimedOut(WebCore::ServiceWorkerIdentifier);
 
-    void transferServiceWorkerLoadToNewWebProcess(NetworkResourceLoader&, WebCore::SWServerRegistration&, WebCore::ProcessIdentifier);
+    void transferServiceWorkerLoadToNewWebProcess(NetworkResourceLoader&, WebCore::SWServerRegistration&, const WebCore::ResourceRequest&);
     std::optional<WebCore::SWServer::GatheredClientData> gatherClientData(WebCore::ScriptExecutionContextIdentifier);
 
     void registerServiceWorkerClient(WebCore::ClientOrigin&&, WebCore::ServiceWorkerClientData&&, const std::optional<WebCore::ServiceWorkerRegistrationIdentifier>&, String&& userAgent);


### PR DESCRIPTION
#### 687b1d8c28edad817a19de884599ba26cbf4923d
<pre>
SWServer is being registered a client with a potentially wrong origin in case of load transfer
<a href="https://rdar.apple.com/153775893">rdar://153775893</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=294836">https://bugs.webkit.org/show_bug.cgi?id=294836</a>

Reviewed by Chris Dumez.

In case of navigation redirection and process swap, we would reuse the original request URL to register the client.
This could trigger a mismatch as the client origin is with the most recent request URL.

The consequence is that we would register a client with an ID and an origin A.
And we would later on register a client with an ID and an origin B.

This is breaking the model in SWServer and would trigger a desynchronization of the internal maps, leading to a nullptr crash in SWServer::forEachClientForOrigin.

To prevent this, we update WebSWServerConnection::transferServiceWorkerLoadToNewWebProcess to use the most recent URL and not the original one.

Covered by updated test in debug with added assertion.

* LayoutTests/http/tests/workers/service/resultingClientId.https.html:
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::validateClientOrigin):
(WebCore::SWServer::registerServiceWorkerClient):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::transferToNewWebProcess):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp:
(WebKit::WebSWServerConnection::resolveUnregistrationJobInClient):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h:

Canonical link: <a href="https://commits.webkit.org/296552@main">https://commits.webkit.org/296552@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b566dcf4f1e299cb466a9906fa102e51c934640

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108826 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28486 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18911 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114034 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59185 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110789 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29170 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37050 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82687 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111774 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23179 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98020 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63126 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22603 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16157 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58739 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92551 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16205 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117155 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35876 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26500 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91702 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36249 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94286 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91512 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23310 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36408 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14167 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31748 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35776 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41308 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35478 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38823 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37163 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->