### PR TITLE
[SaferCPP] Fix smart pointer issues in WKProtectionSpace.cpp

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -29,7 +29,6 @@ UIProcess/API/C/WKOpenPanelParametersRef.cpp
 UIProcess/API/C/WKOpenPanelResultListener.cpp
 UIProcess/API/C/WKPage.cpp
 UIProcess/API/C/WKPageConfigurationRef.cpp
-UIProcess/API/C/WKProtectionSpace.cpp
 UIProcess/API/C/WKQueryPermissionResultCallback.cpp
 UIProcess/API/C/WKSpeechRecognitionPermissionCallback.cpp
 UIProcess/API/C/WKUserContentControllerRef.cpp

--- a/Source/WebKit/UIProcess/API/C/WKProtectionSpace.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKProtectionSpace.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,35 +38,35 @@ WKTypeID WKProtectionSpaceGetTypeID()
 
 WKStringRef WKProtectionSpaceCopyHost(WKProtectionSpaceRef protectionSpaceRef)
 {
-    return toCopiedAPI(toImpl(protectionSpaceRef)->host());
+    return toCopiedAPI(toProtectedImpl(protectionSpaceRef)->host());
 }
 
 int WKProtectionSpaceGetPort(WKProtectionSpaceRef protectionSpaceRef)
 {
-    return toImpl(protectionSpaceRef)->port();
+    return toProtectedImpl(protectionSpaceRef)->port();
 }
 
 WKStringRef WKProtectionSpaceCopyRealm(WKProtectionSpaceRef protectionSpaceRef)
 {
-    return toCopiedAPI(toImpl(protectionSpaceRef)->realm());
+    return toCopiedAPI(toProtectedImpl(protectionSpaceRef)->realm());
 }
 
 bool WKProtectionSpaceGetIsProxy(WKProtectionSpaceRef protectionSpaceRef)
 {
-    return toImpl(protectionSpaceRef)->isProxy();
+    return toProtectedImpl(protectionSpaceRef)->isProxy();
 }
 
 WKProtectionSpaceServerType WKProtectionSpaceGetServerType(WKProtectionSpaceRef protectionSpaceRef)
 {
-    return toAPI(toImpl(protectionSpaceRef)->serverType());
+    return toAPI(toProtectedImpl(protectionSpaceRef)->serverType());
 }
 
 bool WKProtectionSpaceGetReceivesCredentialSecurely(WKProtectionSpaceRef protectionSpaceRef)
 {
-    return toImpl(protectionSpaceRef)->receivesCredentialSecurely();
+    return toProtectedImpl(protectionSpaceRef)->receivesCredentialSecurely();
 }
 
 WKProtectionSpaceAuthenticationScheme WKProtectionSpaceGetAuthenticationScheme(WKProtectionSpaceRef protectionSpaceRef)
 {
-    return toAPI(toImpl(protectionSpaceRef)->authenticationScheme());
+    return toAPI(toProtectedImpl(protectionSpaceRef)->authenticationScheme());
 }


### PR DESCRIPTION
#### 2bbfd6067006759652c13d90fc5851f5d298d223
<pre>
[SaferCPP] Fix smart pointer issues in WKProtectionSpace.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=294874">https://bugs.webkit.org/show_bug.cgi?id=294874</a>
<a href="https://rdar.apple.com/154137544">rdar://154137544</a>

Reviewed by Chris Dumez.

Fix smart pointer issues in WKProtectionSpace.cpp

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/API/C/WKProtectionSpace.cpp:
(WKProtectionSpaceCopyHost):
(WKProtectionSpaceGetPort):
(WKProtectionSpaceCopyRealm):
(WKProtectionSpaceGetIsProxy):
(WKProtectionSpaceGetServerType):
(WKProtectionSpaceGetReceivesCredentialSecurely):
(WKProtectionSpaceGetAuthenticationScheme):

Canonical link: <a href="https://commits.webkit.org/296547@main">https://commits.webkit.org/296547@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6216e2f0e0b28cc6cb5edd95d1de08a054fa6997

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108859 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18944 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114068 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59212 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29203 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37085 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82715 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111807 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23209 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98051 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63154 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22628 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58769 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92580 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16235 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117188 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35909 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26525 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91730 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36282 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94316 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91537 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23306 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36438 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14195 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31776 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35808 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41336 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35509 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38853 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37195 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->