### PR TITLE
Remove respondsToSelector for AVSpeechSynthesisVoice

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/AXSpeechManagerSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AXSpeechManagerSPI.h
@@ -29,8 +29,7 @@ DECLARE_SYSTEM_HEADER
 
 #if PLATFORM(COCOA)
 
-// FIXME: Undo when isSystemVoice is available in all SDKs.
-#if USE(APPLE_INTERNAL_SDK) && 0
+#if USE(APPLE_INTERNAL_SDK)
 
 #include <AXSpeechManager.h>
 
@@ -39,11 +38,10 @@ DECLARE_SYSTEM_HEADER
 #include <AVFoundation/AVFoundation.h>
 
 @interface AVSpeechSynthesisVoice (PrivateAttributes)
-@property (nonatomic, readonly) BOOL isSystemVoice SPI_AVAILABLE(macos(11.3), ios(13.3), tvos(13.3), watchos(6.3));
-+ (nonnull NSArray<AVSpeechSynthesisVoice *> *)speechVoicesIncludingSuperCompact SPI_AVAILABLE(macos(13.4), ios(16.5), tvos(16.5), watchos(9.5));
+@property (nonatomic, readonly) BOOL isSystemVoice;
++ (nonnull NSArray<AVSpeechSynthesisVoice *> *)speechVoicesIncludingSuperCompact;
 @end
 
 #endif // USE(APPLE_INTERNAL_SDK)
 
 #endif // PLATFORM(COCOA)
-

--- a/Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm
+++ b/Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm
@@ -293,17 +293,10 @@ void PlatformSpeechSynthesizer::initializeVoiceList()
         return;
 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    NSArray<AVSpeechSynthesisVoice *> *voices = nil;
     // SpeechSynthesis replaces on-device compact with higher quality compact voices. These
     // are not available to WebKit so we're losing these default voices for WebSpeech.
-    // FIXME: Remove respondsToSelector check when is available on all SDKs.
-    if ([PAL::getAVSpeechSynthesisVoiceClass() respondsToSelector:@selector(speechVoicesIncludingSuperCompact)])
-        voices = [PAL::getAVSpeechSynthesisVoiceClass() speechVoicesIncludingSuperCompact];
-    else
-        voices = [PAL::getAVSpeechSynthesisVoiceClass() speechVoices];
-
     // Only show built-in voices when requesting through WebKit to reduce fingerprinting surface area.
-    for (AVSpeechSynthesisVoice *voice in voices) {
+    for (AVSpeechSynthesisVoice *voice in [PAL::getAVSpeechSynthesisVoiceClass() speechVoicesIncludingSuperCompact]) {
         if (voice.isSystemVoice)
             m_voiceList.append(PlatformSpeechSynthesisVoice::create(voice.identifier, voice.name, voice.language, true, true));
     }


### PR DESCRIPTION
#### a34db14abacc7f9e2a7de6f230000dbf73e7d281
<pre>
Remove respondsToSelector for AVSpeechSynthesisVoice
<a href="https://bugs.webkit.org/show_bug.cgi?id=295026">https://bugs.webkit.org/show_bug.cgi?id=295026</a>

Reviewed by Tyler Wilcock.

isSystemVoice and speechVoicesIncludingSuperCompact are available in
all recent Cocoa SDKs.

Canonical link: <a href="https://commits.webkit.org/296737@main">https://commits.webkit.org/296737@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18681bb8373891f35311b93be78d97d658221c50

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109247 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28905 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19333 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114454 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59518 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111210 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29587 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37494 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83027 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112195 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23548 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98398 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63477 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22937 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16543 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59080 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92917 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16583 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117570 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36291 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26853 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92040 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36663 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94661 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91849 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36770 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14523 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32124 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17661 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36187 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41675 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35873 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39205 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37564 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->