### PR TITLE
[check-webkit-style] Fix false positive parameter name errors for control structure keywords

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -1745,6 +1745,10 @@ def detect_functions(clean_lines, line_number, function_state, error):
     if function_name != 'TEST' and function_name != 'TEST_F' and match(r'[A-Z_]+$', function_name):
         return
 
+    # Skip control structure keywords that are not function declarations
+    if search(r'\b(if|for|while|switch|else)\b', line):
+        return
+
     joined_line = ''
     for start_line_number in range(line_number, clean_lines.num_lines()):
         start_line = clean_lines.elided[start_line_number]

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -6866,6 +6866,9 @@ class WebKitStyleTest(CppStyleTestBase):
                                             '{\n'
                                             '}\n', 'test.cpp', parameter_error_rules))
 
+        # Control structure keywords should not be treated as function declarations.
+        self.assertEqual('', self.perform_lint('else if (!condition || value != 0.0)\n    return;', 'test.cpp', parameter_error_rules))
+
     def test_split_identifier_into_words(self):
         self.assertEqual([], _split_identifier_into_words(''))
         self.assertEqual(['a'], _split_identifier_into_words('a'))


### PR DESCRIPTION
#### 85d2fd1f739bc3ed92d6f402e0205a8b3ac5ff5e
<pre>
[check-webkit-style] Fix false positive parameter name errors for control structure keywords
<a href="https://bugs.webkit.org/show_bug.cgi?id=294841">https://bugs.webkit.org/show_bug.cgi?id=294841</a>

Reviewed by NOBODY (OOPS!).

Control structure keywords (if, for, while, switch, else) were
incorrectly identified as function declarations, causing false
parameter name errors. This occurred when these keywords appeared
at global scope, particularly within macro function bodies that
are filtered out during function detection[1].

[1]: <a href="https://github.com/WebKit/WebKit/pull/43432#issuecomment-2772367119">https://github.com/WebKit/WebKit/pull/43432#issuecomment-2772367119</a>

* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(detect_functions):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(WebKitStyleTest.test_parameter_names):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85d2fd1f739bc3ed92d6f402e0205a8b3ac5ff5e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108776 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28437 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113986 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59155 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110739 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37001 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82646 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111724 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23145 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97980 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63084 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/108208 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22571 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16118 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58687 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92515 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16166 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117108 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35830 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26461 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91672 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36203 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94247 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91479 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23362 "Failed to checkout and rebase branch from PR 47061") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36374 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14128 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31714 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35730 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35440 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38786 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37118 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->