### PR TITLE
Drag snapshot does not paint for normal flow content

### DIFF
--- a/LayoutTests/fast/snapshot/positioned-abs-relative-body.html
+++ b/LayoutTests/fast/snapshot/positioned-abs-relative-body.html
@@ -9,6 +9,7 @@
     color: black;
 }
 </style>
+<script type="text/javascript" src="../../resources/snapshot-helper.js"></script>
 </head>
 <body>
     <div id="box" style="opacity: 0.9;">
@@ -16,44 +17,28 @@
             Is this included?
         </div>
     </div>
-    <canvas id="canvas"></canvas>
 <script>
 if (window.testRunner) {
     testRunner.waitUntilDone();
 }
 
 async function main() {
-    const box = document.getElementById('box');
-    const canvas = document.getElementById('canvas');
-
     if (!window.internals) {
         console.log('FAIL: window.internals is not available');
         return;
     }
-
-    const imageData = internals.snapshotNode(box);
-
-    if (!imageData) {
-        console.log('FAIL: snapshotNode returned null');
-        return;
-    }
-
-    canvas.width = imageData.width;
-    canvas.height = imageData.height;
     
-    const ctx = canvas.getContext('2d');
-    ctx.putImageData(imageData, 0, 0);
-
+    const box = document.getElementById('box');
+    const canvas = await SnapshotHelper.takeSnapshot(box);
     box.remove();
+    document.body.appendChild(canvas);
 
     if (window.testRunner) {
         testRunner.notifyDone();
     }
 }
 
-window.addEventListener('load', () => {
-    setTimeout(main, 200);
-}, false)
+window.addEventListener('load', main, false);
 </script>
 </body>
 </html>

--- a/LayoutTests/fast/snapshot/positioned-static-abs-expected.html
+++ b/LayoutTests/fast/snapshot/positioned-static-abs-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+#box {
+    width: 100px;
+    height: 100px;
+    background-color: blue;
+    color: black;
+}
+</style>
+</head>
+<body>
+    <div id="box"></div>
+</body>
+</html>

--- a/LayoutTests/fast/snapshot/positioned-static-abs.html
+++ b/LayoutTests/fast/snapshot/positioned-static-abs.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-10000" />
 <style>
 #box {
     width: 100px;
@@ -13,10 +12,8 @@
 <script type="text/javascript" src="../../resources/snapshot-helper.js"></script>
 </head>
 <body>
-    <div id="box" style="opacity: 0.95;">
-        <div style="opacity: 0.95;">
-            Is this included?
-        </div>
+    <div id="box">
+        <div style="position: absolute; z-index: 1;">Is this included?</div>
     </div>
 <script>
 if (window.testRunner) {

--- a/LayoutTests/fast/snapshot/positioned-static-expected.html
+++ b/LayoutTests/fast/snapshot/positioned-static-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+#box {
+    width: 100px;
+    height: 100px;
+    background-color: blue;
+    color: black;
+}
+</style>
+</head>
+<body>
+    <div id="box">
+        Is this included?
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/snapshot/positioned-static.html
+++ b/LayoutTests/fast/snapshot/positioned-static.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-10000" />
 <style>
 #box {
     width: 100px;
@@ -13,11 +12,7 @@
 <script type="text/javascript" src="../../resources/snapshot-helper.js"></script>
 </head>
 <body>
