### PR TITLE
Remove respondsToSelector from ApplePaySetupFeature

### DIFF
--- a/Source/WebCore/Modules/applepay/ApplePaySetupFeature.mm
+++ b/Source/WebCore/Modules/applepay/ApplePaySetupFeature.mm
@@ -81,10 +81,6 @@ ApplePaySetupFeatureState ApplePaySetupFeature::state() const
 #if ENABLE(APPLE_PAY_INSTALLMENTS)
 bool ApplePaySetupFeature::supportsInstallments() const
 {
-#if PLATFORM(MAC)
-    if (![m_feature respondsToSelector:@selector(supportedOptions)])
-        return false;
-#endif
     return [m_feature supportedOptions] & PKPaymentSetupFeatureSupportedOptionsInstallments;
 }
 #endif

--- a/Source/WebCore/PAL/pal/spi/cocoa/PassKitInstallmentsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/PassKitInstallmentsSPI.h
@@ -113,25 +113,6 @@ typedef NS_ENUM(NSUInteger, PKPaymentRequestType) {
 @property (nonatomic, copy) NSString *installmentGroupIdentifier;
 @end
 
-// FIXME: The SPIs above can be declared by WebKit without causing redeclaration errors on Catalina
-// internal SDKs because we can avoid including the SPIs' private headers from PassKit, but we can't
-// avoid importing PKPaymentSetupFeature.h due to how many other private headers include it. To avoid
-// redeclaration errors while continuing to support all Catalina SDKs, declare -supportedOptions
-// only when building against an internal SDK without PKPaymentInstallmentConfiguration.h (so that we
-// can implement a -respondsToSelector: check). The __has_include portion of this check can be
-// removed once the minimum supported Catalina internal SDK is known to contain this private header.
-#if !__has_include(<PassKitCore/PKPaymentInstallmentConfiguration.h>)
-
-typedef NS_OPTIONS(NSInteger, PKPaymentSetupFeatureSupportedOptions) {
-    PKPaymentSetupFeatureSupportedOptionsInstallments = 1 << 0,
-};
-
-@interface PKPaymentSetupFeature ()
-@property (nonatomic, assign, readonly) PKPaymentSetupFeatureSupportedOptions supportedOptions;
-@end
-
-#endif // !__has_include(<PassKitCore/PKPaymentInstallmentConfiguration.h>)
-
 #endif // !USE(APPLE_INTERNAL_SDK)
 
 #endif // HAVE(PASSKIT_INSTALLMENTS)

--- a/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
@@ -267,6 +267,10 @@ typedef NS_ENUM(NSInteger, PKPaymentSetupFeatureType) {
     PKPaymentSetupFeatureTypeAppleCard,
 };
 
+typedef NS_OPTIONS(NSInteger, PKPaymentSetupFeatureSupportedOptions) {
+    PKPaymentSetupFeatureSupportedOptionsInstallments = 1 << 0,
+};
+
 @interface PKPaymentSetupConfiguration : NSObject <NSSecureCoding>
 @property (nonatomic, copy) NSString *referrerIdentifier;
 @end
@@ -286,6 +290,7 @@ typedef NS_ENUM(NSInteger, PKPaymentSetupFeatureType) {
 @interface PKPaymentSetupFeature : NSObject <NSSecureCoding, NSCopying>
 @property (nonatomic, assign, readonly) PKPaymentSetupFeatureType type;
 @property (nonatomic, assign, readonly) PKPaymentSetupFeatureState state;
+@property (nonatomic, assign, readonly) PKPaymentSetupFeatureSupportedOptions supportedOptions;
 @end
 
 @interface PKPaymentSetupRequest : NSObject <NSSecureCoding>


### PR DESCRIPTION
#### 2b981ab99b248641b1834a1aa889497fa1a3a4c2
<pre>
Remove respondsToSelector from ApplePaySetupFeature
<a href="https://bugs.webkit.org/show_bug.cgi?id=294972">https://bugs.webkit.org/show_bug.cgi?id=294972</a>

Reviewed by Andy Estes.

This mostly reverts 226869@main now we are far enough in the future.

Canonical link: <a href="https://commits.webkit.org/296621@main">https://commits.webkit.org/296621@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1be1c365eff962626bc0057bf2c1a80f6340e4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109094 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28754 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19179 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114305 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59393 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111057 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29437 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37321 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82908 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112042 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23415 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98259 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63353 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22815 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16401 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/58989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92786 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16444 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117423 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36142 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26714 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91924 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36513 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94523 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91730 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36640 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14393 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31997 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17609 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36039 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41544 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35732 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39071 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37418 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->