### PR TITLE
[Liquid Glass] [iOS] Blank gap above top fixed header when rubber-banding against top of page

### DIFF
--- a/Source/WebCore/page/PageColorSampler.h
+++ b/Source/WebCore/page/PageColorSampler.h
@@ -38,7 +38,7 @@ enum class PredominantColorType : uint8_t;
 class PageColorSampler {
 public:
     static std::optional<Color> sampleTop(Page&);
-    static bool colorsAreSimilar(const Color&, const Color&);
+    WEBCORE_EXPORT static bool colorsAreSimilar(const Color&, const Color&);
 
     static constexpr auto nearlyTransparentAlphaThreshold = 0.1;
     static Variant<PredominantColorType, Color> predominantColor(Page&, const LayoutRect&);

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
@@ -95,7 +95,9 @@
 
 - (void)_doAfterNextVisibleContentRectAndStablePresentationUpdate:(void (^)(void))updateBlock;
 
-- (NSString *)_scrollbarState:(unsigned long long)scrollingNodeID processID: (unsigned long long)processID isVertical:(bool)isVertical;
+- (NSString *)_scrollbarState:(unsigned long long)scrollingNodeID processID:(unsigned long long)processID isVertical:(bool)isVertical;
+
+- (UIView *)_colorExtensionViewForTesting:(UIRectEdge)edge;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
@@ -335,6 +335,25 @@ static void dumpUIView(TextStream& ts, UIView *view)
     return _page->scrollbarStateForScrollingNodeID(scrollingNodeID, isVertical).createNSString().autorelease();
 }
 
+- (UIView *)_colorExtensionViewForTesting:(UIRectEdge)edge
+{
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+    switch (edge) {
+    case UIRectEdgeTop:
+        return _fixedColorExtensionViews.at(WebCore::BoxSide::Top).get();
+    case UIRectEdgeLeft:
+        return _fixedColorExtensionViews.at(WebCore::BoxSide::Left).get();
+    case UIRectEdgeBottom:
+        return _fixedColorExtensionViews.at(WebCore::BoxSide::Bottom).get();
+    case UIRectEdgeRight:
+        return _fixedColorExtensionViews.at(WebCore::BoxSide::Right).get();
+    default:
+        break;
+    }
+#endif // ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+    return nil;
+}
+
 - (NSNumber *)_stableStateOverride
 {
     // For subclasses to override.

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1386,6 +1386,7 @@
 		F4E0A28F211E5D5B00AF7C7F /* DragAndDropTestsMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4E0A28E211E5D5B00AF7C7F /* DragAndDropTestsMac.mm */; };
 		F4E0A2B82122847400AF7C7F /* TestFilePromiseReceiver.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4E0A2B72122847400AF7C7F /* TestFilePromiseReceiver.mm */; };
 		F4E5CCC92A6C79770051934C /* MouseEventTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4E5CCC12A6C79770051934C /* MouseEventTests.mm */; };
+		F4EBD7702E0B6E23000DB069 /* top-fixed-element.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4EBD76F2E0B6E23000DB069 /* top-fixed-element.html */; };
 		F4EC78102ADF8BC300C37592 /* LoadWebViewWithEmptyAppName.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4EC780F2ADF8BC300C37592 /* LoadWebViewWithEmptyAppName.mm */; };
 		F4F5BB5221667BAA002D06B9 /* TestFontOptions.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4F5BB5121667BAA002D06B9 /* TestFontOptions.mm */; };
 		F4FA2A4F24D1F05700618A46 /* AttributedSubstringForProposedRange.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4FA2A4E24D1F05700618A46 /* AttributedSubstringForProposedRange.mm */; };
@@ -2117,6 +2118,7 @@
 				A17C480F2C98E5C20023F3C7 /* text-with-web-font.webarchive in Copy Resources */,
 				A17C48102C98E5C20023F3C7 /* textarea-to-input.html in Copy Resources */,
 				A17C48112C98E5C20023F3C7 /* TextWidth.html in Copy Resources */,
+				F4EBD7702E0B6E23000DB069 /* top-fixed-element.html in Copy Resources */,
 				A17C48122C98E5C20023F3C7 /* try-text-select-with-disabled-text-interaction.html in Copy Resources */,
 				A17C48132C98E5C20023F3C7 /* two-paragraph-contenteditable.html in Copy Resources */,
 				A17C484A2C98E6360023F3C7 /* two-videos.html in Copy Resources */,
