### PR TITLE
AX: string for text marker range should not skip an emitted newline if it's the first character

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/simple-word-navigation-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/simple-word-navigation-expected.txt
@@ -39,7 +39,8 @@ Left word is: text
 Right word is:
 Pre word start to next word end: text
 
-Current character is: I
+Current character is:
+I
 Left word is: I'm
 Right word is: I'm
 Pre word start to next word end: I'm

--- a/LayoutTests/accessibility/mac/text-marker-emitted-newlines-expected.txt
+++ b/LayoutTests/accessibility/mac/text-marker-emitted-newlines-expected.txt
@@ -1,0 +1,22 @@
+This tests that text marker ranges include emitted newlines in the string for range, even when the emitted newline is at the beginning or the only character in the range.
+
+String for text marker range: "Two"
+Incrementing end marker
+String for text marker range: "Two[NEWLINE]"
+Incrementing start marker
+String for text marker range: "wo[NEWLINE]"
+Incrementing start marker
+String for text marker range: "o[NEWLINE]"
+Incrementing start marker
+String for text marker range: "[NEWLINE]"
+Incrementing end marker
+String for text marker range: "[NEWLINE]T"
+Incrementing end marker
+String for text marker range: "[NEWLINE]Th"
+Incrementing end marker
+String for text marker range: "[NEWLINE]Thr"
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/text-marker-emitted-newlines.html
+++ b/LayoutTests/accessibility/mac/text-marker-emitted-newlines.html
@@ -1,0 +1,77 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/js-test.js"></script>
+</head>
+<body id="body">
+
+<div id="all">
+  <ul>
+    <li>One</li>
+  </ul>
+  <h2 id="element">Two</h2>
+  <a href="#"><img src="#"></a>
+  <div>Three</div>
+</div>
+
+<script>
+var output = "This tests that text marker ranges include emitted newlines in the string for range, even when the emitted newline is at the beginning or the only character in the range.\n\n";
+
+if (window.accessibilityController) {
+    var element = accessibilityController.accessibleElementById("element");
+    var elementRange = element.textMarkerRangeForElement(element);
+
+    outputRange();
+
+    elementRange = incrementEndMarker(elementRange);
+    outputRange();
+
+    for (var i = 0; i < 3; i++) {
+        elementRange = incrementStartMarker(elementRange);
+        outputRange();
+    }
+
+    for (var i = 0; i < 3; i++) {
+        elementRange = incrementEndMarker(elementRange);
+        outputRange();
+    }
+
+    debug(output);
+    document.getElementById('all').hidden = true;
+
+    function outputRange() {
+        str = element.stringForTextMarkerRange(elementRange);
+        str = replaceAttachmentsAndNewlinesInString(str);
+        output += `String for text marker range: "${str}"\n`;
+    }
+
+    function incrementEndMarker(textMarkerRange) {
+        output += 'Incrementing end marker\n';
+        const startMarker = element.startTextMarkerForTextMarkerRange(textMarkerRange);
+        const endMarker = element.endTextMarkerForTextMarkerRange(textMarkerRange);
+        const newEndMarker = element.nextTextMarker(endMarker);
+        return element.textMarkerRangeForMarkers(startMarker, newEndMarker);
+    }
+
+    function incrementStartMarker(textMarkerRange) {
+        output += 'Incrementing start marker\n';
+        const startMarker = element.startTextMarkerForTextMarkerRange(textMarkerRange);
+        const endMarker = element.endTextMarkerForTextMarkerRange(textMarkerRange);
+        const newStartMarker = element.nextTextMarker(startMarker);
+        return element.textMarkerRangeForMarkers(newStartMarker, endMarker);
+    }
+
+    function replaceAttachmentsAndNewlinesInString(str) {
+        // FIXME: ITM outputs attachment characters, live tree does not
+        str = str.replaceAll(String.fromCharCode(65532), "");
+
+        // FIXME: ITM and live tree output different numbers of newlines sometimes
+        str = str.replaceAll(/\n+/g, "[NEWLINE]");
+        return str;
+    }
+}
+</script>
+
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -575,7 +575,7 @@ String AXTextMarkerRange::toString() const
                 return;
 
             // Like TextIterator, don't emit a newline if the most recently emitted character was already a newline.
-            if (result.length() && result[result.length() - 1] != '\n') {
+            if (!result.length() || result[result.length() - 1] != '\n') {
                 result.append('\n');
                 if (behavior == TextEmissionBehavior::DoubleNewline)
                     result.append('\n');


### PR DESCRIPTION
#### bde3bff51de25b231de2b22517438a911e2e8e3a
<pre>
AX: string for text marker range should not skip an emitted newline if it&apos;s the first character
<a href="https://bugs.webkit.org/show_bug.cgi?id=295017">https://bugs.webkit.org/show_bug.cgi?id=295017</a>
<a href="https://rdar.apple.com/154368379">rdar://154368379</a>

Reviewed by Tyler Wilcock.

The user-facing issue was that VoiceOver would fail to speak the text
of a new line in a document when navigating by line using caret
navigation, because VoiceOver thought the new cursor position was
visually equivalent to the previous one.

The underlying cause was that if a text marker range consisted of only
an emitted newline, the newline was being suppressed by mistake, so it
made it seem like the range was empty, indicating that two positions
were equivalent when in fact they differ due to the emitted newline.

* LayoutTests/accessibility/isolated-tree/simple-word-navigation-expected.txt:
* LayoutTests/accessibility/mac/text-marker-emitted-newlines-expected.txt: Added.
* LayoutTests/accessibility/mac/text-marker-emitted-newlines.html: Added.
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarkerRange::toString const):

Canonical link: <a href="https://commits.webkit.org/296690@main">https://commits.webkit.org/296690@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/594443a478a17854b1a7726a104158028424340f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109226 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28884 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19312 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114433 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59497 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111189 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29566 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37473 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83002 "Found 1 new test failure: fast/events/domactivate-sets-underlying-click-event-as-handled.html (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112174 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23527 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98379 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63452 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22914 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16523 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59060 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92894 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16564 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117549 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36270 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26832 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92018 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36642 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94642 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91826 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23403 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36752 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14504 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32101 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36166 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41654 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35852 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39184 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37543 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->