### PR TITLE
[Skia] Symbols with the emoji variation selector are rendered with the text version

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2703,6 +2703,8 @@ imported/w3c/web-platform-tests/fetch/metadata/window-open.https.sub.html [ Skip
 # This test times out only in mac-wk1, WPE and GTK.
 imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-order.html [ Skip ]
 
+webkit.org/b/260972 imported/w3c/web-platform-tests/css/css-fonts/font-variant-emoji-2.html [ ImageOnlyFailure ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of WPT-related bugs
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/glib/fast/text/emoji-expected.txt
+++ b/LayoutTests/platform/glib/fast/text/emoji-expected.txt
@@ -11,9 +11,9 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,1) size 20x17
           text run at (0,1) width 20: "\x{D83D}\x{DE01}"
       RenderBlock {DIV} at (0,55) size 784x375
-        RenderText {#text} at (0,2) size 534x71
-          text run at (0,2) width 534: "\x{D83D}\x{DC66}\x{D83C}\x{DFFB}\x{D83D}\x{DC69}\x{D83C}\x{DFFC}\x{D83D}\x{DC66}\x{D83C}\x{DFFE}\x{2764}\x{FE0F}\x{D83D}\x{DC8B}\x{D83D}\x{DD75}\x{D83C}\x{DFFB}\x{D83C}\x{DFC7}\x{D83C}\x{DFFB}"
-        RenderBR {BR} at (534,2) size 0x71
+        RenderText {#text} at (0,2) size 560x71
+          text run at (0,2) width 560: "\x{D83D}\x{DC66}\x{D83C}\x{DFFB}\x{D83D}\x{DC69}\x{D83C}\x{DFFC}\x{D83D}\x{DC66}\x{D83C}\x{DFFE}\x{2764}\x{FE0F}\x{D83D}\x{DC8B}\x{D83D}\x{DD75}\x{D83C}\x{DFFB}\x{D83C}\x{DFC7}\x{D83C}\x{DFFB}"
+        RenderBR {BR} at (560,2) size 0x71
         RenderText {#text} at (0,77) size 528x71
           text run at (0,77) width 528: "\x{D83D}\x{DC68}\x{200D}\x{D83D}\x{DC69}\x{200D}\x{D83D}\x{DC66} \x{D83D}\x{DC68}\x{200D}\x{D83D}\x{DC69}\x{200D}\x{D83D}\x{DC67} \x{D83D}\x{DC6A} \x{D83D}\x{DC66}\x{D83C}\x{DFFB}\x{D83D}\x{DC69}\x{D83C}\x{DFFC}\x{D83D}\x{DC66}\x{D83C}\x{DFFE}"
         RenderBR {BR} at (528,77) size 0x71

--- a/Source/WTF/wtf/unicode/CharacterNames.h
+++ b/Source/WTF/wtf/unicode/CharacterNames.h
@@ -61,6 +61,7 @@ constexpr char16_t doubleHighReversed9QuotationMark = 0x201F;
 constexpr char16_t doubleLowReversed9QuotationMark = 0x2E42;
 constexpr char16_t doublePrimeQuotationMark = 0x301E;
 constexpr char16_t emSpace = 0x2003;
+constexpr char32_t emojiCat = 0x1F408;
 constexpr char16_t emojiVariationSelector = 0xFE0F; // Technical name is "VARIATION SELECTOR-16"
 constexpr char16_t enDash = 0x2013;
 constexpr char16_t ethiopicPrefaceColon = 0x1366;
@@ -201,6 +202,7 @@ using WTF::Unicode::doubleHighReversed9QuotationMark;
 using WTF::Unicode::doubleLowReversed9QuotationMark;
 using WTF::Unicode::doublePrimeQuotationMark;
 using WTF::Unicode::emSpace;
+using WTF::Unicode::emojiCat;
 using WTF::Unicode::emojiVariationSelector;
 using WTF::Unicode::enDash;
 using WTF::Unicode::ethiopicPrefaceColon;

--- a/Source/WebCore/platform/graphics/skia/FontCascadeSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCascadeSkia.cpp
@@ -127,7 +127,14 @@ RefPtr<const Font> FontCascade::fontForCombiningCharacterSequence(StringView str
     char32_t baseCharacter = *codePointsIterator;
     ++codePointsIterator;
     bool isOnlySingleCodePoint = codePointsIterator == codePoints.end();
-    GlyphData baseCharacterGlyphData = glyphDataForCharacter(baseCharacter, false, NormalVariant);
+
+    char32_t baseCharacterForBaseFont = baseCharacter;
+    if (!isOnlySingleCodePoint && *codePointsIterator == emojiVariationSelector) {
+        // System fallback doesn't support character sequences, so here we override
+        // the base character with the cat emoji to try to force an emoji font.
+        baseCharacterForBaseFont = emojiCat;
+    }
+    GlyphData baseCharacterGlyphData = glyphDataForCharacter(baseCharacterForBaseFont, false, NormalVariant);
     if (!baseCharacterGlyphData.glyph)
         return nullptr;
 


### PR DESCRIPTION
#### 718cbaab72f862b05fb577379234d5776229ce48
<pre>
[Skia] Symbols with the emoji variation selector are rendered with the text version
<a href="https://bugs.webkit.org/show_bug.cgi?id=294966">https://bugs.webkit.org/show_bug.cgi?id=294966</a>

Reviewed by Adrian Perez de Castro.

The system fallback fonts code only supports querying the font by a
single charater, so in case of a cluster consisting of base character +
emoji variation selector, the variation selector is ignored and if
there&apos;s a non-emoji font supporting the base character it&apos;s used instead.
In that case we can override the base character with an emoji character
when querying the font to try to ensure an emoji font is retrieved.

Canonical link: <a href="https://commits.webkit.org/296658@main">https://commits.webkit.org/296658@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9a88b5b9bbfdfae30312fe1a9389fa0db65b4c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109233 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28891 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114440 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59504 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111196 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37480 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83011 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112181 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23536 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98385 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63461 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22926 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16529 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59066 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/101749 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92903 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16570 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117556 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/107791 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36277 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26840 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92026 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36649 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94648 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91835 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36759 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14510 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32108 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17620 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36173 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41661 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/132060 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35859 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35790 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39191 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37550 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->