### PR TITLE
AX: accessibility/clip-path-bounding-box.html fails in macOS Tahoe because AccessibilityNodeObject and AccessibilityRenderObject don't explicitly enforce a minimum size for controls

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1969,6 +1969,19 @@ String roleToPlatformString(AccessibilityRole);
 std::optional<AXTextMarkerRange> markerRangeFrom(NSRange, const AXCoreObject&);
 #endif
 
+// Intended to work with size-types (like IntSize) or rect-types (like LayoutRect).
+template <typename SizeOrRectType>
+void adjustControlSize(SizeOrRectType& sizeOrRect)
+{
+    // It's very common for web developers to have a "screenreader only" CSS class that makes important
+    // elements like controls unrendered (e.g. via opacity:0 or CSS clipping) with a width and height
+    // of 1px. VoiceOver on macOS won't draw a cursor for 1px-large elements, so enforce a minimum size of 2px.
+    if (sizeOrRect.width() < 2)
+        sizeOrRect.setWidth(2);
+    if (sizeOrRect.height() < 2)
+        sizeOrRect.setHeight(2);
+}
+
 } // namespace Accessibility
 
 inline bool AXCoreObject::isDescendantOfObject(const AXCoreObject& axObject) const

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -1057,11 +1057,10 @@ FloatRect AXIsolatedObject::relativeFrame() const
         });
     }
 
-    bool isControl = this->isControl();
     // Having an empty relative frame at this point means a frame hasn't been cached yet.
     if (relativeFrame.isEmpty()) {
         std::optional<IntRect> rectFromLabels;
-        if (isControl) {
+        if (isControl()) {
             // For controls, we can try to use the frame of any associated labels.
             auto labels = labeledByObjects();
             for (const auto& label : labels) {
@@ -1101,16 +1100,6 @@ FloatRect AXIsolatedObject::relativeFrame() const
             relativeFrame.setY(0);
     }
     relativeFrame.moveBy({ remoteFrameOffset() });
-
-    if (isControl) {
-        // It's very common for web developers to have a "screenreader only" CSS class that makes important
-        // elements like controls unrendered (e.g. via opacity:0 or CSS clipping) with a width and height
-        // of 1px. VoiceOver on macOS won't draw a cursor for 1px-large elements, so enforce a minimum size of 2px.
-        if (relativeFrame.width() == 1)
-            relativeFrame.setWidth(2);
-        if (relativeFrame.height() == 1)
-            relativeFrame.setHeight(2);
-    }
     return relativeFrame;
 }
 

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -1376,8 +1376,12 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     if ([attributeName isEqualToString: NSAccessibilityEnabledAttribute])
         return [NSNumber numberWithBool: backingObject->isEnabled()];
 
-    if ([attributeName isEqualToString:NSAccessibilitySizeAttribute])
-        return [NSValue valueWithSize:(CGSize)backingObject->size()];
+    if ([attributeName isEqualToString:NSAccessibilitySizeAttribute]) {
+        auto size = backingObject->size();
+        if (backingObject->isControl())
+            Accessibility::adjustControlSize(size);
+        return [NSValue valueWithSize:(CGSize)size];
+    }
 
     if ([attributeName isEqualToString:NSAccessibilityPrimaryScreenHeightAttribute])
         return @(backingObject->primaryScreenRect().height());
@@ -1822,8 +1826,12 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     if ([attributeName isEqualToString:NSAccessibilityBrailleRoleDescriptionAttribute])
         return backingObject->brailleRoleDescription().createNSString().autorelease();
 
-    if ([attributeName isEqualToString:NSAccessibilityRelativeFrameAttribute])
-        return [NSValue valueWithRect:(NSRect)backingObject->relativeFrame()];
+    if ([attributeName isEqualToString:NSAccessibilityRelativeFrameAttribute]) {
+        auto frame = backingObject->relativeFrame();
+        if (backingObject->isControl())
+            Accessibility::adjustControlSize(frame);
+        return [NSValue valueWithRect:(NSRect)frame];
+    }
 
     if ([attributeName isEqualToString:NSAccessibilityErrorMessageElementsAttribute]) {
         // Only expose error messages for objects in an invalid state.


### PR DESCRIPTION
#### f79edb6f8fda2ffba7120582bc69ad46dd148410
<pre>
AX: accessibility/clip-path-bounding-box.html fails in macOS Tahoe because AccessibilityNodeObject and AccessibilityRenderObject don&apos;t explicitly enforce a minimum size for controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=294868">https://bugs.webkit.org/show_bug.cgi?id=294868</a>
<a href="https://rdar.apple.com/154135798">rdar://154135798</a>

Reviewed by Joshua Hoffman.

With this commit, we now enforce a minimum size for controls for main-thread accessibility objects (matching the same
change done for AXIsolatedObjects some time ago), ensuring the rects we return are large enough for assistive technologies
to draw a cursor for. This is helpful for low-vision users who rely on magnifying the cursor contents — having no cursor
(as happens for 1x1px elements in ATs like VoiceOver) can be disorienting, especially for interactive elements like controls.

Fixes accessibility/clip-path-bounding-box.html for macOS Tahoe. We used to implicitly get this behavior, but no longer
do after the controls redesign in Tahoe, so this commit makes it explicit to fix the test. This logic, which was in
AXIsolatedObject, is now moved to the WebAccessibilityObjectWrapperMac so both object subclasses benefit from it.

* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::Accessibility::adjustControlRect):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::relativeFrame const):

Canonical link: <a href="https://commits.webkit.org/296550@main">https://commits.webkit.org/296550@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a37f1b68378a8084007c0fa67dbf5361669eb9f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108868 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28528 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18953 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114077 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59220 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110831 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29212 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37094 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82723 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111816 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23218 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98062 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63162 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22636 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16198 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58777 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92591 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16245 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117197 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35918 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91737 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36291 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94326 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91544 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23309 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36447 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14205 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31784 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35817 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41345 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35518 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38862 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37204 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->