### PR TITLE
Re-import html/editing/the-hidden-attribute WPT

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7945,6 +7945,8 @@ imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-f
 imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-005.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-007.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-scroll-to-text-fragment.html [ Skip ]
+imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-text-fragment.html [ Skip ]
 
 # This test hits an assert in debug
 webkit.org/b/290133 [ Debug ] svg/dom/SVGGeometry-isPointInFill-with-null-path.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-element-fragment-navigation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-element-fragment-navigation-expected.txt
@@ -9,4 +9,5 @@ FAIL Verifies that no scrolling occurs when an element selected by the fragment 
 FAIL No scrolling should occur when the beforematch event handler sets the target element's style to display: none. assert_true: beforematch should be called when window.location.hash is set to #displaynone. expected true got false
 FAIL Scrolling should still occur when beforematch sets visiblity:hidden on the target element. assert_true: beforematch should be called when window.location.hash is set to #visibilityhidden. expected true got false
 PASS Verifies that the beforematch event is not fired on elements without hidden=until-found.
+FAIL The hidden attribute should still be set inside the beforematch event handler. assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-element-fragment-navigation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-element-fragment-navigation.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <link rel="author" title="Joey Arhar" href="mailto:jarhar@chromium.org">
-<link rel="help" href="https://github.com/WICG/display-locking">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#the-hidden-attribute:event-beforematch">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
@@ -197,4 +197,21 @@ test(t => {
   div.addEventListener('beforematch', t.unreached_func('beforematch should not be fired without hidden=until-found.'));
   window.location.hash = '#target';
 }, 'Verifies that the beforematch event is not fired on elements without hidden=until-found.');
+
+test(t => {
+  window.location.hash = '';
+  const div = document.createElement('div');
+  div.id = 'target';
+  div.textContent = 'target';
+  div.hidden = 'until-found';
+  document.body.appendChild(div);
+  t.add_cleanup(() => div.remove());
+
+  let hiddenAttributeSet = false;
+  div.addEventListener('beforematch', () => {
+    hiddenAttributeSet = div.hasAttribute('hidden');
+  });
+  window.location.hash = '#target';
+  assert_true(hiddenAttributeSet);
+}, 'The hidden attribute should still be set inside the beforematch event handler.');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-scroll-to-text-fragment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-scroll-to-text-fragment-expected.txt
@@ -1,5 +1,7 @@
 
-FAIL Verifies that the beforematch event is fired on the matching element of a ScrollToTextFragment navigation. assert_equals: Scrolling should happen after beforematch is fired. expected (number) 0 but got (undefined) undefined
-FAIL Verifies that beforematch is only fired on elements targeted by a text fragment when there is both a text fragment and an element fragment. assert_true: foo was searched for, so it should get the beforematch event. expected true got false
-FAIL Verifies that the beforematch event bubbles with scroll to text fragment. assert_true: The element containing the searched text should have beforematch fired on it. expected true got false
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT Verifies that the beforematch event is fired on the matching element of a ScrollToTextFragment navigation. Test timed out
+NOTRUN Verifies that beforematch is only fired on elements targeted by a text fragment when there is both a text fragment and an element fragment.
+NOTRUN Verifies that the beforematch event bubbles with scroll to text fragment.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-scroll-to-text-fragment.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-scroll-to-text-fragment.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<meta name=timeout content=long>
 <title>beforematch fired on ScrollToTextFragment</title>
 <link rel="author" title="Joey Arhar" href="mailto:jarhar@chromium.org">
-<link rel="help" href="https://github.com/WICG/display-locking">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#the-hidden-attribute:event-beforematch">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
@@ -12,57 +13,65 @@
 <script src="/scroll-to-text-fragment/stash.js"></script>
 
 <script>
