### PR TITLE
[GStreamer][EME] imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-clear-encrypted-segmented.https.html is failing

### DIFF
--- a/LayoutTests/media/encrypted-media/encrypted-media-append-clear-encrypted-expected.txt
+++ b/LayoutTests/media/encrypted-media/encrypted-media-append-clear-encrypted-expected.txt
@@ -1,0 +1,12 @@
+
+EME API is supported OK
+Appending chunks...
+EVENT(encrypted)
+MediaKeys is created OK
+EVENT(message)
+EVENT(keystatuseschange)
+Session: keyId=b0b1b2b3b4b5b6b7b8b9babbbcbdbebf status=usable OK
+All appends are completed
+EXPECTED (video.duration >= '23') OK
+END OF TEST
+

--- a/LayoutTests/media/encrypted-media/encrypted-media-append-clear-encrypted.html
+++ b/LayoutTests/media/encrypted-media/encrypted-media-append-clear-encrypted.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Append clear and encrypted content</title>
+    <script src="../video-test.js"></script>
+    <script src="../media-source/media-source-loader-simple.js"></script>
+    <script src="medias-enc.js"></script>
+    <script src="clearKey/encrypted-media-clearKey-handler.js"></script>
+    <script>
+
+     const audioConf = streamMedias["clearToEncryptedMSE"].audio;
+
+     function runTest() {
+
+         findMediaElement();
+
+         const emeHandler = new EncryptedMediaHandler(video, audioConf);
+         if (!emeHandler)
+             endTest();
+
+         function checkEndTest() {
+             consoleWrite("All appends are completed");
+             testExpected('video.duration', 23, '>=');
+             endTest();
+         }
+
+         consoleWrite("Appending chunks...");
+         const ms = new MediaSourceLoaderSimple(video);
+         ms.onready = function() {
+             ms.createSourceBuffer(audioConf, 11).then(checkEndTest, failTest);
+         };
+     }
+    </script>
+</head>
+<body onload="runTest()">
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/media/encrypted-media/medias-enc.js
+++ b/LayoutTests/media/encrypted-media/medias-enc.js
@@ -63,5 +63,20 @@ const streamMedias = {
                                                       ],
                                        keys         : {   	"b0b1b2b3b4b5b6b7b8b9babbbcbdbebf" : "a0a1a2a3a4a5a6a7a8a9aaabacadaeaf" }
                                    }
+                                  },
+    "clearToEncryptedMSE" : {    audio : {    initDataType : "cenc",
+                                       mimeType     : 'audio/mp4; codecs="mp4a.40.2"',
+                                       segments     : [
+                                                        "../media-source/content/test-48kHz.m4a",
+                                                        { timestampOffset: 10 },
+                                                        "../content/encrypted/segments/AudioClearKeyCenc-seg-0.mp4",
+                                                        "../content/encrypted/segments/AudioClearKeyCenc-seg-1.mp4",
+                                                        "../content/encrypted/segments/AudioClearKeyCenc-seg-2.mp4",
+                                                        "../content/encrypted/segments/AudioClearKeyCenc-seg-3.mp4",
+                                                        { timestampOffset: 13 },
+                                                        "../media-source/content/test-48kHz.m4a",
+                                                      ],
+                                       keys         : {   	"b0b1b2b3b4b5b6b7b8b9babbbcbdbebf" : "a0a1a2a3a4a5a6a7a8a9aaabacadaeaf" }
+                                   }
                       }
                    };

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2771,7 +2771,6 @@ webkit.org/b/190991 imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4
 webkit.org/b/190991 imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-retrieve-persistent-usage-record.https.html [ Skip ]
 webkit.org/b/211840 imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-retrieve-persistent-license.https.html [ Failure ]
 webkit.org/b/211840 imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-destroy-persistent-license.https.html [ Failure ]
-webkit.org/b/211375 imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-clear-encrypted-segmented.https.html [ Skip ]
 webkit.org/b/210113 imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-reset-src-after-setmediakeys.https.html [ Failure ]
 webkit.org/b/178707 imported/w3c/web-platform-tests/encrypted-media/encrypted-media-default-feature-policy.https.sub.html [ Skip ]
 
