### PR TITLE
[GTK][WPE][Skia] Improve text rendering performance, bring back simple text code path

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -657,11 +657,6 @@ FontCascade::CodePath FontCascade::codePath(const TextRun& run, std::optional<un
 
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=150791: @font-face features should also cause this to be complex.
 
-#if !USE(FONT_VARIANT_VIA_FEATURES) && !USE(FREETYPE)
-    if (run.length() > 1 && (enableKerning() || requiresShaping()))
-        return CodePath::Complex;
-#endif
-
     if (!run.characterScanForCodePath())
         return CodePath::Simple;
 

--- a/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
@@ -143,8 +143,6 @@ static void seatDevicesChangedCallback(GdkSeat* seat, GdkDevice*, WebProcessPool
 
 void WebProcessPool::platformInitialize(NeedsGlobalStaticInitialization)
 {
-    m_alwaysUsesComplexTextCodePath = true;
-
     if (const char* forceComplexText = getenv("WEBKIT_FORCE_COMPLEX_TEXT"))
         m_alwaysUsesComplexTextCodePath = !strcmp(forceComplexText, "1");
 


### PR DESCRIPTION
#### ce43649df17a868f57db7c2ec88ede38e51aa18f
<pre>
[GTK][WPE][Skia] Improve text rendering performance, bring back simple text code path
<a href="https://bugs.webkit.org/show_bug.cgi?id=295019">https://bugs.webkit.org/show_bug.cgi?id=295019</a>

Reviewed by NOBODY (OOPS!).

WIP: Investigate if we can improve performance, while retaining correctness,
when switching from always-force-complex-text mode to auto-detection again.

Covered by existing tests.

* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::codePath const):
* Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp:
(WebKit::WebProcessPool::platformInitialize):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce43649df17a868f57db7c2ec88ede38e51aa18f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109227 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28885 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19313 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114434 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59498 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111190 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29567 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37474 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83005 "Failure limit exceed. At least found 496 new test failures: accessibility/press-targets-center-point.html accessibility/table-cell-spans.html animations/3d/matrix-transform-type-animation.html compositing/compositing-visible-descendant.html compositing/direct-image-compositing.html compositing/generated-content.html compositing/geometry/abs-position-inside-opacity.html compositing/geometry/fixed-in-composited.html compositing/geometry/fixed-position.html compositing/geometry/partial-layout-update.html ... (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112175 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23530 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98378 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63455 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22918 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16522 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59061 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92897 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16563 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117550 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36271 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26834 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92020 "Failure limit exceed. At least found 493 new test failures: accessibility/press-targets-center-point.html accessibility/table-cell-spans.html animations/3d/matrix-transform-type-animation.html compositing/compositing-visible-descendant.html compositing/direct-image-compositing.html compositing/generated-content.html compositing/geometry/abs-position-inside-opacity.html compositing/geometry/fixed-in-composited.html compositing/geometry/fixed-position.html compositing/geometry/partial-layout-update.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36643 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94641 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91828 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36751 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14503 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32102 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36167 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41655 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35853 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39185 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37544 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->