### PR TITLE
Drop CSSSelectorList::next() and port call sites to using modern range loops instead

### DIFF
--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -834,11 +834,8 @@ bool CSSSelector::visitAllSimpleSelectors(auto& apply) const
 
         // Visit the selector list member (if any) recursively (such as: :has(<list>), :is(<list>),...)
         if (auto selectorList = current->selectorList()) {
-            auto next = selectorList->first();
-            while (next) {
-                worklist.push(next);
-                next = CSSSelectorList::next(next);
-            }
+            for (auto& selector : *selectorList)
+                worklist.push(&selector);
         }
 
         // Visit the next simple selector

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -52,16 +52,15 @@ public:
 
     bool isEmpty() const { return !m_selectorArray; }
     const CSSSelector* first() const { return m_selectorArray.get(); }
-    static const CSSSelector* next(const CSSSelector*);
     const CSSSelector* selectorAt(size_t index) const { return &m_selectorArray[index]; }
 
     size_t indexOfNextSelectorAfter(size_t index) const
     {
-        const CSSSelector* current = selectorAt(index);
-        current = next(current);
-        if (!current)
+        const_iterator current = selectorAt(index);
+        ++current;
+        if (current == end())
             return notFound;
-        return current - m_selectorArray.get();
+        return &*current - m_selectorArray.get();
     }
 
     struct const_iterator {
@@ -75,12 +74,28 @@ public:
         pointer operator->() const { return m_ptr; }
         bool operator==(const const_iterator&) const = default;
         const_iterator() = default;
-        const_iterator(pointer ptr) : m_ptr(ptr) { };
+        const_iterator(pointer ptr)
+            : m_ptr(ptr)
+        { }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         const_iterator& operator++()
         {
-            m_ptr = CSSSelectorList::next(m_ptr);
+            // Skip subparts of compound selectors.
+            while (!m_ptr->isLastInTagHistory())
+                ++m_ptr;
+            m_ptr = m_ptr->isLastInSelectorList() ? nullptr : m_ptr + 1;
             return *this;
         }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+        const_iterator operator++(int)
+        {
+            const_iterator temp = *this;
+            ++*this;
+            return temp;
+        }
+
     private:
         pointer m_ptr = nullptr;
     };
