### PR TITLE
[SaferCPP] Adopt smart pointers in WKDownloadRef.cpp & WKCredential.cpp

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -12,8 +12,6 @@ UIProcess/API/C/WKBackForwardListRef.cpp
 UIProcess/API/C/WKContext.cpp
 UIProcess/API/C/WKContextConfigurationRef.cpp
 UIProcess/API/C/WKContextMenuListener.cpp
-UIProcess/API/C/WKCredential.cpp
-UIProcess/API/C/WKDownloadRef.cpp
 UIProcess/API/C/WKFormSubmissionListener.cpp
 UIProcess/API/C/WKFrameInfoRef.cpp
 UIProcess/API/C/WKFramePolicyListener.cpp

--- a/Source/WebKit/UIProcess/API/C/WKCredential.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKCredential.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,7 +39,7 @@ WKTypeID WKCredentialGetTypeID()
 
 WKCredentialRef WKCredentialCreate(WKStringRef username, WKStringRef password, WKCredentialPersistence persistence)
 {
-    return toAPILeakingRef(WebCredential::create(WebCore::Credential(toImpl(username)->string(), toImpl(password)->string(), toCredentialPersistence(persistence))));
+    return toAPILeakingRef(WebCredential::create(WebCore::Credential(toProtectedImpl(username)->string(), toProtectedImpl(password)->string(), toCredentialPersistence(persistence))));
 }
 
 WKCredentialRef WKCredentialCreateWithCertificateInfo(WKCertificateInfoRef certificateInfo)
@@ -49,6 +49,5 @@ WKCredentialRef WKCredentialCreateWithCertificateInfo(WKCertificateInfoRef certi
 
 WKStringRef WKCredentialCopyUser(WKCredentialRef credentialRef)
 {
-    return toCopiedAPI(toImpl(credentialRef)->credential().user());
+    return toCopiedAPI(toProtectedImpl(credentialRef)->credential().user());
 }
-

--- a/Source/WebKit/UIProcess/API/C/WKDownloadRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKDownloadRef.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,7 +56,7 @@ WKURLRequestRef WKDownloadCopyRequest(WKDownloadRef download)
 
 void WKDownloadCancel(WKDownloadRef download, const void* functionContext, WKDownloadCancelCallback callback)
 {
-    return toImpl(download)->cancel([functionContext, callback](auto* resumeData) {
+    return toProtectedImpl(download)->cancel([functionContext, callback](auto* resumeData) {
         if (callback)
             callback(toAPI(resumeData), functionContext);
     });
@@ -64,7 +64,8 @@ void WKDownloadCancel(WKDownloadRef download, const void* functionContext, WKDow
 
 WKPageRef WKDownloadGetOriginatingPage(WKDownloadRef download)
 {
-    return toAPI(toImpl(download)->originatingPage());
+    RefPtr originatingPage = toProtectedImpl(download)->originatingPage();
+    return toAPI(originatingPage.get());
 }
 
 bool WKDownloadGetWasUserInitiated(WKDownloadRef download)
@@ -147,5 +148,5 @@ void WKDownloadSetClient(WKDownloadRef download, WKDownloadClientBase* client)
         }
     };
 
-    toImpl(download)->setClient(adoptRef(*new DownloadClient(client)));
+    toProtectedImpl(download)->setClient(adoptRef(*new DownloadClient(client)));
 }


### PR DESCRIPTION
#### 043b56038e649f6fca46d71199ae78c20b04c9d0
<pre>
[SaferCPP] Adopt smart pointers in WKDownloadRef.cpp &amp; WKCredential.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=294875">https://bugs.webkit.org/show_bug.cgi?id=294875</a>
<a href="https://rdar.apple.com/154138792">rdar://154138792</a>

Reviewed by Anne van Kesteren.

Adopt smart pointers in:
    - WKDownloadRef.cpp
    - WKCredential.cpp

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/API/C/WKCredential.cpp:
(WKCredentialCreate):
(WKCredentialCopyUser):
* Source/WebKit/UIProcess/API/C/WKDownloadRef.cpp:
(WKDownloadCancel):
(WKDownloadGetOriginatingPage):
(WKDownloadSetClient):

Canonical link: <a href="https://commits.webkit.org/296566@main">https://commits.webkit.org/296566@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/282aff86bbe8859ac49dc12f9f1a410cd944b94c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108889 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28549 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18974 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114098 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59237 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29233 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37115 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82740 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111837 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23235 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98079 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63179 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22656 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58797 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92609 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16262 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117218 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35939 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26553 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91758 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36312 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94343 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91565 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23317 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36466 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14222 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31801 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35838 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41365 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35539 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38883 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37225 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->