### PR TITLE
git-webkit setup installs hooks in cwd repository

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py
@@ -150,6 +150,21 @@ class InstallHooks(Command):
             sys.stderr.write('No hooks to install\n')
             return 1
 
+        url = repository.url()
+        match = repository.SSH_REMOTE.match(url) or repository.HTTP_REMOTE.match(url)
+        if match:
+            path = match.group('path')
+            if 'webkit' not in path.lower():
+                print(f'This is not a repository under the WebKit Project. Installing WebKit hooks may override existing hooks and introduce undefined behavior.')
+                response = Terminal.choose(
+                    'Would you like to continue installation?',
+                    options=('No', 'Yes'),
+                    default='No',
+                )
+                if response == 'No':
+                    print(f'Skipping hook installation for this repository')
+                    return 0
+
         candidates = os.listdir(hooks)
         if getattr(args, 'arguments', []):
             hook_names = []

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/install_hooks_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/install_hooks_unittest.py
@@ -78,20 +78,20 @@ class TestInstallHooks(testing.PathTestCase):
         )
 
     def test_security_levels(self):
-        with OutputCapture(level=logging.INFO), mocks.local.Git(self.path, remote='git@example.org:project/project'), mocks.local.Svn():
+        with OutputCapture(level=logging.INFO), mocks.local.Git(self.path, remote='git@example.org:WebKit/project.git'), mocks.local.Svn():
             self.write_config(
                 origin={
-                    'url': 'git@example.org:project/project',
+                    'url': 'git@example.org:webkit/project',
                     'security-level': 0,
                 }, security={
-                    'url': 'git@example.org:project/project-security',
+                    'url': 'git@example.org:webkit/project-security',
                     'security-level': 1,
                 },
             )
 
             self.assertDictEqual({
-                'example.org:project/project': 0,
-                'example.org:project/project-security': 1,
+                'example.org:webkit/project': 0,
+                'example.org:webkit/project-security': 1,
             }, program.InstallHooks._security_levels(local.Git(self.path)))
 
     def test_version_re(self):
@@ -102,7 +102,7 @@ class TestInstallHooks(testing.PathTestCase):
         self.assertEqual(program.InstallHooks.VERSION_RE.match('import os'), None)
 
     def test_install_hook(self):
-        with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path, remote='git@example.org:project/project'), mocks.local.Svn():
+        with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path, remote='git@example.org:WebKit/project.git'), mocks.local.Svn():
             self.write_hook(os.path.join(self.path, 'hooks', 'pre-commit'))
             self.assertEqual(0, program.main(
                 args=('install-hooks', '-v'),
@@ -129,7 +129,7 @@ class TestInstallHooks(testing.PathTestCase):
             )
 
     def test_install_hook_alternate_hook_path_change(self):
-        with OutputCapture(level=logging.INFO) as captured, MockTerminal.input('Change'), mocks.local.Git(self.path, remote='git@example.org:project/project'), mocks.local.Svn():
+        with OutputCapture(level=logging.INFO) as captured, MockTerminal.input('Change'), mocks.local.Git(self.path, remote='git@example.org:WebKit/project.git'), mocks.local.Svn():
             run(
                 [local.Git.executable(), 'config', 'core.hookspath', os.path.join(self.path, 'alternate-hooks-path')],
                 capture_output=True, cwd=self.path,
@@ -168,7 +168,7 @@ class TestInstallHooks(testing.PathTestCase):
             )
 
     def test_install_hook_alternate_hook_path_use(self):
-        with OutputCapture(level=logging.INFO) as captured, MockTerminal.input('Use'), mocks.local.Git(self.path, remote='git@example.org:project/project'), mocks.local.Svn():
+        with OutputCapture(level=logging.INFO) as captured, MockTerminal.input('Use'), mocks.local.Git(self.path, remote='git@example.org:WebKit/project.git'), mocks.local.Svn():
             run(
                 [local.Git.executable(), 'config', 'core.hookspath', os.path.join(self.path, 'alternate-hooks-path')],
                 capture_output=True, cwd=self.path,
@@ -207,7 +207,7 @@ class TestInstallHooks(testing.PathTestCase):
             )
 
     def test_install_hook_alternate_hook_path_exit(self):
-        with OutputCapture(level=logging.INFO) as captured, MockTerminal.input('Exit'), mocks.local.Git(self.path, remote='git@example.org:project/project'), mocks.local.Svn():
+        with OutputCapture(level=logging.INFO) as captured, MockTerminal.input('Exit'), mocks.local.Git(self.path, remote='git@example.org:WebKit/project.git'), mocks.local.Svn():
             run(
                 [local.Git.executable(), 'config', 'core.hookspath', os.path.join(self.path, 'alternate-hooks-path')],
                 capture_output=True, cwd=self.path,
@@ -227,14 +227,14 @@ class TestInstallHooks(testing.PathTestCase):
         self.assertEqual(captured.root.log.getvalue(), '')
 
     def test_security_level_in_hook(self):
-        with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path, remote='git@example.org:project/project'), mocks.local.Svn():
+        with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path, remote='git@example.org:WebKit/project.git'), mocks.local.Svn():
             self.write_hook(os.path.join(self.path, 'hooks', 'pre-push'), security_levels=True)
             self.write_config(
                 origin={
-                    'url': 'git@example.org:project/project',
+                    'url': 'git@example.org:webkit/project',
                     'security-level': 0,
                 }, security={
-                    'url': 'git@example.org:project/project-security',
+                    'url': 'git@example.org:webkit/project-security',
                     'security-level': 1,
                 },
             )
