### PR TITLE
TestWebKitAPI.WKScrollGeometry.ContentSizeTallerThanWebView is a constant failure pre-macOS Tahoe

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKScrollGeometryTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKScrollGeometryTests.mm
@@ -34,6 +34,10 @@
 #import "Utilities.h"
 #import <wtf/RetainPtr.h>
 
+#if PLATFORM(MAC)
+#import <pal/spi/mac/NSScrollerImpSPI.h>
+#endif
+
 @interface WKWebView (ScrollGeometryTesting)
 - (void)_setNeedsScrollGeometryUpdates:(BOOL)needsScrollGeometryUpdates;
 @end
@@ -84,12 +88,10 @@ static void runContentSizeTest(NSString *html, CGSize expectedSize, BOOL needsSc
 
 TEST(WKScrollGeometry, ContentSizeTallerThanWebView)
 {
-#if PLATFORM(IOS_FAMILY)
     CGFloat expectedWidth = 800;
-#elif (PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED <= 140000)
-    CGFloat expectedWidth = 785;
-#else
-    CGFloat expectedWidth = 786;
+#if PLATFORM(MAC)
+    RetainPtr scroller = [NSScrollerImp scrollerImpWithStyle:NSScroller.preferredScrollerStyle controlSize:NSControlSizeRegular horizontal:NO replacingScrollerImp:nil];
+    expectedWidth -= [scroller trackBoxWidth];
 #endif
 
     runContentSizeTest(@""


### PR DESCRIPTION
#### 7f8af8b0d00a47562245f3fb64581527f17e5c26
<pre>
TestWebKitAPI.WKScrollGeometry.ContentSizeTallerThanWebView is a constant failure pre-macOS Tahoe
<a href="https://bugs.webkit.org/show_bug.cgi?id=294915">https://bugs.webkit.org/show_bug.cgi?id=294915</a>
<a href="https://rdar.apple.com/154213450">rdar://154213450</a>

Reviewed by Alexey Proskuryakov.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKScrollGeometryTests.mm:
(TEST(WKScrollGeometry, ContentSizeTallerThanWebView)):

The change in 296604@main was incorrect on macOS, since EWS is using point
updates of macOS 14 and 15.

Derive the scrollbar width programmatically to avoid hardcoding the value.

Canonical link: <a href="https://commits.webkit.org/296669@main">https://commits.webkit.org/296669@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbe980d4c81426381cbbf797ca43ebe434e38e51

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109207 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28865 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19293 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114414 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59478 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111170 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29547 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37454 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82988 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112155 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23513 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98360 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63438 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22901 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16503 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59049 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92881 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16545 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117530 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36251 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26820 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92005 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36623 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94623 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91813 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36737 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14486 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32089 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17625 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36147 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35833 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39165 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37524 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->