### PR TITLE
[JSC] Simplify double-to-string cache

### DIFF
--- a/Source/JavaScriptCore/runtime/NumberPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/NumberPrototype.cpp
@@ -495,8 +495,10 @@ JSString* NumericStrings::addJSString(VM& vm, int i)
         entry.jsString = jsNontrivialString(vm, entry.value);
         return entry.jsString;
     }
+
+    ASSERT(i);
     auto& entry = lookup(i);
-    if (i != entry.key || entry.value.isNull()) {
+    if (i != entry.key) {
         entry.key = i;
         entry.value = String::number(i);
     } else {
@@ -507,12 +509,16 @@ JSString* NumericStrings::addJSString(VM& vm, int i)
     return entry.jsString;
 }
 
-JSString* NumericStrings::addJSString(VM& vm, double value)
+JSString* NumericStrings::addJSString(VM& vm, double d)
 {
-    auto& entry = lookup(value);
-    if (value != entry.key || entry.value.isNull()) {
+    uint64_t value = std::bit_cast<uint64_t>(d);
+    if (!value)
+        return addJSString(vm, 0);
+
+    auto& entry = lookupDouble(value);
+    if (value != entry.key) {
         entry.key = value;
-        entry.value = String::number(value);
+        entry.value = String::number(d);
     } else {
         if (entry.jsString)
             return entry.jsString;

--- a/Source/JavaScriptCore/runtime/NumericStrings.h
+++ b/Source/JavaScriptCore/runtime/NumericStrings.h
@@ -40,13 +40,13 @@ public:
 
     template<typename T>
     struct CacheEntry {
-        T key;
+        T key { };
         String value;
     };
 
     template<typename T>
     struct CacheEntryWithJSString {
-        T key;
+        T key { };
         String value;
         JSString* jsString { nullptr };
     };
@@ -60,10 +60,14 @@ public:
 
     ALWAYS_INLINE const String& add(double d)
     {
-        auto& entry = lookup(d);
-        if (d == entry.key && !entry.value.isNull())
+        uint64_t value = std::bit_cast<uint64_t>(d);
+        if (!value)
+            return lookupSmallString(0).value;
+
+        auto& entry = lookupDouble(value);
+        if (value == entry.key)
             return entry.value;
-        entry.key = d;
+        entry.key = value;
         entry.value = String::number(d);
         entry.jsString = nullptr;
         return entry.value;
@@ -71,10 +75,12 @@ public:
 
     ALWAYS_INLINE const String& add(int i)
     {
-        if (static_cast<unsigned>(i) < cacheSize)
+        if (static_cast<unsigned>(i) < m_smallIntCache.size())
             return lookupSmallString(static_cast<unsigned>(i)).value;
+
+        ASSERT(i);
         auto& entry = lookup(i);
-        if (i == entry.key && !entry.value.isNull())
+        if (i == entry.key)
             return entry.value;
         entry.key = i;
         entry.value = String::number(i);
@@ -84,10 +90,12 @@ public:
 
     ALWAYS_INLINE const String& add(unsigned i)
     {
-        if (i < cacheSize)
+        if (i < m_smallIntCache.size())
             return lookupSmallString(static_cast<unsigned>(i)).value;
+
+        ASSERT(i);
         auto& entry = lookup(i);
-        if (i == entry.key && !entry.value.isNull())
+        if (i == entry.key)
             return entry.value;
         entry.key = i;
         entry.value = String::number(i);
@@ -125,12 +133,12 @@ public:
     void initializeSmallIntCache(VM&);
 
 private:
-    CacheEntryWithJSString<double>& lookup(double d) { return m_doubleCache[WTF::FloatHash<double>::hash(d) & (cacheSize - 1)]; }
-    CacheEntryWithJSString<int>& lookup(int i) { return m_intCache[WTF::IntHash<int>::hash(i) & (cacheSize - 1)]; }
-    CacheEntry<unsigned>& lookup(unsigned i) { return m_unsignedCache[WTF::IntHash<unsigned>::hash(i) & (cacheSize - 1)]; }
+    CacheEntryWithJSString<uint64_t>& lookupDouble(uint64_t d) { return m_doubleCache[WTF::IntHash<uint64_t>::hash(d) & (m_doubleCache.size() - 1)]; }
+    CacheEntryWithJSString<int>& lookup(int i) { return m_intCache[WTF::IntHash<int>::hash(i) & (m_intCache.size() - 1)]; }
+    CacheEntry<unsigned>& lookup(unsigned i) { return m_unsignedCache[WTF::IntHash<unsigned>::hash(i) & (m_unsignedCache.size() - 1)]; }
     ALWAYS_INLINE StringWithJSString& lookupSmallString(unsigned i)
     {
-        ASSERT(i < cacheSize);
+        ASSERT(i < m_smallIntCache.size());
         if (m_smallIntCache[i].value.isNull())
             m_smallIntCache[i].value = String::number(i);
         return m_smallIntCache[i];
@@ -138,7 +146,7 @@ private:
 
     std::array<StringWithJSString, cacheSize> m_smallIntCache { };
     std::array<CacheEntryWithJSString<int>, cacheSize> m_intCache { };
-    std::array<CacheEntryWithJSString<double>, cacheSize> m_doubleCache { };
+    std::array<CacheEntryWithJSString<uint64_t>, cacheSize> m_doubleCache { };
     std::array<CacheEntry<unsigned>, cacheSize> m_unsignedCache { };
 };
 


### PR DESCRIPTION
#### 411d996262ca03b105fdb82c8350331e3fdfd54b
<pre>
[JSC] Simplify double-to-string cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=294959">https://bugs.webkit.org/show_bug.cgi?id=294959</a>
<a href="https://rdar.apple.com/154269517">rdar://154269517</a>

Reviewed by NOBODY (OOPS!).

WIP

* Source/JavaScriptCore/runtime/NumberPrototype.cpp:
(JSC::NumericStrings::addJSString):
* Source/JavaScriptCore/runtime/NumericStrings.h:
(JSC::NumericStrings::add):
(JSC::NumericStrings::lookupDouble):
(JSC::NumericStrings::lookup):
(JSC::NumericStrings::lookupSmallString):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/411d996262ca03b105fdb82c8350331e3fdfd54b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109100 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28760 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19185 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114311 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59399 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29443 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37327 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82914 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112048 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23420 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98265 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63359 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22820 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16407 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58994 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/101629 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92791 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16450 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117429 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/107658 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36148 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26720 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91934 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36519 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94529 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91740 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36646 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14399 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32006 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36045 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41550 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/131929 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35738 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35758 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39077 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37424 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->