### PR TITLE
Classification of test gardening commits should be standardized across services

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_classifier.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_classifier.py
@@ -73,7 +73,7 @@ class CommitClassifier(object):
             self.trailers = [CommitClassifier.LineFilter(trailer) for trailer in trailers or []]
             self.paths = [re.compile(r'^{}'.format(path)) for path in (paths or [])]
 
-            if not self.headers and not self.trailers and not self.paths:
+            if not self.headers and not self.trailers and not self.paths and not self.contents:
                 raise ValueError('A CommitClass must not match all commits')
 
             for argument, _ in kwargs.items():
@@ -86,6 +86,16 @@ class CommitClassifier(object):
                 description += '    headers = [\n'
                 for header in self.headers:
                     description += '        {}\n'.format(header)
+                description += '    ]\n'
+            if self.contents:
+                description += '    contents = [\n'
+                for content in self.contents:
+                    description += '        {}\n'.format(content)
+                description += '    ]\n'
+            if self.trailers:
+                description += '    trailers = [\n'
+                for trailer in self.trailers:
+                    description += '        {}\n'.format(trailer)
                 description += '    ]\n'
             if self.paths:
                 description += '    paths = [\n'
@@ -126,7 +136,9 @@ class CommitClassifier(object):
             matches_header = klass.headers and header and any([f(header) for f in klass.headers])
             matches_trailers = klass.trailers and trailers and any([any([f(trailer) for f in klass.trailers]) for trailer in trailers])
             matches_content = klass.contents and contents and any([f(contents) for f in klass.contents])
-            if (matching_header or matching_trailer or matching_content) and not matches_header and not matches_trailers and not matches_content:
+            if (matching_header or matching_trailer) and not matches_header and not matches_trailers:
+                continue
+            if matching_content and not matches_content:
                 continue
 
             if klass.paths and paths_for.value and not all([

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/classify_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/classify_unittest.py
@@ -173,3 +173,46 @@ class TestClassify(testing.PathTestCase):
                     'Reviewed by NOBODY (OOPS!)\n\n'
                     'cherry-pick: 2.3@branch-b (790725a6d79e)\n',
         )))
+
+    def test_content_success(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path) as repository, mocks.local.Svn():
+            repository.commits[repository.default_branch].append(Commit(
+                revision=10,
+                hash='898d20c0b1efc7b717173804676349f079df3b7e',
+                identifier='6@main',
+                timestamp=int(time.time()),
+                author=Contributor.Encoder().default(Contributor.from_scm_log('Author: jbedard@apple.com <jbedard@apple.com>')),
+                message='Commit title\n'
+                        'https://bugs.example.com/show_bug.cgi?id=1\n\n'
+                        'test gardening\n\n'
+            ))
+            repository.head = repository.commits[repository.default_branch][-1]
+
+            self.assertEqual(0, program.main(
+                args=('classify', 'HEAD'),
+                path=self.path,
+                classifier=CommitClassifier([CommitClassifier.CommitClass(
+                    name='Gardening',
+                    headers=[r'^.*'],
+                    contents=['test gardening'],
+                )])
+            ))
+        self.assertEqual(captured.stdout.getvalue(), 'Gardening\n')
+        self.assertEqual(captured.stderr.getvalue(), '')
+
+    def test_content_failure(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path), mocks.local.Svn():
+            self.assertEqual(1, program.main(
+                args=('classify', 'HEAD'),
+                path=self.path,
+                classifier=CommitClassifier([CommitClassifier.CommitClass(
+                    name='Gardening',
+                    headers=[r'^.*'],
+                    contents=['test gardening'],
+                )])
+            ))
+        self.assertEqual(captured.stdout.getvalue(), 'None\n')
+        self.assertEqual(
+            captured.stderr.getvalue(),
+            'Provided commit does not match a known class in this repository\n',
+        )


### PR DESCRIPTION
#### 247def164ebcb5b8d9c0525a9120694162c04d29
<pre>
Classification of test gardening commits should be standardized across services
<a href="https://bugs.webkit.org/show_bug.cgi?id=294940">https://bugs.webkit.org/show_bug.cgi?id=294940</a>
<a href="https://rdar.apple.com/150067500">rdar://150067500</a>

Reviewed by NOBODY (OOPS!).

EWS (merge-queue) searches for “unreviewed test gardening” in the entire commit message.
This was added to commit classes but it should actually be a hard requirement.
This PR makes it so test gardening commits are required to have “unreviewed test gardening”
in the commit message to be classified as such.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_classifier.py:
(CommitClassifier.CommitClass.__init__): Check for contents.
(CommitClassifier.CommitClass.__repr__): Update repr with contents and trailers.
(CommitClassifier.classify): Content matching in a commit message should be a hard requirement.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/classify_unittest.py:
(TestClassify.test_path_no_repository):
(TestClassify):
(TestClassify.test_content_success):
(TestClassify.test_content_failure):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/247def164ebcb5b8d9c0525a9120694162c04d29

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28675 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114225 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59336 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110977 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29357 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37241 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82845 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111962 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23351 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98188 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63287 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/108446 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22758 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16327 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58917 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92720 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16373 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117343 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36063 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26658 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91859 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/108510 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36433 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94452 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91664 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36574 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14322 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31921 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35960 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35657 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38996 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37343 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->