### PR TITLE
HTMLImageElement: Zoom should not affect 'width' and 'height'

### DIFF
--- a/LayoutTests/fast/images/zoomed-img-size-expected.txt
+++ b/LayoutTests/fast/images/zoomed-img-size-expected.txt
@@ -1,46 +1,15 @@
-Ideally, all ovals below should be reported as having width=37, height=33. Currently rounding prevents us from doing this.
 
 
-Zoom 1% PASS: 100x100 close enough to 37x33
+PASS Zoom 4% should not affect width/height of images.
+PASS Zoom 5% should not affect width/height of images.
+PASS Zoom 30% should not affect width/height of images.
+PASS Zoom 33% should not affect width/height of images.
+PASS Zoom 50% should not affect width/height of images.
+PASS Zoom 70% should not affect width/height of images.
+PASS Zoom 100% should not affect width/height of images.
+PASS Zoom 111% should not affect width/height of images.
+PASS Zoom 150% should not affect width/height of images.
+PASS Zoom 333% should not affect width/height of images.
+PASS Zoom 400% should not affect width/height of images.
+PASS Zoom 1234% should not affect width/height of images.
 
-
-Zoom 2% PASS: 50x50 close enough to 37x33
-
-
-Zoom 3% PASS: 33x33 close enough to 37x33
-
-
-Zoom 4% PASS: 25x25 close enough to 37x33
-
-
-Zoom 5% PASS: 40x40 close enough to 37x33
-
-
-Zoom 30% PASS: 36x33 close enough to 37x33
-
-
-Zoom 33% PASS: 36x33 close enough to 37x33
-
-
-Zoom 50% PASS: 38x34 close enough to 37x33
-
-
-Zoom 70% PASS: 37x32 close enough to 37x33
-
-
-Zoom 100% PASS: 37x33
-
-
-Zoom 111% PASS: 37x34 close enough to 37x33
-
-
-Zoom 150% PASS: 38x34 close enough to 37x33
-
-
-Zoom 333% PASS: 37x33
-
-
-Zoom 400% PASS: 37x33
-
-
-Zoom 1234% PASS: 37x33

--- a/LayoutTests/fast/images/zoomed-img-size.html
+++ b/LayoutTests/fast/images/zoomed-img-size.html
@@ -1,74 +1,40 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script type="text/javascript">
-      if (window.testRunner)
-        testRunner.dumpAsText();
-
-      function update() {
-        var el = document.getElementById('subpixel-test');
-        var hasSubpixelSupport = el.getBoundingClientRect().width == 4.5;
-        el.parentNode.removeChild(el);
-    
-        // These arrays will become unnecessary if we fix the rounding issues that make us not always report "37x33".
-        var expectedWidths, expectedHeights;
-        if (hasSubpixelSupport) {
-            expectedWidths = [100, 50, 33, 25, 40, 36, 36, 38, 37, 37, 37, 38, 37, 37, 37];
-            expectedHeights = [100, 50, 33, 25, 40, 33, 33, 34, 32, 33, 34, 34, 33, 33, 33];
-        } else {
-            expectedWidths = [100, 50, 33, 25, 20, 36, 36, 36, 35, 37, 37, 37, 37, 37, 37];
-            expectedHeights = [100, 50, 33, 25, 20, 30, 30, 32, 32, 33, 33, 33, 33, 33, 33];
-        }
-        for (i = 0; i < 15; ++i) {
-          var oval = document.getElementById('oval' + i);
-          var status = document.getElementById('status' + i);
-          var sizes = document.getElementById('sizes' + i);
-          if ((oval.width == expectedWidths[i]) && (oval.height == expectedHeights[i])) {
-            status.style.color = "green";
-            status.innerHTML = "PASS";
-            sizes.innerHTML = oval.width + "x" + oval.height + (((oval.width != 37) || (oval.height != 33)) ? " close enough to 37x33" : "");
-          } else {
-            status.style.color = "red";
-            status.innerHTML = "FAIL";
-            sizes.innerHTML = oval.width + "x" + oval.height + " not close enough to 37x33";
-          }
-        }
-      }
-      window.onload = update;
-    </script>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
   </head>
   <body>
