### PR TITLE
[SaferCPP] Fix smart pointer fails in WKNotification{Manager}.cpp

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -12,8 +12,6 @@ UIProcess/API/C/WKBackForwardListRef.cpp
 UIProcess/API/C/WKContext.cpp
 UIProcess/API/C/WKContextConfigurationRef.cpp
 UIProcess/API/C/WKFormSubmissionListener.cpp
-UIProcess/API/C/WKNotification.cpp
-UIProcess/API/C/WKNotificationManager.cpp
 UIProcess/API/C/WKPage.cpp
 UIProcess/API/C/WKQueryPermissionResultCallback.cpp
 UIProcess/API/C/WKSpeechRecognitionPermissionCallback.cpp

--- a/Source/WebKit/UIProcess/API/C/WKNotification.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKNotification.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -81,7 +81,7 @@ WKStringRef WKNotificationCopyDir(WKNotificationRef notification)
 
 WKSecurityOriginRef WKNotificationGetSecurityOrigin(WKNotificationRef notification)
 {
-    return toAPI(toImpl(notification)->origin());
+    return toAPI(RefPtr { toProtectedImpl(notification)->origin() }.get());
 }
 
 uint64_t WKNotificationGetID(WKNotificationRef notification)

--- a/Source/WebKit/UIProcess/API/C/WKNotificationManager.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKNotificationManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,17 +42,17 @@ WKTypeID WKNotificationManagerGetTypeID()
 
 void WKNotificationManagerSetProvider(WKNotificationManagerRef managerRef, const WKNotificationProviderBase* wkProvider)
 {
-    toImpl(managerRef)->setProvider(makeUnique<WebNotificationProvider>(wkProvider));
+    toProtectedImpl(managerRef)->setProvider(makeUnique<WebNotificationProvider>(wkProvider));
 }
 
 void WKNotificationManagerProviderDidShowNotification(WKNotificationManagerRef managerRef, uint64_t notificationID)
 {
-    toImpl(managerRef)->providerDidShowNotification(WebNotificationIdentifier { notificationID });
+    toProtectedImpl(managerRef)->providerDidShowNotification(WebNotificationIdentifier { notificationID });
 }
 
 void WKNotificationManagerProviderDidClickNotification(WKNotificationManagerRef managerRef, uint64_t notificationID)
 {
-    toImpl(managerRef)->providerDidClickNotification(WebNotificationIdentifier { notificationID });
+    toProtectedImpl(managerRef)->providerDidClickNotification(WebNotificationIdentifier { notificationID });
 }
 
 void WKNotificationManagerProviderDidClickNotification_b(WKNotificationManagerRef managerRef, WKDataRef identifier)
@@ -61,22 +61,22 @@ void WKNotificationManagerProviderDidClickNotification_b(WKNotificationManagerRe
     if (span.size() != 16)
         return;
 
-    toImpl(managerRef)->providerDidClickNotification(WTF::UUID { std::span<const uint8_t, 16> { span } });
+    toProtectedImpl(managerRef)->providerDidClickNotification(WTF::UUID { std::span<const uint8_t, 16> { span } });
 }
 
 void WKNotificationManagerProviderDidCloseNotifications(WKNotificationManagerRef managerRef, WKArrayRef notificationIDs)
 {
-    toImpl(managerRef)->providerDidCloseNotifications(toImpl(notificationIDs));
+    toProtectedImpl(managerRef)->providerDidCloseNotifications(toProtectedImpl(notificationIDs).get());
 }
 
 void WKNotificationManagerProviderDidUpdateNotificationPolicy(WKNotificationManagerRef managerRef, WKSecurityOriginRef origin, bool allowed)
 {
-    toImpl(managerRef)->providerDidUpdateNotificationPolicy(toImpl(origin), allowed);
+    toProtectedImpl(managerRef)->providerDidUpdateNotificationPolicy(toProtectedImpl(origin).get(), allowed);
 }
 
 void WKNotificationManagerProviderDidRemoveNotificationPolicies(WKNotificationManagerRef managerRef, WKArrayRef origins)
 {
-    toImpl(managerRef)->providerDidRemoveNotificationPolicies(toImpl(origins));
+    toProtectedImpl(managerRef)->providerDidRemoveNotificationPolicies(toProtectedImpl(origins).get());
 }
 
 WKNotificationManagerRef WKNotificationManagerGetSharedServiceWorkerNotificationManager()


### PR DESCRIPTION
#### fa6ad85bc43e4df15cf38673b915f40e6029cea3
<pre>
[SaferCPP] Fix smart pointer fails in WKNotification{Manager}.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=294867">https://bugs.webkit.org/show_bug.cgi?id=294867</a>
<a href="https://rdar.apple.com/154134470">rdar://154134470</a>

Reviewed by Charlie Wolfe.

Fix smart pointer fails in WKNotification.cpp &amp; WKNotificationManager.cpp

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/API/C/WKNotification.cpp:
(WKNotificationGetSecurityOrigin):
* Source/WebKit/UIProcess/API/C/WKNotificationManager.cpp:
(WKNotificationManagerSetProvider):
(WKNotificationManagerProviderDidShowNotification):
(WKNotificationManagerProviderDidClickNotification):
(WKNotificationManagerProviderDidClickNotification_b):
(WKNotificationManagerProviderDidCloseNotifications):
(WKNotificationManagerProviderDidUpdateNotificationPolicy):
(WKNotificationManagerProviderDidRemoveNotificationPolicies):

Canonical link: <a href="https://commits.webkit.org/296639@main">https://commits.webkit.org/296639@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e314a6f5059508eee82b65a2031b86e1c51bdcb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109163 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28821 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19248 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114370 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/59444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29502 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37387 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82956 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/59444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112111 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23477 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98323 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63404 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/22868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/59023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92845 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16508 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117486 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36207 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/26766 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/91971 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36579 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94586 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91777 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23365 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36700 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14450 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/32060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36103 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41601 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35790 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39126 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37480 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->