### PR TITLE
[WPE] WPE Platform: add more WPEDisplay API tests

### DIFF
--- a/Tools/Scripts/run-gtk-tests
+++ b/Tools/Scripts/run-gtk-tests
@@ -86,6 +86,9 @@ class GtkTestRunner(TestRunner):
     def is_qt_test(self, test_program):
         return False
 
+    def is_wpe_platform_test(self, test_program):
+        return False
+
     def is_wpe_platform_wayland_test(self, test_program):
         return False
 

--- a/Tools/Scripts/run-wpe-tests
+++ b/Tools/Scripts/run-wpe-tests
@@ -46,8 +46,11 @@ class WPETestRunner(TestRunner):
     def is_qt_test(self, test_program):
         return os.path.basename(os.path.dirname(test_program)) == "WPEQt"
 
+    def is_wpe_platform_test(self, test_program):
+        return os.path.basename(os.path.dirname(test_program)) == "WPEPlatform"
+
     def is_wpe_platform_wayland_test(self, test_program):
-        return os.path.basename(os.path.dirname(test_program)) == "WPEPlatform" and "Wayland" in os.path.basename(test_program)
+        return self.is_wpe_platform_test(test_program) and "Wayland" in os.path.basename(test_program)
 
 if __name__ == "__main__":
     runner_args = get_runner_args(sys.argv)

--- a/Tools/TestWebKitAPI/Tests/WPEPlatform/TestDisplay.cpp
+++ b/Tools/TestWebKitAPI/Tests/WPEPlatform/TestDisplay.cpp
@@ -25,7 +25,12 @@
 
 #include "config.h"
 
+#include "WPEDisplayMock.h"
 #include "WPEMockPlatformTest.h"
+
+#if USE(LIBDRM)
+#include <drm_fourcc.h>
+#endif
 
 namespace TestWebKitAPI {
 
@@ -40,9 +45,177 @@ static void testDisplayConnect(WPEMockPlatformTest* test, gconstpointer)
     g_assert_error(error.get(), WPE_DISPLAY_ERROR, WPE_DISPLAY_ERROR_CONNECTION_FAILED);
 }
 
