### PR TITLE
Import the latest cookie prefixes and cookie-store special names WPTs

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -869,13 +869,6 @@ imported/w3c/web-platform-tests/workers/interfaces/WorkerGlobalScope/onerror/mes
 imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace.html [ ImageOnlyFailure ]
 
 # Cookie tests that are flaky since their import because they fail and and out some kind of unique id.
-imported/w3c/web-platform-tests/cookies/prefix/__host.document-cookie.html [ Pass Failure ]
-imported/w3c/web-platform-tests/cookies/prefix/__host.document-cookie.https.html [ Pass Failure ]
-imported/w3c/web-platform-tests/cookies/prefix/__host.header.html [ Pass Failure ]
-imported/w3c/web-platform-tests/cookies/prefix/__host.header.https.html [ Pass Failure ]
-imported/w3c/web-platform-tests/cookies/prefix/__secure.document-cookie.html [ Pass Failure ]
-imported/w3c/web-platform-tests/cookies/prefix/__secure.document-cookie.https.html [ Pass Failure ]
-imported/w3c/web-platform-tests/cookies/prefix/__secure.header.html [ Pass Failure ]
 imported/w3c/web-platform-tests/cookies/prefix/document-cookie.non-secure.html [ Pass Failure ]
 
 # These tests have generated UUIDs in their output.

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any-expected.txt
@@ -15,5 +15,11 @@ PASS cookieStore.set with __Host- prefix and a domain option
 PASS cookieStore.set with __Host- prefix a path option
 PASS cookieStore.set with __host- prefix and a domain option
 PASS cookieStore.set with __host- prefix a path option
+FAIL cookieStore.set with __HostHttp- prefix rejects assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL cookieStore.set with __hosthttp- prefix rejects assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL cookieStore.set with __Http- prefix rejects assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL cookieStore.set with __http- prefix rejects assert_unreached: Should have rejected: undefined Reached unreachable code
 PASS cookieStore.set with malformed name.
+FAIL cookieStore.set a nameless cookie cannot have __Host- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
+FAIL cookieStore.set a nameless cookie cannot have __Secure- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.js
@@ -54,6 +54,13 @@
   }, `cookieStore.set with ${prefix} prefix a path option`);
 });
 
