### PR TITLE
[JSC] Concurrently computing CodeBlockHash

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlockHash.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlockHash.h
@@ -54,7 +54,8 @@ public:
     {
     }
 
-    CodeBlockHash(const SourceCode&, CodeSpecializationKind);
+    JS_EXPORT_PRIVATE CodeBlockHash(const SourceCode&, CodeSpecializationKind);
+    JS_EXPORT_PRIVATE CodeBlockHash(StringView codeBlockSourceCode, StringView entireSourceCode, CodeSpecializationKind);
 
     explicit CodeBlockHash(std::span<const char, stringLength>);
 

--- a/Source/JavaScriptCore/parser/SourceProvider.cpp
+++ b/Source/JavaScriptCore/parser/SourceProvider.cpp
@@ -54,6 +54,12 @@ void SourceProvider::unlockUnderlyingBuffer()
         unlockUnderlyingBufferImpl();
 }
 
+CodeBlockHash SourceProvider::codeBlockHashConcurrently(int startOffset, int endOffset, CodeSpecializationKind kind)
+{
+    auto entireSourceCode = source();
+    return CodeBlockHash { entireSourceCode.substring(startOffset, endOffset - startOffset), entireSourceCode, kind };
+}
+
 void SourceProvider::lockUnderlyingBufferImpl() { }
 
 void SourceProvider::unlockUnderlyingBufferImpl() { }

--- a/Source/JavaScriptCore/parser/SourceProvider.h
+++ b/Source/JavaScriptCore/parser/SourceProvider.h
@@ -33,6 +33,7 @@
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 #include "CachedBytecode.h"
+#include "CodeBlockHash.h"
 #include "CodeSpecializationKind.h"
 #include "SourceOrigin.h"
 #include "SourceTaintedOrigin.h"
@@ -106,6 +107,7 @@ public:
 
     JS_EXPORT_PRIVATE void lockUnderlyingBuffer();
     JS_EXPORT_PRIVATE void unlockUnderlyingBuffer();
+    JS_EXPORT_PRIVATE virtual CodeBlockHash codeBlockHashConcurrently(int startOffset, int endOffset, CodeSpecializationKind);
 
 private:
     JS_EXPORT_PRIVATE virtual void lockUnderlyingBufferImpl();
@@ -225,6 +227,8 @@ public:
         if (m_sourceProvider)
             m_sourceProvider->unlockUnderlyingBuffer();
     }
+
+    SourceProvider* provider() { return m_sourceProvider; }
 
 private:
     // This must not be RefPtr. It is possible that this is used by the concurrent compiler and

--- a/Source/WebCore/bindings/js/CachedScriptSourceProvider.h
+++ b/Source/WebCore/bindings/js/CachedScriptSourceProvider.h
@@ -46,16 +46,9 @@ public:
     unsigned hash() const override;
     StringView source() const override;
 
-    void lockUnderlyingBufferImpl() final
+    JSC::CodeBlockHash codeBlockHashConcurrently(int startOffset, int endOffset, JSC::CodeSpecializationKind kind) override
     {
-        ASSERT(!m_buffer);
-        m_buffer = m_cachedScript->resourceBuffer();
-    }
-
-    void unlockUnderlyingBufferImpl() final
-    {
-        ASSERT(m_buffer);
-        m_buffer = nullptr;
+        return m_cachedScript->codeBlockHashConcurrently(startOffset, endOffset, kind, sourceType() == JSC::SourceProviderSourceType::Module ? CachedScript::ShouldDecodeAsUTF8Only::Yes : CachedScript::ShouldDecodeAsUTF8Only::No);
     }
 
 private:
@@ -67,7 +60,6 @@ private:
     }
 
     CachedResourceHandle<CachedScript> m_cachedScript;
-    RefPtr<FragmentedSharedBuffer> m_buffer;
 };
 
 inline unsigned CachedScriptSourceProvider::hash() const

