### PR TITLE
[visionOS] Gaze glow shape is incorrect for elements with associated label and non-uniform border radii or clip path

### DIFF
--- a/LayoutTests/interaction-region/clip-path-with-label-expected.txt
+++ b/LayoutTests/interaction-region/clip-path-with-label-expected.txt
@@ -1,0 +1,22 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 1600.00 2092.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 1600.00 2092.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=1600 height=2092)
+
+      (interaction regions [
+        (interaction (4,3) width=116.84 height=44)
+        (clipPath move to (36,8), add line to (36,8), add curve to (36,3.58) (39.58,0) (44,0), add line to (108.84,0), add line to (108.84,0), add curve to (113.26,0) (116.84,3.58) (116.84,8), add line to (116.84,36), add line to (116.84,36), add curve to (116.84,40.42) (113.26,44) (108.84,44), add line to (44,44), add line to (44,44), add curve to (39.58,44) (36,40.42) (36,36), close subpath, move to (32,19), add curve to (32,27.84) (24.84,35) (16,35), add curve to (7.16,35) (0,27.84) (0,19), add curve to (0,10.16) (7.16,3) (16,3), add curve to (24.84,3) (32,10.16) (32,19), close subpath),
+        (interaction (4,50) width=124.84 height=57)
+        (clipPath move to (44,13), add line to (44,13), add line to (124.84,13), add line to (124.84,13), add line to (124.84,57), add line to (124.84,57), add line to (44,57), add line to (44,57), close subpath, move to (40,16.13), add line to (40,23.23), add curve to (40,32.49) (32.49,40) (23.23,40), add line to (23.22,40), add curve to (10.40,40) (0,29.60) (0,16.78), add line to (0,2.58), add curve to (0,1.15) (1.15,0) (2.58,0), add line to (30.97,0), add curve to (35.96,0) (40,4.04) (40,9.03), close subpath)])
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/clip-path-with-label.html
+++ b/LayoutTests/interaction-region/clip-path-with-label.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta name="viewport" content="width=1600">
+    <style>
+        body { margin: 0; }
+        input, label { zoom: 2; }
+        #circle-checkbox { clip-path: circle(50% at 50% 50%); }
+        
+        #non-uniform-border-radii-checkbox {
+            appearance: none;
+            border-radius: 2px 7px 13px 18px;
+            width: 20px;
+            height: 20px;
+            background-color: blue;
+        }
+    </style>
+</head>
+<body>
+<div id="test">
+    <section>
+       <input id="circle-checkbox" name="circle-checkbox" type="checkbox">
+       <label for="circle-checkbox">Label</label>
+       <br>
+       <input id="non-uniform-border-radii-checkbox" name="non-uniform-border-radii-checkbox" type="checkbox">
+       <label for="non-uniform-border-radii-checkbox">Label</label>
+    </section>
+</div>
+<pre id="results"></pre>
+<script>
+document.body.addEventListener("click", function(e) {
+    console.log(e, "event delegation");
+});
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = function () {
+    if (!window.internals)
+       return;
+
+   results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+   document.getElementById('test').remove();
+};
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### b1e40d13effbbf84d58e2b9a575aff21ade320cb
<pre>
[visionOS] Gaze glow shape is incorrect for elements with associated label and non-uniform border radii or clip path
<a href="https://bugs.webkit.org/show_bug.cgi?id=294952">https://bugs.webkit.org/show_bug.cgi?id=294952</a>
<a href="https://rdar.apple.com/154258426">rdar://154258426</a>

Reviewed by Abrar Rahman Protyasha.

During the shrink wrapping of interaction regions, we previously
collected the rect of each discovered region, and then set the
clip path equal to the result of `pathWithShrinkWrappedRects`
with the collected rects passed as a parameter.

Now, for each discovered region, we only add its rect to the
collection if the region does not have a clip path. If a clip
path is present, we add it a collection of clip paths. The
final clip path is then set to a path consisting of all of the
discovered clip paths + the result of `pathWithShrinkWrappedRect`
for the collected rects.

* LayoutTests/interaction-region/clip-path-with-label-expected.txt: Added.
* LayoutTests/interaction-region/clip-path-with-label.html: Added.
* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegionContext::shrinkWrapInteractionRegions):

Canonical link: <a href="https://commits.webkit.org/296646@main">https://commits.webkit.org/296646@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5685983e0a554c8e5f94667579bed7d40b497f75

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109147 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28805 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19232 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114355 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59434 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111110 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29486 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37429 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82944 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112095 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23460 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98308 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63391 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22857 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16450 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/59016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92831 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16493 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117470 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36191 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/26798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91962 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36563 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94571 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91768 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23371 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36685 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14437 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/32052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36087 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41589 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35778 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39115 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37465 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->