### PR TITLE
[macOS] Adopt -[NSScrollPocket setPrefersSolidColorHardPocket:] for WKWebView's top scroll edge effect

### DIFF
--- a/Source/WebKit/Platform/spi/mac/AppKitSPI.h
+++ b/Source/WebKit/Platform/spi/mac/AppKitSPI.h
@@ -124,13 +124,13 @@ typedef void (^NSWindowSnapshotReadinessHandler) (void);
 
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
 
-@interface NSScrollPocket (Staging_147805180)
-@property (nonatomic, copy) NSColor *captureColor;
-@end
-
 @interface NSScrollPocket (Staging_151173930)
 - (void)addElementContainer:(NSView *)elementContainer;
 - (void)removeElementContainer:(NSView *)elementContainer;
+@end
+
+@interface NSScrollPocket (Staging_149248735)
+@property (nonatomic) BOOL prefersSolidColorHardPocket;
 @end
 
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3307,6 +3307,11 @@ static WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::Fixe
 
 - (void)colorExtensionViewWillDisappear:(WKColorExtensionView *)view
 {
+#if PLATFORM(MAC)
+    if (view == _fixedColorExtensionViews.at(WebCore::BoxSide::Top))
+        _impl->updatePrefersSolidColorHardPocket();
+#endif
+
 #if PLATFORM(IOS_FAMILY)
     [self _updateHiddenScrollPocketEdges];
 #endif
@@ -3314,6 +3319,11 @@ static WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::Fixe
 
 - (void)colorExtensionViewDidAppear:(WKColorExtensionView *)view
 {
+#if PLATFORM(MAC)
+    if (view == _fixedColorExtensionViews.at(WebCore::BoxSide::Top))
+        _impl->updatePrefersSolidColorHardPocket();
+#endif
+
 #if PLATFORM(IOS_FAMILY)
     [self _updateHiddenScrollPocketEdges];
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/WKColorExtensionView.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKColorExtensionView.mm
@@ -43,6 +43,7 @@
         return nil;
 
     _delegate = delegate;
+    self.hidden = YES;
     return self;
 }
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -793,6 +793,7 @@ public:
     void updateScrollPocketVisibilityWhenScrolledToTop();
     void updateTopScrollPocketCaptureColor();
     void updateTopScrollPocketStyle();
+    void updatePrefersSolidColorHardPocket();
 #endif
 
 private:

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2364,6 +2364,7 @@ void WebViewImpl::pageDidScroll(const IntPoint& scrollPosition)
 
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
     updateScrollPocketVisibilityWhenScrolledToTop();
+    updatePrefersSolidColorHardPocket();
 #endif
 
     [m_view didChangeValueForKey:@"hasScrolledContentsUnderTitlebar"];
@@ -6935,6 +6936,19 @@ void WebViewImpl::fulfillDeferredImageAnalysisOverlayViewHierarchyTask()
 #endif // ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
 
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+
+void WebViewImpl::updatePrefersSolidColorHardPocket()
+{
+    static bool canSetPrefersSolidColorHardPocket = [NSScrollPocket instancesRespondToSelector:@selector(setPrefersSolidColorHardPocket:)];
+    if (!canSetPrefersSolidColorHardPocket)
+        return;
+
+    RetainPtr view = m_view.get();
+    if (!view)
+        return;
+
+    [m_topScrollPocket setPrefersSolidColorHardPocket:[view _hasVisibleColorExtensionView:BoxSide::Top] || m_pageIsScrolledToTop];
+}
 
 void WebViewImpl::updateScrollPocket()
 {


### PR DESCRIPTION
#### 66975840c9fa80bd68a3582c79eda2a7032d36fe
<pre>
[macOS] Adopt -[NSScrollPocket setPrefersSolidColorHardPocket:] for WKWebView&apos;s top scroll edge effect
<a href="https://bugs.webkit.org/show_bug.cgi?id=294856">https://bugs.webkit.org/show_bug.cgi?id=294856</a>
<a href="https://rdar.apple.com/154114377">rdar://154114377</a>

Reviewed by Abrar Rahman Protyasha.

Adopt `-[NSScrollPocket setPrefersSolidColorHardPocket:]`, which gives a hint to AppKit&apos;s scroll
pocket that it sits on top of content with a solid background color, and that it doesn&apos;t need to
insert any expensive visual effect views to blur the underlying content, when using the hard pocket
appearance.

This is true in the case where either:
1. There&apos;s a fixed color extension view at the top of the viewport.
2. The page is scrolled to the top (i.e. the pocket is just over the page background color).

* Source/WebKit/Platform/spi/mac/AppKitSPI.h:

Remove an old staging declaration.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView colorExtensionViewWillDisappear:]):
(-[WKWebView colorExtensionViewDidAppear:]):

Call into `updatePrefersSolidColorHardPocket()` below.

* Source/WebKit/UIProcess/Cocoa/WKColorExtensionView.mm:
(-[WKColorExtensionView initWithFrame:delegate:]):

Set `.hidden=YES` upon initialization here, so that when we update to the initial background color,
`isBeingRevealed` is true and we&apos;ll actually call into `-colorExtensionViewDidAppear:`.

* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::pageDidScroll):

Call into `updatePrefersSolidColorHardPocket()` below.

(WebKit::WebViewImpl::updatePrefersSolidColorHardPocket):

Consolidate logic for updating `-[NSScrollPocket prefersSolidColorHardPocket]` state into a single
helper method; called whenever:
- The top fixed color extension view is about to fade out, or
- The top fixed color extension view is done fading in, or
- `m_pageIsScrolledToTop` is changing.

Canonical link: <a href="https://commits.webkit.org/296542@main">https://commits.webkit.org/296542@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4a6ce177ef7e231000f9cb345c7016d6dc4da2a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108845 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28505 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18930 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114053 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/59201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29189 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37071 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82702 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/59201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111793 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23198 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98034 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63141 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22619 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58756 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92570 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16219 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117174 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35895 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/26516 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91717 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36268 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94300 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91525 "Found 2 new API test failures: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23304 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36426 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14180 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35794 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41324 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35495 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38839 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37181 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->