--- a/Source/WebCore/bindings/js/ScriptBufferSourceProvider.h
+++ b/Source/WebCore/bindings/js/ScriptBufferSourceProvider.h
@@ -64,6 +64,43 @@ public:
 
     StringView source() const final
     {
+        return sourceImpl(Locker { m_lock });
+    }
+
+    void clearDecodedData() final
+    {
+        Locker locker { m_lock };
+        m_cachedScriptString = String();
+    }
+
+    void tryReplaceScriptBuffer(const ScriptBuffer& scriptBuffer) final
+    {
+        // If this new file-mapped script buffer is identical to the one we have, then replace
+        // ours to save dirty memory.
+        Locker locker { m_lock };
+        if (m_scriptBuffer != scriptBuffer)
+            return;
+
+        m_scriptBuffer = scriptBuffer;
+        m_contiguousBuffer = nullptr;
+    }
+
+    JSC::CodeBlockHash codeBlockHashConcurrently(int startOffset, int endOffset, JSC::CodeSpecializationKind kind) override
+    {
+        Locker locker { m_lock };
+        auto view = sourceImpl(locker);
+        return JSC::CodeBlockHash { view.substring(startOffset, endOffset - startOffset), view, kind };
+    }
+
+private:
+    ScriptBufferSourceProvider(const ScriptBuffer& scriptBuffer, const JSC::SourceOrigin& sourceOrigin, String&& sourceURL, String&& preRedirectURL, const TextPosition& startPosition, JSC::SourceProviderSourceType sourceType)
+        : JSC::SourceProvider(sourceOrigin, WTFMove(sourceURL), WTFMove(preRedirectURL), JSC::SourceTaintedOrigin::Untainted, startPosition, sourceType)
+        , m_scriptBuffer(scriptBuffer)
+    {
+    }
+
+    StringView sourceImpl(const AbstractLocker&) const
+    {
         if (m_scriptBuffer.isEmpty())
             return emptyString();
 
@@ -86,53 +123,12 @@ public:
         return m_cachedScriptString;
     }
 
-    void clearDecodedData() final
-    {
-        m_cachedScriptString = String();
-    }
-
-    void tryReplaceScriptBuffer(const ScriptBuffer& scriptBuffer) final
-    {
-        // If this new file-mapped script buffer is identical to the one we have, then replace
-        // ours to save dirty memory.
-        if (m_scriptBuffer != scriptBuffer)
-            return;
-
-        m_scriptBuffer = scriptBuffer;
-        m_contiguousBuffer = nullptr;
-    }
-
-    void lockUnderlyingBufferImpl() final
-    {
-        ASSERT(!m_buffer);
-        m_buffer = m_scriptBuffer.buffer();
-
-        if (!m_buffer)
-            return;
-
-        if (!m_buffer->isContiguous())
-            m_buffer = m_buffer->makeContiguous();
-    }
-
-    void unlockUnderlyingBufferImpl() final
-    {
-        ASSERT(m_buffer);
-        m_buffer = nullptr;
-    }
-
-private:
-    ScriptBufferSourceProvider(const ScriptBuffer& scriptBuffer, const JSC::SourceOrigin& sourceOrigin, String&& sourceURL, String&& preRedirectURL, const TextPosition& startPosition, JSC::SourceProviderSourceType sourceType)
-        : JSC::SourceProvider(sourceOrigin, WTFMove(sourceURL), WTFMove(preRedirectURL), JSC::SourceTaintedOrigin::Untainted, startPosition, sourceType)
-        , m_scriptBuffer(scriptBuffer)
-    {
-    }
-
     ScriptBuffer m_scriptBuffer;
-    RefPtr<const FragmentedSharedBuffer> m_buffer;
     mutable RefPtr<SharedBuffer> m_contiguousBuffer;
     mutable unsigned m_scriptHash { 0 };
     mutable String m_cachedScriptString;
     mutable std::optional<bool> m_containsOnlyASCII;
+    mutable Lock m_lock;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/loader/TextResourceDecoder.cpp
+++ b/Source/WebCore/loader/TextResourceDecoder.cpp
@@ -284,16 +284,22 @@ const PAL::TextEncoding& TextResourceDecoder::defaultEncoding(ContentType conten
     return specifiedDefaultEncoding;
 }
 
-inline TextResourceDecoder::TextResourceDecoder(const String& mimeType, const PAL::TextEncoding& specifiedDefaultEncoding, bool usesEncodingDetector)
-    : m_contentType(determineContentType(mimeType))
-    , m_encoding(defaultEncoding(m_contentType, specifiedDefaultEncoding))
+inline TextResourceDecoder::TextResourceDecoder(ContentType contentType, const PAL::TextEncoding& encoding, bool usesEncodingDetector)
+    : m_contentType(contentType)
+    , m_encoding(encoding)
     , m_usesEncodingDetector(usesEncodingDetector)
 {
 }
 
