### PR TITLE
[WPE][cross-toolchain-helper] Enable opus codec support for GStreamer

### DIFF
--- a/Tools/yocto/rpi/local-rpi3-32bits-mesa.conf
+++ b/Tools/yocto/rpi/local-rpi3-32bits-mesa.conf
@@ -43,6 +43,10 @@ PREFERRED_PROVIDER_virtual/wpebackend = "wpebackend-fdo"
 # Enable GStreamer plugin for accelerated video decoding with RPi opens source drivers.
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " v4l2codecs"
 
+# Enable opus codec support in GStreamer
+PACKAGECONFIG:append:pn-gstreamer1.0-plugins-base = " opus"
+PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " opusparse"
+
 # Add netdata to automatically collect system performance metrics
 IMAGE_INSTALL:append = " netdata"
 

--- a/Tools/yocto/rpi/local-rpi3-32bits-userland.conf
+++ b/Tools/yocto/rpi/local-rpi3-32bits-userland.conf
@@ -45,6 +45,10 @@ PACKAGECONFIG:pn-wpebackend-rdk = "rpi input-libinput input-udev"
 # Install GStreamer plugin for accelerated video decoding with RPi propietary drivers.
 IMAGE_INSTALL:append = " gstreamer1.0-omx"
 
+# Enable opus codec support in GStreamer
+PACKAGECONFIG:append:pn-gstreamer1.0-plugins-base = " opus"
+PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " opusparse"
+
 # Workarounds for buildfailures with userland graphic drivers
 # Can be removed once https://github.com/agherzan/meta-raspberrypi/pull/1118 is integrated into meta-raspberry
 PACKAGECONFIG:remove:pn-weston = "egl clients"

--- a/Tools/yocto/rpi/local-rpi3-64bits-mesa.conf
+++ b/Tools/yocto/rpi/local-rpi3-64bits-mesa.conf
@@ -43,6 +43,10 @@ PREFERRED_PROVIDER_virtual/wpebackend = "wpebackend-fdo"
 # Enable GStreamer plugin for accelerated video decoding with RPi opens source drivers.
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " v4l2codecs"
 
+# Enable opus codec support in GStreamer
+PACKAGECONFIG:append:pn-gstreamer1.0-plugins-base = " opus"
+PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " opusparse"
+
 # Add netdata to automatically collect system performance metrics
 IMAGE_INSTALL:append = " netdata"
 

--- a/Tools/yocto/rpi/local-rpi4-32bits-mesa.conf
+++ b/Tools/yocto/rpi/local-rpi4-32bits-mesa.conf
@@ -43,6 +43,10 @@ PREFERRED_PROVIDER_virtual/wpebackend = "wpebackend-fdo"
 # Enable GStreamer plugin for accelerated video decoding with RPi opens source drivers.
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " v4l2codecs"
 
+# Enable opus codec support in GStreamer
+PACKAGECONFIG:append:pn-gstreamer1.0-plugins-base = " opus"
+PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " opusparse"
+
 # Add netdata to automatically collect system performance metrics
 IMAGE_INSTALL:append = " netdata"
 

--- a/Tools/yocto/rpi/local-rpi4-64bits-mesa.conf
+++ b/Tools/yocto/rpi/local-rpi4-64bits-mesa.conf
@@ -43,6 +43,10 @@ PREFERRED_PROVIDER_virtual/wpebackend = "wpebackend-fdo"
 # Enable GStreamer plugin for accelerated video decoding with RPi opens source drivers.
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " v4l2codecs"
 
+# Enable opus codec support in GStreamer
+PACKAGECONFIG:append:pn-gstreamer1.0-plugins-base = " opus"
+PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " opusparse"
+
 # Add netdata to automatically collect system performance metrics
 IMAGE_INSTALL:append = " netdata"
 


### PR DESCRIPTION
#### 75545d0391e1e9fab19eaf859079bed170bded0d
<pre>
[WPE][cross-toolchain-helper] Enable opus codec support for GStreamer
<a href="https://bugs.webkit.org/show_bug.cgi?id=294962">https://bugs.webkit.org/show_bug.cgi?id=294962</a>

Reviewed by Adrian Perez de Castro.

Some multimedia tests rely on the presence of opus codec support,
thus enable that feature in GStreamer in our webkitdevci image.

* Tools/yocto/rpi/local-rpi3-32bits-mesa.conf:
* Tools/yocto/rpi/local-rpi3-32bits-userland.conf:
* Tools/yocto/rpi/local-rpi3-64bits-mesa.conf:
* Tools/yocto/rpi/local-rpi4-32bits-mesa.conf:
* Tools/yocto/rpi/local-rpi4-64bits-mesa.conf:

Canonical link: <a href="https://commits.webkit.org/296611@main">https://commits.webkit.org/296611@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7580839a42c29ee001b081c5bc242c2dd0d4f79e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109080 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28740 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19165 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114291 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59379 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111043 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29423 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37306 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82891 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112028 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23403 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98243 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63336 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22803 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16383 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58975 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92773 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16428 "Found 1 new test failure: fast/mediastream/video-background-with-canvas.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117409 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36128 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26700 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91905 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36499 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94507 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91712 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23345 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36627 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14377 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31978 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36025 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35718 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39057 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37404 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->