### PR TITLE
[macOS] Ensure context menu images are localized consistently and update paragraph direction images

### DIFF
--- a/Source/WebCore/platform/graphics/FontDescription.cpp
+++ b/Source/WebCore/platform/graphics/FontDescription.cpp
@@ -107,7 +107,7 @@ void FontDescription::setSpecifiedLocale(const AtomString& locale)
 {
     ASSERT(isMainThread());
     m_specifiedLocale = locale;
-    m_script = localeToScriptCodeForFontSelection(m_specifiedLocale);
+    m_script = localeToScriptCode(m_specifiedLocale);
     m_locale = m_script == USCRIPT_HAN ? specializedChineseLocale() : m_specifiedLocale;
 }
 

--- a/Source/WebCore/platform/text/LocaleICU.cpp
+++ b/Source/WebCore/platform/text/LocaleICU.cpp
@@ -74,7 +74,7 @@ LocaleICU::~LocaleICU()
 Locale::WritingDirection LocaleICU::defaultWritingDirection() const
 {
 #if USE(HARFBUZZ)
-    UScriptCode icuScript = localeToScriptCodeForFontSelection(m_locale.span());
+    UScriptCode icuScript = localeToScriptCode(m_locale.span());
     hb_script_t script = hb_icu_script_to_script(icuScript);
 
     switch (hb_script_get_horizontal_direction(script)) {

--- a/Source/WebCore/platform/text/LocaleToScriptMapping.cpp
+++ b/Source/WebCore/platform/text/LocaleToScriptMapping.cpp
@@ -158,7 +158,7 @@ UScriptCode scriptNameToCode(StringView scriptName)
     return map.get(scriptName, USCRIPT_INVALID_CODE);
 }
 
-UScriptCode localeToScriptCodeForFontSelection(const String& locale)
+UScriptCode localeToScriptCode(const String& locale)
 {
     using LocaleName = PackedASCIILowerCodes<uint64_t>;
     static constexpr std::pair<LocaleName, UScriptCode> localeScriptList[] = {

--- a/Source/WebCore/platform/text/LocaleToScriptMapping.h
+++ b/Source/WebCore/platform/text/LocaleToScriptMapping.h
@@ -35,7 +35,7 @@
 
 namespace WebCore {
 
-UScriptCode localeToScriptCodeForFontSelection(const String&);
+WEBCORE_EXPORT UScriptCode localeToScriptCode(const String&);
 WEBCORE_EXPORT UScriptCode scriptNameToCode(StringView);
 
 }


### PR DESCRIPTION
#### e95e526fe4b07658bf5ed657275853438bf821a3
<pre>
[macOS] Ensure context menu images are localized consistently and update paragraph direction images
<a href="https://bugs.webkit.org/show_bug.cgi?id=295021">https://bugs.webkit.org/show_bug.cgi?id=295021</a>
<a href="https://rdar.apple.com/154374848">rdar://154374848</a>

Reviewed by Abrar Rahman Protyasha and Wenson Hsieh.

Only show images in the context menu’s transformations submenu if a localized
image exists for all 3 items, otherwise show nothing. Update the images for
the paragraph direction items as well.

Renamed `localeToScriptCodeForFontSelection` to `localeToScriptCode` since
it is no longer used solely for font selection.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/FontDescription.cpp:
(WebCore::FontDescription::setSpecifiedLocale):
* Source/WebCore/platform/text/LocaleToScriptMapping.cpp:
(WebCore::localeToScriptCode):
(WebCore::localeToScriptCodeForFontSelection): Deleted.
* Source/WebCore/platform/text/LocaleToScriptMapping.h:
* Source/WebKit/Platform/mac/MenuUtilities.mm:
(WebKit::symbolForTransformationItem):
(WebKit::symbolNameWithTypeForAction):

Canonical link: <a href="https://commits.webkit.org/296777@main">https://commits.webkit.org/296777@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c09c4f3b9b47c3ee51489d11cccbb96fb2f70918

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109271 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28929 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19357 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114477 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59537 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111234 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29610 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37518 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83042 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112219 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23566 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98421 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63492 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22955 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16565 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59104 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92935 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16605 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117594 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36313 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26874 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92058 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36685 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94683 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91869 "Found 3 new API test failures: /WebKitGTK/TestResources:/webkit/WebKitWebResource/get-data-error, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23456 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36786 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14545 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32144 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36210 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41697 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35894 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39226 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37586 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->