### PR TITLE
Reduce scope of WTF_ALLOW_UNSAFE_BUFFER_USAGE macros in wtf/text

### DIFF
--- a/Source/WTF/wtf/text/AdaptiveStringSearcher.h
+++ b/Source/WTF/wtf/text/AdaptiveStringSearcher.h
@@ -30,8 +30,6 @@
 #include <wtf/text/StringCommon.h>
 #include <wtf/text/StringView.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 //---------------------------------------------------------------------
@@ -67,6 +65,7 @@ public:
     static constexpr bool exceedsOneByte(LChar) { return false; }
     static constexpr bool exceedsOneByte(char16_t c) { return c > 0xff; }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     template <typename PatternChar, typename SubjectChar>
     static inline int findFirstCharacter(std::span<const PatternChar> pattern, std::span<const SubjectChar> subject, int index)
     {
@@ -92,6 +91,7 @@ public:
             return -1;
         return static_cast<int>(charPos - subjectPtr);
     }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 };
 
 class AdaptiveStringSearcherTables {
@@ -172,6 +172,7 @@ private:
 
     void populateBoyerMooreTable();
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     static inline int charOccurrence(int* badCharOccurrence, SubjectChar charCode)
     {
         if constexpr (sizeof(SubjectChar) == 1)
@@ -187,6 +188,7 @@ private:
         int equivClass = charCode % ucharAlphabetSize;
         return badCharOccurrence[equivClass];
     }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     // The following tables are shared by all searches.
     // TODO(lrn): Introduce a way for a pattern to keep its tables
@@ -197,6 +199,7 @@ private:
     // pattern.
     int* badCharTable() { return m_tables.badCharShiftTable(); }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     // Store for the BoyerMoore good suffix shift table.
     int* goodSuffixShiftTable()
     {
@@ -213,6 +216,7 @@ private:
         // to the kSuffixTable array.
         return m_tables.suffixTable() - m_start;
     }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     AdaptiveStringSearcherTables& m_tables;
     // The pattern to search for.
@@ -243,6 +247,7 @@ int AdaptiveStringSearcher<PatternChar, SubjectChar>::singleCharSearch(AdaptiveS
 // Linear Search Strategy
 //---------------------------------------------------------------------
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 // Simple linear search for short patterns. Never bails out.
 template <typename PatternChar, typename SubjectChar>
 int AdaptiveStringSearcher<PatternChar, SubjectChar>::linearSearch(AdaptiveStringSearcher<PatternChar, SubjectChar>& search, std::span<const SubjectChar> subject, int index)
@@ -511,6 +516,7 @@ int AdaptiveStringSearcher<PatternChar, SubjectChar>::initialSearch(AdaptiveStri
     }
     return -1;
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 // Perform a a single stand-alone search.
 // If searching multiple times for the same pattern, a search
@@ -528,5 +534,3 @@ int searchString(AdaptiveStringSearcherTables& tables, std::span<const SubjectCh
 using WTF::AdaptiveStringSearcher;
 using WTF::AdaptiveStringSearcherTables;
 using WTF::searchString;
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/text/SuperFastHash.h
+++ b/Source/WTF/wtf/text/SuperFastHash.h
@@ -25,8 +25,6 @@
 #include <wtf/Compiler.h>
 #include <wtf/text/StringHasher.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 // Paul Hsieh's SuperFastHash
@@ -77,6 +75,7 @@ public:
         addCharactersAssumingAligned(a, b);
     }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     template<typename T, typename Converter = DefaultConverter>
     void addCharactersAssumingAligned(const T* data, unsigned length)
     {
@@ -121,6 +120,7 @@ public:
         }
         addCharactersAssumingAligned<T, Converter>(data, length);
     }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     template<typename T, typename Converter = DefaultConverter>
     void addCharacters(std::span<const T> data)
@@ -237,6 +237,7 @@ private:
         return result;
     }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     template<typename T, typename Converter>
     static constexpr unsigned computeHashImpl(const T* characters)
     {
@@ -249,6 +250,7 @@ private:
         }
         return result;
     }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     unsigned processPendingCharacter() const
     {
@@ -276,7 +278,5 @@ private:
 };
 
 } // namespace WTF
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 using WTF::SuperFastHash;

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -37,8 +37,6 @@
 #include <wtf/text/win/WCharStringExtras.h>
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 // Declarations of string operations
@@ -565,7 +563,7 @@ inline String operator""_str(const char* characters, size_t)
 
 inline String operator""_str(const char16_t* characters, size_t length)
 {
-    return String({ characters, length });
+    return String(unsafeMakeSpan(characters, length));
 }
 
 } // inline StringLiterals
@@ -588,5 +586,3 @@ using WTF::reverseFind;
 using WTF::codePointCompareLessThan;
 
 #include <wtf/text/AtomString.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### 7befcc577da59c10e70116a74dad4de50b2f0bf0
<pre>
Reduce scope of WTF_ALLOW_UNSAFE_BUFFER_USAGE macros in wtf/text
<a href="https://bugs.webkit.org/show_bug.cgi?id=294953">https://bugs.webkit.org/show_bug.cgi?id=294953</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/text/AdaptiveStringSearcher.h:
* Source/WTF/wtf/text/StringHasherInlines.h:
(WTF::StringHasher::computeLiteralHashAndMaskTop8Bits):
(WTF::StringHasher::addCharacter):
(WTF::StringHasher::hashWithTop8BitsMasked):
* Source/WTF/wtf/text/SuperFastHash.h:
* Source/WTF/wtf/text/WTFString.h:
(WTF::StringLiterals::operator_str):

Canonical link: <a href="https://commits.webkit.org/296624@main">https://commits.webkit.org/296624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e9f987f86d56b91f2cd5d2edf933738015dfcde

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109044 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28705 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19129 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114255 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59358 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29387 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37271 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82876 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111992 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23378 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98221 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63319 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22782 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16361 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58944 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/101575 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92748 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16406 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117373 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/107602 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36093 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26679 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91895 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36464 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94485 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91700 "Found 2 new API test failures: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23352 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36602 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14355 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31950 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35990 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41502 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/131877 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35688 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35747 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39026 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37373 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->