### PR TITLE
[Baseline Alignment][Cleanup] Replace child with alignmentSubject to match spec terms

### DIFF
--- a/Source/WebCore/rendering/BaselineAlignment.h
+++ b/Source/WebCore/rendering/BaselineAlignment.h
@@ -46,76 +46,69 @@ class RenderBox;
 //     side of the alignment context).
 //
 // Once the BaselineGroup is instantiated, defined by a 'block flow direction' and a 'baseline-preference'
-// (first/last baseline), it's ready to collect the items that will participate in the Baseline Alignment logic.
+// (first/last baseline), it's ready to collect the alignment subjects that will participate in the Baseline Alignment logic.
 //
 class BaselineGroup {
     WTF_MAKE_TZONE_ALLOCATED(BaselineGroup);
 public:
-    // It stores an item (if not already present) and update the max_ascent associated to this
-    // baseline-sharing group.
+    // It stores an alignment subject(if not already present) and update the max_ascent
+    // associated to this baseline-sharing group.
     void update(const RenderBox&, LayoutUnit ascent);
     LayoutUnit maxAscent() const { return m_maxAscent; }
-    int computeSize() const { return m_items.computeSize(); }
-    auto begin() LIFETIME_BOUND { return m_items.begin(); }
-    auto end() LIFETIME_BOUND { return m_items.end(); }
+    int computeSize() const { return m_alignmentSubjects.computeSize(); }
+    auto begin() LIFETIME_BOUND { return m_alignmentSubjects.begin(); }
+    auto end() LIFETIME_BOUND { return m_alignmentSubjects.end(); }
 
 private:
     friend class BaselineAlignmentState;
     BaselineGroup(FlowDirection, ItemPosition childPreference);
 
-    // Determines whether a baseline-sharing group is compatible with an item, based on its 'block-flow' and
-    // 'baseline-preference'
+    // Determines whether a baseline-sharing group is compatible with an alignment subject,
+    // based on its 'block-flow' and 'baseline-preference'
     bool isCompatible(FlowDirection, ItemPosition) const;
 
     // Determines whether the baseline-sharing group's associated block-flow is opposite (LR vs RL) to particular
-    // item's writing-mode.
+    // alignment subject's writing-mode.
     bool isOppositeBlockFlow(FlowDirection) const;
 
     // Determines whether the baseline-sharing group's associated block-flow is orthogonal (vertical vs horizontal)
-    // to particular item's writing-mode.
+    // to particular alignment subject's writing-mode.
     bool isOrthogonalBlockFlow(FlowDirection) const;
 
     FlowDirection m_blockFlow;
     ItemPosition m_preference;
     LayoutUnit m_maxAscent;
-    SingleThreadWeakHashSet<RenderBox> m_items;
+    SingleThreadWeakHashSet<RenderBox> m_alignmentSubjects;
 };
 
 //
 // BaselineAlignmentState provides an API to interact with baseline sharing groups in various
-// ways such as adding items to appropriate ones and querying the baseline sharing group for
-// an item. A BaselineAlignmentState should be created by a formatting context to use for each
-// of its baseline alignment contexts.
+// ways such as adding alignment subjects to appropriate ones and querying the baseline
+// sharing group for an alignment subject. A BaselineAlignmentState should be created by a formatting
+// context to use for each of its baseline alignment contexts.
 //
 // https://drafts.csswg.org/css-align-3/#baseline-sharing-group
 // A Baseline alignment-context may handle several baseline-sharing groups. In order to create an instance, we
 // need to pass the required data to define the first baseline-sharing group; a BaselineAlignmentState must have at
 // least one baseline-sharing group.
 //
-// By adding new items to a BaselineAlignmentState, the baseline-sharing groups it handles are automatically updated,
-// if there is one that is compatible with such item. Otherwise, a new baseline-sharing group is created,
-// compatible with the new item.
+// By adding new alignment subjects to a BaselineAlignmentState, the baseline-sharing
+// groups it handles are automatically updated, if there is one that is compatible with
+// such alignment subject. Otherwise, a new baseline-sharing group is created, compatible with the new
+// alignment subject.
 class BaselineAlignmentState {
     WTF_MAKE_TZONE_ALLOCATED(BaselineAlignmentState);
 public:
-    BaselineAlignmentState(const RenderBox& child, ItemPosition preference, LayoutUnit ascent, LogicalBoxAxis alignmentContextAxis, WritingMode alignmentContainerWritingMode);
-    const BaselineGroup& sharedGroup(const RenderBox& child, ItemPosition preference) const;
+    BaselineAlignmentState(const RenderBox& alignmentSubject, ItemPosition preference, LayoutUnit ascent, LogicalBoxAxis alignmentContextAxis, WritingMode alignmentContainerWritingMode);
+    const BaselineGroup& sharedGroup(const RenderBox& alignmentSubject, ItemPosition preference) const;
 
-    // Updates the baseline-sharing group compatible with the item.
-    // We pass the item's baseline-preference to avoid dependencies with the LayoutGrid class, which is the one
-    // managing the alignment behavior of the Grid Items.
-    void updateSharedGroup(const RenderBox& child, ItemPosition preference, LayoutUnit ascent);
+    void updateSharedGroup(const RenderBox& alignmentSubject, ItemPosition preference, LayoutUnit ascent);
     Vector<BaselineGroup>& sharedGroups();
 
     static WritingMode usedWritingModeForBaselineAlignment(LogicalBoxAxis alignmentContextAxis, WritingMode alignmentContainerWritingMode, WritingMode alignmentSubjectWritingMode);
 
 private:
-    // Returns the baseline-sharing group compatible with an item.
-    // We pass the item's baseline-preference to avoid dependencies with the LayoutGrid class, which is the one
-    // managing the alignment behavior of the Grid Items.
-    // FIXME: Properly implement baseline-group compatibility.
-    // See https://github.com/w3c/csswg-drafts/issues/721
-    BaselineGroup& findCompatibleSharedGroup(const RenderBox& child, ItemPosition preference);
+    BaselineGroup& findCompatibleSharedGroup(const RenderBox& alignmentSubject, ItemPosition preference);
 
     Vector<BaselineGroup> m_sharedGroups;
     WritingMode m_alignmentContainerWritingMode;


### PR DESCRIPTION
#### 184a2efdbf36dba0eb6cdecebb2f5ee3244f1d87
<pre>
[Baseline Alignment][Cleanup] Replace child with alignmentSubject to match spec terms
<a href="https://bugs.webkit.org/show_bug.cgi?id=294988">https://bugs.webkit.org/show_bug.cgi?id=294988</a>
<a href="https://rdar.apple.com/problem/154314396">rdar://problem/154314396</a>

Reviewed by Brent Fulgham.

The spec has a section named &quot;Alignment Terminology,&quot; and defines the
term &quot;alignment subject,&quot; to refer to the things being aligned inside
the alignment container. Instead of using the term &quot;child,&quot; let&apos;s
replace it with the one defined by the spec.

<a href="https://drafts.csswg.org/css-align-3/#terms">https://drafts.csswg.org/css-align-3/#terms</a>
Canonical link: <a href="https://commits.webkit.org/296634@main">https://commits.webkit.org/296634@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58ee28c0f0d3dc2d6caedbdd05342ab90f53702d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109132 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28790 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114340 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59423 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111095 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29471 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37356 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82934 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23446 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98289 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63381 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22846 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16431 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/59008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92817 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16474 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117455 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36176 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26743 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91949 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36548 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94552 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91755 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23361 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36670 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14419 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32031 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36073 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41577 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35766 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39103 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37452 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->