### PR TITLE
[Liquid Glass] [macOS] Blank gap above top fixed header when rubber-banding against top of page

### DIFF
--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -841,13 +841,22 @@ GraphicsLayer* LocalFrameView::layerForOverhangAreas() const
     return renderView->compositor().layerForOverhangAreas();
 }
 
-GraphicsLayer* LocalFrameView::setWantsLayerForTopOverHangArea(bool wantsLayer) const
+GraphicsLayer* LocalFrameView::setWantsLayerForTopOverhangColorExtension(bool wantsLayer) const
 {
-    RenderView* renderView = this->renderView();
+    CheckedPtr renderView = this->renderView();
     if (!renderView)
         return nullptr;
 
-    return renderView->compositor().updateLayerForTopOverhangArea(wantsLayer);
+    return renderView->compositor().updateLayerForTopOverhangColorExtension(wantsLayer);
+}
+
+GraphicsLayer* LocalFrameView::setWantsLayerForTopOverhangImage(bool wantsLayer) const
+{
+    CheckedPtr renderView = this->renderView();
+    if (!renderView)
+        return nullptr;
+
+    return renderView->compositor().updateLayerForTopOverhangImage(wantsLayer);
 }
 
 GraphicsLayer* LocalFrameView::setWantsLayerForBottomOverHangArea(bool wantsLayer) const

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -622,7 +622,8 @@ public:
     void setPagination(const Pagination&);
 
 #if HAVE(RUBBER_BANDING)
-    WEBCORE_EXPORT GraphicsLayer* setWantsLayerForTopOverHangArea(bool) const;
+    GraphicsLayer* setWantsLayerForTopOverhangColorExtension(bool) const;
+    WEBCORE_EXPORT GraphicsLayer* setWantsLayerForTopOverhangImage(bool) const;
     WEBCORE_EXPORT GraphicsLayer* setWantsLayerForBottomOverHangArea(bool) const;
 #endif
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5348,6 +5348,15 @@ void Page::updateFixedContainerEdges(BoxSideSet sides)
     }
 
     m_fixedContainerEdgesAndElements = std::make_pair(makeUniqueRef<FixedContainerEdges>(WTFMove(edges)), WTFMove(elements));
+
+#if HAVE(RUBBER_BANDING)
+    auto topOverhangColor = fixedContainerEdges().predominantColor(BoxSide::Top);
+    if (RefPtr layer = frameView->setWantsLayerForTopOverhangColorExtension(topOverhangColor.isVisible())) {
+        layer->setBackgroundColor(WTFMove(topOverhangColor));
+        if (CheckedPtr renderView = frameView->renderView())
+            renderView->compositor().updateSizeAndPositionForTopOverhangColorExtensionLayer();
+    }
+#endif
 }
 
 Element* Page::lastFixedContainer(BoxSide side) const

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -368,12 +368,14 @@ public:
     GraphicsLayer* layerForOverhangAreas() const { return m_layerForOverhangAreas.get(); }
     GraphicsLayer* layerForContentShadow() const { return m_contentShadowLayer.get(); }
 
-    GraphicsLayer* updateLayerForTopOverhangArea(bool wantsLayer);
+    GraphicsLayer* updateLayerForTopOverhangColorExtension(bool wantsLayer);
+    GraphicsLayer* updateLayerForTopOverhangImage(bool wantsLayer);
     GraphicsLayer* updateLayerForBottomOverhangArea(bool wantsLayer);
     GraphicsLayer* updateLayerForHeader(bool wantsLayer);
     GraphicsLayer* updateLayerForFooter(bool wantsLayer);
 
     void updateLayerForOverhangAreasBackgroundColor();
+    void updateSizeAndPositionForTopOverhangColorExtensionLayer();
     void updateSizeAndPositionForOverhangAreaLayer();
 #endif // HAVE(RUBBER_BANDING)
 
@@ -672,7 +674,8 @@ private:
 #if HAVE(RUBBER_BANDING)
     RefPtr<GraphicsLayer> m_layerForOverhangAreas;
     RefPtr<GraphicsLayer> m_contentShadowLayer;
-    RefPtr<GraphicsLayer> m_layerForTopOverhangArea;
+    RefPtr<GraphicsLayer> m_layerForTopOverhangImage;
+    RefPtr<GraphicsLayer> m_layerForTopOverhangColorExtension;
     RefPtr<GraphicsLayer> m_layerForBottomOverhangArea;
     RefPtr<GraphicsLayer> m_layerForHeader;
     RefPtr<GraphicsLayer> m_layerForFooter;

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -583,7 +583,7 @@ void WebPage::setTopOverhangImage(WebImage* image)
     if (!frameView)
         return;
 
-    RefPtr layer = frameView->setWantsLayerForTopOverHangArea(image);
+    RefPtr layer = frameView->setWantsLayerForTopOverhangImage(image);
     if (!layer)
         return;
 

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -106,6 +106,8 @@ class Color;
 #endif
 #endif // PLATFORM(IOS_FAMILY)
 