-Ref<TextResourceDecoder> TextResourceDecoder::create(const String& mimeType, const PAL::TextEncoding& defaultEncoding, bool usesEncodingDetector)
+Ref<TextResourceDecoder> TextResourceDecoder::create(const String& mimeType, const PAL::TextEncoding& encoding, bool usesEncodingDetector)
 {
-    return adoptRef(*new TextResourceDecoder(mimeType, defaultEncoding, usesEncodingDetector));
+    auto contentType = determineContentType(mimeType);
+    return adoptRef(*new TextResourceDecoder(contentType, defaultEncoding(contentType, encoding), usesEncodingDetector));
+}
+
+Ref<TextResourceDecoder> TextResourceDecoder::create(ContentType contentType, const PAL::TextEncoding& encoding, bool usesEncodingDetector)
+{
+    return adoptRef(*new TextResourceDecoder(contentType, encoding, usesEncodingDetector));
 }
 
 TextResourceDecoder::~TextResourceDecoder() = default;

--- a/Source/WebCore/loader/TextResourceDecoder.h
+++ b/Source/WebCore/loader/TextResourceDecoder.h
@@ -45,13 +45,17 @@ public:
         EncodingFromParentFrame
     };
 
+    enum ContentType { PlainText, HTML, XML, CSS }; // PlainText only checks for BOM.
+
     WEBCORE_EXPORT static Ref<TextResourceDecoder> create(const String& mimeType, const PAL::TextEncoding& defaultEncoding = { }, bool usesEncodingDetector = false);
+    WEBCORE_EXPORT static Ref<TextResourceDecoder> create(ContentType, const PAL::TextEncoding&, bool usesEncodingDetector);
     WEBCORE_EXPORT ~TextResourceDecoder();
 
     static String textFromUTF8(std::span<const uint8_t>);
 
     void setEncoding(const PAL::TextEncoding&, EncodingSource);
     const PAL::TextEncoding& encoding() const { return m_encoding; }
+    ContentType contentType() const { return m_contentType; }
     const PAL::TextEncoding* encodingForURLParsing();
 
     bool hasEqualEncodingForCharset(const String& charset) const;
@@ -67,10 +71,11 @@ public:
 
     void setAlwaysUseUTF8() { ASSERT(m_encoding.name() == "UTF-8"_s); m_alwaysUseUTF8 = true; }
 
-private:
-    TextResourceDecoder(const String& mimeType, const PAL::TextEncoding& defaultEncoding, bool usesEncodingDetector);
+    bool usesEncodingDetector() const { return m_usesEncodingDetector; }
 
-    enum ContentType { PlainText, HTML, XML, CSS }; // PlainText only checks for BOM.
+private:
+    TextResourceDecoder(ContentType, const PAL::TextEncoding&, bool usesEncodingDetector);
+
     static ContentType determineContentType(const String& mimeType);
     static const PAL::TextEncoding& defaultEncoding(ContentType, const PAL::TextEncoding& defaultEncoding);
 

