### PR TITLE
Reduce scope of WTF_ALLOW_UNSAFE_BUFFER_USAGE in ImmutableStyleProperties

### DIFF
--- a/Source/WebCore/css/ImmutableStyleProperties.cpp
+++ b/Source/WebCore/css/ImmutableStyleProperties.cpp
@@ -39,25 +39,20 @@ DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(ImmutableStyleProperties);
 ImmutableStyleProperties::ImmutableStyleProperties(std::span<const CSSProperty> properties, CSSParserMode mode)
     : StyleProperties(mode, properties.size())
 {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    auto* metadataArray = const_cast<StylePropertyMetadata*>(this->metadataArray());
-    auto* valueArray = std::bit_cast<PackedPtr<CSSValue>*>(this->valueArray());
+    auto metadataSpan = spanConstCast<StylePropertyMetadata>(this->metadataSpan());
+    auto valueSpan = this->valueSpan();
     for (auto [i, property] : indexedRange(properties)) {
-        metadataArray[i] = property.metadata();
+        metadataSpan[i] = property.metadata();
         RefPtr value = property.value();
-        valueArray[i] = value.get();
+        valueSpan[i] = value.get();
         value->ref();
     }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 ImmutableStyleProperties::~ImmutableStyleProperties()
 {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    auto* valueArray = std::bit_cast<PackedPtr<CSSValue>*>(this->valueArray());
-    for (unsigned i = 0; i < m_arraySize; ++i)
-        valueArray[i]->deref();
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    for (auto& value : valueSpan())
+        value->deref();
 }
 
 Ref<ImmutableStyleProperties> ImmutableStyleProperties::create(std::span<const CSSProperty> properties, CSSParserMode mode)
@@ -125,28 +120,27 @@ int ImmutableStyleProperties::findPropertyIndex(CSSPropertyID propertyID) const
     // Convert here propertyID into an uint16_t to compare it with the metadata's m_propertyID to avoid
     // the compiler converting it to an int multiple times in the loop.
     uint16_t id = enumToUnderlyingType(propertyID);
-    for (int n = m_arraySize - 1 ; n >= 0; --n) {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        if (metadataArray()[n].m_propertyID == id)
+    auto metadataSpan = this->metadataSpan();
+    for (int n = metadataSpan.size() - 1 ; n >= 0; --n) {
+        if (metadataSpan[n].m_propertyID == id)
             return n;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
     return -1;
 }
 
 int ImmutableStyleProperties::findCustomPropertyIndex(StringView propertyName) const
 {
-    for (int n = m_arraySize - 1 ; n >= 0; --n) {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        if (metadataArray()[n].m_propertyID == CSSPropertyCustom) {
+    auto metadataSpan = this->metadataSpan();
+    auto valueSpan = this->valueSpan();
+    for (int n = metadataSpan.size() - 1 ; n >= 0; --n) {
+        if (metadataSpan[n].m_propertyID == CSSPropertyCustom) {
             // We found a custom property. See if the name matches.
-            auto* value = valueArray()[n].get();
+            auto* value = valueSpan[n].get();
             if (!value)
                 continue;
             if (downcast<CSSCustomPropertyValue>(*value).name() == propertyName)
                 return n;
         }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
     return -1;
 }

--- a/Source/WebCore/css/ImmutableStyleProperties.h
+++ b/Source/WebCore/css/ImmutableStyleProperties.h
@@ -56,8 +56,8 @@ public:
     void* m_storage;
 
 private:
-    PackedPtr<const CSSValue>* valueArray() const;
-    const StylePropertyMetadata* metadataArray() const;
+    std::span<PackedPtr<const CSSValue>> valueSpan() const;
+    std::span<const StylePropertyMetadata> metadataSpan() const;
     ImmutableStyleProperties(std::span<const CSSProperty>, CSSParserMode);
 };
 
@@ -68,30 +68,28 @@ inline void ImmutableStyleProperties::deref() const
 }
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-inline PackedPtr<const CSSValue>* ImmutableStyleProperties::valueArray() const
+inline std::span<PackedPtr<const CSSValue>> ImmutableStyleProperties::valueSpan() const
 {
-    return std::bit_cast<PackedPtr<const CSSValue>*>(std::bit_cast<const uint8_t*>(metadataArray()) + (m_arraySize * sizeof(StylePropertyMetadata)));
+    return unsafeMakeSpan(std::bit_cast<PackedPtr<const CSSValue>*>(std::bit_cast<const uint8_t*>(metadataSpan().data()) + (m_arraySize * sizeof(StylePropertyMetadata))), propertyCount());
 }
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
-inline const StylePropertyMetadata* ImmutableStyleProperties::metadataArray() const
+inline std::span<const StylePropertyMetadata> ImmutableStyleProperties::metadataSpan() const
 {
-    return reinterpret_cast<const StylePropertyMetadata*>(const_cast<const void**>((&(this->m_storage))));
+    return unsafeMakeSpan(reinterpret_cast<const StylePropertyMetadata*>(const_cast<const void**>((&(this->m_storage)))), propertyCount());
 }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 inline ImmutableStyleProperties::PropertyReference ImmutableStyleProperties::propertyAt(unsigned index) const
 {
-    return PropertyReference(metadataArray()[index], valueArray()[index].get());
+    return PropertyReference(metadataSpan()[index], valueSpan()[index].get());
 }
 
 constexpr size_t ImmutableStyleProperties::objectSize(unsigned count)
 {
     return sizeof(ImmutableStyleProperties) - sizeof(void*) + sizeof(StylePropertyMetadata) * count + sizeof(PackedPtr<const CSSValue>) * count;
 }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
-}
+} // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ImmutableStyleProperties)
     static bool isType(const WebCore::StyleProperties& properties) { return !properties.isMutable(); }


### PR DESCRIPTION
#### d6dcfd454746cdbb48de0e9b41fc10f03b0843e8
<pre>
Reduce scope of WTF_ALLOW_UNSAFE_BUFFER_USAGE in ImmutableStyleProperties
<a href="https://bugs.webkit.org/show_bug.cgi?id=294884">https://bugs.webkit.org/show_bug.cgi?id=294884</a>

Reviewed by Anne van Kesteren.

This tested as performance neutral on Speedometer.

* Source/WebCore/css/ImmutableStyleProperties.cpp:
(WebCore::ImmutableStyleProperties::ImmutableStyleProperties):
(WebCore::ImmutableStyleProperties::~ImmutableStyleProperties):
(WebCore::ImmutableStyleProperties::findPropertyIndex const):
(WebCore::ImmutableStyleProperties::findCustomPropertyIndex const):
* Source/WebCore/css/ImmutableStyleProperties.h:
(WebCore::ImmutableStyleProperties::valueSpan const):
(WebCore::ImmutableStyleProperties::metadataSpan const):
(WebCore::ImmutableStyleProperties::propertyAt const):
(WebCore::ImmutableStyleProperties::objectSize):
(WebCore::ImmutableStyleProperties::valueArray const): Deleted.
(WebCore::ImmutableStyleProperties::metadataArray const): Deleted.

Canonical link: <a href="https://commits.webkit.org/296564@main">https://commits.webkit.org/296564@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ed82d687a3110742f945ce764cf21378e8a8784

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108882 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18967 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114091 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59231 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110845 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29226 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37108 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82736 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111830 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23232 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98073 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63175 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22651 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16209 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58790 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92605 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16256 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117211 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35932 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26546 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91746 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36305 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94337 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91553 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36459 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14216 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31795 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17583 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35831 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41358 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35532 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38876 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37218 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->