@@ -2783,6 +2782,7 @@ imported/w3c/web-platform-tests/encrypted-media/clearkey-events-session-closed-e
 imported/w3c/web-platform-tests/encrypted-media/clearkey-invalid-license.https.html [ Pass ]
 imported/w3c/web-platform-tests/encrypted-media/clearkey-keystatuses.https.html [ Pass ]
 imported/w3c/web-platform-tests/encrypted-media/clearkey-keystatuses-multiple-sessions.https.html [ Pass ]
+imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-clear-encrypted-segmented.https.html [ Pass ]
 imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-clear-encrypted.https.html [ Pass ]
 imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-encrypted-clear.https.html [ Pass ]
 imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-encrypted-clear-sources.https.html [ Pass ]

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-clear-encrypted-segmented.https-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-clear-encrypted-segmented.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS org.w3.clearkey, temporary, mp4, playback, encrypted and clear sources in separate segments
+

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1064,6 +1064,7 @@ webkit.org/b/181594 media/encrypted-media/clearKey/clearKey-cenc-video-playback-
 webkit.org/b/189200 media/encrypted-media/clearKey/clearKey-webm-video-playback-mse.html [ Skip ]
 media/encrypted-media/clearKey/clearKey-cenc-video-playback-mse-multikey.html [ Skip ]
 webkit.org/b/258070 media/encrypted-media/clearKey/clearKey-cenc-stop-playback-before-key.html [ Skip ]
+media/encrypted-media/encrypted-media-append-clear-encrypted.html [ Skip ]
 
 webkit.org/b/162507 http/tests/media/hls/hls-video-resize.html [ Pass Failure ]
 

--- a/Source/WebCore/platform/SourcesGStreamer.txt
+++ b/Source/WebCore/platform/SourcesGStreamer.txt
@@ -85,6 +85,7 @@ platform/graphics/gstreamer/eme/CDMThunder.cpp
 platform/graphics/gstreamer/eme/GStreamerEMEUtilities.cpp
 platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
 platform/graphics/gstreamer/eme/WebKitThunderDecryptorGStreamer.cpp
+platform/graphics/gstreamer/eme/WebKitThunderParser.cpp
 
 platform/graphics/gstreamer/mse/AppendPipeline.cpp
 platform/graphics/gstreamer/mse/GStreamerMediaDescription.cpp

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -85,6 +85,7 @@
 #if ENABLE(ENCRYPTED_MEDIA) && ENABLE(THUNDER)
 #include "CDMThunder.h"
 #include "WebKitThunderDecryptorGStreamer.h"
+#include "WebKitThunderParser.h"
 #endif
 
 #if ENABLE(VIDEO)
@@ -442,8 +443,12 @@ void registerWebKitGStreamerElements()
         // - Use GST_RANK_NONE for elements explicitely created by WebKit (no auto-plugging).
 
 #if ENABLE(ENCRYPTED_MEDIA) && ENABLE(THUNDER)
-        if (!CDMFactoryThunder::singleton().supportedKeySystems().isEmpty())
+        if (!CDMFactoryThunder::singleton().supportedKeySystems().isEmpty()) {
+            // The Thunder parser is auto-plugged by parsebin and its internal parsebin can
+            // auto-plug the Thunder decryptor.
             gst_element_register(nullptr, "webkitthunder", GST_RANK_PRIMARY + 100, WEBKIT_TYPE_MEDIA_THUNDER_DECRYPT);
+            gst_element_register(nullptr, "webkitthunderparser", GST_RANK_PRIMARY + 101, WEBKIT_TYPE_MEDIA_THUNDER_PARSER);
+        }
 #endif
 
 #if ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -536,6 +536,7 @@ private:
     void configureVideoDecoder(GstElement*);
     void configureElement(GstElement*);
     void configureParsebin(GstElement*);
