### PR TITLE
[HDR] Gray background appears when switching from Safari tab overview to a tab with HDR images.

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -242,8 +242,8 @@ public:
 #if HAVE(SUPPORT_HDR_DISPLAY)
     virtual void setMaxEDRHeadroom(std::optional<float>) { }
     virtual float maxPaintedEDRHeadroom() const { return 1; }
-    virtual bool hasPaintedClampedEDRHeadroom() const { return false; }
-    virtual void clearMaxPaintedEDRHeadroom() { }
+    virtual float maxRequestedEDRHeadroom() const { return 1; }
+    virtual void clearMaxEDRHeadrooms() { }
 #endif
 
     // Images, Patterns, ControlParts, and Media

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -396,10 +396,10 @@ void GraphicsContextCG::drawNativeImageInternal(NativeImage& nativeImage, const 
     auto headroom = options.headroom();
     if (headroom == Headroom::FromImage)
         headroom = nativeImage.headroom();
+    if (m_maxEDRHeadroom)
+        headroom = std::min(headroom.headroom, *m_maxEDRHeadroom);
 
-    if (headroom > Headroom::None) {
-        if (m_maxEDRHeadroom)
-            headroom = std::min(headroom.headroom, *m_maxEDRHeadroom);
+    if (nativeImage.headroom() > headroom) {
         LOG_WITH_STREAM(HDR, stream << "GraphicsContextCG::drawNativeImageInternal setEDRTargetHeadroom " << headroom << " max(" << m_maxEDRHeadroom << ")");
         CGContextSetEDRTargetHeadroom(context, headroom);
     }

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -214,8 +214,8 @@ protected:
     MonotonicTime m_lastDisplayTime;
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
-    float m_edrHeadroom { 1.0f };
-    bool m_hasPaintedClampedEDRHeadroom { false };
+    float m_maxPaintedEDRHeadroom { 1 };
+    float m_maxRequestedEDRHeadroom { 1 };
 #endif
 };
 
@@ -264,7 +264,7 @@ private:
     bool m_isOpaque;
     RemoteLayerBackingStore::Type m_type;
 #if HAVE(SUPPORT_HDR_DISPLAY)
-    float m_edrHeadroom;
+    float m_maxRequestedEDRHeadroom;
 #endif
 };
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -103,7 +103,7 @@ header: "RemoteLayerBackingStore.h"
     bool m_isOpaque;
     WebKit::RemoteLayerBackingStore::Type m_type;
 #if HAVE(SUPPORT_HDR_DISPLAY)
-    float m_edrHeadroom;
+    float m_maxRequestedEDRHeadroom;
 #endif
     std::optional<WebKit::ImageBufferBackendHandle> m_bufferHandle;
     std::optional<WebKit::RemoteImageBufferSetIdentifier> m_bufferSet;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -558,7 +558,6 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, Remo
             ALLOW_DEPRECATED_DECLARATIONS_BEGIN
             [layer setWantsExtendedDynamicRangeContent:true];
             ALLOW_DEPRECATED_DECLARATIONS_END
-            [layer setToneMapMode:CAToneMapModeIfSupported];
         }
 #endif
     }

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
@@ -171,7 +171,8 @@ void RemoteLayerWithRemoteRenderingBackingStore::dump(WTF::TextStream& ts) const
     ts.dumpProperty("cache identifiers"_s, m_bufferCacheIdentifiers);
     ts.dumpProperty("is opaque"_s, isOpaque());
 #if HAVE(SUPPORT_HDR_DISPLAY)
