### PR TITLE
Reduce alloc and copying in AsyncNodeDeletionQueue

### DIFF
--- a/Source/WebCore/dom/AsyncNodeDeletionQueue.h
+++ b/Source/WebCore/dom/AsyncNodeDeletionQueue.h
@@ -43,7 +43,7 @@ public:
     ALWAYS_INLINE static bool isNodeLikelyLarge(const Node&);
 
 private:
-    Vector<Ref<Node>> m_queue;
+    Vector<NodeVector> m_queue;
     unsigned m_nodeCount { 0 };
     static constexpr unsigned s_maxSizeAsyncNodeDeletionQueue = 100000;
 };

--- a/Source/WebCore/dom/AsyncNodeDeletionQueueInlines.h
+++ b/Source/WebCore/dom/AsyncNodeDeletionQueueInlines.h
@@ -45,7 +45,7 @@ ALWAYS_INLINE void AsyncNodeDeletionQueue::addIfSubtreeSizeIsUnderLimit(NodeVect
     if (m_nodeCount + subTreeSize > s_maxSizeAsyncNodeDeletionQueue)
         return;
     m_nodeCount += subTreeSize;
-    m_queue.appendVector(WTFMove(children));
+    m_queue.append(WTFMove(children));
 }
 
 ALWAYS_INLINE void AsyncNodeDeletionQueue::deleteNodesNow()


### PR DESCRIPTION
#### e131d104c61c538763b69ead1e84b551b929c9bf
<pre>
Reduce alloc and copying in AsyncNodeDeletionQueue
<a href="https://bugs.webkit.org/show_bug.cgi?id=294987">https://bugs.webkit.org/show_bug.cgi?id=294987</a>
<a href="https://rdar.apple.com/154311875">rdar://154311875</a>

Reviewed by NOBODY (OOPS!).

Instead of moving the contents of the NodeVector to m_queue,
just move the inline part of the NodeVector so that we don&apos;t
need to grow m_queue as many times, can destruct the NodeVector
opportunistically, and do less copying.

* Source/WebCore/dom/AsyncNodeDeletionQueue.h:
* Source/WebCore/dom/AsyncNodeDeletionQueueInlines.h:
(WebCore::AsyncNodeDeletionQueue::addIfSubtreeSizeIsUnderLimit):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e131d104c61c538763b69ead1e84b551b929c9bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109143 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28801 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19228 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114351 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59432 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111106 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37433 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82947 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112091 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23454 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98305 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63394 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22853 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16447 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59014 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92825 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16490 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117466 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36187 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26806 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91961 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36559 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94568 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91767 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36681 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14435 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32050 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36084 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41587 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35776 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39113 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37463 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->