### PR TITLE
[SaferCPP] Fix smart pointer fails in WKMockMediaDevice.cpp & WKMessageListener.cpp

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -22,8 +22,6 @@ UIProcess/API/C/WKGeolocationPermissionRequest.cpp
 UIProcess/API/C/WKHTTPCookieStoreRef.cpp
 UIProcess/API/C/WKInspector.cpp
 UIProcess/API/C/WKMediaKeySystemPermissionCallback.cpp
-UIProcess/API/C/WKMessageListener.cpp
-UIProcess/API/C/WKMockMediaDevice.cpp
 UIProcess/API/C/WKNotification.cpp
 UIProcess/API/C/WKNotificationManager.cpp
 UIProcess/API/C/WKNotificationPermissionRequest.cpp

--- a/Source/WebKit/UIProcess/API/C/WKMessageListener.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKMessageListener.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,5 +38,5 @@ WKTypeID WKMessageListenerGetTypeID()
 
 void WKMessageListenerSendReply(WKMessageListenerRef listenerRef, WKTypeRef value)
 {
-    toImpl(listenerRef)->sendReply(toImpl(value));
+    toProtectedImpl(listenerRef)->sendReply(toImpl(value));
 }

--- a/Source/WebKit/UIProcess/API/C/WKMockMediaDevice.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKMockMediaDevice.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,7 +39,7 @@ using namespace WebKit;
 void WKAddMockMediaDevice(WKContextRef context, WKStringRef persistentId, WKStringRef label, WKStringRef type, WKDictionaryRef properties, bool isDefault)
 {
 #if ENABLE(MEDIA_STREAM)
-    String typeString = WebKit::toImpl(type)->string();
+    String typeString = WebKit::toProtectedImpl(type)->string();
     Variant<WebCore::MockMicrophoneProperties, WebCore::MockSpeakerProperties, WebCore::MockCameraProperties, WebCore::MockDisplayProperties> deviceProperties;
     if (typeString == "camera"_s) {
         WebCore::MockCameraProperties cameraProperties;
@@ -72,26 +72,26 @@ void WKAddMockMediaDevice(WKContextRef context, WKStringRef persistentId, WKStri
         }
     }
 
-    toImpl(context)->addMockMediaDevice({ WebKit::toImpl(persistentId)->string(), WebKit::toImpl(label)->string(), flags, isDefault, WTFMove(deviceProperties) });
+    toProtectedImpl(context)->addMockMediaDevice({ WebKit::toProtectedImpl(persistentId)->string(), WebKit::toProtectedImpl(label)->string(), flags, isDefault, WTFMove(deviceProperties) });
 #endif
 }
 
 void WKClearMockMediaDevices(WKContextRef context)
 {
-    toImpl(context)->clearMockMediaDevices();
+    toProtectedImpl(context)->clearMockMediaDevices();
 }
 
 void WKRemoveMockMediaDevice(WKContextRef context, WKStringRef persistentId)
 {
-    toImpl(context)->removeMockMediaDevice(WebKit::toImpl(persistentId)->string());
+    toProtectedImpl(context)->removeMockMediaDevice(WebKit::toProtectedImpl(persistentId)->string());
 }
 
 void WKResetMockMediaDevices(WKContextRef context)
 {
-    toImpl(context)->resetMockMediaDevices();
+    toProtectedImpl(context)->resetMockMediaDevices();
 }
 
 void WKSetMockMediaDeviceIsEphemeral(WKContextRef context, WKStringRef persistentId, bool isEphemeral)
 {
-    toImpl(context)->setMockMediaDeviceIsEphemeral(WebKit::toImpl(persistentId)->string(), isEphemeral);
+    toProtectedImpl(context)->setMockMediaDeviceIsEphemeral(WebKit::toProtectedImpl(persistentId)->string(), isEphemeral);
 }


### PR DESCRIPTION
#### ad18f31bb8ac003cb8afe6e04d955e9d13d2556f
<pre>
[SaferCPP] Fix smart pointer fails in WKMockMediaDevice.cpp &amp; WKMessageListener.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=294870">https://bugs.webkit.org/show_bug.cgi?id=294870</a>
&lt;<a href="https://rdar.apple.com/154137011">rdar://154137011</a>&gt;

Reviewed by Chris Dumez.

Fix smart pointer fails in `WKMockMediaDevice.cpp` &amp; `WKMessageListener.cpp`

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/API/C/WKMessageListener.cpp:
(WKMessageListenerSendReply):
* Source/WebKit/UIProcess/API/C/WKMockMediaDevice.cpp:
(WKAddMockMediaDevice):
(WKClearMockMediaDevices):
(WKRemoveMockMediaDevice):
(WKResetMockMediaDevices):
(WKSetMockMediaDeviceIsEphemeral):

Canonical link: <a href="https://commits.webkit.org/296546@main">https://commits.webkit.org/296546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b379fcdccd9395cfb4a8ad409a4d6a3f819d8fcd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108857 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28517 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18942 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114066 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59210 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29201 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37083 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82712 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111805 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23207 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98049 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63151 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22626 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58767 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92578 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16234 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117186 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35907 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26523 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91729 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36280 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94315 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91536 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23307 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36437 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14194 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31774 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35806 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41334 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35507 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38851 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37193 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->