-promise_test(t => new Promise((resolve, reject) => {
-  const key = token();
-  test_driver.bless('Open a scroll to text fragment URL', () => {
-    window.open(
-      `resources/beforematch-scroll-to-text-fragment-basic.html?key=${key}#:~:text=foo`,
-      '_blank',
-      'noopener');
+async function fetchResultsNoResolver(key) {
+  return new Promise((resolve, reject) => {
+    fetchResults(key, resolve, reject);
   });
-  fetchResults(key, resolve, reject);
-}).then(results => {
-  assert_equals(results.pageYOffsetDuringBeforematch, 0,
-    'Scrolling should happen after beforematch is fired.');
+}
+
+promise_test(async () => {
+  const key = token();
+  await test_driver.bless('Open a scroll to text fragment URL');
+  window.open(
+    `resources/beforematch-scroll-to-text-fragment-basic.html?key=${key}#:~:text=foo`,
+    '_blank',
+    'noopener');
+  const results = await fetchResultsNoResolver(key);
   assert_true(results.beforematchFiredOnFoo,
     'Foo was searched for, so it should get a beforematch event.');
   assert_false(results.beforematchFiredOnBar,
     'Bar was not searched for, so it should not get a beforematch event.');
+  assert_equals(results.pageYOffsetDuringBeforematch, 0,
+    'Scrolling should happen after beforematch is fired.');
   assert_true(results.pageYOffsetAfterRaf > 0,
     'The page should be scrolled down to foo.');
-}), 'Verifies that the beforematch event is fired on the matching element of a ScrollToTextFragment navigation.');
+  assert_true(results.beforematchHiddenAttributePresent,
+    'The hidden attribute should be set inside the beforematch event handler.');
+}, 'Verifies that the beforematch event is fired on the matching element of a ScrollToTextFragment navigation.');
 
-promise_test(t => new Promise((resolve, reject) => {
+promise_test(async () => {
   const key = token();
-  test_driver.bless('Open a scroll to text fragment URL', () => {
-    window.open(
-      `resources/beforematch-scroll-to-text-fragment-with-anchor.html?key=${key}#:~:text=foo`,
-      '_blank',
-      'noopener');
-  });
-  fetchResults(key, resolve, reject);
-}).then(results => {
+  await test_driver.bless('Open a scroll to text fragment URL');
+  window.open(
+    `resources/beforematch-scroll-to-text-fragment-with-anchor.html?key=${key}#bar:~:text=foo`,
+    '_blank',
+    'noopener');
+  const results = await fetchResultsNoResolver(key);
+  assert_true(results.fooHasHiddenAttribute,
+    'hidden=until-found revealing should not happen until after the script tag loads.');
   assert_true(results.beforematchFiredOnFoo,
     'foo was searched for, so it should get the beforematch event.');
   assert_false(results.beforematchFiredOnBar,
     'bar should not get the beforematch event despite being the target of an element fragment due to the text fragment.');
-}), 'Verifies that beforematch is only fired on elements targeted by a text fragment when there is both a text fragment and an element fragment.');
+  assert_equals(results.pageYOffsetDuringBeforematch, 0,
+    'Scrolling should happen after beforematch is fired.');
+  assert_true(results.pageYOffsetAfterRaf > 0,
+    'The page should be scrolled down to foo.');
+}, 'Verifies that beforematch is only fired on elements targeted by a text fragment when there is both a text fragment and an element fragment.');
 
-promise_test(t => new Promise((resolve, reject) => {
+promise_test(async () => {
   const key = token();
-  test_driver.bless('Open a scroll to text fragment URL', () => {
-    window.open(
-      `resources/beforematch-scroll-to-text-fragment-bubble.html?key=${key}#:~:text=foo`,
-      '_blank',
-      'noopener');
-  });
-  fetchResults(key, resolve, reject);
-}).then(results => {
+  await test_driver.bless('Open a scroll to text fragment URL');
+  window.open(
+    `resources/beforematch-scroll-to-text-fragment-bubble.html?key=${key}#:~:text=foo`,
+    '_blank',
+    'noopener');
+  const results = await fetchResultsNoResolver(key);
   assert_true(results.beforematchFiredOnChild,
     'The element containing the searched text should have beforematch fired on it.');
   assert_true(results.beforematchFiredOnParent,
     'The parent element of the element containing the matching text should have the beforematch event fired on it because the event should bubble.');
-}), 'Verifies that the beforematch event bubbles with scroll to text fragment.');
+}, 'Verifies that the beforematch event bubbles with scroll to text fragment.');
 
 // TODO(jarhar): Write more tests here once we decide on a behavior here: https://github.com/WICG/display-locking/issues/150
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-ua-stylesheet.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-ua-stylesheet.html
@@ -28,7 +28,10 @@ function testCVHidden(description) {
         `${description} should not affect the div's display property.`);
     assert_equals(getComputedStyle(div).contentVisibility, 'hidden',
         `${description} should make the div content-visibility:hidden.`);
+    assert_equals(div.hidden, "until-found",
+      `${description} should make the div hidden=until-found.`);
   }, description);
