### PR TITLE
AX: AXTextMarker::findMarker, a frequently called function, can copy all the text-runs strings, causing performance issues on pages with lots of text

### DIFF
--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -1280,9 +1280,7 @@ TextStream& operator<<(TextStream& stream, AXObjectCache& axObjectCache)
 #if ENABLE(AX_THREAD_TEXT_APIS)
 static void streamTextRuns(TextStream& stream, const AXTextRuns& runs)
 {
-    stream.dumpProperty("textRuns"_s, makeString(interleave(runs.runs, [](auto& builder, auto& run) {
-        builder.append(run.lineIndex, ":|"_s, run.text, "|(len: "_s, run.text.length(), ')');
-    }, ", "_s)));
+    stream.dumpProperty("textRuns"_s, runs.debugDescription());
 }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 

--- a/Source/WebCore/accessibility/AXTextRun.h
+++ b/Source/WebCore/accessibility/AXTextRun.h
@@ -62,7 +62,6 @@ struct AXTextRunLineID {
 struct AXTextRun {
     // The line index of this run within the context of the containing RenderBlock of the main-thread AX object.
     size_t lineIndex;
-    String text;
     // This data structure stores the DOM offsets that form the text runs that are concatenated to create |text|.
     // DOM offsets are offsets into the raw text node contents, pre-whitespace-collapse, while the |text| we store
     // is the rendered-text, post-whitespace-collapse.
@@ -87,32 +86,34 @@ struct AXTextRun {
     // The distance between the RenderText's position and the start of the text run (useful for things that are not left-aligned, like `text-align: center`).
     float distanceFromBoundsInDirection;
 
-    AXTextRun(size_t lineIndex, String&& text, Vector<std::array<uint16_t, 2>>&& domOffsets, Vector<uint16_t>&& characterAdvances, float lineHeight, float distanceFromBoundsInDirection)
+    // The index in the containing AXTextRuns string where this run begins.
+    unsigned startIndex { 0 };
+    // The exclusive index in the containing AXTextRuns string where this run ends.
+    unsigned endIndex { 0 };
+
+    AXTextRun(size_t lineIndex, unsigned startIndex, unsigned endIndexInclusive, Vector<std::array<uint16_t, 2>>&& domOffsets, Vector<uint16_t>&& characterAdvances, float lineHeight, float distanceFromBoundsInDirection)
         : lineIndex(lineIndex)
-        , text(WTFMove(text))
         , textRunDomOffsets(WTFMove(domOffsets))
         , characterAdvances(WTFMove(characterAdvances))
         , lineHeight(lineHeight)
         , distanceFromBoundsInDirection(distanceFromBoundsInDirection)
-    { }
-
-    String debugDescription(void* containingBlock) const
+        , startIndex(startIndex)
+        , endIndex(endIndexInclusive)
     {
-        AXTextRunLineID lineID = { containingBlock, lineIndex };
-        return makeString(lineID.debugDescription(), ": |"_s, makeStringByReplacingAll(text, '\n', "{newline}"_s), "|(len "_s, text.length(), ")"_s);
+        // Runs should have a non-zero length (i.e. endIndex should strictly be greater than startIndex).
+        // This is important because several parts of AXTextMarker rely on this assumption.
+        RELEASE_ASSERT(endIndex > startIndex);
     }
+
     const FixedVector<std::array<uint16_t, 2>>& domOffsets() const { return textRunDomOffsets; }
     const FixedVector<uint16_t>& advances() const { return characterAdvances; }
 
-    // Convenience methods for TextUnit movement.
-    bool startsWithLineBreak() const { return text.startsWith('\n'); }
-    bool endsWithLineBreak() const { return text.endsWith('\n'); }
-
-    UChar characterAt(unsigned index) const { return text.characterAt(index); }
-    unsigned textLength() const { return text.length(); }
+    unsigned length() const { return endIndex - startIndex; }
 };
 
 struct AXTextRuns {
+    // The text for all runs, concatenated into a single string.
+    String text;
     // The containing block for the text runs. This is required because based on the structure
     // of the AX tree, text runs for different objects can have the same line index but different
     // containing blocks, meaning they are rendered on different lines.
@@ -122,8 +123,9 @@ struct AXTextRuns {
     bool containsOnlyASCII { true };
 
     AXTextRuns() = default;
-    AXTextRuns(RenderBlock* containingBlock, Vector<AXTextRun>&& textRuns, bool containsOnlyASCII = true)
-        : containingBlock(containingBlock)
+    AXTextRuns(RenderBlock* containingBlock, Vector<AXTextRun>&& textRuns, String&& text, bool containsOnlyASCII = true)
+        : text(WTFMove(text))
+        , containingBlock(containingBlock)
         , runs(WTFMove(textRuns))
         , containsOnlyASCII(containsOnlyASCII)
     { }
@@ -131,29 +133,16 @@ struct AXTextRuns {
     String debugDescription() const;
 
     size_t size() const { return runs.size(); }
-    const AXTextRun& at(size_t index) const
-    {
-        return (*this)[index];
-    }
-    const AXTextRun& operator[](size_t index) const
-    {
-        RELEASE_ASSERT(index < runs.size());
-        return runs[index];
-    }
+    const AXTextRun& at(size_t index) const { return (*this)[index]; }
+    const AXTextRun& operator[](size_t index) const { return runs[index]; }
 
-    unsigned runLength(size_t index) const
-    {
-        RELEASE_ASSERT(index < runs.size());
-        // Runs should have a non-zero length. This is important because several parts of AXTextMarker rely on this assumption.
-        RELEASE_ASSERT(runs[index].text.length());
-        return runs[index].text.length();
-    }
+    unsigned runLength(size_t index) const { return runs[index].length(); }
     size_t lastRunIndex() const { return size() - 1; }
     unsigned lastRunLength() const
     {
         if (runs.isEmpty())
             return 0;
-        return runs[runs.size() - 1].text.length();
+        return runLength(runs.size() - 1);
     }
     unsigned totalLength() const
     {
@@ -164,13 +153,20 @@ struct AXTextRuns {
     unsigned domOffset(unsigned) const;
 
     size_t indexForOffset(unsigned textOffset, Affinity) const;
-    AXTextRunLineID lineID(size_t index) const
+    AXTextRunLineID lineID(size_t index) const { return { containingBlock, runs[index].lineIndex }; }
+    String toString() const { return text; }
+    StringView toStringView() const { return StringView(text); }
+    StringView substring(unsigned start, unsigned length = StringImpl::MaxLength) const
     {
-        RELEASE_ASSERT(index < runs.size());
-        return { containingBlock, runs[index].lineIndex };
+        return StringView(text).substring(start, length);
     }
-    String substring(unsigned start, unsigned length = StringImpl::MaxLength) const;
-    String toString() const { return substring(0); }
+
+    String runString(size_t runIndex) const { return runStringView(runIndex).toString(); }
+    StringView runStringView(size_t runIndex) const
+    {
+        const auto& run = runs[runIndex];
+        return StringView(text).substring(run.startIndex, /* substringLength */ run.endIndex - run.startIndex);
+    }
 
     // Returns a "local" rect representing the range specified by |start| and |end|.
     // "Local" means the rect is relative only to the top-left of this AXTextRuns instance.
@@ -180,6 +176,10 @@ struct AXTextRuns {
     // The local rect would be:
     //   {x: width_of_single_b, y: |lineHeight| * 1, width: width_of_two_b, height: |lineHeight * 1|}
     FloatRect localRect(unsigned start, unsigned end, FontOrientation) const;
+
+    // Convenience methods for TextUnit movement.
+    bool runStartsWithLineBreak(size_t runIndex) const { return text[runs[runIndex].startIndex] == '\n'; }
+    bool runEndsWithLineBreak(size_t runIndex) const { return text[runs[runIndex].endIndex] == '\n'; }
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### d05070c1f5a99cbb7b38243b5924899c1c7280bc
<pre>
AX: AXTextMarker::findMarker, a frequently called function, can copy all the text-runs strings, causing performance issues on pages with lots of text
<a href="https://bugs.webkit.org/show_bug.cgi?id=294996">https://bugs.webkit.org/show_bug.cgi?id=294996</a>
<a href="https://rdar.apple.com/154332688">rdar://154332688</a>

Reviewed by Joshua Hoffman.

For groups of text runs that contain non-ASCII characters, AXTextMarker::findMarker needs to use CachedTextBreakIterator
to determine how many offsets to move forward or backward. This is relevant for things like multi-byte emojis. CachedTextBreakIterator
takes a StringView, but we were always doing the far less efficient thing of combining the text from all AXTextRun structs
into a single String, requiring multiple allocations along the way. This is a major performance problem on webpages that
have lots of text (e.g. 40 seconds of a 60 second sample was spent building and allocating strings underneath findMarker).

We had to do it this way because CachedTextBreakIterator needs the full string from all runs, but because each AXTextRun
owned its own string, we couldn&apos;t just naively use StringView here, because you can&apos;t combine disparate StringViews (one
for each AXTextRun) into one larger StringView (that&apos;s not how StringViews work).

Solve the issue by making AXTextRuns own a singular string for all runs, and add start and end index fields to AXTextRun
that point into this string. This allows us to use StringViews in many more places, which this commit does.

* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::streamTextRuns):
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarkerRange::toString const):
(WebCore::AXTextMarker::findMarker const):
(WebCore::AXTextMarker::findParagraph const):
(WebCore::AXTextMarker::findWordOrSentence const):
* Source/WebCore/accessibility/AXTextRun.cpp:
(WebCore::AXTextRuns::debugDescription const):
(WebCore::AXTextRuns::localRect const):
(WebCore::AXTextRuns::substring const): Deleted.
* Source/WebCore/accessibility/AXTextRun.h:
(WebCore::AXTextRun::AXTextRun):
(WebCore::AXTextRun::length const):
(WebCore::AXTextRuns::AXTextRuns):
(WebCore::AXTextRuns::at const):
(WebCore::AXTextRuns::operator[] const):
(WebCore::AXTextRuns::runLength const):
(WebCore::AXTextRuns::lastRunLength const):
(WebCore::AXTextRuns::lineID const):
(WebCore::AXTextRuns::toString const):
(WebCore::AXTextRuns::toStringView const):
(WebCore::AXTextRuns::substring const):
(WebCore::AXTextRuns::runString const):
(WebCore::AXTextRuns::runStringView const):
(WebCore::AXTextRuns::runStartsWithLineBreak const):
(WebCore::AXTextRuns::runEndsWithLineBreak const):
(WebCore::AXTextRun::debugDescription const): Deleted.
(WebCore::AXTextRun::startsWithLineBreak const): Deleted.
(WebCore::AXTextRun::endsWithLineBreak const): Deleted.
(WebCore::AXTextRun::characterAt const): Deleted.
(WebCore::AXTextRun::textLength const): Deleted.
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::textRuns):
* Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm:
(WebCore::AXTextMarkerRange::toAttributedString const):

Canonical link: <a href="https://commits.webkit.org/296681@main">https://commits.webkit.org/296681@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aff5d989f4cf0cb8496fa78b1cb1d4155873afb7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109171 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28829 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114378 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59449 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111134 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29510 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37424 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82963 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112119 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23484 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98328 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63412 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22874 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16471 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59027 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92851 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16513 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/rotated-cat-off-top-edge.html imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-timing.https.sub.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117493 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36215 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26800 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91977 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36587 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94591 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91783 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23395 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36706 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14454 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32064 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36111 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41606 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35797 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39131 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37488 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->