-    <div id="box" style="opacity: 0.95;">
-        <div style="opacity: 0.95;">
-            Is this included?
-        </div>
-    </div>
+    <div id="box">Is this included?</div>
 <script>
 if (window.testRunner) {
     testRunner.waitUntilDone();

--- a/LayoutTests/resources/snapshot-helper.js
+++ b/LayoutTests/resources/snapshot-helper.js
@@ -1,0 +1,19 @@
+
+window.SnapshotHelper = class SnapshotHelper {
+    static async takeSnapshot(node)
+    {
+        const imageData = internals.snapshotNode(node);
+
+        if (!imageData) {
+            console.log('FAIL: snapshotNode returned null');
+            return;
+        }
+
+        const canvas = document.createElement('canvas');
+        canvas.width = imageData.width;
+        canvas.height = imageData.height;
+        canvas.getContext('2d').putImageData(imageData, 0, 0);
+
+        return canvas;
+    }
+}

--- a/Source/WebCore/page/FrameSnapshotting.cpp
+++ b/Source/WebCore/page/FrameSnapshotting.cpp
@@ -111,6 +111,8 @@ RefPtr<ImageBuffer> snapshotFrameRectWithClip(LocalFrame& frame, const IntRect& 
         paintBehavior.add(PaintBehavior::ExcludeText);
     if (options.flags.contains(SnapshotFlags::FixedAndStickyLayersOnly))
         paintBehavior.add(PaintBehavior::FixedAndStickyLayersOnly);
+    if (options.flags.contains(SnapshotFlags::DraggableElement))
+        paintBehavior.add(PaintBehavior::DraggableSnapshot);
 
     // Other paint behaviors are set by paintContentsForSnapshot.
     frame.view()->setPaintBehavior(paintBehavior);

--- a/Source/WebCore/page/FrameSnapshotting.h
+++ b/Source/WebCore/page/FrameSnapshotting.h
@@ -58,6 +58,7 @@ enum class SnapshotFlags : uint16_t {
     PaintWith3xBaseScale                    = 1 << 10,
     ExcludeText                             = 1 << 11,
     FixedAndStickyLayersOnly                = 1 << 12,
+    DraggableElement                        = 1 << 13,
 };
 
 struct SnapshotOptions {

--- a/Source/WebCore/platform/DragImage.cpp
+++ b/Source/WebCore/platform/DragImage.cpp
@@ -120,7 +120,10 @@ static DragImageRef createDragImageFromSnapshot(RefPtr<ImageBuffer> snapshot, No
 DragImageRef createDragImageForNode(LocalFrame& frame, Node& node)
 {
     ScopedNodeDragEnabler enableDrag(frame, node);
-    return createDragImageFromSnapshot(snapshotNode(frame, node, { { }, ImageBufferPixelFormat::BGRA8, DestinationColorSpace::SRGB() }), &node);
+
+    SnapshotOptions options { { SnapshotFlags::DraggableElement }, ImageBufferPixelFormat::BGRA8, DestinationColorSpace::SRGB() };
+
+    return createDragImageFromSnapshot(snapshotNode(frame, node, WTFMove(options)), &node);
 }
 
 #if !PLATFORM(IOS_FAMILY) || !ENABLE(DRAG_SUPPORT)
@@ -218,7 +221,9 @@ DragImageRef createDragImageForImage(LocalFrame& frame, Node& node, IntRect& ima
     elementRect = snappedIntRect(topLevelRect);
     imageRect = paintingRect;
 
-    return createDragImageFromSnapshot(snapshotNode(frame, node, { { }, ImageBufferPixelFormat::BGRA8, DestinationColorSpace::SRGB() }), &node);
+    SnapshotOptions options { { SnapshotFlags::DraggableElement }, ImageBufferPixelFormat::BGRA8, DestinationColorSpace::SRGB() };
+
+    return createDragImageFromSnapshot(snapshotNode(frame, node, WTFMove(options)), &node);
 }
 
 #if !PLATFORM(IOS_FAMILY) || !ENABLE(DRAG_SUPPORT)

--- a/Source/WebCore/rendering/PaintPhase.h
+++ b/Source/WebCore/rendering/PaintPhase.h
@@ -79,6 +79,7 @@ enum class PaintBehavior : uint32_t {
     ExcludeText                                 = 1 << 20,
     FixedAndStickyLayersOnly                    = 1 << 21,
     DrawsHDRContent                             = 1 << 22,
+    DraggableSnapshot                           = 1 << 23,
 };
 
 } // namespace WebCore

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -2118,7 +2118,9 @@ ExceptionOr<RefPtr<ImageData>> Internals::snapshotNode(Node& node)
     if (!document || !document->frame())
         return Exception { ExceptionCode::InvalidAccessError };
 
-    SnapshotOptions options { { }, ImageBufferPixelFormat::BGRA8, DestinationColorSpace::SRGB() };
+    document->updateLayoutIgnorePendingStylesheets();
+
+    SnapshotOptions options { { SnapshotFlags::DraggableElement }, ImageBufferPixelFormat::BGRA8, DestinationColorSpace::SRGB() };
 
     RefPtr imageBuffer = WebCore::snapshotNode(*document->frame(), node, WTFMove(options));
     if (!imageBuffer)


### PR DESCRIPTION
#### 1d76f585b407b4193756ebe2d18d83b230fa962e
<pre>
Drag snapshot does not paint for normal flow content
<a href="https://rdar.apple.com/154202408">rdar://154202408</a>

Reviewed by Simon Fraser.

Drag snapshots did not work for normal flow content because
enclosingLayer found the nearest layer as the HTML root layer.
As a result, the layer used for painting decisions was a much
higher ancestor. We now restrict this with a hasLayer check.

For non-layer roots, we exclude positioned descendants from the
drag image if they extend outside the containing block.

All the special inclusion/exclusion logic is now guraded behind a
new paint behavior DraggableSnapshot.

* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::snapshotNode):

snapshot tests only draggable paint behavior.

Canonical link: <a href="https://commits.webkit.org/297110@main">https://commits.webkit.org/297110@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c040f0fe793ebac8e096140aa24f96959eb0d13d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110520 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30179 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20612 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116546 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60787 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112483 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38767 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84045 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113468 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24627 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99513 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64486 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23989 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17652 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60341 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94008 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17712 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119336 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37560 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27884 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93015 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37934 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95784 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92838 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23665 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37834 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15575 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33533 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37455 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42926 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37117 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40457 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38826 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->