### PR TITLE
[iOS] TestWebKitAPI.EditorStateTests.SelectedTextRange_CaretSelectionWithZoom is a flaky failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EditorStateTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EditorStateTests.mm
@@ -459,10 +459,12 @@ TEST(EditorStateTests, SelectedTextRange_CaretSelectionWithZoom)
     [webView stringByEvaluatingJavaScript:@"input.focus()"];
     [webView _synchronouslyExecuteEditCommand:@"InsertText" argument:@"Test"];
 
+    [webView waitForNextVisibleContentRectUpdate];
     [webView waitForNextPresentationUpdate];
 
     CGFloat zoomScale = 4;
-    [webView scrollView].zoomScale = zoomScale;
+    [webView setZoomScaleSimulatingUserTriggeredZoom:zoomScale];
+
     [webView waitForNextPresentationUpdate];
 
     RetainPtr contentView = [webView textInputContentView];
@@ -470,7 +472,11 @@ TEST(EditorStateTests, SelectedTextRange_CaretSelectionWithZoom)
 
     EXPECT_EQ([[contentView layer] transform].m11, zoomScale);
 
+#if ENABLE(FORM_CONTROL_REFRESH)
+    CGRect caretRect = CGRectMake(137, 107, 2, EditorStateTests::glyphWidth);
+#else
     CGRect caretRect = CGRectMake(137, 106, 3, EditorStateTests::glyphWidth);
+#endif
     EXPECT_EQ(caretRect, [contentView caretRectForPosition:[selectedTextRange start]]);
     EXPECT_EQ(caretRect, [contentView caretRectForPosition:[selectedTextRange end]]);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
@@ -63,11 +63,6 @@
 @end
 
 #if PLATFORM(IOS_FAMILY)
-@interface WKWebView ()
-- (UIView *)viewForZoomingInScrollView:(UIScrollView *)scrollView;
-- (void)scrollViewWillBeginZooming:(UIScrollView *)scrollView withView:(UIView *)view;
-@end
-
 @interface UIPrintInteractionController ()
 - (BOOL)_setupPrintPanel:(void (^)(UIPrintInteractionController *printInteractionController, BOOL completed, NSError *error))completion;
 - (void)_generatePrintPreview:(void (^)(NSURL *previewPDF, BOOL shouldRenderOnChosenPaper))completionHandler;
@@ -564,20 +559,11 @@ UNIFIED_PDF_TEST(KeepRelativeScrollPositionAfterZoomingAndViewportUpdate)
 
     RetainPtr request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"multiple-pages" withExtension:@"pdf"]];
     [webView synchronouslyLoadRequest:request.get()];
+
+    [webView waitForNextVisibleContentRectUpdate];
     [webView waitForNextPresentationUpdate];
 
-    {
-        InstanceMethodSwizzler lookupSwizzler {
-            [UIPinchGestureRecognizer class],
-            @selector(state),
-            imp_implementationWithBlock(^UIGestureRecognizerState {
-                return UIGestureRecognizerStateBegan;
-            })
-        };
-
-        [webView scrollViewWillBeginZooming:scrollView.get() withView:[webView viewForZoomingInScrollView:scrollView.get()]];
-        [scrollView setZoomScale:3];
-    }
+    [webView setZoomScaleSimulatingUserTriggeredZoom:3];
 
     [scrollView setContentOffset:CGPointMake([scrollView contentSize].width - [scrollView frame].size.width, 12000)];
     [webView waitForNextVisibleContentRectUpdate];

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -200,6 +200,7 @@ class Color;
 - (_WKActivatedElementInfo *)activatedElementAtPosition:(CGPoint)position;
 - (void)evaluateJavaScriptAndWaitForInputSessionToChange:(NSString *)script;
 - (WKContentView *)wkContentView;
+- (void)setZoomScaleSimulatingUserTriggeredZoom:(CGFloat)zoomScale;
 @end
 #endif
 


### PR DESCRIPTION
#### f0ec0e0ae7f183a044ce9aba1bfb294c583bd5bb
<pre>
[iOS] TestWebKitAPI.EditorStateTests.SelectedTextRange_CaretSelectionWithZoom is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=294922">https://bugs.webkit.org/show_bug.cgi?id=294922</a>
<a href="https://rdar.apple.com/154216068">rdar://154216068</a>

Reviewed by Abrar Rahman Protyasha.

Wait for a visible content rect update before setting the zoom scale, so that
it does get overridden on next layer tree commit.

Additionally, treat the zoom scale change as a user triggered zoom by swizzling
the state on the gesture recognizer. Without this, the zoom scale may get when
the viewport configuration changes.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/EditorStateTests.mm:
(TestWebKitAPI::TEST(EditorStateTests, SelectedTextRange_CaretSelectionWithZoom)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm:
(TestWebKitAPI::UNIFIED_PDF_TEST):

Adopt the new helper in another test.

* Tools/TestWebKitAPI/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[TestWKWebView setZoomScaleSimulatingUserTriggeredZoom:]):

Canonical link: <a href="https://commits.webkit.org/296645@main">https://commits.webkit.org/296645@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cc3509c368dfed7fa4c81a86cee5322c11f762a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109142 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28800 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19227 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114350 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59431 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111105 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29481 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37366 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82940 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112090 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23456 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98301 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63387 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22860 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16442 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/59013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92827 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16485 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117465 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36186 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26752 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91955 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36558 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94563 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91761 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36676 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14430 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32048 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17616 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36083 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35775 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39112 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37462 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->