### PR TITLE
[Baseline Alignment] Fix css-flexbox/align-items-baseline-column-horz.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-horz-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-horz-expected.txt
@@ -9,9 +9,7 @@ line2
 
 PASS #target > div 1
 PASS #target > div 2
-FAIL #target > div 3 assert_equals:
-<div data-offset-x="37"></div>
-offsetLeft expected 37 but got 67
+PASS #target > div 3
 PASS #target > div 4
 PASS #target > div 5
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-row-axis-self-baseline-synthesized-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-row-axis-self-baseline-synthesized-001-expected.txt
@@ -17,7 +17,7 @@ FAIL .grid 1 assert_equals:
   <div class="secondRowFirstColumn bigFont paddingRight verticalRL" data-offset-x="75" data-offset-y="100" data-expected-width="125" data-expected-height="200">É É ÉÉ</div>
   <div class="autoRowSpanning2AutoColumn width25"></div>
 </div>
-offsetLeft expected 0 but got 60
+offsetLeft expected 75 but got 0
 PASS .grid 2
 PASS .grid 3
 PASS .grid 4

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-row-axis-self-baseline-synthesized-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-row-axis-self-baseline-synthesized-002-expected.txt
@@ -14,7 +14,7 @@ FAIL .grid 2 assert_equals:
   <div class="secondRowFirstColumn bigFont paddingRight verticalRL" data-offset-x="80" data-offset-y="100" data-expected-width="120" data-expected-height="200">É É ÉÉ</div>
   <div class="autoRowSpanning2AutoColumn width25"></div>
 </div>
-offsetLeft expected 0 but got 60
+offsetLeft expected 80 but got 0
 PASS .grid 3
 PASS .grid 4
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-row-axis-self-baseline-synthesized-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-row-axis-self-baseline-synthesized-003-expected.txt
@@ -14,7 +14,7 @@ FAIL .grid 2 assert_equals:
   <div class="secondRowFirstColumn bigFont paddingRight verticalRL" data-offset-x="80" data-offset-y="100" data-expected-width="120" data-expected-height="200">É É ÉÉ</div>
   <div class="autoRowSpanning2AutoColumn width25"></div>
 </div>
-offsetLeft expected 0 but got 60
+offsetLeft expected 80 but got 0
 PASS .grid 3
 PASS .grid 4
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-row-axis-self-baseline-synthesized-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-row-axis-self-baseline-synthesized-004-expected.txt
@@ -14,7 +14,7 @@ FAIL .inline-grid 2 assert_equals:
   <div class="secondRowFirstColumn bigFont paddingRight verticalRL" data-offset-x="5" data-offset-y="100" data-expected-width="120" data-expected-height="200">É É ÉÉ</div>
   <div class="autoRowSpanning2AutoColumn width25"></div>
 </div>
-width expected 150 but got 210
+offsetLeft expected 5 but got 0
 PASS .inline-grid 3
 PASS .inline-grid 4
 

