### PR TITLE
[SaferCPP] Improve smart pointer adoption in the UIProcess C API, part 2

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -7,15 +7,8 @@ Platform/IPC/Connection.cpp
 Platform/IPC/Connection.h
 Platform/IPC/StreamClientConnection.cpp
 Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
-UIProcess/API/C/WKAuthenticationChallenge.cpp
-UIProcess/API/C/WKBackForwardListRef.cpp
 UIProcess/API/C/WKContext.cpp
-UIProcess/API/C/WKContextConfigurationRef.cpp
-UIProcess/API/C/WKFormSubmissionListener.cpp
 UIProcess/API/C/WKPage.cpp
-UIProcess/API/C/WKQueryPermissionResultCallback.cpp
-UIProcess/API/C/WKSpeechRecognitionPermissionCallback.cpp
-UIProcess/API/C/WKWebsiteDataStoreConfigurationRef.cpp
 UIProcess/API/C/WKWebsiteDataStoreRef.cpp
 UIProcess/API/C/mac/WKPagePrivateMac.mm
 UIProcess/API/Cocoa/WKContentWorld.mm

--- a/Source/WebKit/UIProcess/API/C/WKAuthenticationChallenge.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKAuthenticationChallenge.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -46,12 +46,12 @@ WKAuthenticationDecisionListenerRef WKAuthenticationChallengeGetDecisionListener
 
 WKProtectionSpaceRef WKAuthenticationChallengeGetProtectionSpace(WKAuthenticationChallengeRef challenge)
 {
-    return toAPI(toProtectedImpl(challenge)->protectionSpace());
+    return toAPI(toProtectedImpl(challenge)->protectedProtectionSpace().get());
 }
 
 WKCredentialRef WKAuthenticationChallengeGetProposedCredential(WKAuthenticationChallengeRef challenge)
 {
-    return toAPI(toProtectedImpl(challenge)->proposedCredential());
+    return toAPI(toProtectedImpl(challenge)->protectedProposedCredential().get());
 }
 
 int WKAuthenticationChallengeGetPreviousFailureCount(WKAuthenticationChallengeRef challenge)

--- a/Source/WebKit/UIProcess/API/C/WKBackForwardListRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKBackForwardListRef.cpp
@@ -40,22 +40,22 @@ WKTypeID WKBackForwardListGetTypeID()
 
 WKBackForwardListItemRef WKBackForwardListGetCurrentItem(WKBackForwardListRef listRef)
 {
-    return toAPI(toProtectedImpl(listRef)->currentItem());
+    return toAPI(toProtectedImpl(listRef)->protectedCurrentItem().get());
 }
 
 WKBackForwardListItemRef WKBackForwardListGetBackItem(WKBackForwardListRef listRef)
 {
-    return toAPI(toProtectedImpl(listRef)->backItem());
+    return toAPI(toProtectedImpl(listRef)->protectedBackItem().get());
 }
 
 WKBackForwardListItemRef WKBackForwardListGetForwardItem(WKBackForwardListRef listRef)
 {
-    return toAPI(toProtectedImpl(listRef)->forwardItem());
+    return toAPI(toProtectedImpl(listRef)->protectedForwardItem().get());
 }
 
 WKBackForwardListItemRef WKBackForwardListGetItemAtIndex(WKBackForwardListRef listRef, int index)
 {
-    return toAPI(toProtectedImpl(listRef)->itemAtIndex(index));
+    return toAPI(toProtectedImpl(listRef)->protectedItemAtIndex(index).get());
 }
 
 void WKBackForwardListClear(WKBackForwardListRef listRef)

