### PR TITLE
REGRESSION (macOS Tahoe): 13x CSSViewportUnits API tests are constant failures

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CSSViewportUnits.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CSSViewportUnits.mm
@@ -29,6 +29,7 @@
 #import "TestNavigationDelegate.h"
 #import "TestWKWebView.h"
 #import <WebKit/WKWebViewPrivate.h>
+#import <pal/spi/mac/NSScrollerImpSPI.h>
 #import <wtf/RetainPtr.h>
 
 static double evaluateForNumber(RetainPtr<TestWKWebView>& webView, NSString *script)
@@ -61,11 +62,18 @@ static void changeCSSPropertyOfElements(RetainPtr<TestWKWebView>& webView, NSStr
     [webView objectByEvaluatingJavaScript:[NSString stringWithFormat:@"document.querySelectorAll('%@').forEach((element) => element.style['%@'] = %@)", selector, property, value]];
 }
 
+static float scrollbarSize()
+{
+    static float result = 0;
 #if PLATFORM(MAC)
-constexpr auto scrollbarSize = 15;
-#else
-constexpr auto scrollbarSize = 0;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        RetainPtr scroller = [NSScrollerImp scrollerImpWithStyle:NSScroller.preferredScrollerStyle controlSize:NSControlSizeRegular horizontal:NO replacingScrollerImp:nil];
+        result = [scroller trackBoxWidth];
+    });
 #endif
