### PR TITLE
TestWebKitAPI.WKScrollGeometry.ContentSizeTallerThanWebView is a constant failure on macOS Sequoia and iPadOS

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKScrollGeometryTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKScrollGeometryTests.mm
@@ -85,8 +85,8 @@ static void runContentSizeTest(NSString *html, CGSize expectedSize, BOOL needsSc
 TEST(WKScrollGeometry, ContentSizeTallerThanWebView)
 {
 #if PLATFORM(IOS_FAMILY)
-    CGFloat expectedWidth = 980;
-#elif (PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED <= 150000)
+    CGFloat expectedWidth = 800;
+#elif (PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED <= 140000)
     CGFloat expectedWidth = 785;
 #else
     CGFloat expectedWidth = 786;
@@ -95,6 +95,7 @@ TEST(WKScrollGeometry, ContentSizeTallerThanWebView)
     runContentSizeTest(@""
         "<html>"
         "<head>"
+        "<meta name='viewport' content='width=device-width, initial-scale=1'/>"
         "<style>"
         "    div { background: red; height: 10000px; }"
         "</style>"


### PR DESCRIPTION
#### 062184603d305c272b26b97d9e0defa13453b9ed
<pre>
TestWebKitAPI.WKScrollGeometry.ContentSizeTallerThanWebView is a constant failure on macOS Sequoia and iPadOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=294915">https://bugs.webkit.org/show_bug.cgi?id=294915</a>
<a href="https://rdar.apple.com/154213450">rdar://154213450</a>

Reviewed by Wenson Hsieh.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKScrollGeometryTests.mm:
(TEST(WKScrollGeometry, ContentSizeTallerThanWebView)):

Adjust the macOS platform conditional to reflect that the scrollbar size on
macOS Sequoia matches the size on macOS Tahoe, not macOS Sonoma.

Add a viewport meta tag to ensure a consistent width on iOS and iPadOS.

Canonical link: <a href="https://commits.webkit.org/296604@main">https://commits.webkit.org/296604@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/444bddbc528eda609a2c0904dd762a39f12a5d4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109029 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28690 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19114 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114240 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59347 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110992 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37256 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82856 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111977 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23365 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98202 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63298 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22771 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16341 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58931 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92734 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16387 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117358 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36078 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26666 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91868 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36449 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94466 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91673 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36586 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14336 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31938 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17604 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35975 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35673 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39011 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37358 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->