### PR TITLE
Content with a grayscale filter and mix-blend-mode don't get mix-blend-mode applied.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-with-mix-blend-mode-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-with-mix-blend-mode-expected.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Filters: filter and mix-blend mode on the same element (ref)</title>
+<style>
+    html {
+        background: green;
+    }
+    div {
+        width: 200px;
+        height: 200px;
+    }
+    .outer {
+        mix-blend-mode: screen;
+    }
+    .inner {
+        background: red;
+        filter: grayscale();
+    }
+</style>
+</head>
+<body>
+    <div class=outer>
+        <div class=inner></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-with-mix-blend-mode.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-with-mix-blend-mode.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Filters: filter and mix-blend mode on the same element</title>
+<link rel="help" href="https://drafts.fxtf.org/filter-effects-1">
+<link rel="match" href="reference/filter-with-mix-blend-mode-ref.html">
+<style>
+    html {
+        background: green;
+    }
+    div {
+        width: 200px;
+        height: 200px;
+        background: red;
+        filter: grayscale();
+        mix-blend-mode: screen;
+    }
+</style>
+</head>
+<body>
+    <div></div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3865,14 +3865,15 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
 
             // FIXME: Handle more than one fragment.
             backgroundRect = layerFragments.isEmpty() ? ClipRect() : layerFragments[0].backgroundRect;
+
+            if (haveTransparency) {
+                // If we have a filter and transparency, we have to eagerly start a transparency layer here, rather than risk a child layer lazily starts one with the wrong context.
+                beginTransparencyLayers(context, paintingInfo, paintingInfo.paintDirtyRect);
+            }
         }
 
         LayerPaintingInfo localPaintingInfo(paintingInfo);
         GraphicsContext* filterContext = setupFilters(context, localPaintingInfo, paintFlags, columnAwareOffsetFromRoot, backgroundRect);
-        if (filterContext && haveTransparency) {
-            // If we have a filter and transparency, we have to eagerly start a transparency layer here, rather than risk a child layer lazily starts one with the wrong context.
-            beginTransparencyLayers(context, localPaintingInfo, paintingInfo.paintDirtyRect);
-        }
         GraphicsContext& currentContext = filterContext ? *filterContext : context;
 
         if (filterContext)


### PR DESCRIPTION
#### 1e13b3de61a09946b762d6f583869691a33c0705
<pre>
Content with a grayscale filter and mix-blend-mode don&apos;t get mix-blend-mode applied.
<a href="https://bugs.webkit.org/show_bug.cgi?id=293903">https://bugs.webkit.org/show_bug.cgi?id=293903</a>
&lt;<a href="https://rdar.apple.com/152460888">rdar://152460888</a>&gt;

Reviewed by Simon Fraser.

Some filter types (including grayscale) are implemented by pushing a
transparency layer, rather than diverting to a temporary context.

In those cases, the code attempting to setup a transparency layer for opacity
(and mix-blend-mode) ends up doing so too late, and applies the mix-blend-mode
inside the filter (where it has nothing to blend with).

Move this up to before the filter is setup, so that the ordering is always
correct.

* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-with-mix-blend-mode-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-with-mix-blend-mode.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::paintLayerContents):

Canonical link: <a href="https://commits.webkit.org/296827@main">https://commits.webkit.org/296827@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6f7d6b6a0856152c6e7575cf3809f9f92cf4460

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109363 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29021 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19450 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114568 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59606 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111326 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37609 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83114 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112311 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23644 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98503 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63571 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23030 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16646 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59192 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93012 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16688 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117680 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36404 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26943 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92123 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36775 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94765 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91938 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23490 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36869 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14616 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32214 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36297 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41773 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35971 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39308 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37673 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->