--- a/Source/WebKit/UIProcess/API/C/WKContextConfigurationRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKContextConfigurationRef.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -68,7 +68,7 @@ WKStringRef WKContextConfigurationCopyInjectedBundlePath(WKContextConfigurationR
 
 void WKContextConfigurationSetInjectedBundlePath(WKContextConfigurationRef configuration, WKStringRef injectedBundlePath)
 {
-    toImpl(configuration)->setInjectedBundlePath(toImpl(injectedBundlePath)->string());
+    toImpl(configuration)->setInjectedBundlePath(toProtectedImpl(injectedBundlePath)->string());
 }
 
 WKArrayRef WKContextConfigurationCopyCustomClassesForParameterCoder(WKContextConfigurationRef configuration)
@@ -147,7 +147,7 @@ void WKContextConfigurationSetOverrideLanguages(WKContextConfigurationRef, WKArr
     // FIXME: This is an SPI function, and is only (supposed to be) used for testing.
     // However, playwright automation tests rely on it.
     // See https://bugs.webkit.org/show_bug.cgi?id=242827 for details.
-    WebKit::setOverrideLanguages(toImpl(overrideLanguages)->toStringVector());
+    WebKit::setOverrideLanguages(toProtectedImpl(overrideLanguages)->toStringVector());
 }
 
 bool WKContextConfigurationProcessSwapsOnNavigation(WKContextConfigurationRef configuration)
@@ -215,5 +215,5 @@ WKStringRef WKContextConfigurationCopyTimeZoneOverride(WKContextConfigurationRef
 
 void WKContextConfigurationSetTimeZoneOverride(WKContextConfigurationRef configuration, WKStringRef timeZoneOverride)
 {
-    toImpl(configuration)->setTimeZoneOverride(toImpl(timeZoneOverride)->string());
+    toImpl(configuration)->setTimeZoneOverride(toProtectedImpl(timeZoneOverride)->string());
 }

--- a/Source/WebKit/UIProcess/API/C/WKFormSubmissionListener.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKFormSubmissionListener.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,5 +38,5 @@ WKTypeID WKFormSubmissionListenerGetTypeID()
 
 void WKFormSubmissionListenerContinue(WKFormSubmissionListenerRef submissionListener)
 {
-    toImpl(submissionListener)->continueSubmission();
+    toProtectedImpl(submissionListener)->continueSubmission();
 }

--- a/Source/WebKit/UIProcess/API/C/WKQueryPermissionResultCallback.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKQueryPermissionResultCallback.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,15 +38,15 @@ WKTypeID WKQueryPermissionResultCallbackGetTypeID()
 
 void WKQueryPermissionResultCallbackCompleteWithDenied(WKQueryPermissionResultCallbackRef callback)
 {
-    return toImpl(callback)->setPermission(WebCore::PermissionState::Denied);
+    return toProtectedImpl(callback)->setPermission(WebCore::PermissionState::Denied);
 }
 
 void WKQueryPermissionResultCallbackCompleteWithGranted(WKQueryPermissionResultCallbackRef callback)
 {
-    return toImpl(callback)->setPermission(WebCore::PermissionState::Granted);
+    return toProtectedImpl(callback)->setPermission(WebCore::PermissionState::Granted);
 }
 
 void WKQueryPermissionResultCallbackCompleteWithPrompt(WKQueryPermissionResultCallbackRef callback)
 {
-    return toImpl(callback)->setPermission(WebCore::PermissionState::Prompt);
+    return toProtectedImpl(callback)->setPermission(WebCore::PermissionState::Prompt);
 }

--- a/Source/WebKit/UIProcess/API/C/WKSpeechRecognitionPermissionCallback.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKSpeechRecognitionPermissionCallback.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,5 +39,5 @@ WKTypeID WKSpeechRecognitionPermissionCallbackGetTypeID()
 void WKSpeechRecognitionPermissionCallbackComplete(WKSpeechRecognitionPermissionCallbackRef speechRecognitionPermissionCallback, bool granted)
 {
     // FIXME: Deprecate and remove this.
-    return toImpl(speechRecognitionPermissionCallback)->complete(granted);
+    return toProtectedImpl(speechRecognitionPermissionCallback)->complete(granted);
 }

--- a/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreConfigurationRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreConfigurationRef.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -51,7 +51,7 @@ WKStringRef WKWebsiteDataStoreConfigurationCopyApplicationCacheDirectory(WKWebsi
 
 void WKWebsiteDataStoreConfigurationSetApplicationCacheDirectory(WKWebsiteDataStoreConfigurationRef configuration, WKStringRef directory)
 {
-    WebKit::toImpl(configuration)->setApplicationCacheDirectory(WebKit::toImpl(directory)->string());
+    WebKit::toImpl(configuration)->setApplicationCacheDirectory(WebKit::toProtectedImpl(directory)->string());
 }
 
 WKStringRef WKWebsiteDataStoreConfigurationCopyNetworkCacheDirectory(WKWebsiteDataStoreConfigurationRef configuration)
@@ -61,7 +61,7 @@ WKStringRef WKWebsiteDataStoreConfigurationCopyNetworkCacheDirectory(WKWebsiteDa
 
 void WKWebsiteDataStoreConfigurationSetNetworkCacheDirectory(WKWebsiteDataStoreConfigurationRef configuration, WKStringRef directory)
 {
-    WebKit::toImpl(configuration)->setNetworkCacheDirectory(WebKit::toImpl(directory)->string());
+    WebKit::toImpl(configuration)->setNetworkCacheDirectory(WebKit::toProtectedImpl(directory)->string());
 }
 
 WKStringRef WKWebsiteDataStoreConfigurationCopyIndexedDBDatabaseDirectory(WKWebsiteDataStoreConfigurationRef configuration)
@@ -71,7 +71,7 @@ WKStringRef WKWebsiteDataStoreConfigurationCopyIndexedDBDatabaseDirectory(WKWebs
 
 void WKWebsiteDataStoreConfigurationSetIndexedDBDatabaseDirectory(WKWebsiteDataStoreConfigurationRef configuration, WKStringRef directory)
 {
-    WebKit::toImpl(configuration)->setIndexedDBDatabaseDirectory(WebKit::toImpl(directory)->string());
+    WebKit::toImpl(configuration)->setIndexedDBDatabaseDirectory(WebKit::toProtectedImpl(directory)->string());
 }
 
 WKStringRef WKWebsiteDataStoreConfigurationCopyLocalStorageDirectory(WKWebsiteDataStoreConfigurationRef configuration)
@@ -81,7 +81,7 @@ WKStringRef WKWebsiteDataStoreConfigurationCopyLocalStorageDirectory(WKWebsiteDa
 
 void WKWebsiteDataStoreConfigurationSetLocalStorageDirectory(WKWebsiteDataStoreConfigurationRef configuration, WKStringRef directory)
 {
-    WebKit::toImpl(configuration)->setLocalStorageDirectory(WebKit::toImpl(directory)->string());
+    WebKit::toImpl(configuration)->setLocalStorageDirectory(WebKit::toProtectedImpl(directory)->string());
 }
 
 WKStringRef WKWebsiteDataStoreConfigurationCopyWebSQLDatabaseDirectory(WKWebsiteDataStoreConfigurationRef configuration)
@@ -91,7 +91,7 @@ WKStringRef WKWebsiteDataStoreConfigurationCopyWebSQLDatabaseDirectory(WKWebsite
 
 void WKWebsiteDataStoreConfigurationSetWebSQLDatabaseDirectory(WKWebsiteDataStoreConfigurationRef configuration, WKStringRef directory)
 {
-    WebKit::toImpl(configuration)->setWebSQLDatabaseDirectory(WebKit::toImpl(directory)->string());
+    WebKit::toImpl(configuration)->setWebSQLDatabaseDirectory(WebKit::toProtectedImpl(directory)->string());
 }
 
 WKStringRef WKWebsiteDataStoreConfigurationCopyCacheStorageDirectory(WKWebsiteDataStoreConfigurationRef configuration)
@@ -101,7 +101,7 @@ WKStringRef WKWebsiteDataStoreConfigurationCopyCacheStorageDirectory(WKWebsiteDa
 
 void WKWebsiteDataStoreConfigurationSetCacheStorageDirectory(WKWebsiteDataStoreConfigurationRef configuration, WKStringRef directory)
 {
-    WebKit::toImpl(configuration)->setCacheStorageDirectory(WebKit::toImpl(directory)->string());
+    WebKit::toImpl(configuration)->setCacheStorageDirectory(WebKit::toProtectedImpl(directory)->string());
 }
 
 WKStringRef WKWebsiteDataStoreConfigurationCopyGeneralStorageDirectory(WKWebsiteDataStoreConfigurationRef configuration)
@@ -111,7 +111,7 @@ WKStringRef WKWebsiteDataStoreConfigurationCopyGeneralStorageDirectory(WKWebsite
 
 void WKWebsiteDataStoreConfigurationSetGeneralStorageDirectory(WKWebsiteDataStoreConfigurationRef configuration, WKStringRef directory)
 {
-    WebKit::toImpl(configuration)->setGeneralStorageDirectory(WebKit::toImpl(directory)->string());
+    WebKit::toImpl(configuration)->setGeneralStorageDirectory(WebKit::toProtectedImpl(directory)->string());
 }
 
 WKStringRef WKWebsiteDataStoreConfigurationCopyMediaKeysStorageDirectory(WKWebsiteDataStoreConfigurationRef configuration)
@@ -121,7 +121,7 @@ WKStringRef WKWebsiteDataStoreConfigurationCopyMediaKeysStorageDirectory(WKWebsi
 
 void WKWebsiteDataStoreConfigurationSetMediaKeysStorageDirectory(WKWebsiteDataStoreConfigurationRef configuration, WKStringRef directory)
 {
-    WebKit::toImpl(configuration)->setMediaKeysStorageDirectory(WebKit::toImpl(directory)->string());
+    WebKit::toImpl(configuration)->setMediaKeysStorageDirectory(WebKit::toProtectedImpl(directory)->string());
 }
 
 WKStringRef WKWebsiteDataStoreConfigurationCopyResourceLoadStatisticsDirectory(WKWebsiteDataStoreConfigurationRef configuration)
@@ -131,7 +131,7 @@ WKStringRef WKWebsiteDataStoreConfigurationCopyResourceLoadStatisticsDirectory(W
 
 void WKWebsiteDataStoreConfigurationSetResourceLoadStatisticsDirectory(WKWebsiteDataStoreConfigurationRef configuration, WKStringRef directory)
 {
-    WebKit::toImpl(configuration)->setResourceLoadStatisticsDirectory(WebKit::toImpl(directory)->string());
+    WebKit::toImpl(configuration)->setResourceLoadStatisticsDirectory(WebKit::toProtectedImpl(directory)->string());
 }
 
 WKStringRef WKWebsiteDataStoreConfigurationCopyServiceWorkerRegistrationDirectory(WKWebsiteDataStoreConfigurationRef configuration)
@@ -141,7 +141,7 @@ WKStringRef WKWebsiteDataStoreConfigurationCopyServiceWorkerRegistrationDirector
 
 void WKWebsiteDataStoreConfigurationSetServiceWorkerRegistrationDirectory(WKWebsiteDataStoreConfigurationRef configuration, WKStringRef directory)
 {
-    WebKit::toImpl(configuration)->setServiceWorkerRegistrationDirectory(WebKit::toImpl(directory)->string());
+    WebKit::toImpl(configuration)->setServiceWorkerRegistrationDirectory(WebKit::toProtectedImpl(directory)->string());
 }
 
 WKStringRef WKWebsiteDataStoreConfigurationCopyCookieStorageFile(WKWebsiteDataStoreConfigurationRef configuration)
@@ -151,7 +151,7 @@ WKStringRef WKWebsiteDataStoreConfigurationCopyCookieStorageFile(WKWebsiteDataSt
 
 void WKWebsiteDataStoreConfigurationSetCookieStorageFile(WKWebsiteDataStoreConfigurationRef configuration, WKStringRef cookieStorageFile)
 {
-    WebKit::toImpl(configuration)->setCookieStorageFile(WebKit::toImpl(cookieStorageFile)->string());
+    WebKit::toImpl(configuration)->setCookieStorageFile(WebKit::toProtectedImpl(cookieStorageFile)->string());
 }
 
 uint64_t WKWebsiteDataStoreConfigurationGetPerOriginStorageQuota(WKWebsiteDataStoreConfigurationRef configuration)
@@ -201,7 +201,7 @@ WKStringRef WKWebsiteDataStoreConfigurationCopyPCMMachServiceName(WKWebsiteDataS
 
 void WKWebsiteDataStoreConfigurationSetPCMMachServiceName(WKWebsiteDataStoreConfigurationRef configuration, WKStringRef name)
 {
-    WebKit::toImpl(configuration)->setPCMMachServiceName(name ? WebKit::toImpl(name)->string() : String());
+    WebKit::toImpl(configuration)->setPCMMachServiceName(name ? WebKit::toProtectedImpl(name)->string() : String());
 }
 
 bool WKWebsiteDataStoreConfigurationHasOriginQuotaRatio(WKWebsiteDataStoreConfigurationRef configuration)
@@ -236,6 +236,6 @@ WKStringRef WKWebsiteDataStoreConfigurationCopyResourceMonitorThrottlerDirectory
 void WKWebsiteDataStoreConfigurationSetResourceMonitorThrottlerDirectory(WKWebsiteDataStoreConfigurationRef configuration, WKStringRef directory)
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    WebKit::toImpl(configuration)->setResourceMonitorThrottlerDirectory(WebKit::toImpl(directory)->string());
+    WebKit::toImpl(configuration)->setResourceMonitorThrottlerDirectory(WebKit::toProtectedImpl(directory)->string());
 #endif
 }

--- a/Source/WebKit/UIProcess/Authentication/AuthenticationChallengeProxy.cpp
+++ b/Source/WebKit/UIProcess/Authentication/AuthenticationChallengeProxy.cpp
@@ -67,12 +67,22 @@ WebCredential* AuthenticationChallengeProxy::proposedCredential() const
     return m_webCredential.get();
 }
 
+RefPtr<WebCredential> AuthenticationChallengeProxy::protectedProposedCredential() const
+{
+    return proposedCredential();
+}
+
 WebProtectionSpace* AuthenticationChallengeProxy::protectionSpace() const
 {
     if (!m_webProtectionSpace)
         m_webProtectionSpace = WebProtectionSpace::create(m_coreAuthenticationChallenge.protectionSpace());
 
     return m_webProtectionSpace.get();
+}
+
+RefPtr<WebProtectionSpace> AuthenticationChallengeProxy::protectedProtectionSpace() const
+{
+    return protectionSpace();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Authentication/AuthenticationChallengeProxy.h
+++ b/Source/WebKit/UIProcess/Authentication/AuthenticationChallengeProxy.h
@@ -57,7 +57,10 @@ public:
     virtual ~AuthenticationChallengeProxy();
 
     WebCredential* proposedCredential() const;
+    RefPtr<WebCredential> protectedProposedCredential() const;
+
     WebProtectionSpace* protectionSpace() const;
+    RefPtr<WebProtectionSpace> protectedProtectionSpace() const;
 
     AuthenticationDecisionListener& listener() const { return m_listener.get(); }
     const WebCore::AuthenticationChallenge& core() { return m_coreAuthenticationChallenge; }


### PR DESCRIPTION
#### cebb5de1ce776abec286f65b6ea244b1ec9c31a5
<pre>
[SaferCPP] Improve smart pointer adoption in the UIProcess C API, part 2
<a href="https://bugs.webkit.org/show_bug.cgi?id=294941">https://bugs.webkit.org/show_bug.cgi?id=294941</a>
<a href="https://rdar.apple.com/154244293">rdar://154244293</a>

Reviewed by Charlie Wolfe.

Fix many failing smart pointer adoption errors caught by static analyses, in the following files.

    - UIProcess/API/C/WKWebsiteDataStoreConfigurationRef.cpp
    - UIProcess/API/C/WKSpeechRecognitionPermissionCallback.cpp
    - UIProcess/API/C/WKQueryPermissionResultCallback.cpp
    - UIProcess/API/C/WKFormSubmissionListener.cpp
    - UIProcess/API/C/WKContextConfigurationRef.cpp
    - UIProcess/API/C/WKBackForwardListRef.cpp
    - UIProcess/API/C/WKAuthenticationChallenge.cpp

Getting closer to being done with the UIP C API. =)

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/API/C/WKAuthenticationChallenge.cpp:
(WKAuthenticationChallengeGetProtectionSpace):
(WKAuthenticationChallengeGetProposedCredential):
* Source/WebKit/UIProcess/API/C/WKBackForwardListRef.cpp:
(WKBackForwardListGetCurrentItem):
(WKBackForwardListGetBackItem):
(WKBackForwardListGetForwardItem):
(WKBackForwardListGetItemAtIndex):
* Source/WebKit/UIProcess/API/C/WKContextConfigurationRef.cpp:
(WKContextConfigurationSetInjectedBundlePath):
(WKContextConfigurationSetOverrideLanguages):
(WKContextConfigurationSetTimeZoneOverride):
* Source/WebKit/UIProcess/API/C/WKFormSubmissionListener.cpp:
(WKFormSubmissionListenerContinue):
* Source/WebKit/UIProcess/API/C/WKQueryPermissionResultCallback.cpp:
(WKQueryPermissionResultCallbackCompleteWithDenied):
(WKQueryPermissionResultCallbackCompleteWithGranted):
(WKQueryPermissionResultCallbackCompleteWithPrompt):
* Source/WebKit/UIProcess/API/C/WKSpeechRecognitionPermissionCallback.cpp:
(WKSpeechRecognitionPermissionCallbackComplete):
* Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreConfigurationRef.cpp:
(WKWebsiteDataStoreConfigurationSetApplicationCacheDirectory):
(WKWebsiteDataStoreConfigurationSetNetworkCacheDirectory):
(WKWebsiteDataStoreConfigurationSetIndexedDBDatabaseDirectory):
(WKWebsiteDataStoreConfigurationSetLocalStorageDirectory):
(WKWebsiteDataStoreConfigurationSetWebSQLDatabaseDirectory):
(WKWebsiteDataStoreConfigurationSetCacheStorageDirectory):
(WKWebsiteDataStoreConfigurationSetGeneralStorageDirectory):
(WKWebsiteDataStoreConfigurationSetMediaKeysStorageDirectory):
(WKWebsiteDataStoreConfigurationSetResourceLoadStatisticsDirectory):
(WKWebsiteDataStoreConfigurationSetServiceWorkerRegistrationDirectory):
(WKWebsiteDataStoreConfigurationSetCookieStorageFile):
(WKWebsiteDataStoreConfigurationSetPCMMachServiceName):
(WKWebsiteDataStoreConfigurationSetResourceMonitorThrottlerDirectory):
* Source/WebKit/UIProcess/Authentication/AuthenticationChallengeProxy.cpp:
(WebKit::AuthenticationChallengeProxy::protectedProposedCredential const):
(WebKit::AuthenticationChallengeProxy::protectedProtectionSpace const):
* Source/WebKit/UIProcess/Authentication/AuthenticationChallengeProxy.h:

Canonical link: <a href="https://commits.webkit.org/296642@main">https://commits.webkit.org/296642@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d48814526694f75812d36c23f7e6d7aba691e386

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109184 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28842 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19269 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114391 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/59459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29523 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37416 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/82971 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/59459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112132 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/23491 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/98336 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63420 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/22882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/59036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92858 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117506 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36228 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/26789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/91987 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36600 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94599 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91793 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23368 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/36716 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14462 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/32073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36124 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/41616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35810 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39144 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37501 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->