### PR TITLE
[SwiftUI] Improve the ergonomics of loading simple web content in WebPage

### DIFF
--- a/Source/WebKit/UIProcess/API/Swift/WebPage+Navigation.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+Navigation.swift
@@ -37,6 +37,9 @@ extension WebPage {
     }
 
     /// A particular state that occurs during the progression of a navigation.
+    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
     public enum NavigationEvent: Hashable, Sendable {
         /// This event occurs when the page receives provisional approval to process a navigation request,
         /// but before it receives a response to that request.
@@ -67,6 +70,9 @@ extension WebPage {
 
         /// The process for the web content of this page was terminated for any reason.
         case webContentProcessTerminated
+
+        /// The URL to navigate to is invalid.
+        case invalidURL
     }
 }
 


### PR DESCRIPTION
#### e409318c348583665faf264919689decda631944
<pre>
[SwiftUI] Improve the ergonomics of loading simple web content in WebPage
<a href="https://bugs.webkit.org/show_bug.cgi?id=294885">https://bugs.webkit.org/show_bug.cgi?id=294885</a>
<a href="https://rdar.apple.com/152904248">rdar://152904248</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

Improve the set of loading APIs in a few ways:

1. Add an overload of `load(_:)` that accepts a `URL?` to make it more convenient to load URLs
without having to create a URLRequest directly. Consequently, a new error case is added to handle
an unexpected `nil` URL.

2. Add a default value of `about:blank` to the `baseURL` parameter for loading an HTML string so that
the client doesn&apos;t have to repeatedly type this value.

* Source/WebKit/UIProcess/API/Swift/WebPage+Navigation.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage.swift:
(load(_:)):
(load(_:baseURL:)):
(toNavigationSequence(_:)):

Canonical link: <a href="https://commits.webkit.org/296599@main">https://commits.webkit.org/296599@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1e3e4005d6e912377688b53663a2e5a8204de38

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108884 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28544 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18969 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114093 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59233 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29228 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37110 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82735 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111832 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23231 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98074 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63174 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22650 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58792 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92604 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16257 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117213 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35934 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26549 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91747 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36307 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94338 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91554 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36460 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14217 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31797 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17602 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35833 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41360 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35534 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38878 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37220 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->