+
 }
 
 function testNormal(description) {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-001-expected.html
@@ -3,7 +3,7 @@
 <meta charset="utf8">
 <title>CSS Content Visibility: container (reference)</title>
 <link rel="author" title="Vladimir Levin" href="mailto:vmpstr@chromium.org">
-<link rel="help" href="https://github.com/WICG/display-locking">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#attr-hidden-until-found">
 
 <style>
 #container {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-001.html
@@ -4,7 +4,7 @@
 <meta charset="utf8">
 <title>content-visibility changes after a delay</title>
 <link rel="author" title="Vladimir Levin" href="mailto:vmpstr@chromium.org">
-<link rel="help" href="https://github.com/WICG/display-locking">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#attr-hidden-until-found">
 <link rel="match" href="./resources/container-ref.html">
 <meta name="assert" content="scrollIntoView has no effect on hidden=until-found">
 <script src="/common/reftest-wait.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-002.html
@@ -2,7 +2,7 @@
 <meta charset="utf8">
 <title>Content Visibility: tab order navigation ignores hidden=until-found subtrees</title>
 <link rel="author" title="Vladimir Levin" href="mailto:vmpstr@chromium.org">
-<link rel="help" href="https://github.com/WICG/display-locking">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#attr-hidden-until-found">
 <meta name="assert" content="tab order navigation ignores hidden=until-found subtrees.">
 
 <script src="/resources/testharness.js"></script>
@@ -21,7 +21,7 @@
 
 <script>
 async_test((t) => {
-  const tab = "\t";
+  const tab = "\ue004";
   async function step1() {
     await test_driver.send_keys(document.body, tab);
     t.step(() => {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-004-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-004-expected.html
@@ -3,7 +3,7 @@
 <meta charset="utf8">
 <title>CSS Content Visibility: container (reference)</title>
 <link rel="author" title="Vladimir Levin" href="mailto:vmpstr@chromium.org">
-<link rel="help" href="https://github.com/WICG/display-locking">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#attr-hidden-until-found">
 
 <style>
 #container {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-004.html
@@ -3,7 +3,7 @@
 <meta charset="utf8">
 <title>hidden=until-found does not paint</title>
 <link rel="author" title="Vladimir Levin" href="mailto:vmpstr@chromium.org">
-<link rel="help" href="https://github.com/WICG/display-locking">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#attr-hidden-until-found">
 <link rel="match" href="./resources/container-ref.html">
 <meta name="assert" content="content-visibility subtrees are not painted">
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-005-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-005-expected.html
@@ -3,7 +3,7 @@
 <meta charset="utf8">
 <title>Content Visibility: hidden-matchable and size contained (reference)</title>
 <link rel="author" title="Vladimir Levin" href="mailto:vmpstr@chromium.org">
-<link rel="help" href="https://github.com/WICG/display-locking">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#attr-hidden-until-found">
 
 <style>
 div {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-005-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-005-ref.html
@@ -3,7 +3,7 @@
 <meta charset="utf8">
 <title>Content Visibility: hidden-matchable and size contained (reference)</title>
 <link rel="author" title="Vladimir Levin" href="mailto:vmpstr@chromium.org">
-<link rel="help" href="https://github.com/WICG/display-locking">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#attr-hidden-until-found">
 
 <style>
 div {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-005.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-005.html
@@ -3,7 +3,7 @@
 <meta charset="utf8">
 <title>hidden=until-found and size contained</title>
 <link rel="author" title="Vladimir Levin" href="mailto:vmpstr@chromium.org">
-<link rel="help" href="https://github.com/WICG/display-locking">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#attr-hidden-until-found">
 <link rel="match" href="hidden-until-found-005-ref.html">
 <meta name="assert" content="hidden=until-found puts in size containment">
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-006-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-006-ref.html
@@ -3,7 +3,7 @@
 <meta charset="utf8">
 <title>content-visibility hidden-matchable + scrollIntoView (reference)</title>
 <link rel="author" title="Vladimir Levin" href="mailto:vmpstr@chromium.org">
-<link rel="help" href="https://github.com/WICG/display-locking">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#attr-hidden-until-found">
 
 <style>
 .spacer {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-007-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-007-expected.html
@@ -3,7 +3,7 @@
 <meta charset="utf8">
 <title>Content Visibility: spacer and a container (reference)</title>
 <link rel="author" title="Vladimir Levin" href="mailto:vmpstr@chromium.org">
-<link rel="help" href="https://github.com/WICG/display-locking">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#attr-hidden-until-found">
 
 <style>
 .spacer {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-007.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-007.html
@@ -4,7 +4,7 @@
 <meta charset="utf8">
 <title>hidden=until-found + focus</title>
 <link rel="author" title="Vladimir Levin" href="mailto:vmpstr@chromium.org">
-<link rel="help" href="https://github.com/WICG/display-locking">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#attr-hidden-until-found">
 <link rel="match" href="./resources/spacer-and-container-ref.html">
 <meta name="assert" content="focus does not scroll or focus element under hidden=until-found">
 <script src="/common/reftest-wait.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-text-fragment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-text-fragment-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL Verifies that the beforematch event is fired on the matching element of a ScrollToTextFragment navigation. assert_false: The matching hidden=until-found element should have its hidden attribute removed so it can be scrolled to. expected false got true
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT Verifies that the beforematch event is fired on the matching element of a ScrollToTextFragment navigation. Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-text-fragment.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-text-fragment.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>beforematch fired on ScrollToTextFragment</title>
 <link rel="author" title="Joey Arhar" href="mailto:jarhar@chromium.org">
-<link rel="help" href="https://github.com/WICG/display-locking">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#attr-hidden-until-found">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/resources/beforematch-scroll-to-text-fragment-basic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/resources/beforematch-scroll-to-text-fragment-basic.html
@@ -3,46 +3,61 @@
 
 <!-- This test is navigated to with the fragment #:~:text=foo -->
 
-<body>
-  <div style="height: 4000px;">spacer</div>
-  <script>
-    const results = {};
+<div style="height: 4000px;">spacer</div>
 
-    const foo = document.createElement('div');
-    foo.textContent = 'foo';
-    foo.hidden = 'until-found';
-    document.body.appendChild(foo);
-    window.beforematchFiredOnFoo = false;
-    foo.addEventListener('beforematch', () => {
-      // This should be zero. Scrolling should happen after beforematch is
-      // fired.
-      results.pageYOffsetDuringBeforematch = window.pageYOffset;
-      window.beforematchFiredOnFoo = true;
-    });
+<script>
+(async () => {
+  const results = {};
+  const key = (new URLSearchParams(window.location.search)).get('key');
 
-    const bar = document.createElement('div');
-    bar.textContent = 'bar';
-    document.body.appendChild(bar);
-    window.beforematchFiredOnBar = false;
-    bar.addEventListener('beforematch', () => {
-      window.beforematchFiredOnBar = true;
-    });
+  // This test adds the elements from JS
+  // (unlike beforematch-scroll-to-text-fragment-with-anchor.html,
+  // which uses parser-created elements)
+  const foo = document.createElement('div');
+  foo.hidden = 'until-found';
+  foo.textContent = 'foo';
+  document.body.appendChild(foo);
 
-    requestAnimationFrame(() => {
-      requestAnimationFrame(async () => {
-        // This should be true. Foo was searched for, so it should get a
-        // beforematch event.
-        results.beforematchFiredOnFoo = window.beforematchFiredOnFoo;
-        // This should be false. Bar was not searched for, so it should not get
-        // a beforematch event.
-        results.beforematchFiredOnBar = window.beforematchFiredOnBar;
-        // This should be greater than zero. The page should be scrolled down
-        // to foo.
-        results.pageYOffsetAfterRaf = window.pageYOffset;
+  let beforematchResolver = null;
+  const beforematchPromise = new Promise(resolve => {
+    beforematchResolver = resolve;
+  });
 
-        params = new URLSearchParams(window.location.search);
-        stashResultsThenClose(params.get('key'), results);
-      });
-    });
-  </script>
-</body>
+  // This should be true. Foo was searched for, so it should get a
+  // beforematch event.
+  results.beforematchFiredOnFoo = false;
+  // This should be true. the hidden attribute should not be removed until
+  // after beforematch is fired.
+  results.beforematchHiddenAttributePresent = false;
+  foo.addEventListener('beforematch', () => {
+    results.beforematchFiredOnFoo = true;
+    results.beforematchHiddenAttributePresent = foo.hasAttribute('hidden');
+    // This should be zero. Scrolling should happen after beforematch is
+    // fired.
+    results.pageYOffsetDuringBeforematch = window.pageYOffset;
+    beforematchResolver();
+  });
+
+  const bar = document.createElement('div');
+  bar.hidden = 'until-found';
+  bar.textContent = 'bar';
+  document.body.appendChild(bar);
+  // This should be false. Bar was not searched for, so it should not get
+  // a beforematch event.
+  results.beforematchFiredOnBar = false;
+  bar.addEventListener('beforematch', () => {
+    // this handler should never run. If it does,
+    // send back the message immediately to make the test fail.
+    results.beforematchFiredOnBar = true;
+    stashResultsThenClose(key, results);
+  });
+
+  await beforematchPromise;
+  await new Promise(requestAnimationFrame);
+  await new Promise(requestAnimationFrame);
+  // This should be greater than zero. The page should be scrolled down
+  // to foo.
+  results.pageYOffsetAfterRaf = window.pageYOffset;
+  stashResultsThenClose(key, results);
+})();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/resources/beforematch-scroll-to-text-fragment-bubble.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/resources/beforematch-scroll-to-text-fragment-bubble.html
@@ -8,23 +8,30 @@
 </div>
 
 <script>
+(async () => {
   const results = {
     beforematchFiredOnChild: false,
     beforematchFiredOnParent: false
   };
 
+  let beforematchResolver = null;
+  const beforematchPromise = new Promise(resolve => {
+    beforematchResolver = resolve;
+  });
+
   childid.addEventListener('beforematch', () => {
     results.beforematchFiredOnChild = true;
+    beforematchResolver();
   });
 
   parentid.addEventListener('beforematch', () => {
     results.beforematchFiredOnParent = true;
   });
 
-  requestAnimationFrame(() => {
-    requestAnimationFrame(() => {
-      const params = new URLSearchParams(window.location.search);
-      stashResultsThenClose(params.get('key'), results);
-    });
-  });
+  await beforematchPromise;
+  await new Promise(requestAnimationFrame);
+  await new Promise(requestAnimationFrame);
+  const params = new URLSearchParams(window.location.search);
+  stashResultsThenClose(params.get('key'), results);
+})();
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/resources/beforematch-scroll-to-text-fragment-with-anchor.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/resources/beforematch-scroll-to-text-fragment-with-anchor.html
@@ -3,34 +3,59 @@
 
 <!-- This test is navigated to with the fragment #bar:~:text=foo -->
 
-<body>
-  <div id=foo hidden=until-found>foo</div>
-  <div id=bar hidden=until-found>bar</div>
-  <script>
-    window.beforematchFiredOnFoo = false;
-    foo.addEventListener('beforematch', () => {
-      window.beforematchFiredOnFoo = true;
-    });
+<!-- This test uses parser-created elements,
+  unlike beforematch-scroll-to-text-fragment-basic.html,
+  which adds them from JS -->
+<div style="height:10000px"></div>
+<div id=foo hidden=until-found>foo</div>
+<div id=bar hidden=until-found>bar</div>
 
-    window.beforematchFiredOnBar = false;
-    bar.addEventListener('beforematch', () => {
-      window.beforematchFiredOnBar = true;
-    });
+<script>
+(async () => {
+  const results = {};
+  const key = (new URLSearchParams(window.location.search)).get('key');
 
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        const results = {};
-        // This should be true. Foo was searched for, so it should get the
-        // beforematch event.
-        results.beforematchFiredOnFoo = window.beforematchFiredOnFoo;
-        // This should be false. Bar should not get the beforematch event
-        // despite being the target of an element fragment due to the text
-        // fragment.
-        results.beforematchFiredOnBar = window.beforematchFiredOnBar;
+  // This should be true. hidden=until-found revealing should not happen until
+  // after the script tag loads.
+  results.fooHasHiddenAttribute = foo.hasAttribute('hidden');
 
-        params = new URLSearchParams(window.location.search);
-        stashResultsThenClose(params.get('key'), results);
-      });
-    });
-  </script>
-</body>
+  let beforematchResolver = null;
+  const beforematchPromise = new Promise(resolve => {
+    beforematchResolver = resolve;
+  });
+
+  // This should be true. Foo was searched for, so it should get the
+  // beforematch event.
+  results.beforematchFiredOnFoo = false;
+  foo.addEventListener('beforematch', () => {
+    results.beforematchFiredOnFoo = true;
+    // This should be zero. Scrolling should happen after beforematch is fired.
+    results.pageYOffsetDuringBeforematch = window.pageYOffset;
+    beforematchResolver();
+  });
+
+  // This should be false. Bar should not get the beforematch event
+  // despite being the target of an element fragment due to the text
+  // fragment.
+  results.beforematchFiredOnBar = false;
+  bar.addEventListener('beforematch', () => {
+    // this handler should never run. If it does,
+    // send back the message immediately to make the test fail.
+    results.beforematchFiredOnBar = true;
+    stashResultsThenClose(key, results);
+  });
+
+  if (!results.fooHasHiddenAttribute) {
+    // No need to wait for the beforematch event if it will never come.
+    stashResultsThenClose(key, results);
+  } else {
+    await beforematchPromise;
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+    // This should be greater than zero. Scrolling should happen after the
+    // beforematch event handler.
+    results.pageYOffsetAfterRaf = window.pageYOffset;
+    stashResultsThenClose(key, results);
+  }
+})();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/resources/container-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/resources/container-ref.html
@@ -3,7 +3,7 @@
 <meta charset="utf8">
 <title>CSS Content Visibility: container (reference)</title>
 <link rel="author" title="Vladimir Levin" href="mailto:vmpstr@chromium.org">
-<link rel="help" href="https://github.com/WICG/display-locking">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#attr-hidden-until-found">
 
 <style>
 #container {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/resources/hidden-until-found-text-fragment.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/resources/hidden-until-found-text-fragment.html
@@ -7,19 +7,28 @@
   <div style="height: 4000px;">spacer</div>
   <div id=target hidden=until-found>foo</div>
   <script>
-    requestAnimationFrame(() => {
+    // scroll-to-text-fragment may delay scrolling for an
+    // arbitrary amount of time for security reasons.
+    // This test would time out if beforematch is not fired, but since the
+    // test file only has one test, this is not shadowing other test results.
+    target.onbeforematch = () => {
+      // Adding two additional requestAnimationFrames ensures
+      // that scrolling has happened after beforematch has fired.
       requestAnimationFrame(() => {
-        const results = {};
-        // This should be false. The hidden=until-found attribute should be
-        // removed in response to ScrollToTextFragment.
-        results.targetHasHiddenAttribute = document.getElementById('target').hasAttribute('hidden');
-        // This should be greater than zero. The page should be scrolled down
-        // to foo.
-        results.pageYOffsetAfterRaf = window.pageYOffset;
+        requestAnimationFrame(() => {
+          const results = {};
+          // This should be false. The hidden=until-found attribute should be
+          // removed in response to ScrollToTextFragment.
+          results.targetHasHiddenAttribute = document.getElementById('target').hasAttribute('hidden');
+          // This should be greater than zero. The page should be scrolled down
+          // to foo.
+          results.pageYOffsetAfterRaf = window.pageYOffset;
 
-        params = new URLSearchParams(window.location.search);
-        stashResultsThenClose(params.get('key'), results);
+          params = new URLSearchParams(window.location.search);
+          stashResultsThenClose(params.get('key'), results);
+
+        });
       });
-    });
+    };
   </script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/resources/spacer-and-container-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/resources/spacer-and-container-ref.html
@@ -3,7 +3,7 @@
 <meta charset="utf8">
 <title>Content Visibility: spacer and a container (reference)</title>
 <link rel="author" title="Vladimir Levin" href="mailto:vmpstr@chromium.org">
-<link rel="help" href="https://github.com/WICG/display-locking">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#attr-hidden-until-found">
 
 <style>
 .spacer {

--- a/LayoutTests/tests-options.json
+++ b/LayoutTests/tests-options.json
@@ -3629,6 +3629,9 @@
     "imported/w3c/web-platform-tests/html/dom/reflection-text.html": [
         "slow"
     ],
+    "imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-scroll-to-text-fragment.html": [
+        "slow"
+    ],
     "imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/utf-16le.html": [
         "slow"
     ],


### PR DESCRIPTION
#### e0d82c231676de376537c1a7091f35b349279be8
<pre>
Re-import html/editing/the-hidden-attribute WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=294891">https://bugs.webkit.org/show_bug.cgi?id=294891</a>
<a href="https://rdar.apple.com/154164234">rdar://154164234</a>

Reviewed by Anne van Kesteren.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/bdbb9106f4810f893834c18de72454630cba05e5">https://github.com/web-platform-tests/wpt/commit/bdbb9106f4810f893834c18de72454630cba05e5</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-element-fragment-navigation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-element-fragment-navigation.html:
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-scroll-to-text-fragment-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-scroll-to-text-fragment.html:
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-ua-stylesheet.html:
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-001-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-001.html:
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-002.html:
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-004-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-004.html:
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-005-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-005-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-005.html:
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-006-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-007-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-007.html:
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-text-fragment-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-text-fragment.html:
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/resources/beforematch-scroll-to-text-fragment-basic.html:
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/resources/beforematch-scroll-to-text-fragment-bubble.html:
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/resources/beforematch-scroll-to-text-fragment-with-anchor.html:
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/resources/container-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/resources/hidden-until-found-text-fragment.html:
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/resources/spacer-and-container-ref.html:
* LayoutTests/tests-options.json:

Canonical link: <a href="https://commits.webkit.org/296557@main">https://commits.webkit.org/296557@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac51a27b3b215f68c5563d60797c7fcaee9fc1fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28561 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18986 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114109 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59246 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37127 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82751 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111849 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23246 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98090 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63190 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22667 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16227 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58808 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92620 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16273 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117229 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35951 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26560 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91762 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36323 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94354 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91569 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23313 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36476 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14233 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31811 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35850 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35551 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38893 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37236 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->