+- (void)forEachCALayer:(void(^)(CALayer *))visitor;
+
 @property (nonatomic, readonly) CGImageRef snapshotAfterScreenUpdates;
 @property (nonatomic, readonly) NSUInteger gpuToWebProcessConnectionCount;
 @property (nonatomic, readonly) NSUInteger modelProcessModelPlayerCount;

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -722,6 +722,19 @@ static WebEvent *unwrap(BEKeyEntry *event)
     return CGPointMake(CGRectGetMidX(rect), CGRectGetMidY(rect));
 }
 
+static void forEachCALayer(CALayer *layer, void(^visitor)(CALayer *))
+{
+    visitor(layer);
+
+    for (CALayer *sublayer in layer.sublayers)
+        forEachCALayer(sublayer, visitor);
+}
+
+- (void)forEachCALayer:(void(^)(CALayer *))visitor
+{
+    forEachCALayer(self.layer, visitor);
+}
+
 - (CGImageRef)snapshotAfterScreenUpdates
 {
     __block RetainPtr<CGImage> result;


### PR DESCRIPTION
#### ddea07179839833efb4df7022cbc6269d7b070cd
<pre>
[Liquid Glass] [macOS] Blank gap above top fixed header when rubber-banding against top of page
<a href="https://bugs.webkit.org/show_bug.cgi?id=295001">https://bugs.webkit.org/show_bug.cgi?id=295001</a>
<a href="https://rdar.apple.com/151482288">rdar://151482288</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

Currently, when rubber-banding against the top of a webpage in Safari with a fixed element near the
top of the viewport, the page background color shows up in the gap between the bottom of the color
extension view and the top edge of the fixed element.

To fill in this gap, we introduce a new `m_layerForTopOverhangColorExtension` whose background color
is updated to match the predominant sampled color of the fixed element near the top. We then place
this new layer above the existing overhang layer for the page&apos;s extended background color. The layer
becomes visible when rubber-banding past the top of the page.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::setWantsLayerForTopOverhangColorExtension const):

Add a new helper method to create and install `m_layerForTopOverhangColorExtension` in the
`GraphicsLayer` hierarchy. This layer is inserted right before the existing
`m_layerForTopOverhangArea` (which has now been renamed to avoid confusion).

(WebCore::LocalFrameView::setWantsLayerForTopOverhangImage const):
(WebCore::LocalFrameView::setWantsLayerForTopOverHangArea const): Deleted.

Rename the existing `m_layerForTopOverhangArea` to `m_layerForTopOverhangImage`, to clarify that
it&apos;s only used to contain the image supplied by the injected bundle client via the SPI function
`WKBundlePageSetTopOverhangImage`. Note that this is only used by Safari&apos;s continuous reader mode.
This renaming is important to disambiguate it from this new `m_layerForTopOverhangColorExtension`,
which also sits inside the overhang area.

* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateFixedContainerEdges):

Add or remove `m_layerForTopOverhangColorExtension` as needed (i.e., when there&apos;s a predominant
sampled color).

* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::~RenderLayerCompositor):
(WebCore::RenderLayerCompositor::frameViewDidChangeSize):

Update the `m_layerForTopOverhangColorExtension`&apos;s bounds, alongside the existing
`m_layerForOverhangAreas`.

(WebCore::RenderLayerCompositor::updateRootLayerPosition):
(WebCore::RenderLayerCompositor::updateLayerForTopOverhangImage):
(WebCore::RenderLayerCompositor::updateLayerForTopOverhangColorExtension):

Add logic to add or remove `m_layerForTopOverhangColorExtension` — note that this new layer is
inserted under `m_scrolledContentsLayer` (matching `m_layerForTopOverhangImage`), but goes beneath
`m_layerForTopOverhangImage` in sublayer order if that already exists.

(WebCore::RenderLayerCompositor::updateSizeAndPositionForOverhangAreaLayer):
(WebCore::RenderLayerCompositor::updateSizeAndPositionForTopOverhangColorExtensionLayer):
(WebCore::RenderLayerCompositor::updateLayerForTopOverhangArea): Deleted.
* Source/WebCore/rendering/RenderLayerCompositor.h:
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::setTopOverhangImage):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ObscuredContentInsets.mm:
(TestWebKitAPI::TEST(ObscuredContentInsets, TopOverhangColorExtensionLayer)):

Add an API test that searches the layer hierarchy for this new `CALayer` (by name) and sanity checks
its bounds, position, and background color.

* Tools/TestWebKitAPI/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(forEachCALayer):
(-[WKWebView forEachCALayer:]):

Canonical link: <a href="https://commits.webkit.org/296667@main">https://commits.webkit.org/296667@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6073282f061b24af606409ef01ab468202f6a215

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109249 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28907 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19335 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114456 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59520 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111212 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29589 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37496 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83025 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112197 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23551 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98401 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63475 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22940 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16546 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59082 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92919 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16586 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117572 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36293 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26855 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92041 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36665 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94664 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91850 "run-api-tests-without-change (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23387 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36772 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14526 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32127 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36189 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41677 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35875 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39207 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37566 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->