### PR TITLE
ANGLE: Failure to compile TensorFlow.js WebGL shaders

### DIFF
--- a/Source/ThirdParty/ANGLE/src/compiler/translator/msl/ProgramPrelude.cpp
+++ b/Source/ThirdParty/ANGLE/src/compiler/translator/msl/ProgramPrelude.cpp
@@ -2896,42 +2896,116 @@ ANGLE_ALWAYS_INLINE T ANGLE_interpolateAtOffset(T value, float2) { return value;
 
 PROGRAM_PRELUDE_DECLARE(preIncrementInt,
                         R"(
-template <typename T>
-ANGLE_ALWAYS_INLINE thread T &ANGLE_preIncrementInt(thread T &a)
+ANGLE_ALWAYS_INLINE int ANGLE_preIncrementInt(thread int &a)
 {
-    a = as_type<T>(metal::make_unsigned_t<T>(a) + 1);
+    a = as_type<int>(as_type<metal::uint>(a) + 1u);
+    return a;
+}
+
+ANGLE_ALWAYS_INLINE metal::int2 ANGLE_preIncrementInt(thread metal::int2 &a)
+{
+    a = as_type<metal::int2>(as_type<metal::uint2>(a) + 1u);
+    return a;
+}
+
+ANGLE_ALWAYS_INLINE metal::int3 ANGLE_preIncrementInt(thread metal::int3 &a)
+{
+    a = as_type<metal::int3>(as_type<metal::uint3>(a) + 1u);
+    return a;
+}
+
+ANGLE_ALWAYS_INLINE metal::int4 ANGLE_preIncrementInt(thread metal::int4 &a)
+{
+    a = as_type<metal::int4>(as_type<metal::uint4>(a) + 1u);
     return a;
 }
 )")
 
 PROGRAM_PRELUDE_DECLARE(postIncrementInt,
                         R"(
-template <typename T>
-ANGLE_ALWAYS_INLINE T ANGLE_postIncrementInt(thread T &a)
+ANGLE_ALWAYS_INLINE int ANGLE_postIncrementInt(thread int &a)
 {
-    T r = a;
-    a = as_type<T>(metal::make_unsigned_t<T>(a) + 1);
+    int r = a;
+    a = as_type<int>(as_type<metal::uint>(a) + 1u);
+    return r;
+}
+
+ANGLE_ALWAYS_INLINE metal::int2 ANGLE_postIncrementInt(thread metal::int2 &a)
+{
+    metal::int2 r = a;
+    a = as_type<metal::int2>(as_type<metal::uint2>(a) + 1u);
+    return r;
+}
+
+ANGLE_ALWAYS_INLINE metal::int3 ANGLE_postIncrementInt(thread metal::int3 &a)
+{
+    metal::int3 r = a;
+    a = as_type<metal::int3>(as_type<metal::uint3>(a) + 1u);
+    return r;
+}
+
+ANGLE_ALWAYS_INLINE metal::int4 ANGLE_postIncrementInt(thread metal::int4 &a)
+{
+    metal::int4 r = a;
+    a = as_type<metal::int4>(as_type<metal::uint4>(a) + 1u);
     return r;
 }
 )")
 
 PROGRAM_PRELUDE_DECLARE(preDecrementInt,
                         R"(
-template <typename T>
-ANGLE_ALWAYS_INLINE thread T &ANGLE_preDecrementInt(thread T &a)
+ANGLE_ALWAYS_INLINE int ANGLE_preDecrementInt(thread int &a)
 {
-    a = as_type<T>(metal::make_unsigned_t<T>(a) - 1);
+    a = as_type<int>(as_type<metal::uint>(a) - 1u);
+    return a;
+}
+
+ANGLE_ALWAYS_INLINE metal::int2 ANGLE_preDecrementInt(thread metal::int2 &a)
+{
+    a = as_type<metal::int2>(as_type<metal::uint2>(a) - 1u);
+    return a;
+}
+
+ANGLE_ALWAYS_INLINE metal::int3 ANGLE_preDecrementInt(thread metal::int3 &a)
+{
+    a = as_type<metal::int3>(as_type<metal::uint3>(a) - 1u);
+    return a;
+}
+
+ANGLE_ALWAYS_INLINE metal::int4 ANGLE_preDecrementInt(thread metal::int4 &a)
+{
+    a = as_type<metal::int4>(as_type<metal::uint4>(a) - 1u);
     return a;
 }
 )")
 
 PROGRAM_PRELUDE_DECLARE(postDecrementInt,
                         R"(
-template <typename T>
-ANGLE_ALWAYS_INLINE T ANGLE_postDecrementInt(thread T &a)
+ANGLE_ALWAYS_INLINE int ANGLE_postDecrementInt(thread int &a)
 {
-    T r = a;
-    a = as_type<T>(metal::make_unsigned_t<T>(a) - 1);
+    int r = a;
+    a = as_type<int>(as_type<metal::uint>(a) - 1u);
+    return r;
+}
+
+ANGLE_ALWAYS_INLINE metal::int2 ANGLE_postDecrementInt(thread metal::int2 &a)
+{
+    metal::int2 r = a;
+    a = as_type<metal::int2>(as_type<metal::uint2>(a) - 1u);
+    return r;
+}
+
+ANGLE_ALWAYS_INLINE metal::int3 ANGLE_postDecrementInt(thread metal::int3 &a)
+{
+    metal::int3 r = a;
+    a = as_type<metal::int3>(as_type<metal::uint3>(a) - 1u);
+    return r;
+}
+
+ANGLE_ALWAYS_INLINE metal::int4 ANGLE_postDecrementInt(thread metal::int4 &a)
+{
+    metal::int4 r = a;
+    a = as_type<metal::int4>(as_type<metal::uint4>(a) - 1u);
     return r;
 }
 )")

--- a/Source/ThirdParty/ANGLE/src/tests/compiler_tests/MSLOutput_test.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/compiler_tests/MSLOutput_test.cpp
@@ -11,6 +11,7 @@
 #include "GLSLANG/ShaderLang.h"
 #include "angle_gl.h"
 #include "gtest/gtest.h"
+#include "gmock/gmock.h"
 #include "tests/test_utils/compiler_test.h"
 
 using namespace sh;
@@ -1115,4 +1116,100 @@ TEST_F(MSLOutputTest, EnsureLoopForwardProgressFinite)
         })";
     compile(shaderString, options);
     ASSERT_FALSE(foundInCode(SH_MSL_METAL_OUTPUT, "loopForwardProgress();"));
