### PR TITLE
[Style] Remove exposure of the underlying LengthType in Style::LengthWrappers

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -93,6 +93,7 @@ rendering/BackgroundPainter.cpp
 rendering/BorderPainter.cpp
 rendering/RenderBox.cpp
 rendering/RenderElement.cpp
+rendering/RenderFlexibleBox.cpp
 rendering/RenderGrid.cpp
 rendering/RenderLayer.cpp
 rendering/RenderLayerCompositor.cpp

--- a/Source/WebCore/rendering/AutoTableLayout.h
+++ b/Source/WebCore/rendering/AutoTableLayout.h
@@ -45,7 +45,7 @@ private:
     void recalcColumn(unsigned effCol);
 
     float calcEffectiveLogicalWidth();
-    float shrinkCellWidth(const LengthType&, float available);
+    template<typename> float shrinkCellWidthForType(float available);
 
     void insertSpanCell(RenderTableCell*);
 

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -4208,7 +4208,7 @@ static bool isNonBlocksOrNonFixedHeightListItems(const RenderObject& renderer)
     if (!renderer.isRenderBlock())
         return true;
     if (CheckedPtr renderListItem = dynamicDowncast<RenderListItem>(renderer))
-        return renderListItem->style().height().type() != LengthType::Fixed;
+        return !renderListItem->style().height().isFixed();
     return false;
 }
 

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1468,60 +1468,33 @@ bool RenderBox::hasTrimmedMargin(std::optional<MarginTrimType> marginTrimType) c
 
 LayoutUnit RenderBox::adjustBorderBoxLogicalWidthForBoxSizing(const Style::Length<CSS::Nonnegative, float>& logicalWidth) const
 {
-    auto width = LayoutUnit { logicalWidth.value };
-    auto bordersPlusPadding = borderAndPaddingLogicalWidth();
-    if (style().boxSizing() == BoxSizing::ContentBox)
-        return width + bordersPlusPadding;
-    return std::max(width, bordersPlusPadding);
+    return adjustBorderBoxLogicalWidthForBoxSizing(LayoutUnit { logicalWidth.value });
 }
 
-static bool isIntrinsicOrLegacyIntrinsicOrAuto(LengthType originalType)
+LayoutUnit RenderBox::adjustBorderBoxLogicalWidthForBoxSizing(LayoutUnit computedLogicalWidth) const
 {
-    switch (originalType) {
-    case LengthType::MinContent:
-    case LengthType::MaxContent:
-    case LengthType::FillAvailable:
-    case LengthType::FitContent:
-    case LengthType::Intrinsic:
-    case LengthType::MinIntrinsic:
-    case LengthType::Auto:
-        return true;
-    default:
-        return false;
-    }
-}
-
-LayoutUnit RenderBox::adjustBorderBoxLogicalWidthForBoxSizing(LayoutUnit computedLogicalWidth, LengthType originalType) const
-{
-    if (originalType == LengthType::Calculated)
-        return adjustBorderBoxLogicalWidthForBoxSizing(Style::Length<CSS::Nonnegative, float> { computedLogicalWidth });
     auto bordersAndPadding = borderAndPaddingLogicalWidth();
-    if (style().boxSizing() == BoxSizing::ContentBox || isIntrinsicOrLegacyIntrinsicOrAuto(originalType))
+    if (style().boxSizing() == BoxSizing::ContentBox)
         return computedLogicalWidth + bordersAndPadding;
     return std::max(computedLogicalWidth, bordersAndPadding);
 }
 
-LayoutUnit RenderBox::adjustBorderBoxLogicalHeightForBoxSizing(LayoutUnit height) const
+LayoutUnit RenderBox::adjustBorderBoxLogicalHeightForBoxSizing(LayoutUnit computedLogicalHeight) const
 {
-    LayoutUnit bordersPlusPadding = borderAndPaddingLogicalHeight();
+    auto bordersPlusPadding = borderAndPaddingLogicalHeight();
     if (style().boxSizing() == BoxSizing::ContentBox)
-        return height + bordersPlusPadding;
-    return std::max(height, bordersPlusPadding);
+        return computedLogicalHeight + bordersPlusPadding;
+    return std::max(computedLogicalHeight, bordersPlusPadding);
 }
 
 LayoutUnit RenderBox::adjustContentBoxLogicalWidthForBoxSizing(const Style::Length<CSS::Nonnegative, float>& logicalWidth) const
 {
-    auto width = LayoutUnit { logicalWidth.value };
-    if (style().boxSizing() == BoxSizing::ContentBox)
-        return std::max(0_lu, width);
-    return std::max(0_lu, width - borderAndPaddingLogicalWidth());
+    return adjustContentBoxLogicalWidthForBoxSizing(LayoutUnit { logicalWidth.value });
 }
 