--- a/Source/WebCore/loader/cache/CachedScript.cpp
+++ b/Source/WebCore/loader/cache/CachedScript.cpp
@@ -76,7 +76,10 @@ StringView CachedScript::script(ShouldDecodeAsUTF8Only shouldDecodeAsUTF8Only)
         && contiguousData->size()
         && charactersAreAllASCII(contiguousData->span())) {
 
-        m_decodingState = DataAndDecodedStringHaveSameBytes;
+        {
+            Locker locker { m_lock };
+            m_decodingState = DataAndDecodedStringHaveSameBytes;
+        }
 
         // If the encoded and decoded data are the same, there is no decoded data cost!
         setDecodedSize(0);
@@ -91,22 +94,76 @@ StringView CachedScript::script(ShouldDecodeAsUTF8Only shouldDecodeAsUTF8Only)
     bool shouldForceRedecoding = m_wasForceDecodedAsUTF8 != (shouldDecodeAsUTF8Only == ShouldDecodeAsUTF8Only::Yes);
     if (!m_script || shouldForceRedecoding) {
         ASSERT(contiguousData->span().size() == encodedSize());
+        String result;
         if (shouldDecodeAsUTF8Only == ShouldDecodeAsUTF8Only::Yes) {
             Ref forceUTF8Decoder = TextResourceDecoder::create("text/javascript"_s, PAL::UTF8Encoding());
             forceUTF8Decoder->setAlwaysUseUTF8();
-            m_script = forceUTF8Decoder->decodeAndFlush(contiguousData->span());
+            result = forceUTF8Decoder->decodeAndFlush(contiguousData->span());
         } else
-            m_script = protectedDecoder()->decodeAndFlush(contiguousData->span());
+            result = protectedDecoder()->decodeAndFlush(contiguousData->span());
+
+
         if (m_decodingState == NeverDecoded || shouldForceRedecoding)
-            m_scriptHash = m_script.hash();
-        ASSERT(!m_scriptHash || m_scriptHash == m_script.hash());
-        m_decodingState = DataAndDecodedStringHaveDifferentBytes;
-        m_wasForceDecodedAsUTF8 = shouldDecodeAsUTF8Only == ShouldDecodeAsUTF8Only::Yes;
+            m_scriptHash = result.hash();
+        ASSERT(!m_scriptHash || m_scriptHash == result.hash());
+
+        {
+            Locker locker { m_lock };
+            m_script = WTFMove(result);
+            m_decodingState = DataAndDecodedStringHaveDifferentBytes;
+            m_wasForceDecodedAsUTF8 = shouldDecodeAsUTF8Only == ShouldDecodeAsUTF8Only::Yes;
+        }
         setDecodedSize(m_script.sizeInBytes());
     }
 
     restartDecodedDataDeletionTimer();
     return m_script;
+}
+
+JSC::CodeBlockHash CachedScript::codeBlockHashConcurrently(int startOffset, int endOffset, JSC::CodeSpecializationKind kind, ShouldDecodeAsUTF8Only shouldDecodeAsUTF8Only)
+{
+    Locker locker { m_lock };
+    auto data = m_data;
+    if (!data)
+        return JSC::CodeBlockHash { emptyString(), emptyString(), kind };
+
+    switch (m_decodingState) {
+    case NeverDecoded: {
+        // This is rare, but unfortunately, when running CodeBlockHash concurrently, CachedScript was not decoding the source code.
+        // Thus, we need to decode them and need to compute. This is costly, but fine as CodeBlockHash is only used for debugging.
+        if (!data->isContiguous())
+            data = data->makeContiguous();
+        Ref contiguousData = downcast<SharedBuffer>(*data);
+
+        if (PAL::TextEncoding(encoding()).isByteBasedEncoding() && contiguousData->size() && charactersAreAllASCII(contiguousData->span())) {
+            StringView entireSource { contiguousData->span() };
+            return JSC::CodeBlockHash { entireSource.substring(startOffset, endOffset - startOffset), entireSource, kind };
+        }
+
+        String result;
+        if (shouldDecodeAsUTF8Only == ShouldDecodeAsUTF8Only::Yes) {
+            Ref forceUTF8Decoder = TextResourceDecoder::create("text/javascript"_s, PAL::UTF8Encoding());
+            forceUTF8Decoder->setAlwaysUseUTF8();
+            result = forceUTF8Decoder->decodeAndFlush(contiguousData->span());
+        } else {
+            auto decoder = TextResourceDecoder::create(protectedDecoder()->contentType(), protectedDecoder()->encoding(), protectedDecoder()->usesEncodingDetector());
+            result = decoder->decodeAndFlush(contiguousData->span());
+        }
+
+        StringView entireSource { result };
+        return JSC::CodeBlockHash { entireSource.substring(startOffset, endOffset - startOffset), entireSource, kind };
+    }
+    case DataAndDecodedStringHaveSameBytes: {
+        StringView entireSource { downcast<SharedBuffer>(*data).span() };
+        return JSC::CodeBlockHash { entireSource.substring(startOffset, endOffset - startOffset), entireSource, kind };
+    }
+
+    case DataAndDecodedStringHaveDifferentBytes: {
+        StringView entireSource { m_script };
+        return JSC::CodeBlockHash { entireSource.substring(startOffset, endOffset - startOffset), entireSource, kind };
+    }
+    }
+    return { };
 }
 
 unsigned CachedScript::scriptHash(ShouldDecodeAsUTF8Only shouldDecodeAsUTF8Only)