+}
+
+// Tests that uint assignment operators use the expected functions.
+TEST_F(MSLOutputTest, UintAssignmentOperators)
+{
+    const std::string &shaderString =R"(#version 300 es
+precision highp float;
+in vec4 i;
+out vec4 o;
+void main() {
+    ivec4 ii = ivec4(i);
+    ii += 2;
+    ii -= 3;
+    ii *= 4;
+    ii /= 5;
+    ii %= 6;
+    ii &= 7;
+    ii |= 8;
+    ii ^= 9;
+    ii <<= 10;
+    ii >>= 11;
+    ii++;
+    ++ii;
+    ii--;
+    --ii;
+    o = vec4(ii);
+})";
+    const char expected[] = R"(void ANGLE__0_main(thread ANGLE_FragmentOut & ANGLE_fragmentOut, thread ANGLE_FragmentIn & ANGLE_fragmentIn)
+{
+  metal::int4 _uii = ANGLE_ftoi<metal::int4>(ANGLE_fragmentIn._ui);
+  _uii = ANGLE_addAssignInt(_uii, 2);
+  _uii = ANGLE_subAssignInt(_uii, 3);
+  _uii = ANGLE_imul(_uii, 4);
+  _uii = ANGLE_div(_uii, 5);
+  _uii = ANGLE_imod(_uii, 6);
+  _uii &= 7;
+  _uii |= 8;
+  _uii ^= 9;
+  _uii = ANGLE_ilshift(_uii, 10);
+  _uii = ANGLE_rshift(_uii, 11);
+  ANGLE_postIncrementInt(_uii);
+  ANGLE_preIncrementInt(_uii);
+  ANGLE_postDecrementInt(_uii);
+  ANGLE_preDecrementInt(_uii);
+  ANGLE_fragmentOut._uo = metal::float4(_uii);
+})";
+    compile(shaderString);
+    EXPECT_THAT(outputCode(SH_MSL_METAL_OUTPUT), testing::HasSubstr(expected));
+}
+
+// Tests that some uint assignment operators use the swizzle ref helper if the swizzle is in lvalue position in the generated code.
+TEST_F(MSLOutputTest, UintSwizzleAssignmentOperators)
+{
+    const std::string &shaderString =R"(#version 300 es
+precision highp float;
+in vec4 i;
+out vec4 o;
+void main() {
+    ivec4 ii = ivec4(i);
+    ii.x += 2;
+    ii.y -= 3;
+    ii.z *= 4;
+    ii.w /= 5;
+    ii.x %= 6;
+    ii.y &= 7;
+    ii.y |= 8;
+    ii.z ^= 9;
+    ii.y <<= 10;
+    ii.z >>= 11;
+    ii.x++;
+    ++ii.y;
+    ii.x--;
+    --ii.y;
+    o = vec4(ii);
+})";
+    const char expected[] = R"(void ANGLE__0_main(thread ANGLE_FragmentOut & ANGLE_fragmentOut, thread ANGLE_FragmentIn & ANGLE_fragmentIn)
+{
+  metal::int4 _uii = ANGLE_ftoi<metal::int4>(ANGLE_fragmentIn._ui);
+  _uii.x = ANGLE_addInt(_uii.x, 2);
+  _uii.y = ANGLE_subInt(_uii.y, 3);
+  _uii.z = ANGLE_imul(_uii.z, 4);
+  _uii.w = ANGLE_div(_uii.w, 5);
+  _uii.x = ANGLE_imod(_uii.x, 6);
+  _uii.y = (_uii.y & 7);
+  _uii.y = (_uii.y | 8);
+  _uii.z = (_uii.z ^ 9);
+  _uii.y = ANGLE_ilshift(_uii.y, 10);
+  _uii.z = ANGLE_rshift(_uii.z, 11);
+  ANGLE_postIncrementInt(ANGLE_swizzle_ref(_uii, 0u));
+  ANGLE_preIncrementInt(ANGLE_swizzle_ref(_uii, 1u));
+  ANGLE_postDecrementInt(ANGLE_swizzle_ref(_uii, 0u));
+  ANGLE_preDecrementInt(ANGLE_swizzle_ref(_uii, 1u));
+  ANGLE_fragmentOut._uo = metal::float4(_uii);
+})";
+    compile(shaderString);
+    EXPECT_THAT(outputCode(SH_MSL_METAL_OUTPUT), testing::HasSubstr(expected));
 }


