### PR TITLE
Remove respondsToSelector for AVOutputDevice

### DIFF
--- a/Source/WebCore/PAL/pal/avfoundation/OutputDevice.mm
+++ b/Source/WebCore/PAL/pal/avfoundation/OutputDevice.mm
@@ -32,11 +32,6 @@
 
 #include <pal/cocoa/AVFoundationSoftLink.h>
 
-// FIXME(rdar://70358894): Remove once -allowsHeadTrackedSpatialAudio lands:
-@interface AVOutputDevice (AllowsHeadTrackedSpatialAudio)
-- (BOOL)allowsHeadTrackedSpatialAudio;
-@end
-
 namespace PAL {
 
 OutputDevice::OutputDevice(RetainPtr<AVOutputDevice>&& device)
@@ -66,12 +61,7 @@ uint8_t OutputDevice::deviceFeatures() const
 
 bool OutputDevice::supportsSpatialAudio() const
 {
-    if (![m_device respondsToSelector:@selector(supportsHeadTrackedSpatialAudio)]
-        || ![m_device supportsHeadTrackedSpatialAudio])
-        return false;
-
-    return ![m_device respondsToSelector:@selector(allowsHeadTrackedSpatialAudio)]
-        || [m_device allowsHeadTrackedSpatialAudio];
+    return [m_device supportsHeadTrackedSpatialAudio] && [m_device allowsHeadTrackedSpatialAudio];
 }
 
 }


### PR DESCRIPTION
#### c3cad65dc73316ac70084e7941b7b84adcccce70
<pre>
Remove respondsToSelector for AVOutputDevice
<a href="https://bugs.webkit.org/show_bug.cgi?id=294970">https://bugs.webkit.org/show_bug.cgi?id=294970</a>

Reviewed by Eric Carlson.

supportsHeadTrackedSpatialAudio and allowsHeadTrackedSpatialAudio are
supported by all Cocoa SDKs.

Canonical link: <a href="https://commits.webkit.org/296724@main">https://commits.webkit.org/296724@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d07e0c51935b96f5e865b5fbee09f848c323f07a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109091 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28751 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114302 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59390 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111054 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29434 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37318 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82906 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112039 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23413 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98255 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63351 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22813 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16397 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58986 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92784 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16440 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117420 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36139 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26710 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91922 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36510 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94519 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91728 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36637 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14389 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31989 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17654 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36036 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41541 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35729 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39068 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37415 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->