### PR TITLE
[view-transitions] Properly serialize match-element in computed style

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/view-transition-name-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/view-transition-name-computed-expected.txt
@@ -8,4 +8,6 @@ PASS Property view-transition-name value 'initial'
 PASS Property view-transition-name value 'inherit'
 PASS Property view-transition-name value 'revert'
 PASS Property view-transition-name value 'revert-layer'
+PASS Property view-transition-name value 'match-element'
+PASS Property view-transition-name value 'maTch-element'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/view-transition-name-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/view-transition-name-computed.html
@@ -22,6 +22,9 @@ test_computed_value("view-transition-name", "initial", "none");
 test_computed_value("view-transition-name", "inherit", "none");
 test_computed_value("view-transition-name", "revert", "none");
 test_computed_value("view-transition-name", "revert-layer", "none");
+
+test_computed_value("view-transition-name", "match-element");
+test_computed_value("view-transition-name", "maTch-element", "match-element");
 </script>
 </body>
 </html>

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -12190,20 +12190,13 @@
             "initial": "none",
             "values": [
                 "none",
-                {
-                    "value": "auto",
-                    "status": "non-standard"
-                },
-                {
-                    "value": "match-element",
-                    "status": "non-standard"
-                }
+                "auto",
+                "match-element"
             ],
             "codegen-properties": {
                 "settings-flag": "viewTransitionsEnabled",
                 "style-converter": "ViewTransitionName",
-                "parser-grammar": "none | auto | match-element | <custom-ident>",
-                "parser-grammar-comment": "Current spec grammar is 'none | <custom-ident>'"
+                "parser-grammar": "none | auto | match-element | <custom-ident>"
             },
             "specification": {
                 "category": "css-view-transitions",

--- a/Source/WebCore/style/StyleExtractorSerializer.h
+++ b/Source/WebCore/style/StyleExtractorSerializer.h
@@ -1235,6 +1235,11 @@ inline void ExtractorSerializer::serializeViewTransitionName(ExtractorState& sta
         return;
     }
 
+    if (viewTransitionName.isMatchElement()) {
+        serializationForCSS(builder, context, state.style, CSS::Keyword::MatchElement { });
+        return;
+    }
+
     serializationForCSS(builder, context, state.style, CustomIdentifier { viewTransitionName.customIdent() });
 }
 


### PR DESCRIPTION
#### 1e326825bb296fe2899a281960f4ecf4b28d2edc
<pre>
[view-transitions] Properly serialize match-element in computed style
<a href="https://bugs.webkit.org/show_bug.cgi?id=294887">https://bugs.webkit.org/show_bug.cgi?id=294887</a>
<a href="https://rdar.apple.com/154161055">rdar://154161055</a>

Reviewed by Anne van Kesteren.

Properly handle match-element in computed style, instead of serializing it as empty string.

Also fix CSSProperties.json to not mention it&apos;s non-standard (since it&apos;s standardized in the level 2 specification).

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/view-transition-name-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/view-transition-name-computed.html:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/style/StyleExtractorSerializer.h:
(WebCore::Style::ExtractorSerializer::serializeViewTransitionName):

Canonical link: <a href="https://commits.webkit.org/296556@main">https://commits.webkit.org/296556@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa23f0dee21d094e702431ecb58191df2a44ea38

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108896 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28556 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18981 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114104 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59242 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110859 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29240 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37122 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82746 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111844 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23240 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98085 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63185 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22661 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16222 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58803 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92614 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16268 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117224 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35946 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26558 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91756 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36318 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94349 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91563 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23312 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36471 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14228 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31806 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35845 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41371 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35546 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38888 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37231 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->