### PR TITLE
Slack is not recreating its web socket in case of network process crash

### DIFF
--- a/LayoutTests/http/tests/websocket/tests/hybi/network-process-crash-error-expected.txt
+++ b/LayoutTests/http/tests/websocket/tests/hybi/network-process-crash-error-expected.txt
@@ -1,4 +1,5 @@
 ALERT: Created a socket to 'ws://127.0.0.1:8880/websocket/tests/hybi/slow-reply'; readyState 0.
 ALERT: Terminating network process.
 ALERT: Received error:[object Event]
+ALERT: Closed; readyState 3.[object CloseEvent]
 

--- a/LayoutTests/http/tests/websocket/tests/hybi/network-process-crash-error.html
+++ b/LayoutTests/http/tests/websocket/tests/hybi/network-process-crash-error.html
@@ -24,7 +24,6 @@ ws.onopen = function()
 ws.onerror = function(e)
 {
     alert("Received error:" + e);
-    endTest();
 };
 
 ws.onclose = function(e)

--- a/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
@@ -355,7 +355,7 @@ void WebSocketChannel::didReceiveMessageError(String&& errorMessage)
 
 void WebSocketChannel::networkProcessCrashed()
 {
-    didReceiveMessageError("WebSocket network error: Network process crashed."_s);
+    fail("WebSocket network error: Network process crashed."_s);
 }
 
 void WebSocketChannel::suspend()

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -450,7 +450,7 @@
                 "expected": {"all": {"status": ["FAIL", "PASS"], "bug": "webkit.org/b/264507"}}
             },
             "/webkit/WebKitWebView/web-socket-tls-errors": {
-                "expected": {"all": {"status": ["TIMEOUT", "CRASH"], "bug": "webkit.org/b/286063"}}
+                "expected": {"all": {"status": ["TIMEOUT", "CRASH", "FAIL"], "bug": "webkit.org/b/286063"}}
             },
             "/webkit/WebKitWebView/web-socket-client-side-certificate": {
                 "expected": {"all": {"status": ["TIMEOUT", "CRASH"], "bug": "webkit.org/b/286063"}}


### PR DESCRIPTION
#### 58242111e7740d4968b59bdce4398bb8655a1d84
<pre>
Slack is not recreating its web socket in case of network process crash
<a href="https://rdar.apple.com/153243346">rdar://153243346</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=294842">https://bugs.webkit.org/show_bug.cgi?id=294842</a>

Reviewed by Anne van Kesteren.

Slack is reacting to onclose but not onerror.
In case of network process crash, we were firing an error event but not a close event.
We now fire a close event, which gets us closer to spec.
We add a FAIL expectation to web-socket-tls test since, in debug, network process may crash, which will trigger a close event now.

* LayoutTests/http/tests/websocket/tests/hybi/network-process-crash-error-expected.txt:
* LayoutTests/http/tests/websocket/tests/hybi/network-process-crash-error.html:
* Source/WebKit/WebProcess/Network/WebSocketChannel.cpp:
(WebKit::WebSocketChannel::networkProcessCrashed):
* Tools/TestWebKitAPI/glib/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/296607@main">https://commits.webkit.org/296607@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d1d74a87a051f1ce5a2bf06b105e133af537ddc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108892 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28552 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18977 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114101 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59240 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110855 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29236 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37118 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82742 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111840 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23237 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98082 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63181 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22658 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16219 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58800 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92611 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16265 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117221 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35942 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26556 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91753 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36315 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94346 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91560 "Found 2 new API test failures: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23341 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36469 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14225 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31804 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35841 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41368 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35542 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38886 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37228 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->