+static void testDisplayPrimary(WPEMockPlatformTest* test, gconstpointer)
+{
+    // The first created display is always the primary.
+    g_assert_true(wpe_display_get_primary() == test->display());
+
+    GRefPtr<WPEDisplay> display2 = adoptGRef(wpeDisplayMockNew());
+    test->assertObjectIsDeletedWhenTestFinishes(display2.get());
+    g_assert_true(wpe_display_get_primary() == test->display());
+    wpe_display_set_primary(display2.get());
+    g_assert_true(wpe_display_get_primary() == display2.get());
+
+    // If the primary display is destroyed, there's no primary unless explicitly set again.
+    display2 = nullptr;
+    g_assert_null(wpe_display_get_primary());
+
+    wpe_display_set_primary(test->display());
+    g_assert_true(wpe_display_get_primary() == test->display());
+}
+
+static void testDisplayKeymap(WPEMockPlatformTest* test, gconstpointer)
+{
+    // Default XKB keymap is returned when platform doesn't implement it.
+    auto* keymap = wpe_display_get_keymap(test->display());
+    g_assert_true(WPE_IS_KEYMAP_XKB(keymap));
+    test->assertObjectIsDeletedWhenTestFinishes(keymap);
+}
+
+static void testDisplayDRMNodes(WPEMockPlatformTest* test, gconstpointer)
+{
+    g_assert_null(wpe_display_get_drm_device(test->display()));
+    g_assert_null(wpe_display_get_drm_render_node(test->display()));
+
+    wpeDisplayMockUseFakeDRMNodes(WPE_DISPLAY_MOCK(test->display()), TRUE);
+    g_assert_cmpstr(wpe_display_get_drm_device(test->display()), ==, "/dev/dri/mock0");
+    g_assert_cmpstr(wpe_display_get_drm_render_node(test->display()), ==, "/dev/dri/mockD128");
+}
+
+static void testDisplayDMABufFormats(WPEMockPlatformTest* test, gconstpointer)
+{
+    g_assert_null(wpe_display_get_preferred_dma_buf_formats(test->display()));
+
+    wpeDisplayMockUseFakeDRMNodes(WPE_DISPLAY_MOCK(test->display()), TRUE);
+    wpeDisplayMockUseFakeDMABufFormats(WPE_DISPLAY_MOCK(test->display()), TRUE);
+    auto* formats = wpe_display_get_preferred_dma_buf_formats(test->display());
+    g_assert_true(WPE_IS_BUFFER_DMA_BUF_FORMATS(formats));
+    test->assertObjectIsDeletedWhenTestFinishes(formats);
+
+#if USE(LIBDRM)
+    g_assert_cmpstr(wpe_buffer_dma_buf_formats_get_device(formats), ==, "/dev/dri/mockD128");
+    g_assert_cmpuint(wpe_buffer_dma_buf_formats_get_n_groups(formats), ==, 2);
+
+    g_assert_cmpuint(wpe_buffer_dma_buf_formats_get_group_usage(formats, 0), ==, WPE_BUFFER_DMA_BUF_FORMAT_USAGE_SCANOUT);
+    g_assert_cmpstr(wpe_buffer_dma_buf_formats_get_group_device(formats, 0), ==, "/dev/dri/mock0");
+    g_assert_cmpuint(wpe_buffer_dma_buf_formats_get_group_n_formats(formats, 0), ==, 1);
+    g_assert_true(wpe_buffer_dma_buf_formats_get_format_fourcc(formats, 0, 0) == DRM_FORMAT_XRGB8888);
+    auto* modifiers = wpe_buffer_dma_buf_formats_get_format_modifiers(formats, 0, 0);
+    g_assert_cmpuint(modifiers->len, ==, 2);
+    guint64* modifier = &g_array_index(modifiers, guint64, 0);
+    g_assert_cmpuint(*modifier, ==, DRM_FORMAT_MOD_VIVANTE_SUPER_TILED);
+    modifier = &g_array_index(modifiers, guint64, 1);
+    g_assert_cmpuint(*modifier, ==, DRM_FORMAT_MOD_VIVANTE_TILED);
+
+    g_assert_cmpuint(wpe_buffer_dma_buf_formats_get_group_usage(formats, 1), ==, WPE_BUFFER_DMA_BUF_FORMAT_USAGE_RENDERING);
+    g_assert_null(wpe_buffer_dma_buf_formats_get_group_device(formats, 1));
+    g_assert_cmpuint(wpe_buffer_dma_buf_formats_get_group_n_formats(formats, 1), ==, 2);
+    g_assert_true(wpe_buffer_dma_buf_formats_get_format_fourcc(formats, 1, 0) == DRM_FORMAT_XRGB8888);
+    modifiers = wpe_buffer_dma_buf_formats_get_format_modifiers(formats, 1, 0);
+    g_assert_cmpuint(modifiers->len, ==, 1);
+    modifier = &g_array_index(modifiers, guint64, 0);
+    g_assert_cmpuint(*modifier, ==, DRM_FORMAT_MOD_LINEAR);
+    g_assert_true(wpe_buffer_dma_buf_formats_get_format_fourcc(formats, 1, 1) == DRM_FORMAT_ARGB8888);
+    modifiers = wpe_buffer_dma_buf_formats_get_format_modifiers(formats, 1, 1);
+    g_assert_cmpuint(modifiers->len, ==, 1);
+    modifier = &g_array_index(modifiers, guint64, 0);
+    g_assert_cmpuint(*modifier, ==, DRM_FORMAT_MOD_LINEAR);
+#endif
+}
+
+static void testDisplayExplicitSync(WPEMockPlatformTest* test, gconstpointer)
+{
+    g_assert_false(wpe_display_use_explicit_sync(test->display()));
+    wpeDisplayMockSetUseExplicitSync(WPE_DISPLAY_MOCK(test->display()), TRUE);
+    g_assert_true(wpe_display_use_explicit_sync(test->display()));
+}
+
+class WPEMockAvailableInputDevicesTest : public WPEMockPlatformTest {
+public:
+    WPE_PLATFORM_TEST_FIXTURE(WPEMockAvailableInputDevicesTest);
+
+    WPEMockAvailableInputDevicesTest()
+    {
+        wpeDisplayMockSetInitialInputDevices(WPE_DISPLAY_MOCK(display()), static_cast<WPEAvailableInputDevices>(WPE_AVAILABLE_INPUT_DEVICE_MOUSE | WPE_AVAILABLE_INPUT_DEVICE_KEYBOARD));
+        g_signal_connect_swapped(display(), "notify::available-input-devices", G_CALLBACK(+[](WPEMockAvailableInputDevicesTest* test) {
+            test->m_propertyChanged = true;
+        }), this);
+    }
+
+    ~WPEMockAvailableInputDevicesTest()
+    {
+        g_signal_handlers_disconnect_by_data(display(), this);
+    }
+
+    bool addDevice(WPEAvailableInputDevices device)
+    {
+        m_propertyChanged = false;
+        wpeDisplayMockAddInputDevice(WPE_DISPLAY_MOCK(display()), device);
+        return std::exchange(m_propertyChanged, false);
+    }
+
+    bool removeDevice(WPEAvailableInputDevices device)
+    {
+        m_propertyChanged = false;
+        wpeDisplayMockRemoveInputDevice(WPE_DISPLAY_MOCK(display()), device);
+        return std::exchange(m_propertyChanged, false);
+    }
+
+private:
+    bool m_propertyChanged { false };
+};
+
+static void testDisplayAvailableInputDevices(WPEMockAvailableInputDevicesTest* test, gconstpointer)
+{
+    auto devices = wpe_display_get_available_input_devices(test->display());
+    g_assert_true(devices & WPE_AVAILABLE_INPUT_DEVICE_MOUSE);
+    g_assert_true(devices & WPE_AVAILABLE_INPUT_DEVICE_KEYBOARD);
+    g_assert_false(devices & WPE_AVAILABLE_INPUT_DEVICE_TOUCHSCREEN);
+
+    g_assert_true(test->addDevice(WPE_AVAILABLE_INPUT_DEVICE_TOUCHSCREEN));
+    devices = wpe_display_get_available_input_devices(test->display());
+    g_assert_true(devices & WPE_AVAILABLE_INPUT_DEVICE_MOUSE);
+    g_assert_true(devices & WPE_AVAILABLE_INPUT_DEVICE_KEYBOARD);
+    g_assert_true(devices & WPE_AVAILABLE_INPUT_DEVICE_TOUCHSCREEN);
+
+    g_assert_false(test->addDevice(WPE_AVAILABLE_INPUT_DEVICE_MOUSE));
+    g_assert_false(test->addDevice(WPE_AVAILABLE_INPUT_DEVICE_KEYBOARD));
+    g_assert_false(test->addDevice(WPE_AVAILABLE_INPUT_DEVICE_TOUCHSCREEN));
+
+    g_assert_true(test->removeDevice(WPE_AVAILABLE_INPUT_DEVICE_MOUSE));
+    devices = wpe_display_get_available_input_devices(test->display());
+    g_assert_false(devices & WPE_AVAILABLE_INPUT_DEVICE_MOUSE);
+    g_assert_true(devices & WPE_AVAILABLE_INPUT_DEVICE_KEYBOARD);
+    g_assert_true(devices & WPE_AVAILABLE_INPUT_DEVICE_TOUCHSCREEN);
+    g_assert_false(test->removeDevice(WPE_AVAILABLE_INPUT_DEVICE_MOUSE));
+
+    g_assert_true(test->removeDevice(WPE_AVAILABLE_INPUT_DEVICE_KEYBOARD));
+    devices = wpe_display_get_available_input_devices(test->display());
+    g_assert_false(devices & WPE_AVAILABLE_INPUT_DEVICE_MOUSE);
+    g_assert_false(devices & WPE_AVAILABLE_INPUT_DEVICE_KEYBOARD);
+    g_assert_true(devices & WPE_AVAILABLE_INPUT_DEVICE_TOUCHSCREEN);
+    g_assert_false(test->removeDevice(WPE_AVAILABLE_INPUT_DEVICE_MOUSE));
+    g_assert_false(test->removeDevice(WPE_AVAILABLE_INPUT_DEVICE_KEYBOARD));
+
+    g_assert_true(test->removeDevice(WPE_AVAILABLE_INPUT_DEVICE_TOUCHSCREEN));
+    devices = wpe_display_get_available_input_devices(test->display());
+    g_assert_false(devices & WPE_AVAILABLE_INPUT_DEVICE_MOUSE);
+    g_assert_false(devices & WPE_AVAILABLE_INPUT_DEVICE_KEYBOARD);
+    g_assert_false(devices & WPE_AVAILABLE_INPUT_DEVICE_TOUCHSCREEN);
+    g_assert_false(test->removeDevice(WPE_AVAILABLE_INPUT_DEVICE_MOUSE));
+    g_assert_false(test->removeDevice(WPE_AVAILABLE_INPUT_DEVICE_KEYBOARD));
+    g_assert_false(test->removeDevice(WPE_AVAILABLE_INPUT_DEVICE_TOUCHSCREEN));
+}
+
 void beforeAll()
 {
     WPEMockPlatformTest::add("Display", "connect", testDisplayConnect);
+    WPEMockPlatformTest::add("Display", "primary", testDisplayPrimary);
+    WPEMockPlatformTest::add("Display", "keymap", testDisplayKeymap);
+    WPEMockPlatformTest::add("Display", "drm-nodes", testDisplayDRMNodes);
+    WPEMockPlatformTest::add("Display", "dmabuf-formats", testDisplayDMABufFormats);
+    WPEMockPlatformTest::add("Display", "explicit-sync", testDisplayExplicitSync);
+    WPEMockAvailableInputDevicesTest::add("Display", "available-input-devices", testDisplayAvailableInputDevices);
 }
 
 void afterAll()

