### PR TITLE
[HDR] Moving the WebView from a screen to another should change backing store formats.

### DIFF
--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -1146,6 +1146,17 @@ void LocalFrame::deviceOrPageScaleFactorChanged()
         root->compositor().deviceOrPageScaleFactorChanged();
 }
 
+void LocalFrame::screenSupportedContentsFormatsChanged()
+{
+    for (RefPtr child = tree().firstChild(); child; child = child->tree().nextSibling()) {
+        if (RefPtr localFrame = dynamicDowncast<LocalFrame>(child.get()))
+            localFrame->screenSupportedContentsFormatsChanged();
+    }
+
+    if (CheckedPtr root = contentRenderer())
+        root->compositor().screenSupportedContentsFormatsChanged();
+}
+
 void LocalFrame::dropChildren()
 {
     ASSERT(isMainFrame());

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -223,7 +223,8 @@ public:
     WEBCORE_EXPORT float frameScaleFactor() const;
 
     void deviceOrPageScaleFactorChanged();
-    
+    void screenSupportedContentsFormatsChanged();
+
 #if ENABLE(DATA_DETECTION)
     DataDetectionResultsStorage* dataDetectionResultsIfExists() const { return m_dataDetectionResults.get(); }
     WEBCORE_EXPORT DataDetectionResultsStorage& dataDetectionResults();

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1197,6 +1197,8 @@ public:
 
     ModelPlayerProvider& modelPlayerProvider();
 
+    void updateScreenSupportedContentsFormats();
+
 #if ENABLE(ATTACHMENT_ELEMENT)
     AttachmentElementClient* attachmentElementClient() { return m_attachmentElementClient.get(); }
 #endif
@@ -1784,6 +1786,7 @@ private:
 #if HAVE(SUPPORT_HDR_DISPLAY)
     Headroom m_displayEDRHeadroom { Headroom::None };
     bool m_suppressEDR { false };
+    bool m_screenSupportsHDR { false };
 #endif
 
     HashSet<std::pair<URL, ScriptTrackingPrivacyCategory>> m_scriptTrackingPrivacyReports;

--- a/Source/WebCore/platform/PlatformScreen.h
+++ b/Source/WebCore/platform/PlatformScreen.h
@@ -99,6 +99,7 @@ constexpr DynamicRangeMode preferredDynamicRangeMode(Widget* = nullptr) { return
 
 #if PLATFORM(MAC) || PLATFORM(IOS_FAMILY)
 WEBCORE_EXPORT bool screenSupportsHighDynamicRange(Widget* = nullptr);
+WEBCORE_EXPORT bool screenSupportsHighDynamicRange(PlatformDisplayID);
 #else
 constexpr bool screenSupportsHighDynamicRange(Widget* = nullptr) { return false; }
 #endif

--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -598,6 +598,20 @@ void GraphicsLayer::noteDeviceOrPageScaleFactorChangedIncludingDescendants()
         layer->noteDeviceOrPageScaleFactorChangedIncludingDescendants();
 }
 
+void GraphicsLayer::noteScreenSupportedContentsFormatsChangedIncludingDescendants()
+{
+    screenSupportedContentsFormatsChanged();
+
+    if (m_maskLayer)
+        m_maskLayer->screenSupportedContentsFormatsChanged();
+
+    if (m_replicaLayer)
+        m_replicaLayer->noteScreenSupportedContentsFormatsChangedIncludingDescendants();
+
+    for (auto& layer : children())
+        layer->noteScreenSupportedContentsFormatsChangedIncludingDescendants();
+}
+
 void GraphicsLayer::setIsInWindow(bool inWindow)
 {
     if (auto* tiledBacking = this->tiledBacking())

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -661,9 +661,11 @@ public:
     virtual bool allowsTiling() const { return m_allowsTiling; }
 
     virtual void deviceOrPageScaleFactorChanged() { }
+    virtual void screenSupportedContentsFormatsChanged() { }
     virtual void setShouldUpdateRootRelativeScaleFactor(bool) { }
 
     WEBCORE_EXPORT void noteDeviceOrPageScaleFactorChangedIncludingDescendants();
+    void noteScreenSupportedContentsFormatsChangedIncludingDescendants();
 
     WEBCORE_EXPORT void setIsInWindow(bool);
 

--- a/Source/WebCore/platform/graphics/GraphicsLayerClient.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayerClient.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "ContentsFormat.h"
 #include "LayerTreeAsTextOptions.h"
 #include "TiledBacking.h"
 #include "TransformationMatrix.h"
@@ -147,6 +148,8 @@ public:
     virtual bool layerNeedsPlatformContext(const GraphicsLayer*) const { return false; }
 
     virtual bool backdropRootIsOpaque(const GraphicsLayer*) const { return false; }
+
+    virtual OptionSet<ContentsFormat> screenContentsFormats() const { return { }; }
 
 #ifndef NDEBUG
     // RenderLayerBacking overrides this to verify that it is not

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -338,7 +338,7 @@ Ref<PlatformCALayer> GraphicsLayerCA::createPlatformCALayer(PlatformCALayer::Lay
     auto result = PlatformCALayerCocoa::create(layerType, owner);
 
     if (result->canHaveBackingStore()) {
-        auto contentsFormat = PlatformCALayer::contentsFormatForLayer(nullptr, owner);
+        auto contentsFormat = PlatformCALayer::contentsFormatForLayer(owner);
         result->setContentsFormat(contentsFormat);
     }
 
@@ -3334,10 +3334,15 @@ void GraphicsLayerCA::updateReplicatedLayers()
 #if HAVE(SUPPORT_HDR_DISPLAY)
 void GraphicsLayerCA::updateDrawsHDRContent()
 {
-    auto contentsFormat = PlatformCALayer::contentsFormatForLayer(nullptr, this);
+    auto contentsFormat = PlatformCALayer::contentsFormatForLayer(this);
     protectedLayer()->setContentsFormat(contentsFormat);
 }
 #endif
+
+OptionSet<ContentsFormat> GraphicsLayerCA::screenContentsFormats() const
+{
+    return client().screenContentsFormats();
+}
 
 // For now, this assumes that layers only ever have one replica, so replicaIndices contains only 0 and 1.
 GraphicsLayerCA::CloneID GraphicsLayerCA::ReplicaState::cloneID() const
@@ -5138,6 +5143,13 @@ void GraphicsLayerCA::updateOpacityOnLayer()
 void GraphicsLayerCA::deviceOrPageScaleFactorChanged()
 {
     noteChangesForScaleSensitiveProperties();
+}
+
+void GraphicsLayerCA::screenSupportedContentsFormatsChanged()
+{
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    noteLayerPropertyChanged(DrawsHDRContentChanged | DebugIndicatorsChanged);
+#endif
 }
 
 void GraphicsLayerCA::noteChangesForScaleSensitiveProperties()

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -198,6 +198,7 @@ public:
     WEBCORE_EXPORT void setCustomAppearance(CustomAppearance) override;
 
     WEBCORE_EXPORT void deviceOrPageScaleFactorChanged() override;
+    WEBCORE_EXPORT void screenSupportedContentsFormatsChanged() override;
     void setShouldUpdateRootRelativeScaleFactor(bool value) override { m_shouldUpdateRootRelativeScaleFactor = value; }
 
     float rootRelativeScaleFactor() { return m_rootRelativeScaleFactor; }
@@ -276,6 +277,8 @@ private:
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
     bool platformCALayerAllowsDynamicContentScaling(const PlatformCALayer*) const override { return client().layerAllowsDynamicContentScaling(this); }
 #endif
+
+    WEBCORE_EXPORT OptionSet<ContentsFormat> screenContentsFormats() const override;
 
     bool isCommittingChanges() const override { return m_isCommittingChanges; }
     bool isUsingDisplayListDrawing(PlatformCALayer*) const override { return m_usesDisplayListDrawing; }

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
@@ -353,7 +353,7 @@ public:
     static void drawRepaintIndicator(GraphicsContext&, PlatformCALayer*, int repaintCount, Color customBackgroundColor = { });
     static CGRect frameForLayer(const PlatformLayer*);
 
-    static ContentsFormat contentsFormatForLayer(Widget* = nullptr, PlatformCALayerClient* = nullptr);
+    static ContentsFormat contentsFormatForLayer(PlatformCALayerClient* = nullptr);
 
     virtual void markFrontBufferVolatileForTesting() { }
     void moveToLayerPool();

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
@@ -178,9 +178,14 @@ Ref<PlatformCALayer> PlatformCALayer::createCompatibleLayerOrTakeFromPool(Platfo
     return layer;
 }
 
-ContentsFormat PlatformCALayer::contentsFormatForLayer(Widget* widget, PlatformCALayerClient* client)
+ContentsFormat PlatformCALayer::contentsFormatForLayer(PlatformCALayerClient* client)
 {
-    auto contentsFormats = screenContentsFormats(widget);
+    OptionSet<ContentsFormat> contentsFormats;
+    if (client)
+        contentsFormats = client->screenContentsFormats();
+    if (contentsFormats.isEmpty())
+        contentsFormats = screenContentsFormats(nullptr);
+
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
     if (client && client->drawsHDRContent() && contentsFormats.contains(ContentsFormat::RGBA16F))
         return ContentsFormat::RGBA16F;

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayerClient.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayerClient.h
@@ -81,6 +81,8 @@ public:
     virtual bool drawsHDRContent() const { return false; }
 #endif
 
+    virtual OptionSet<ContentsFormat> screenContentsFormats() const = 0;
+
     virtual void platformCALayerLogFilledVisibleFreshTile(unsigned /* blankPixelCount */) { }
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)

--- a/Source/WebCore/platform/graphics/ca/TileCoverageMap.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileCoverageMap.cpp
@@ -178,4 +178,9 @@ void TileCoverageMap::setDeviceScaleFactor(float deviceScaleFactor)
     m_layer.get().setContentsScale(deviceScaleFactor);
 }
 
+OptionSet<ContentsFormat> TileCoverageMap::screenContentsFormats() const
+{
+    return m_controller.rootLayer().owner()->screenContentsFormats();
+}
+
 }

--- a/Source/WebCore/platform/graphics/ca/TileCoverageMap.h
+++ b/Source/WebCore/platform/graphics/ca/TileCoverageMap.h
@@ -68,6 +68,7 @@ private:
     bool platformCALayerDrawsContent() const override { return true; }
     void platformCALayerPaintContents(PlatformCALayer*, GraphicsContext&, const FloatRect&, OptionSet<GraphicsLayerPaintBehavior>) override;
     float platformCALayerDeviceScaleFactor() const override;
+    OptionSet<ContentsFormat> screenContentsFormats() const override;
 
     void updateTimerFired();
     

--- a/Source/WebCore/platform/graphics/ca/TileGrid.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.cpp
@@ -824,6 +824,13 @@ bool TileGrid::platformCALayerNeedsPlatformContext(const PlatformCALayer* layer)
     return false;
 }
 
