### PR TITLE
Dynamic media queries in user-agent shadow DOM stylesheet don't get updated when accessibility settings change

### DIFF
--- a/LayoutTests/fast/media/mq-inverted-colors-ua-style-on-to-off-expected.html
+++ b/LayoutTests/fast/media/mq-inverted-colors-ua-style-on-to-off-expected.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+
+<html>
+
+<body>
+    <p>@media(inverted-colors) in main document: false</p>
+    <p>@media(inverted-colors) in user-agent shadow DOM: false</p>
+</body>
+
+</html>

--- a/LayoutTests/fast/media/mq-inverted-colors-ua-style-on-to-off.html
+++ b/LayoutTests/fast/media/mq-inverted-colors-ua-style-on-to-off.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+
+<html>
+
+<head>
+    <title>Tests that @media(inverted-colors) in user-agent shadow DOM is false when "Invert colors" setting toggles from on to off</title>
+</head>
+
+<body>
+    <style>
+        @media (inverted-colors) {
+            #inverted-colors-value::before {
+                content: "true" !important;
+            }
+        }
+
+        #inverted-colors-value::before {
+            content: "false";
+        }
+    </style>
+    <p>@media(inverted-colors) in main document: <span id="inverted-colors-value"></span></p>
+
+    <template id="template">
+        <style>
+            @media (inverted-colors) {
+                #inverted-colors-value::before {
+                    content: "true" !important;
+                }
+            }
+
+            #inverted-colors-value::before {
+                content: "false";
+            }
+        </style>
+
+        <p>@media(inverted-colors) in user-agent shadow DOM: <span id="inverted-colors-value"></span></p>
+    </template>
+    <div id="shadow-host"></div>
+
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        const host = document.getElementById("shadow-host");
+        // Use internal method to create a user-agent shadow DOM
+        // Bug won't reproduce with open/closed shadow DOM, created using .attachShadow
+        const shadow = window.internals.ensureUserAgentShadowRoot(host);
+
+        const template = document.getElementById("template");
+        shadow.appendChild(template.content);
+
+        const uiScript =
+            `(function() {
+                uiController.simulateAccessibilitySettingsChangeNotification(function() {
+                    uiController.uiScriptComplete();
+                });
+            })();`;
+
+        // Bug only reproduces when inverted colors goes from off to on, then off.
+
+        window.internals.settings.forcedColorsAreInvertedAccessibilityValue = "on";
+
+        testRunner.runUIScript(uiScript, () => {
+            window.internals.settings.forcedColorsAreInvertedAccessibilityValue = "off";
+            testRunner.runUIScript(uiScript, () => testRunner.notifyDone());
+        });
+    </script>
+</body>
+
+</html>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1872,3 +1872,5 @@ imported/w3c/web-platform-tests/svg/painting/reftests/marker-path-001.svg [ Imag
 imported/w3c/web-platform-tests/svg/painting/reftests/marker-path-011.svg [ ImageOnlyFailure ]
 
 webkit.org/b/267992 [ Debug ] imported/w3c/web-platform-tests/html/anonymous-iframe/initial-empty-document.tentative.https.window.html [ Crash Pass ]
+
+fast/media/mq-inverted-colors-ua-style-on-to-off.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### ae31aa9f4098d28ea997a4f9e04e585e637be6cb
<pre>
Dynamic media queries in user-agent shadow DOM stylesheet don&apos;t get updated when accessibility settings change
<a href="https://rdar.apple.com/142851714">rdar://142851714</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=294905">https://bugs.webkit.org/show_bug.cgi?id=294905</a>

Reviewed by Simon Fraser.

Two events occur when an accessibilty setting changes (like toggling &quot;Smart invert&quot;):

1. Web process got an IPC message that ScreenProperties has changed.
(WebKit::WebProcess::setScreenProperties). This calls
WebKit::WebPage::screenPropertiesDidChange -&gt;
Page::screenPropertiesDidChange -&gt;
Page::setNeedsRecalcStyleInAllFrames -&gt;
Scope::didChangeStyleSheetEnvironment -&gt; calls
Scope::scheduleUpdate on document scope and non-user-agent shadow root scopes.
Scope::scheduleUpdate clears out the resolver so they could be rebuilt with
the new ScreenProperties on the next update. Crucially, resolvers of user-agent
shadow root scopes don&apos;t get cleared. So it&apos;s possible that the resolver of the
document scope is cleared, but not resolvers of user-agent shadow root scopes. (1)

2. Web process got an IPC message that accessibility settings has changed
(Page::accessibilitySettingsDidChange). This calls
Scope::evaluateMediaQueriesForAccessibilitySettingsChange() -&gt;
Scope::evaluateMediaQueries() to re-evaluate dynamic media queries in the document.
To do that, it calls Scope::collectResolverScopes() to collect resolvers for
re-evaluation. The method assumes that if the document scope doesn&apos;t have a
resolver, then the scopes of shadow roots in the document also won&apos;t have a
resolver. This is wrong because of (1)

The effect: When an accessibility setting changes, dynamic media queries in the
document are re-evaluated, except for media queries in user-agent shadow-DOM trees.
This breaks &quot;Smart invert&quot;, since this uses @media (inverted-colors) in
user-agent stylesheet (see Source/WebCore/css/html.css and
Source/WebCore/Modules/modern-media-controls/controls/media-controls.css)

* LayoutTests/fast/media/mq-inverted-colors-ua-style-on-to-off-expected.html: Added.
* LayoutTests/fast/media/mq-inverted-colors-ua-style-on-to-off.html: Added.
* LayoutTests/platform/gtk/TestExpectations:
    - New test is failing on GTK, adding expectation for it.
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::collectResolverScopes):
    - Collect resolvers of shadow root scopes, even when the document scope
      resolver doesn&apos;t exist.
(WebCore::Style::Scope::didChangeStyleSheetEnvironment):
    - Call Scope::scheduleUpdate on all shadow root scopes, including user-agent
      shadow roots.

Canonical link: <a href="https://commits.webkit.org/297386@main">https://commits.webkit.org/297386@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/441c514b3c3f1ede0d6594dfeea3082dd478d407

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111616 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31283 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21757 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117651 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/61887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113578 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39868 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84801 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/61887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114563 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25519 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100457 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65242 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24856 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18592 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61482 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94902 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18661 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120897 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38669 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28726 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93700 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39047 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96715 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93525 "Found 2 new API test failures: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23842 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38665 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16457 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/34705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38558 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44042 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/38221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41557 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39923 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->