@@ -259,21 +259,21 @@ class TestInstallHooks(testing.PathTestCase):
         with open(resolved_hook, 'r') as f:
             self.assertEqual(
                 f.read(), '''#!/usr/bin/env {}
-SECURITY_LEVELS = {{'example.org:project/project': 0,
- 'example.org:project/project-security': 1}}
+SECURITY_LEVELS = {{'example.org:webkit/project': 0,
+ 'example.org:webkit/project-security': 1}}
 print('Hello, world!\\n')
 '''.format(os.path.basename(sys.executable)),
             )
 
     def test_security_level_addition(self):
-        with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path, remote='git@example.org:project/project'), mocks.local.Svn():
+        with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path, remote='git@example.org:WebKit/project.git'), mocks.local.Svn():
             self.write_hook(os.path.join(self.path, 'hooks', 'pre-push'), security_levels=True)
             self.write_config(
                 origin={
-                    'url': 'git@example.org:project/project',
+                    'url': 'git@example.org:webkit/project',
                     'security-level': 0,
                 }, security={
-                    'url': 'git@example.org:project/project-security',
+                    'url': 'git@example.org:webkit/project-security',
                     'security-level': 1,
                 },
             )
@@ -298,37 +298,55 @@ print('Hello, world!\\n')
         with open(resolved_hook, 'r') as f:
             self.assertEqual(
                 f.read(), '''#!/usr/bin/env {}
-SECURITY_LEVELS = {{'example.org:project/project': 0,
- 'example.org:project/project-security': 1,
+SECURITY_LEVELS = {{'example.org:webkit/project': 0,
+ 'example.org:webkit/project-security': 1,
  'example.org:organization/project': 2}}
 print('Hello, world!\\n')
 '''.format(os.path.basename(sys.executable)),
             )
 
     def test_security_level_override(self):
-        with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path, remote='git@example.org:project/project'), mocks.local.Svn():
+        with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path, remote='git@example.org:WebKit/project.git'), mocks.local.Svn():
             self.write_hook(os.path.join(self.path, 'hooks', 'pre-push'), security_levels=True)
             self.write_config(
                 origin={
-                    'url': 'git@example.org:project/project',
+                    'url': 'git@example.org:webkit/project',
                     'security-level': 0,
                 }, security={
-                    'url': 'git@example.org:project/project-security',
+                    'url': 'git@example.org:webkit/project-security',
                     'security-level': 1,
                 },
             )
             self.assertEqual(1, program.main(
-                args=('install-hooks', '-v', '--level', 'example.org:project/project=2'),
+                args=('install-hooks', '-v', '--level', 'example.org:WebKit/project=2'),
                 path=self.path,
                 hooks=os.path.join(self.path, 'hooks'),
             ))
 
         self.assertEqual(captured.stdout.getvalue(), '')
-        self.assertEqual(captured.stderr.getvalue(), "'example.org:project/project' already has a security level of '0'\n")
+        self.assertEqual(captured.stderr.getvalue(), "'example.org:WebKit/project' already has a security level of '0'\n")
         self.assertEqual(captured.root.log.getvalue(), '')
 
         resolved_hook = os.path.join(self.path, '.git', 'hooks', 'pre-push')
         self.assertFalse(os.path.isfile(resolved_hook))
+
+    def test_not_webkit(self):
+        with OutputCapture(level=logging.INFO) as captured, MockTerminal.input('No'), mocks.local.Git(self.path, remote='git@example.org:project/project.git'), mocks.local.Svn():
+            self.write_hook(os.path.join(self.path, 'hooks', 'pre-commit'))
+            self.assertEqual(0, program.main(
+                args=('install-hooks', '-v'),
+                path=self.path,
+                hooks=os.path.join(self.path, 'hooks'),
+            ))
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'This is not a repository under the WebKit Project. Installing WebKit hooks may override existing hooks and introduce undefined behavior.\n'
+            'Would you like to continue installation? ([No]/Yes): \n'
+            'Skipping hook installation for this repository\n'
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(captured.root.log.getvalue(), '')
 
     def test_svn(self):
         with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(), mocks.local.Svn(self.path):


### PR DESCRIPTION
#### e6080b61a05a998de41c719af138abbb293005fb
<pre>
git-webkit setup installs hooks in cwd repository
<a href="https://rdar.apple.com/143774918">rdar://143774918</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=293771">https://bugs.webkit.org/show_bug.cgi?id=293771</a>

Reviewed by Jonathan Bedard.

Check whether the repository the program is run in is under the WebKit Project.
If not, warn the user that installing hooks may be undesirable.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py:
(InstallHooks.main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/install_hooks_unittest.py:
(TestInstallHooks.test_security_levels):
(TestInstallHooks.test_install_hook):
(TestInstallHooks.test_install_hook_alternate_hook_path_change):
(TestInstallHooks.test_install_hook_alternate_hook_path_use):
(TestInstallHooks.test_install_hook_alternate_hook_path_exit):
(TestInstallHooks.test_security_level_in_hook):

Canonical link: <a href="https://commits.webkit.org/296586@main">https://commits.webkit.org/296586@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7a6f97663e953ee122ac66e520a1e957a3f2015

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108992 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28652 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19077 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114202 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/59318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110955 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37219 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82823 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/59318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111940 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23329 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98168 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63264 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/108424 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/22741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16306 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58897 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/92699 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16353 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117321 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36041 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/26635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/91842 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/108488 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36412 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94432 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91644 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36555 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14305 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31901 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17597 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35938 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35636 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38976 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37323 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->