### PR TITLE
Address assorted smart pointer warnings in Source/WebKit

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -43,12 +43,9 @@ UIProcess/Cocoa/VideoPresentationManagerProxy.mm
 UIProcess/DisplayLink.cpp
 UIProcess/Inspector/WebPageInspectorController.cpp
 UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm
-UIProcess/ProvisionalPageProxy.cpp
 UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
-UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
 UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
 UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
-UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
 UIProcess/WebFullScreenManagerProxy.cpp
 UIProcess/WebPageProxy.cpp
 UIProcess/mac/PageClientImplMac.mm

--- a/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -3,7 +3,6 @@ NetworkProcess/NetworkSession.cpp
 NetworkProcess/cocoa/NetworkSessionCocoa.mm
 Platform/IPC/ArgumentCoders.h
 UIProcess/WebPageProxy.cpp
-UIProcess/mac/WKTextAnimationManagerMac.mm
 WebProcess/FullScreen/WebFullScreenManager.cpp
 WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
 WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -70,9 +70,6 @@ UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.mm
 UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
 UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
 UIProcess/Cocoa/VideoPresentationManagerProxy.mm
-UIProcess/ProvisionalPageProxy.cpp
-UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
-UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
 UIProcess/WebPageProxy.cpp
 UIProcess/mac/ViewGestureControllerMac.mm
 WebDriverBidiFrontendDispatchers.cpp
@@ -133,7 +130,6 @@ WebProcess/Inspector/WebInspectorInternal.cpp
 WebProcess/Inspector/WebInspectorUI.cpp
 WebProcess/Inspector/WebInspectorUIExtensionController.cpp
 WebProcess/Network/webrtc/LibWebRTCProvider.cpp
-WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp
 WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
 WebProcess/Plugins/PDF/PDFPluginBase.mm
 WebProcess/Plugins/PDF/PDFPluginPasswordField.mm

--- a/Source/WebKit/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -1,2 +1,0 @@
-Shared/cf/CoreIPCCFArray.mm
-UIProcess/mac/WKTextAnimationManagerMac.mm

--- a/Source/WebKit/Shared/cf/CoreIPCCFArray.mm
+++ b/Source/WebKit/Shared/cf/CoreIPCCFArray.mm
@@ -45,10 +45,10 @@ CoreIPCCFArray::CoreIPCCFArray(CFArrayRef array)
 {
     CFIndex count = array ? CFArrayGetCount(array) : 0;
     for (CFIndex i = 0; i < count; i++) {
-        CFTypeRef element = CFArrayGetValueAtIndex(array, i);
-        if (IPC::typeFromCFTypeRef(element) == IPC::CFType::Unknown)
+        RetainPtr element = CFArrayGetValueAtIndex(array, i);
+        if (IPC::typeFromCFTypeRef(element.get()) == IPC::CFType::Unknown)
             continue;
-        m_array.append(CoreIPCCFType(element));
+        m_array.append(CoreIPCCFType(element.get()));
     }
 }
 

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -249,7 +249,8 @@ void ProvisionalPageProxy::cancel()
 void ProvisionalPageProxy::initializeWebPage(RefPtr<API::WebsitePolicies>&& websitePolicies)
 {
     Ref page = *m_page;
-    m_drawingArea = page->protectedPageClient()->createDrawingAreaProxy(protectedProcess());
+    RefPtr drawingArea = page->protectedPageClient()->createDrawingAreaProxy(protectedProcess());
+    m_drawingArea = drawingArea.copyRef();
 
     bool registerWithInspectorController { true };
     if (websitePolicies)
@@ -278,7 +279,7 @@ void ProvisionalPageProxy::initializeWebPage(RefPtr<API::WebsitePolicies>&& webs
     }
 
     RefPtr mainFrame = m_mainFrame;
-    auto creationParameters = page->creationParametersForProvisionalPage(process, *m_drawingArea, websitePolicies.copyRef(), mainFrame->frameID());
+    auto creationParameters = page->creationParametersForProvisionalPage(process, *drawingArea, websitePolicies.copyRef(), mainFrame->frameID());
     if (preferences->siteIsolationEnabled()) {
         creationParameters.remotePageParameters = RemotePageParameters {
             m_request.url(),

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -83,7 +83,7 @@ private:
 #endif
 
 #if ENABLE(SCROLLING_THREAD)
-    RefPtr<RemoteLayerTreeEventDispatcher> m_eventDispatcher;
+    const Ref<RemoteLayerTreeEventDispatcher> m_eventDispatcher;
 #endif
 };
 

--- a/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp
@@ -51,7 +51,7 @@ RTCDataChannelRemoteManager& RTCDataChannelRemoteManager::singleton()
 
 RTCDataChannelRemoteManager::RTCDataChannelRemoteManager()
     : m_queue(WorkQueue::create("RTCDataChannelRemoteManager"_s))
-    , m_connection(&WebProcess::singleton().ensureNetworkProcessConnection().connection())
+    , m_connection(WebProcess::singleton().ensureNetworkProcessConnection().connection())
 {
 }
 

--- a/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.h
@@ -105,7 +105,7 @@ private:
     };
 
     const Ref<WorkQueue> m_queue;
-    RefPtr<IPC::Connection> m_connection;
+    const Ref<IPC::Connection> m_connection;
     RefPtr<RemoteHandlerConnection> m_remoteHandlerConnection;
     RefPtr<RemoteSourceConnection> m_remoteSourceConnection;
     HashMap<WebCore::RTCDataChannelLocalIdentifier, UniqueRef<WebCore::RTCDataChannelRemoteSource>> m_sources;


### PR DESCRIPTION
#### ddfd739bf3d34db41a64ca150677620dd564900f
<pre>
Address assorted smart pointer warnings in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=294899">https://bugs.webkit.org/show_bug.cgi?id=294899</a>

Reviewed by Chris Dumez.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a> and
notably in RemoteScrollingCoordinatorProxyMac and
RTCDataChannelRemoteManager we change a member variable from RefPtr to
Ref and make it const.

Canonical link: <a href="https://commits.webkit.org/296576@main">https://commits.webkit.org/296576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/654a545b820d527ad56c9e2d35d8cbff0f53f649

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108925 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19010 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114133 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59270 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29269 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37152 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82771 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111873 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23267 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98110 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63210 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22689 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58831 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92642 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16293 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117253 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35975 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26586 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91784 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36347 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94374 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91591 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36497 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14253 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31845 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17590 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35874 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41400 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35575 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38917 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37260 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->