### PR TITLE
Remove respondsToSelector for minimizedLanguagesFromLanguages

### DIFF
--- a/Source/WTF/wtf/cocoa/LanguageCocoa.mm
+++ b/Source/WTF/wtf/cocoa/LanguageCocoa.mm
@@ -68,7 +68,7 @@ LocaleComponents parseLocale(const String& localeIdentifier)
 bool canMinimizeLanguages()
 {
     static const bool result = []() -> bool {
-        return linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::MinimizesLanguages) && [NSLocale respondsToSelector:@selector(minimizedLanguagesFromLanguages:)];
+        return linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::MinimizesLanguages);
     }();
     return result;
 }


### PR DESCRIPTION
#### 2a42bd7336447425938af65f5a5e74745715073d
<pre>
Remove respondsToSelector for minimizedLanguagesFromLanguages
<a href="https://bugs.webkit.org/show_bug.cgi?id=294968">https://bugs.webkit.org/show_bug.cgi?id=294968</a>

Reviewed by NOBODY (OOPS!).

This is supported by all relevant Cocoa SDKs.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a42bd7336447425938af65f5a5e74745715073d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28749 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19174 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114300 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59388 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29432 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37316 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82903 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112037 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23412 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98254 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63348 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22812 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16396 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58984 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/101618 "Found 2599 jsc stress test failures: ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Basics/equal_object.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/bug934443.js.default, ChakraCore.yaml/ChakraCore/test/GlobalFunctions/InternalToString.js.default, ChakraCore.yaml/ChakraCore/test/Object/toLocaleStringBasics.js.default ..., JSC test binary failure: testapi") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92783 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16439 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117418 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/107647 "Found 1 new JSC binary failure: testapi, Found 2598 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Basics/equal_object.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/bug934443.js.default, ChakraCore.yaml/ChakraCore/test/GlobalFunctions/InternalToString.js.default, ChakraCore.yaml/ChakraCore/test/Object/toLocaleStringBasics.js.default, ChakraCore.yaml/ChakraCore/test/Operators/equals.js.default, ChakraCore.yaml/ChakraCore/test/Strings/compare.js.default, ChakraCore.yaml/ChakraCore/test/es5/DateGetSet9.js.default, ChakraCore.yaml/ChakraCore/test/fieldopts/objtypespec-newobj.2.js.default, cdjs-tests.yaml/main.js.bytecode-cache ... (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36137 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26709 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91919 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36508 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91725 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36634 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14388 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31987 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36034 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41539 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/131918 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35727 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35755 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39066 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37413 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->