-    <p>Ideally, all ovals below should be reported as having width=37, height=33.  Currently rounding prevents us from doing this.</p>
-    <img id="oval0" src="resources/oval.png" style="zoom: 1%">
-    <p>Zoom 1% <span id="status0"></span>: <span id="sizes0"></span></p>
-    <img id="oval1" src="resources/oval.png" style="zoom: 2%">
-    <p>Zoom 2% <span id="status1"></span>: <span id="sizes1"></span></p>
-    <img id="oval2" src="resources/oval.png" style="zoom: 3%">
-    <p>Zoom 3% <span id="status2"></span>: <span id="sizes2"></span></p>
-    <img id="oval3" src="resources/oval.png" style="zoom: 4%">
-    <p>Zoom 4% <span id="status3"></span>: <span id="sizes3"></span></p>
-    <img id="oval4" src="resources/oval.png" style="zoom: 5%">
-    <p>Zoom 5% <span id="status4"></span>: <span id="sizes4"></span></p>
-    <img id="oval5" src="resources/oval.png" style="zoom: 30%">
-    <p>Zoom 30% <span id="status5"></span>: <span id="sizes5"></span></p>
-    <img id="oval6" src="resources/oval.png" style="zoom: 33%">
-    <p>Zoom 33% <span id="status6"></span>: <span id="sizes6"></span></p>
-    <img id="oval7" src="resources/oval.png" style="zoom: 50%">
-    <p>Zoom 50% <span id="status7"></span>: <span id="sizes7"></span></p>
-    <img id="oval8" src="resources/oval.png" style="zoom: 70%">
-    <p>Zoom 70% <span id="status8"></span>: <span id="sizes8"></span></p>
-    <img id="oval9" src="resources/oval.png" style="zoom: 100%">
-    <p>Zoom 100% <span id="status9"></span>: <span id="sizes9"></span></p>
-    <img id="oval10" src="resources/oval.png" style="zoom: 111%">
-    <p>Zoom 111% <span id="status10"></span>: <span id="sizes10"></span></p>
-    <img id="oval11" src="resources/oval.png" style="zoom: 150%">
-    <p>Zoom 150% <span id="status11"></span>: <span id="sizes11"></span></p>
-    <img id="oval12" src="resources/oval.png" style="zoom: 333%">
-    <p>Zoom 333% <span id="status12"></span>: <span id="sizes12"></span></p>
-    <img id="oval13" src="resources/oval.png" style="zoom: 400%">
-    <p>Zoom 400% <span id="status13"></span>: <span id="sizes13"></span></p>
-    <img id="oval14" src="resources/oval.png" style="zoom: 1234%">
-    <p>Zoom 1234% <span id="status14"></span>: <span id="sizes14"></span></p>
-    <div id="subpixel-test" style="width: 4.5px; height: 10px;"></div>
+    <img id="oval0" src="resources/oval.png" style="zoom: 4%">
+    <img id="oval1" src="resources/oval.png" style="zoom: 5%">
+    <img id="oval2" src="resources/oval.png" style="zoom: 30%">
+    <img id="oval3" src="resources/oval.png" style="zoom: 33%">
+    <img id="oval4" src="resources/oval.png" style="zoom: 50%">
+    <img id="oval5" src="resources/oval.png" style="zoom: 70%">
+    <img id="oval6" src="resources/oval.png" style="zoom: 100%">
+    <img id="oval7" src="resources/oval.png" style="zoom: 111%">
+    <img id="oval8" src="resources/oval.png" style="zoom: 150%">
+    <img id="oval9" src="resources/oval.png" style="zoom: 333%">
+    <img id="oval10" src="resources/oval.png" style="zoom: 400%">
+    <img id="oval11" src="resources/oval.png" style="zoom: 1234%">
+<script>
+const EXPECTED_WIDTH = 37;
+const EXPECTED_HEIGHT = 33;
+for (i = 0; i < 12; ++i) {
+  const oval = document.getElementById('oval' + i);
+  const testDesc = `Zoom ${oval.style.zoom} should not affect width/height of images.`;
+  const testBody = () => {
+    assert_equals(oval.width, EXPECTED_WIDTH, oval.getAttribute('style'));
+    assert_equals(oval.height, EXPECTED_HEIGHT, oval.getAttribute('style'));
+  };
+  if (oval.complete) {
+    test(testBody, testDesc);
+  } else {
+    async_test(t => {
+      oval.onload = t.step_func_done(testBody);
+    }, testDesc);
+  }
+}
+</script>
   </body>
 </html>

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -584,7 +584,7 @@ unsigned HTMLImageElement::width()
     if (!box)
         return 0;
     LayoutRect contentRect = box->contentBoxRect();
-    return adjustForAbsoluteZoom(snappedIntRect(contentRect).width(), *box);
+    return adjustLayoutUnitForAbsoluteZoom(contentRect.width(), *box).round();
 }
 
 unsigned HTMLImageElement::height()
@@ -607,7 +607,7 @@ unsigned HTMLImageElement::height()
     if (!box)
         return 0;
     LayoutRect contentRect = box->contentBoxRect();
-    return adjustForAbsoluteZoom(snappedIntRect(contentRect).height(), *box);
+    return adjustLayoutUnitForAbsoluteZoom(contentRect.height(), *box).round();
 }
 
 float HTMLImageElement::effectiveImageDevicePixelRatio() const


### PR DESCRIPTION
#### f96c4ccffa3594101129a4941c48476a2809ea60
<pre>
HTMLImageElement: Zoom should not affect &apos;width&apos; and &apos;height&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=292027">https://bugs.webkit.org/show_bug.cgi?id=292027</a>
<a href="https://rdar.apple.com/150473104">rdar://150473104</a>

Reviewed by Alan Baradlay.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/166592a28edb3051b1d667eb181686c2edefe496">https://chromium.googlesource.com/chromium/src.git/+/166592a28edb3051b1d667eb181686c2edefe496</a>

This patch updates &apos;width&apos; and &apos;height&apos; to don&apos;t have &apos;snappedIntRect&apos; and
update adjust to LayoutUnit with zoom with rounding to ensure that we don&apos;t
get any mismatch in width / height on zooming.

Additionally, this test updates &apos;zoomed-img-size.html&apos; to use &apos;testharness&apos;.

* LayoutTests/fast/images/zoomed-img-size-expected.txt:
* LayoutTests/fast/images/zoomed-img-size.html:
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::width):
(WebCore::HTMLImageElement::height):

Canonical link: <a href="https://commits.webkit.org/296596@main">https://commits.webkit.org/296596@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b6346f8d7543fa30244dddc7c77cca84a1cdb4b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108988 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28648 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19073 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114198 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59316 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110951 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29331 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37215 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82822 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111936 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23327 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98167 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63263 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22740 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16304 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58893 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92698 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16351 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117317 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36037 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26634 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91840 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36408 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94430 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91641 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23333 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36551 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14304 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31898 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35934 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41452 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35633 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38973 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37320 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->