@@ -130,7 +187,10 @@ void CachedScript::finishLoading(const FragmentedSharedBuffer* data, const Netwo
 
 void CachedScript::destroyDecodedData()
 {
-    m_script = String();
+    {
+        Locker locker { m_lock };
+        m_script = String();
+    }
     setDecodedSize(0);
 }
 
@@ -141,11 +201,14 @@ void CachedScript::setBodyDataFrom(const CachedResource& resource)
 
     CachedResource::setBodyDataFrom(resource);
 
-    m_script = script.m_script;
-    m_scriptHash = script.m_scriptHash;
-    m_wasForceDecodedAsUTF8 = script.m_wasForceDecodedAsUTF8;
-    m_decodingState = script.m_decodingState;
-    m_decoder = script.m_decoder;
+    {
+        Locker locker { m_lock };
+        m_script = script.m_script;
+        m_scriptHash = script.m_scriptHash;
+        m_wasForceDecodedAsUTF8 = script.m_wasForceDecodedAsUTF8;
+        m_decodingState = script.m_decodingState;
+        m_decoder = script.m_decoder;
+    }
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/cache/CachedScript.h
+++ b/Source/WebCore/loader/cache/CachedScript.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "CachedResource.h"
+#include <JavaScriptCore/CodeBlockHash.h>
 
 namespace WebCore {
 
@@ -41,6 +42,7 @@ public:
     enum class ShouldDecodeAsUTF8Only : bool { No, Yes };
     WEBCORE_EXPORT StringView script(ShouldDecodeAsUTF8Only = ShouldDecodeAsUTF8Only::No);
     WEBCORE_EXPORT unsigned scriptHash(ShouldDecodeAsUTF8Only = ShouldDecodeAsUTF8Only::No);
+    WEBCORE_EXPORT JSC::CodeBlockHash codeBlockHashConcurrently(int startOffset, int endOffset, JSC::CodeSpecializationKind, ShouldDecodeAsUTF8Only);
 
     bool requiresPrivacyProtections() const { return m_requiresPrivacyProtections; }
 
@@ -62,8 +64,10 @@ private:
     bool m_wasForceDecodedAsUTF8 { false };
     bool m_requiresPrivacyProtections { false };
 
-    enum DecodingState { NeverDecoded, DataAndDecodedStringHaveSameBytes, DataAndDecodedStringHaveDifferentBytes };
+    enum DecodingState : uint8_t { NeverDecoded, DataAndDecodedStringHaveSameBytes, DataAndDecodedStringHaveDifferentBytes };
     DecodingState m_decodingState { NeverDecoded };
+
+    mutable Lock m_lock;
 
     RefPtr<TextResourceDecoder> m_decoder;
 };


### PR DESCRIPTION
#### 82de5bb8778460c45a1eda6245f1de2b93f46952
<pre>
[JSC] Concurrently computing CodeBlockHash
<a href="https://bugs.webkit.org/show_bug.cgi?id=295000">https://bugs.webkit.org/show_bug.cgi?id=295000</a>
<a href="https://rdar.apple.com/154307835">rdar://154307835</a>

Reviewed by Yijia Huang.

This patch fixes an issue for concurrent CodeBlockHash. We put some
locks around CachedScriptSourceProvider / ScriptBufferSourceProvider
to ensure that we can touch these source code safely (do not ref them.
This is concurrently touched).

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::hash const):
* Source/JavaScriptCore/bytecode/CodeBlockHash.cpp:
(JSC::CodeBlockHash::CodeBlockHash):
* Source/JavaScriptCore/bytecode/CodeBlockHash.h:
* Source/JavaScriptCore/parser/SourceProvider.cpp:
(JSC::SourceProvider::codeBlockHashConcurrently):
* Source/JavaScriptCore/parser/SourceProvider.h:
(JSC::SourceProviderBufferGuard::provider):
* Source/WebCore/bindings/js/CachedScriptSourceProvider.h:
* Source/WebCore/bindings/js/ScriptBufferSourceProvider.h:
* Source/WebCore/loader/TextResourceDecoder.cpp:
(WebCore::TextResourceDecoder::TextResourceDecoder):
(WebCore::TextResourceDecoder::create):
* Source/WebCore/loader/TextResourceDecoder.h:
(WebCore::TextResourceDecoder::contentType const):
(WebCore::TextResourceDecoder::usesEncodingDetector const):
* Source/WebCore/loader/cache/CachedScript.cpp:
(WebCore::CachedScript::script):
(WebCore::CachedScript::codeBlockHashConcurrently):
(WebCore::CachedScript::destroyDecodedData):
(WebCore::CachedScript::setBodyDataFrom):
* Source/WebCore/loader/cache/CachedScript.h:

Canonical link: <a href="https://commits.webkit.org/296668@main">https://commits.webkit.org/296668@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a8d18c26f110d30816838778626d35fb1c90143

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109245 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28903 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19331 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114453 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59516 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111208 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29585 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37492 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83026 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112193 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed webkitperl tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23547 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98397 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63476 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22936 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16542 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59078 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/101761 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92914 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16582 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117569 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/107803 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36289 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26852 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92038 "Found 1 new test failure: svg/text/timeout-long-text-content.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36661 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94660 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91847 "Found 2 new API test failures: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36769 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14522 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32122 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17624 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36185 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41673 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/132072 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35871 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35792 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39203 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37562 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->