### PR TITLE
Web Extensions: Parse getRecent() bookmark function

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIBookmarks.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIBookmarks.h
@@ -34,6 +34,18 @@ namespace WebKit {
 
 class WebExtensionAPIBookmarks : public WebExtensionAPIObject, public JSWebExtensionWrappable {
     WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIBookmarks, bookmarks, bookmarks);
+private:
+
+    struct MockBookmarkNode {
+        String id;
+        String title;
+        String url;
+        WallTime dateAdded;
+    };
+
+    Vector<MockBookmarkNode> m_mockBookmarks;
+
+    NSDictionary *createDictionaryFromNode(const MockBookmarkNode& node);
 
 public:
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIBookmarks.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIBookmarks.idl
@@ -30,16 +30,16 @@
 ] interface WebExtensionAPIBookmarks {
     [RaisesException, ImplementedAs=createBookmark] void create([NSDictionary] any bookmark, [Optional, CallbackHandler] function callback);
     
-    [RaisesException] void getChildren(DOMString bookmarkIdentifier, [Optional, CallbackHandler] function callback);
+    [RaisesException] void getChildren(DOMString id, [Optional, CallbackHandler] function callback);
     [RaisesException] void getRecent(long numberOfItems, [Optional, CallbackHandler] function callback);
-    [RaisesException] void getSubTree(DOMString bookmarkIdentifier, [Optional, CallbackHandler] function callback);
+    [RaisesException] void getSubTree(DOMString id, [Optional, CallbackHandler] function callback);
     [RaisesException] void getTree([Optional, CallbackHandler] function callback);
     [RaisesException] void get([NSObject] any idOrIdList, [Optional, CallbackHandler] function callback);
 
-    [RaisesException] void remove(DOMString bookmarkIdentifier, [Optional, CallbackHandler] function callback);
-    [RaisesException] void removeTree(DOMString bookmarkIdentifier, [Optional, CallbackHandler] function callback);
+    [RaisesException] void remove(DOMString id, [Optional, CallbackHandler] function callback);
+    [RaisesException] void removeTree(DOMString id, [Optional, CallbackHandler] function callback);
 
     [RaisesException] void search([NSObject] any query, [Optional, CallbackHandler] function callback);
-    [RaisesException] void update(DOMString bookmarkIdentifier, [NSDictionary] any changes, [Optional, CallbackHandler] function callback);
-    [RaisesException] void move(DOMString bookmarkIdentifier, [NSDictionary] any destination, [Optional, CallbackHandler] function callback);
+    [RaisesException] void update(DOMString id, [NSDictionary] any changes, [Optional, CallbackHandler] function callback);
+    [RaisesException] void move(DOMString id, [NSDictionary] any destination, [Optional, CallbackHandler] function callback);
 };


### PR DESCRIPTION
#### 66634381c1e4ac756c042f55015e98a85dd61b04
<pre>
Web Extensions: Parse getRecent() bookmark function
<a href="https://rdar.apple.com/153924872">rdar://153924872</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=294766">https://bugs.webkit.org/show_bug.cgi?id=294766</a>

Reviewed by Timothy Hatcher.

Added Parsing for getRecent that uses mock BookmarkTreeNodes created by Create()
to test its functionality. Added tests for this as well.

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIBookmarksCocoa.mm:
(WebKit::WebExtensionAPIBookmarks::createDictionaryFromNode):
(WebKit::WebExtensionAPIBookmarks::createBookmark):
(WebKit::WebExtensionAPIBookmarks::getRecent):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIBookmarks.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIBookmarks.idl:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIBookmarks.mm:
(TestWebKitAPI::TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPICheckgetRecent)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPIMockNodeWithgetRecent)):

Canonical link: <a href="https://commits.webkit.org/296640@main">https://commits.webkit.org/296640@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66e36a3b60c0e5cdccce0b2c7071dba4a5fb039a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109173 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28831 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19258 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114380 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/59451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111136 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37398 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/82964 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/59451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112121 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/23482 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98331 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63413 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/22872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16474 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/59029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92849 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16516 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117495 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36217 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/26774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/91980 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36589 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94594 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91786 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36707 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14457 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/32066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17614 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36113 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/41608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35799 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39133 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37490 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->