### PR TITLE
[SaferCPP] Fix smart pointer fails in WKInspector.cpp

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -20,7 +20,6 @@ UIProcess/API/C/WKFramePolicyListener.cpp
 UIProcess/API/C/WKGeolocationManager.cpp
 UIProcess/API/C/WKGeolocationPermissionRequest.cpp
 UIProcess/API/C/WKHTTPCookieStoreRef.cpp
-UIProcess/API/C/WKInspector.cpp
 UIProcess/API/C/WKMediaKeySystemPermissionCallback.cpp
 UIProcess/API/C/WKNotification.cpp
 UIProcess/API/C/WKNotificationManager.cpp

--- a/Source/WebKit/UIProcess/API/C/WKInspector.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKInspector.cpp
@@ -42,62 +42,62 @@ WKTypeID WKInspectorGetTypeID()
 
 WKPageRef WKInspectorGetPage(WKInspectorRef inspectorRef)
 {
-    return toAPI(toImpl(inspectorRef)->protectedInspectedPage().get());
+    return toAPI(toProtectedImpl(inspectorRef)->protectedInspectedPage().get());
 }
 
 bool WKInspectorIsConnected(WKInspectorRef inspectorRef)
 {
-    return toImpl(inspectorRef)->isConnected();
+    return toProtectedImpl(inspectorRef)->isConnected();
 }
 
 bool WKInspectorIsVisible(WKInspectorRef inspectorRef)
 {
-    return toImpl(inspectorRef)->isVisible();
+    return toProtectedImpl(inspectorRef)->isVisible();
 }
 
 bool WKInspectorIsFront(WKInspectorRef inspectorRef)
 {
-    return toImpl(inspectorRef)->isFront();
+    return toProtectedImpl(inspectorRef)->isFront();
 }
 
 void WKInspectorConnect(WKInspectorRef inspectorRef)
 {
-    toImpl(inspectorRef)->connect();
+    toProtectedImpl(inspectorRef)->connect();
 }
 
 void WKInspectorShow(WKInspectorRef inspectorRef)
 {
-    toImpl(inspectorRef)->show();
+    toProtectedImpl(inspectorRef)->show();
 }
 
 void WKInspectorHide(WKInspectorRef inspectorRef)
 {
-    toImpl(inspectorRef)->hide();
+    toProtectedImpl(inspectorRef)->hide();
 }
 
 void WKInspectorClose(WKInspectorRef inspectorRef)
 {
-    toImpl(inspectorRef)->close();
+    toProtectedImpl(inspectorRef)->close();
 }
 
 void WKInspectorShowConsole(WKInspectorRef inspectorRef)
 {
-    toImpl(inspectorRef)->showConsole();
+    toProtectedImpl(inspectorRef)->showConsole();
 }
 
 void WKInspectorShowResources(WKInspectorRef inspectorRef)
 {
-    toImpl(inspectorRef)->showResources();
+    toProtectedImpl(inspectorRef)->showResources();
 }
 
 void WKInspectorShowMainResourceForFrame(WKInspectorRef inspectorRef, WKFrameRef frameRef)
 {
-    toImpl(inspectorRef)->showMainResourceForFrame(toImpl(frameRef)->frameID());
+    toProtectedImpl(inspectorRef)->showMainResourceForFrame(toProtectedImpl(frameRef)->frameID());
 }
 
 bool WKInspectorIsAttached(WKInspectorRef inspectorRef)
 {
-    return toImpl(inspectorRef)->isAttached();
+    return toProtectedImpl(inspectorRef)->isAttached();
 }
 
 void WKInspectorAttach(WKInspectorRef inspectorRef)
@@ -108,27 +108,27 @@ void WKInspectorAttach(WKInspectorRef inspectorRef)
 
 void WKInspectorDetach(WKInspectorRef inspectorRef)
 {
-    toImpl(inspectorRef)->detach();
+    toProtectedImpl(inspectorRef)->detach();
 }
 
 bool WKInspectorIsProfilingPage(WKInspectorRef inspectorRef)
 {
-    return toImpl(inspectorRef)->isProfilingPage();
+    return toProtectedImpl(inspectorRef)->isProfilingPage();
 }
 
 void WKInspectorTogglePageProfiling(WKInspectorRef inspectorRef)
 {
-    toImpl(inspectorRef)->togglePageProfiling();
+    toProtectedImpl(inspectorRef)->togglePageProfiling();
 }
 
 bool WKInspectorIsElementSelectionActive(WKInspectorRef inspectorRef)
 {
-    return toImpl(inspectorRef)->isElementSelectionActive();
+    return toProtectedImpl(inspectorRef)->isElementSelectionActive();
 }
 
 void WKInspectorToggleElementSelection(WKInspectorRef inspectorRef)
 {
-    toImpl(inspectorRef)->toggleElementSelection();
+    toProtectedImpl(inspectorRef)->toggleElementSelection();
 }
 
 #endif // !PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### f05f1d364edbb8ba8a185ecf008cb8038cba8268
<pre>
[SaferCPP] Fix smart pointer fails in WKInspector.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=294866">https://bugs.webkit.org/show_bug.cgi?id=294866</a>
<a href="https://rdar.apple.com/154133153">rdar://154133153</a>

Reviewed by Chris Dumez.

Fix `UncountedCallArgsCheckerExpectations` fails in `WKInspector.cpp`

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/API/C/WKInspector.cpp:
(WKInspectorIsConnected):
(WKInspectorIsVisible):
(WKInspectorIsFront):
(WKInspectorConnect):
(WKInspectorShow):
(WKInspectorHide):
(WKInspectorClose):
(WKInspectorShowConsole):
(WKInspectorShowResources):
(WKInspectorShowMainResourceForFrame):
(WKInspectorIsAttached):
(WKInspectorDetach):
(WKInspectorIsProfilingPage):
(WKInspectorTogglePageProfiling):
(WKInspectorIsElementSelectionActive):
(WKInspectorToggleElementSelection):

Canonical link: <a href="https://commits.webkit.org/296548@main">https://commits.webkit.org/296548@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2dee8950f4988f323c5013b5c1c2a5ef72b9725

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108849 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28509 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114057 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59204 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37075 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82706 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111797 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23199 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98038 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63145 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58759 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16223 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117178 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35899 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26518 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91721 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36272 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94304 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91529 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23308 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36428 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14184 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31767 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35798 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41327 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35499 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38843 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37185 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->