### PR TITLE
Remove respondsToSelector for AVOutputContext

### DIFF
--- a/Source/WebCore/PAL/pal/avfoundation/OutputContext.mm
+++ b/Source/WebCore/PAL/pal/avfoundation/OutputContext.mm
@@ -47,9 +47,6 @@ OutputContext::OutputContext(RetainPtr<AVOutputContext>&& context)
 std::optional<OutputContext>& OutputContext::sharedAudioPresentationOutputContext()
 {
     static NeverDestroyed<std::optional<OutputContext>> sharedAudioPresentationOutputContext = [] () -> std::optional<OutputContext> {
-        if (![PAL::getAVOutputContextClass() respondsToSelector:@selector(sharedAudioPresentationOutputContext)])
-            return std::nullopt;
-
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
         AVOutputContext* context = [getAVOutputContextClass() sharedSystemAudioContext];
 #else
@@ -65,9 +62,7 @@ std::optional<OutputContext>& OutputContext::sharedAudioPresentationOutputContex
 
 bool OutputContext::supportsMultipleOutputDevices()
 {
-    return [m_context respondsToSelector:@selector(supportsMultipleOutputDevices)]
-        && [m_context respondsToSelector:@selector(outputDevices)]
-        && [m_context supportsMultipleOutputDevices];
+    return [m_context supportsMultipleOutputDevices];
 }
 
 String OutputContext::deviceName()
@@ -82,18 +77,11 @@ String OutputContext::deviceName()
 
 Vector<OutputDevice> OutputContext::outputDevices() const
 {
-    if (![m_context respondsToSelector:@selector(outputDevices)]) {
-        if (auto *outputDevice = [m_context outputDevice])
-            return { retainPtr(outputDevice) };
-        return { };
-    }
-
     auto *avOutputDevices = [m_context outputDevices];
     return Vector<OutputDevice>(avOutputDevices.count, [&](size_t i) {
         return OutputDevice { retainPtr((AVOutputDevice *)avOutputDevices[i]) };
     });
 }
-
 
 }
 

--- a/Source/WebCore/PAL/pal/spi/cocoa/AVFoundationSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AVFoundationSPI.h
@@ -115,7 +115,7 @@ typedef NSString * AVVideoRange NS_TYPED_ENUM;
 - (void)requestNotificationOfMediaDataChangeAsSoonAsPossible;
 @end
 
-#if ENABLE(WIRELESS_PLAYBACK_TARGET) || PLATFORM(IOS_FAMILY)
+#if ENABLE(WIRELESS_PLAYBACK_TARGET)
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -166,7 +166,7 @@ typedef NS_ENUM(NSInteger, AVPlayerExternalPlaybackType) {
 
 NS_ASSUME_NONNULL_END
 
-#endif // ENABLE(WIRELESS_PLAYBACK_TARGET) || PLATFORM(IOS_FAMILY)
+#endif // ENABLE(WIRELESS_PLAYBACK_TARGET)
 
 #import <AVFoundation/AVAssetCache.h>
 NS_ASSUME_NONNULL_BEGIN

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.mm
@@ -63,12 +63,12 @@ String MediaPlaybackTargetContextCocoa::deviceName() const
 
 bool MediaPlaybackTargetContextCocoa::hasActiveRoute() const
 {
-    if ([m_outputContext respondsToSelector:@selector(supportsMultipleOutputDevices)] && [m_outputContext supportsMultipleOutputDevices] && [m_outputContext respondsToSelector:@selector(outputDevices)]) {
+    if ([m_outputContext supportsMultipleOutputDevices]) {
         for (AVOutputDevice *outputDevice in [m_outputContext outputDevices]) {
             if (outputDevice.deviceFeatures & (AVOutputDeviceFeatureVideo | AVOutputDeviceFeatureAudio))
                 return true;
         }
-    } else if ([m_outputContext respondsToSelector:@selector(outputDevice)]) {
+    } else {
         if (auto *outputDevice = [m_outputContext outputDevice])
             return outputDevice.deviceFeatures & (AVOutputDeviceFeatureVideo | AVOutputDeviceFeatureAudio);
     }
@@ -76,14 +76,6 @@ bool MediaPlaybackTargetContextCocoa::hasActiveRoute() const
 }
 bool MediaPlaybackTargetContextCocoa::supportsRemoteVideoPlayback() const
 {
-    if (![m_outputContext respondsToSelector:@selector(supportsMultipleOutputDevices)] || ![m_outputContext supportsMultipleOutputDevices] || ![m_outputContext respondsToSelector:@selector(outputDevices)]) {
-        if (auto *outputDevice = [m_outputContext outputDevice]) {
-            if (outputDevice.deviceFeatures & AVOutputDeviceFeatureVideo)
-                return true;
-        }
-        return false;
-    }
-
     for (AVOutputDevice *outputDevice in [m_outputContext outputDevices]) {
         if (outputDevice.deviceFeatures & AVOutputDeviceFeatureVideo)
             return true;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVRoutePickerViewTargetPicker.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVRoutePickerViewTargetPicker.mm
@@ -202,7 +202,7 @@ bool AVRoutePickerViewTargetPicker::hasActiveRoute() const
     if (!m_outputContext)
         return false;
 
-    if ([m_outputContext respondsToSelector:@selector(supportsMultipleOutputDevices)] && [m_outputContext respondsToSelector:@selector(outputDevices)]&& [m_outputContext supportsMultipleOutputDevices]) {
+    if ([m_outputContext supportsMultipleOutputDevices]) {
         for (AVOutputDevice *outputDevice in [m_outputContext outputDevices]) {
             if (outputDevice.deviceFeatures & (AVOutputDeviceFeatureVideo | AVOutputDeviceFeatureAudio))
                 return true;
@@ -211,10 +211,8 @@ bool AVRoutePickerViewTargetPicker::hasActiveRoute() const
         return false;
     }
 
-    if ([m_outputContext respondsToSelector:@selector(outputDevice)]) {
-        if (auto *outputDevice = [m_outputContext outputDevice])
-            return outputDevice.deviceFeatures & (AVOutputDeviceFeatureVideo | AVOutputDeviceFeatureAudio);
-    }
+    if (auto *outputDevice = [m_outputContext outputDevice])
+        return outputDevice.deviceFeatures & (AVOutputDeviceFeatureVideo | AVOutputDeviceFeatureAudio);
 
     return [m_outputContext deviceName];
 }


### PR DESCRIPTION
#### 0e4b984e61c04d1b9f596543155792e31f7d3fc6
<pre>
Remove respondsToSelector for AVOutputContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=294969">https://bugs.webkit.org/show_bug.cgi?id=294969</a>

Reviewed by Eric Carlson.

ENABLE_WIRELESS_PLAYBACK_TARGET is true for all of Cocoa.
sharedAudioPresentationOutputContext, supportsMultipleOutputDevices,
outputDevices, and outputDevice are supported across all Cocoa SDKs
allowing us to simplify our code.

Canonical link: <a href="https://commits.webkit.org/296723@main">https://commits.webkit.org/296723@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9faabfbcf8eee54b4135ff4d576cf5caccd483ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109090 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28750 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19175 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114301 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59389 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111053 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37317 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82904 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112038 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23661 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98256 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63349 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22811 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16398 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58985 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92782 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16441 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117419 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36138 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26711 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91920 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36509 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94520 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91726 "Found 4 new API test failures: /WebKitGTK/TestResources:/webkit/WebKitWebResource/get-data-error, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/cut-copy-paste/non-editable, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36636 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14390 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31988 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17653 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36035 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41540 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35728 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39067 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37414 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->