### PR TITLE
Setting innerHTML doesn't always use a scoped custom element registry associated with the context object

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Element-innerHTML-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Element-innerHTML-expected.txt
@@ -1,4 +1,6 @@
 
 PASS innerHTML on a disconnected element should use the scoped registry it was created with
+PASS nested descendants in innerHTML on a disconnected element should use the scoped registry the element was created with
+PASS innerHTML on a disconnected element should use the scoped registry it was created with when parsing a simple HTML
 PASS innerHTML on an inserted element should continue to use the scoped registry it was created with
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Element-innerHTML.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Element-innerHTML.html
@@ -32,12 +32,56 @@ test((test) => {
     class ScopedOtherElement extends HTMLElement { };
     registry.define('other-element', ScopedOtherElement);
 
-    const shadowRoot = createConnectedShadowTree(test, registry);
     const someElement = document.createElement('some-element', {customElementRegistry: registry});
     assert_true(someElement instanceof ScopedSomeElement);
     someElement.innerHTML = '<other-element></other-element>';
     assert_true(someElement.querySelector('other-element') instanceof ScopedOtherElement);
 }, 'innerHTML on a disconnected element should use the scoped registry it was created with');
+
+test((test) => {
+    const registry = new CustomElementRegistry;
+
+    class ScopedSomeElement extends HTMLElement { };
+    registry.define('some-element', ScopedSomeElement);
+
+    class ScopedOtherElement extends HTMLElement { };
+    registry.define('other-element', ScopedOtherElement);
+
+    const someElement = document.createElement('some-element', {customElementRegistry: registry});
+    assert_true(someElement instanceof ScopedSomeElement);
+    someElement.innerHTML = `
+        <other-element id="foo">
+            <other-element id="bar">
+                <div id="baz">
+                    <other-element id="nested-ce"></other-element>
+                </div>
+            </other-element>
+        </other-element>
+        <div id="bux"></div>
+        <another-element></another-element>`;
+
+    assert_true(someElement.querySelector('#foo') instanceof ScopedOtherElement);
+    assert_true(someElement.querySelector('#bar') instanceof ScopedOtherElement);
+    assert_true(someElement.querySelector('#nested-ce') instanceof ScopedOtherElement);
+
+    assert_true(someElement.querySelector('#foo').customElementRegistry === registry);
+    assert_true(someElement.querySelector('#bar').customElementRegistry === registry);
+    assert_true(someElement.querySelector('#baz').customElementRegistry === registry);
+    assert_true(someElement.querySelector('#nested-ce').customElementRegistry === registry);
+    assert_true(someElement.querySelector('#bux').customElementRegistry === registry);
+    assert_true(someElement.querySelector('another-element').customElementRegistry === registry);
+}, 'nested descendants in innerHTML on a disconnected element should use the scoped registry the element was created with');
+
+test((test) => {
+    const registry = new CustomElementRegistry;
+
+    class ScopedSomeElement extends HTMLElement { };
+    registry.define('some-element', ScopedSomeElement);
+
+    const div = document.createElement('div', {customElementRegistry: registry});
+    div.innerHTML = '<span></span>';
+    assert_equals(div.querySelector('span').customElementRegistry, registry);
+}, 'innerHTML on a disconnected element should use the scoped registry it was created with when parsing a simple HTML');
 
 test((test) => {
     const registry1 = new CustomElementRegistry;

--- a/Source/WebCore/dom/DocumentFragment.cpp
+++ b/Source/WebCore/dom/DocumentFragment.cpp
@@ -93,7 +93,7 @@ Ref<Node> DocumentFragment::cloneNodeInternal(Document& document, CloningOperati
 void DocumentFragment::parseHTML(const String& source, Element& contextElement, OptionSet<ParserContentPolicy> parserContentPolicy, CustomElementRegistry* registry)
 {
     Ref document = this->document();
-    if (tryFastParsingHTMLFragment(source, document, *this, contextElement, parserContentPolicy)) {
+    if (!registry && tryFastParsingHTMLFragment(source, document, *this, contextElement, parserContentPolicy)) {
 #if ASSERT_ENABLED
         // As a sanity check for the fast-path, create another fragment using the full parser and compare the results.
         auto referenceFragment = DocumentFragment::create(document);

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -827,16 +827,14 @@ std::tuple<RefPtr<HTMLElement>, RefPtr<JSCustomElementInterface>, RefPtr<CustomE
     Ref ownerDocument = treeScope->documentScope();
     bool insideTemplateElement = m_openElements.containsTemplateElement();
     RefPtr element = HTMLElementFactory::createKnownElement(token.tagName(), ownerDocument, insideTemplateElement ? nullptr : form(), true);
+    RefPtr<CustomElementRegistry> registry = m_openElements.stackDepth() > 1 ? registryForCurrentNode(currentNode(), treeScope) : m_registry;
     if (!element) [[unlikely]] {
-        RefPtr<CustomElementRegistry> registry = m_openElements.stackDepth() > 1 ? registryForCurrentNode(currentNode(), treeScope) : m_registry;
         auto* elementInterface = registry ? registry->findInterface(token.name()) : nullptr;
         if (elementInterface) [[unlikely]] {
             if (!m_isParsingFragment)
                 return { nullptr, elementInterface, WTFMove(registry) };
             ASSERT(qualifiedNameForHTMLTag(token) == elementInterface->name());
             element = elementInterface->createElement(ownerDocument);
-            if (registry->isScoped()) [[unlikely]]
-                CustomElementRegistry::addToScopedCustomElementRegistryMap(*element, *registry);
             element->setIsCustomElementUpgradeCandidate();
             element->enqueueToUpgrade(*elementInterface);
         } else {
@@ -851,6 +849,8 @@ std::tuple<RefPtr<HTMLElement>, RefPtr<JSCustomElementInterface>, RefPtr<CustomE
             element->setUsesNullCustomElementRegistry();
     }
     ASSERT(element);
+    if (registry && registry->isScoped() && registry != treeScope->customElementRegistry()) [[unlikely]]
+        CustomElementRegistry::addToScopedCustomElementRegistryMap(*element, *registry);
 
     // FIXME: This is a hack to connect images to pictures before the image has
     // been inserted into the document. It can be removed once asynchronous image


### PR DESCRIPTION
#### 78eef71291c83deedd9620cf3aa709dda414ad48
<pre>
Setting innerHTML doesn&apos;t always use a scoped custom element registry associated with the context object
<a href="https://bugs.webkit.org/show_bug.cgi?id=294956">https://bugs.webkit.org/show_bug.cgi?id=294956</a>

Reviewed by Anne van Kesteren.

The bug was caused by HTMLConstructionSite::createHTMLElementOrFindCustomElementInterface not associating the newly created
element with the scoped custom element registry. This PR also fixes a bug in DocumentFragment::parseHTML that fast HTML parser
ignores scoped custom element registry by disabling fast parser when registry is not null.

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Element-innerHTML-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Element-innerHTML.html: Synced as of
461b1b8ef3b0c998ab27ba57e85643f07a443096.
* Source/WebCore/dom/DocumentFragment.cpp:
(WebCore::DocumentFragment::parseHTML):
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::HTMLConstructionSite::createHTMLElementOrFindCustomElementInterface):

Canonical link: <a href="https://commits.webkit.org/296637@main">https://commits.webkit.org/296637@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44e59c71ae825ad734291cb3f467bfeab8b12393

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109133 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28791 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114341 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59424 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29472 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37357 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82935 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112081 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23447 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98293 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63382 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22847 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16435 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/59009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92818 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16478 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117456 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36177 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26748 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91951 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36549 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94556 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91757 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36673 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14423 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32032 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17613 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36074 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41578 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35767 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39104 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37453 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->