### PR TITLE
Protocol conformances in WebKitSwift needlessly use @retroactive

### DIFF
--- a/Source/WebKit/Configurations/WebKitSwift.xcconfig
+++ b/Source/WebKit/Configurations/WebKitSwift.xcconfig
@@ -24,6 +24,7 @@
 #include "BaseTarget.xcconfig"
 
 PRODUCT_NAME = libWebKitSwift;
+PRODUCT_MODULE_NAME = WebKitSwift;
 
 INSTALL_PATH = $(WEBKIT_FRAMEWORKS_DIR)/WebKit.framework/$(WK_FRAMEWORK_VERSION_PREFIX)Frameworks;
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1946,6 +1946,7 @@
 		A14F9B672B686E0200AD9C56 /* WebKitSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = A14F9B662B686E0200AD9C56 /* WebKitSwift.h */; };
 		A14F9B762B68CA6C00AD9C56 /* WKSLinearMediaPlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = A14F9B742B68CA6B00AD9C56 /* WKSLinearMediaPlayer.h */; };
 		A14F9B772B68CA6C00AD9C56 /* LinearMediaPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A14F9B752B68CA6B00AD9C56 /* LinearMediaPlayer.swift */; };
+		A1555C522E0C5B9400EB2341 /* WebKitSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1555C512E0C5B9400EB2341 /* WebKitSwift.swift */; };
 		A15EEDE61E301CEE000069B0 /* WKPasswordView.h in Headers */ = {isa = PBXBuildFile; fileRef = A15EEDE41E301CEE000069B0 /* WKPasswordView.h */; };
 		A175C44A21AA3171000037D0 /* ArgumentCodersCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = A175C44921AA3170000037D0 /* ArgumentCodersCocoa.h */; };
 		A1798B3E222D97A2000764BD /* PaymentAuthorizationPresenter.h in Headers */ = {isa = PBXBuildFile; fileRef = A1798B3D222D97A2000764BD /* PaymentAuthorizationPresenter.h */; };
@@ -7332,6 +7333,7 @@
 		A14F9B662B686E0200AD9C56 /* WebKitSwift.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebKitSwift.h; sourceTree = "<group>"; };
 		A14F9B742B68CA6B00AD9C56 /* WKSLinearMediaPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKSLinearMediaPlayer.h; sourceTree = "<group>"; };
 		A14F9B752B68CA6B00AD9C56 /* LinearMediaPlayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinearMediaPlayer.swift; sourceTree = "<group>"; };
+		A1555C512E0C5B9400EB2341 /* WebKitSwift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebKitSwift.swift; sourceTree = "<group>"; };
 		A15EEDE31E301CEE000069B0 /* WKPasswordView.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WKPasswordView.mm; path = ios/WKPasswordView.mm; sourceTree = "<group>"; };
 		A15EEDE41E301CEE000069B0 /* WKPasswordView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WKPasswordView.h; path = ios/WKPasswordView.h; sourceTree = "<group>"; };
 		A175C44921AA3170000037D0 /* ArgumentCodersCocoa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ArgumentCodersCocoa.h; sourceTree = "<group>"; };
@@ -14295,6 +14297,7 @@
 				AE9552872D756E920039B9F9 /* CredentialUpdaterShim.swift */,
 				A14F9B652B686E0200AD9C56 /* module.modulemap */,
 				A14F9B662B686E0200AD9C56 /* WebKitSwift.h */,
+				A1555C512E0C5B9400EB2341 /* WebKitSwift.swift */,
 			);
 			path = WebKitSwift;
 			sourceTree = "<group>";
@@ -21146,6 +21149,7 @@
 				A14F9B642B686DD300AD9C56 /* LinearMediaTypes.swift in Sources */,
 				0785E8002CBCDFFD00F68126 /* PlatformIntelligenceTextEffectView.swift in Sources */,
 				DD5697CD2DC06F7700050321 /* rdar150228472.swift in Sources */,
