### PR TITLE
Stop using UncheckedKey containers in WebCore/animation

### DIFF
--- a/Source/WebCore/animation/AnimationTimelinesController.h
+++ b/Source/WebCore/animation/AnimationTimelinesController.h
@@ -88,7 +88,7 @@ private:
 #endif
 
     Vector<Ref<ScrollTimeline>> m_updatedScrollTimelines;
-    UncheckedKeyHashMap<FramesPerSecond, ReducedResolutionSeconds> m_animationFrameRateToLastTickTimeMap;
+    HashMap<FramesPerSecond, ReducedResolutionSeconds> m_animationFrameRateToLastTickTimeMap;
     WeakHashSet<AnimationTimeline> m_timelines;
     WeakHashSet<WebAnimation, WeakPtrImplWithEventTargetData> m_pendingAnimations;
     TaskCancellationGroup m_pendingAnimationsProcessingTaskCancellationGroup;

--- a/Source/WebCore/animation/BlendingKeyframes.cpp
+++ b/Source/WebCore/animation/BlendingKeyframes.cpp
@@ -166,8 +166,8 @@ void BlendingKeyframes::fillImplicitKeyframes(const KeyframeEffect& effect, cons
     // We need to establish which properties are implicit for 0% and 100%.
     // We start each list off with the full list of properties, and see if
     // any 0% and 100% keyframes specify them.
-    UncheckedKeyHashSet<AnimatableCSSProperty> expectedExplicitProperties;
-    UncheckedKeyHashSet<AnimatableCSSProperty> zeroKeyframeExplicitProperties;
+    HashSet<AnimatableCSSProperty> expectedExplicitProperties;
+    HashSet<AnimatableCSSProperty> zeroKeyframeExplicitProperties;
 
     BlendingKeyframe* implicitZeroKeyframe = nullptr;
 
@@ -207,7 +207,7 @@ void BlendingKeyframes::fillImplicitKeyframes(const KeyframeEffect& effect, cons
             expectedExplicitProperties.formUnion(keyframe.properties());
     }
 
-    auto addImplicitKeyframe = [&](double key, const UncheckedKeyHashSet<AnimatableCSSProperty>& implicitProperties, const StyleRuleKeyframe& keyframeRule, BlendingKeyframe* existingImplicitBlendingKeyframe) {
+    auto addImplicitKeyframe = [&](double key, const HashSet<AnimatableCSSProperty>& implicitProperties, const StyleRuleKeyframe& keyframeRule, BlendingKeyframe* existingImplicitBlendingKeyframe) {
         // If we're provided an existing implicit keyframe, we need to add all the styles for the implicit properties.
         if (existingImplicitBlendingKeyframe) {
             ASSERT(existingImplicitBlendingKeyframe->style());
@@ -236,7 +236,7 @@ void BlendingKeyframes::fillImplicitKeyframes(const KeyframeEffect& effect, cons
     if (!zeroKeyframeImplicitProperties.isEmpty())
         addImplicitKeyframe(0, zeroKeyframeImplicitProperties, zeroPercentKeyframe(), implicitZeroKeyframe);
 
-    UncheckedKeyHashSet<AnimatableCSSProperty> oneKeyframeExplicitProperties;
+    HashSet<AnimatableCSSProperty> oneKeyframeExplicitProperties;
     BlendingKeyframe* implicitOneKeyframe = nullptr;
 
     for (auto& keyframe : m_keyframes) {
@@ -311,7 +311,7 @@ bool BlendingKeyframes::hasPropertySetToCurrentColor() const
     return !m_propertiesSetToCurrentColor.isEmpty();
 }
 
-const UncheckedKeyHashSet<AnimatableCSSProperty>& BlendingKeyframes::propertiesSetToInherit() const
+const HashSet<AnimatableCSSProperty>& BlendingKeyframes::propertiesSetToInherit() const
 {
     return m_propertiesSetToInherit;
 }

--- a/Source/WebCore/animation/BlendingKeyframes.h
+++ b/Source/WebCore/animation/BlendingKeyframes.h
@@ -76,7 +76,7 @@ public:
     bool isBlendingKeyframe() const final { return true; }
 
     void addProperty(const AnimatableCSSProperty&);
-    const UncheckedKeyHashSet<AnimatableCSSProperty>& properties() const { return m_properties; }
+    const HashSet<AnimatableCSSProperty>& properties() const { return m_properties; }
 
     const Offset& specifiedOffset() const { return m_specifiedOffset; }
     void setComputedOffset(double offset) { m_computedOffset = offset; }
@@ -97,7 +97,7 @@ public:
 private:
     Offset m_specifiedOffset;
     double m_computedOffset { std::numeric_limits<double>::quiet_NaN() };
-    UncheckedKeyHashSet<AnimatableCSSProperty> m_properties; // The properties specified in this keyframe.
+    HashSet<AnimatableCSSProperty> m_properties; // The properties specified in this keyframe.
     std::unique_ptr<RenderStyle> m_style;
     RefPtr<TimingFunction> m_timingFunction;
     std::optional<CompositeOperation> m_compositeOperation;
@@ -127,7 +127,7 @@ public:
 
     void addProperty(const AnimatableCSSProperty&);
     bool containsProperty(const AnimatableCSSProperty&) const;
-    const UncheckedKeyHashSet<AnimatableCSSProperty>& properties() const { return m_properties; }
+    const HashSet<AnimatableCSSProperty>& properties() const { return m_properties; }
 
     bool containsAnimatableCSSProperty() const;
     bool containsDirectionAwareProperty() const;
@@ -150,7 +150,7 @@ public:
     bool hasCSSVariableReferences() const;
     bool hasColorSetToCurrentColor() const;
     bool hasPropertySetToCurrentColor() const;
-    const UncheckedKeyHashSet<AnimatableCSSProperty>& propertiesSetToInherit() const;
+    const HashSet<AnimatableCSSProperty>& propertiesSetToInherit() const;
 
     void updatePropertiesMetadata(const StyleProperties&);
 
@@ -171,11 +171,11 @@ private:
     KeyframesIdentifier m_identifier;
     mutable String m_acceleratedAnimationName;
     Vector<BlendingKeyframe> m_keyframes; // Kept sorted by key.
-    UncheckedKeyHashSet<AnimatableCSSProperty> m_properties; // The properties being animated.
-    UncheckedKeyHashSet<AnimatableCSSProperty> m_explicitToProperties; // The properties with an explicit value for the 100% keyframe.
-    UncheckedKeyHashSet<AnimatableCSSProperty> m_explicitFromProperties; // The properties with an explicit value for the 0% keyframe.
-    UncheckedKeyHashSet<AnimatableCSSProperty> m_propertiesSetToInherit;
-    UncheckedKeyHashSet<AnimatableCSSProperty> m_propertiesSetToCurrentColor;
+    HashSet<AnimatableCSSProperty> m_properties; // The properties being animated.
+    HashSet<AnimatableCSSProperty> m_explicitToProperties; // The properties with an explicit value for the 100% keyframe.
+    HashSet<AnimatableCSSProperty> m_explicitFromProperties; // The properties with an explicit value for the 0% keyframe.
+    HashSet<AnimatableCSSProperty> m_propertiesSetToInherit;
+    HashSet<AnimatableCSSProperty> m_propertiesSetToCurrentColor;
     bool m_usesRelativeFontWeight { false };
     bool m_containsCSSVariableReferences { false };
     bool m_usesAnchorFunctions { false };

--- a/Source/WebCore/animation/DocumentTimeline.cpp
+++ b/Source/WebCore/animation/DocumentTimeline.cpp
@@ -247,7 +247,7 @@ IGNORE_GCC_WARNINGS_END
         return property;
     };
 
-    UncheckedKeyHashSet<AnimatableCSSProperty> propertiesToMatch;
+    HashSet<AnimatableCSSProperty> propertiesToMatch;
     for (auto property : keyframeEffect->animatedProperties())
         propertiesToMatch.add(resolvedProperty(property));
 
@@ -420,7 +420,7 @@ void DocumentTimeline::applyPendingAcceleratedAnimations()
 
     auto acceleratedAnimationsPendingRunningStateChange = std::exchange(m_acceleratedAnimationsPendingRunningStateChange, { });
 
-    UncheckedKeyHashSet<KeyframeEffectStack*> keyframeEffectStacksToUpdate;
+    HashSet<KeyframeEffectStack*> keyframeEffectStacksToUpdate;
 
     bool hasForcedLayout = false;
     for (auto& animation : acceleratedAnimationsPendingRunningStateChange) {

--- a/Source/WebCore/animation/DocumentTimeline.h
+++ b/Source/WebCore/animation/DocumentTimeline.h
@@ -103,7 +103,7 @@ private:
     bool shouldRunUpdateAnimationsAndSendEventsIgnoringSuspensionState() const;
 
     Timer m_tickScheduleTimer;
-    UncheckedKeyHashSet<RefPtr<WebAnimation>> m_acceleratedAnimationsPendingRunningStateChange;
+    HashSet<RefPtr<WebAnimation>> m_acceleratedAnimationsPendingRunningStateChange;
     AnimationEvents m_pendingAnimationEvents;
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
     Seconds m_originTime;

--- a/Source/WebCore/animation/FrameRateAligner.h
+++ b/Source/WebCore/animation/FrameRateAligner.h
@@ -55,7 +55,7 @@ private:
         bool isNew { true };
     };
 
-    UncheckedKeyHashMap<FramesPerSecond, FrameRateData> m_frameRates;
+    HashMap<FramesPerSecond, FrameRateData> m_frameRates;
     ReducedResolutionSeconds m_timestamp;
 };
 

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1279,7 +1279,7 @@ void KeyframeEffect::updateBlendingKeyframes(RenderStyle& elementStyle, const St
     setBlendingKeyframes(WTFMove(blendingKeyframes));
 }
 
-const UncheckedKeyHashSet<AnimatableCSSProperty>& KeyframeEffect::animatedProperties()
+const HashSet<AnimatableCSSProperty>& KeyframeEffect::animatedProperties()
 {
     if (!m_blendingKeyframes.isEmpty())
         return m_blendingKeyframes.properties();
@@ -1712,7 +1712,7 @@ bool KeyframeEffect::isRunningAcceleratedAnimationForProperty(CSSPropertyID prop
     return Style::Interpolation::isAccelerated(property, document()->settings()) && m_blendingKeyframes.properties().contains(property);
 }
 
-static bool propertiesContainTransformRelatedProperty(const UncheckedKeyHashSet<AnimatableCSSProperty>& properties)
+static bool propertiesContainTransformRelatedProperty(const HashSet<AnimatableCSSProperty>& properties)
 {
     return properties.contains(CSSPropertyTranslate)
         || properties.contains(CSSPropertyScale)
@@ -2796,9 +2796,9 @@ void KeyframeEffect::computeHasImplicitKeyframeForAcceleratedProperty()
             // We keep three property lists, one which contains all properties seen across keyframes
             // which will be filtered eventually to only contain implicit properties, one containing
             // properties seen on the 0% keyframe and one containing properties seen on the 100% keyframe.
-            UncheckedKeyHashSet<CSSPropertyID> implicitProperties;
-            UncheckedKeyHashSet<CSSPropertyID> explicitZeroProperties;
-            UncheckedKeyHashSet<CSSPropertyID> explicitOneProperties;
+            HashSet<CSSPropertyID> implicitProperties;
+            HashSet<CSSPropertyID> explicitZeroProperties;
+            HashSet<CSSPropertyID> explicitOneProperties;
             auto styleProperties = keyframe.style;
             for (auto propertyReference : styleProperties.get()) {
                 auto computedOffset = keyframe.computedOffset;

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -98,8 +98,8 @@ public:
     };
 
     struct ComputedKeyframe : BaseComputedKeyframe {
-        UncheckedKeyHashMap<CSSPropertyID, String> styleStrings;
-        UncheckedKeyHashMap<AtomString, String> customStyleStrings;
+        HashMap<CSSPropertyID, String> styleStrings;
+        HashMap<AtomString, String> customStyleStrings;
     };
 
     struct ParsedKeyframe : ComputedKeyframe {
@@ -158,10 +158,10 @@ public:
 
     void computeStyleOriginatedAnimationBlendingKeyframes(const RenderStyle* oldStyle, const RenderStyle& newStyle, const Style::ResolutionContext&);
     const BlendingKeyframes& blendingKeyframes() const { return m_blendingKeyframes; }
-    const UncheckedKeyHashSet<AnimatableCSSProperty>& animatedProperties();
+    const HashSet<AnimatableCSSProperty>& animatedProperties();
     bool animatesProperty(const AnimatableCSSProperty&) const;
-    const UncheckedKeyHashSet<AnimatableCSSProperty>& acceleratedProperties() const { return m_acceleratedProperties; }
-    const UncheckedKeyHashSet<AnimatableCSSProperty>& acceleratedPropertiesWithImplicitKeyframe() const { return m_acceleratedPropertiesWithImplicitKeyframe; }
+    const HashSet<AnimatableCSSProperty>& acceleratedProperties() const { return m_acceleratedProperties; }
+    const HashSet<AnimatableCSSProperty>& acceleratedPropertiesWithImplicitKeyframe() const { return m_acceleratedPropertiesWithImplicitKeyframe; }
 
     bool computeExtentOfTransformAnimation(LayoutRect&) const;
     bool computeTransformedExtentViaTransformList(const FloatRect&, const RenderStyle&, LayoutRect&) const;
@@ -300,9 +300,9 @@ private:
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
 
     BlendingKeyframes m_blendingKeyframes { };
-    UncheckedKeyHashSet<AnimatableCSSProperty> m_animatedProperties;
-    UncheckedKeyHashSet<AnimatableCSSProperty> m_acceleratedProperties;
-    UncheckedKeyHashSet<AnimatableCSSProperty> m_acceleratedPropertiesWithImplicitKeyframe;
+    HashSet<AnimatableCSSProperty> m_animatedProperties;
+    HashSet<AnimatableCSSProperty> m_acceleratedProperties;
+    HashSet<AnimatableCSSProperty> m_acceleratedPropertiesWithImplicitKeyframe;
     Vector<ParsedKeyframe> m_parsedKeyframes;
     Vector<AcceleratedAction> m_pendingAcceleratedActions;
     RefPtr<Element> m_target;

--- a/Source/WebCore/animation/KeyframeEffectStack.cpp
+++ b/Source/WebCore/animation/KeyframeEffectStack.cpp
@@ -146,7 +146,7 @@ void KeyframeEffectStack::setCSSAnimationList(RefPtr<const AnimationList>&& cssA
     m_isSorted = false;
 }
 
-OptionSet<AnimationImpact> KeyframeEffectStack::applyKeyframeEffects(RenderStyle& targetStyle, UncheckedKeyHashSet<AnimatableCSSProperty>& affectedProperties, const RenderStyle* previousLastStyleChangeEventStyle, const Style::ResolutionContext& resolutionContext)
+OptionSet<AnimationImpact> KeyframeEffectStack::applyKeyframeEffects(RenderStyle& targetStyle, HashSet<AnimatableCSSProperty>& affectedProperties, const RenderStyle* previousLastStyleChangeEventStyle, const Style::ResolutionContext& resolutionContext)
 {
     OptionSet<AnimationImpact> impact;
 
@@ -228,7 +228,7 @@ bool KeyframeEffectStack::allowsAcceleration() const
     // stack is unable to be accelerated, or if we have more than one effect animating
     // an accelerated property with an implicit keyframe.
 
-    UncheckedKeyHashSet<AnimatableCSSProperty> allAcceleratedProperties;
+    HashSet<AnimatableCSSProperty> allAcceleratedProperties;
 
     for (auto& effect : m_effects) {
         if (effect->preventsAcceleration())
@@ -268,9 +268,9 @@ void KeyframeEffectStack::lastStyleChangeEventStyleDidChange(const RenderStyle* 
         effect->lastStyleChangeEventStyleDidChange(previousStyle, currentStyle);
 }
 
-void KeyframeEffectStack::cascadeDidOverrideProperties(const UncheckedKeyHashSet<AnimatableCSSProperty>& overriddenProperties, const Document& document)
+void KeyframeEffectStack::cascadeDidOverrideProperties(const HashSet<AnimatableCSSProperty>& overriddenProperties, const Document& document)
 {
-    UncheckedKeyHashSet<AnimatableCSSProperty> acceleratedPropertiesOverriddenByCascade;
+    HashSet<AnimatableCSSProperty> acceleratedPropertiesOverriddenByCascade;
     for (auto animatedProperty : overriddenProperties) {
         if (Style::Interpolation::isAccelerated(animatedProperty, document.settings()))
             acceleratedPropertiesOverriddenByCascade.add(animatedProperty);

--- a/Source/WebCore/animation/KeyframeEffectStack.h
+++ b/Source/WebCore/animation/KeyframeEffectStack.h
@@ -66,7 +66,7 @@ public:
     bool containsProperty(CSSPropertyID) const;
     bool isCurrentlyAffectingProperty(CSSPropertyID) const;
     bool requiresPseudoElement() const;
-    OptionSet<AnimationImpact> applyKeyframeEffects(RenderStyle& targetStyle, UncheckedKeyHashSet<AnimatableCSSProperty>& affectedProperties, const RenderStyle* previousLastStyleChangeEventStyle, const Style::ResolutionContext&);
+    OptionSet<AnimationImpact> applyKeyframeEffects(RenderStyle& targetStyle, HashSet<AnimatableCSSProperty>& affectedProperties, const RenderStyle* previousLastStyleChangeEventStyle, const Style::ResolutionContext&);
     bool hasEffectWithImplicitKeyframes() const;
 
     void effectAbilityToBeAcceleratedDidChange(const KeyframeEffect&);
@@ -78,9 +78,9 @@ public:
     void addInvalidCSSAnimationName(const String&);
 
     void lastStyleChangeEventStyleDidChange(const RenderStyle* previousStyle, const RenderStyle* currentStyle);
-    void cascadeDidOverrideProperties(const UncheckedKeyHashSet<AnimatableCSSProperty>&, const Document&);
+    void cascadeDidOverrideProperties(const HashSet<AnimatableCSSProperty>&, const Document&);
 
-    const UncheckedKeyHashSet<AnimatableCSSProperty>& acceleratedPropertiesOverriddenByCascade() const { return m_acceleratedPropertiesOverriddenByCascade; }
+    const HashSet<AnimatableCSSProperty>& acceleratedPropertiesOverriddenByCascade() const { return m_acceleratedPropertiesOverriddenByCascade; }
 
     void applyPendingAcceleratedActions() const;
 
@@ -99,8 +99,8 @@ private:
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     WeakListHashSet<AcceleratedEffect> m_acceleratedEffects;
 #endif
-    UncheckedKeyHashSet<String> m_invalidCSSAnimationNames;
-    UncheckedKeyHashSet<AnimatableCSSProperty> m_acceleratedPropertiesOverriddenByCascade;
+    HashSet<String> m_invalidCSSAnimationNames;
+    HashSet<AnimatableCSSProperty> m_acceleratedPropertiesOverriddenByCascade;
     RefPtr<const AnimationList> m_cssAnimationList;
     bool m_isSorted { true };
 };

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
@@ -478,7 +478,7 @@ void StyleOriginatedTimelinesController::unregisterNamedTimelinesAssociatedWithE
 {
     LOG_WITH_STREAM(Animations, stream << "StyleOriginatedTimelinesController::unregisterNamedTimelinesAssociatedWithElement element: " << styleable);
 
-    UncheckedKeyHashSet<AtomString> namesToClear;
+    HashSet<AtomString> namesToClear;
 
     for (auto& entry : m_nameToTimelineMap) {
         auto& timelines = entry.value;

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.h
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.h
@@ -87,7 +87,7 @@ private:
 
     Vector<Ref<CSSAnimation>> m_cssAnimationsPendingAttachment;
     Vector<std::pair<NameScope, WeakStyleable>> m_timelineScopeEntries;
-    UncheckedKeyHashMap<AtomString, Vector<Ref<ScrollTimeline>>> m_nameToTimelineMap;
+    HashMap<AtomString, Vector<Ref<ScrollTimeline>>> m_nameToTimelineMap;
     HashSet<Ref<ScrollTimeline>> m_removedTimelines;
 };
 

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -66,9 +66,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebAnimation);
 
-UncheckedKeyHashSet<WebAnimation*>& WebAnimation::instances()
+HashSet<WebAnimation*>& WebAnimation::instances()
 {
-    static NeverDestroyed<UncheckedKeyHashSet<WebAnimation*>> instances;
+    static NeverDestroyed<HashSet<WebAnimation*>> instances;
     return instances;
 }
 
@@ -1827,7 +1827,7 @@ ExceptionOr<void> WebAnimation::commitStyles()
 
     // 2.4 Let targeted properties be the set of physical longhand properties that are a target property for at least one
     // animation effect associated with animation whose effect target is target.
-    UncheckedKeyHashSet<AnimatableCSSProperty> targetedProperties;
+    HashSet<AnimatableCSSProperty> targetedProperties;
     for (auto property : effect->animatedProperties()) {
         if (std::holds_alternative<CSSPropertyID>(property)) {
             for (auto longhand : shorthandForProperty(std::get<CSSPropertyID>(property)))

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -69,7 +69,7 @@ public:
     static Ref<WebAnimation> create(Document&, AnimationEffect*, AnimationTimeline*);
     ~WebAnimation();
 
-    WEBCORE_EXPORT static UncheckedKeyHashSet<WebAnimation*>& instances();
+    WEBCORE_EXPORT static HashSet<WebAnimation*>& instances();
 
     virtual bool isStyleOriginatedAnimation() const { return false; }
     virtual bool isCSSAnimation() const { return false; }

--- a/Source/WebCore/animation/WebAnimationTypes.h
+++ b/Source/WebCore/animation/WebAnimationTypes.h
@@ -79,7 +79,7 @@ using AnimationEvents = Vector<Ref<AnimationEventBase>>;
 using CSSAnimationCollection = ListHashSet<Ref<CSSAnimation>>;
 
 using AnimatableCSSProperty = Variant<CSSPropertyID, AtomString>;
-using AnimatableCSSPropertyToTransitionMap = UncheckedKeyHashMap<AnimatableCSSProperty, Ref<CSSTransition>>;
+using AnimatableCSSPropertyToTransitionMap = HashMap<AnimatableCSSProperty, Ref<CSSTransition>>;
 
 enum class AcceleratedEffectProperty : uint16_t {
     Invalid = 1 << 0,

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -144,7 +144,7 @@ struct SecurityPolicyViolationEventInit;
 struct ShadowRootInit;
 
 using AnimatableCSSProperty = Variant<CSSPropertyID, AtomString>;
-using AnimatableCSSPropertyToTransitionMap = UncheckedKeyHashMap<AnimatableCSSProperty, Ref<CSSTransition>>;
+using AnimatableCSSPropertyToTransitionMap = HashMap<AnimatableCSSProperty, Ref<CSSTransition>>;
 using AnimationCollection = ListHashSet<Ref<WebAnimation>>;
 using CSSAnimationCollection = ListHashSet<Ref<CSSAnimation>>;
 using ElementName = NodeName;

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -43,7 +43,7 @@ namespace Style {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PropertyCascade);
 
-PropertyCascade::PropertyCascade(const MatchResult& matchResult, CascadeLevel maximumCascadeLevel, IncludedProperties&& includedProperties, const UncheckedKeyHashSet<AnimatableCSSProperty>* animatedProperties, const StyleProperties* positionTryFallbackProperties)
+PropertyCascade::PropertyCascade(const MatchResult& matchResult, CascadeLevel maximumCascadeLevel, IncludedProperties&& includedProperties, const HashSet<AnimatableCSSProperty>* animatedProperties, const StyleProperties* positionTryFallbackProperties)
     : m_matchResult(matchResult)
     , m_includedProperties(WTFMove(includedProperties))
     , m_maximumCascadeLevel(maximumCascadeLevel)
@@ -71,7 +71,7 @@ PropertyCascade::PropertyCascade(const PropertyCascade& parent, CascadeLevel max
 
 PropertyCascade::~PropertyCascade() = default;
 
-PropertyCascade::AnimationLayer::AnimationLayer(const UncheckedKeyHashSet<AnimatableCSSProperty>& properties)
+PropertyCascade::AnimationLayer::AnimationLayer(const HashSet<AnimatableCSSProperty>& properties)
     : properties(properties)
 {
     hasCustomProperties = std::ranges::find_if(properties, [](auto& property) {
@@ -441,7 +441,7 @@ void PropertyCascade::sortLogicalGroupPropertyIDs()
     });
 }
 
-const UncheckedKeyHashSet<AnimatableCSSProperty> PropertyCascade::overriddenAnimatedProperties() const
+const HashSet<AnimatableCSSProperty> PropertyCascade::overriddenAnimatedProperties() const
 {
     if (m_animationLayer)
         return m_animationLayer->overriddenProperties;

--- a/Source/WebCore/style/PropertyCascade.h
+++ b/Source/WebCore/style/PropertyCascade.h
@@ -65,7 +65,7 @@ public:
 
     static IncludedProperties normalProperties() { return { normalPropertyTypes() }; }
 
-    PropertyCascade(const MatchResult&, CascadeLevel, IncludedProperties&&, const UncheckedKeyHashSet<AnimatableCSSProperty>* = nullptr, const StyleProperties* positionTryFallbackProperties = nullptr);
+    PropertyCascade(const MatchResult&, CascadeLevel, IncludedProperties&&, const HashSet<AnimatableCSSProperty>* = nullptr, const StyleProperties* positionTryFallbackProperties = nullptr);
     PropertyCascade(const PropertyCascade&, CascadeLevel, std::optional<ScopeOrdinal> rollbackScope = { }, std::optional<CascadeLayerPriority> maximumCascadeLayerPriorityForRollback = { });
 
     ~PropertyCascade();
@@ -95,7 +95,7 @@ public:
     std::span<const CSSPropertyID> logicalGroupPropertyIDs() const;
     const UncheckedKeyHashMap<AtomString, Property>& customProperties() const { return m_customProperties; }
 
-    const UncheckedKeyHashSet<AnimatableCSSProperty> overriddenAnimatedProperties() const;
+    const HashSet<AnimatableCSSProperty> overriddenAnimatedProperties() const;
 
     PropertyBitSet& propertyIsPresent() { return m_propertyIsPresent; }
     const PropertyBitSet& propertyIsPresent() const { return m_propertyIsPresent; }
@@ -128,10 +128,10 @@ private:
     const std::optional<CascadeLayerPriority> m_maximumCascadeLayerPriorityForRollback;
 
     struct AnimationLayer {
-        AnimationLayer(const UncheckedKeyHashSet<AnimatableCSSProperty>&);
+        AnimationLayer(const HashSet<AnimatableCSSProperty>&);
 
-        const UncheckedKeyHashSet<AnimatableCSSProperty>& properties;
-        UncheckedKeyHashSet<AnimatableCSSProperty> overriddenProperties;
+        const HashSet<AnimatableCSSProperty>& properties;
+        HashSet<AnimatableCSSProperty> overriddenProperties;
         bool hasCustomProperties { false };
         bool hasFontSize { false };
         bool hasLineHeight { false };

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -95,7 +95,7 @@ static auto positionTryFallbackProperties(const BuilderContext& context)
     return context.positionTryFallback ? context.positionTryFallback->properties.get() : nullptr;
 }
 
-Builder::Builder(RenderStyle& style, BuilderContext&& context, const MatchResult& matchResult, CascadeLevel cascadeLevel, PropertyCascade::IncludedProperties&& includedProperties, const UncheckedKeyHashSet<AnimatableCSSProperty>* animatedPropertes)
+Builder::Builder(RenderStyle& style, BuilderContext&& context, const MatchResult& matchResult, CascadeLevel cascadeLevel, PropertyCascade::IncludedProperties&& includedProperties, const HashSet<AnimatableCSSProperty>* animatedPropertes)
     : m_cascade(matchResult, cascadeLevel, WTFMove(includedProperties), animatedPropertes, positionTryFallbackProperties(context))
     , m_state(style, WTFMove(context))
 {

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -42,7 +42,7 @@ class CustomProperty;
 class Builder {
     WTF_MAKE_TZONE_ALLOCATED(Builder);
 public:
-    Builder(RenderStyle&, BuilderContext&&, const MatchResult&, CascadeLevel, PropertyCascade::IncludedProperties&& = PropertyCascade::normalProperties(), const UncheckedKeyHashSet<AnimatableCSSProperty>* animatedProperties = nullptr);
+    Builder(RenderStyle&, BuilderContext&&, const MatchResult&, CascadeLevel, PropertyCascade::IncludedProperties&& = PropertyCascade::normalProperties(), const HashSet<AnimatableCSSProperty>* animatedProperties = nullptr);
     ~Builder();
 
     void applyAllProperties();
@@ -58,7 +58,7 @@ public:
 
     BuilderState& state() { return m_state; }
 
-    const UncheckedKeyHashSet<AnimatableCSSProperty> overriddenAnimatedProperties() const { return m_cascade.overriddenAnimatedProperties(); }
+    const HashSet<AnimatableCSSProperty> overriddenAnimatedProperties() const { return m_cascade.overriddenAnimatedProperties(); }
 
 private:
     void applyProperties(int firstProperty, int lastProperty);

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -744,7 +744,7 @@ ElementUpdate TreeResolver::createAnimatedElementUpdate(ResolvedStyle&& resolved
         styleable.setLastStyleChangeEventStyle(RenderStyle::clonePtr(*resolvedStyle.style));
 
         // Apply all keyframe effects to the new style.
-        UncheckedKeyHashSet<AnimatableCSSProperty> animatedProperties;
+        HashSet<AnimatableCSSProperty> animatedProperties;
         auto animatedStyle = RenderStyle::clonePtr(*resolvedStyle.style);
 
         auto animationImpact = styleable.applyKeyframeEffects(*animatedStyle, animatedProperties, previousLastStyleChangeEventStyle.get(), resolutionContext);
@@ -915,7 +915,7 @@ const RenderStyle& TreeResolver::parentAfterChangeStyle(const Styleable& styleab
     return *resolutionContext.parentStyle;
 }
 
-UncheckedKeyHashSet<AnimatableCSSProperty> TreeResolver::applyCascadeAfterAnimation(RenderStyle& animatedStyle, const UncheckedKeyHashSet<AnimatableCSSProperty>& animatedProperties, bool isTransition, const MatchResult& matchResult, const Element& element, const ResolutionContext& resolutionContext)
+HashSet<AnimatableCSSProperty> TreeResolver::applyCascadeAfterAnimation(RenderStyle& animatedStyle, const HashSet<AnimatableCSSProperty>& animatedProperties, bool isTransition, const MatchResult& matchResult, const Element& element, const ResolutionContext& resolutionContext)
 {
     auto builderContext = BuilderContext {
         m_document.get(),

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -97,7 +97,7 @@ private:
     std::unique_ptr<RenderStyle> resolveAgainInDifferentContext(const ResolvedStyle&, const Styleable&, const RenderStyle& parentStyle,  OptionSet<PropertyCascade::PropertyType>, std::optional<BuilderPositionTryFallback>&&, const ResolutionContext&);
     const RenderStyle& parentAfterChangeStyle(const Styleable&, const ResolutionContext&) const;
 
-    UncheckedKeyHashSet<AnimatableCSSProperty> applyCascadeAfterAnimation(RenderStyle&, const UncheckedKeyHashSet<AnimatableCSSProperty>&, bool isTransition, const MatchResult&, const Element&, const ResolutionContext&);
+    HashSet<AnimatableCSSProperty> applyCascadeAfterAnimation(RenderStyle&, const HashSet<AnimatableCSSProperty>&, bool isTransition, const MatchResult&, const Element&, const ResolutionContext&);
 
     std::optional<ElementUpdate> resolvePseudoElement(Element&, const PseudoElementIdentifier&, const ElementUpdate&, IsInDisplayNoneTree);
     std::optional<ElementUpdate> resolveAncestorPseudoElement(Element&, const PseudoElementIdentifier&, const ElementUpdate&);

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -312,7 +312,7 @@ void Styleable::willChangeRenderer() const
     }
 }
 
-OptionSet<AnimationImpact> Styleable::applyKeyframeEffects(RenderStyle& targetStyle, UncheckedKeyHashSet<AnimatableCSSProperty>& affectedProperties, const RenderStyle* previousLastStyleChangeEventStyle, const Style::ResolutionContext& resolutionContext) const
+OptionSet<AnimationImpact> Styleable::applyKeyframeEffects(RenderStyle& targetStyle, HashSet<AnimatableCSSProperty>& affectedProperties, const RenderStyle* previousLastStyleChangeEventStyle, const Style::ResolutionContext& resolutionContext) const
 {
     return element.ensureKeyframeEffectStack(pseudoElementIdentifier).applyKeyframeEffects(targetStyle, affectedProperties, previousLastStyleChangeEventStyle, resolutionContext);
 }

--- a/Source/WebCore/style/Styleable.h
+++ b/Source/WebCore/style/Styleable.h
@@ -101,7 +101,7 @@ struct Styleable {
         return element.hasKeyframeEffects(pseudoElementIdentifier);
     }
 
-    OptionSet<AnimationImpact> applyKeyframeEffects(RenderStyle& targetStyle, UncheckedKeyHashSet<AnimatableCSSProperty>& affectedProperties, const RenderStyle* previousLastStyleChangeEventStyle, const Style::ResolutionContext&) const;
+    OptionSet<AnimationImpact> applyKeyframeEffects(RenderStyle& targetStyle, HashSet<AnimatableCSSProperty>& affectedProperties, const RenderStyle* previousLastStyleChangeEventStyle, const Style::ResolutionContext&) const;
 
     const AnimationCollection* animations() const
     {


### PR DESCRIPTION
#### 52e9bf5298f316188f22b34fe26bb852ab7797e0
<pre>
Stop using UncheckedKey containers in WebCore/animation
<a href="https://bugs.webkit.org/show_bug.cgi?id=294948">https://bugs.webkit.org/show_bug.cgi?id=294948</a>

Reviewed by Antoine Quint.

Stop using UncheckedKey containers in WebCore/animation, for added safety.
This tested as performance neutral on Speedometer.

* Source/WebCore/animation/AnimationTimelinesController.h:
* Source/WebCore/animation/BlendingKeyframes.cpp:
(WebCore::BlendingKeyframes::fillImplicitKeyframes):
(WebCore::BlendingKeyframes::propertiesSetToInherit const):
* Source/WebCore/animation/BlendingKeyframes.h:
(WebCore::BlendingKeyframes::properties const):
* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::animationCanBeRemoved):
(WebCore::DocumentTimeline::applyPendingAcceleratedAnimations):
* Source/WebCore/animation/DocumentTimeline.h:
* Source/WebCore/animation/FrameRateAligner.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::animatedProperties):
(WebCore::propertiesContainTransformRelatedProperty):
(WebCore::KeyframeEffect::computeHasImplicitKeyframeForAcceleratedProperty):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/KeyframeEffectStack.cpp:
(WebCore::KeyframeEffectStack::applyKeyframeEffects):
(WebCore::KeyframeEffectStack::allowsAcceleration const):
(WebCore::KeyframeEffectStack::cascadeDidOverrideProperties):
* Source/WebCore/animation/KeyframeEffectStack.h:
(WebCore::KeyframeEffectStack::acceleratedPropertiesOverriddenByCascade const):
* Source/WebCore/animation/StyleOriginatedTimelinesController.cpp:
(WebCore::StyleOriginatedTimelinesController::unregisterNamedTimelinesAssociatedWithElement):
* Source/WebCore/animation/StyleOriginatedTimelinesController.h:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::commitStyles):
* Source/WebCore/animation/WebAnimation.h:
* Source/WebCore/animation/WebAnimationTypes.h:
* Source/WebCore/dom/Element.h:
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::PropertyCascade):
(WebCore::Style::PropertyCascade::AnimationLayer::AnimationLayer):
(WebCore::Style::PropertyCascade::overriddenAnimatedProperties const):
* Source/WebCore/style/PropertyCascade.h:
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::Builder):
* Source/WebCore/style/StyleBuilder.h:
(WebCore::Style::Builder::overriddenAnimatedProperties const):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::createAnimatedElementUpdate):
(WebCore::Style::TreeResolver::applyCascadeAfterAnimation):
* Source/WebCore/style/StyleTreeResolver.h:
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::applyKeyframeEffects const):
* Source/WebCore/style/Styleable.h:

Canonical link: <a href="https://commits.webkit.org/296620@main">https://commits.webkit.org/296620@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8da5d06ea25b2dfcd5df624d535cd6b8f89ea69a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109034 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28695 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19119 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114245 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59352 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110997 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37261 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82861 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111982 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23367 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98208 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63303 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22773 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16347 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58936 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92736 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16393 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117363 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36083 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26673 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91875 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36454 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94472 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91680 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23351 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36592 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14342 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31943 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35980 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41494 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35678 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39016 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37363 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->