### PR TITLE
[SaferCPP] Improve smart pointer adoption in the UIProcess C API, part 3/3

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -7,9 +7,7 @@ Platform/IPC/Connection.cpp
 Platform/IPC/Connection.h
 Platform/IPC/StreamClientConnection.cpp
 Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
-UIProcess/API/C/WKContext.cpp
 UIProcess/API/C/WKPage.cpp
-UIProcess/API/C/WKWebsiteDataStoreRef.cpp
 UIProcess/API/C/mac/WKPagePrivateMac.mm
 UIProcess/API/Cocoa/WKContentWorld.mm
 UIProcess/API/Cocoa/WKDownload.mm

--- a/Source/WebKit/UIProcess/API/C/WKContext.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKContext.cpp
@@ -94,12 +94,12 @@ WKContextRef WKContextCreateWithConfiguration(WKContextConfigurationRef configur
 
 void WKContextSetClient(WKContextRef contextRef, const WKContextClientBase* wkClient)
 {
-    WebKit::toImpl(contextRef)->initializeClient(wkClient);
+    WebKit::toProtectedImpl(contextRef)->initializeClient(wkClient);
 }
 
 void WKContextSetInjectedBundleClient(WKContextRef contextRef, const WKContextInjectedBundleClientBase* wkClient)
 {
-    WebKit::toImpl(contextRef)->setInjectedBundleClient(makeUnique<WebKit::WebContextInjectedBundleClient>(wkClient));
+    WebKit::toProtectedImpl(contextRef)->setInjectedBundleClient(makeUnique<WebKit::WebContextInjectedBundleClient>(wkClient));
 }
 
 void WKContextSetHistoryClient(WKContextRef contextRef, const WKContextHistoryClientBase* wkClient)
@@ -253,7 +253,7 @@ void WKContextSetDownloadClient(WKContextRef context, const WKContextDownloadCli
         }
         WKContextRef m_context;
     };
-    WebKit::toImpl(context)->setLegacyDownloadClient(adoptRef(*new LegacyDownloadClient(wkClient, context)));
+    WebKit::toProtectedImpl(context)->setLegacyDownloadClient(adoptRef(*new LegacyDownloadClient(wkClient, context)));
 }
 
 void WKContextSetInitializationUserDataForInjectedBundle(WKContextRef contextRef,  WKTypeRef userDataRef)
