### PR TITLE
[iPhone] nba.com: Fullscreen broken when requesting Desktop Website

### DIFF
--- a/Source/WebCore/bindings/js/JSElementCustom.cpp
+++ b/Source/WebCore/bindings/js/JSElementCustom.cpp
@@ -44,6 +44,7 @@
 #include "JSSVGElementWrapperFactory.h"
 #include "MathMLElement.h"
 #include "NodeList.h"
+#include "Quirks.h"
 #include "SVGElement.h"
 #include "WebCoreJSClientData.h"
 
@@ -146,6 +147,24 @@ JSValue JSElement::ariaLabelledByElements(JSGlobalObject& lexicalGlobalObject) c
 JSValue JSElement::ariaOwnsElements(JSGlobalObject& lexicalGlobalObject) const
 {
     return getElementsArrayAttribute(lexicalGlobalObject, *this, WebCore::HTMLNames::aria_ownsAttr);
+}
+
+bool JSElement::shouldEnableWebkitRequestFullScreen(ScriptExecutionContext* context)
+{
+#if ENABLE(FULLSCREEN_API)
+    RefPtr document = dynamicDowncast<Document>(context);
+    if (!document)
+        return false;
+
+    if (document->quirks().shouldDisableElementFullscreenQuirk())
+        return false;
+
+    return document->settings().fullScreenEnabled()
+        || document->quirks().shouldEnterNativeFullscreenWhenCallingElementRequestFullscreenQuirk();
+#else
+    UNUSED_PARAM(context);
+    return false;
+#endif
 }
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/scripts/IDLAttributes.json
+++ b/Source/WebCore/bindings/scripts/IDLAttributes.json
@@ -105,6 +105,10 @@
         "CustomDeleteProperty": {
             "contextsAllowed": ["interface"]
         },
+        "CustomEnabledBy": {
+            "contextsAllowed": ["attribute", "operation"],
+            "values": ["*"]
+        },
         "CustomGetCallData": {
             "contextsAllowed": ["interface"]
         },

--- a/Source/WebCore/dom/Element+Fullscreen.idl
+++ b/Source/WebCore/dom/Element+Fullscreen.idl
@@ -34,8 +34,8 @@
     attribute EventHandler onfullscreenerror;
 
     // Non-standard: WebKit prefixed variants.
-    [ImplementedAs=webkitRequestFullscreen] undefined webkitRequestFullScreen(); // Prefixed Mozilla version.
-    undefined webkitRequestFullscreen(); // Prefixed W3C version.
+    [ImplementedAs=webkitRequestFullscreen, CustomEnabledBy=shouldEnableWebkitRequestFullScreen] undefined webkitRequestFullScreen(); // Prefixed Mozilla version.
+    [CustomEnabledBy=shouldEnableWebkitRequestFullScreen] undefined webkitRequestFullscreen(); // Prefixed W3C version.
     [NotEnumerable] attribute EventHandler onwebkitfullscreenchange;
     [NotEnumerable] attribute EventHandler onwebkitfullscreenerror;
 };

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1905,6 +1905,11 @@ bool Quirks::shouldPreventKeyframeEffectAcceleration(const KeyframeEffect& effec
     return target && Ref { target->element }->localName() == "ea-network-nav"_s;
 }
 
+bool Quirks::shouldEnterNativeFullscreenWhenCallingElementRequestFullscreenQuirk() const
+{
+    return needsQuirks() && m_quirksData.shouldEnterNativeFullscreenWhenCallingElementRequestFullscreen;
+}
+
 URL Quirks::topDocumentURL() const
 {
     if (!m_topDocumentURLForTesting.isEmpty()) [[unlikely]]
@@ -2562,6 +2567,19 @@ static void handleMenloSecurityQuirks(QuirksData& quirksData, const URL& quirksU
     quirksData.shouldDisableWritingSuggestionsByDefaultQuirk = true;
 }
 
+static void handleNBAQuirks(QuirksData& quirksData, const URL&, const String& quirksDomainString, const URL&)
+{
+#if PLATFORM(IOS)
+    if (quirksDomainString != "nba.com"_s)
+        return;
+
+    quirksData.shouldEnterNativeFullscreenWhenCallingElementRequestFullscreen = PAL::currentUserInterfaceIdiomIsSmallScreen();
+#else
+    UNUSED_PARAM(quirksData);
+    UNUSED_PARAM(quirksDomainString);
+#endif
+}
+
 static void handleNHLQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
 {
     if (quirksDomainString != "nhl.com"_s)
@@ -2929,6 +2947,7 @@ void Quirks::determineRelevantQuirks()
         { "medium"_s, &handleMediumQuirks },
         { "menlosecurity"_s, &handleMenloSecurityQuirks },
         { "netflix"_s, &handleNetflixQuirks },
+        { "nba"_s, &handleNBAQuirks },
         { "nhl"_s, &handleNHLQuirks },
 #if PLATFORM(IOS) || PLATFORM(VISION)
         { "nytimes"_s, &handleNYTimesQuirks },

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -265,6 +265,8 @@ public:
 
     bool shouldPreventKeyframeEffectAcceleration(const KeyframeEffect&) const;
 
+    bool shouldEnterNativeFullscreenWhenCallingElementRequestFullscreenQuirk() const;
+
 private:
     bool needsQuirks() const;
     bool isDomain(const String&) const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -187,6 +187,7 @@ struct WEBCORE_EXPORT QuirksData {
     bool needsNowPlayingFullscreenSwapQuirk : 1 { false };
     bool needsWebKitMediaTextTrackDisplayQuirk : 1 { false };
     bool needsMediaRewriteRangeRequestQuirk : 1 { false };
+    bool shouldEnterNativeFullscreenWhenCallingElementRequestFullscreen : 1 { false };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### ca89498e8f6576d629c2b23c62970b1c9b2eb6f1
<pre>
[iPhone] nba.com: Fullscreen broken when requesting Desktop Website
<a href="https://rdar.apple.com/133321190">rdar://133321190</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=294992">https://bugs.webkit.org/show_bug.cgi?id=294992</a>

Reviewed by Eric Carlson.

Adds a quirk that, because the Destop version of nba.com uses
webkitRequestFullscreen() unconditionally, finds the biggest video inside the
requesting element and takes that video into fullscreen instead.

* Source/WebCore/bindings/js/JSElementCustom.cpp:
(WebCore::JSElement::shouldEnableWebkitRequestFullScreen):
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateHeader):
(GenerateRuntimeEnableConditionalString):
* Source/WebCore/bindings/scripts/IDLAttributes.json:
* Source/WebCore/dom/DocumentFullscreen.cpp:
(WebCore::DocumentFullscreen::requestFullscreen):
* Source/WebCore/dom/Element+Fullscreen.idl:
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldEnterNativeFullscreenWhenCallingElementRequestFullscreenQuirk const):
(WebCore::handleNBAQuirks):
(WebCore::Quirks::determineRelevantQuirks):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:

Canonical link: <a href="https://commits.webkit.org/296749@main">https://commits.webkit.org/296749@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/456b86a233bba3afd43361a9bbbcb3556af2f76f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109339 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28997 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19426 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114544 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59591 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111302 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29676 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37586 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83098 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112287 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23627 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98485 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63553 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23015 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16628 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59171 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92995 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16670 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117657 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36380 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26931 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92109 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36752 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94747 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91921 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23434 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36851 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14602 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32199 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36276 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41757 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35954 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39287 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37652 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->