+    return result;
+}
 
 TEST(CSSViewportUnits, AllSame)
 {
@@ -95,7 +103,7 @@ TEST(CSSViewportUnits, AllSame)
     EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
         double fixedHeight = heightOfElementWithID(webView, @"fixed"); // No horizontal overflow.
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
@@ -135,8 +143,8 @@ TEST(CSSViewportUnits, AllSame)
     EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
-        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
+        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize();
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvmin"));
@@ -170,8 +178,8 @@ TEST(CSSViewportUnits, AllSame)
     EXPECT_FLOAT_EQ(500, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
-        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
+        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize();
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvmin"));
@@ -205,8 +213,8 @@ TEST(CSSViewportUnits, AllSame)
     EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
-        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
+        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize();
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvmin"));
@@ -321,7 +329,7 @@ TEST(CSSViewportUnits, MinimumViewportInset)
     EXPECT_FLOAT_EQ(258, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
         double fixedHeight = heightOfElementWithID(webView, @"fixed"); // No horizontal overflow.
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
@@ -362,7 +370,7 @@ TEST(CSSViewportUnits, MaximumViewportInset)
     EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
         double fixedHeight = heightOfElementWithID(webView, @"fixed"); // No horizontal overflow.
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
@@ -410,8 +418,8 @@ TEST(CSSViewportUnits, MinimumViewportInsetWithZoom)
     EXPECT_FLOAT_EQ(258, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
-        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
+        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize();
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvmin"));
@@ -458,8 +466,8 @@ TEST(CSSViewportUnits, MaximumViewportInsetWithZoom)
     EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
-        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
+        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize();
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvmin"));
@@ -500,8 +508,8 @@ TEST(CSSViewportUnits, MinimumViewportInsetWithWritingMode)
     EXPECT_FLOAT_EQ(458, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
-        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
+        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize();
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvmin"));
@@ -535,8 +543,8 @@ TEST(CSSViewportUnits, MinimumViewportInsetWithWritingMode)
     EXPECT_FLOAT_EQ(258, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
-        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
+        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize();
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvmin"));
@@ -577,8 +585,8 @@ TEST(CSSViewportUnits, MaximumViewportInsetWithWritingMode)
     EXPECT_FLOAT_EQ(500, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
-        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
+        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize();
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvmin"));
@@ -612,8 +620,8 @@ TEST(CSSViewportUnits, MaximumViewportInsetWithWritingMode)
     EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
-        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
+        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize();
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvmin"));
@@ -655,7 +663,7 @@ TEST(CSSViewportUnits, MinimumViewportInsetWithFrame)
     EXPECT_FLOAT_EQ(158, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
         double fixedHeight = heightOfElementWithID(webView, @"fixed"); // No horizontal overflow.
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
@@ -698,7 +706,7 @@ TEST(CSSViewportUnits, MaximumViewportInsetWithFrame)
     EXPECT_FLOAT_EQ(220, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
         double fixedHeight = heightOfElementWithID(webView, @"fixed"); // No horizontal overflow.
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
@@ -741,7 +749,7 @@ TEST(CSSViewportUnits, MinimumViewportInsetWithBounds)
     EXPECT_FLOAT_EQ(258, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
         double fixedHeight = heightOfElementWithID(webView, @"fixed"); // No horizontal overflow.
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
@@ -784,7 +792,7 @@ TEST(CSSViewportUnits, MaximumViewportInsetWithBounds)
     EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
         double fixedHeight = heightOfElementWithID(webView, @"fixed"); // No horizontal overflow.
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
@@ -839,7 +847,7 @@ TEST(CSSViewportUnits, TopContentInset)
     EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
         double fixedHeight = heightOfElementWithID(webView, @"fixed");
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
@@ -888,7 +896,7 @@ TEST(CSSViewportUnits, MinimumViewportInsetWithTopContentInset)
     EXPECT_FLOAT_EQ(258, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
         double fixedHeight = heightOfElementWithID(webView, @"fixed");
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
@@ -942,7 +950,7 @@ TEST(CSSViewportUnits, MaximumViewportInsetWithTopContentInset)
     EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
         double fixedHeight = heightOfElementWithID(webView, @"fixed");
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
@@ -989,8 +997,8 @@ TEST(CSSViewportUnits, MinimumViewportInsetWithContentInset)
     EXPECT_FLOAT_EQ(258, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
-        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
+        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize();
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvmin"));
@@ -1032,8 +1040,8 @@ TEST(CSSViewportUnits, MaximumViewportInsetWithContentInset)
     EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
-        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
+        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize();
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvmin"));
@@ -1077,8 +1085,8 @@ TEST(CSSViewportUnits, MinimumViewportInsetWithSafeAreaInsets)
     EXPECT_FLOAT_EQ(258, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
-        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
+        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize();
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvmin"));
@@ -1122,8 +1130,8 @@ TEST(CSSViewportUnits, MaximumViewportInsetWithSafeAreaInsets)
     EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
-        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
+        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize();
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvmin"));
@@ -1165,8 +1173,8 @@ TEST(CSSViewportUnits, UnobscuredSizeOverridesIgnoreMinimumViewportInset)
     EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
-        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
+        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize();
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvmin"));
@@ -1208,8 +1216,8 @@ TEST(CSSViewportUnits, UnobscuredSizeOverridesIgnoreMaximumViewportInset)
     EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
-        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
+        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize();
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvmin"));
@@ -1248,8 +1256,8 @@ TEST(CSSViewportUnits, EmptyUnobscuredSizeOverrides)
     EXPECT_FLOAT_EQ(10.5, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
-        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
+        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize();
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvmin"));
@@ -1283,8 +1291,8 @@ TEST(CSSViewportUnits, EmptyUnobscuredSizeOverrides)
     EXPECT_FLOAT_EQ(10.5, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
-        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
+        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize();
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvmin"));
@@ -1318,8 +1326,8 @@ TEST(CSSViewportUnits, EmptyUnobscuredSizeOverrides)
     EXPECT_FLOAT_EQ(20.5, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
-        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
+        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize();
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvmin"));
@@ -1353,8 +1361,8 @@ TEST(CSSViewportUnits, EmptyUnobscuredSizeOverrides)
     EXPECT_FLOAT_EQ(10.5, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
-        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
+        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize();
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvmin"));
@@ -1394,8 +1402,8 @@ TEST(CSSViewportUnits, SameUnobscuredSizeOverrides)
     EXPECT_FLOAT_EQ(10.5, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
-        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
+        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize();
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvmin"));
@@ -1429,8 +1437,8 @@ TEST(CSSViewportUnits, SameUnobscuredSizeOverrides)
     EXPECT_FLOAT_EQ(10.5, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
-        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
+        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize();
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvmin"));
@@ -1464,8 +1472,8 @@ TEST(CSSViewportUnits, SameUnobscuredSizeOverrides)
     EXPECT_FLOAT_EQ(20.5, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
-        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
+        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize();
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvmin"));
@@ -1499,8 +1507,8 @@ TEST(CSSViewportUnits, SameUnobscuredSizeOverrides)
     EXPECT_FLOAT_EQ(10.5, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
-        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
+        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize();
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvmin"));
@@ -1539,8 +1547,8 @@ TEST(CSSViewportUnits, DifferentUnobscuredSizeOverrides)
     EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
-        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
+        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize();
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvmin"));
@@ -1574,8 +1582,8 @@ TEST(CSSViewportUnits, DifferentUnobscuredSizeOverrides)
     EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
-        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
+        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize();
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvmin"));
@@ -1609,8 +1617,8 @@ TEST(CSSViewportUnits, DifferentUnobscuredSizeOverrides)
     EXPECT_FLOAT_EQ(40.5, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
-        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
+        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize();
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvmin"));
@@ -1644,8 +1652,8 @@ TEST(CSSViewportUnits, DifferentUnobscuredSizeOverrides)
     EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
-        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize();
+        double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize();
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvmin"));
@@ -1740,8 +1748,8 @@ TEST(CSSViewportUnits, SVGDocument)
 
         double dvw = viewportUnitLength(webView, @"dvw");
         double dvh = viewportUnitLength(webView, @"dvh");
-        EXPECT_FLOAT_EQ(widthOfElementWithID(webView, @"fixed") + scrollbarSize, dvw);
-        EXPECT_FLOAT_EQ(heightOfElementWithID(webView, @"fixed") + scrollbarSize, dvh);
+        EXPECT_FLOAT_EQ(widthOfElementWithID(webView, @"fixed") + scrollbarSize(), dvw);
+        EXPECT_FLOAT_EQ(heightOfElementWithID(webView, @"fixed") + scrollbarSize(), dvh);
         EXPECT_FLOAT_EQ(dvw, viewportUnitLength(webView, @"dvmin"));
         EXPECT_FLOAT_EQ(dvh, viewportUnitLength(webView, @"dvmax"));
         EXPECT_FLOAT_EQ(dvh, viewportUnitLength(webView, @"dvb"));
@@ -1781,8 +1789,8 @@ TEST(CSSViewportUnits, SVGDocument)
 
         double dvw = viewportUnitLength(webView, @"dvw");
         double dvh = viewportUnitLength(webView, @"dvh");
-        EXPECT_FLOAT_EQ(widthOfElementWithID(webView, @"fixed") + scrollbarSize, dvw);
-        EXPECT_FLOAT_EQ(heightOfElementWithID(webView, @"fixed") + scrollbarSize, dvh);
+        EXPECT_FLOAT_EQ(widthOfElementWithID(webView, @"fixed") + scrollbarSize(), dvw);
+        EXPECT_FLOAT_EQ(heightOfElementWithID(webView, @"fixed") + scrollbarSize(), dvh);
         EXPECT_FLOAT_EQ(dvw, viewportUnitLength(webView, @"dvmin"));
         EXPECT_FLOAT_EQ(dvh, viewportUnitLength(webView, @"dvmax"));
         EXPECT_FLOAT_EQ(dvw, viewportUnitLength(webView, @"dvb"));
@@ -1822,8 +1830,8 @@ TEST(CSSViewportUnits, SVGDocument)
 
         double dvw = viewportUnitLength(webView, @"dvw");
         double dvh = viewportUnitLength(webView, @"dvh");
-        EXPECT_FLOAT_EQ(widthOfElementWithID(webView, @"fixed") + scrollbarSize, dvw);
-        EXPECT_FLOAT_EQ(heightOfElementWithID(webView, @"fixed") + scrollbarSize, dvh);
+        EXPECT_FLOAT_EQ(widthOfElementWithID(webView, @"fixed") + scrollbarSize(), dvw);
+        EXPECT_FLOAT_EQ(heightOfElementWithID(webView, @"fixed") + scrollbarSize(), dvh);
         EXPECT_FLOAT_EQ(dvw, viewportUnitLength(webView, @"dvmin"));
         EXPECT_FLOAT_EQ(dvh, viewportUnitLength(webView, @"dvmax"));
         EXPECT_FLOAT_EQ(dvh, viewportUnitLength(webView, @"dvb"));


### PR DESCRIPTION
#### c4a44e4be7715f69c4f86425923cdbe167b6426d
<pre>
REGRESSION (macOS Tahoe): 13x CSSViewportUnits API tests are constant failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=294980">https://bugs.webkit.org/show_bug.cgi?id=294980</a>
<a href="https://rdar.apple.com/154219736">rdar://154219736</a>

Reviewed by Simon Fraser.

After <a href="https://rdar.apple.com/146130865">rdar://146130865</a>, the width of the system legacy scrollbar on macOS has changed from 15 to 14
(i.e., the width exposed through `-[NSScrollerImp trackBoxWidth]` for a scrollbar with control size
`NSControlSizeRegular`). These API tests currently rely on a hard-coded size of 15, so they began
failing with small deltas.

To fix this, instead of hard-coding a new width here, we adjust the tests to directly ask the system
for the width via `-[NSScrollerImp trackBoxWidth]`.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/CSSViewportUnits.mm:
(scrollbarSize):
(TEST(CSSViewportUnits, AllSame)):
(TEST(CSSViewportUnits, MinimumViewportInset)):
(TEST(CSSViewportUnits, MaximumViewportInset)):
(TEST(CSSViewportUnits, MinimumViewportInsetWithZoom)):
(TEST(CSSViewportUnits, MaximumViewportInsetWithZoom)):
(TEST(CSSViewportUnits, MinimumViewportInsetWithWritingMode)):
(TEST(CSSViewportUnits, MaximumViewportInsetWithWritingMode)):
(TEST(CSSViewportUnits, MinimumViewportInsetWithFrame)):
(TEST(CSSViewportUnits, MaximumViewportInsetWithFrame)):
(TEST(CSSViewportUnits, MinimumViewportInsetWithBounds)):
(TEST(CSSViewportUnits, MaximumViewportInsetWithBounds)):
(TEST(CSSViewportUnits, TopContentInset)):
(TEST(CSSViewportUnits, MinimumViewportInsetWithTopContentInset)):
(TEST(CSSViewportUnits, MaximumViewportInsetWithTopContentInset)):
(TEST(CSSViewportUnits, MinimumViewportInsetWithContentInset)):
(TEST(CSSViewportUnits, MaximumViewportInsetWithContentInset)):
(TEST(CSSViewportUnits, MinimumViewportInsetWithSafeAreaInsets)):
(TEST(CSSViewportUnits, MaximumViewportInsetWithSafeAreaInsets)):
(TEST(CSSViewportUnits, UnobscuredSizeOverridesIgnoreMinimumViewportInset)):
(TEST(CSSViewportUnits, UnobscuredSizeOverridesIgnoreMaximumViewportInset)):
(TEST(CSSViewportUnits, EmptyUnobscuredSizeOverrides)):
(TEST(CSSViewportUnits, SameUnobscuredSizeOverrides)):
(TEST(CSSViewportUnits, DifferentUnobscuredSizeOverrides)):
(TEST(CSSViewportUnits, SVGDocument)):

Canonical link: <a href="https://commits.webkit.org/296628@main">https://commits.webkit.org/296628@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1b823bbbc0cc1c34172e57a1b485299ab9ea331

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109108 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28768 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19193 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114319 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59407 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111071 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29451 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37335 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82921 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112056 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23427 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98272 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63366 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22828 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16414 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/58999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92798 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16457 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117437 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36156 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26727 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/91935 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36527 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94536 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91741 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23355 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36653 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14406 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32014 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36053 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35747 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39085 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37432 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->