### PR TITLE
[Style] Add more defense for invalid <length-percentage> values

### DIFF
--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h
@@ -103,6 +103,13 @@ template<Range range, std::floating_point T> constexpr T clampToRange(T value)
         return std::clamp<T>(value, range.min, range.max);
 }
 
+// Clamps a floating point value to within `range` and within additional provided range.
+template<Range range, std::floating_point T> constexpr T clampToRange(T value, T additionalMinimum, T additionalMaximum)
+{
+    return std::clamp<T>(value, std::max<T>(range.min, additionalMinimum), std::min<T>(range.max, additionalMaximum));
+}
+
+
 // Checks if a floating point value is within `range`.
 template<Range range, std::floating_point T> constexpr bool isWithinRange(T value)
 {

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper+CSSValueConversion.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper+CSSValueConversion.h
@@ -48,7 +48,7 @@ template<LengthWrapperBaseDerived T> struct CSSValueConversion<T> {
 
             if (primitiveValue->isLength()) {
                 return T { WebCore::Length {
-                    clampTo<float>(primitiveValue->resolveAsLength(conversionData), minValueForCssLength, maxValueForCssLength),
+                    CSS::clampToRange<T::Fixed::range, float>(primitiveValue->resolveAsLength(conversionData), minValueForCssLength, maxValueForCssLength),
                     LengthType::Fixed,
                     primitiveValue->primitiveType() == CSSUnitType::CSS_QUIRKY_EM
                 } };
@@ -56,7 +56,7 @@ template<LengthWrapperBaseDerived T> struct CSSValueConversion<T> {
 
             if (primitiveValue->isPercentage()) {
                 return T { WebCore::Length {
-                    primitiveValue->resolveAsPercentage(conversionData),
+                    CSS::clampToRange<T::Percentage::range, float>(primitiveValue->resolveAsPercentage(conversionData)),
                     LengthType::Percent
                 } };
             }

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
@@ -74,8 +74,8 @@ template<typename Numeric, CSS::PrimitiveKeyword... Ks> struct LengthWrapperBase
     LengthWrapperBase(CSS::ValueLiteral<CSS::LengthUnit::Px> literal) : m_value(static_cast<float>(literal.value), WebCore::LengthType::Fixed) { }
     LengthWrapperBase(CSS::ValueLiteral<CSS::PercentageUnit::Percentage> literal) : m_value(static_cast<float>(literal.value), WebCore::LengthType::Percent) { }
 
-    explicit LengthWrapperBase(WebCore::Length&& other) : m_value(WTFMove(other)) { RELEASE_ASSERT(isValid(m_value)); }
-    explicit LengthWrapperBase(const WebCore::Length& other) : m_value(other) { RELEASE_ASSERT(isValid(m_value)); }
+    explicit LengthWrapperBase(WebCore::Length&& other) : m_value(WTFMove(other)) { validate(m_value); }
+    explicit LengthWrapperBase(const WebCore::Length& other) : m_value(other) { validate(m_value); }
 
     explicit LengthWrapperBase(WTF::HashTableEmptyValueType token) : m_value(token) { }
 
@@ -183,26 +183,26 @@ template<typename Numeric, CSS::PrimitiveKeyword... Ks> struct LengthWrapperBase
 protected:
     template<typename> friend struct ToPlatform;
 
-    static bool isValid(const WebCore::Length& length)
+    static void validate(const WebCore::Length& length)
     {
         switch (length.type()) {
-        case WebCore::LengthType::Fixed:            return CSS::isWithinRange<Fixed::range>(length.value());
-        case WebCore::LengthType::Percent:          return CSS::isWithinRange<Percentage::range>(length.value());
-        case WebCore::LengthType::Calculated:       return true;
-        case WebCore::LengthType::Auto:             return SupportsAuto;
-        case WebCore::LengthType::Intrinsic:        return SupportsIntrinsic;
-        case WebCore::LengthType::MinIntrinsic:     return SupportsMinIntrinsic;
-        case WebCore::LengthType::MinContent:       return SupportsMinContent;
-        case WebCore::LengthType::MaxContent:       return SupportsMaxContent;
-        case WebCore::LengthType::FillAvailable:    return SupportsWebkitFillAvailable;
-        case WebCore::LengthType::FitContent:       return SupportsFitContent;
-        case WebCore::LengthType::Content:          return SupportsContent;
-        case WebCore::LengthType::Normal:           return SupportsNormal;
-        case WebCore::LengthType::Undefined:        return SupportsNone;
+        case WebCore::LengthType::Fixed:            RELEASE_ASSERT(CSS::isWithinRange<Fixed::range>(length.value())); return;
+        case WebCore::LengthType::Percent:          RELEASE_ASSERT(CSS::isWithinRange<Percentage::range>(length.value())); return;
+        case WebCore::LengthType::Calculated:       return;
+        case WebCore::LengthType::Auto:             if constexpr (SupportsAuto) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
+        case WebCore::LengthType::Intrinsic:        if constexpr (SupportsIntrinsic) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
+        case WebCore::LengthType::MinIntrinsic:     if constexpr (SupportsMinIntrinsic) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
+        case WebCore::LengthType::MinContent:       if constexpr (SupportsMinContent) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
+        case WebCore::LengthType::MaxContent:       if constexpr (SupportsMaxContent) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
+        case WebCore::LengthType::FillAvailable:    if constexpr (SupportsWebkitFillAvailable) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
+        case WebCore::LengthType::FitContent:       if constexpr (SupportsFitContent) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
+        case WebCore::LengthType::Content:          if constexpr (SupportsContent) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
+        case WebCore::LengthType::Normal:           if constexpr (SupportsNormal) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
+        case WebCore::LengthType::Undefined:        if constexpr (SupportsNone) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
         case WebCore::LengthType::Relative:
             break;
         }
-        return false;
+        RELEASE_ASSERT_NOT_REACHED();
     }
 
     WebCore::Length m_value;


### PR DESCRIPTION
#### b575725c1a31158589504ac00f13fb63c0333a87
<pre>
[Style] Add more defense for invalid &lt;length-percentage&gt; values
<a href="https://bugs.webkit.org/show_bug.cgi?id=294990">https://bugs.webkit.org/show_bug.cgi?id=294990</a>

Reviewed by Antti Koivisto.

- Adds additional clamping for value ranges during CSSValue -&gt; LengthWrapper conversion
  for cases where CSSOM might be able to sneak in an out of range length.
- Moves assertions to within validity check to make crashlogs clearly show the violation.

* Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h:
* Source/WebCore/style/values/primitives/StyleLengthWrapper+CSSValueConversion.h:
* Source/WebCore/style/values/primitives/StyleLengthWrapper.h:

Canonical link: <a href="https://commits.webkit.org/296664@main">https://commits.webkit.org/296664@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a3c438c9d4bf7e1c4aad06cad95cee2242ff2bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109166 "12 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28824 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114373 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59446 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111129 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37422 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82967 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112114 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23475 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98326 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63416 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22867 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16469 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59024 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92843 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16511 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117488 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36210 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26796 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91982 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36582 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94589 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91788 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23385 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36704 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14453 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32061 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36106 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41603 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35793 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39128 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37483 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->