@@ -103,15 +118,5 @@ private:
     // End of the array is indicated by m_isLastInSelectorList bit in the last item.
     UniqueArray<CSSSelector> m_selectorArray;
 };
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-inline const CSSSelector* CSSSelectorList::next(const CSSSelector* current)
-{
-    // Skip subparts of compound selectors.
-    while (!current->isLastInTagHistory())
-        current++;
-    return current->isLastInSelectorList() ? 0 : current + 1;
-}
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 } // namespace WebCore

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -785,11 +785,11 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
         if (selector.pseudoClass() == CSSSelector::PseudoClass::Not) {
             const CSSSelectorList* selectorList = selector.selectorList();
 
-            for (const CSSSelector* subselector = selectorList->first(); subselector; subselector = CSSSelectorList::next(subselector)) {
+            for (auto& subselector : *selectorList) {
                 LocalContext subcontext(context);
                 subcontext.inFunctionalPseudoClass = true;
                 subcontext.pseudoElementEffective = false;
-                subcontext.selector = subselector;
+                subcontext.selector = &subselector;
                 subcontext.firstSelectorOfTheFragment = selectorList->first();
                 PseudoIdSet ignoreDynamicPseudo;
 
@@ -939,8 +939,8 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
                 return hasMatchedAnything;
             }
         case CSSSelector::PseudoClass::Has: {
-            for (auto* hasSelector = selector.selectorList()->first(); hasSelector; hasSelector = CSSSelectorList::next(hasSelector)) {
-                if (matchHasPseudoClass(checkingContext, element, *hasSelector))
+            for (auto& hasSelector : *selector.selectorList()) {
+                if (matchHasPseudoClass(checkingContext, element, hasSelector))
                     return true;
             }
             return false;
@@ -1212,8 +1212,9 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
             LocalContext subcontext(context);
 
             const CSSSelector* const & selector = context.selector;
-            for (subcontext.selector = selector->selectorList()->first(); subcontext.selector; subcontext.selector = CSSSelectorList::next(subcontext.selector)) {
-                subcontext.firstSelectorOfTheFragment = subcontext.selector;
+            for (auto& subselector : *selector->selectorList()) {
+                subcontext.selector = &subselector;
+                subcontext.firstSelectorOfTheFragment = &subselector;
                 subcontext.inFunctionalPseudoClass = true;
                 subcontext.pseudoElementEffective = false;
                 PseudoIdSet ignoredDynamicPseudo;
@@ -1321,13 +1322,13 @@ bool SelectorChecker::matchSelectorList(CheckingContext& checkingContext, const 
 {
     bool hasMatchedAnything = false;
 
-    for (const CSSSelector* subselector = selectorList.first(); subselector; subselector = CSSSelectorList::next(subselector)) {
+    for (auto& subselector : selectorList) {
         LocalContext subcontext(context);
         subcontext.element = &element;
-        subcontext.selector = subselector;
+        subcontext.selector = &subselector;
         subcontext.inFunctionalPseudoClass = true;
         subcontext.pseudoElementEffective = false;
-        subcontext.firstSelectorOfTheFragment = subselector;
+        subcontext.firstSelectorOfTheFragment = &subselector;
         PseudoIdSet ignoreDynamicPseudo;
         if (matchRecursively(checkingContext, subcontext, ignoreDynamicPseudo).match == Match::SelectorMatches) {
             ASSERT(!ignoreDynamicPseudo);

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -319,9 +319,9 @@ Vector<Ref<StyleRule>> StyleRule::splitIntoMultipleRulesWithMaximumSelectorCompo
     Vector<Ref<StyleRule>> rules;
     Vector<const CSSSelector*> componentsSinceLastSplit;
 
-    for (const CSSSelector* selector = selectorList().first(); selector; selector = CSSSelectorList::next(selector)) {
+    for (auto& selector : selectorList()) {
         Vector<const CSSSelector*, 8> componentsInThisSelector;
-        for (const CSSSelector* component = selector; component; component = component->tagHistory())
+        for (const CSSSelector* component = &selector; component; component = component->tagHistory())
             componentsInThisSelector.append(component);
 
         if (componentsInThisSelector.size() + componentsSinceLastSplit.size() > maxCount && !componentsSinceLastSplit.isEmpty()) {

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -1307,18 +1307,15 @@ CSSSelectorList CSSSelectorParser::resolveNestingParent(const CSSSelectorList& n
 {
     MutableCSSSelectorList result;
     CSSSelectorList copiedSelectorList { nestedSelectorList };
-    auto selector = copiedSelectorList.first();
-    while (selector) {
+    for (auto& selector : copiedSelectorList) {
         if (parentResolvedSelectorList) {
             // FIXME: We should build a new MutableCSSSelector from this selector and resolve it
-            const_cast<CSSSelector*>(selector)->resolveNestingParentSelectors(*parentResolvedSelectorList);
+            const_cast<CSSSelector&>(selector).resolveNestingParentSelectors(*parentResolvedSelectorList);
         } else {
             // It's top-level, the nesting parent selector should be replaced by :scope
-            const_cast<CSSSelector*>(selector)->replaceNestingParentByPseudoClassScope();
+            const_cast<CSSSelector&>(selector).replaceNestingParentByPseudoClassScope();
         }
-        auto mutableSelector = makeUnique<MutableCSSSelector>(*selector);
-        result.append(WTFMove(mutableSelector));
-        selector = copiedSelectorList.next(selector);
+        result.append(makeUnique<MutableCSSSelector>(selector));
     }
 
     auto final = CSSSelectorList { WTFMove(result) };

--- a/Source/WebCore/css/parser/MutableCSSSelector.cpp
+++ b/Source/WebCore/css/parser/MutableCSSSelector.cpp
@@ -189,8 +189,8 @@ static bool selectorListMatchesPseudoElement(const CSSSelectorList* selectorList
     if (!selectorList)
         return false;
 
-    for (const CSSSelector* subSelector = selectorList->first(); subSelector; subSelector = CSSSelectorList::next(subSelector)) {
-        for (const CSSSelector* selector = subSelector; selector; selector = selector->tagHistory()) {
+    for (auto& subSelector : *selectorList) {
+        for (const CSSSelector* selector = &subSelector; selector; selector = selector->tagHistory()) {
             if (selector->matchesPseudoElement())
                 return true;
             if (const CSSSelectorList* subselectorList = selector->selectorList()) {

--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -124,13 +124,11 @@ static bool canOptimizeSingleAttributeExactMatch(const CSSSelector& selector)
 
 SelectorDataList::SelectorDataList(const CSSSelectorList& selectorList)
 {
-    unsigned selectorCount = 0;
-    for (const CSSSelector* selector = selectorList.first(); selector; selector = CSSSelectorList::next(selector))
-        selectorCount++;
+    unsigned selectorCount = std::ranges::distance(selectorList);
 
     m_selectors.reserveInitialCapacity(selectorCount);
-    for (const CSSSelector* selector = selectorList.first(); selector; selector = CSSSelectorList::next(selector))
-        m_selectors.append({ selector });
+    for (auto& selector : selectorList)
+        m_selectors.append({ &selector });
 
     if (selectorCount == 1) {
         const CSSSelector& selector = *m_selectors.first().selector;

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -1360,8 +1360,8 @@ Vector<const CSSSelector*> InspectorStyleSheet::selectorsForCSSStyleRule(CSSStyl
 
     Vector<const CSSSelector*> selectors;
     for (auto& rule : cssStyleRulesSplitFromSameRule(rule)) {
-        for (const CSSSelector* selector = rule->styleRule().selectorList().first(); selector; selector = CSSSelectorList::next(selector))
-            selectors.append(selector);
+        for (auto& selector : rule->styleRule().selectorList())
+            selectors.append(&selector);
     }
     return selectors;
 }

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -1358,8 +1358,8 @@ Ref<JSON::ArrayOf<Inspector::Protocol::CSS::RuleMatch>> InspectorCSSAgent::build
         auto matchingSelectors = JSON::ArrayOf<int>::create();
         const CSSSelectorList& selectorList = matchedRule->selectorList();
         int index = 0;
-        for (const CSSSelector* selector = selectorList.first(); selector; selector = CSSSelectorList::next(selector)) {
-            bool matched = selectorChecker.match(*selector, element, context);
+        for (auto& selector : selectorList) {
+            bool matched = selectorChecker.match(selector, element, context);
             if (matched)
                 matchingSelectors->addItem(index);
             ++index;

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -1537,14 +1537,14 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightSelector(co
         auto isInUserAgentShadowTree = descendantElement->isInUserAgentShadowTree();
         auto pseudoId = descendantElement->pseudoId();
 
-        for (const auto* selector = selectorList->first(); selector; selector = CSSSelectorList::next(selector)) {
-            if (isInUserAgentShadowTree && (selector->match() != CSSSelector::Match::PseudoElement || selector->value() != descendantElement->userAgentPart()))
+        for (auto& selector : *selectorList) {
+            if (isInUserAgentShadowTree && (selector.match() != CSSSelector::Match::PseudoElement || selector.value() != descendantElement->userAgentPart()))
                 continue;
 
             SelectorChecker::CheckingContext context(SelectorChecker::Mode::ResolvingStyle);
             context.pseudoId = pseudoId;
 
-            if (selectorChecker.match(*selector, *descendantElement, context)) {
+            if (selectorChecker.match(selector, *descendantElement, context)) {
                 if (seenNodes.add(*descendantElement))
                     nodeList.append(*descendantElement);
             }

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -665,11 +665,11 @@ std::pair<bool, std::optional<Vector<ElementRuleCollector::ScopingRootWithDistan
             unsigned distance = 0;
             const auto* ancestor = &element();
             while (ancestor) {
-                for (const auto* selector = selectorList.first(); selector; selector = CSSSelectorList::next(selector)) {
+                for (auto& selector : selectorList) {
                     auto appendIfMatch = [&] (const ContainerNode* previousScopingRoot = nullptr) {
                         auto subContext = context;
                         subContext.scope = previousScopingRoot;
-                        auto match = checker.match(*selector, *ancestor, subContext);
+                        auto match = checker.match(selector, *ancestor, subContext);
                         if (match)
                             scopingRoots.append({ ancestor, distance });
                     };
@@ -710,8 +710,8 @@ std::pair<bool, std::optional<Vector<ElementRuleCollector::ScopingRootWithDistan
             Vector<ScopingRootWithDistance> scopingRootsWithinScope;
             for (auto scopingRootWithDistance : scopingRoots) {
                 bool anyScopingLimitMatch = false;
-                for (const auto* selector = scopeEnd.first(); selector; selector = CSSSelectorList::next(selector)) {
-                    if (match(scopingRootWithDistance.scopingRoot.get(), selector)) {
+                for (auto& selector : scopeEnd) {
+                    if (match(scopingRootWithDistance.scopingRoot.get(), &selector)) {
                         anyScopingLimitMatch = true;
                         break;
                     }

--- a/Source/WebCore/style/RuleData.cpp
+++ b/Source/WebCore/style/RuleData.cpp
@@ -94,8 +94,8 @@ static bool selectorCanMatchPseudoElement(const CSSSelector& rootSelector)
             return true;
 
         if (const CSSSelectorList* selectorList = selector->selectorList()) {
-            for (const CSSSelector* subSelector = selectorList->first(); subSelector; subSelector = CSSSelectorList::next(subSelector)) {
-                if (selectorCanMatchPseudoElement(*subSelector))
+            for (auto& subSelector : *selectorList) {
+                if (selectorCanMatchPseudoElement(subSelector))
                     return true;
             }
         }
@@ -123,8 +123,8 @@ static inline PropertyAllowlist determinePropertyAllowlist(const CSSSelector* se
             return propertyAllowlistForPseudoId(PseudoId::Marker);
 
         if (const auto* selectorList = selector->selectorList()) {
-            for (const auto* subSelector = selectorList->first(); subSelector; subSelector = CSSSelectorList::next(subSelector)) {
-                auto allowlistType = determinePropertyAllowlist(subSelector);
+            for (auto& subSelector : *selectorList) {
+                auto allowlistType = determinePropertyAllowlist(&subSelector);
                 if (allowlistType != PropertyAllowlist::None)
                     return allowlistType;
             }

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -317,12 +317,12 @@ DoesBreakScope RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFe
             if (selector->match() == CSSSelector::Match::PseudoClass && selector->pseudoClass() == CSSSelector::PseudoClass::Not)
                 subSelectorIsNegation = isNegation == IsNegation::No ? IsNegation::Yes : IsNegation::No;
 
-            for (const CSSSelector* subSelector = selectorList->first(); subSelector; subSelector = CSSSelectorList::next(subSelector)) {
-                auto subSelectorMatchElement = computeSubSelectorMatchElement(matchElement, *selector, *subSelector);
-                auto pseudoClassDoesBreakScope = recursivelyCollectFeaturesFromSelector(selectorFeatures, *subSelector, subSelectorMatchElement, subSelectorIsNegation, canBreakScope);
+            for (auto& subSelector : *selectorList) {
+                auto subSelectorMatchElement = computeSubSelectorMatchElement(matchElement, *selector, subSelector);
+                auto pseudoClassDoesBreakScope = recursivelyCollectFeaturesFromSelector(selectorFeatures, subSelector, subSelectorMatchElement, subSelectorIsNegation, canBreakScope);
 
                 if (selector->match() == CSSSelector::Match::PseudoClass && selector->pseudoClass() == CSSSelector::PseudoClass::Has)
-                    selectorFeatures.hasPseudoClasses.append({ subSelector, subSelectorMatchElement, isNegation, pseudoClassDoesBreakScope });
+                    selectorFeatures.hasPseudoClasses.append({ &subSelector, subSelectorMatchElement, isNegation, pseudoClassDoesBreakScope });
 
                 if (pseudoClassDoesBreakScope == DoesBreakScope::Yes)
                     doesBreakScope = DoesBreakScope::Yes;
@@ -391,9 +391,9 @@ void RuleFeatureSet::collectFeatures(const RuleData& ruleData, const Vector<Ref<
     for (auto& scopeRule : scopeRules) {
         auto collectSelectorList = [&] (const auto& selectorList) {
             if (!selectorList.isEmpty()) {
-                for (const auto* subSelector = selectorList.first() ; subSelector; subSelector = CSSSelectorList::next(subSelector)) {
-                    recursivelyCollectFeaturesFromSelector(selectorFeatures, *subSelector, MatchElement::Ancestor);
-                    recursivelyCollectFeaturesFromSelector(selectorFeatures, *subSelector, MatchElement::Subject);
+                for (auto& subSelector : selectorList) {
+                    recursivelyCollectFeaturesFromSelector(selectorFeatures, subSelector, MatchElement::Ancestor);
+                    recursivelyCollectFeaturesFromSelector(selectorFeatures, subSelector, MatchElement::Subject);
                 }
             }
         };


### PR DESCRIPTION
#### ca6229de87ba8d87aff701886136867cc6950e64
<pre>
Drop CSSSelectorList::next() and port call sites to using modern range loops instead
<a href="https://bugs.webkit.org/show_bug.cgi?id=294925">https://bugs.webkit.org/show_bug.cgi?id=294925</a>

Reviewed by Darin Adler.

Drop CSSSelectorList::next() and port call sites to using modern range loops instead,
to avoid dealing with raw pointers. This also restricts the WTF_ALLOW_UNSAFE_BUFFER_USAGE
to `CSSSelectorList::const_iterator::operator++()`.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::visitAllSimpleSelectors const):
* Source/WebCore/css/CSSSelectorList.h:
(WebCore::CSSSelectorList::first const):
(WebCore::CSSSelectorList::indexOfNextSelectorAfter const):
(WebCore::CSSSelectorList::const_iterator::const_iterator):
(WebCore::CSSSelectorList::const_iterator::operator++):
(WebCore::CSSSelectorList::next): Deleted.
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
(WebCore::SelectorChecker::matchSelectorList const):
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRule::splitIntoMultipleRulesWithMaximumSelectorComponentCount const):
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::resolveNestingParent):
* Source/WebCore/css/parser/MutableCSSSelector.cpp:
(WebCore::selectorListMatchesPseudoElement):
* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::SelectorDataList::SelectorDataList):
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::buildArrayForMatchedRuleList):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::highlightSelector):
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::scopeRulesMatch):
* Source/WebCore/style/RuleData.cpp:
(WebCore::Style::selectorCanMatchPseudoElement):
(WebCore::Style::determinePropertyAllowlist):
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::RuleFeatureSet::recursivelyCollectFeaturesFromSelector):
(WebCore::Style::RuleFeatureSet::collectFeatures):

Canonical link: <a href="https://commits.webkit.org/296627@main">https://commits.webkit.org/296627@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d817c1c9550aafc21045e501c2b89cb51b926b1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109110 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28770 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114321 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/59409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111073 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29453 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37337 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/82922 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/59409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112058 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/23433 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/98274 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63367 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22834 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/16416 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/59000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92804 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16459 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117439 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36158 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/26732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/91937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36529 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94538 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/91743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23354 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36655 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14408 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32016 "Failed to checkout and rebase branch from PR 47131") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36055 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/41560 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35749 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39087 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37434 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->