+['__HostHttp-', '__hosthttp-', '__Http-', '__http-'].forEach(prefix => {
+  promise_test(async testCase => {
+    await promise_rejects_js(testCase, TypeError,
+        cookieStore.set({ name: `${prefix}cookie-name`, value: 'cookie-value'}));
+  }, `cookieStore.set with ${prefix} prefix rejects`);
+});
+
 promise_test(async testCase => {
     let exceptionThrown = false;
     try {
@@ -64,3 +71,33 @@ promise_test(async testCase => {
     }
     assert_true(exceptionThrown, "No exception thrown.");
 }, 'cookieStore.set with malformed name.');
+
+promise_test(async testCase => {
+  // Nameless cookies cannot have a __Host- prefix
+  await cookieStore.delete('');
+
+  const currentUrl = new URL(self.location.href);
+  const currentDomain = currentUrl.hostname;
+
+  await promise_rejects_js(testCase, TypeError, cookieStore.set(
+      { name: '',
+        value: '__Host-nameless-cookie',
+        domain: `.${currentDomain}` }));
+  const cookie = await cookieStore.get('');
+  assert_equals(cookie, null);
+}, 'cookieStore.set a nameless cookie cannot have __Host- prefix');
+
+promise_test(async testCase => {
+  // Nameless cookies cannot have a __Secure- prefix
+  await cookieStore.delete('');
+
+  const currentUrl = new URL(self.location.href);
+  const currentDomain = currentUrl.hostname;
+
+  await promise_rejects_js(testCase, TypeError, cookieStore.set(
+      { name: '',
+        value: '__Secure-nameless-cookie',
+        domain: `.${currentDomain}` }));
+  const cookie = await cookieStore.get('');
+  assert_equals(cookie, null);
+}, 'cookieStore.set a nameless cookie cannot have __Secure- prefix');

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.serviceworker-expected.txt
@@ -15,5 +15,11 @@ PASS cookieStore.set with __Host- prefix and a domain option
 PASS cookieStore.set with __Host- prefix a path option
 PASS cookieStore.set with __host- prefix and a domain option
 PASS cookieStore.set with __host- prefix a path option
+FAIL cookieStore.set with __HostHttp- prefix rejects assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL cookieStore.set with __hosthttp- prefix rejects assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL cookieStore.set with __Http- prefix rejects assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL cookieStore.set with __http- prefix rejects assert_unreached: Should have rejected: undefined Reached unreachable code
 PASS cookieStore.set with malformed name.
+FAIL cookieStore.set a nameless cookie cannot have __Host- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
+FAIL cookieStore.set a nameless cookie cannot have __Secure- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__HostHttp.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__HostHttp.https-expected.txt
@@ -1,0 +1,9 @@
+
+FAIL __HostHttp: Does not set via DOM 'Secure; Path=/' assert_equals: `__HostHttp-prefixtestcookie=foo1` in `document.cookie` expected false but got true
+FAIL __HostHttp: Does not set via DOM with Domain attribute 'Secure; Path=/; Domain=localhost' assert_equals: `__HostHttp-prefixtestcookie=foo2` in `document.cookie` expected false but got true
+FAIL __HostHttp: Does not set via HTTP with 'Secure; Path=/' assert_equals: expected (undefined) undefined but got (string) "bar1"
+PASS __HostHttp: Set via HTTP with 'Secure; Path=/; httponly'
+FAIL __HostHttp: Does not set via HTTP with 'Secure; Path=/cookies/; httponly' assert_equals: expected (undefined) undefined but got (string) "bar3"
+FAIL __HostHttp: Does not set via HTTP with 'Path=/;' (without Secure) assert_equals: expected (undefined) undefined but got (string) "bar4"
+FAIL __HostHttp: Does not set via HTTP with Domain attribute 'Secure; Path=/; Domain=localhost' assert_equals: expected (undefined) undefined but got (string) "bar5"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__HostHttp.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__HostHttp.https.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/cookies/resources/cookie-helper.sub.js"></script>
+<script>
+  set_prefixed_cookie_via_dom_test({
+    prefix: "__HostHttp-",
+    params: "Secure; Path=/",
+    shouldExistInDOM: false,
+    shouldExistViaHTTP: false,
+    title: "__HostHttp: Does not set via DOM 'Secure; Path=/'"
+  });
+
+  set_prefixed_cookie_via_dom_test({
+    prefix: "__HostHttp-",
+    params: "Secure; Path=/; Domain=" + document.location.hostname,
+    shouldExistInDOM: false,
+    shouldExistViaHTTP: false,
+    title: "__HostHttp: Does not set via DOM with Domain attribute 'Secure; Path=/; Domain=" +
+           document.location.hostname + "'"
+  });
+
+  set_prefixed_cookie_via_http_test({
+    prefix: "__HostHttp-",
+    params: "Secure; Path=/",
+    shouldExistViaHTTP: false,
+    origin: self.origin,
+    title: "__HostHttp: Does not set via HTTP with 'Secure; Path=/'"
+  });
+
+  set_prefixed_cookie_via_http_test({
+    prefix: "__HostHttp-",
+    params: "Secure; Path=/;httponly",
+    shouldExistViaHTTP: true,
+    origin: self.origin,
+    title: "__HostHttp: Set via HTTP with 'Secure; Path=/; httponly'"
+  });
+
+  set_prefixed_cookie_via_http_test({
+    prefix: "__HostHttp-",
+    params: "Secure; Path=/cookies/;httponly",
+    shouldExistViaHTTP: false,
+    origin: self.origin,
+    title: "__HostHttp: Does not set via HTTP with 'Secure; Path=/cookies/; httponly'"
+  });
+
+  set_prefixed_cookie_via_http_test({
+    prefix: "__HostHttp-",
+    params: "Path=/",
+    shouldExistViaHTTP: false,
+    origin: self.origin,
+    title: "__HostHttp: Does not set via HTTP with 'Path=/;' (without Secure)"
+  });
+
+  set_prefixed_cookie_via_http_test({
+    prefix: "__HostHttp-",
+    params: "Secure; Path=/; Domain=" + document.location.hostname,
+    shouldExistViaHTTP: false,
+    origin: self.origin,
+    title: "__HostHttp: Does not set via HTTP with Domain attribute 'Secure; Path=/; Domain=" +
+           document.location.hostname + "'"
+  });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__Http.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__Http.https-expected.txt
@@ -1,0 +1,9 @@
+
+FAIL __Http: Does not set via DOM 'Path=/' assert_equals: `__Http-prefixtestcookie=foo1` in `document.cookie` expected false but got true
+FAIL __Http: Does not set via DOM 'Secure; Path=/' assert_equals: `__Http-prefixtestcookie=foo2` in `document.cookie` expected false but got true
+PASS __Http: Does not set via DOM 'Secure; Path=/; httponly'
+FAIL __Http: Does not set via HTTP with 'Path=/;' (without Secure) assert_equals: expected (undefined) undefined but got (string) "bar1"
+FAIL __Http: Does not set via HTTP with 'Secure; Path=/' assert_equals: expected (undefined) undefined but got (string) "bar2"
+PASS __Http: Does set via HTTP with 'Secure; Path=/;httponly'
+PASS __Http: Does set via HTTP with 'Secure; Path=/cookies/;httponly'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__Http.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__Http.https.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/cookies/resources/cookie-helper.sub.js"></script>
+<script>
+  set_prefixed_cookie_via_dom_test({
+    prefix: "__Http-",
+    params: "Path=/",
+    shouldExistInDOM: false,
+    shouldExistViaHTTP: false,
+    title: "__Http: Does not set via DOM 'Path=/'"
+  });
+
+  set_prefixed_cookie_via_dom_test({
+    prefix: "__Http-",
+    params: "Secure; Path=/",
+    shouldExistInDOM: false,
+    shouldExistViaHTTP: false,
+    title: "__Http: Does not set via DOM 'Secure; Path=/'"
+  });
+
+  set_prefixed_cookie_via_dom_test({
+    prefix: "__Http-",
+    params: "Secure; Path=/;httponly",
+    shouldExistInDOM: false,
+    shouldExistViaHTTP: false,
+    title: "__Http: Does not set via DOM 'Secure; Path=/; httponly'"
+  });
+
+  set_prefixed_cookie_via_http_test({
+    prefix: "__Http-",
+    params: "Path=/",
+    shouldExistViaHTTP: false,
+    origin: self.origin,
+    title: "__Http: Does not set via HTTP with 'Path=/;' (without Secure)"
+  });
+
+  set_prefixed_cookie_via_http_test({
+    prefix: "__Http-",
+    params: "Secure;Path=/",
+    shouldExistViaHTTP: false,
+    origin: self.origin,
+    title: "__Http: Does not set via HTTP with 'Secure; Path=/'"
+  });
+
+  set_prefixed_cookie_via_http_test({
+    prefix: "__Http-",
+    params: "Secure;Path=/;httponly",
+    shouldExistViaHTTP: true,
+    origin: self.origin,
+    title: "__Http: Does set via HTTP with 'Secure; Path=/;httponly'"
+  });
+
+  set_prefixed_cookie_via_http_test({
+    prefix: "__Http-",
+    params: "Secure;Path=/cookies/;httponly",
+    shouldExistViaHTTP: true,
+    origin: self.origin,
+    title: "__Http: Does set via HTTP with 'Secure; Path=/cookies/;httponly'"
+  });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__host.document-cookie-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__host.document-cookie-expected.txt
@@ -1,14 +1,14 @@
 
 PASS __Host: Non-secure origin: 'Path=/;'
-FAIL __HoSt: Non-secure origin: 'Path=/;' assert_equals: `__HoSt-prefixtestcookie=0.1255974629690073` in `document.cookie` expected false but got true
+FAIL __HoSt: Non-secure origin: 'Path=/;' assert_equals: `__HoSt-prefixtestcookie=foo2` in `document.cookie` expected false but got true
 PASS __Host: Non-secure origin: 'Secure; Path=/;'
 PASS __HoSt: Non-secure origin: 'Secure; Path=/;'
 PASS __Host: Non-secure origin: 'Path=/;domain=localhost'
-FAIL __HoSt: Non-secure origin: 'Path=/;domain=localhost' assert_equals: `__HoSt-prefixtestcookie=0.7223283941774045` in `document.cookie` expected false but got true
+FAIL __HoSt: Non-secure origin: 'Path=/;domain=localhost' assert_equals: `__HoSt-prefixtestcookie=foo6` in `document.cookie` expected false but got true
 PASS __Host: Non-secure origin: 'Secure; Path=/;domain=localhost'
 PASS __HoSt: Non-secure origin: 'Secure; Path=/;domain=localhost'
 PASS __Host: Non-secure origin: 'Path=/;MaxAge=10'
-FAIL __HoSt: Non-secure origin: 'Path=/;MaxAge=10' assert_equals: `__HoSt-prefixtestcookie=0.09439738441530887` in `document.cookie` expected false but got true
+FAIL __HoSt: Non-secure origin: 'Path=/;MaxAge=10' assert_equals: `__HoSt-prefixtestcookie=foo10` in `document.cookie` expected false but got true
 PASS __Host: Non-secure origin: 'Secure; Path=/;MaxAge=10'
 PASS __HoSt: Non-secure origin: 'Secure; Path=/;MaxAge=10'
 PASS __Host: Non-secure origin: 'Path=/;HttpOnly'

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__host.document-cookie.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__host.document-cookie.https-expected.txt
@@ -1,16 +1,16 @@
 
 PASS __Host: Secure origin: Does not set 'Path=/;'
-FAIL __HoSt: Secure origin: Does not set 'Path=/;' assert_equals: `__HoSt-prefixtestcookie=0.6775402624621644` in `document.cookie` expected false but got true
+FAIL __HoSt: Secure origin: Does not set 'Path=/;' assert_equals: `__HoSt-prefixtestcookie=foo2` in `document.cookie` expected false but got true
 PASS __Host: Secure origin: Does set 'Secure; Path=/;'
 PASS __HoSt: Secure origin: Does set 'Secure; Path=/;'
 PASS __Host: Secure origin: Does not set 'Secure; Path=/; Domain=localhost; '
-FAIL __HoSt: Secure origin: Does not set 'Secure; Path=/; Domain=localhost; ' assert_equals: `__HoSt-prefixtestcookie=0.6290646384668973` in `document.cookie` expected false but got true
+FAIL __HoSt: Secure origin: Does not set 'Secure; Path=/; Domain=localhost; ' assert_equals: `__HoSt-prefixtestcookie=foo6` in `document.cookie` expected false but got true
 PASS __Host: Secure origin: Does not set 'Path=/;MaxAge=10'
-FAIL __HoSt: Secure origin: Does not set 'Path=/;MaxAge=10' assert_equals: `__HoSt-prefixtestcookie=0.6851707717121366` in `document.cookie` expected false but got true
+FAIL __HoSt: Secure origin: Does not set 'Path=/;MaxAge=10' assert_equals: `__HoSt-prefixtestcookie=foo8` in `document.cookie` expected false but got true
 PASS __Host: Secure origin: Does set 'Secure; Path=/;MaxAge=10'
 PASS __HoSt: Secure origin: Does set 'Secure; Path=/;MaxAge=10'
 PASS __Host: Secure origin: Does not set 'Secure; Path=/; Domain=localhost; MaxAge=10'
-FAIL __HoSt: Secure origin: Does not set 'Secure; Path=/; Domain=localhost; MaxAge=10' assert_equals: `__HoSt-prefixtestcookie=0.8404971212210027` in `document.cookie` expected false but got true
+FAIL __HoSt: Secure origin: Does not set 'Secure; Path=/; Domain=localhost; MaxAge=10' assert_equals: `__HoSt-prefixtestcookie=foo12` in `document.cookie` expected false but got true
 PASS __Host: Secure origin: Does not set 'Secure; Path=/cookies/resources/list.py'
-FAIL __HoSt: Secure origin: Does not set 'Secure; Path=/cookies/resources/list.py' assert_equals: expected (undefined) undefined but got (string) "0.1072062478000616"
+FAIL __HoSt: Secure origin: Does not set 'Secure; Path=/cookies/resources/list.py' assert_equals: expected (undefined) undefined but got (string) "foo14"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__host.header-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__host.header-expected.txt
@@ -1,24 +1,24 @@
 
 PASS __Host: Non-secure origin: Does not set 'Path=/;'
-FAIL __HoSt: Non-secure origin: Does not set 'Path=/;' assert_equals: expected (undefined) undefined but got (string) "0.4352760571301042"
+FAIL __HoSt: Non-secure origin: Does not set 'Path=/;' assert_equals: expected (undefined) undefined but got (string) "bar2"
 PASS __Host: Non-secure origin: Does not set 'Secure; Path=/;'
 PASS __HoSt: Non-secure origin: Does not set 'Secure; Path=/;'
 PASS __Host: Secure origin: Does not set 'Secure; Path=/; Domain=localhost; '
 PASS __HoSt: Secure origin: Does not set 'Secure; Path=/; Domain=localhost; '
 PASS __Host: Non-secure origin: Does not set 'Path=/;domain=localhost'
-FAIL __HoSt: Non-secure origin: Does not set 'Path=/;domain=localhost' assert_equals: expected (undefined) undefined but got (string) "0.2586018799905354"
+FAIL __HoSt: Non-secure origin: Does not set 'Path=/;domain=localhost' assert_equals: expected (undefined) undefined but got (string) "bar8"
 PASS __Host: Non-secure origin: Does not set 'Secure; Path=/;domain=localhost'
 PASS __HoSt: Non-secure origin: Does not set 'Secure; Path=/;domain=localhost'
 PASS __Host: Secure origin: Does not set 'Secure; Path=/; Domain=localhost; domain=localhost'
 PASS __HoSt: Secure origin: Does not set 'Secure; Path=/; Domain=localhost; domain=localhost'
 PASS __Host: Non-secure origin: Does not set 'Path=/;MaxAge=10'
-FAIL __HoSt: Non-secure origin: Does not set 'Path=/;MaxAge=10' assert_equals: expected (undefined) undefined but got (string) "0.21950010948218235"
+FAIL __HoSt: Non-secure origin: Does not set 'Path=/;MaxAge=10' assert_equals: expected (undefined) undefined but got (string) "bar14"
 PASS __Host: Non-secure origin: Does not set 'Secure; Path=/;MaxAge=10'
 PASS __HoSt: Non-secure origin: Does not set 'Secure; Path=/;MaxAge=10'
 PASS __Host: Secure origin: Does not set 'Secure; Path=/; Domain=localhost; MaxAge=10'
 PASS __HoSt: Secure origin: Does not set 'Secure; Path=/; Domain=localhost; MaxAge=10'
 PASS __Host: Non-secure origin: Does not set 'Path=/;HttpOnly'
-FAIL __HoSt: Non-secure origin: Does not set 'Path=/;HttpOnly' assert_equals: expected (undefined) undefined but got (string) "0.023582010753375293"
+FAIL __HoSt: Non-secure origin: Does not set 'Path=/;HttpOnly' assert_equals: expected (undefined) undefined but got (string) "bar20"
 PASS __Host: Non-secure origin: Does not set 'Secure; Path=/;HttpOnly'
 PASS __HoSt: Non-secure origin: Does not set 'Secure; Path=/;HttpOnly'
 PASS __Host: Secure origin: Does not set 'Secure; Path=/; Domain=localhost; HttpOnly'

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__host.header.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__host.header.https-expected.txt
@@ -1,22 +1,22 @@
 
 PASS __Host: Secure origin: Does not set 'Path=/;'
-FAIL __HoSt: Secure origin: Does not set 'Path=/;' assert_equals: expected (undefined) undefined but got (string) "0.02745361323050355"
+FAIL __HoSt: Secure origin: Does not set 'Path=/;' assert_equals: expected (undefined) undefined but got (string) "bar2"
 PASS __Host: Secure origin: Does set 'Secure; Path=/;'
 PASS __HoSt: Secure origin: Does set 'Secure; Path=/;'
 PASS __Host: Secure origin: Does not set 'Secure; Path=/; Domain=localhost; '
-FAIL __HoSt: Secure origin: Does not set 'Secure; Path=/; Domain=localhost; ' assert_equals: expected (undefined) undefined but got (string) "0.09586554926477497"
+FAIL __HoSt: Secure origin: Does not set 'Secure; Path=/; Domain=localhost; ' assert_equals: expected (undefined) undefined but got (string) "bar6"
 PASS __Host: Secure origin: Does not set 'Path=/;MaxAge=10'
-FAIL __HoSt: Secure origin: Does not set 'Path=/;MaxAge=10' assert_equals: expected (undefined) undefined but got (string) "0.528527237577119"
+FAIL __HoSt: Secure origin: Does not set 'Path=/;MaxAge=10' assert_equals: expected (undefined) undefined but got (string) "bar8"
 PASS __Host: Secure origin: Does set 'Secure; Path=/;MaxAge=10'
 PASS __HoSt: Secure origin: Does set 'Secure; Path=/;MaxAge=10'
 PASS __Host: Secure origin: Does not set 'Secure; Path=/; Domain=localhost; MaxAge=10'
-FAIL __HoSt: Secure origin: Does not set 'Secure; Path=/; Domain=localhost; MaxAge=10' assert_equals: expected (undefined) undefined but got (string) "0.9628031845641266"
+FAIL __HoSt: Secure origin: Does not set 'Secure; Path=/; Domain=localhost; MaxAge=10' assert_equals: expected (undefined) undefined but got (string) "bar12"
 PASS __Host: Secure origin: Does not set 'Path=/;HttpOnly'
-FAIL __HoSt: Secure origin: Does not set 'Path=/;HttpOnly' assert_equals: expected (undefined) undefined but got (string) "0.17186113442674777"
+FAIL __HoSt: Secure origin: Does not set 'Path=/;HttpOnly' assert_equals: expected (undefined) undefined but got (string) "bar14"
 PASS __Host: Secure origin: Does set 'Secure; Path=/;HttpOnly'
 PASS __HoSt: Secure origin: Does set 'Secure; Path=/;HttpOnly'
 PASS __Host: Secure origin: Does not set 'Secure; Path=/; Domain=localhost; HttpOnly'
-FAIL __HoSt: Secure origin: Does not set 'Secure; Path=/; Domain=localhost; HttpOnly' assert_equals: expected (undefined) undefined but got (string) "0.41733921848427913"
+FAIL __HoSt: Secure origin: Does not set 'Secure; Path=/; Domain=localhost; HttpOnly' assert_equals: expected (undefined) undefined but got (string) "bar18"
 PASS __Host: Secure origin: Does not set 'Secure; Path=/cookies/resources/list.py'
-FAIL __HoSt: Secure origin: Does not set 'Secure; Path=/cookies/resources/list.py' assert_equals: expected (undefined) undefined but got (string) "0.7000720201711788"
+FAIL __HoSt: Secure origin: Does not set 'Secure; Path=/cookies/resources/list.py' assert_equals: expected (undefined) undefined but got (string) "bar20"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__secure.document-cookie-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__secure.document-cookie-expected.txt
@@ -1,14 +1,14 @@
 
 PASS __Secure: Non-secure origin: Should not set 'Path=/;'
-FAIL __SeCuRe: Non-secure origin: Should not set 'Path=/;' assert_equals: `__SeCuRe-prefixtestcookie=0.9119429574415184` in `document.cookie` expected false but got true
+FAIL __SeCuRe: Non-secure origin: Should not set 'Path=/;' assert_equals: `__SeCuRe-prefixtestcookie=foo2` in `document.cookie` expected false but got true
 PASS __Secure: Non-secure origin: Should not set 'Secure; Path=/;'
 PASS __SeCuRe: Non-secure origin: Should not set 'Secure; Path=/;'
 PASS __Secure: Non-secure origin: Should not set 'Path=/;MaxAge=10'
-FAIL __SeCuRe: Non-secure origin: Should not set 'Path=/;MaxAge=10' assert_equals: `__SeCuRe-prefixtestcookie=0.40869500878194387` in `document.cookie` expected false but got true
+FAIL __SeCuRe: Non-secure origin: Should not set 'Path=/;MaxAge=10' assert_equals: `__SeCuRe-prefixtestcookie=foo6` in `document.cookie` expected false but got true
 PASS __Secure: Non-secure origin: Should not set 'Secure; Path=/;MaxAge=10'
 PASS __SeCuRe: Non-secure origin: Should not set 'Secure; Path=/;MaxAge=10'
 PASS __Secure: Non-secure origin: Should not set 'Path=/;domain=localhost'
-FAIL __SeCuRe: Non-secure origin: Should not set 'Path=/;domain=localhost' assert_equals: `__SeCuRe-prefixtestcookie=0.4183664625484089` in `document.cookie` expected false but got true
+FAIL __SeCuRe: Non-secure origin: Should not set 'Path=/;domain=localhost' assert_equals: `__SeCuRe-prefixtestcookie=foo10` in `document.cookie` expected false but got true
 PASS __Secure: Non-secure origin: Should not set 'Secure; Path=/;domain=localhost'
 PASS __SeCuRe: Non-secure origin: Should not set 'Secure; Path=/;domain=localhost'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__secure.document-cookie.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__secure.document-cookie.https-expected.txt
@@ -1,14 +1,14 @@
 
 PASS __Secure: Secure origin: Should not set 'Path=/;'
-FAIL __SeCuRe: Secure origin: Should not set 'Path=/;' assert_equals: `__SeCuRe-prefixtestcookie=0.6024020825942948` in `document.cookie` expected false but got true
+FAIL __SeCuRe: Secure origin: Should not set 'Path=/;' assert_equals: `__SeCuRe-prefixtestcookie=foo2` in `document.cookie` expected false but got true
 PASS __Secure: Secure origin: Should set 'Secure; Path=/;'
 PASS __SeCuRe: Secure origin: Should set 'Secure; Path=/;'
 PASS __Secure: Secure origin: Should not set 'Path=/;MaxAge=10'
-FAIL __SeCuRe: Secure origin: Should not set 'Path=/;MaxAge=10' assert_equals: `__SeCuRe-prefixtestcookie=0.8654057676521862` in `document.cookie` expected false but got true
+FAIL __SeCuRe: Secure origin: Should not set 'Path=/;MaxAge=10' assert_equals: `__SeCuRe-prefixtestcookie=foo6` in `document.cookie` expected false but got true
 PASS __Secure: Secure origin: Should set 'Secure; Path=/;MaxAge=10'
 PASS __SeCuRe: Secure origin: Should set 'Secure; Path=/;MaxAge=10'
 PASS __Secure: Secure origin: Should not set 'Path=/;domain=localhost'
-FAIL __SeCuRe: Secure origin: Should not set 'Path=/;domain=localhost' assert_equals: `__SeCuRe-prefixtestcookie=0.9063855693384636` in `document.cookie` expected false but got true
+FAIL __SeCuRe: Secure origin: Should not set 'Path=/;domain=localhost' assert_equals: `__SeCuRe-prefixtestcookie=foo10` in `document.cookie` expected false but got true
 PASS __Secure: Secure origin: Should set 'Secure; Path=/;domain=localhost'
 PASS __SeCuRe: Secure origin: Should set 'Secure; Path=/;domain=localhost'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__secure.header-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__secure.header-expected.txt
@@ -1,18 +1,18 @@
 
 PASS __Secure: Non-secure origin: Should not set 'Path=/;'
-FAIL __SeCuRe: Non-secure origin: Should not set 'Path=/;' assert_equals: expected (undefined) undefined but got (string) "0.023894435577849094"
+FAIL __SeCuRe: Non-secure origin: Should not set 'Path=/;' assert_equals: expected (undefined) undefined but got (string) "bar2"
 PASS __Secure: Non-secure origin: Should not set 'Secure; Path=/;'
 PASS __SeCuRe: Non-secure origin: Should not set 'Secure; Path=/;'
 PASS __Secure: Non-secure origin: Should not set 'Path=/;domain=localhost'
-FAIL __SeCuRe: Non-secure origin: Should not set 'Path=/;domain=localhost' assert_equals: expected (undefined) undefined but got (string) "0.4041873598930722"
+FAIL __SeCuRe: Non-secure origin: Should not set 'Path=/;domain=localhost' assert_equals: expected (undefined) undefined but got (string) "bar6"
 PASS __Secure: Non-secure origin: Should not set 'Secure; Path=/;domain=localhost'
 PASS __SeCuRe: Non-secure origin: Should not set 'Secure; Path=/;domain=localhost'
 PASS __Secure: Non-secure origin: Should not set 'Path=/;MaxAge=10'
-FAIL __SeCuRe: Non-secure origin: Should not set 'Path=/;MaxAge=10' assert_equals: expected (undefined) undefined but got (string) "0.16476032691404519"
+FAIL __SeCuRe: Non-secure origin: Should not set 'Path=/;MaxAge=10' assert_equals: expected (undefined) undefined but got (string) "bar10"
 PASS __Secure: Non-secure origin: Should not set 'Secure; Path=/;MaxAge=10'
 PASS __SeCuRe: Non-secure origin: Should not set 'Secure; Path=/;MaxAge=10'
 PASS __Secure: Non-secure origin: Should not set 'Path=/;HttpOnly'
-FAIL __SeCuRe: Non-secure origin: Should not set 'Path=/;HttpOnly' assert_equals: expected (undefined) undefined but got (string) "0.7251950854736183"
+FAIL __SeCuRe: Non-secure origin: Should not set 'Path=/;HttpOnly' assert_equals: expected (undefined) undefined but got (string) "bar14"
 PASS __Secure: Non-secure origin: Should not set 'Secure; Path=/;HttpOnly'
 PASS __SeCuRe: Non-secure origin: Should not set 'Secure; Path=/;HttpOnly'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__secure.header.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__secure.header.https-expected.txt
@@ -1,10 +1,18 @@
 
 PASS __Secure: secure origin: Should not set 'Path=/;'
+FAIL __SeCuRe: secure origin: Should not set 'Path=/;' assert_equals: expected (undefined) undefined but got (string) "bar2"
 PASS __Secure: secure origin: Should set 'Secure;Path=/;'
+PASS __SeCuRe: secure origin: Should set 'Secure;Path=/;'
 PASS __Secure: secure origin: Should not set 'Path=/;MaxAge=10'
+FAIL __SeCuRe: secure origin: Should not set 'Path=/;MaxAge=10' assert_equals: expected (undefined) undefined but got (string) "bar6"
 PASS __Secure: secure origin: Should set 'Secure;Path=/;MaxAge=10'
+PASS __SeCuRe: secure origin: Should set 'Secure;Path=/;MaxAge=10'
 PASS __Secure: secure origin: Should not set 'Path=/;HttpOnly'
+FAIL __SeCuRe: secure origin: Should not set 'Path=/;HttpOnly' assert_equals: expected (undefined) undefined but got (string) "bar10"
 PASS __Secure: secure origin: Should set 'Secure;Path=/;HttpOnly'
+PASS __SeCuRe: secure origin: Should set 'Secure;Path=/;HttpOnly'
 PASS __Secure: secure origin: Should not set 'Path=/;domain=127.0.0.1'
-FAIL __Secure: secure origin: Should set 'Secure;Path=/;domain=127.0.0.1' assert_equals: expected (string) "0.26261606557964934" but got (undefined) undefined
+PASS __SeCuRe: secure origin: Should not set 'Path=/;domain=127.0.0.1'
+FAIL __Secure: secure origin: Should set 'Secure;Path=/;domain=127.0.0.1' assert_equals: expected (string) "bar15" but got (undefined) undefined
+FAIL __SeCuRe: secure origin: Should set 'Secure;Path=/;domain=127.0.0.1' assert_equals: expected (string) "bar16" but got (undefined) undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/w3c-import.log
@@ -14,6 +14,8 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__HostHttp.https.html
+/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__Http.https.html
 /LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__host.document-cookie.html
 /LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__host.document-cookie.https.html
 /LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__host.header.html

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/resources/cookie-helper.sub.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/resources/cookie-helper.sub.js
@@ -73,12 +73,13 @@ async function create_cookie(origin, name, value, extras) {
 //
 // Prefix-specific test helpers
 //
+window.dom_prefix_counter = 0;
 function set_prefixed_cookie_via_dom_test(options) {
   promise_test(t => {
     var name = options.prefix + "prefixtestcookie";
     erase_cookie_from_js(name, options.params);
     t.add_cleanup(() => erase_cookie_from_js(name, options.params));
-    var value = "" + Math.random();
+    var value = "foo" + ++window.dom_prefix_counter;
     document.cookie = name + "=" + value + ";" + options.params;
 
     assert_dom_cookie(name, value, options.shouldExistInDOM);
@@ -89,10 +90,11 @@ function set_prefixed_cookie_via_dom_test(options) {
   }, options.title);
 }
 
+window.http_prefix_counter = 0;
 function set_prefixed_cookie_via_http_test(options) {
   promise_test(t => {
     var name = options.prefix + "prefixtestcookie";
-    var value = "" + Math.random();
+    var value = "bar" + ++window.http_prefix_counter;
 
     t.add_cleanup(() => {
       var cookie = name + "=0;expires=" + new Date(0).toUTCString() + ";" +

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/cookies/prefix/__HostHttp.https-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/cookies/prefix/__HostHttp.https-expected.txt
@@ -1,0 +1,9 @@
+
+FAIL __HostHttp: Does not set via DOM 'Secure; Path=/' assert_equals: `__HostHttp-prefixtestcookie=foo1` in `document.cookie` expected false but got true
+FAIL __HostHttp: Does not set via DOM with Domain attribute 'Secure; Path=/; Domain=web-platform.test' assert_equals: `__HostHttp-prefixtestcookie=foo2` in `document.cookie` expected false but got true
+FAIL __HostHttp: Does not set via HTTP with 'Secure; Path=/' assert_equals: expected (undefined) undefined but got (string) "bar1"
+PASS __HostHttp: Set via HTTP with 'Secure; Path=/; httponly'
+FAIL __HostHttp: Does not set via HTTP with 'Secure; Path=/cookies/; httponly' assert_equals: expected (undefined) undefined but got (string) "bar3"
+FAIL __HostHttp: Does not set via HTTP with 'Path=/;' (without Secure) assert_equals: expected (undefined) undefined but got (string) "bar4"
+FAIL __HostHttp: Does not set via HTTP with Domain attribute 'Secure; Path=/; Domain=web-platform.test' assert_equals: expected (undefined) undefined but got (string) "bar5"
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/cookies/prefix/__HostHttp.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/cookies/prefix/__HostHttp.https-expected.txt
@@ -1,0 +1,9 @@
+
+FAIL __HostHttp: Does not set via DOM 'Secure; Path=/' assert_equals: `__HostHttp-prefixtestcookie=foo1` in `document.cookie` expected false but got true
+FAIL __HostHttp: Does not set via DOM with Domain attribute 'Secure; Path=/; Domain=web-platform.test' assert_equals: `__HostHttp-prefixtestcookie=foo2` in `document.cookie` expected false but got true
+FAIL __HostHttp: Does not set via HTTP with 'Secure; Path=/' assert_equals: expected (undefined) undefined but got (string) "bar1"
+PASS __HostHttp: Set via HTTP with 'Secure; Path=/; httponly'
+FAIL __HostHttp: Does not set via HTTP with 'Secure; Path=/cookies/; httponly' assert_equals: expected (undefined) undefined but got (string) "bar3"
+FAIL __HostHttp: Does not set via HTTP with 'Path=/;' (without Secure) assert_equals: expected (undefined) undefined but got (string) "bar4"
+FAIL __HostHttp: Does not set via HTTP with Domain attribute 'Secure; Path=/; Domain=web-platform.test' assert_equals: expected (undefined) undefined but got (string) "bar5"
+


### PR DESCRIPTION
#### 8afd08557be462ffe1b3cf06cd39c806dcf37afc
<pre>
Import the latest cookie prefixes and cookie-store special names WPTs
<a href="https://bugs.webkit.org/show_bug.cgi?id=295007">https://bugs.webkit.org/show_bug.cgi?id=295007</a>

Reviewed by Anne van Kesteren.

This imports the latest WPTs for both the cookieStore API and cookies prefixes.
Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/5aadede8c5042de90d80a9875c018679b89f70ab">https://github.com/web-platform-tests/wpt/commit/5aadede8c5042de90d80a9875c018679b89f70ab</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.js:
(string_appeared_here.forEach.prefix.promise_test.async testCase):
(promise_test.async testCase):
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__HostHttp.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__HostHttp.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__Http.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__Http.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__host.document-cookie-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__host.document-cookie.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__host.header-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__host.header.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__secure.document-cookie-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__secure.document-cookie.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__secure.header-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__secure.header.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cookies/resources/cookie-helper.sub.js:
(set_prefixed_cookie_via_dom_test): Ensure the tests have a consistent output.
(set_prefixed_cookie_via_http_test): Ensure the tests have a consistent output.
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/cookies/prefix/__HostHttp.https-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/cookies/prefix/__HostHttp.https-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/297126@main">https://commits.webkit.org/297126@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9441bc0f993db8381aa9e6fb779bbee9f7cd4602

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30219 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20652 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116586 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60827 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30898 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38807 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84077 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113508 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24671 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99554 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64518 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24034 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17694 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60381 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94056 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17753 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119376 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37600 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27918 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93047 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37974 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95825 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92865 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23671 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37874 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15614 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33573 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37495 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37158 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40497 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38866 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->