-LayoutUnit RenderBox::adjustContentBoxLogicalWidthForBoxSizing(LayoutUnit computedLogicalWidth, LengthType originalType) const
+LayoutUnit RenderBox::adjustContentBoxLogicalWidthForBoxSizing(LayoutUnit computedLogicalWidth) const
 {
-    if (originalType == LengthType::Calculated)
-        return adjustContentBoxLogicalWidthForBoxSizing(Style::Length<CSS::Nonnegative, float> { computedLogicalWidth });
-    if (style().boxSizing() == BoxSizing::ContentBox || isIntrinsicOrLegacyIntrinsicOrAuto(originalType))
+    if (style().boxSizing() == BoxSizing::ContentBox)
         return std::max(0_lu, computedLogicalWidth);
     return std::max(0_lu, computedLogicalWidth - borderAndPaddingLogicalWidth());
 }
@@ -2903,12 +2876,12 @@ template<typename SizeType> LayoutUnit RenderBox::computeLogicalWidthUsingGeneri
 {
     if constexpr (std::same_as<SizeType, Style::MinimumSize>) {
         if (logicalWidth.isAuto())
-            return adjustBorderBoxLogicalWidthForBoxSizing(0, LengthType::Auto);
+            return borderAndPaddingLogicalWidth();
     }
 
-    if (!logicalWidth.isIntrinsicOrLegacyIntrinsicOrAuto()) {
+    if (logicalWidth.isSpecified()) {
         // FIXME: If the containing block flow is perpendicular to our direction we need to use the available logical height instead.
-        return adjustBorderBoxLogicalWidthForBoxSizing(Style::evaluate(logicalWidth, availableLogicalWidth), logicalWidth.type());
+        return adjustBorderBoxLogicalWidthForBoxSizing(Style::evaluate(logicalWidth, availableLogicalWidth));
     }
 
     if (logicalWidth.isIntrinsic() || logicalWidth.isMinIntrinsic())
@@ -3032,7 +3005,7 @@ bool RenderBox::sizesPreferredLogicalWidthToFitContent() const
     // This code may look a bit strange.  Basically width:intrinsic should clamp the size when testing both
     // min-width and width.  max-width is only clamped if it is also intrinsic.
     auto& logicalWidth = style().logicalWidth();
-    if (logicalWidth.type() == LengthType::Intrinsic)
+    if (logicalWidth.isIntrinsicKeyword())
         return true;
 
     // Children of a horizontal marquee do not fill the container by default.
@@ -3771,6 +3744,11 @@ std::optional<LayoutUnit> RenderBox::computePercentageLogicalHeight(const Style:
     return computePercentageLogicalHeightGeneric(logicalHeight, updateDescendants);
 }
 
+std::optional<LayoutUnit> RenderBox::computePercentageLogicalHeight(const Style::UnevaluatedCalculation<CSS::LengthPercentage<CSS::Nonnegative, float>>& logicalHeight, UpdatePercentageHeightDescendants updateDescendants) const
+{
+    return computePercentageLogicalHeightGeneric(logicalHeight, updateDescendants);
+}
+
 LayoutUnit RenderBox::computeReplacedLogicalWidth(ShouldComputePreferred shouldComputePreferred) const
 {
     return computeReplacedLogicalWidthRespectingMinMaxWidth(computeReplacedLogicalWidthUsing(style().logicalWidth()), shouldComputePreferred);
@@ -3792,10 +3770,29 @@ LayoutUnit RenderBox::computeReplacedLogicalWidthRespectingMinMaxWidth(LayoutUni
 
 template<typename SizeType> LayoutUnit RenderBox::computeReplacedLogicalWidthUsingGeneric(const SizeType& logicalWidth) const
 {
-    if constexpr (std::same_as<SizeType, Style::MinimumSize>) {
-        if (logicalWidth.isAuto())
-            return adjustContentBoxLogicalWidthForBoxSizing(0, logicalWidth.type());
-    }
+    auto calculateContainerWidth = [&] {
+        if (isOutOfFlowPositioned()) {
+            PositionedLayoutConstraints constraints(*this, LogicalBoxAxis::Inline);
+            return constraints.containingSize();
+        }
+        if (isHorizontalWritingMode() == containingBlock()->isHorizontalWritingMode())
+            return containingBlockLogicalWidthForContent();
+        return perpendicularContainingBlockLogicalHeight();
+    };
+
+    auto percentageOrCalc = [&] {
+        // FIXME: Handle cases when containing block width is calculated or viewport percent.
+        // https://bugs.webkit.org/show_bug.cgi?id=91071
+        if (auto containerWidth = calculateContainerWidth(); containerWidth > 0 || (!containerWidth && (containingBlock()->style().logicalWidth().isSpecified())))
+            return adjustContentBoxLogicalWidthForBoxSizing(Style::evaluateMinimum(logicalWidth, containerWidth));
+        return 0_lu;
+    };
+
+    auto fitContentOrFillAvailable = [&] {
+        // FIXME: Handle cases when containing block width is calculated or viewport percent.
+        // https://bugs.webkit.org/show_bug.cgi?id=91071
+        return computeIntrinsicLogicalWidthUsing(logicalWidth, calculateContainerWidth(), borderAndPaddingLogicalWidth()) - borderAndPaddingLogicalWidth();
+    };
 
     auto minMaxContent = [&] {
         // MinContent/MaxContent don't need the availableLogicalWidth argument.
@@ -3803,40 +3800,21 @@ template<typename SizeType> LayoutUnit RenderBox::computeReplacedLogicalWidthUsi
         return computeIntrinsicLogicalWidthUsing(logicalWidth, availableLogicalWidth, borderAndPaddingLogicalWidth()) - borderAndPaddingLogicalWidth();
     };
 
-    auto calculated = [&] {
-        LayoutUnit containerWidth;
-        if (isOutOfFlowPositioned()) {
-            PositionedLayoutConstraints constraints(*this, LogicalBoxAxis::Inline);
-            containerWidth = constraints.containingSize();
-        } else if (isHorizontalWritingMode() == containingBlock()->isHorizontalWritingMode())
-            containerWidth = containingBlockLogicalWidthForContent();
-        else
-            containerWidth = perpendicularContainingBlockLogicalHeight();
-        auto& containerLogicalWidth = containingBlock()->style().logicalWidth();
-        // FIXME: Handle cases when containing block width is calculated or viewport percent.
-        // https://bugs.webkit.org/show_bug.cgi?id=91071
-        if (logicalWidth.isIntrinsic())
-            return computeIntrinsicLogicalWidthUsing(logicalWidth, containerWidth, borderAndPaddingLogicalWidth()) - borderAndPaddingLogicalWidth();
-        if (containerWidth > 0 || (!containerWidth && (containerLogicalWidth.isSpecified())))
-            return adjustContentBoxLogicalWidthForBoxSizing(Style::evaluateMinimum(logicalWidth, containerWidth), logicalWidth.type());
-        return 0_lu;
-    };
-
     return WTF::switchOn(logicalWidth,
         [&](const typename SizeType::Fixed& fixedLogicalWidth) -> LayoutUnit {
             return adjustContentBoxLogicalWidthForBoxSizing(fixedLogicalWidth);
         },
         [&](const typename SizeType::Percentage&) -> LayoutUnit {
-            return calculated();
+            return percentageOrCalc();
         },
         [&](const typename SizeType::Calc&) -> LayoutUnit {
-            return calculated();
+            return percentageOrCalc();
         },
         [&](const CSS::Keyword::FitContent&) -> LayoutUnit {
-            return calculated();
+            return fitContentOrFillAvailable();
         },
         [&](const CSS::Keyword::WebkitFillAvailable&) -> LayoutUnit {
-            return calculated();
+            return fitContentOrFillAvailable();
         },
         [&](const CSS::Keyword::MinContent&) -> LayoutUnit {
             return minMaxContent();
@@ -3851,7 +3829,10 @@ template<typename SizeType> LayoutUnit RenderBox::computeReplacedLogicalWidthUsi
             return intrinsicLogicalWidth();
         },
         [&](const CSS::Keyword::Auto&) -> LayoutUnit {
-            return intrinsicLogicalWidth();
+            if constexpr (std::same_as<SizeType, Style::MinimumSize>)
+                return 0_lu;
+            else
+                return intrinsicLogicalWidth();
         },
         [&](const CSS::Keyword::None&) -> LayoutUnit {
             return intrinsicLogicalWidth();
@@ -4401,7 +4382,7 @@ LayoutUnit RenderBox::computePositionedLogicalWidthUsing(const Style::PreferredS
 
     bool logicalWidthIsAuto = logicalWidth.isIntrinsicOrLegacyIntrinsicOrAuto() && !shouldComputeLogicalWidthFromAspectRatio();
     if (!logicalWidthIsAuto)
-        return adjustContentBoxLogicalWidthForBoxSizing(Style::evaluate(logicalWidth, inlineConstraints.containingSize()), originalLogicalWidth.type());
+        return adjustContentBoxLogicalWidthForBoxSizing(Style::evaluate(logicalWidth, inlineConstraints.containingSize()));
 
     bool logicalLeftIsAuto = inlineConstraints.insetBefore().isAuto();
     bool logicalRightIsAuto = inlineConstraints.insetAfter().isAuto();
@@ -4438,7 +4419,7 @@ LayoutUnit RenderBox::computePositionedLogicalWidthUsing(const Style::MinimumSiz
 
     bool logicalWidthIsAuto = logicalWidth.isIntrinsicOrLegacyIntrinsicOrAuto() && !shouldComputeLogicalWidthFromAspectRatio();
     if (!logicalWidthIsAuto)
-        return adjustContentBoxLogicalWidthForBoxSizing(Style::evaluate(logicalWidth, inlineConstraints.containingSize()), originalLogicalWidth.type());
+        return adjustContentBoxLogicalWidthForBoxSizing(Style::evaluate(logicalWidth, inlineConstraints.containingSize()));
 
     bool logicalLeftIsAuto = inlineConstraints.insetBefore().isAuto();
     bool logicalRightIsAuto = inlineConstraints.insetAfter().isAuto();
@@ -4467,7 +4448,7 @@ LayoutUnit RenderBox::computePositionedLogicalWidthUsing(const Style::MaximumSiz
 
     bool logicalWidthIsAuto = logicalWidth.isIntrinsicOrLegacyIntrinsicOrAuto() && !shouldComputeLogicalWidthFromAspectRatio();
     if (!logicalWidthIsAuto)
-        return adjustContentBoxLogicalWidthForBoxSizing(Style::evaluate(logicalWidth, inlineConstraints.containingSize()), originalLogicalWidth.type());
+        return adjustContentBoxLogicalWidthForBoxSizing(Style::evaluate(logicalWidth, inlineConstraints.containingSize()));
 
     bool logicalLeftIsAuto = inlineConstraints.insetBefore().isAuto();
     bool logicalRightIsAuto = inlineConstraints.insetAfter().isAuto();

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -310,13 +310,9 @@ public:
     LayoutSize offsetFromContainer(const RenderElement&, const LayoutPoint&, bool* offsetDependsOnPoint = nullptr) const override;
     
     LayoutUnit adjustBorderBoxLogicalWidthForBoxSizing(const Style::Length<CSS::Nonnegative, float>& logicalWidth) const;
+    LayoutUnit adjustBorderBoxLogicalWidthForBoxSizing(LayoutUnit computedLogicalWidth) const;
     LayoutUnit adjustContentBoxLogicalWidthForBoxSizing(const Style::Length<CSS::Nonnegative, float>& logicalWidth) const;
-
-    LayoutUnit adjustBorderBoxLogicalWidthForBoxSizing(LayoutUnit computedLogicalWidth, LengthType originalType) const;
-    LayoutUnit adjustContentBoxLogicalWidthForBoxSizing(LayoutUnit computedLogicalWidth, LengthType originalType) const;
-
-    template<typename T> LayoutUnit adjustBorderBoxLogicalWidthForBoxSizing(T computedLogicalWidth, LengthType originalType) const { return adjustBorderBoxLogicalWidthForBoxSizing(LayoutUnit(computedLogicalWidth), originalType); }
-    template<typename T> LayoutUnit adjustContentBoxLogicalWidthForBoxSizing(T computedLogicalWidth, LengthType originalType) const { return adjustContentBoxLogicalWidthForBoxSizing(LayoutUnit(computedLogicalWidth), originalType); }
+    LayoutUnit adjustContentBoxLogicalWidthForBoxSizing(LayoutUnit computedLogicalWidth) const;
 
     // Overridden by fieldsets to subtract out the intrinsic border.
     virtual LayoutUnit adjustBorderBoxLogicalHeightForBoxSizing(LayoutUnit height) const;
@@ -433,6 +429,7 @@ public:
     std::optional<LayoutUnit> computePercentageLogicalHeight(const Style::MaximumSize& logicalHeight, UpdatePercentageHeightDescendants = UpdatePercentageHeightDescendants::Yes) const;
     std::optional<LayoutUnit> computePercentageLogicalHeight(const Style::FlexBasis& logicalHeight, UpdatePercentageHeightDescendants = UpdatePercentageHeightDescendants::Yes) const;
     std::optional<LayoutUnit> computePercentageLogicalHeight(const Style::Percentage<CSS::Nonnegative, float>& logicalHeight, UpdatePercentageHeightDescendants = UpdatePercentageHeightDescendants::Yes) const;
+    std::optional<LayoutUnit> computePercentageLogicalHeight(const Style::UnevaluatedCalculation<CSS::LengthPercentage<CSS::Nonnegative, float>>& logicalHeight, UpdatePercentageHeightDescendants = UpdatePercentageHeightDescendants::Yes) const;
     bool hasAutoHeightOrContainingBlockWithAutoHeight(UpdatePercentageHeightDescendants = UpdatePercentageHeightDescendants::Yes) const;
 
     virtual LayoutUnit availableLogicalHeight(AvailableLogicalHeightType) const;

--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
@@ -1159,7 +1159,7 @@ LayoutUnit RenderDeprecatedFlexibleBox::allowedChildFlex(RenderBox* child, bool 
             LayoutUnit width = contentWidthForChild(child);
             if (auto fixedMaxWidth = child->style().maxWidth().tryFixed())
                 maxWidth = fixedMaxWidth->value;
-            else if (child->style().maxWidth().type() == LengthType::Intrinsic)
+            else if (child->style().maxWidth().isIntrinsicKeyword())
                 maxWidth = child->maxPreferredLogicalWidth();
             else if (child->style().maxWidth().isMinIntrinsic())
                 maxWidth = child->minPreferredLogicalWidth();
@@ -1184,7 +1184,7 @@ LayoutUnit RenderDeprecatedFlexibleBox::allowedChildFlex(RenderBox* child, bool 
         LayoutUnit width = contentWidthForChild(child);
         if (auto fixedMinWidth = child->style().minWidth().tryFixed())
             minWidth = fixedMinWidth->value;
-        else if (child->style().minWidth().type() == LengthType::Intrinsic)
+        else if (child->style().minWidth().isIntrinsicKeyword())
             minWidth = child->maxPreferredLogicalWidth();
         else if (child->style().minWidth().isMinIntrinsic())
             minWidth = child->minPreferredLogicalWidth();

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
@@ -131,9 +131,6 @@ template<typename Numeric, CSS::PrimitiveKeyword... Ks> struct LengthWrapperBase
     ALWAYS_INLINE bool isPositive() const { return m_value.isPositive(); }
     ALWAYS_INLINE bool isNegative() const { return m_value.isNegative(); }
 
-    // FIXME: Remove this when RenderBox's adjust*Box functions no longer need it.
-    ALWAYS_INLINE WebCore::LengthType type() const { return m_value.type(); }
-
     std::optional<Fixed> tryFixed() const { return isFixed() ? std::make_optional(Fixed { m_value.value() }) : std::nullopt; }
     std::optional<Percentage> tryPercentage() const { return isPercent() ? std::make_optional(Percentage { m_value.value() }) : std::nullopt; }
     std::optional<Calc> tryCalc() const { return isCalculated() ? std::make_optional(Calc { m_value.calculationValue() }) : std::nullopt; }


### PR DESCRIPTION
#### 5f322cac86509b55a857047a417919d5e89dbddf
<pre>
[Style] Remove exposure of the underlying LengthType in Style::LengthWrappers
<a href="https://bugs.webkit.org/show_bug.cgi?id=294923">https://bugs.webkit.org/show_bug.cgi?id=294923</a>

Reviewed by Darin Adler.

Remove the need for Style::LengthWrapperBase to expose the underlying Length&apos;s
LengthType property by removing all callers.

* Source/WebCore/rendering/AutoTableLayout.cpp:
* Source/WebCore/rendering/AutoTableLayout.h:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
* Source/WebCore/rendering/RenderBox.cpp:
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp:
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
* Source/WebCore/rendering/RenderGrid.cpp:
* Source/WebCore/style/values/primitives/StyleLengthWrapper.h:

Canonical link: <a href="https://commits.webkit.org/296584@main">https://commits.webkit.org/296584@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a038a92c19e68c8d7c5766023b1f0a7bc34c4ee4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108982 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28642 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19067 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114192 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59312 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110945 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29325 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37209 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82819 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111930 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23323 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98165 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63260 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/22737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16302 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58887 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/92694 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16349 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117311 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36031 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/26630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91826 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36402 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94428 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91637 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23324 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36550 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14302 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31893 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35929 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41447 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35628 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38968 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37314 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->