### PR TITLE
[WebGPU] Move GPUAdapter isFallbackAdapter attribute to GPUAdapterInfo

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUAdapterInfo.h
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapterInfo.h
@@ -43,6 +43,7 @@ public:
     String architecture() const { return vendor(); }
     String device() const { return vendor(); }
     String description() const { return vendor(); }
+    bool isFallbackAdapter() const { return false; }
 
 private:
     GPUAdapterInfo(String&& name)

--- a/Source/WebCore/Modules/WebGPU/GPUAdapterInfo.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapterInfo.idl
@@ -35,4 +35,5 @@ interface GPUAdapterInfo {
     readonly attribute DOMString architecture;
     readonly attribute DOMString device;
     readonly attribute DOMString description;
+    readonly attribute boolean isFallbackAdapter;
 };


### PR DESCRIPTION
#### c7c76cfe9bf7e8405b2be988389b35348ea48145
<pre>
[WebGPU] Move GPUAdapter isFallbackAdapter attribute to GPUAdapterInfo
<a href="https://bugs.webkit.org/show_bug.cgi?id=290362">https://bugs.webkit.org/show_bug.cgi?id=290362</a>
<a href="https://rdar.apple.com/147800092">rdar://147800092</a>

Reviewed by Tadeu Zagallo.

The spec deprecated this in March and is removing it
from GPUAdapter, but we don&apos;t want to break any clients,
so just add it in the new place for now.

We never create a fallback adapter, so we can always
return false.

* Source/WebCore/Modules/WebGPU/GPUAdapterInfo.h:
(WebCore::GPUAdapterInfo::isFallbackAdapter const):
* Source/WebCore/Modules/WebGPU/GPUAdapterInfo.idl:

Canonical link: <a href="https://commits.webkit.org/296879@main">https://commits.webkit.org/296879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7024dbe8a799c136fc0c29362319b44e76a104a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109064 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28725 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19149 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114275 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59369 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111027 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29407 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37290 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82883 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112012 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23389 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98232 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63327 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22791 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16372 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58961 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92759 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16417 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117393 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36113 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26690 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91898 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36483 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94496 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91703 "Found 4 new API test failures: /WebKitGTK/TestResources:/webkit/WebKitWebResource/get-data-error, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/cut-copy-paste/non-editable, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23519 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36617 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14366 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31962 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36010 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41516 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35703 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39042 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37389 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->