### PR TITLE
Allow self to be passed as validation anchor

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-validation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-validation-expected.txt
@@ -7,6 +7,7 @@ PASS willValidate should throw NotSupportedError if the target element is not a 
 PASS validity and setValidity()
 PASS validity.customError should be false if not explicitly set via setValidity()
 PASS "anchor" argument of setValidity()
+PASS "anchor" argument of setValidity(): passing self
 PASS checkValidity() should throw NotSupportedError if the target element is not a form-associated custom element
 PASS checkValidity()
 PASS reportValidity() should throw NotSupportedError if the target element is not a form-associated custom element

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-validation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-validation.html
@@ -207,10 +207,6 @@ test(() => {
     control.i.setValidity(flags, m, document.body);
   }, 'Not a descendant');
 
-  assert_throws_dom('NotFoundError', () => {
-    control.i.setValidity(flags, m, control);
-  }, 'Self');
-
   let notHTMLElement = document.createElementNS('some-random-namespace', 'foo');
   control.appendChild(notHTMLElement);
   assert_throws_js(TypeError, () => {
@@ -233,6 +229,17 @@ test(() => {
   shadow2.appendChild(nestedShadowChild);
   control.i.setValidity(flags, m, nestedShadowChild);
 }, '"anchor" argument of setValidity()');
+
+test(t => {
+  const control = document.createElement('my-control');
+  document.body.appendChild(control);
+  t.add_cleanup(() => control.remove());
+  const flags = {valueMissing: true};
+  const m = 'non-empty message';
+
+  // Self
+  control.i.setValidity(flags, m, control);
+}, '"anchor" argument of setValidity(): passing self');
 
 test(() => {
   const element = new NotFormAssociatedElement();

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-validation-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-validation-expected.txt
@@ -7,6 +7,7 @@ PASS willValidate should throw NotSupportedError if the target element is not a 
 PASS validity and setValidity()
 PASS validity.customError should be false if not explicitly set via setValidity()
 PASS "anchor" argument of setValidity()
+PASS "anchor" argument of setValidity(): passing self
 PASS checkValidity() should throw NotSupportedError if the target element is not a form-associated custom element
 PASS checkValidity()
 PASS reportValidity() should throw NotSupportedError if the target element is not a form-associated custom element

--- a/Source/WebCore/html/FormAssociatedCustomElement.cpp
+++ b/Source/WebCore/html/FormAssociatedCustomElement.cpp
@@ -68,7 +68,7 @@ ExceptionOr<void> FormAssociatedCustomElement::setValidity(ValidityStateFlags va
     m_validityStateFlags = validityStateFlags;
     setCustomValidity(validityStateFlags.isValid() ? emptyString() : WTFMove(message));
 
-    if (validationAnchor && !validationAnchor->isShadowIncludingDescendantOf(*m_element))
+    if (validationAnchor && !m_element->isShadowIncludingInclusiveAncestorOf(*validationAnchor))
         return Exception { ExceptionCode::NotFoundError };
 
     m_validationAnchor = validationAnchor;


### PR DESCRIPTION
#### f04ebd901becdc731860620a86e0efdc62400e06
<pre>
Allow self to be passed as validation anchor
<a href="https://bugs.webkit.org/show_bug.cgi?id=294903">https://bugs.webkit.org/show_bug.cgi?id=294903</a>

Reviewed by Ryosuke Niwa.

In 292770@main we made the control the fallback when the validation
anchor was not given. This created a slight inconsistency with the API
which would throw if you passed the control as validation anchor.

This changes the API to allow passing the control as per step 8 of
<a href="https://html.spec.whatwg.org/multipage/custom-elements.html#dom-elementinternals-setvalidity">https://html.spec.whatwg.org/multipage/custom-elements.html#dom-elementinternals-setvalidity</a>
(Note that the specification implements the fallback as part of the API
call, but that is not how we implement it.)

Test changes are already upstreamed:

<a href="https://github.com/web-platform-tests/wpt/pull/53353">https://github.com/web-platform-tests/wpt/pull/53353</a>
Canonical link: <a href="https://commits.webkit.org/296622@main">https://commits.webkit.org/296622@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/223ed0bc881d86137198d3ebdb10d3ab18ac72bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109097 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28757 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19182 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114308 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59396 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111060 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29440 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37324 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/82911 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112045 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23419 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98262 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63356 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22819 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16404 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/58992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92790 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16447 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117426 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36145 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26717 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/91929 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36516 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94526 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/91735 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36643 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14396 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32003 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17610 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36042 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41547 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35735 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39074 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37421 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->