### PR TITLE
[webkitapipy] Non-normalized paths treated as separate inputs

### DIFF
--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb_unittest.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb_unittest.py
@@ -30,6 +30,7 @@ from .macho import APIReport
 # Fixtures:
 F = Path('/libdoesntexist.dylib')
 F_Hash = 1234567890
+F_NonNormalized = Path('/foo/../libdoesntexist.dylib')
 R = APIReport(
     file=F, arch='arm64e',
     exports={'_WKDoesntExistLibraryVersion', '_OBJC_CLASS_$_WKDoesntExist'},
@@ -69,3 +70,13 @@ class TestSDKDB(TestCase):
         # ...until the file is again added as in input.
         self.assertTrue(self.sdkdb._cache_hit_preparing_to_insert(F, F_Hash))
         self.assertTrue(self.sdkdb.symbol('_WKDoesntExistLibraryVersion'))
+
+    def test_path_normalized_when_cache_hit(self):
+        with self.sdkdb:
+            self.assertFalse(self.sdkdb._cache_hit_preparing_to_insert(F, F_Hash))
+            self.assertTrue(self.sdkdb._cache_hit_preparing_to_insert(F_NonNormalized, F_Hash))
+
+    def test_path_normalized_when_cache_miss(self):
+        with self.sdkdb:
+            self.assertFalse(self.sdkdb._cache_hit_preparing_to_insert(F_NonNormalized, F_Hash))
+            self.assertTrue(self.sdkdb._cache_hit_preparing_to_insert(F, F_Hash))


### PR DESCRIPTION
#### 73c3b7bf0da1bd8afde83ae59a8553aa3f7ffbf6
<pre>
[webkitapipy] Non-normalized paths treated as separate inputs
<a href="https://rdar.apple.com/154311830">rdar://154311830</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=294986">https://bugs.webkit.org/show_bug.cgi?id=294986</a>

Reviewed by Brianna Fan.

Use Path.resolve() instead of Path.absolute(). It ought to be safe from
causing incremental build breakage because these paths aren&apos;t emitted
back to Xcode, they are only used for internal bookkeeping.

* Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb.py:
(SDKDB._cache_hit_preparing_to_insert):
* Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb_unittest.py:

Canonical link: <a href="https://commits.webkit.org/296638@main">https://commits.webkit.org/296638@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3617ef0af7f4854cecbeb23e913dbe6a52640f9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28827 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19254 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114376 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/59447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111132 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29508 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37393 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/82959 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/59447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23480 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98325 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/63407 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/108601 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/22870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16468 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/59025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/92847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16510 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117491 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36213 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/26772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/91974 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36585 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94588 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91780 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23367 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36701 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/14452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/32062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36109 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35795 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39129 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37486 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->