### PR TITLE
Adopt smart pointers in Webkit/NetworkProcess

### DIFF
--- a/Source/WebKit/NetworkProcess/Downloads/DownloadManager.h
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadManager.h
@@ -27,7 +27,6 @@
 
 #include "DownloadID.h"
 #include "DownloadMap.h"
-#include "NetworkDataTask.h"
 #include "PendingDownload.h"
 #include "PolicyDecision.h"
 #include "SandboxExtension.h"
@@ -61,6 +60,7 @@ namespace WebKit {
 class AuthenticationManager;
 class Download;
 class NetworkConnectionToWebProcess;
+class NetworkDataTask;
 class NetworkLoad;
 class PendingDownload;
 

--- a/Source/WebKit/NetworkProcess/NetworkDataTask.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.cpp
@@ -208,27 +208,6 @@ void NetworkDataTask::setH2PingCallback(const URL& url, CompletionHandler<void(E
     completionHandler(makeUnexpected(internalError(url)));
 }
 
-PAL::SessionID NetworkDataTask::sessionID() const
-{
-    return m_session->sessionID();
-}
-
-const NetworkSession* NetworkDataTask::networkSession() const
-{
-    return m_session.get();
-}
-
-NetworkSession* NetworkDataTask::networkSession()
-{
-    return m_session.get();
-}
-
-CheckedPtr<NetworkSession> NetworkDataTask::checkedNetworkSession()
-{
-    ASSERT(m_session);
-    return m_session.get();
-}
-
 void NetworkDataTask::restrictRequestReferrerToOriginIfNeeded(WebCore::ResourceRequest& request)
 {
     CheckedPtr session = m_session.get();

--- a/Source/WebKit/NetworkProcess/NetworkDataTask.h
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "DownloadID.h"
+#include "NetworkSession.h"
 #include "SandboxExtension.h"
 #include "WebPageProxyIdentifier.h"
 #include <WebCore/Credential.h>
@@ -147,11 +148,15 @@ public:
     virtual void setEmulatedConditions(const std::optional<int64_t>& /* bytesPerSecondLimit */) { }
 #endif
 
-    PAL::SessionID sessionID() const;
+    PAL::SessionID sessionID() const { return m_session->sessionID(); }
+    const NetworkSession* networkSession() const { return m_session.get(); }
+    NetworkSession* networkSession() { return m_session.get(); }
 
-    const NetworkSession* networkSession() const;
-    NetworkSession* networkSession();
-    CheckedPtr<NetworkSession> checkedNetworkSession();
+    CheckedPtr<NetworkSession> checkedNetworkSession()
+    {
+        ASSERT(m_session);
+        return m_session.get();
+    }
 
     virtual void setTimingAllowFailedFlag() { }
 

--- a/Source/WebKit/NetworkProcess/NetworkLoad.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.cpp
@@ -89,9 +89,10 @@ void NetworkLoad::start()
 
 void NetworkLoad::startWithScheduling()
 {
-    if (!m_task || !m_task->networkSession())
+    RefPtr task = m_task;
+    if (!task || !task->networkSession())
         return;
-    Ref scheduler = m_task->networkSession()->networkLoadScheduler();
+    Ref scheduler = task->checkedNetworkSession()->networkLoadScheduler();
     m_scheduler = scheduler.get();
     scheduler->schedule(*this);
 }
@@ -136,12 +137,14 @@ void NetworkLoad::reprioritizeRequest(ResourceLoadPriority priority)
 
 bool NetworkLoad::shouldCaptureExtraNetworkLoadMetrics() const
 {
-    return m_client && m_client->shouldCaptureExtraNetworkLoadMetrics();
+    CheckedPtr client = m_client;
+    return client && client->shouldCaptureExtraNetworkLoadMetrics();
 }
 
 bool NetworkLoad::isAllowedToAskUserForCredentials() const
 {
-    return m_client && m_client->isAllowedToAskUserForCredentials();
+    CheckedPtr client = m_client;
+    return client && client->isAllowedToAskUserForCredentials();
 }
 
 void NetworkLoad::convertTaskToDownload(PendingDownload& pendingDownload, const ResourceRequest& updatedRequest, const ResourceResponse& response, ResponseCompletionHandler&& completionHandler)
@@ -193,7 +196,9 @@ void NetworkLoad::willPerformHTTPRedirection(ResourceResponse&& redirectResponse
         return;
     }
 
-    if (!m_client)
+    CheckedPtr client = m_client;
+
+    if (!client)
         return completionHandler({ });
 
     redirectResponse.setSource(ResourceResponse::Source::Network);
@@ -202,7 +207,7 @@ void NetworkLoad::willPerformHTTPRedirection(ResourceResponse&& redirectResponse
     request.setRequester(oldRequest.requester());
 
     m_currentRequest = request;
-    m_client->willSendRedirectedRequest(WTFMove(oldRequest), WTFMove(request), WTFMove(redirectResponse), [weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)] (ResourceRequest&& newRequest) mutable {
+    client->willSendRedirectedRequest(WTFMove(oldRequest), WTFMove(request), WTFMove(redirectResponse), [weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)] (ResourceRequest&& newRequest) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return completionHandler({ });
@@ -219,18 +224,20 @@ void NetworkLoad::willPerformHTTPRedirection(ResourceResponse&& redirectResponse
 
 void NetworkLoad::didReceiveChallenge(AuthenticationChallenge&& challenge, NegotiatedLegacyTLS negotiatedLegacyTLS, ChallengeCompletionHandler&& completionHandler)
 {
-    if (!m_client) {
+    CheckedPtr client = m_client;
+
+    if (!client) {
         completionHandler(AuthenticationChallengeDisposition::Cancel, { });
         return;
     }
 
-    m_client->didReceiveChallenge(challenge);
+    client->didReceiveChallenge(challenge);
 
     auto scheme = challenge.protectionSpace().authenticationScheme();
     bool isTLSHandshake = scheme == ProtectionSpace::AuthenticationScheme::ServerTrustEvaluationRequested
         || scheme == ProtectionSpace::AuthenticationScheme::ClientCertificateRequested;
     if (!isAllowedToAskUserForCredentials() && !isTLSHandshake && !challenge.protectionSpace().isProxy()) {
-        m_client->didBlockAuthenticationChallenge();
+        client->didBlockAuthenticationChallenge();
         completionHandler(AuthenticationChallengeDisposition::UseCredential, { });
         return;
     }
@@ -243,8 +250,8 @@ void NetworkLoad::didReceiveChallenge(AuthenticationChallenge&& challenge, Negot
 
 void NetworkLoad::didReceiveInformationalResponse(ResourceResponse&& response)
 {
-    if (m_client)
-        m_client->didReceiveInformationalResponse(WTFMove(response));
+    if (CheckedPtr client = m_client)
+        client->didReceiveInformationalResponse(WTFMove(response));
 }
 
 void NetworkLoad::didReceiveResponse(ResourceResponse&& response, NegotiatedLegacyTLS negotiatedLegacyTLS, PrivateRelayed privateRelayed, ResponseCompletionHandler&& completionHandler)
@@ -266,7 +273,9 @@ void NetworkLoad::notifyDidReceiveResponse(ResourceResponse&& response, Negotiat
 {
     ASSERT(RunLoop::isMain());
 
-    if (!m_client)
+    CheckedPtr client = m_client;
+
+    if (!client)
         return completionHandler(WebCore::PolicyAction::Ignore);
 
     if (m_parameters.needsCertificateInfo) {
@@ -281,13 +290,13 @@ void NetworkLoad::notifyDidReceiveResponse(ResourceResponse&& response, Negotiat
         response.includeCertificateInfo(auditToken);
     }
 
-    m_client->didReceiveResponse(WTFMove(response), privateRelayed, WTFMove(completionHandler));
+    client->didReceiveResponse(WTFMove(response), privateRelayed, WTFMove(completionHandler));
 }
 
 void NetworkLoad::didReceiveData(const WebCore::SharedBuffer& buffer)
 {
-    if (m_client)
-        m_client->didReceiveBuffer(buffer);
+    if (CheckedPtr client = m_client)
+        client->didReceiveBuffer(buffer);
 }
 
 void NetworkLoad::didCompleteWithError(const ResourceError& error, const WebCore::NetworkLoadMetrics& networkLoadMetrics)
@@ -295,43 +304,44 @@ void NetworkLoad::didCompleteWithError(const ResourceError& error, const WebCore
     if (RefPtr scheduler = std::exchange(m_scheduler, nullptr).get())
         scheduler->unschedule(*this, &networkLoadMetrics);
 
-    if (!m_client)
+    CheckedPtr client = m_client;
+    if (!client)
         return;
 
     if (error.isNull())
-        m_client->didFinishLoading(networkLoadMetrics);
+        client->didFinishLoading(networkLoadMetrics);
     else
-        m_client->didFailLoading(error);
+        client->didFailLoading(error);
 }
 
 void NetworkLoad::didSendData(uint64_t totalBytesSent, uint64_t totalBytesExpectedToSend)
 {
-    if (m_client)
-        m_client->didSendData(totalBytesSent, totalBytesExpectedToSend);
+    if (CheckedPtr client = m_client)
+        client->didSendData(totalBytesSent, totalBytesExpectedToSend);
 }
 
 void NetworkLoad::wasBlocked()
 {
-    if (m_client)
-        m_client->didFailLoading(blockedError(m_currentRequest));
+    if (CheckedPtr client = m_client)
+        client->didFailLoading(blockedError(m_currentRequest));
 }
 
 void NetworkLoad::cannotShowURL()
 {
-    if (m_client)
-        m_client->didFailLoading(cannotShowURLError(m_currentRequest));
+    if (CheckedPtr client = m_client)
+        client->didFailLoading(cannotShowURLError(m_currentRequest));
 }
 
 void NetworkLoad::wasBlockedByRestrictions()
 {
-    if (m_client)
-        m_client->didFailLoading(wasBlockedByRestrictionsError(m_currentRequest));
+    if (CheckedPtr client = m_client)
+        client->didFailLoading(wasBlockedByRestrictionsError(m_currentRequest));
 }
 
 void NetworkLoad::wasBlockedByDisabledFTP()
 {
-    if (m_client)
-        m_client->didFailLoading(ftpDisabledError(m_currentRequest));
+    if (CheckedPtr client = m_client)
+        client->didFailLoading(ftpDisabledError(m_currentRequest));
 }
 
 void NetworkLoad::didNegotiateModernTLS(const URL& url)

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -537,7 +537,7 @@ ContentSecurityPolicy* NetworkLoadChecker::contentSecurityPolicy()
     if (!m_contentSecurityPolicy && m_cspResponseHeaders) {
         // FIXME: Pass the URL of the protected resource instead of its origin.
         m_contentSecurityPolicy = makeUnique<ContentSecurityPolicy>(URL { protectedOrigin()->toRawString() }, nullptr, m_networkResourceLoader.get());
-        m_contentSecurityPolicy->didReceiveHeaders(*m_cspResponseHeaders, String { m_referrer }, ContentSecurityPolicy::ReportParsingErrors::No);
+        CheckedPtr { m_contentSecurityPolicy.get() }->didReceiveHeaders(*m_cspResponseHeaders, String { m_referrer }, ContentSecurityPolicy::ReportParsingErrors::No);
         if (!m_documentURL.isEmpty())
             m_contentSecurityPolicy->setDocumentURL(m_documentURL);
     }

--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -2,9 +2,6 @@ EventDispatcherMessages.h
 NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
 NetworkProcess/DatabaseUtilities.cpp
 NetworkProcess/NetworkConnectionToWebProcess.cpp
-NetworkProcess/NetworkLoad.cpp
-NetworkProcess/NetworkLoadChecker.cpp
-NetworkProcess/NetworkProcess.cpp
 NetworkProcess/NetworkResourceLoader.cpp
 NetworkProcess/NetworkSocketChannel.cpp
 NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -1,4 +1,3 @@
-NetworkProcess/NetworkProcess.cpp
 NetworkProcess/NetworkSession.cpp
 NetworkProcess/cocoa/NetworkSessionCocoa.mm
 Platform/IPC/ArgumentCoders.h


### PR DESCRIPTION
#### 9dfdee9809d5868102acf67c4c813891c23f511a
<pre>
Adopt smart pointers in Webkit/NetworkProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=294928">https://bugs.webkit.org/show_bug.cgi?id=294928</a>
<a href="https://rdar.apple.com/154227081">rdar://154227081</a>

Reviewed by Per Arne Vollan.

Smart pointer adoption as per the static analyzer.

* Source/WebKit/NetworkProcess/Downloads/DownloadManager.h:
* Source/WebKit/NetworkProcess/NetworkDataTask.cpp:
(WebKit::NetworkDataTask::sessionID const): Deleted.
(WebKit::NetworkDataTask::networkSession const): Deleted.
(WebKit::NetworkDataTask::networkSession): Deleted.
(WebKit::NetworkDataTask::checkedNetworkSession): Deleted.
* Source/WebKit/NetworkProcess/NetworkDataTask.h:
(WebKit::NetworkDataTask::sessionID const):
(WebKit::NetworkDataTask::networkSession const):
(WebKit::NetworkDataTask::networkSession):
(WebKit::NetworkDataTask::checkedNetworkSession):
* Source/WebKit/NetworkProcess/NetworkLoad.cpp:
(WebKit::NetworkLoad::startWithScheduling):
(WebKit::NetworkLoad::shouldCaptureExtraNetworkLoadMetrics const):
(WebKit::NetworkLoad::isAllowedToAskUserForCredentials const):
(WebKit::NetworkLoad::willPerformHTTPRedirection):
(WebKit::NetworkLoad::didReceiveChallenge):
(WebKit::NetworkLoad::didReceiveInformationalResponse):
(WebKit::NetworkLoad::notifyDidReceiveResponse):
(WebKit::NetworkLoad::didReceiveData):
(WebKit::NetworkLoad::didCompleteWithError):
(WebKit::NetworkLoad::didSendData):
(WebKit::NetworkLoad::wasBlocked):
(WebKit::NetworkLoad::cannotShowURL):
(WebKit::NetworkLoad::wasBlockedByRestrictions):
(WebKit::NetworkLoad::wasBlockedByDisabledFTP):
* Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp:
(WebKit::NetworkLoadChecker::contentSecurityPolicy):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::addStorageSession):
(WebKit::NetworkProcess::deleteAndRestrictWebsiteDataForRegistrableDomains):
(WebKit::NetworkProcess::downloadRequest):
(WebKit::NetworkProcess::resumeDownload):
(WebKit::NetworkProcess::cancelDownload):
(WebKit::NetworkProcess::publishDownloadProgress):
(WebKit::NetworkProcess::findPendingDownloadLocation):
(WebKit::NetworkProcess::dataTaskWithRequest):
* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/296755@main">https://commits.webkit.org/296755@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3709c2925987d5b40f7a6db0ae97a302db43f3f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109472 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29130 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19559 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114676 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59698 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29809 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37718 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83203 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112420 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23743 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98603 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63663 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23125 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59296 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93114 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16786 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117790 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36513 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27035 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92218 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36884 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94863 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92034 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36966 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14712 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/32314 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17668 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36407 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41879 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36074 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39415 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37779 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->