+				A1555C522E0C5B9400EB2341 /* WebKitSwift.swift in Sources */,
 				0765D1C52DEBFF840029CDD0 /* WKGroupSession.swift in Sources */,
 				F46C34352DCD369B00B476F8 /* WKIdentityDocumentPresentmentController.swift in Sources */,
 				F4D59C122DCC0292004492FB /* WKIdentityDocumentPresentmentError.mm in Sources */,

--- a/Source/WebKit/WebKitSwift/GroupActivities/WKGroupSession.swift
+++ b/Source/WebKit/WebKitSwift/GroupActivities/WKGroupSession.swift
@@ -36,7 +36,6 @@ internal import GroupActivities_SPI
 @_implementationOnly import GroupActivities_SPI
 #endif
 #endif
-import WebKitSwift
 
 extension WKGroupSessionState {
     fileprivate init(_ state: GroupSession<URLActivity>.State) {

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift
@@ -27,7 +27,6 @@ import AVFoundation
 import Combine
 import RealityKit
 import UIKit
-import WebKitSwift
 import os
 
 #if canImport(AVKit, _version: 1270)
@@ -345,12 +344,12 @@ extension WKSLinearMediaPlayer {
 
 #if compiler(>=6.0)
 #if os(visionOS)
-@_spi(Internal) extension WKSLinearMediaPlayer: @retroactive @preconcurrency Playable {
+@_spi(Internal) extension WKSLinearMediaPlayer: @preconcurrency Playable {
 }
 #endif
 #else
 #if os(visionOS)
-@_spi(Internal) extension WKSLinearMediaPlayer: @retroactive Playable {
+@_spi(Internal) extension WKSLinearMediaPlayer: Playable {
 }
 #endif
 #endif

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift
@@ -23,8 +23,6 @@
 
 #if os(visionOS)
 
-import WebKitSwift
-
 #if canImport(AVKit, _version: 1270)
 @_spi(LinearMediaKit) @_spi(LinearMediaKit_WebKitOnly) import AVKit
 #else
@@ -176,7 +174,7 @@ extension WKSLinearMediaContentType {
     }
 }
 
-extension WKSLinearMediaPresentationState: @retroactive CustomStringConvertible {
+extension WKSLinearMediaPresentationState: CustomStringConvertible {
     public var description: String {
         switch self {
         case .inline:
@@ -195,7 +193,7 @@ extension WKSLinearMediaPresentationState: @retroactive CustomStringConvertible 
     }
 }
 
-extension WKSLinearMediaViewingMode: @retroactive CustomStringConvertible {
+extension WKSLinearMediaViewingMode: CustomStringConvertible {
     init(_ viewingMode: ViewingMode?) {
         switch viewingMode {
         case .mono?:
@@ -268,7 +266,7 @@ extension WKSLinearMediaTimeRange {
     }
 }
 
-@_spi(Internal) extension WKSLinearMediaTrack: @retroactive Track {
+@_spi(Internal) extension WKSLinearMediaTrack: Track {
 }
 
 extension WKSLinearMediaSpatialVideoMetadata {

--- a/Source/WebKit/WebKitSwift/Preview/WKPreviewWindowController.swift
+++ b/Source/WebKit/WebKitSwift/Preview/WKPreviewWindowController.swift
@@ -24,7 +24,6 @@
 #if ENABLE_QUICKLOOK_FULLSCREEN
 
 import OSLog
-import WebKitSwift
 
 #if USE_APPLE_INTERNAL_SDK
 @_spi(PreviewApplication) internal import QuickLook

--- a/Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.swift
+++ b/Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.swift
@@ -26,7 +26,6 @@
 import Combine
 import CoreGraphics
 import Foundation
-import WebKitSwift
 import os
 import simd
 @_spi(Private) @_spi(RealityKit) @_spi(RealityKit_Webkit) import RealityKit

--- a/Source/WebKit/WebKitSwift/StageMode/WKStageMode.swift
+++ b/Source/WebKit/WebKitSwift/StageMode/WKStageMode.swift
@@ -27,7 +27,6 @@ import Combine
 import Spatial
 import Foundation
 @_spi(Observation) @_spi(RealityKit) import RealityKit
-import WebKitSwift
 import os
 import simd
 

--- a/Source/WebKit/WebKitSwift/TextAnimation/WKTextAnimationManagerIOS.swift
+++ b/Source/WebKit/WebKitSwift/TextAnimation/WKTextAnimationManagerIOS.swift
@@ -26,7 +26,6 @@
 #if ENABLE_WRITING_TOOLS && canImport(UIKit)
 
 import OSLog
-import WebKitSwift
 
 #if USE_APPLE_INTERNAL_SDK
 @_spi(TextEffects) import UIKit
@@ -108,10 +107,8 @@ extension WKTextAnimationManager {
     }
 }
 
-// FIXME: This conformance is unfortunate, and should be refactored into a separate type so `@retroactive` can be removed.
-// swift-format-ignore: AvoidRetroactiveConformances
 @_spi(TextEffects)
-extension WKTextAnimationManager: @retroactive @preconcurrency UITextEffectViewSource {
+extension WKTextAnimationManager: @preconcurrency UITextEffectViewSource {
     // This can be made non-public once the retroactive conformance is removed.
     // It is currently safe due to the fact that WebKitSwift is not itself public.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
@@ -157,10 +154,8 @@ extension WKTextAnimationManager: @retroactive @preconcurrency UITextEffectViewS
     }
 }
 
-// FIXME: This conformance is unfortunate, and should be refactored into a separate type so `@retroactive` can be removed.
-// swift-format-ignore: AvoidRetroactiveConformances
 @_spi(TextEffects)
-extension WKTextAnimationManager: @retroactive @preconcurrency UITextEffectView.ReplacementTextEffect.Delegate {
+extension WKTextAnimationManager: @preconcurrency UITextEffectView.ReplacementTextEffect.Delegate {
     // This can be made non-public once the retroactive conformance is removed.
     // It is currently safe due to the fact that WebKitSwift is not itself public.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation

--- a/Source/WebKit/WebKitSwift/WebKitSwift.swift
+++ b/Source/WebKit/WebKitSwift/WebKitSwift.swift
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Apple Inc. All rights reserved.
+// Copyright (C) 2025 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -21,26 +21,4 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if HAVE_MARKETPLACE_KIT
-
-import Foundation
-import OSLog
-
-// FIXME: (rdar://150642154) This cannot be used in WebKit.framework due to a dependency cycle.
-internal import MarketplaceKit
-
-@objc @implementation extension WKMarketplaceKit {
-    @nonobjc private static let logger = Logger(subsystem: "com.apple.WebKit", category: "Loading")
-
-    class func requestAppInstallation(withTopOrigin topOrigin: URL, url: URL) async throws {
-        do {
-            try await AppLibrary.current.requestAppInstallationFromBrowser(for: url, referrer: topOrigin)
-            logger.debug("WKMarketplaceKit.requestAppInstallation with top origin \(topOrigin, privacy: .sensitive) for \(url, privacy: .sensitive) succeeded")
-        } catch {
-            logger.error("WKMarketplaceKit.requestAppInstallation with top origin \(topOrigin, privacy: .sensitive) for \(url, privacy: .sensitive) failed: \(error, privacy: .public)")
-            throw error
-        }
-    }
-}
-
-#endif // HAVE_MARKETPLACE_KIT
+@_exported import WebKitSwift

--- a/Source/WebKit/WebKitSwift/WritingTools/IntelligenceTextEffectViewManager.swift
+++ b/Source/WebKit/WebKitSwift/WritingTools/IntelligenceTextEffectViewManager.swift
@@ -25,7 +25,6 @@
 
 import Foundation
 import WebKit
-import WebKitSwift
 @_spi(Private) import WebKit
 
 @MainActor

--- a/Source/WebKit/WebKitSwift/WritingTools/PlatformIntelligenceTextEffectView.swift
+++ b/Source/WebKit/WebKitSwift/WritingTools/PlatformIntelligenceTextEffectView.swift
@@ -50,7 +50,6 @@ import UIKit_SPI
 
 #endif // canImport(AppKit) && !targetEnvironment(macCatalyst)
 
-import WebKitSwift
 // Work around rdar://145157171 by manually importing the cross-import module.
 #if canImport(_WebKit_SwiftUI)
 internal import _WebKit_SwiftUI

--- a/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceReplacementTextEffectCoordinator.swift
+++ b/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceReplacementTextEffectCoordinator.swift
@@ -25,7 +25,6 @@
 
 import Foundation
 import WebKit
-import WebKitSwift
 @_spi(Private) import WebKit
 
 #if USE_APPLE_INTERNAL_SDK

--- a/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceSmartReplyTextEffectCoordinator.swift
+++ b/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceSmartReplyTextEffectCoordinator.swift
@@ -25,7 +25,6 @@
 
 import Foundation
 import WebKit
-import WebKitSwift
 @_spi(Private) import WebKit
 
 #if USE_APPLE_INTERNAL_SDK


### PR DESCRIPTION
#### 55b925eb3c6b6d494733e97cc3095bd518f993b9
<pre>
Protocol conformances in WebKitSwift needlessly use @retroactive
<a href="https://bugs.webkit.org/show_bug.cgi?id=294955">https://bugs.webkit.org/show_bug.cgi?id=294955</a>
<a href="https://rdar.apple.com/154261967">rdar://154261967</a>

Reviewed by Richard Robinson.

WebKitSwift vends Objective-C interfaces declared in headers imported by the WebKitSwift.h umbrella
header, but implements these interfaces in Swift using @objc @implementation extensions. In order
for the Swift compiler to see the Objective-C declarations, WebKitSwift defines a clang module
named WebKitSwift that imports WebKitSwift.h, and Swift files containing the implementations import
the WebKitSwift clang module. Since the WebKitSwift Swift module is named libWebKitSwift,
technically the Objective-C declarations come from a different module than their implementations.

This presents a problem when we attempt to conform these types to a protocol imported from another
module. Since the Swift compiler thinks both the interface and the protocol are from imported
modules, a &quot;extension declares a conformance of imported type &apos;Foo&apos; to imported protocol &apos;Bar&apos;&quot;
warning is emitted. Previously we have silenced this warning by annotating the conformance with
@retroactive, but it turns out this is unnecessary.

Similar to how Swift overlays are implemented in mixed-source frameworks, we can convince Swift
that our Objective-C interfaces come from the same module that implements them by giving both the
clang and Swift modules the same name (WebKitSwift), and importing the clang module via
`@_exported import WebKitSwift`. This allows us to remove the needless @retroactive attributes.

* Source/WebKit/Configurations/WebKitSwift.xcconfig:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebKitSwift/GroupActivities/WKGroupSession.swift:
* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift:
* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift:
* Source/WebKit/WebKitSwift/MarketplaceKit/WKMarketplaceKit.swift:
* Source/WebKit/WebKitSwift/Preview/WKPreviewWindowController.swift:
* Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.swift:
* Source/WebKit/WebKitSwift/StageMode/WKStageMode.swift:
* Source/WebKit/WebKitSwift/TextAnimation/WKTextAnimationManagerIOS.swift:
* Source/WebKit/WebKitSwift/WebKitSwift.swift: Copied from Source/WebKit/WebKitSwift/MarketplaceKit/WKMarketplaceKit.swift.
* Source/WebKit/WebKitSwift/WritingTools/IntelligenceTextEffectViewManager.swift:
* Source/WebKit/WebKitSwift/WritingTools/PlatformIntelligenceTextEffectView.swift:
* Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceReplacementTextEffectCoordinator.swift:
* Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceSmartReplyTextEffectCoordinator.swift:

Canonical link: <a href="https://commits.webkit.org/296629@main">https://commits.webkit.org/296629@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e255a029f586b1335ccc55c1eb0f6ce0738a724

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109105 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28765 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19190 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114316 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59404 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111068 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29448 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37332 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82916 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112053 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23425 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98267 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63361 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22826 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16409 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/58998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92796 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16452 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117434 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36153 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26724 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91931 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36524 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94531 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91737 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23357 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36649 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14401 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32011 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36050 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41555 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35744 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39082 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37429 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->