--- a/Tools/TestWebKitAPI/glib/WPEPlatform/mock/WPEDisplayMock.h
+++ b/Tools/TestWebKitAPI/glib/WPEPlatform/mock/WPEDisplayMock.h
@@ -36,5 +36,11 @@ G_DECLARE_FINAL_TYPE(WPEDisplayMock, wpe_display_mock, WPE, DISPLAY_MOCK, WPEDis
 
 void wpeDisplayMockRegister(GIOModule*);
 WPEDisplay* wpeDisplayMockNew();
+void wpeDisplayMockUseFakeDRMNodes(WPEDisplayMock*, gboolean);
+void wpeDisplayMockUseFakeDMABufFormats(WPEDisplayMock*, gboolean);
+void wpeDisplayMockSetUseExplicitSync(WPEDisplayMock*, gboolean);
+void wpeDisplayMockSetInitialInputDevices(WPEDisplayMock*, WPEAvailableInputDevices);
+void wpeDisplayMockAddInputDevice(WPEDisplayMock*, WPEAvailableInputDevices);
+void wpeDisplayMockRemoveInputDevice(WPEDisplayMock*, WPEAvailableInputDevices);
 
 G_END_DECLS

--- a/Tools/glib/api_test_runner.py
+++ b/Tools/glib/api_test_runner.py
@@ -184,6 +184,10 @@ class TestRunner(object):
         timeout = self._options.timeout
         wpe_legacy_api = self._use_wpe_legacy_api()
         env = self._weston_env if self.is_wpe_platform_wayland_test(test_program) else self._test_env
+        if self.is_wpe_platform_test(test_program):
+            # WPE Platform tests can run without swrast since nothing is rendered.
+            env = dict(env)
+            env.pop('LIBGL_ALWAYS_SOFTWARE')
 
         def is_slow_test(test, subtest):
             return self._expectations.is_slow(test, subtest)
@@ -288,6 +292,9 @@ class TestRunner(object):
         raise NotImplementedError
 
     def is_qt_test(self, test_program):
+        raise NotImplementedError
+
+    def is_wpe_platform_test(self, test_program):
         raise NotImplementedError
 
     def is_wpe_platform_wayland_test(self, test_program):


### PR DESCRIPTION
#### 4dca1c0416a7741b3234a95dad41426fc25c76e1
<pre>
[WPE] WPE Platform: add more WPEDisplay API tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=294898">https://bugs.webkit.org/show_bug.cgi?id=294898</a>

Reviewed by Adrian Perez de Castro.

Canonical link: <a href="https://commits.webkit.org/296613@main">https://commits.webkit.org/296613@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81d5b1883302d84c30cfd2884e112abc0a2ac2d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108911 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28571 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114119 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59256 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110874 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29255 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37137 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82759 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111859 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23255 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98100 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63198 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22676 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16238 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58817 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92630 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16283 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117239 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35961 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26572 "Found 7 new test failures: http/tests/media/hls/hls-audio-tracks-language.html http/tests/media/hls/hls-webvtt-default.html http/tests/media/hls/hls-webvtt-style.html http/tests/media/hls/range-request-cross-origin.html http/tests/media/hls/track-in-band-multiple-cues.html http/tests/media/hls/track-webvtt-multitracks.html platform/mac/media/encrypted-media/fps-generateRequest.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91771 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36333 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94364 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91578 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36485 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14243 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31827 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17607 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35860 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35561 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38903 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37246 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->