### PR TITLE
REGRESSION (296172@main): Crash when searching for products on lowes.com

### DIFF
--- a/LayoutTests/fast/forms/number/number-min-max-spinbutton-appearance-none-crash-expected.txt
+++ b/LayoutTests/fast/forms/number/number-min-max-spinbutton-appearance-none-crash-expected.txt
@@ -1,0 +1,3 @@
+PASS if no crash.
+
+

--- a/LayoutTests/fast/forms/number/number-min-max-spinbutton-appearance-none-crash.html
+++ b/LayoutTests/fast/forms/number/number-min-max-spinbutton-appearance-none-crash.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+input::-webkit-inner-spin-button {
+    appearance: none;
+}
+
+</style>
+</head>
+<body>
+<p>PASS if no crash.</p>
+<input type="number" min="0" max="10">
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/NumberInputType.cpp
+++ b/Source/WebCore/html/NumberInputType.cpp
@@ -208,8 +208,11 @@ float NumberInputType::decorationWidth() const
         // Since the width of spinRenderer is not calculated yet, spinRenderer->logicalWidth() returns 0.
         // So computedStyle()->logicalWidth() is used instead.
 
-        // FIXME: Document what invariant holds to allow not checking if the logicalWidth() is fixed.
-        width += spinButton->computedStyle()->logicalWidth().tryFixed()->value;
+        // FIXME <https://webkit.org/b/294858>: This is incorrect for anything other than fixed widths.
+        if (auto fixedLogicalWidth = spinButton->computedStyle()->logicalWidth().tryFixed())
+            width += fixedLogicalWidth->value;
+        else if (auto percentageLogicalWidth = spinButton->computedStyle()->logicalWidth().tryPercentage())
+            width += percentageLogicalWidth->value;
     }
     return width;
 }


### PR DESCRIPTION
#### 95ed1aab1df31fbc852a890436729cab2414715a
<pre>
REGRESSION (296172@main): Crash when searching for products on lowes.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=294857">https://bugs.webkit.org/show_bug.cgi?id=294857</a>
<a href="https://rdar.apple.com/153989680">rdar://153989680</a>

Reviewed by Abrar Rahman Protyasha.

296172@main introduced an unconditional optional dereference in
`NumberInputType::decorationWidth`, when obtaining the width of the spin button.

The logic in that method has never worked correctly for non-fixed values. It
only runs when autosizing number inputs based on their min/max values. For now,
restore the original behavior by safely dereferencing the optional.

<a href="https://webkit.org/b/294858">https://webkit.org/b/294858</a> has been filed to track a longer term solution.

* LayoutTests/fast/forms/number/number-min-max-spinbutton-appearance-none-crash-expected.txt: Added.
* LayoutTests/fast/forms/number/number-min-max-spinbutton-appearance-none-crash.html: Added.
* Source/WebCore/html/NumberInputType.cpp:
(WebCore::NumberInputType::decorationWidth const):

Percentage values are also checked to restore the old behavior.

Canonical link: <a href="https://commits.webkit.org/296537@main">https://commits.webkit.org/296537@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ddd4de54c9ff8603d1115e83db96e2c026824774

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108825 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28485 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18910 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114033 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59184 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110788 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37049 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82685 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111773 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23178 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98019 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63124 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22602 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16156 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58738 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92549 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16204 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117154 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35875 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26499 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91706 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36248 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94285 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91514 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36409 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14166 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31747 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17569 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35775 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41307 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35477 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38822 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37162 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->