### PR DESCRIPTION
#### adfd582f7f8453e44d10940ac7020a1dd5bdf83c
<pre>
ANGLE: Failure to compile TensorFlow.js WebGL shaders
<a href="https://bugs.webkit.org/show_bug.cgi?id=294738">https://bugs.webkit.org/show_bug.cgi?id=294738</a>
<a href="https://rdar.apple.com/153836970">rdar://153836970</a>

Reviewed by Mike Wyrzykowski.

Increment, decrement operators with swizzles would fail to compile for
integer vectors:
    ivec4 vec;
    vec.xyz++;

This would produce:
    metal::int4 _uii;
    ANGLE_postIncrementInt(ANGLE_swizzle_ref(_uii, 0u, 1u, 2u));

ANGLE_postIncrementInt(T &amp;a) would not match because the argument was
rvalue ANGLE_SwizzleRef, and rvalues cannot bind to non-const lvalue
references. Even if this was worked around somehow, the template would
not work because T == ANGLE_SwizzleRef, when the original intention
was that the T would be metal int, int2, int3, int4.

Write the ANGLE_postIncrementInt and other functions without templates.
This way the overload resolution applies the
ANGLE_SwizzleRef::operator intX&amp;() conversion operator. Since the
conversion operator is applied, the returned value is a lvalue reference
and can be bound to the arg.

Due to the use of temporaries changes ANGLE_preIncrementInt,
ANGLE_preDecrementInt functions to return the result by value instead
by reference. In GLSL, these operators are not specified to produce a
lvalue. As per the current code, the translator treats the result as
rvalue.

* Source/ThirdParty/ANGLE/src/compiler/translator/msl/ProgramPrelude.cpp:
* Source/ThirdParty/ANGLE/src/compiler/translator/tree_ops/msl/RewriteUnaddressableReferences.cpp:
(sh::ReturnsReference):
(sh::IsUnaryLValueOp):
* Source/ThirdParty/ANGLE/src/tests/compiler_tests/MSLOutput_test.cpp:
((MSLOutputTest, UintAssignmentOperators)):
((MSLOutputTest, UintSwizzleAssignmentOperators)):
* Source/ThirdParty/ANGLE/src/tests/gl_tests/GLSLTest.cpp:

Canonical link: <a href="https://commits.webkit.org/296744@main">https://commits.webkit.org/296744@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbca0a30cc92ce2bc831f7e5c8c348f66c8b734f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109421 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19508 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114626 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59654 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29758 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37667 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83167 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112369 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23699 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98555 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63625 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23080 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16698 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59246 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93067 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16740 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/rotated-cat-off-top-edge.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117740 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36462 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26992 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92177 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36833 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94817 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91992 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23428 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36920 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14666 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32266 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36355 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36026 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39365 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37730 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->