@@ -4051,6 +4053,7 @@
 		F4E7A66227222BB100E74D36 /* canvas-image-data.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "canvas-image-data.html"; sourceTree = "<group>"; };
 		F4EB4E8F2328AC3000574DAB /* NSItemProviderAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = NSItemProviderAdditions.h; path = cocoa/NSItemProviderAdditions.h; sourceTree = SOURCE_ROOT; };
 		F4EB4E902328AC3000574DAB /* NSItemProviderAdditions.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = NSItemProviderAdditions.mm; path = cocoa/NSItemProviderAdditions.mm; sourceTree = SOURCE_ROOT; };
+		F4EBD76F2E0B6E23000DB069 /* top-fixed-element.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "top-fixed-element.html"; sourceTree = "<group>"; };
 		F4EC780F2ADF8BC300C37592 /* LoadWebViewWithEmptyAppName.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = LoadWebViewWithEmptyAppName.mm; sourceTree = "<group>"; };
 		F4EC8093260D2E620010311D /* simple-image-overlay.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "simple-image-overlay.html"; sourceTree = "<group>"; };
 		F4F137911D9B6832002BEC57 /* large-video-test-now-playing.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "large-video-test-now-playing.html"; sourceTree = "<group>"; };
@@ -5568,6 +5571,7 @@
 				F40398892B2D0AC700A7AA85 /* text-with-web-font.webarchive */,
 				F41AB9951EF4692C0083FA08 /* textarea-to-input.html */,
 				C22FA32C228F877A009D7988 /* TextWidth.html */,
+				F4EBD76F2E0B6E23000DB069 /* top-fixed-element.html */,
 				4952BE5C2578113900B0AEF1 /* try-text-select-with-disabled-text-interaction.html */,
 				F4451C751EB8FD7C0020C5DA /* two-paragraph-contenteditable.html */,
 				31727A5229F733D300A7FB0F /* UnitBox.usdz */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/top-fixed-element.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/top-fixed-element.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+html, body {
+     margin: 0;
+     width: 100%;
+     height: 100%;
+}
+header {
+     position: fixed;
+     top: 0;
+     left: 0;
+     width: 100%;
+     height: 100px;
+     background: tomato;
+}
+</style>
+</head>
+<body><header></header>Hello world</body>
+</html>


### PR DESCRIPTION
#### f1caad5335df2a781bf0998c20bdde7234fcad8d
<pre>
[Liquid Glass] [iOS] Blank gap above top fixed header when rubber-banding against top of page
<a href="https://bugs.webkit.org/show_bug.cgi?id=294933">https://bugs.webkit.org/show_bug.cgi?id=294933</a>
<a href="https://rdar.apple.com/154233194">rdar://154233194</a>

Reviewed by Abrar Rahman Protyasha.

Make an adjustment to how we compute `-_obscuredInsetsForFixedColorExtension` on iOS, such that we
expand the height of the top fixed color to span the area above the content while rubber-banding.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/PageColorSampler.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _obscuredInsetsForFixedColorExtension]):

There are a few conditions where we avoid performing this extension:

1.  If the scroll view is not scrolled past the top `adjustedContentInset`, we&apos;re not rubber-
    banding, so there&apos;s no gap to close in the first place.

2.  If there is no predominant color on the top, then there is either no detected fixed header near
    the top of the page, or the fixed header near the top of the page has a backdrop filter. In
    either case we just fall back to the background color, which is what would show up in the gap
    anyways without extending the height of the color extension view.

3.  If the sampled page top color is different than the sampled top fixed/sticky color, then there&apos;s
    no need to extend the height of the color extension view because the color extension view isn&apos;t
    adjacent to the top of the page. This can occur in the case where the header is sticky, or
    changes between static and fixed depending on the page&apos;s scroll position.

4.  If the under-page background color is the same as the sampled top fixed color, then there&apos;s no
    need to extend the height of the color extension view since the result would be visually similar
    anyways.

If none of the conditions above are met, we expand the height of the color extension view.

* Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm:
(-[WKWebView _colorExtensionViewForTesting:]):

Add a testing-only helper to retrieve color extension views on each side.

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SampledPageTopColor.mm:
(TEST(SampledPageTopColor, TopColorExtensionWhenRubberBanding)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/top-fixed-element.html: Added.

Add an API test to exercise this new behavior, by checking the height of fixed color extension
views before and after scrolling past the top scroll extent.

Canonical link: <a href="https://commits.webkit.org/296602@main">https://commits.webkit.org/296602@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6463fab69069c9c532c8fea42b07fbe85c6fe41a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109015 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28676 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19100 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114226 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59337 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110978 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37242 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82846 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111963 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23353 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98191 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63288 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22760 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16330 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58918 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92722 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16376 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117344 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36064 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26659 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91860 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36435 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94455 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91665 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23337 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36577 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14325 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31924 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35961 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41475 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35658 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38997 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37344 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->