--- a/Source/WebCore/rendering/BaselineAlignment.h
+++ b/Source/WebCore/rendering/BaselineAlignment.h
@@ -98,7 +98,7 @@ private:
 class BaselineAlignmentState {
     WTF_MAKE_TZONE_ALLOCATED(BaselineAlignmentState);
 public:
-    BaselineAlignmentState(const RenderBox& child, ItemPosition preference, LayoutUnit ascent);
+    BaselineAlignmentState(const RenderBox& child, ItemPosition preference, LayoutUnit ascent, LogicalBoxAxis alignmentContextAxis, WritingMode alignmentContainerWritingMode);
     const BaselineGroup& sharedGroup(const RenderBox& child, ItemPosition preference) const;
 
     // Updates the baseline-sharing group compatible with the item.
@@ -106,6 +106,8 @@ public:
     // managing the alignment behavior of the Grid Items.
     void updateSharedGroup(const RenderBox& child, ItemPosition preference, LayoutUnit ascent);
     Vector<BaselineGroup>& sharedGroups();
+
+    static WritingMode usedWritingModeForBaselineAlignment(LogicalBoxAxis alignmentContextAxis, WritingMode alignmentContainerWritingMode, WritingMode alignmentSubjectWritingMode);
 
 private:
     // Returns the baseline-sharing group compatible with an item.
@@ -116,6 +118,8 @@ private:
     BaselineGroup& findCompatibleSharedGroup(const RenderBox& child, ItemPosition preference);
 
     Vector<BaselineGroup> m_sharedGroups;
+    WritingMode m_alignmentContainerWritingMode;
+    LogicalBoxAxis m_alignmentContextAxis;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/GridBaselineAlignment.cpp
+++ b/Source/WebCore/rendering/GridBaselineAlignment.cpp
@@ -145,10 +145,10 @@ void GridBaselineAlignment::updateBaselineAlignmentContext(ItemPosition preferen
     // alignment axis.
     auto& baselineAlignmentStateMap = alignmentContextType == GridTrackSizingDirection::ForRows ? m_rowAlignmentContextStates : m_columnAlignmentContextStates;
     // Looking for a compatible baseline-sharing group.
-    if (auto* baselineAlignmentStateSearch = baselineAlignmentStateMap.get(sharedContext))
-        baselineAlignmentStateSearch->updateSharedGroup(gridItem, preference, ascent);
-    else
-        baselineAlignmentStateMap.add(sharedContext, makeUnique<BaselineAlignmentState>(gridItem, preference, ascent));
+    baselineAlignmentStateMap.ensure(sharedContext, [&] {
+        auto alignmentAxis = alignmentContextType == GridTrackSizingDirection::ForColumns ? LogicalBoxAxis::Block : LogicalBoxAxis::Inline;
+        return makeUnique<BaselineAlignmentState>(gridItem, preference, ascent, alignmentAxis, m_writingMode);
+    }).iterator->value->updateSharedGroup(gridItem, preference, ascent);
 }
 
 LayoutUnit GridBaselineAlignment::baselineOffsetForGridItem(ItemPosition preference, unsigned sharedContext, const RenderBox& gridItem, GridTrackSizingDirection alignmentContextType) const


### PR DESCRIPTION
#### 72c3b9e4364ab54555f90ad1ab497d70dc6c96ff
<pre>
[Baseline Alignment] Fix css-flexbox/align-items-baseline-column-horz.
<a href="https://bugs.webkit.org/show_bug.cgi?id=294917">https://bugs.webkit.org/show_bug.cgi?id=294917</a>
<a href="https://rdar.apple.com/problem/154213989">rdar://problem/154213989</a>

Reviewed by Alan Baradlay.

The aforementioned WPT test case contains some content with the following
structure:

&lt;flexbox style=&quot;flex-direction: column; align-items: baseline;&quot;&gt;
  &lt;item style=&quot;width: 40px; height: 40px;&quot;&gt;&lt;/item&gt;
  &lt;item style=&quot;writing-mode: vertical-lr;&quot;&gt;line1&lt;br&gt;line2&lt;/item&gt;
&lt;/flexbox&gt;

The problem is that the two items should be part of the baseline sharing
group, causing them to get aligned together, but we end up putting them
into different groups. Boxes are part of the same baseline sharing group
if they:

1.) Share an alignment context along an axis perpendicular to the axis
they’re being baseline-aligned in.
  - In this case, the items are in the same column.
2.) Have compatible baseline alignment preferences (i.e., the baselines
that want to align are on the same side of the alignment context).
  - The first item has a computed writing mode of horizontal-tb and the
    second item has a computed writing mode of vertical-lr, but that is
    not the one used for baseline alignment according to the rules the
    spec outlines for synthesizing baselines. The writing-mode that ends
    up getting used according to these rules is vertical-lr.

We actually already have the logic to make this determination in
RenderFlexibleBox for the purposes of whether or not the items need to
be moved to the end of the cross axis due to their fallback alignment,
So most of this patch is just moving over this logic to
BaselineAlignment.

* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-horz-expected.txt:
Pass!

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-row-axis-self-baseline-synthesized-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-row-axis-self-baseline-synthesized-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-row-axis-self-baseline-synthesized-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-row-axis-self-baseline-synthesized-004-expected.txt:
The impacted subtests are already failing.

* Source/WebCore/rendering/BaselineAlignment.cpp:
Most of the code added to this class and its methods are just the logic
from RenderFlexibleBox. In order to accomplish the same goal, we needed
to pass it the direction of the alignment axis along with the writing
mode of the alignment container.

(WebCore::BaselineAlignmentState::usedWritingModeForBaselineAlignment):
This is used to determine the writing mode that is used for baseline
alignment. It is really only needed when you need to synthesize a
baseline, but it is safe and correct to use it even when you do not need
to, since one of the first things we do is use the alignment axis
direction and the alignment subject&apos;s writing mode to check to see if
We need to apply the special rules mentioned in the spec to determine
the writing mode for synthesis.

* Source/WebCore/rendering/GridBaselineAlignment.cpp:
(WebCore::GridBaselineAlignment::updateBaselineAlignmentContext):
This is just a small refactoring to ensure use with the HashMap. Mostly
just for a stylistic improvement.

* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::layoutAndPlaceFlexItems):
This code was changed just for the purposes of style and should have no
changes to functionality.

Canonical link: <a href="https://commits.webkit.org/296601@main">https://commits.webkit.org/296601@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa8a12ff9f090f2ac2c275fd525069a996d83083

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108949 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28609 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19034 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114157 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59289 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110912 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37176 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82790 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23292 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98133 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63229 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22711 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16270 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58855 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92666 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16317 "Found 1 new test failure: imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-timing.https.sub.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117277 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35999 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26607 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91800 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36371 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94397 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91607 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23335 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36519 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14275 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31865 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35897 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41423 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35598 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38939 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37282 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->