### PR TITLE
[Swift in WebKit] Fix Swift 6 warnings and errors in intelligence text effects code

### DIFF
--- a/Source/WebKit/WebKitSwift/TextAnimation/WKTextAnimationManagerIOS.swift
+++ b/Source/WebKit/WebKitSwift/TextAnimation/WKTextAnimationManagerIOS.swift
@@ -21,6 +21,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
+#if compiler(>=6.0)
+
 #if ENABLE_WRITING_TOOLS && canImport(UIKit)
 
 import OSLog
@@ -106,12 +108,12 @@ extension WKTextAnimationManager {
     }
 }
 
-// FIXME: This conformance is unfortunate, and should be refactored into a seperate type so `@retroactive` can be removed.
+// FIXME: This conformance is unfortunate, and should be refactored into a separate type so `@retroactive` can be removed.
 // swift-format-ignore: AvoidRetroactiveConformances
 @_spi(TextEffects)
-extension WKTextAnimationManager: @retroactive UITextEffectViewSource {
+extension WKTextAnimationManager: @retroactive @preconcurrency UITextEffectViewSource {
     // This can be made non-public once the retroactive conformance is removed.
-    // It is currently safe due to the fact that WebKitSwift is not iteself public.
+    // It is currently safe due to the fact that WebKitSwift is not itself public.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func targetedPreview(for chunk: UITextEffectTextChunk) async -> UITargetedPreview {
         guard let delegate else {
@@ -140,7 +142,7 @@ extension WKTextAnimationManager: @retroactive UITextEffectViewSource {
     }
 
     // This can be made non-public once the retroactive conformance is removed.
-    // It is currently safe due to the fact that WebKitSwift is not iteself public.
+    // It is currently safe due to the fact that WebKitSwift is not itself public.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func updateTextChunkVisibilityForAnimation(_ chunk: UITextEffectTextChunk, visible: Bool) async {
         guard let uuidChunk = chunk as? TextEffectChunk else {
@@ -155,12 +157,12 @@ extension WKTextAnimationManager: @retroactive UITextEffectViewSource {
     }
 }
 
-// FIXME: This conformance is unfortunate, and should be refactored into a seperate type so `@retroactive` can be removed.
+// FIXME: This conformance is unfortunate, and should be refactored into a separate type so `@retroactive` can be removed.
 // swift-format-ignore: AvoidRetroactiveConformances
 @_spi(TextEffects)
-extension WKTextAnimationManager: @retroactive UITextEffectView.ReplacementTextEffect.Delegate {
+extension WKTextAnimationManager: @retroactive @preconcurrency UITextEffectView.ReplacementTextEffect.Delegate {
     // This can be made non-public once the retroactive conformance is removed.
-    // It is currently safe due to the fact that WebKitSwift is not iteself public.
+    // It is currently safe due to the fact that WebKitSwift is not itself public.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func performReplacementAndGeneratePreview(
         for chunk: UITextEffectTextChunk,
@@ -187,7 +189,7 @@ extension WKTextAnimationManager: @retroactive UITextEffectView.ReplacementTextE
     }
 
     // This can be made non-public once the retroactive conformance is removed.
-    // It is currently safe due to the fact that WebKitSwift is not iteself public.
+    // It is currently safe due to the fact that WebKitSwift is not itself public.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func replacementEffectDidComplete(_ effect: UITextEffectView.ReplacementTextEffect) {
         effectView.removeEffect(effect.id)
@@ -209,3 +211,5 @@ extension WKTextAnimationManager: @retroactive UITextEffectView.ReplacementTextE
 }
 
 #endif // ENABLE_WRITING_TOOLS && canImport(UIKit)
+
+#endif // compiler(>=6.0)

--- a/Source/WebKit/WebKitSwift/WritingTools/PlatformIntelligenceTextEffectView.swift
+++ b/Source/WebKit/WebKitSwift/WritingTools/PlatformIntelligenceTextEffectView.swift
@@ -23,6 +23,8 @@
 
 import Foundation
 
+#if compiler(>=6.0)
+
 #if ENABLE_WRITING_TOOLS
 
 #if canImport(AppKit) && !targetEnvironment(macCatalyst)
@@ -130,7 +132,7 @@ protocol PlatformIntelligenceTextEffectViewSource: AnyObject {
 #if canImport(UIKit)
 
 @MainActor
-private final class UITextEffectViewSourceAdapter<Wrapped>: NSObject, UITextEffectViewSource
+private final class UITextEffectViewSourceAdapter<Wrapped>: NSObject, @preconcurrency UITextEffectViewSource
 where Wrapped: PlatformIntelligenceTextEffectViewSource {
     private var wrapped: Wrapped
 
@@ -183,7 +185,7 @@ where Wrapped: PlatformIntelligenceTextEffectViewSource {
 }
 
 @MainActor
-private final class UIReplacementTextEffectDelegateAdapter<Wrapped>: UITextEffectView.ReplacementTextEffect.Delegate
+private final class UIReplacementTextEffectDelegateAdapter<Wrapped>: @preconcurrency UITextEffectView.ReplacementTextEffect.Delegate
 where Wrapped: PlatformIntelligenceTextEffectViewSource {
     private let wrapped: Wrapped
     private weak var view: PlatformIntelligenceTextEffectView<Wrapped>?
@@ -250,7 +252,7 @@ where Wrapped: PlatformIntelligenceTextEffectChunk {
 #else
 
 @MainActor
-private final class WTTextPreviewAsyncSourceAdapter<Wrapped>: NSObject, _WTTextPreviewAsyncSource
+private final class WTTextPreviewAsyncSourceAdapter<Wrapped>: NSObject, @preconcurrency _WTTextPreviewAsyncSource
 where Wrapped: PlatformIntelligenceTextEffectViewSource {
     private let wrapped: Wrapped
 
@@ -694,3 +696,5 @@ class PlatformIntelligencePonderingTextEffect<Chunk>: PlatformIntelligenceTextEf
 }
 
 #endif // ENABLE_WRITING_TOOLS
+
+#endif // compiler(>=6.0)

--- a/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceReplacementTextEffectCoordinator.swift
+++ b/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceReplacementTextEffectCoordinator.swift
@@ -465,7 +465,7 @@ extension WKIntelligenceReplacementTextEffectCoordinator: PlatformIntelligenceTe
 // MARK: Misc. helper functions
 
 /// Converts a block with a completion handler into an async block.
-private func async(_ block: @escaping (@escaping () -> Void) -> Void) -> (() async -> Void) {
+private func async(_ block: @MainActor @Sendable @escaping (@MainActor @Sendable @escaping () -> Void) -> Void) -> (() async -> Void) {
     { @MainActor in
         await withCheckedContinuation { continuation in
             block(continuation.resume)

--- a/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceSmartReplyTextEffectCoordinator.swift
+++ b/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceSmartReplyTextEffectCoordinator.swift
@@ -308,7 +308,7 @@ extension WKIntelligenceSmartReplyTextEffectCoordinator: PlatformIntelligenceTex
 // MARK: Misc. helper functions
 
 /// Converts a block with a completion handler into an async block.
-private func async(_ block: @escaping (@escaping () -> Void) -> Void) -> (() async -> Void) {
+private func async(_ block: @MainActor @Sendable @escaping (@MainActor @Sendable @escaping () -> Void) -> Void) -> (() async -> Void) {
     { @MainActor in
         await withCheckedContinuation { continuation in
             block(continuation.resume)


### PR DESCRIPTION
#### 57d7ed700f788fdcc458d3e75d803b3a2500ed5e
<pre>
[Swift in WebKit] Fix Swift 6 warnings and errors in intelligence text effects code
<a href="https://bugs.webkit.org/show_bug.cgi?id=294949">https://bugs.webkit.org/show_bug.cgi?id=294949</a>
<a href="https://rdar.apple.com/154256234">rdar://154256234</a>

Reviewed by Aditya Keerthi.

Add `@preconcurrency` to applicable protocol conformances to maintain existing behavior, as the
relevant protocols have not been refined for strict concurrency.

* Source/WebKit/WebKitSwift/TextAnimation/WKTextAnimationManagerIOS.swift:
* Source/WebKit/WebKitSwift/WritingTools/PlatformIntelligenceTextEffectView.swift:
* Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceReplacementTextEffectCoordinator.swift:
(async(_:)):
* Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceSmartReplyTextEffectCoordinator.swift:
(async(_:)):

Canonical link: <a href="https://commits.webkit.org/296605@main">https://commits.webkit.org/296605@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f871390f31fd7f13f1980a989f7187b30b9b651a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109036 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28697 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19121 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114247 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/59354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110999 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29379 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37263 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82862 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/59354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111984 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23370 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98207 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63304 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22776 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16346 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58938 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92740 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16392 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117365 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36085 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/26674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91874 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36456 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94471 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91679 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23338 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36595 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14341 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31945 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35982 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41496 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35680 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39018 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37365 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->