+OptionSet<ContentsFormat> TileGrid::screenContentsFormats() const
+{
+    if (auto* layerOwner = m_controller->rootLayer().owner())
+        return layerOwner->screenContentsFormats();
+    return { };
+}
+
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
 std::optional<DynamicContentScalingDisplayList> TileGrid::platformCALayerDynamicContentScalingDisplayList(const PlatformCALayer* layer) const
 {

--- a/Source/WebCore/platform/graphics/ca/TileGrid.h
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.h
@@ -167,6 +167,7 @@ private:
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
     std::optional<DynamicContentScalingDisplayList> platformCALayerDynamicContentScalingDisplayList(const PlatformCALayer*) const override;
 #endif
+    OptionSet<ContentsFormat> screenContentsFormats() const override;
 
     TileGridIdentifier m_identifier;
     const CheckedRef<TileController> m_controller;

--- a/Source/WebCore/platform/ios/PlatformScreenIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformScreenIOS.mm
@@ -120,6 +120,11 @@ bool screenSupportsHighDynamicRange(Widget*)
     return false;
 }
 
+bool screenSupportsHighDynamicRange(PlatformDisplayID)
+{
+    return screenSupportsHighDynamicRange(nullptr);
+}
+
 #if HAVE(SUPPORT_HDR_DISPLAY)
 float currentEDRHeadroomForDisplay(PlatformDisplayID)
 {

--- a/Source/WebCore/platform/mac/PlatformScreenMac.mm
+++ b/Source/WebCore/platform/mac/PlatformScreenMac.mm
@@ -430,20 +430,23 @@ bool screenSupportsExtendedColor(Widget* widget)
 
 bool screenSupportsHighDynamicRange(Widget* widget)
 {
+    return screenSupportsHighDynamicRange(displayID(widget));
+}
+
+bool screenSupportsHighDynamicRange(PlatformDisplayID displayID)
+{
 #if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGBA16F)
     if (screenContentsFormatsForTesting().contains(ContentsFormat::RGBA16F))
         return true;
 #endif
 
-    if (auto data = screenProperties(widget))
+    if (auto data = screenData(displayID))
         return data->screenSupportsHighDynamicRange;
 
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
 #if USE(MEDIATOOLBOX)
-    if (PAL::isMediaToolboxFrameworkAvailable() && PAL::canLoad_MediaToolbox_MTShouldPlayHDRVideo()) {
-        auto displayID = WebCore::displayID(screen(widget));
+    if (PAL::isMediaToolboxFrameworkAvailable() && PAL::canLoad_MediaToolbox_MTShouldPlayHDRVideo())
         return PAL::softLink_MediaToolbox_MTShouldPlayHDRVideo((__bridge CFArrayRef)@[ @(displayID) ]);
-    }
 #endif
     return false;
 }

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -4736,4 +4736,14 @@ void RenderLayerBacking::setNeedsFixedContainerEdgesUpdateIfNeeded()
     renderer().page().chrome().client().setNeedsFixedContainerEdgesUpdate();
 }
 