@@ -263,7 +263,7 @@ void WKContextSetInitializationUserDataForInjectedBundle(WKContextRef contextRef
 
 void WKContextPostMessageToInjectedBundle(WKContextRef contextRef, WKStringRef messageNameRef, WKTypeRef messageBodyRef)
 {
-    WebKit::toImpl(contextRef)->postMessageToInjectedBundle(WebKit::toImpl(messageNameRef)->string(), WebKit::toImpl(messageBodyRef));
+    WebKit::toProtectedImpl(contextRef)->postMessageToInjectedBundle(WebKit::toProtectedImpl(messageNameRef)->string(), WebKit::toProtectedImpl(messageBodyRef).get());
 }
 
 void WKContextGetGlobalStatistics(WKContextStatistics* statistics)
@@ -277,7 +277,7 @@ void WKContextGetGlobalStatistics(WKContextStatistics* statistics)
 
 void WKContextAddVisitedLink(WKContextRef contextRef, WKStringRef visitedURL)
 {
-    String visitedURLString = WebKit::toImpl(visitedURL)->string();
+    String visitedURLString = WebKit::toProtectedImpl(visitedURL)->string();
     if (visitedURLString.isEmpty())
         return;
 
@@ -312,12 +312,12 @@ unsigned WKContextGetMaximumNumberOfProcesses(WKContextRef)
 
 void WKContextSetAlwaysUsesComplexTextCodePath(WKContextRef contextRef, bool alwaysUseComplexTextCodePath)
 {
-    WebKit::toImpl(contextRef)->setAlwaysUsesComplexTextCodePath(alwaysUseComplexTextCodePath);
+    WebKit::toProtectedImpl(contextRef)->setAlwaysUsesComplexTextCodePath(alwaysUseComplexTextCodePath);
 }
 
 void WKContextSetDisableFontSubpixelAntialiasingForTesting(WKContextRef contextRef, bool disable)
 {
-    WebKit::toImpl(contextRef)->setDisableFontSubpixelAntialiasingForTesting(disable);
+    WebKit::toProtectedImpl(contextRef)->setDisableFontSubpixelAntialiasingForTesting(disable);
 }
 
 void WKContextSetAdditionalPluginsDirectory(WKContextRef contextRef, WKStringRef pluginsDirectory)
@@ -333,32 +333,32 @@ void WKContextRefreshPlugIns(WKContextRef context)
 
 void WKContextRegisterURLSchemeAsEmptyDocument(WKContextRef contextRef, WKStringRef urlScheme)
 {
-    WebKit::toImpl(contextRef)->registerURLSchemeAsEmptyDocument(WebKit::toImpl(urlScheme)->string());
+    WebKit::toProtectedImpl(contextRef)->registerURLSchemeAsEmptyDocument(WebKit::toProtectedImpl(urlScheme)->string());
 }
 
 void WKContextRegisterURLSchemeAsSecure(WKContextRef contextRef, WKStringRef urlScheme)
 {
-    WebKit::toImpl(contextRef)->registerURLSchemeAsSecure(WebKit::toImpl(urlScheme)->string());
+    WebKit::toProtectedImpl(contextRef)->registerURLSchemeAsSecure(WebKit::toProtectedImpl(urlScheme)->string());
 }
 
 void WKContextRegisterURLSchemeAsBypassingContentSecurityPolicy(WKContextRef contextRef, WKStringRef urlScheme)
 {
-    WebKit::toImpl(contextRef)->registerURLSchemeAsBypassingContentSecurityPolicy(WebKit::toImpl(urlScheme)->string());
+    WebKit::toProtectedImpl(contextRef)->registerURLSchemeAsBypassingContentSecurityPolicy(WebKit::toProtectedImpl(urlScheme)->string());
 }
 
 void WKContextRegisterURLSchemeAsCachePartitioned(WKContextRef contextRef, WKStringRef urlScheme)
 {
-    WebKit::toImpl(contextRef)->registerURLSchemeAsCachePartitioned(WebKit::toImpl(urlScheme)->string());
+    WebKit::toProtectedImpl(contextRef)->registerURLSchemeAsCachePartitioned(WebKit::toProtectedImpl(urlScheme)->string());
 }
 
 void WKContextRegisterURLSchemeAsCanDisplayOnlyIfCanRequest(WKContextRef contextRef, WKStringRef urlScheme)
 {
-    WebKit::toImpl(contextRef)->registerURLSchemeAsCanDisplayOnlyIfCanRequest(WebKit::toImpl(urlScheme)->string());
+    WebKit::toProtectedImpl(contextRef)->registerURLSchemeAsCanDisplayOnlyIfCanRequest(WebKit::toProtectedImpl(urlScheme)->string());
 }
 
 void WKContextSetDomainRelaxationForbiddenForURLScheme(WKContextRef contextRef, WKStringRef urlScheme)
 {
-    WebKit::toImpl(contextRef)->setDomainRelaxationForbiddenForURLScheme(WebKit::toImpl(urlScheme)->string());
+    WebKit::toProtectedImpl(contextRef)->setDomainRelaxationForbiddenForURLScheme(WebKit::toProtectedImpl(urlScheme)->string());
 }
 
 void WKContextSetCanHandleHTTPSServerTrustEvaluation(WKContextRef contextRef, bool value)
@@ -404,7 +404,7 @@ WKApplicationCacheManagerRef WKContextGetApplicationCacheManager(WKContextRef co
 
 WKGeolocationManagerRef WKContextGetGeolocationManager(WKContextRef contextRef)
 {
-    return WebKit::toAPI(WebKit::toImpl(contextRef)->supplement<WebKit::WebGeolocationManagerProxy>());
+    return WebKit::toAPI(WebKit::toProtectedImpl(contextRef)->protectedSupplement<WebKit::WebGeolocationManagerProxy>().get());
 }
 
 WKIconDatabaseRef WKContextGetIconDatabase(WKContextRef)
@@ -419,7 +419,7 @@ WKKeyValueStorageManagerRef WKContextGetKeyValueStorageManager(WKContextRef cont
 
 WKNotificationManagerRef WKContextGetNotificationManager(WKContextRef contextRef)
 {
-    return WebKit::toAPI(WebKit::toImpl(contextRef)->supplement<WebKit::WebNotificationManagerProxy>());
+    return WebKit::toAPI(WebKit::toProtectedImpl(contextRef)->protectedSupplement<WebKit::WebNotificationManagerProxy>().get());
 }
 
 WKResourceCacheManagerRef WKContextGetResourceCacheManager(WKContextRef context)
@@ -429,12 +429,12 @@ WKResourceCacheManagerRef WKContextGetResourceCacheManager(WKContextRef context)
 
 void WKContextStartMemorySampler(WKContextRef contextRef, WKDoubleRef interval)
 {
-    WebKit::toImpl(contextRef)->startMemorySampler(WebKit::toImpl(interval)->value());
+    WebKit::toProtectedImpl(contextRef)->startMemorySampler(WebKit::toImpl(interval)->value());
 }
 
 void WKContextStopMemorySampler(WKContextRef contextRef)
 {
-    WebKit::toImpl(contextRef)->stopMemorySampler();
+    WebKit::toProtectedImpl(contextRef)->stopMemorySampler();
 }
 
 void WKContextSetIconDatabasePath(WKContextRef, WKStringRef)
@@ -447,22 +447,22 @@ void WKContextAllowSpecificHTTPSCertificateForHost(WKContextRef, WKCertificateIn
 
 void WKContextDisableProcessTermination(WKContextRef contextRef)
 {
-    WebKit::toImpl(contextRef)->disableProcessTermination();
+    WebKit::toProtectedImpl(contextRef)->disableProcessTermination();
 }
 
 void WKContextEnableProcessTermination(WKContextRef contextRef)
 {
-    WebKit::toImpl(contextRef)->enableProcessTermination();
+    WebKit::toProtectedImpl(contextRef)->enableProcessTermination();
 }
 
 void WKContextSetHTTPPipeliningEnabled(WKContextRef contextRef, bool enabled)
 {
-    WebKit::toImpl(contextRef)->setHTTPPipeliningEnabled(enabled);
+    WebKit::toProtectedImpl(contextRef)->setHTTPPipeliningEnabled(enabled);
 }
 
 void WKContextWarmInitialProcess(WKContextRef contextRef)
 {
-    WebKit::toImpl(contextRef)->prewarmProcess();
+    WebKit::toProtectedImpl(contextRef)->prewarmProcess();
 }
 
 void WKContextGetStatistics(WKContextRef contextRef, void* context, WKContextGetStatisticsFunction callback)
@@ -480,17 +480,17 @@ bool WKContextJavaScriptConfigurationFileEnabled(WKContextRef contextRef)
 
 void WKContextSetJavaScriptConfigurationFileEnabled(WKContextRef contextRef, bool enable)
 {
-    WebKit::toImpl(contextRef)->setJavaScriptConfigurationFileEnabled(enable);
+    WebKit::toProtectedImpl(contextRef)->setJavaScriptConfigurationFileEnabled(enable);
 }
 
 void WKContextGarbageCollectJavaScriptObjects(WKContextRef contextRef)
 {
-    WebKit::toImpl(contextRef)->garbageCollectJavaScriptObjects();
+    WebKit::toProtectedImpl(contextRef)->garbageCollectJavaScriptObjects();
 }
 
 void WKContextSetJavaScriptGarbageCollectorTimerEnabled(WKContextRef contextRef, bool enable)
 {
-    WebKit::toImpl(contextRef)->setJavaScriptGarbageCollectorTimerEnabled(enable);
+    WebKit::toProtectedImpl(contextRef)->setJavaScriptGarbageCollectorTimerEnabled(enable);
 }
 
 WKDictionaryRef WKContextCopyPlugInAutoStartOriginHashes(WKContextRef)
@@ -517,12 +517,12 @@ void WKContextSetInvalidMessageFunction(WKContextInvalidMessageFunction invalidM
 
 void WKContextSetMemoryCacheDisabled(WKContextRef contextRef, bool disabled)
 {
-    WebKit::toImpl(contextRef)->setMemoryCacheDisabled(disabled);
+    WebKit::toProtectedImpl(contextRef)->setMemoryCacheDisabled(disabled);
 }
 
 void WKContextSetFontAllowList(WKContextRef contextRef, WKArrayRef arrayRef)
 {
-    WebKit::toImpl(contextRef)->setFontAllowList(WebKit::toImpl(arrayRef));
+    WebKit::toProtectedImpl(contextRef)->setFontAllowList(WebKit::toProtectedImpl(arrayRef).get());
 }
 
 void WKContextTerminateGPUProcess(WKContextRef)
@@ -535,7 +535,7 @@ void WKContextTerminateGPUProcess(WKContextRef)
 
 void WKContextTerminateServiceWorkers(WKContextRef context)
 {
-    WebKit::toImpl(context)->terminateServiceWorkers();
+    WebKit::toProtectedImpl(context)->terminateServiceWorkers();
 }
 
 void WKContextAddSupportedPlugin(WKContextRef contextRef, WKStringRef domainRef, WKStringRef nameRef, WKArrayRef mimeTypesRef, WKArrayRef extensionsRef)
@@ -548,7 +548,7 @@ void WKContextClearSupportedPlugins(WKContextRef contextRef)
 
 void WKContextClearCurrentModifierStateForTesting(WKContextRef contextRef)
 {
-    WebKit::toImpl(contextRef)->clearCurrentModifierStateForTesting();
+    WebKit::toProtectedImpl(contextRef)->clearCurrentModifierStateForTesting();
 }
 
 void WKContextSetUseSeparateServiceWorkerProcess(WKContextRef, bool useSeparateServiceWorkerProcess)
@@ -567,7 +567,7 @@ WKArrayRef WKContextCopyLocalhostAliases(WKContextRef)
 
 void WKContextSetLocalhostAliases(WKContextRef, WKArrayRef localhostAliases)
 {
-    for (const auto& hostname : WebKit::toImpl(localhostAliases)->toStringVector())
+    for (const auto& hostname : WebKit::toProtectedImpl(localhostAliases)->toStringVector())
         WebKit::LegacyGlobalSettings::singleton().registerHostnameAsLocal(hostname);
 }
 
@@ -582,7 +582,7 @@ void WKContextClearMockGamepadsForTesting(WKContextRef)
 void WKContextSetResourceMonitorURLsForTesting(WKContextRef contextRef, WKStringRef rulesText, void* context, WKContextSetResourceMonitorURLsFunction callback)
 {
 #if ENABLE(CONTENT_EXTENSIONS) && PLATFORM(COCOA)
-    WebKit::toImpl(contextRef)->setResourceMonitorURLsForTesting(WebKit::toWTFString(rulesText), [context, callback] {
+    WebKit::toProtectedImpl(contextRef)->setResourceMonitorURLsForTesting(WebKit::toWTFString(rulesText), [context, callback] {
         if (callback)
             callback(context);
     });

--- a/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,69 +72,69 @@ WKWebsiteDataStoreRef WKWebsiteDataStoreCreateWithConfiguration(WKWebsiteDataSto
 
 void WKWebsiteDataStoreTerminateNetworkProcess(WKWebsiteDataStoreRef dataStore)
 {
-    WebKit::toImpl(dataStore)->terminateNetworkProcess();
+    WebKit::toProtectedImpl(dataStore)->terminateNetworkProcess();
 }
 
 WKProcessID WKWebsiteDataStoreGetNetworkProcessIdentifier(WKWebsiteDataStoreRef dataStore)
 {
-    return WebKit::toImpl(dataStore)->networkProcess().processID();
+    return WebKit::toProtectedImpl(dataStore)->networkProcess().processID();
 }
 
 void WKWebsiteDataStoreRemoveITPDataForDomain(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, void* context, WKWebsiteDataStoreRemoveITPDataForDomainFunction callback)
 {
     WebKit::WebsiteDataRecord dataRecord;
     dataRecord.types.add(WebKit::WebsiteDataType::ResourceLoadStatistics);
-    dataRecord.addResourceLoadStatisticsRegistrableDomain(WebCore::RegistrableDomain::uncheckedCreateFromHost(WebKit::toImpl(host)->string()));
+    dataRecord.addResourceLoadStatisticsRegistrableDomain(WebCore::RegistrableDomain::uncheckedCreateFromHost(WebKit::toProtectedImpl(host)->string()));
     Vector<WebKit::WebsiteDataRecord> dataRecords = { WTFMove(dataRecord) };
 
     OptionSet<WebKit::WebsiteDataType> dataTypes = WebKit::WebsiteDataType::ResourceLoadStatistics;
-    WebKit::toImpl(dataStoreRef)->removeData(dataTypes, dataRecords, [context, callback] {
+    WebKit::toProtectedImpl(dataStoreRef)->removeData(dataTypes, dataRecords, [context, callback] {
         callback(context);
     });
 }
 
 void WKWebsiteDataStoreDoesStatisticsDomainIDExistInDatabase(WKWebsiteDataStoreRef dataStoreRef, int domainID, void* context, WKWebsiteDataStoreDoesStatisticsDomainIDExistInDatabaseFunction callback)
 {
-    WebKit::toImpl(dataStoreRef)->domainIDExistsInDatabase(domainID, [context, callback](bool exists) {
+    WebKit::toProtectedImpl(dataStoreRef)->domainIDExistsInDatabase(domainID, [context, callback](bool exists) {
         callback(exists, context);
     });
 }
 
 void WKWebsiteDataStoreSetServiceWorkerFetchTimeoutForTesting(WKWebsiteDataStoreRef dataStore, double seconds)
 {
-    WebKit::toImpl(dataStore)->setServiceWorkerTimeoutForTesting(Seconds(seconds));
+    WebKit::toProtectedImpl(dataStore)->setServiceWorkerTimeoutForTesting(Seconds(seconds));
 }
 
 void WKWebsiteDataStoreResetServiceWorkerFetchTimeoutForTesting(WKWebsiteDataStoreRef dataStore)
 {
-    WebKit::toImpl(dataStore)->resetServiceWorkerTimeoutForTesting();
+    WebKit::toProtectedImpl(dataStore)->resetServiceWorkerTimeoutForTesting();
 }
 
 void WKWebsiteDataStoreSetResourceLoadStatisticsEnabled(WKWebsiteDataStoreRef dataStoreRef, bool enable)
 {
-    WebKit::toImpl(dataStoreRef)->setTrackingPreventionEnabled(enable);
+    WebKit::toProtectedImpl(dataStoreRef)->setTrackingPreventionEnabled(enable);
 }
 
 void WKWebsiteDataStoreIsStatisticsEphemeral(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreStatisticsEphemeralFunction completionHandler)
 {
-    WebKit::toImpl(dataStoreRef)->isResourceLoadStatisticsEphemeral([context, completionHandler](bool isEphemeral) {
+    WebKit::toProtectedImpl(dataStoreRef)->isResourceLoadStatisticsEphemeral([context, completionHandler](bool isEphemeral) {
         completionHandler(isEphemeral, context);
     });
 }
 
 bool WKWebsiteDataStoreGetResourceLoadStatisticsEnabled(WKWebsiteDataStoreRef dataStoreRef)
 {
-    return WebKit::toImpl(dataStoreRef)->trackingPreventionEnabled();
+    return WebKit::toProtectedImpl(dataStoreRef)->trackingPreventionEnabled();
 }
 
 void WKWebsiteDataStoreSetResourceLoadStatisticsDebugMode(WKWebsiteDataStoreRef dataStoreRef, bool enable)
 {
-    WebKit::toImpl(dataStoreRef)->setResourceLoadStatisticsDebugMode(enable);
+    WebKit::toProtectedImpl(dataStoreRef)->setResourceLoadStatisticsDebugMode(enable);
 }
 
 void WKWebsiteDataStoreSyncLocalStorage(WKWebsiteDataStoreRef dataStore, void* context, WKWebsiteDataStoreSyncLocalStorageCallback callback)
 {
-    WebKit::toImpl(dataStore)->syncLocalStorage([context, callback] {
+    WebKit::toProtectedImpl(dataStore)->syncLocalStorage([context, callback] {
         if (callback)
             callback(context);
     });
@@ -142,7 +142,7 @@ void WKWebsiteDataStoreSyncLocalStorage(WKWebsiteDataStoreRef dataStore, void* c
 
 WKHTTPCookieStoreRef WKWebsiteDataStoreGetHTTPCookieStore(WKWebsiteDataStoreRef dataStoreRef)
 {
-    return WebKit::toAPI(&WebKit::toImpl(dataStoreRef)->cookieStore());
+    return WebKit::toAPI(WebKit::toProtectedImpl(dataStoreRef)->protectedCookieStore().get());
 }
 
 void WKWebsiteDataStoreSetAllowsAnySSLCertificateForWebSocketTesting(WKWebsiteDataStoreRef, bool)
@@ -151,34 +151,34 @@ void WKWebsiteDataStoreSetAllowsAnySSLCertificateForWebSocketTesting(WKWebsiteDa
 
 void WKWebsiteDataStoreSetResourceLoadStatisticsDebugModeWithCompletionHandler(WKWebsiteDataStoreRef dataStoreRef, bool enable, void* context, WKWebsiteDataStoreStatisticsDebugModeFunction completionHandler)
 {
-    WebKit::toImpl(dataStoreRef)->setResourceLoadStatisticsDebugMode(enable, [context, completionHandler] {
+    WebKit::toProtectedImpl(dataStoreRef)->setResourceLoadStatisticsDebugMode(enable, [context, completionHandler] {
         completionHandler(context);
     });
 }
 
 void WKWebsiteDataStoreSetResourceLoadStatisticsPrevalentResourceForDebugMode(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, void* context, WKWebsiteDataStoreStatisticsDebugModeFunction completionHandler)
 {
-    WebKit::toImpl(dataStoreRef)->setPrevalentResourceForDebugMode(URL { WebKit::toImpl(host)->string() }, [context, completionHandler] {
+    WebKit::toProtectedImpl(dataStoreRef)->setPrevalentResourceForDebugMode(URL { WebKit::toProtectedImpl(host)->string() }, [context, completionHandler] {
         completionHandler(context);
     });
 }
 void WKWebsiteDataStoreSetStatisticsLastSeen(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, double seconds, void* context, WKWebsiteDataStoreStatisticsLastSeenFunction completionHandler)
 {
-    WebKit::toImpl(dataStoreRef)->setLastSeen(URL { WebKit::toImpl(host)->string() }, Seconds { seconds }, [context, completionHandler] {
+    WebKit::toProtectedImpl(dataStoreRef)->setLastSeen(URL { WebKit::toProtectedImpl(host)->string() }, Seconds { seconds }, [context, completionHandler] {
         completionHandler(context);
     });
 }
 
 void WKWebsiteDataStoreSetStatisticsMergeStatistic(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, WKStringRef topFrameDomain1, WKStringRef topFrameDomain2, double lastSeen, bool hadUserInteraction, double mostRecentUserInteraction, bool isGrandfathered, bool isPrevalent, bool isVeryPrevalent, unsigned dataRecordsRemoved, void* context, WKWebsiteDataStoreStatisticsMergeStatisticFunction completionHandler)
 {
-    WebKit::toImpl(dataStoreRef)->mergeStatisticForTesting(URL { WebKit::toImpl(host)->string() }, URL { WebKit::toImpl(topFrameDomain1)->string() }, URL { WebKit::toImpl(topFrameDomain2)->string() }, Seconds { lastSeen }, hadUserInteraction, Seconds { mostRecentUserInteraction }, isGrandfathered, isPrevalent, isVeryPrevalent, dataRecordsRemoved, [context, completionHandler] {
+    WebKit::toProtectedImpl(dataStoreRef)->mergeStatisticForTesting(URL { WebKit::toProtectedImpl(host)->string() }, URL { WebKit::toProtectedImpl(topFrameDomain1)->string() }, URL { WebKit::toProtectedImpl(topFrameDomain2)->string() }, Seconds { lastSeen }, hadUserInteraction, Seconds { mostRecentUserInteraction }, isGrandfathered, isPrevalent, isVeryPrevalent, dataRecordsRemoved, [context, completionHandler] {
         completionHandler(context);
     });
 }
 
 void WKWebsiteDataStoreSetStatisticsExpiredStatistic(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, unsigned numberOfOperatingDaysPassed, bool hadUserInteraction, bool isScheduledForAllButCookieDataRemoval, bool isPrevalent, void* context, WKWebsiteDataStoreStatisticsMergeStatisticFunction completionHandler)
 {
-    WebKit::toImpl(dataStoreRef)->insertExpiredStatisticForTesting(URL { WebKit::toImpl(host)->string() }, numberOfOperatingDaysPassed, hadUserInteraction, isScheduledForAllButCookieDataRemoval, isPrevalent, [context, completionHandler] {
+    WebKit::toProtectedImpl(dataStoreRef)->insertExpiredStatisticForTesting(URL { WebKit::toProtectedImpl(host)->string() }, numberOfOperatingDaysPassed, hadUserInteraction, isScheduledForAllButCookieDataRemoval, isPrevalent, [context, completionHandler] {
         completionHandler(context);
     });
 }
@@ -188,11 +188,11 @@ void WKWebsiteDataStoreSetStatisticsPrevalentResource(WKWebsiteDataStoreRef data
     Ref websiteDataStore = *WebKit::toImpl(dataStoreRef);
 
     if (value)
-        websiteDataStore->setPrevalentResource(URL { WebKit::toImpl(host)->string() }, [context, completionHandler] {
+        websiteDataStore->setPrevalentResource(URL { WebKit::toProtectedImpl(host)->string() }, [context, completionHandler] {
             completionHandler(context);
         });
     else
-        websiteDataStore->clearPrevalentResource(URL { WebKit::toImpl(host)->string() }, [context, completionHandler] {
+        websiteDataStore->clearPrevalentResource(URL { WebKit::toProtectedImpl(host)->string() }, [context, completionHandler] {
             completionHandler(context);
         });
 }
@@ -202,204 +202,204 @@ void WKWebsiteDataStoreSetStatisticsVeryPrevalentResource(WKWebsiteDataStoreRef 
     Ref websiteDataStore = *WebKit::toImpl(dataStoreRef);
 
     if (value)
-        websiteDataStore->setVeryPrevalentResource(URL { WebKit::toImpl(host)->string() }, [context, completionHandler] {
+        websiteDataStore->setVeryPrevalentResource(URL { WebKit::toProtectedImpl(host)->string() }, [context, completionHandler] {
             completionHandler(context);
         });
     else
-        websiteDataStore->clearPrevalentResource(URL { WebKit::toImpl(host)->string() }, [context, completionHandler] {
+        websiteDataStore->clearPrevalentResource(URL { WebKit::toProtectedImpl(host)->string() }, [context, completionHandler] {
             completionHandler(context);
         });
 }
 
 void WKWebsiteDataStoreDumpResourceLoadStatistics(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreDumpResourceLoadStatisticsFunction callback)
 {
-    WebKit::toImpl(dataStoreRef)->dumpResourceLoadStatistics([context, callback] (const String& resourceLoadStatistics) {
+    WebKit::toProtectedImpl(dataStoreRef)->dumpResourceLoadStatistics([context, callback] (const String& resourceLoadStatistics) {
         callback(WebKit::toAPI(resourceLoadStatistics.impl()), context);
     });
 }
 
 void WKWebsiteDataStoreIsStatisticsPrevalentResource(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, void* context, WKWebsiteDataStoreIsStatisticsPrevalentResourceFunction callback)
 {
-    WebKit::toImpl(dataStoreRef)->isPrevalentResource(URL { WebKit::toImpl(host)->string() }, [context, callback](bool isPrevalentResource) {
+    WebKit::toProtectedImpl(dataStoreRef)->isPrevalentResource(URL { WebKit::toProtectedImpl(host)->string() }, [context, callback](bool isPrevalentResource) {
         callback(isPrevalentResource, context);
     });
 }
 
 void WKWebsiteDataStoreIsStatisticsVeryPrevalentResource(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, void* context, WKWebsiteDataStoreIsStatisticsPrevalentResourceFunction callback)
 {
-    WebKit::toImpl(dataStoreRef)->isVeryPrevalentResource(URL { WebKit::toImpl(host)->string() }, [context, callback](bool isVeryPrevalentResource) {
+    WebKit::toProtectedImpl(dataStoreRef)->isVeryPrevalentResource(URL { WebKit::toProtectedImpl(host)->string() }, [context, callback](bool isVeryPrevalentResource) {
         callback(isVeryPrevalentResource, context);
     });
 }
 
 void WKWebsiteDataStoreIsStatisticsRegisteredAsSubresourceUnder(WKWebsiteDataStoreRef dataStoreRef, WKStringRef subresourceHost, WKStringRef topFrameHost, void* context, WKWebsiteDataStoreIsStatisticsRegisteredAsSubresourceUnderFunction callback)
 {
-    WebKit::toImpl(dataStoreRef)->isRegisteredAsSubresourceUnder(URL { WebKit::toImpl(subresourceHost)->string() }, URL { WebKit::toImpl(topFrameHost)->string() }, [context, callback](bool isRegisteredAsSubresourceUnder) {
+    WebKit::toProtectedImpl(dataStoreRef)->isRegisteredAsSubresourceUnder(URL { WebKit::toProtectedImpl(subresourceHost)->string() }, URL { WebKit::toProtectedImpl(topFrameHost)->string() }, [context, callback](bool isRegisteredAsSubresourceUnder) {
         callback(isRegisteredAsSubresourceUnder, context);
     });
 }
 
 void WKWebsiteDataStoreIsStatisticsRegisteredAsSubFrameUnder(WKWebsiteDataStoreRef dataStoreRef, WKStringRef subFrameHost, WKStringRef topFrameHost, void* context, WKWebsiteDataStoreIsStatisticsRegisteredAsSubFrameUnderFunction callback)
 {
-    WebKit::toImpl(dataStoreRef)->isRegisteredAsSubFrameUnder(URL { WebKit::toImpl(subFrameHost)->string() }, URL { WebKit::toImpl(topFrameHost)->string() }, [context, callback](bool isRegisteredAsSubFrameUnder) {
+    WebKit::toProtectedImpl(dataStoreRef)->isRegisteredAsSubFrameUnder(URL { WebKit::toProtectedImpl(subFrameHost)->string() }, URL { WebKit::toProtectedImpl(topFrameHost)->string() }, [context, callback](bool isRegisteredAsSubFrameUnder) {
         callback(isRegisteredAsSubFrameUnder, context);
     });
 }
 
 void WKWebsiteDataStoreIsStatisticsRegisteredAsRedirectingTo(WKWebsiteDataStoreRef dataStoreRef, WKStringRef hostRedirectedFrom, WKStringRef hostRedirectedTo, void* context, WKWebsiteDataStoreIsStatisticsRegisteredAsRedirectingToFunction callback)
 {
-    WebKit::toImpl(dataStoreRef)->isRegisteredAsRedirectingTo(URL { WebKit::toImpl(hostRedirectedFrom)->string() }, URL { WebKit::toImpl(hostRedirectedTo)->string() }, [context, callback](bool isRegisteredAsRedirectingTo) {
+    WebKit::toProtectedImpl(dataStoreRef)->isRegisteredAsRedirectingTo(URL { WebKit::toProtectedImpl(hostRedirectedFrom)->string() }, URL { WebKit::toProtectedImpl(hostRedirectedTo)->string() }, [context, callback](bool isRegisteredAsRedirectingTo) {
         callback(isRegisteredAsRedirectingTo, context);
     });
 }
 
 void WKWebsiteDataStoreSetStatisticsHasHadUserInteraction(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, bool value, void* context, WKWebsiteDataStoreStatisticsHasHadUserInteractionFunction completionHandler)
 {
-    Ref dataStore = *WebKit::toImpl(dataStoreRef);
+    Ref dataStore = *WebKit::toProtectedImpl(dataStoreRef);
 
     if (value)
-        dataStore->logUserInteraction(URL { WebKit::toImpl(host)->string() }, [context, completionHandler] {
+        dataStore->logUserInteraction(URL { WebKit::toProtectedImpl(host)->string() }, [context, completionHandler] {
             completionHandler(context);
         });
     else
-        dataStore->clearUserInteraction(URL { WebKit::toImpl(host)->string() }, [context, completionHandler] {
+        dataStore->clearUserInteraction(URL { WebKit::toProtectedImpl(host)->string() }, [context, completionHandler] {
             completionHandler(context);
         });
 }
 
 void WKWebsiteDataStoreIsStatisticsHasHadUserInteraction(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, void* context, WKWebsiteDataStoreIsStatisticsHasHadUserInteractionFunction callback)
 {
-    WebKit::toImpl(dataStoreRef)->hasHadUserInteraction(URL { WebKit::toImpl(host)->string() }, [context, callback](bool hasHadUserInteraction) {
+    WebKit::toProtectedImpl(dataStoreRef)->hasHadUserInteraction(URL { WebKit::toProtectedImpl(host)->string() }, [context, callback](bool hasHadUserInteraction) {
         callback(hasHadUserInteraction, context);
     });
 }
 
 void WKWebsiteDataStoreIsStatisticsOnlyInDatabaseOnce(WKWebsiteDataStoreRef dataStoreRef, WKStringRef subHost, WKStringRef topHost, void* context, WKWebsiteDataStoreIsStatisticsOnlyInDatabaseOnceFunction callback)
 {
-    WebKit::toImpl(dataStoreRef)->isRelationshipOnlyInDatabaseOnce(URL { WebKit::toImpl(subHost)->string() }, URL { WebKit::toImpl(topHost)->string() }, [context, callback](bool onlyInDatabaseOnce) {
+    WebKit::toProtectedImpl(dataStoreRef)->isRelationshipOnlyInDatabaseOnce(URL { WebKit::toProtectedImpl(subHost)->string() }, URL { WebKit::toProtectedImpl(topHost)->string() }, [context, callback](bool onlyInDatabaseOnce) {
         callback(onlyInDatabaseOnce, context);
     });
 }
 
 void WKWebsiteDataStoreSetStatisticsGrandfathered(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, bool value)
 {
-    WebKit::toImpl(dataStoreRef)->setGrandfathered(URL { WebKit::toImpl(host)->string() }, value, [] { });
+    WebKit::toProtectedImpl(dataStoreRef)->setGrandfathered(URL { WebKit::toProtectedImpl(host)->string() }, value, [] { });
 }
 
 void WKWebsiteDataStoreIsStatisticsGrandfathered(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, void* context, WKWebsiteDataStoreIsStatisticsGrandfatheredFunction callback)
 {
-    WebKit::toImpl(dataStoreRef)->isGrandfathered(URL { WebKit::toImpl(host)->string() }, [context, callback](bool isGrandfathered) {
+    WebKit::toProtectedImpl(dataStoreRef)->isGrandfathered(URL { WebKit::toProtectedImpl(host)->string() }, [context, callback](bool isGrandfathered) {
         callback(isGrandfathered, context);
     });
 }
 
 void WKWebsiteDataStoreSetStatisticsSubframeUnderTopFrameOrigin(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, WKStringRef topFrameHost)
 {
-    WebKit::toImpl(dataStoreRef)->setSubframeUnderTopFrameDomain(URL { WebKit::toImpl(host)->string() }, URL { WebKit::toImpl(topFrameHost)->string() }, [] { });
+    WebKit::toProtectedImpl(dataStoreRef)->setSubframeUnderTopFrameDomain(URL { WebKit::toProtectedImpl(host)->string() }, URL { WebKit::toProtectedImpl(topFrameHost)->string() }, [] { });
 }
 
 void WKWebsiteDataStoreSetStatisticsSubresourceUnderTopFrameOrigin(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, WKStringRef topFrameHost)
 {
-    WebKit::toImpl(dataStoreRef)->setSubresourceUnderTopFrameDomain(URL { WebKit::toImpl(host)->string() }, URL { WebKit::toImpl(topFrameHost)->string() }, [] { });
+    WebKit::toProtectedImpl(dataStoreRef)->setSubresourceUnderTopFrameDomain(URL { WebKit::toProtectedImpl(host)->string() }, URL { WebKit::toProtectedImpl(topFrameHost)->string() }, [] { });
 }
 
 void WKWebsiteDataStoreSetStatisticsSubresourceUniqueRedirectTo(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, WKStringRef hostRedirectedTo)
 {
-    WebKit::toImpl(dataStoreRef)->setSubresourceUniqueRedirectTo(URL { WebKit::toImpl(host)->string() }, URL { WebKit::toImpl(hostRedirectedTo)->string() }, [] { });
+    WebKit::toProtectedImpl(dataStoreRef)->setSubresourceUniqueRedirectTo(URL { WebKit::toProtectedImpl(host)->string() }, URL { WebKit::toProtectedImpl(hostRedirectedTo)->string() }, [] { });
 }
 
 void WKWebsiteDataStoreSetStatisticsSubresourceUniqueRedirectFrom(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, WKStringRef hostRedirectedFrom)
 {
-    WebKit::toImpl(dataStoreRef)->setSubresourceUniqueRedirectFrom(URL { WebKit::toImpl(host)->string() }, URL { WebKit::toImpl(hostRedirectedFrom)->string() }, [] { });
+    WebKit::toProtectedImpl(dataStoreRef)->setSubresourceUniqueRedirectFrom(URL { WebKit::toProtectedImpl(host)->string() }, URL { WebKit::toProtectedImpl(hostRedirectedFrom)->string() }, [] { });
 }
 
 void WKWebsiteDataStoreSetStatisticsTopFrameUniqueRedirectTo(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, WKStringRef hostRedirectedTo)
 {
-    WebKit::toImpl(dataStoreRef)->setTopFrameUniqueRedirectTo(URL { WebKit::toImpl(host)->string() }, URL { WebKit::toImpl(hostRedirectedTo)->string() }, [] { });
+    WebKit::toProtectedImpl(dataStoreRef)->setTopFrameUniqueRedirectTo(URL { WebKit::toProtectedImpl(host)->string() }, URL { WebKit::toProtectedImpl(hostRedirectedTo)->string() }, [] { });
 }
 
 void WKWebsiteDataStoreSetStatisticsTopFrameUniqueRedirectFrom(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, WKStringRef hostRedirectedFrom)
 {
-    WebKit::toImpl(dataStoreRef)->setTopFrameUniqueRedirectFrom(URL { WebKit::toImpl(host)->string() }, URL { WebKit::toImpl(hostRedirectedFrom)->string() }, [] { });
+    WebKit::toProtectedImpl(dataStoreRef)->setTopFrameUniqueRedirectFrom(URL { WebKit::toProtectedImpl(host)->string() }, URL { WebKit::toProtectedImpl(hostRedirectedFrom)->string() }, [] { });
 }
 
 void WKWebsiteDataStoreSetStatisticsCrossSiteLoadWithLinkDecoration(WKWebsiteDataStoreRef dataStoreRef, WKStringRef fromHost, WKStringRef toHost, bool wasFiltered, void* context, WKWebsiteDataStoreSetStatisticsCrossSiteLoadWithLinkDecorationFunction callback)
 {
-    WebKit::toImpl(dataStoreRef)->setCrossSiteLoadWithLinkDecorationForTesting(URL { WebKit::toImpl(fromHost)->string() }, URL { WebKit::toImpl(toHost)->string() }, wasFiltered, [context, callback] {
+    WebKit::toProtectedImpl(dataStoreRef)->setCrossSiteLoadWithLinkDecorationForTesting(URL { WebKit::toProtectedImpl(fromHost)->string() }, URL { WebKit::toProtectedImpl(toHost)->string() }, wasFiltered, [context, callback] {
         callback(context);
     });
 }
 
 void WKWebsiteDataStoreSetStatisticsTimeToLiveUserInteraction(WKWebsiteDataStoreRef dataStoreRef, double seconds, void* context, WKWebsiteDataStoreSetStatisticsTimeToLiveUserInteractionFunction callback)
 {
-    WebKit::toImpl(dataStoreRef)->setTimeToLiveUserInteraction(Seconds { seconds }, [context, callback] {
+    WebKit::toProtectedImpl(dataStoreRef)->setTimeToLiveUserInteraction(Seconds { seconds }, [context, callback] {
         callback(context);
     });
 }
 
 void WKWebsiteDataStoreStatisticsProcessStatisticsAndDataRecords(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreStatisticsProcessStatisticsAndDataRecordsFunction callback)
 {
-    WebKit::toImpl(dataStoreRef)->scheduleStatisticsAndDataRecordsProcessing([context, callback] {
+    WebKit::toProtectedImpl(dataStoreRef)->scheduleStatisticsAndDataRecordsProcessing([context, callback] {
         callback(context);
     });
 }
 
 void WKWebsiteDataStoreStatisticsUpdateCookieBlocking(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreStatisticsUpdateCookieBlockingFunction completionHandler)
 {
-    WebKit::toImpl(dataStoreRef)->scheduleCookieBlockingUpdate([context, completionHandler]() {
+    WebKit::toProtectedImpl(dataStoreRef)->scheduleCookieBlockingUpdate([context, completionHandler]() {
         completionHandler(context);
     });
 }
 
 void WKWebsiteDataStoreSetResourceLoadStatisticsTimeAdvanceForTesting(WKWebsiteDataStoreRef dataStoreRef, double value, void* context, WKWebsiteDataStoreSetStatisticsIsRunningTestFunction callback)
 {
-    WebKit::toImpl(dataStoreRef)->setResourceLoadStatisticsTimeAdvanceForTesting(Seconds { value }, [context, callback] {
+    WebKit::toProtectedImpl(dataStoreRef)->setResourceLoadStatisticsTimeAdvanceForTesting(Seconds { value }, [context, callback] {
         callback(context);
     });
 }
 
 void WKWebsiteDataStoreSetStatisticsIsRunningTest(WKWebsiteDataStoreRef dataStoreRef, bool value, void* context, WKWebsiteDataStoreSetStatisticsIsRunningTestFunction callback)
 {
-    WebKit::toImpl(dataStoreRef)->setIsRunningResourceLoadStatisticsTest(value, [context, callback] {
+    WebKit::toProtectedImpl(dataStoreRef)->setIsRunningResourceLoadStatisticsTest(value, [context, callback] {
         callback(context);
     });
 }
 
 void WKWebsiteDataStoreSetStatisticsShouldClassifyResourcesBeforeDataRecordsRemoval(WKWebsiteDataStoreRef dataStoreRef, bool value)
 {
-    WebKit::toImpl(dataStoreRef)->setShouldClassifyResourcesBeforeDataRecordsRemoval(value, []() { });
+    WebKit::toProtectedImpl(dataStoreRef)->setShouldClassifyResourcesBeforeDataRecordsRemoval(value, []() { });
 }
 
 void WKWebsiteDataStoreSetStatisticsMinimumTimeBetweenDataRecordsRemoval(WKWebsiteDataStoreRef dataStoreRef, double seconds)
 {
-    WebKit::toImpl(dataStoreRef)->setMinimumTimeBetweenDataRecordsRemoval(Seconds { seconds }, []() { });
+    WebKit::toProtectedImpl(dataStoreRef)->setMinimumTimeBetweenDataRecordsRemoval(Seconds { seconds }, []() { });
 }
 
 void WKWebsiteDataStoreSetStatisticsGrandfatheringTime(WKWebsiteDataStoreRef dataStoreRef, double seconds)
 {
-    WebKit::toImpl(dataStoreRef)->setGrandfatheringTime(Seconds { seconds }, []() { });
+    WebKit::toProtectedImpl(dataStoreRef)->setGrandfatheringTime(Seconds { seconds }, []() { });
 }
 
 void WKWebsiteDataStoreSetStatisticsMaxStatisticsEntries(WKWebsiteDataStoreRef dataStoreRef, unsigned entries)
 {
-    WebKit::toImpl(dataStoreRef)->setMaxStatisticsEntries(entries, []() { });
+    WebKit::toProtectedImpl(dataStoreRef)->setMaxStatisticsEntries(entries, []() { });
 }
 
 void WKWebsiteDataStoreSetStatisticsPruneEntriesDownTo(WKWebsiteDataStoreRef dataStoreRef, unsigned entries)
 {
-    WebKit::toImpl(dataStoreRef)->setPruneEntriesDownTo(entries, []() { });
+    WebKit::toProtectedImpl(dataStoreRef)->setPruneEntriesDownTo(entries, []() { });
 }
 
 void WKWebsiteDataStoreStatisticsClearInMemoryAndPersistentStore(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreStatisticsClearInMemoryAndPersistentStoreFunction callback)
 {
-    WebKit::toImpl(dataStoreRef)->scheduleClearInMemoryAndPersistent(WebKit::ShouldGrandfatherStatistics::Yes, [context, callback]() {
+    WebKit::toProtectedImpl(dataStoreRef)->scheduleClearInMemoryAndPersistent(WebKit::ShouldGrandfatherStatistics::Yes, [context, callback]() {
         callback(context);
     });
 }
 
 void WKWebsiteDataStoreStatisticsClearInMemoryAndPersistentStoreModifiedSinceHours(WKWebsiteDataStoreRef dataStoreRef, unsigned hours, void* context, WKWebsiteDataStoreStatisticsClearInMemoryAndPersistentStoreModifiedSinceHoursFunction callback)
 {
-    WebKit::toImpl(dataStoreRef)->scheduleClearInMemoryAndPersistent(WallTime::now() - Seconds::fromHours(hours), WebKit::ShouldGrandfatherStatistics::Yes, [context, callback]() {
+    WebKit::toProtectedImpl(dataStoreRef)->scheduleClearInMemoryAndPersistent(WallTime::now() - Seconds::fromHours(hours), WebKit::ShouldGrandfatherStatistics::Yes, [context, callback]() {
         callback(context);
     });
 }
@@ -407,35 +407,35 @@ void WKWebsiteDataStoreStatisticsClearInMemoryAndPersistentStoreModifiedSinceHou
 void WKWebsiteDataStoreStatisticsClearThroughWebsiteDataRemoval(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreStatisticsClearThroughWebsiteDataRemovalFunction callback)
 {
     OptionSet<WebKit::WebsiteDataType> dataTypes = WebKit::WebsiteDataType::ResourceLoadStatistics;
-    WebKit::toImpl(dataStoreRef)->removeData(dataTypes, WallTime::fromRawSeconds(0), [context, callback] {
+    WebKit::toProtectedImpl(dataStoreRef)->removeData(dataTypes, WallTime::fromRawSeconds(0), [context, callback] {
         callback(context);
     });
 }
 
 void WKWebsiteDataStoreStatisticsDeleteCookiesForTesting(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, bool includeHttpOnlyCookies, void* context, WKWebsiteDataStoreStatisticsDeleteCookiesForTestingFunction callback)
 {
-    WebKit::toImpl(dataStoreRef)->deleteCookiesForTesting(URL { WebKit::toImpl(host)->string() }, includeHttpOnlyCookies, [context, callback] {
+    WebKit::toProtectedImpl(dataStoreRef)->deleteCookiesForTesting(URL { WebKit::toProtectedImpl(host)->string() }, includeHttpOnlyCookies, [context, callback] {
         callback(context);
     });
 }
 
 void WKWebsiteDataStoreStatisticsHasLocalStorage(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, void* context, WKWebsiteDataStoreStatisticsHasLocalStorageFunction callback)
 {
-    WebKit::toImpl(dataStoreRef)->hasLocalStorageForTesting(URL { WebKit::toImpl(host)->string() }, [context, callback](bool hasLocalStorage) {
+    WebKit::toProtectedImpl(dataStoreRef)->hasLocalStorageForTesting(URL { WebKit::toProtectedImpl(host)->string() }, [context, callback](bool hasLocalStorage) {
         callback(hasLocalStorage, context);
     });
 }
 
 void WKWebsiteDataStoreSetStatisticsCacheMaxAgeCap(WKWebsiteDataStoreRef dataStoreRef, double seconds, void* context, WKWebsiteDataStoreSetStatisticsCacheMaxAgeCapFunction callback)
 {
-    WebKit::toImpl(dataStoreRef)->setCacheMaxAgeCapForPrevalentResources(Seconds { seconds }, [context, callback] {
+    WebKit::toProtectedImpl(dataStoreRef)->setCacheMaxAgeCapForPrevalentResources(Seconds { seconds }, [context, callback] {
         callback(context);
     });
 }
 
 void WKWebsiteDataStoreStatisticsHasIsolatedSession(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, void* context, WKWebsiteDataStoreStatisticsHasIsolatedSessionFunction callback)
 {
-    WebKit::toImpl(dataStoreRef)->hasIsolatedSessionForTesting(URL { WebKit::toImpl(host)->string() }, [context, callback](bool hasIsolatedSession) {
+    WebKit::toProtectedImpl(dataStoreRef)->hasIsolatedSessionForTesting(URL { WebKit::toProtectedImpl(host)->string() }, [context, callback](bool hasIsolatedSession) {
         callback(hasIsolatedSession, context);
     });
 }
@@ -454,7 +454,7 @@ void WKWebsiteDataStoreHasAppBoundSession(WKWebsiteDataStoreRef dataStoreRef, vo
 
 void WKWebsiteDataStoreSetResourceLoadStatisticsShouldDowngradeReferrerForTesting(WKWebsiteDataStoreRef dataStoreRef, bool enabled, void* context, WKWebsiteDataStoreSetResourceLoadStatisticsShouldDowngradeReferrerForTestingFunction completionHandler)
 {
-    WebKit::toImpl(dataStoreRef)->setResourceLoadStatisticsShouldDowngradeReferrerForTesting(enabled, [context, completionHandler] {
+    WebKit::toProtectedImpl(dataStoreRef)->setResourceLoadStatisticsShouldDowngradeReferrerForTesting(enabled, [context, completionHandler] {
         completionHandler(context);
     });
 }
@@ -479,35 +479,35 @@ void WKWebsiteDataStoreSetResourceLoadStatisticsShouldBlockThirdPartyCookiesForT
 
     }
 
-    WebKit::toImpl(dataStoreRef)->setResourceLoadStatisticsShouldBlockThirdPartyCookiesForTesting(enabled, blockingMode, [context, completionHandler] {
+    WebKit::toProtectedImpl(dataStoreRef)->setResourceLoadStatisticsShouldBlockThirdPartyCookiesForTesting(enabled, blockingMode, [context, completionHandler] {
         completionHandler(context);
     });
 }
 
 void WKWebsiteDataStoreSetResourceLoadStatisticsFirstPartyWebsiteDataRemovalModeForTesting(WKWebsiteDataStoreRef dataStoreRef, bool enabled, void* context, WKWebsiteDataStoreSetResourceLoadStatisticsFirstPartyWebsiteDataRemovalModeForTestingFunction completionHandler)
 {
-    WebKit::toImpl(dataStoreRef)->setResourceLoadStatisticsFirstPartyWebsiteDataRemovalModeForTesting(enabled, [context, completionHandler] {
+    WebKit::toProtectedImpl(dataStoreRef)->setResourceLoadStatisticsFirstPartyWebsiteDataRemovalModeForTesting(enabled, [context, completionHandler] {
         completionHandler(context);
     });
 }
 
 void WKWebsiteDataStoreSetResourceLoadStatisticsToSameSiteStrictCookiesForTesting(WKWebsiteDataStoreRef dataStoreRef, WKStringRef hostName, void* context, WKWebsiteDataStoreSetResourceLoadStatisticsToSameSiteStrictCookiesForTestingFunction completionHandler)
 {
-    WebKit::toImpl(dataStoreRef)->setResourceLoadStatisticsToSameSiteStrictCookiesForTesting(URL { WebKit::toImpl(hostName)->string() }, [context, completionHandler] {
+    WebKit::toProtectedImpl(dataStoreRef)->setResourceLoadStatisticsToSameSiteStrictCookiesForTesting(URL { WebKit::toProtectedImpl(hostName)->string() }, [context, completionHandler] {
         completionHandler(context);
     });
 }
 
 void WKWebsiteDataStoreSetResourceLoadStatisticsFirstPartyHostCNAMEDomainForTesting(WKWebsiteDataStoreRef dataStoreRef, WKStringRef firstPartyURLString, WKStringRef cnameURLString, void* context, WKWebsiteDataStoreSetResourceLoadStatisticsFirstPartyHostCNAMEDomainForTestingFunction completionHandler)
 {
-    WebKit::toImpl(dataStoreRef)->setResourceLoadStatisticsFirstPartyHostCNAMEDomainForTesting(URL { WebKit::toImpl(firstPartyURLString)->string() }, URL { WebKit::toImpl(cnameURLString)->string() }, [context, completionHandler] {
+    WebKit::toProtectedImpl(dataStoreRef)->setResourceLoadStatisticsFirstPartyHostCNAMEDomainForTesting(URL { WebKit::toProtectedImpl(firstPartyURLString)->string() }, URL { WebKit::toProtectedImpl(cnameURLString)->string() }, [context, completionHandler] {
         completionHandler(context);
     });
 }
 
 void WKWebsiteDataStoreSetResourceLoadStatisticsThirdPartyCNAMEDomainForTesting(WKWebsiteDataStoreRef dataStoreRef, WKStringRef cnameURLString, void* context, WKWebsiteDataStoreSetResourceLoadStatisticsThirdPartyCNAMEDomainForTestingFunction completionHandler)
 {
-    WebKit::toImpl(dataStoreRef)->setResourceLoadStatisticsThirdPartyCNAMEDomainForTesting(URL { WebKit::toImpl(cnameURLString)->string() }, [context, completionHandler] {
+    WebKit::toProtectedImpl(dataStoreRef)->setResourceLoadStatisticsThirdPartyCNAMEDomainForTesting(URL { WebKit::toProtectedImpl(cnameURLString)->string() }, [context, completionHandler] {
         completionHandler(context);
     });
 }
@@ -583,7 +583,7 @@ void WKWebsiteDataStoreStatisticsResetToConsistentState(WKWebsiteDataStoreRef da
 void WKWebsiteDataStoreRemoveAllFetchCaches(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreRemoveFetchCacheRemovalFunction callback)
 {
     OptionSet<WebKit::WebsiteDataType> dataTypes = WebKit::WebsiteDataType::DOMCache;
-    WebKit::toImpl(dataStoreRef)->removeData(dataTypes, -WallTime::infinity(), [context, callback] {
+    WebKit::toProtectedImpl(dataStoreRef)->removeData(dataTypes, -WallTime::infinity(), [context, callback] {
         callback(context);
     });
 }
@@ -591,7 +591,7 @@ void WKWebsiteDataStoreRemoveAllFetchCaches(WKWebsiteDataStoreRef dataStoreRef, 
 void WKWebsiteDataStoreRemoveNetworkCache(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreRemoveNetworkCacheCallback callback)
 {
     OptionSet<WebKit::WebsiteDataType> dataTypes = WebKit::WebsiteDataType::DiskCache;
-    WebKit::toImpl(dataStoreRef)->removeData(dataTypes, -WallTime::infinity(), [context, callback] {
+    WebKit::toProtectedImpl(dataStoreRef)->removeData(dataTypes, -WallTime::infinity(), [context, callback] {
         callback(context);
     });
 }
@@ -599,7 +599,7 @@ void WKWebsiteDataStoreRemoveNetworkCache(WKWebsiteDataStoreRef dataStoreRef, vo
 void WKWebsiteDataStoreRemoveMemoryCaches(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreRemoveMemoryCachesRemovalFunction callback)
 {
     OptionSet<WebKit::WebsiteDataType> dataTypes = WebKit::WebsiteDataType::MemoryCache;
-    WebKit::toImpl(dataStoreRef)->removeData(dataTypes, -WallTime::infinity(), [context, callback] {
+    WebKit::toProtectedImpl(dataStoreRef)->removeData(dataTypes, -WallTime::infinity(), [context, callback] {
         callback(context);
     });
 }
@@ -611,7 +611,7 @@ void WKWebsiteDataStoreRemoveFetchCacheForOrigin(WKWebsiteDataStoreRef dataStore
     Vector<WebKit::WebsiteDataRecord> dataRecords = { WTFMove(dataRecord) };
 
     OptionSet<WebKit::WebsiteDataType> dataTypes = WebKit::WebsiteDataType::DOMCache;
-    WebKit::toImpl(dataStoreRef)->removeData(dataTypes, dataRecords, [context, callback] {
+    WebKit::toProtectedImpl(dataStoreRef)->removeData(dataTypes, dataRecords, [context, callback] {
         callback(context);
     });
 }
@@ -619,7 +619,7 @@ void WKWebsiteDataStoreRemoveFetchCacheForOrigin(WKWebsiteDataStoreRef dataStore
 void WKWebsiteDataStoreRemoveAllIndexedDatabases(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreRemoveAllIndexedDatabasesCallback callback)
 {
     OptionSet<WebKit::WebsiteDataType> dataTypes = WebKit::WebsiteDataType::IndexedDBDatabases;
-    WebKit::toImpl(dataStoreRef)->removeData(dataTypes, -WallTime::infinity(), [context, callback] {
+    WebKit::toProtectedImpl(dataStoreRef)->removeData(dataTypes, -WallTime::infinity(), [context, callback] {
     if (callback)
         callback(context);
     });
@@ -628,7 +628,7 @@ void WKWebsiteDataStoreRemoveAllIndexedDatabases(WKWebsiteDataStoreRef dataStore
 void WKWebsiteDataStoreRemoveLocalStorage(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreRemoveLocalStorageCallback callback)
 {
     OptionSet<WebKit::WebsiteDataType> dataTypes = WebKit::WebsiteDataType::LocalStorage;
-    WebKit::toImpl(dataStoreRef)->removeData(dataTypes, -WallTime::infinity(), [context, callback] {
+    WebKit::toProtectedImpl(dataStoreRef)->removeData(dataTypes, -WallTime::infinity(), [context, callback] {
         if (callback)
             callback(context);
     });
@@ -637,14 +637,14 @@ void WKWebsiteDataStoreRemoveLocalStorage(WKWebsiteDataStoreRef dataStoreRef, vo
 void WKWebsiteDataStoreRemoveAllServiceWorkerRegistrations(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreRemoveAllServiceWorkerRegistrationsCallback callback)
 {
     OptionSet<WebKit::WebsiteDataType> dataTypes = WebKit::WebsiteDataType::ServiceWorkerRegistrations;
-    WebKit::toImpl(dataStoreRef)->removeData(dataTypes, -WallTime::infinity(), [context, callback] {
+    WebKit::toProtectedImpl(dataStoreRef)->removeData(dataTypes, -WallTime::infinity(), [context, callback] {
         callback(context);
     });
 }
 
 void WKWebsiteDataStoreGetFetchCacheOrigins(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreGetFetchCacheOriginsFunction callback)
 {
-    WebKit::toImpl(dataStoreRef)->fetchData(WebKit::WebsiteDataType::DOMCache, { }, [context, callback] (auto dataRecords) {
+    WebKit::toProtectedImpl(dataStoreRef)->fetchData(WebKit::WebsiteDataType::DOMCache, { }, [context, callback] (auto dataRecords) {
         Vector<RefPtr<API::Object>> securityOrigins;
         for (const auto& dataRecord : dataRecords) {
             for (const auto& origin : dataRecord.origins)
@@ -658,8 +658,8 @@ void WKWebsiteDataStoreGetFetchCacheSizeForOrigin(WKWebsiteDataStoreRef dataStor
 {
     OptionSet<WebKit::WebsiteDataFetchOption> fetchOptions = WebKit::WebsiteDataFetchOption::ComputeSizes;
 
-    WebKit::toImpl(dataStoreRef)->fetchData(WebKit::WebsiteDataType::DOMCache, fetchOptions, [origin, context, callback] (auto dataRecords) {
-        auto originData = WebCore::SecurityOrigin::createFromString(WebKit::toImpl(origin)->string())->data();
+    WebKit::toProtectedImpl(dataStoreRef)->fetchData(WebKit::WebsiteDataType::DOMCache, fetchOptions, [origin, context, callback] (auto dataRecords) {
+        auto originData = WebCore::SecurityOrigin::createFromString(WebKit::toProtectedImpl(origin)->string())->data();
         for (auto& dataRecord : dataRecords) {
             for (const auto& recordOrigin : dataRecord.origins) {
                 if (originData == recordOrigin) {
@@ -680,26 +680,26 @@ void WKWebsiteDataStoreSetPerOriginStorageQuota(WKWebsiteDataStoreRef, uint64_t)
 void WKWebsiteDataStoreClearAllDeviceOrientationPermissions(WKWebsiteDataStoreRef dataStoreRef)
 {
 #if ENABLE(DEVICE_ORIENTATION)
-    WebKit::toImpl(dataStoreRef)->deviceOrientationAndMotionAccessController().clearPermissions();
+    WebKit::toProtectedImpl(dataStoreRef)->protectedDeviceOrientationAndMotionAccessController()->clearPermissions();
 #endif
 }
 
 void WKWebsiteDataStoreClearPrivateClickMeasurementsThroughWebsiteDataRemoval(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreClearPrivateClickMeasurementsThroughWebsiteDataRemovalFunction callback)
 {
     OptionSet<WebKit::WebsiteDataType> dataTypes = WebKit::WebsiteDataType::PrivateClickMeasurements;
-    WebKit::toImpl(dataStoreRef)->removeData(dataTypes, WallTime::fromRawSeconds(0), [context, callback] {
+    WebKit::toProtectedImpl(dataStoreRef)->removeData(dataTypes, WallTime::fromRawSeconds(0), [context, callback] {
         callback(context);
     });
 }
 
 void WKWebsiteDataStoreSetCacheModelSynchronouslyForTesting(WKWebsiteDataStoreRef dataStoreRef, WKCacheModel cacheModel)
 {
-    WebKit::toImpl(dataStoreRef)->setCacheModelSynchronouslyForTesting(WebKit::toCacheModel(cacheModel));
+    WebKit::toProtectedImpl(dataStoreRef)->setCacheModelSynchronouslyForTesting(WebKit::toCacheModel(cacheModel));
 }
 
 void WKWebsiteDataStoreResetQuota(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreResetQuotaCallback callback)
 {
-    WebKit::toImpl(dataStoreRef)->resetQuota([context, callback] {
+    WebKit::toProtectedImpl(dataStoreRef)->resetQuota([context, callback] {
         if (callback)
             callback(context);
     });
@@ -707,7 +707,7 @@ void WKWebsiteDataStoreResetQuota(WKWebsiteDataStoreRef dataStoreRef, void* cont
 
 void WKWebsiteDataStoreResetStoragePersistedState(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreResetStoragePersistedStateCallback callback)
 {
-    WebKit::toImpl(dataStoreRef)->resetStoragePersistedState([context, callback] {
+    WebKit::toProtectedImpl(dataStoreRef)->resetStoragePersistedState([context, callback] {
         if (callback)
             callback(context);
     });
@@ -723,7 +723,7 @@ void WKWebsiteDataStoreClearStorage(WKWebsiteDataStoreRef dataStoreRef, void* co
         WebKit::WebsiteDataType::Credentials,
         WebKit::WebsiteDataType::ServiceWorkerRegistrations
     };
-    WebKit::toImpl(dataStoreRef)->removeData(dataTypes, -WallTime::infinity(), [context, callback] {
+    WebKit::toProtectedImpl(dataStoreRef)->removeData(dataTypes, -WallTime::infinity(), [context, callback] {
         if (callback)
             callback(context);
     });
@@ -731,7 +731,7 @@ void WKWebsiteDataStoreClearStorage(WKWebsiteDataStoreRef dataStoreRef, void* co
 
 void WKWebsiteDataStoreSetOriginQuotaRatioEnabled(WKWebsiteDataStoreRef dataStoreRef, bool enabled, void* context, WKWebsiteDataStoreResetQuotaCallback callback)
 {
-    WebKit::toImpl(dataStoreRef)->setOriginQuotaRatioEnabledForTesting(enabled, [context, callback] {
+    WebKit::toProtectedImpl(dataStoreRef)->setOriginQuotaRatioEnabledForTesting(enabled, [context, callback] {
         if (callback)
             callback(context);
     });
@@ -760,21 +760,21 @@ void WKWebsiteDataStoreReinitializeAppBoundDomains(WKWebsiteDataStoreRef dataSto
 
 void WKWebsiteDataStoreUpdateBundleIdentifierInNetworkProcess(WKWebsiteDataStoreRef dataStoreRef, const WKStringRef bundleIdentifier, void* context, WKWebsiteDataStoreUpdateBundleIdentifierInNetworkProcessFunction completionHandler)
 {
-    WebKit::toImpl(dataStoreRef)->updateBundleIdentifierInNetworkProcess(WebKit::toImpl(bundleIdentifier)->string(), [context, completionHandler] {
+    WebKit::toProtectedImpl(dataStoreRef)->updateBundleIdentifierInNetworkProcess(WebKit::toProtectedImpl(bundleIdentifier)->string(), [context, completionHandler] {
         completionHandler(context);
     });
 }
 
 void WKWebsiteDataStoreClearBundleIdentifierInNetworkProcess(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreClearBundleIdentifierInNetworkProcessFunction completionHandler)
 {
-    WebKit::toImpl(dataStoreRef)->clearBundleIdentifierInNetworkProcess([context, completionHandler] {
+    WebKit::toProtectedImpl(dataStoreRef)->clearBundleIdentifierInNetworkProcess([context, completionHandler] {
         completionHandler(context);
     });
 }
 
 void WKWebsiteDataStoreGetAllStorageAccessEntries(WKWebsiteDataStoreRef dataStoreRef, WKPageRef pageRef, void* context, WKWebsiteDataStoreGetAllStorageAccessEntriesFunction callback)
 {
-    WebKit::toImpl(dataStoreRef)->getAllStorageAccessEntries(WebKit::toImpl(pageRef)->identifier(), [context, callback] (Vector<String>&& domains) {
+    WebKit::toProtectedImpl(dataStoreRef)->getAllStorageAccessEntries(WebKit::toImpl(pageRef)->identifier(), [context, callback] (Vector<String>&& domains) {
         auto domainArrayRef = WKMutableArrayCreate();
         for (auto domain : domains)
             WKArrayAppendItem(domainArrayRef, adoptWK(WKStringCreateWithUTF8CString(domain.utf8().data())).get());
@@ -786,7 +786,7 @@ void WKWebsiteDataStoreGetAllStorageAccessEntries(WKWebsiteDataStoreRef dataStor
 void WKWebsiteDataStoreResetResourceMonitorThrottler(WKWebsiteDataStoreRef dataStoreRef, void* context, KWebsiteDataStoreResetResourceMonitorThrottler callback)
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    WebKit::toImpl(dataStoreRef)->resetResourceMonitorThrottlerForTesting([context, callback] () {
+    WebKit::toProtectedImpl(dataStoreRef)->resetResourceMonitorThrottlerForTesting([context, callback] () {
         if (callback)
             callback(context);
     });


### PR DESCRIPTION
#### 6331db806049dbacf2487c8368e3605e1d939fc0
<pre>
[SaferCPP] Improve smart pointer adoption in the UIProcess C API, part 3/3
<a href="https://bugs.webkit.org/show_bug.cgi?id=294994">https://bugs.webkit.org/show_bug.cgi?id=294994</a>
<a href="https://rdar.apple.com/154329301">rdar://154329301</a>

Reviewed by Chris Dumez.

Finish the last two files with failing smart pointer warnings in the UIProcess C API:

        - Source/WebKit/UIProcess/API/C/WKContext.cpp
        - Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/API/C/WKContext.cpp:
(WKContextSetClient):
(WKContextSetInjectedBundleClient):
(WKContextSetDownloadClient):
(WKContextPostMessageToInjectedBundle):
(WKContextAddVisitedLink):
(WKContextSetAlwaysUsesComplexTextCodePath):
(WKContextSetDisableFontSubpixelAntialiasingForTesting):
(WKContextRegisterURLSchemeAsEmptyDocument):
(WKContextRegisterURLSchemeAsSecure):
(WKContextRegisterURLSchemeAsBypassingContentSecurityPolicy):
(WKContextRegisterURLSchemeAsCachePartitioned):
(WKContextRegisterURLSchemeAsCanDisplayOnlyIfCanRequest):
(WKContextSetDomainRelaxationForbiddenForURLScheme):
(WKContextGetGeolocationManager):
(WKContextGetNotificationManager):
(WKContextStartMemorySampler):
(WKContextStopMemorySampler):
(WKContextDisableProcessTermination):
(WKContextEnableProcessTermination):
(WKContextSetHTTPPipeliningEnabled):
(WKContextWarmInitialProcess):
(WKContextSetJavaScriptConfigurationFileEnabled):
(WKContextGarbageCollectJavaScriptObjects):
(WKContextSetJavaScriptGarbageCollectorTimerEnabled):
(WKContextSetMemoryCacheDisabled):
(WKContextSetFontAllowList):
(WKContextTerminateServiceWorkers):
(WKContextClearCurrentModifierStateForTesting):
(WKContextSetLocalhostAliases):
(WKContextSetResourceMonitorURLsForTesting):
* Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp:
(WKWebsiteDataStoreTerminateNetworkProcess):
(WKWebsiteDataStoreGetNetworkProcessIdentifier):
(WKWebsiteDataStoreRemoveITPDataForDomain):
(WKWebsiteDataStoreDoesStatisticsDomainIDExistInDatabase):
(WKWebsiteDataStoreSetServiceWorkerFetchTimeoutForTesting):
(WKWebsiteDataStoreResetServiceWorkerFetchTimeoutForTesting):
(WKWebsiteDataStoreSetResourceLoadStatisticsEnabled):
(WKWebsiteDataStoreIsStatisticsEphemeral):
(WKWebsiteDataStoreGetResourceLoadStatisticsEnabled):
(WKWebsiteDataStoreSetResourceLoadStatisticsDebugMode):
(WKWebsiteDataStoreSyncLocalStorage):
(WKWebsiteDataStoreGetHTTPCookieStore):
(WKWebsiteDataStoreSetResourceLoadStatisticsDebugModeWithCompletionHandler):
(WKWebsiteDataStoreSetResourceLoadStatisticsPrevalentResourceForDebugMode):
(WKWebsiteDataStoreSetStatisticsLastSeen):
(WKWebsiteDataStoreSetStatisticsMergeStatistic):
(WKWebsiteDataStoreSetStatisticsExpiredStatistic):
(WKWebsiteDataStoreSetStatisticsPrevalentResource):
(WKWebsiteDataStoreSetStatisticsVeryPrevalentResource):
(WKWebsiteDataStoreDumpResourceLoadStatistics):
(WKWebsiteDataStoreIsStatisticsPrevalentResource):
(WKWebsiteDataStoreIsStatisticsVeryPrevalentResource):
(WKWebsiteDataStoreIsStatisticsRegisteredAsSubresourceUnder):
(WKWebsiteDataStoreIsStatisticsRegisteredAsSubFrameUnder):
(WKWebsiteDataStoreIsStatisticsRegisteredAsRedirectingTo):
(WKWebsiteDataStoreSetStatisticsHasHadUserInteraction):
(WKWebsiteDataStoreIsStatisticsHasHadUserInteraction):
(WKWebsiteDataStoreIsStatisticsOnlyInDatabaseOnce):
(WKWebsiteDataStoreSetStatisticsGrandfathered):
(WKWebsiteDataStoreIsStatisticsGrandfathered):
(WKWebsiteDataStoreSetStatisticsSubframeUnderTopFrameOrigin):
(WKWebsiteDataStoreSetStatisticsSubresourceUnderTopFrameOrigin):
(WKWebsiteDataStoreSetStatisticsSubresourceUniqueRedirectTo):
(WKWebsiteDataStoreSetStatisticsSubresourceUniqueRedirectFrom):
(WKWebsiteDataStoreSetStatisticsTopFrameUniqueRedirectTo):
(WKWebsiteDataStoreSetStatisticsTopFrameUniqueRedirectFrom):
(WKWebsiteDataStoreSetStatisticsCrossSiteLoadWithLinkDecoration):
(WKWebsiteDataStoreSetStatisticsTimeToLiveUserInteraction):
(WKWebsiteDataStoreStatisticsProcessStatisticsAndDataRecords):
(WKWebsiteDataStoreStatisticsUpdateCookieBlocking):
(WKWebsiteDataStoreSetResourceLoadStatisticsTimeAdvanceForTesting):
(WKWebsiteDataStoreSetStatisticsIsRunningTest):
(WKWebsiteDataStoreSetStatisticsShouldClassifyResourcesBeforeDataRecordsRemoval):
(WKWebsiteDataStoreSetStatisticsMinimumTimeBetweenDataRecordsRemoval):
(WKWebsiteDataStoreSetStatisticsGrandfatheringTime):
(WKWebsiteDataStoreSetStatisticsMaxStatisticsEntries):
(WKWebsiteDataStoreSetStatisticsPruneEntriesDownTo):
(WKWebsiteDataStoreStatisticsClearInMemoryAndPersistentStore):
(WKWebsiteDataStoreStatisticsClearInMemoryAndPersistentStoreModifiedSinceHours):
(WKWebsiteDataStoreStatisticsClearThroughWebsiteDataRemoval):
(WKWebsiteDataStoreStatisticsDeleteCookiesForTesting):
(WKWebsiteDataStoreStatisticsHasLocalStorage):
(WKWebsiteDataStoreSetStatisticsCacheMaxAgeCap):
(WKWebsiteDataStoreStatisticsHasIsolatedSession):
(WKWebsiteDataStoreSetResourceLoadStatisticsShouldDowngradeReferrerForTesting):
(WKWebsiteDataStoreSetResourceLoadStatisticsShouldBlockThirdPartyCookiesForTesting):
(WKWebsiteDataStoreSetResourceLoadStatisticsFirstPartyWebsiteDataRemovalModeForTesting):
(WKWebsiteDataStoreSetResourceLoadStatisticsToSameSiteStrictCookiesForTesting):
(WKWebsiteDataStoreSetResourceLoadStatisticsFirstPartyHostCNAMEDomainForTesting):
(WKWebsiteDataStoreSetResourceLoadStatisticsThirdPartyCNAMEDomainForTesting):
(WKWebsiteDataStoreRemoveAllFetchCaches):
(WKWebsiteDataStoreRemoveNetworkCache):
(WKWebsiteDataStoreRemoveMemoryCaches):
(WKWebsiteDataStoreRemoveFetchCacheForOrigin):
(WKWebsiteDataStoreRemoveAllIndexedDatabases):
(WKWebsiteDataStoreRemoveLocalStorage):
(WKWebsiteDataStoreRemoveAllServiceWorkerRegistrations):
(WKWebsiteDataStoreGetFetchCacheOrigins):
(WKWebsiteDataStoreGetFetchCacheSizeForOrigin):
(WKWebsiteDataStoreClearAllDeviceOrientationPermissions):
(WKWebsiteDataStoreClearPrivateClickMeasurementsThroughWebsiteDataRemoval):
(WKWebsiteDataStoreSetCacheModelSynchronouslyForTesting):
(WKWebsiteDataStoreResetQuota):
(WKWebsiteDataStoreResetStoragePersistedState):
(WKWebsiteDataStoreClearStorage):
(WKWebsiteDataStoreSetOriginQuotaRatioEnabled):
(WKWebsiteDataStoreUpdateBundleIdentifierInNetworkProcess):
(WKWebsiteDataStoreClearBundleIdentifierInNetworkProcess):
(WKWebsiteDataStoreGetAllStorageAccessEntries):
(WKWebsiteDataStoreResetResourceMonitorThrottler):

Canonical link: <a href="https://commits.webkit.org/296672@main">https://commits.webkit.org/296672@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b51b5c6d14065962535c6fc7e0299028246ce0e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109225 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28883 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114432 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59496 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29565 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37472 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83003 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112173 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23529 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98377 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63453 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22916 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59059 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92896 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16562 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117548 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36269 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26833 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92016 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36641 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94640 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91829 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23391 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36750 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14502 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32100 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36165 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41653 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35851 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39183 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37542 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->