### PR TITLE
Refactor common FocusController code path to be site-isolation aware

### DIFF
--- a/Source/WebCore/editing/cocoa/AutofillElements.cpp
+++ b/Source/WebCore/editing/cocoa/AutofillElements.cpp
@@ -27,6 +27,7 @@
 #include "AutofillElements.h"
 
 #include "FocusController.h"
+#include "Logging.h"
 #include "Page.h"
 #include <wtf/TZoneMallocInlines.h>
 
@@ -47,7 +48,10 @@ static inline RefPtr<HTMLInputElement> nextAutofillableElement(Node* startNode, 
         return nullptr;
 
     do {
-        nextElement = focusController.nextFocusableElement(*nextElement.get());
+        auto result = focusController.nextFocusableElement(*nextElement.get());
+        if (!result.element && result.continuedSearchInRemoteFrame == ContinuedSearchInRemoteFrame::Yes)
+            LOG(SiteIsolation, "Crossing site isolation process barrier searching for `nextAutofillableElement` is not yet supported");
+        nextElement = result.element;
     } while (nextElement && !isAutofillableElement(*nextElement.get()));
 
     if (!nextElement)
@@ -63,7 +67,10 @@ static inline RefPtr<HTMLInputElement> previousAutofillableElement(Node* startNo
         return nullptr;
 
     do {
-        previousElement = focusController.previousFocusableElement(*previousElement.get());
+        auto result = focusController.previousFocusableElement(*previousElement.get());
+        if (!result.element && result.continuedSearchInRemoteFrame == ContinuedSearchInRemoteFrame::Yes)
+            LOG(SiteIsolation, "Crossing site isolation process barrier searching for `previousAutofillableElement` is not yet supported");
+        previousElement = result.element;
     } while (previousElement && !isAutofillableElement(*previousElement.get()));
 
     if (!previousElement)

--- a/Source/WebCore/page/FocusController.h
+++ b/Source/WebCore/page/FocusController.h
@@ -50,6 +50,12 @@ class TreeScope;
 
 struct FocusCandidate;
 
+enum class ContinuedSearchInRemoteFrame : bool { No, Yes };
+struct FocusableElementSearchResult {
+    RefPtr<Element> element;
+    ContinuedSearchInRemoteFrame continuedSearchInRemoteFrame { ContinuedSearchInRemoteFrame::No };
+};
+
 class FocusController final : public CanMakeCheckedPtr<FocusController> {
     WTF_MAKE_TZONE_ALLOCATED(FocusController);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FocusController);
@@ -78,9 +84,8 @@ public:
 
     bool contentIsVisible() const { return m_activityState.contains(ActivityState::IsVisible); }
 
-    // These methods are used in WebCore/bindings/objc/DOM.mm.
-    WEBCORE_EXPORT Element* nextFocusableElement(Node&);
-    WEBCORE_EXPORT Element* previousFocusableElement(Node&);
+    WEBCORE_EXPORT FocusableElementSearchResult nextFocusableElement(Node&);
+    WEBCORE_EXPORT FocusableElementSearchResult previousFocusableElement(Node&);
 
     void setFocusedElementNeedsRepaint();
     Seconds timeSinceFocusWasSet() const;
@@ -95,13 +100,13 @@ private:
     bool advanceFocusDirectionally(FocusDirection, KeyboardEvent*);
     bool advanceFocusInDocumentOrder(FocusDirection, KeyboardEvent*, bool initialFocus);
 
-    Element* findFocusableElementAcrossFocusScope(FocusDirection, const FocusNavigationScope& startScope, Node* start, KeyboardEvent*);
+    FocusableElementSearchResult findFocusableElementAcrossFocusScope(FocusDirection, const FocusNavigationScope& startScope, Node* start, KeyboardEvent*);
 
-    Element* findFocusableElementWithinScope(FocusDirection, const FocusNavigationScope&, Node* start, KeyboardEvent*);
-    Element* nextFocusableElementWithinScope(const FocusNavigationScope&, Node* start, KeyboardEvent*);
-    Element* previousFocusableElementWithinScope(const FocusNavigationScope&, Node* start, KeyboardEvent*);
+    FocusableElementSearchResult findFocusableElementWithinScope(FocusDirection, const FocusNavigationScope&, Node* start, KeyboardEvent*);
+    FocusableElementSearchResult nextFocusableElementWithinScope(const FocusNavigationScope&, Node* start, KeyboardEvent*);
+    FocusableElementSearchResult previousFocusableElementWithinScope(const FocusNavigationScope&, Node* start, KeyboardEvent*);
 
-    Element* findFocusableElementDescendingIntoSubframes(FocusDirection, Element*, KeyboardEvent*);
+    FocusableElementSearchResult findFocusableElementDescendingIntoSubframes(FocusDirection, Element*, KeyboardEvent*);
 
     // Searches through the given tree scope, starting from start node, for the next/previous selectable element that comes after/before start node.
     // The order followed is as specified in section 17.11.1 of the HTML4 spec, which is elements with tab indexes

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -4109,7 +4109,11 @@ static inline RefPtr<Element> nextAssistableElement(Node* startNode, Page& page,
 
     CheckedRef focusController { page.focusController() };
     do {
-        nextElement = isForward ? focusController->nextFocusableElement(*nextElement) : focusController->previousFocusableElement(*nextElement);
+        auto result = isForward ? focusController->nextFocusableElement(*nextElement) : focusController->previousFocusableElement(*nextElement);
+        if (!result.element && result.continuedSearchInRemoteFrame == ContinuedSearchInRemoteFrame::Yes)
+            RELEASE_LOG(SiteIsolation, "Crossing site isolation process barrier searching for `nextAssistableElement` is not yet supported");
+
+        nextElement = result.element;
     } while (nextElement && (!isAssistableElement(*nextElement) || isObscuredElement(*nextElement)));
 
     return nextElement;

--- a/Source/WebKitLegacy/mac/DOM/DOM.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOM.mm
@@ -468,7 +468,7 @@ id <DOMEventTarget> kit(EventTarget* target)
     Page* page = core(self)->document().page();
     if (!page)
         return nil;
-    return kit(page->focusController().nextFocusableElement(*core(self)));
+    return kit(page->focusController().nextFocusableElement(*core(self)).element.get());
 }
 
 - (DOMNode *)previousFocusNode
@@ -476,7 +476,7 @@ id <DOMEventTarget> kit(EventTarget* target)
     Page* page = core(self)->document().page();
     if (!page)
         return nil;
-    return kit(page->focusController().previousFocusableElement(*core(self)));
+    return kit(page->focusController().previousFocusableElement(*core(self)).element.get());
 }
 
 #endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 5ae55be289fbe0881e10b5d1c5f3a35b2474583a
<pre>
Refactor common FocusController code path to be site-isolation aware
<a href="https://rdar.apple.com/154258045">rdar://154258045</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=294951">https://bugs.webkit.org/show_bug.cgi?id=294951</a>

Reviewed by Ryosuke Niwa.

To prepare for making &quot;advancing focus&quot; to be able to cross frame boundaries with site isolation enabled,
this patch refactors the relevant code path of FocusController to include more context about an attempted
focus operation.

With site isolation disabled, this doesn&apos;t change behavior.

With site isolation enabled, you&apos;ll see the added log statements fire when you try certain operations into
an isolated iframe.

* Source/WebCore/editing/cocoa/AutofillElements.cpp:
(WebCore::nextAutofillableElement):
(WebCore::previousAutofillableElement):
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::findFocusableElementDescendingIntoSubframes):
(WebCore::FocusController::advanceFocusInDocumentOrder):
(WebCore::FocusController::findFocusableElementAcrossFocusScope):
(WebCore::FocusController::findFocusableElementWithinScope):
(WebCore::FocusController::nextFocusableElementWithinScope):
(WebCore::FocusController::previousFocusableElementWithinScope):
(WebCore::FocusController::nextFocusableElement):
(WebCore::FocusController::previousFocusableElement):
(WebCore::shouldClearSelectionWhenChangingFocusedElement):
(WebCore::updateFocusCandidateIfNeeded):
* Source/WebCore/page/FocusController.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::nextAssistableElement):
* Source/WebKitLegacy/mac/DOM/DOM.mm:
(-[DOMNode nextFocusNode]):
(-[DOMNode previousFocusNode]):

Canonical link: <a href="https://commits.webkit.org/296625@main">https://commits.webkit.org/296625@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36029b01ea5b8b076d5513373090be10096f9398

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109098 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28758 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19183 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114309 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59397 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111061 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29441 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37325 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82912 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112046 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23421 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98264 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63357 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22821 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16406 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/58993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92792 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16449 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117427 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36146 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26719 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91928 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36517 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94528 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91734 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23353 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36644 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14398 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32004 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36043 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41548 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35736 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39075 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37422 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->