### PR TITLE
Re-import html/rendering/the-details-element WPT

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -973,6 +973,9 @@ imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-e
 imported/w3c/web-platform-tests/html/rendering/the-details-element/details-pseudo-elements-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/rendering/the-details-element/details-pseudo-elements-005.html [ ImageOnlyFailure ]
 
+# https://bugs.webkit.org/show_bug.cgi?id=228843
+imported/w3c/web-platform-tests/html/rendering/the-details-element/auto-expand-details-text-fragment.html [ Skip ]
+
 # Cross-Origin-Embedder-Policy: credentialless is not supported.
 imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/credentialless
 

--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -11206,6 +11206,8 @@
         "web-platform-tests/html/rendering/the-details-element/details-pseudo-elements-004-ref.html",
         "web-platform-tests/html/rendering/the-details-element/details-pseudo-elements-005-ref.html",
         "web-platform-tests/html/rendering/the-details-element/details-revert-ref.html",
+        "web-platform-tests/html/rendering/the-details-element/details-summary-display-inline-001-ref.html",
+        "web-platform-tests/html/rendering/the-details-element/details-summary-display-inline-002-ref.html",
         "web-platform-tests/html/rendering/the-details-element/details-two-pages-print-ref.html",
         "web-platform-tests/html/rendering/the-details-element/single-summary.html",
         "web-platform-tests/html/rendering/the-details-element/summary-display-flex-ref.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/auto-expand-details-text-fragment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/auto-expand-details-text-fragment-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL Verifies that the beforematch event is fired on the matching element of a ScrollToTextFragment navigation. assert_true: The matching closed details element should be open. expected true got false
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT Verifies that the target page has scrolled as a result of a ScrollToTextFragment navigation. Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/auto-expand-details-text-fragment.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/auto-expand-details-text-fragment.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>beforematch fired on ScrollToTextFragment</title>
 <link rel="author" title="Joey Arhar" href="mailto:jarhar@chromium.org">
-<link rel="help" href="https://github.com/WICG/display-locking">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
@@ -26,5 +26,5 @@ promise_test(t => new Promise((resolve, reject) => {
     'The matching closed details element should be open.');
   assert_true(results.pageYOffsetAfterRaf > 0,
     'The page should be scrolled down to the match.');
-}), 'Verifies that the beforematch event is fired on the matching element of a ScrollToTextFragment navigation.');
+}), 'Verifies that the target page has scrolled as a result of a ScrollToTextFragment navigation.');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/resources/auto-expand-details-text-fragment.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/resources/auto-expand-details-text-fragment.html
@@ -9,19 +9,18 @@
     <div>foo</div>
   </details>
   <script>
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        const results = {};
-        // This should be true. The details element should be opened by
-        // ScrollToTextFragment because it has matching text.
-        results.detailsHasOpenAttribute = document.querySelector('details').hasAttribute('open');
-        // This should be greater than zero. The page should be scrolled down
-        // to the matching target.
-        results.pageYOffsetAfterRaf = window.pageYOffset;
+    const details = document.querySelector("details");
+    details.ontoggle = () => {
+      const results = {};
+      // This should be true. The details element should be opened by
+      // ScrollToTextFragment because it has matching text.
+      results.detailsHasOpenAttribute = document.querySelector('details').hasAttribute('open');
+      // This should be greater than zero. The page should be scrolled down
+      // to the matching target.
+      results.pageYOffsetAfterRaf = window.pageYOffset;
 
-        params = new URLSearchParams(window.location.search);
-        stashResultsThenClose(params.get('key'), results);
-      });
-    });
+      params = new URLSearchParams(window.location.search);
+      stashResultsThenClose(params.get('key'), results);
+    };
   </script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/w3c-import.log
@@ -23,6 +23,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/details-before-expected-mismatch.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/details-before.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/details-blockification.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/details-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/details-display-type-001-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/details-display-type-001-ref-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/details-display-type-001-ref.html
@@ -55,6 +56,12 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/details-revert-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/details-revert-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/details-revert.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/details-summary-display-inline-001-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/details-summary-display-inline-001-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/details-summary-display-inline-001.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/details-summary-display-inline-002-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/details-summary-display-inline-002-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/details-summary-display-inline-002.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/details-two-pages-print-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/empty-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/single-summary.html


### PR DESCRIPTION
#### 8c760a07cc8f1796593ff53d7fe4d253143808cf
<pre>
Re-import html/rendering/the-details-element WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=294892">https://bugs.webkit.org/show_bug.cgi?id=294892</a>
<a href="https://rdar.apple.com/154165662">rdar://154165662</a>

Reviewed by Anne van Kesteren.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/bdbb9106f4810f893834c18de72454630cba05e5">https://github.com/web-platform-tests/wpt/commit/bdbb9106f4810f893834c18de72454630cba05e5</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/auto-expand-details-text-fragment-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/auto-expand-details-text-fragment.html:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/resources/auto-expand-details-text-fragment.html:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-details-element/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/296570@main">https://commits.webkit.org/296570@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23a94a6de2894bad0d1da2bb11d5fdc2327d85ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108900 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28560 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114108 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59245 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29244 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37126 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82750 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111848 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23245 "Found 1 new test failure: http/tests/geolocation/geolocation-get-current-position-does-not-leak.https.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98087 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63189 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22666 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16224 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58807 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92619 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16270 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117228 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35950 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26563 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91761 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36322 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94351 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91568 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36474 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14230 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31810 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17586 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35849 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35550 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38892 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37235 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->