+    void configureUriDecodebin2(GstElement*);
 
     void configureElementPlatformQuirks(GstElement*);
 

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderParser.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderParser.cpp
@@ -1,0 +1,191 @@
+/* GStreamer Thunder Parser
+ *
+ * Copyright (C) 2025 Comcast Inc.
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "WebKitThunderParser.h"
+
+#if ENABLE(ENCRYPTED_MEDIA) && ENABLE(THUNDER) && USE(GSTREAMER)
+
+#include "CDMProxyThunder.h"
+#include "GStreamerCommon.h"
+#include "GStreamerEMEUtilities.h"
+#include <wtf/glib/WTFGType.h>
+#include <wtf/text/StringView.h>
+
+GST_DEBUG_CATEGORY(webkitMediaThunderParserDebugCategory);
+#define GST_CAT_DEFAULT webkitMediaThunderParserDebugCategory
+
+typedef struct _WebKitMediaThunderParserPrivate {
+    GRefPtr<GstElement> decryptor;
+    GRefPtr<GstElement> parser;
+} WebKitMediaThunderParserPrivate;
+
+typedef struct _WebKitMediaThunderParser {
+    GstBin parent;
+    WebKitMediaThunderParserPrivate* priv;
+} WebKitMediaThunderParser;
+
+typedef struct _WebKitMediaThunderParserClass {
+    GstBinClass parentClass;
+} WebKitMediaThunderParserClass;
+
+using namespace WebCore;
+
+WEBKIT_DEFINE_TYPE(WebKitMediaThunderParser, webkit_media_thunder_parser, GST_TYPE_BIN)
+
+static GstStaticPadTemplate thunderParseSrcTemplate = GST_STATIC_PAD_TEMPLATE("src_%u",
+    GST_PAD_SRC,
+    GST_PAD_SOMETIMES,
+    GST_STATIC_CAPS(
+        "video/webm; "
+        "audio/webm; "
+        "video/mp4; "
+        "audio/mp4; "
+        "audio/mpeg; "
+        "audio/x-flac; "
+        "audio/x-eac3; "
+        "audio/x-ac3; "
+        "video/x-h264; "
+        "video/x-h265; "
+        "video/x-vp9; video/x-vp8; "
+        "video/x-av1; "
+        "audio/x-opus; audio/x-vorbis"));
+
+static GRefPtr<GstCaps> createThunderParseSinkPadTemplateCaps()
+{
+    GRefPtr<GstCaps> caps = adoptGRef(gst_caps_new_empty());
+
+    auto& supportedKeySystems = CDMFactoryThunder::singleton().supportedKeySystems();
+
+    if (supportedKeySystems.isEmpty()) {
+        GST_WARNING("no supported key systems in Thunder, we won't be able to decrypt anything with the decryptor");
+        return caps;
+    }
+
+    for (const auto& mediaType : GStreamerEMEUtilities::s_cencEncryptionMediaTypes) {
+        gst_caps_append_structure(caps.get(), gst_structure_new_empty(mediaType.characters()));
+        gst_caps_append_structure(caps.get(), gst_structure_new("application/x-cenc", "original-media-type", G_TYPE_STRING, mediaType.characters(), nullptr));
+    }
+    for (const auto& keySystem : supportedKeySystems) {
+        for (const auto& mediaType : GStreamerEMEUtilities::s_cencEncryptionMediaTypes) {
+            gst_caps_append_structure(caps.get(), gst_structure_new("application/x-cenc", "original-media-type", G_TYPE_STRING,
+                mediaType.characters(), "protection-system", G_TYPE_STRING, GStreamerEMEUtilities::keySystemToUuid(keySystem), nullptr));
+        }
+    }
+
+    if (supportedKeySystems.contains(GStreamerEMEUtilities::s_WidevineKeySystem) || supportedKeySystems.contains(GStreamerEMEUtilities::s_ClearKeyKeySystem)) {
+        for (const auto& mediaType : GStreamerEMEUtilities::s_webmEncryptionMediaTypes) {
+            gst_caps_append_structure(caps.get(), gst_structure_new_empty(mediaType.characters()));
+            gst_caps_append_structure(caps.get(), gst_structure_new("application/x-webm-enc", "original-media-type", G_TYPE_STRING, mediaType.characters(), nullptr));
+        }
+    }
+
+    return caps;
+}
+
+static void webkitMediaThunderParserConstructed(GObject* object)
+{
+    G_OBJECT_CLASS(webkit_media_thunder_parser_parent_class)->constructed(object);
+
+    auto self = WEBKIT_MEDIA_THUNDER_PARSER(object);
+    self->priv->parser = makeGStreamerElement("parsebin"_s, "inner-parser"_s);
+
+    auto factories = gst_element_factory_list_get_elements(GST_ELEMENT_FACTORY_TYPE_DECRYPTOR, GST_RANK_MARGINAL);
+    factories = g_list_sort(factories, gst_plugin_feature_rank_compare_func);
+    for (GList* tmp = factories; tmp; tmp = tmp->next) {
+        auto factory = GST_ELEMENT_FACTORY_CAST(tmp->data);
+        self->priv->decryptor = gst_element_factory_create(factory, nullptr);
+        if (self->priv->decryptor) {
+            GST_DEBUG_OBJECT(self, "Using decryptor %" GST_PTR_FORMAT, self->priv->decryptor.get());
+            break;
+        }
+    }
+    gst_plugin_feature_list_free(factories);
+
+    if (!self->priv->decryptor) [[unlikely]] {
+        GST_DEBUG_OBJECT(self, "Unable to find any decryptor, encrypted buffers will be passed-through");
+        self->priv->decryptor = gst_element_factory_make("identity", nullptr);
+    }
+
+    gst_bin_add_many(GST_BIN_CAST(self), self->priv->decryptor.get(), self->priv->parser.get(), nullptr);
+    gst_element_link(self->priv->decryptor.get(), self->priv->parser.get());
+
+    g_signal_connect(self->priv->parser.get(), "autoplug-factories", G_CALLBACK(+[](GstElement*, GstPad*, GstCaps* caps, gpointer userData) -> GValueArray* {
+        auto self = WEBKIT_MEDIA_THUNDER_PARSER(userData);
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN;
+        GValueArray* result;
+
+        auto factories = gst_element_factory_list_get_elements(GST_ELEMENT_FACTORY_TYPE_DECODABLE, GST_RANK_MARGINAL);
+        auto list = gst_element_factory_list_filter(factories, caps, GST_PAD_SINK, gst_caps_is_fixed(caps));
+        result = g_value_array_new(g_list_length(list));
+        for (GList* tmp = list; tmp; tmp = tmp->next) {
+            auto factory = GST_ELEMENT_FACTORY_CAST(tmp->data);
+            auto name = StringView::fromLatin1(gst_plugin_feature_get_name(GST_PLUGIN_FEATURE_CAST(factory)));
+            if (name == "webkitthunderparser"_s)
+                continue;
+
+            auto decryptorFactoryName = StringView::fromLatin1(gst_plugin_feature_get_name(GST_PLUGIN_FEATURE_CAST(gst_element_get_factory(self->priv->decryptor.get()))));
+            if (name == decryptorFactoryName)
+                continue;
+
+            GValue value = G_VALUE_INIT;
+            g_value_init(&value, G_TYPE_OBJECT);
+            g_value_set_object(&value, factory);
+            g_value_array_append(result, &value);
+            g_value_unset(&value);
+        }
+        gst_plugin_feature_list_free(list);
+        gst_plugin_feature_list_free(factories);
+        return result;
+        ALLOW_DEPRECATED_DECLARATIONS_END;
+    }), self);
+
+    g_signal_connect(self->priv->parser.get(), "pad-added", G_CALLBACK(+[](GstElement*, GstPad* pad, gpointer userData) {
+        static unsigned counter = 0;
+        auto name = makeString("src_"_s, counter);
+        counter++;
+        gst_element_add_pad(GST_ELEMENT_CAST(userData), gst_ghost_pad_new(name.ascii().data(), pad));
+    }), self);
+
+    auto decryptorSinkPad = adoptGRef(gst_element_get_static_pad(self->priv->decryptor.get(), "sink"));
+    gst_element_add_pad(GST_ELEMENT_CAST(self), gst_ghost_pad_new("sink", decryptorSinkPad.get()));
+    gst_bin_sync_children_states(GST_BIN_CAST(self));
+}
+
+static void webkit_media_thunder_parser_class_init(WebKitMediaThunderParserClass* klass)
+{
+    GST_DEBUG_CATEGORY_INIT(webkitMediaThunderParserDebugCategory, "webkitthunderparser", 0, "Thunder parser");
+
+    auto objectClass = G_OBJECT_CLASS(klass);
+    objectClass->constructed = webkitMediaThunderParserConstructed;
+
+    auto elementClass = GST_ELEMENT_CLASS(klass);
+    auto padTemplateCaps = createThunderParseSinkPadTemplateCaps();
+    gst_element_class_add_pad_template(elementClass, gst_pad_template_new("sink", GST_PAD_SINK, GST_PAD_ALWAYS, padTemplateCaps.get()));
+    gst_element_class_add_pad_template(elementClass, gst_static_pad_template_get(&thunderParseSrcTemplate));
+
+    gst_element_class_set_static_metadata(elementClass, "Parse potentially encrypted content", "Codec/Parser/Audio/Video",
+        "Parse potentially encrypted content", "Philippe Normand <philn@igalia.com>");
+}
+
+#undef GST_CAT_DEFAULT
+
+#endif // ENABLE(ENCRYPTED_MEDIA) && ENABLE(THUNDER) && USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderParser.h
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderParser.h
@@ -1,0 +1,37 @@
+/* GStreamer Thunder Parser
+ *
+ * Copyright (C) 2025 Comcast Inc.
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#if ENABLE(ENCRYPTED_MEDIA) && ENABLE(THUNDER) && USE(GSTREAMER)
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define WEBKIT_TYPE_MEDIA_THUNDER_PARSER          (webkit_media_thunder_parser_get_type())
+#define WEBKIT_MEDIA_THUNDER_PARSER(obj)          (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_MEDIA_THUNDER_PARSER, WebKitMediaThunderParser))
+
+GType webkit_media_thunder_parser_get_type(void);
+
+G_END_DECLS
+
+#endif // ENABLE(ENCRYPTED_MEDIA) && ENABLE(THUNDER) && USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
@@ -109,6 +109,7 @@ private:
     };
 
     void configureOptionalDemuxerFromAnyThread();
+    void removeParserForDemuxerPad(const GRefPtr<GstPad>&);
     void handleErrorSyncMessage(GstMessage*);
     void handleNeedContextSyncMessage(GstMessage*);
     // For debug purposes only:

--- a/Tools/Scripts/webkitpy/style/checker.py
+++ b/Tools/Scripts/webkitpy/style/checker.py
@@ -305,6 +305,8 @@ _PATH_RULES_SPECIFIER = [
       os.path.join('Source', 'WebCore', 'platform', 'graphics', 'gstreamer', 'WebKitWebSourceGStreamer.cpp'),
       os.path.join('Source', 'WebCore', 'platform', 'graphics', 'gstreamer', 'WebKitAudioSinkGStreamer.cpp'),
       os.path.join('Source', 'WebCore', 'platform', 'graphics', 'gstreamer', 'WebKitAudioSinkGStreamer.h'),
+      os.path.join('Source', 'WebCore', 'platform', 'graphics', 'gstreamer', 'eme', 'WebKitThunderParser.cpp'),
+      os.path.join('Source', 'WebCore', 'platform', 'graphics', 'gstreamer', 'eme', 'WebKitThunderParser.h'),
       os.path.join('Source', 'WebCore', 'platform', 'graphics', 'gstreamer', 'mse', 'WebKitMediaSourceGStreamer.cpp'),
       os.path.join('Source', 'WebCore', 'platform', 'audio', 'gstreamer', 'WebKitWebAudioSourceGStreamer.cpp'),
       os.path.join('Source', 'WebCore', 'platform', 'gstreamer', 'VideoEncoderPrivateGStreamer.cpp'),


### PR DESCRIPTION
#### cec614145e4b30e8654782ce53d970bf465b9efd
<pre>
[GStreamer][EME] imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-clear-encrypted-segmented.https.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=211375">https://bugs.webkit.org/show_bug.cgi?id=211375</a>

Reviewed by Xabier Rodriguez-Calvar.

Wrap the decryptor in a new bin along with parsebin. This should allow seamless switching between
encrypted and clear content processing. As this new parser is auto-plugged by parsebin in
urisourcebin we have to be cautious regarding the infinite auto-plugging outcome by removing our new
parser from the autoplug-factories passed to the inner parsebin element.

Test: media/encrypted-media/encrypted-media-append-clear-encrypted.html
Canonical link: <a href="https://commits.webkit.org/296959@main">https://commits.webkit.org/296959@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0759c1e407e7ea8048ef771b2e97c248c3071ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109943 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20032 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115965 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60191 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111906 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30279 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38189 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83579 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24136 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99010 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64021 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/109375 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23508 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17159 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59759 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93507 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17200 "Found 2 new test failures: fast/mediastream/play-newly-added-audio-track.html imported/w3c/web-platform-tests/css/css-view-transitions/rotated-cat-off-top-edge.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118756 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36982 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27409 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92556 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37355 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95276 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92380 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23575 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37357 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15101 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32853 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36877 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42348 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36537 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39879 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38246 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->