+OptionSet<ContentsFormat> RenderLayerBacking::screenContentsFormats() const
+{
+#if PLATFORM(MAC) || PLATFORM(IOS_FAMILY)
+    return WebCore::screenContentsFormats(&renderer().view().frameView());
+#else
+    return { };
+#endif
+}
+
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -260,6 +260,8 @@ public:
     void logFilledVisibleFreshTile(unsigned) override;
     bool needsPixelAligment() const override { return !m_isMainFrameRenderViewLayer; }
 
+    OptionSet<ContentsFormat> screenContentsFormats() const override;
+
     LayoutSize subpixelOffsetFromRenderer() const { return m_subpixelOffsetFromRenderer; }
 
     TransformationMatrix transformMatrixForProperty(AnimatedProperty) const final;

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -5315,6 +5315,12 @@ void RenderLayerCompositor::deviceOrPageScaleFactorChanged()
         rootLayer->noteDeviceOrPageScaleFactorChangedIncludingDescendants();
 }
 
+void RenderLayerCompositor::screenSupportedContentsFormatsChanged()
+{
+    if (RefPtr rootLayer = rootGraphicsLayer())
+        rootLayer->noteScreenSupportedContentsFormatsChangedIncludingDescendants();
+}
+
 void RenderLayerCompositor::removeFromScrollCoordinatedLayers(RenderLayer& layer)
 {
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -359,6 +359,7 @@ public:
     bool acceleratedDrawingEnabled() const { return m_acceleratedDrawingEnabled; }
 
     void deviceOrPageScaleFactorChanged();
+    void screenSupportedContentsFormatsChanged();
 
     GraphicsLayer* layerForHorizontalScrollbar() const { return m_layerForHorizontalScrollbar.get(); }
     GraphicsLayer* layerForVerticalScrollbar() const { return m_layerForVerticalScrollbar.get(); }

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
@@ -75,7 +75,7 @@ Ref<PlatformCALayer> GraphicsLayerCARemote::createPlatformCALayer(PlatformCALaye
 
     if (result->canHaveBackingStore()) {
         RefPtr localMainFrameView = context->protectedWebPage()->localMainFrameView();
-        result->setContentsFormat(PlatformCALayer::contentsFormatForLayer(localMainFrameView.get(), owner));
+        result->setContentsFormat(PlatformCALayer::contentsFormatForLayer(owner));
     }
     return WTFMove(result);
 }


### PR DESCRIPTION
#### a08fe899cd50219c26ee2942bc74ba09f5322417
<pre>
[HDR] Moving the WebView from a screen to another should change backing store formats.
<a href="https://bugs.webkit.org/show_bug.cgi?id=294757">https://bugs.webkit.org/show_bug.cgi?id=294757</a>
&lt;<a href="https://rdar.apple.com/problem/153908494">rdar://problem/153908494</a>&gt;

Reviewed by Simon Fraser.

Add code to PlatformCALayerClient/GraphicsLayerClient to query the currently
supported ContentsFormats for the screen that the layer is on. Use this version,
rather than querying the values for the primary display for all layers.

Add change handling to Page (similar to deviceOrPageScaleFactorChanged) that
notifies all GraphicsLayers when this result might change.

* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::screenContentsFormatsChanged):
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::screenPropertiesDidChange):
(WebCore::Page::windowScreenDidChange):
* Source/WebCore/page/Page.h:
* Source/WebCore/platform/PlatformScreen.h:
* Source/WebCore/platform/graphics/GraphicsLayer.cpp:
(WebCore::GraphicsLayer::noteScreenContentsFormatsChangedIncludingDescendants):
* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::screenContentsFormatsChanged):
* Source/WebCore/platform/graphics/GraphicsLayerClient.h:
(WebCore::GraphicsLayerClient::screenContentsFormats const):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::createPlatformCALayer):
(WebCore::GraphicsLayerCA::ensureStructuralLayer):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayer.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayer.mm:
(WebCore::PlatformCALayer::contentsFormatForLayer):
* Source/WebCore/platform/graphics/ca/PlatformCALayerClient.h:
* Source/WebCore/platform/graphics/ca/TileCoverageMap.cpp:
(WebCore::TileCoverageMap::screenContentsFormats const):
* Source/WebCore/platform/graphics/ca/TileCoverageMap.h:
* Source/WebCore/platform/graphics/ca/TileGrid.cpp:
(WebCore::TileGrid::screenContentsFormats const):
* Source/WebCore/platform/graphics/ca/TileGrid.h:
* Source/WebCore/platform/ios/PlatformScreenIOS.mm:
(WebCore::screenSupportsHighDynamicRange):
* Source/WebCore/platform/mac/PlatformScreenMac.mm:
(WebCore::screenSupportsHighDynamicRange):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::screenContentsFormats const):
* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::screenContentsFormatsChanged):
* Source/WebCore/rendering/RenderLayerCompositor.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm:
(WebKit::GraphicsLayerCARemote::createPlatformCALayer):

Canonical link: <a href="https://commits.webkit.org/296635@main">https://commits.webkit.org/296635@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39555cda555f28bcbc6ee3fb4cd1609cfc7f6a3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109035 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28696 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19120 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114246 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59353 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110998 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29378 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37262 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82863 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111983 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23366 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98209 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63305 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22772 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16348 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58937 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92735 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16394 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117364 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36084 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26672 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91877 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36455 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94473 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91682 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23363 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36593 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14343 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31944 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35981 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41495 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35679 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39017 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37364 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->