-    ts.dumpProperty("headroom", m_edrHeadroom);
+    ts.dumpProperty("requested-headroom", m_maxRequestedEDRHeadroom);
+    ts.dumpProperty("painted-headroom", m_maxPaintedEDRHeadroom);
 #endif
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -301,12 +301,11 @@ void RemoteDisplayListRecorderProxy::drawNativeImageInternal(NativeImage& image,
     if (headroom == Headroom::FromImage)
         headroom = image.headroom();
     if (m_maxEDRHeadroom) {
-        if (*m_maxEDRHeadroom < headroom) {
+        if (*m_maxEDRHeadroom < headroom)
             headroom = *m_maxEDRHeadroom;
-            m_hasPaintedClampedEDRHeadroom = true;
-        }
     }
     m_maxPaintedEDRHeadroom = std::max(m_maxPaintedEDRHeadroom, headroom.headroom);
+    m_maxRequestedEDRHeadroom = std::max(m_maxRequestedEDRHeadroom, image.headroom().headroom);
     ImagePaintingOptions clampedOptions(options, headroom);
 #endif
     appendStateChangeItemIfNecessary();

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
@@ -162,8 +162,8 @@ private:
 #if HAVE(SUPPORT_HDR_DISPLAY)
     void setMaxEDRHeadroom(std::optional<float> headroom) final { m_maxEDRHeadroom = headroom; }
     float maxPaintedEDRHeadroom() const final { return m_maxPaintedEDRHeadroom; }
-    bool hasPaintedClampedEDRHeadroom() const final { return m_hasPaintedClampedEDRHeadroom; }
-    void clearMaxPaintedEDRHeadroom() final { m_maxPaintedEDRHeadroom = 1; m_hasPaintedClampedEDRHeadroom = false; }
+    float maxRequestedEDRHeadroom() const final { return m_maxRequestedEDRHeadroom; }
+    void clearMaxEDRHeadrooms() final { m_maxPaintedEDRHeadroom = 1; m_maxRequestedEDRHeadroom = 1; }
 #endif
 
     const WebCore::RenderingMode m_renderingMode;
@@ -179,7 +179,7 @@ private:
 #if HAVE(SUPPORT_HDR_DISPLAY)
     std::optional<float> m_maxEDRHeadroom;
     float m_maxPaintedEDRHeadroom { 1 };
-    bool m_hasPaintedClampedEDRHeadroom { false };
+    float m_maxRequestedEDRHeadroom { 1 };
 #endif
     // Flag for pending draws. Start with true because we do not know what commands have been scheduled to the context.
     bool m_hasDrawn { true };


### PR DESCRIPTION
#### e29aed83c50ffbe64b7d09c6bd5ffd5ab4b1ddc8
<pre>
[HDR] Gray background appears when switching from Safari tab overview to a tab with HDR images.
<a href="https://bugs.webkit.org/show_bug.cgi?id=294998">https://bugs.webkit.org/show_bug.cgi?id=294998</a>
&lt;<a href="https://rdar.apple.com/154230589">rdar://154230589</a>&gt;

Reviewed by Simon Fraser and Mike Wyrzykowski.

Content painted by WebKit gets tonemapped at paint time, so we never want it to
be tonemapped again by the system.

Changes GraphicContext/RemoteLayerBackingStore to track the max EDR headroom
requested during painting, rather than just a bool of whether any draw exceeded
the available headroom.

Synchronize this value across to the UI process instead of the painted headroom,
and set it as the contentHeadroom so that the system knows what the intended
headroom is. Set CAToneMapModeNever for these layers, since tonemapping has
already been applied.

Also fixes a bug where GraphicsContextCG wouldn&apos;t call
CGContextSetEDRTargetHeadroom if the clamped headroom was 1, even if the image
had a higher source headroom.

* Source/WebCore/platform/graphics/GraphicsContext.h:
(WebCore::GraphicsContext::maxRequestedEDRHeadroom const):
(WebCore::GraphicsContext::clearMaxEDRHeadrooms):
(WebCore::GraphicsContext::hasPaintedClampedEDRHeadroom const): Deleted.
(WebCore::GraphicsContext::clearMaxPaintedEDRHeadroom): Deleted.
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::drawNativeImageInternal):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::encode const):
(WebKit::RemoteLayerBackingStoreProperties::dump const):
(WebKit::RemoteLayerBackingStore::setNeedsDisplay):
(WebKit::RemoteLayerBackingStore::setNeedsDisplayIfEDRHeadroomExceeds):
(WebKit::RemoteLayerBackingStore::setDelegatedContents):
(WebKit::RemoteLayerBackingStore::drawInContext):
(WebKit::RemoteLayerBackingStoreProperties::applyBackingStoreToLayer):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm:
(WebKit::RemoteLayerWithRemoteRenderingBackingStore::dump const):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::screenPropertiesChanged):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::drawNativeImageInternal):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h:

Canonical link: <a href="https://commits.webkit.org/296647@main">https://commits.webkit.org/296647@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bec5380ccbf7577dda530a3ddcbdee0e2d3c467

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109181 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28839 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19266 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114388 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59456 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111144 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29520 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37431 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82969 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112129 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23489 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98335 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63418 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22878 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16478 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/59033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92856 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16520 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117503 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36225 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/26801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91984 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36597 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94598 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91790 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23372 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36712 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14461 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/32070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36121 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41613 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35807 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39141 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37498 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->