### PR TITLE
[JSC] Use same allocator for Subspaces

### DIFF
--- a/Source/JavaScriptCore/heap/AlignedMemoryAllocator.h
+++ b/Source/JavaScriptCore/heap/AlignedMemoryAllocator.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/PrintStream.h>
+#include <wtf/RefCounted.h>
 #include <wtf/SinglyLinkedListWithTail.h>
 
 namespace JSC {
@@ -34,7 +35,7 @@ class BlockDirectory;
 class Heap;
 class Subspace;
 
-class AlignedMemoryAllocator {
+class AlignedMemoryAllocator : public RefCounted<AlignedMemoryAllocator> {
     WTF_MAKE_NONCOPYABLE(AlignedMemoryAllocator);
     WTF_MAKE_FAST_ALLOCATED;
 public:

--- a/Source/JavaScriptCore/heap/CompleteSubspace.cpp
+++ b/Source/JavaScriptCore/heap/CompleteSubspace.cpp
@@ -36,10 +36,10 @@
 
 namespace JSC {
 
-CompleteSubspace::CompleteSubspace(CString name, JSC::Heap& heap, const HeapCellType& heapCellType, AlignedMemoryAllocator* alignedMemoryAllocator)
-    : Subspace(SubspaceKind::CompleteSubspace, name, heap)
+CompleteSubspace::CompleteSubspace(CString name, JSC::Heap& heap, const HeapCellType& heapCellType, Ref<AlignedMemoryAllocator> alignedMemoryAllocator)
+    : Subspace(SubspaceKind::CompleteSubspace, name, heap, WTFMove(alignedMemoryAllocator))
 {
-    initialize(heapCellType, alignedMemoryAllocator);
+    initialize(heapCellType);
 }
 
 CompleteSubspace::~CompleteSubspace() = default;

--- a/Source/JavaScriptCore/heap/CompleteSubspace.h
+++ b/Source/JavaScriptCore/heap/CompleteSubspace.h
@@ -31,7 +31,7 @@ namespace JSC {
 
 class CompleteSubspace final : public Subspace {
 public:
-    JS_EXPORT_PRIVATE CompleteSubspace(CString name, Heap&, const HeapCellType&, AlignedMemoryAllocator*);
+    JS_EXPORT_PRIVATE CompleteSubspace(CString name, Heap&, const HeapCellType&, Ref<AlignedMemoryAllocator>);
     JS_EXPORT_PRIVATE ~CompleteSubspace() final;
 
     // In some code paths, we need it to be a compile error to call the virtual version of one of

--- a/Source/JavaScriptCore/heap/FastMallocAlignedMemoryAllocator.h
+++ b/Source/JavaScriptCore/heap/FastMallocAlignedMemoryAllocator.h
@@ -35,9 +35,13 @@ namespace JSC {
 
 class FastMallocAlignedMemoryAllocator final : public AlignedMemoryAllocator {
 public:
-    FastMallocAlignedMemoryAllocator();
     ~FastMallocAlignedMemoryAllocator() final;
-    
+
+    static Ref<FastMallocAlignedMemoryAllocator> create()
+    {
+        return adoptRef(*new FastMallocAlignedMemoryAllocator);
+    }
+
     void* tryAllocateAlignedMemory(size_t alignment, size_t size) final;
     void freeAlignedMemory(void*) final;
     
@@ -46,6 +50,9 @@ public:
     void* tryAllocateMemory(size_t) final;
     void freeMemory(void*) final;
     void* tryReallocateMemory(void*, size_t) final;
+
+private:
+    FastMallocAlignedMemoryAllocator();
 
 #if ENABLE(MALLOC_HEAP_BREAKDOWN)
 private:

--- a/Source/JavaScriptCore/heap/GigacageAlignedMemoryAllocator.h
+++ b/Source/JavaScriptCore/heap/GigacageAlignedMemoryAllocator.h
@@ -36,7 +36,6 @@ namespace JSC {
 
 class GigacageAlignedMemoryAllocator final : public AlignedMemoryAllocator {
 public:
-    GigacageAlignedMemoryAllocator(Gigacage::Kind);
     ~GigacageAlignedMemoryAllocator() final;
     
     void* tryAllocateAlignedMemory(size_t alignment, size_t size) final;
@@ -48,7 +47,14 @@ public:
     void freeMemory(void*) final;
     void* tryReallocateMemory(void*, size_t) final;
 
+    static Ref<GigacageAlignedMemoryAllocator> create(Gigacage::Kind kind)
+    {
+        return adoptRef(*new GigacageAlignedMemoryAllocator(kind));
+    }
+
 private:
+    GigacageAlignedMemoryAllocator(Gigacage::Kind);
+
     Gigacage::Kind m_kind;
 #if ENABLE(MALLOC_HEAP_BREAKDOWN)
     WTF::DebugHeap m_heap;

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -302,7 +302,7 @@ private:
     , name ISO_SUBSPACE_INIT(*this, heapCellType, type)
 
 #define INIT_SERVER_STRUCTURE_ISO_SUBSPACE(name, heapCellType, type) \
-    , name("IsoSubspace" #name, *this, heapCellType, WTF::roundUpToMultipleOf<type::atomSize>(sizeof(type)), type::numberOfLowerTierPreciseCells, makeUnique<StructureAlignedMemoryAllocator>())
+    , name("IsoSubspace" #name, *this, heapCellType, WTF::roundUpToMultipleOf<type::atomSize>(sizeof(type)), type::numberOfLowerTierPreciseCells, this->structureAllocator)
 
 Heap::Heap(VM& vm, HeapType heapType)
     : m_heapType(heapType)
@@ -392,16 +392,16 @@ Heap::Heap(VM& vm, HeapType heapType)
 #endif
 
     // AlignedMemoryAllocators
-    , fastMallocAllocator(makeUnique<FastMallocAlignedMemoryAllocator>())
-    , primitiveGigacageAllocator(makeUnique<GigacageAlignedMemoryAllocator>(Gigacage::Primitive))
+    , fastMallocAllocator(FastMallocAlignedMemoryAllocator::create())
+    , primitiveGigacageAllocator(GigacageAlignedMemoryAllocator::create(Gigacage::Primitive))
+    , structureAllocator(StructureAlignedMemoryAllocator::create())
 
     // Subspaces
-    , primitiveGigacageAuxiliarySpace("Primitive Gigacage Auxiliary"_s, *this, auxiliaryHeapCellType, primitiveGigacageAllocator.get()) // Hash:0x3e7cd762
-    , auxiliarySpace("Auxiliary"_s, *this, auxiliaryHeapCellType, fastMallocAllocator.get()) // Hash:0x96255ba1
-    , immutableButterflyAuxiliarySpace("ImmutableButterfly JSCellWithIndexingHeader"_s, *this, immutableButterflyHeapCellType, fastMallocAllocator.get()) // Hash:0xaadcb3c1
-    , cellSpace("JSCell"_s, *this, cellHeapCellType, fastMallocAllocator.get()) // Hash:0xadfb5a79
-    , variableSizedCellSpace("Variable Sized JSCell"_s, *this, cellHeapCellType, fastMallocAllocator.get()) // Hash:0xbcd769cc
-    , destructibleObjectSpace("JSDestructibleObject"_s, *this, destructibleObjectHeapCellType, fastMallocAllocator.get()) // Hash:0x4f5ed7a9
+    , primitiveGigacageAuxiliarySpace("Primitive Gigacage Auxiliary"_s, *this, auxiliaryHeapCellType, primitiveGigacageAllocator) // Hash:0x3e7cd762
+    , auxiliarySpace("Auxiliary"_s, *this, auxiliaryHeapCellType, fastMallocAllocator) // Hash:0x96255ba1
+    , immutableButterflyAuxiliarySpace("ImmutableButterfly JSCellWithIndexingHeader"_s, *this, immutableButterflyHeapCellType, fastMallocAllocator) // Hash:0xaadcb3c1
+    , cellSpace("JSCell"_s, *this, cellHeapCellType, fastMallocAllocator) // Hash:0xadfb5a79
+    , destructibleObjectSpace("JSDestructibleObject"_s, *this, destructibleObjectHeapCellType, fastMallocAllocator) // Hash:0x4f5ed7a9
     FOR_EACH_JSC_COMMON_ISO_SUBSPACE(INIT_SERVER_ISO_SUBSPACE)
     FOR_EACH_JSC_STRUCTURE_ISO_SUBSPACE(INIT_SERVER_STRUCTURE_ISO_SUBSPACE)
     , codeBlockSpaceAndSet ISO_SUBSPACE_INIT(*this, destructibleCellHeapCellType, CodeBlock) // Hash:0x2b743c6a
@@ -3415,7 +3415,7 @@ DEFINE_DYNAMIC_SPACE_AND_SET_MEMBER_SLOW(moduleProgramExecutableSpace, destructi
     SubspaceType* Heap::name##Slow() \
     { \
         ASSERT(!m_##name); \
-        auto space = makeUnique<SubspaceType>(ASCIILiteral(#SubspaceType " " #name), *this, heapCellType, fastMallocAllocator.get()); \
+        auto space = makeUnique<SubspaceType>(ASCIILiteral(#SubspaceType " " #name), *this, heapCellType, fastMallocAllocator); \
         WTF::storeStoreFence(); \
         m_##name = WTFMove(space); \
         return m_##name.get(); \

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -98,6 +98,7 @@ class RunningScope;
 class SlotVisitor;
 class SpaceTimeMutatorScheduler;
 class StopIfNecessaryTimer;
+class StructureAlignedMemoryAllocator;
 class SweepingScope;
 class VM;
 class VerifierSlotVisitor;
@@ -1059,8 +1060,9 @@ public:
 #endif
 
     // AlignedMemoryAllocators
-    std::unique_ptr<FastMallocAlignedMemoryAllocator> fastMallocAllocator;
-    std::unique_ptr<GigacageAlignedMemoryAllocator> primitiveGigacageAllocator;
+    Ref<FastMallocAlignedMemoryAllocator> fastMallocAllocator;
+    Ref<GigacageAlignedMemoryAllocator> primitiveGigacageAllocator;
+    Ref<StructureAlignedMemoryAllocator> structureAllocator;
 
     // Subspaces
     CompleteSubspace primitiveGigacageAuxiliarySpace; // Typed arrays, strings, bitvectors, etc go here.
@@ -1087,7 +1089,6 @@ public:
     
     // Whenever possible, use subspaceFor<CellType>(vm) to get one of these subspaces.
     CompleteSubspace cellSpace;
-    CompleteSubspace variableSizedCellSpace;
     CompleteSubspace destructibleObjectSpace;
 
 #define DECLARE_ISO_SUBSPACE(name, heapCellType, type) \

--- a/Source/JavaScriptCore/heap/IsoSubspace.cpp
+++ b/Source/JavaScriptCore/heap/IsoSubspace.cpp
@@ -36,16 +36,15 @@ namespace JSC {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(IsoSubspace);
 
-IsoSubspace::IsoSubspace(CString name, JSC::Heap& heap, const HeapCellType& heapCellType, size_t size, uint8_t numberOfLowerTierPreciseCells, std::unique_ptr<AlignedMemoryAllocator>&& allocator)
-    : Subspace(SubspaceKind::IsoSubspace, name, heap)
+IsoSubspace::IsoSubspace(CString name, JSC::Heap& heap, const HeapCellType& heapCellType, size_t size, uint8_t numberOfLowerTierPreciseCells, Ref<AlignedMemoryAllocator> allocator)
+    : Subspace(SubspaceKind::IsoSubspace, name, heap, WTFMove(allocator))
     , m_directory(WTF::roundUpToMultipleOf<MarkedBlock::atomSize>(size))
-    , m_allocator(allocator ? WTFMove(allocator) : makeUnique<FastMallocAlignedMemoryAllocator>())
 {
     m_remainingLowerTierPreciseCount = numberOfLowerTierPreciseCells;
     ASSERT(WTF::roundUpToMultipleOf<MarkedBlock::atomSize>(size) == cellSize());
     ASSERT(m_remainingLowerTierPreciseCount <= MarkedBlock::maxNumberOfLowerTierPreciseCells);
 
-    initialize(heapCellType, m_allocator.get());
+    initialize(heapCellType);
 
     Locker locker { m_space.directoryLock() };
     m_directory.setSubspace(this);

--- a/Source/JavaScriptCore/heap/IsoSubspace.h
+++ b/Source/JavaScriptCore/heap/IsoSubspace.h
@@ -43,7 +43,7 @@ class IsoSubspace;
 class IsoSubspace final : public Subspace {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(IsoSubspace, JS_EXPORT_PRIVATE);
 public:
-    JS_EXPORT_PRIVATE IsoSubspace(CString name, Heap&, const HeapCellType&, size_t, uint8_t numberOfLowerTierPreciseCells, std::unique_ptr<AlignedMemoryAllocator>&& = nullptr);
+    JS_EXPORT_PRIVATE IsoSubspace(CString name, Heap&, const HeapCellType&, size_t, uint8_t numberOfLowerTierPreciseCells, Ref<AlignedMemoryAllocator>);
     JS_EXPORT_PRIVATE ~IsoSubspace() final;
 
     size_t cellSize() { return m_directory.cellSize(); }
@@ -67,7 +67,6 @@ private:
     void didBeginSweepingToFreeList(MarkedBlock::Handle*) final;
 
     BlockDirectory m_directory;
-    std::unique_ptr<AlignedMemoryAllocator> m_allocator;
     SentinelLinkedList<PreciseAllocation, BasicRawSentinelNode<PreciseAllocation>> m_lowerTierPreciseFreeList;
     SentinelLinkedList<IsoCellSet, BasicRawSentinelNode<IsoCellSet>> m_cellSets;
 };
@@ -100,7 +99,7 @@ ALWAYS_INLINE Allocator IsoSubspace::allocatorFor(size_t size, AllocatorForMode)
 
 } // namespace GCClient
 
-#define ISO_SUBSPACE_INIT(heap, heapCellType, type) ("IsoSpace " #type ""_s, (heap), (heapCellType), sizeof(type), type::numberOfLowerTierPreciseCells)
+#define ISO_SUBSPACE_INIT(heap, heapCellType, type) ("IsoSpace " #type ""_s, (heap), (heapCellType), sizeof(type), type::numberOfLowerTierPreciseCells, (heap).fastMallocAllocator)
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/heap/MarkedBlockInlines.h
+++ b/Source/JavaScriptCore/heap/MarkedBlockInlines.h
@@ -290,6 +290,7 @@ void MarkedBlock::Handle::specializedSweep(FreeList* freeList, MarkedBlock::Hand
 
     auto setBits = [&] (bool isEmpty) ALWAYS_INLINE_LAMBDA {
         Locker locker { m_directory->bitvectorLock() };
+        bool wasUnswept = m_directory->isUnswept(this);
         m_directory->setIsUnswept(this, false);
         m_directory->setIsDestructible(this, m_attributes.destruction == DestructionMode::MayNeedDestruction && destructionMode != BlockHasNoDestructors && !isEmpty && m_directory->isDestructible(this));
         m_directory->setIsEmpty(this, false);
@@ -297,6 +298,7 @@ void MarkedBlock::Handle::specializedSweep(FreeList* freeList, MarkedBlock::Hand
             m_isFreeListed = true;
         else if (isEmpty)
             m_directory->setIsEmpty(this, true);
+        return wasUnswept;
     };
     UNUSED_PARAM(setBits);
 
@@ -320,12 +322,18 @@ void MarkedBlock::Handle::specializedSweep(FreeList* freeList, MarkedBlock::Hand
         char* payloadBegin = std::bit_cast<char*>(block.atoms() + m_startAtom);
         RELEASE_ASSERT(static_cast<size_t>(payloadEnd - payloadBegin) <= payloadSize, payloadBegin, payloadEnd, &block, cellSize, m_startAtom);
 
-        setBits(true);
+        bool wasUnswept = setBits(true);
         if (space()->isMarking())
             header.m_lock.unlock();
         if (destructionMode != BlockHasNoDestructors) {
-            for (char* cell = payloadBegin; cell < payloadEnd; cell += cellSize)
-                destroy(cell);
+            // If this block is empty and this block is already swept, then we do not need to sweep it again.
+            // When it is used for FreeList, FreeList will maintain newly allocated information / zapping.
+            // When it is not used yet, then it is kept empty and unswept, so this is fine.
+            // This happens when (1) the block is completely new or (2) incremental sweeper already swept it before and it becomes empty.
+            if (wasUnswept) {
+                for (char* cell = payloadBegin; cell < payloadEnd; cell += cellSize)
+                    destroy(cell);
+            }
         }
         if (sweepMode == SweepToFreeList) {
             if (scribbleMode == Scribble) [[unlikely]]

--- a/Source/JavaScriptCore/heap/PreciseSubspace.cpp
+++ b/Source/JavaScriptCore/heap/PreciseSubspace.cpp
@@ -36,10 +36,10 @@ namespace JSC {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PreciseSubspace);
 
-PreciseSubspace::PreciseSubspace(CString name, JSC::Heap& heap, const HeapCellType& heapCellType, AlignedMemoryAllocator* allocator)
-    : Subspace(SubspaceKind::PreciseSubspace, name, heap)
+PreciseSubspace::PreciseSubspace(CString name, JSC::Heap& heap, const HeapCellType& heapCellType, Ref<AlignedMemoryAllocator> allocator)
+    : Subspace(SubspaceKind::PreciseSubspace, name, heap, WTFMove(allocator))
 {
-    initialize(heapCellType, allocator);
+    initialize(heapCellType);
 }
 
 PreciseSubspace::~PreciseSubspace() = default;

--- a/Source/JavaScriptCore/heap/PreciseSubspace.h
+++ b/Source/JavaScriptCore/heap/PreciseSubspace.h
@@ -35,7 +35,7 @@ namespace JSC {
 class PreciseSubspace : public Subspace {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(PreciseSubspace, JS_EXPORT_PRIVATE);
 public:
-    JS_EXPORT_PRIVATE PreciseSubspace(CString name, Heap&, const HeapCellType&, AlignedMemoryAllocator*);
+    JS_EXPORT_PRIVATE PreciseSubspace(CString name, Heap&, const HeapCellType&, Ref<AlignedMemoryAllocator>);
     JS_EXPORT_PRIVATE ~PreciseSubspace() override;
 
     void* tryAllocate(size_t cellSize);

--- a/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.h
+++ b/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.h
@@ -36,8 +36,12 @@ namespace JSC {
 
 class StructureAlignedMemoryAllocator final : public AlignedMemoryAllocator {
 public:
-    StructureAlignedMemoryAllocator();
     ~StructureAlignedMemoryAllocator() final;
+
+    static Ref<StructureAlignedMemoryAllocator> create()
+    {
+        return adoptRef(*new StructureAlignedMemoryAllocator);
+    }
 
     void dump(PrintStream&) const final;
 
@@ -49,6 +53,9 @@ public:
     void freeAlignedMemory(void*) final;
 
     static void initializeStructureAddressSpace();
+
+private:
+    StructureAlignedMemoryAllocator();
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/heap/Subspace.cpp
+++ b/Source/JavaScriptCore/heap/Subspace.cpp
@@ -37,17 +37,17 @@ namespace JSC {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Subspace);
 
-Subspace::Subspace(SubspaceKind kind, CString name, JSC::Heap& heap)
+Subspace::Subspace(SubspaceKind kind, CString name, JSC::Heap& heap, Ref<AlignedMemoryAllocator>&& allocator)
     : m_space(heap.objectSpace())
+    , m_alignedMemoryAllocator(WTFMove(allocator))
     , m_kind(kind)
     , m_name(name)
 {
 }
 
-void Subspace::initialize(const HeapCellType& heapCellType, AlignedMemoryAllocator* alignedMemoryAllocator)
+void Subspace::initialize(const HeapCellType& heapCellType)
 {
     m_heapCellType = &heapCellType;
-    m_alignedMemoryAllocator = alignedMemoryAllocator;
     m_directoryForEmptyAllocation = m_alignedMemoryAllocator->firstDirectory();
 
     JSC::Heap& heap = m_space.heap();

--- a/Source/JavaScriptCore/heap/Subspace.h
+++ b/Source/JavaScriptCore/heap/Subspace.h
@@ -59,7 +59,7 @@ public:
 
     CellAttributes attributes() const;
     const HeapCellType* heapCellType() const { return m_heapCellType; }
-    AlignedMemoryAllocator* alignedMemoryAllocator() const { return m_alignedMemoryAllocator; }
+    AlignedMemoryAllocator* alignedMemoryAllocator() const { return m_alignedMemoryAllocator.ptr(); }
     
     void finishSweep(MarkedBlock::Handle&, FreeList*);
     void destroy(VM&, JSCell*);
@@ -110,14 +110,14 @@ public:
     bool isPreciseOnly() const { return kind() == SubspaceKind::PreciseSubspace; }
 
 protected:
-    Subspace(SubspaceKind, CString name, Heap&);
+    Subspace(SubspaceKind, CString name, Heap&, Ref<AlignedMemoryAllocator>&&);
 
-    void initialize(const HeapCellType&, AlignedMemoryAllocator*);
+    void initialize(const HeapCellType&);
     
     MarkedSpace& m_space;
     
     const HeapCellType* m_heapCellType { nullptr };
-    AlignedMemoryAllocator* m_alignedMemoryAllocator { nullptr };
+    const Ref<AlignedMemoryAllocator> m_alignedMemoryAllocator;
     
     BlockDirectory* m_firstDirectory { nullptr };
     BlockDirectory* m_directoryForEmptyAllocation { nullptr }; // Uses the MarkedSpace linked list of blocks.

--- a/Source/JavaScriptCore/runtime/DirectArguments.h
+++ b/Source/JavaScriptCore/runtime/DirectArguments.h
@@ -53,7 +53,7 @@ public:
     static CompleteSubspace* subspaceFor(VM& vm)
     {
         static_assert(CellType::needsDestruction == DoesNotNeedDestruction);
-        return &vm.variableSizedCellSpace();
+        return &vm.cellSpace();
     }
 
     // Creates an arguments object but leaves it uninitialized. This is dangerous if we GC right

--- a/Source/JavaScriptCore/runtime/JSLexicalEnvironment.h
+++ b/Source/JavaScriptCore/runtime/JSLexicalEnvironment.h
@@ -46,7 +46,7 @@ public:
     static CompleteSubspace* subspaceFor(VM& vm)
     {
         static_assert(CellType::needsDestruction == DoesNotNeedDestruction);
-        return &vm.variableSizedCellSpace();
+        return &vm.cellSpace();
     }
 
     using Base = JSSymbolTableObject;

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -414,7 +414,6 @@ public:
     ALWAYS_INLINE CompleteSubspace& immutableButterflyAuxiliarySpace() { return heap.immutableButterflyAuxiliarySpace; }
     ALWAYS_INLINE CompleteSubspace& gigacageAuxiliarySpace(Gigacage::Kind kind) { return heap.gigacageAuxiliarySpace(kind); }
     ALWAYS_INLINE CompleteSubspace& cellSpace() { return heap.cellSpace; }
-    ALWAYS_INLINE CompleteSubspace& variableSizedCellSpace() { return heap.variableSizedCellSpace; }
     ALWAYS_INLINE CompleteSubspace& destructibleObjectSpace() { return heap.destructibleObjectSpace; }
 #if ENABLE(WEBASSEMBLY)
     template<SubspaceAccess mode>

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
@@ -47,7 +47,7 @@ public:
     template<typename CellType, SubspaceAccess mode>
     static CompleteSubspace* subspaceFor(VM& vm)
     {
-        return &vm.heap.variableSizedCellSpace;
+        return &vm.cellSpace();
     }
 
     DECLARE_INFO;

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h
@@ -47,7 +47,7 @@ public:
     template<typename CellType, SubspaceAccess mode>
     static CompleteSubspace* subspaceFor(VM& vm)
     {
-        return &vm.heap.variableSizedCellSpace;
+        return &vm.cellSpace();
     }
 
     DECLARE_INFO;

--- a/Source/WebCore/bindings/js/WebCoreJSClientData.h
+++ b/Source/WebCore/bindings/js/WebCoreJSClientData.h
@@ -25,6 +25,7 @@
 #include "WebCoreBuiltinNames.h"
 #include "WebCoreJSBuiltins.h"
 #include "WorkerThreadType.h"
+#include <JavaScriptCore/FastMallocAlignedMemoryAllocator.h>
 #include <wtf/Function.h>
 #include <wtf/HashSet.h>
 #include <wtf/RefPtr.h>


### PR DESCRIPTION
#### edd7ee993e3d98aa50163477cc8842902bb9cb96
<pre>
[JSC] Use same allocator for Subspaces
<a href="https://bugs.webkit.org/show_bug.cgi?id=295029">https://bugs.webkit.org/show_bug.cgi?id=295029</a>
<a href="https://rdar.apple.com/154396224">rdar://154396224</a>

Reviewed by NOBODY (OOPS!).

This patch shares the same FastMallocAlignedMemoryAllocator between
IsoSubspaces so that we enable empty block stealing again.

* Source/JavaScriptCore/heap/AlignedMemoryAllocator.h:
* Source/JavaScriptCore/heap/CompleteSubspace.cpp:
(JSC::CompleteSubspace::CompleteSubspace):
* Source/JavaScriptCore/heap/CompleteSubspace.h:
* Source/JavaScriptCore/heap/FastMallocAlignedMemoryAllocator.h:
* Source/JavaScriptCore/heap/GigacageAlignedMemoryAllocator.h:
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::Heap):
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/heap/IsoSubspace.cpp:
(JSC::IsoSubspace::IsoSubspace):
* Source/JavaScriptCore/heap/IsoSubspace.h:
* Source/JavaScriptCore/heap/MarkedBlockInlines.h:
(JSC::MarkedBlock::Handle::specializedSweep):
* Source/JavaScriptCore/heap/PreciseSubspace.cpp:
(JSC::PreciseSubspace::PreciseSubspace):
* Source/JavaScriptCore/heap/PreciseSubspace.h:
* Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.h:
* Source/JavaScriptCore/heap/Subspace.cpp:
(JSC::Subspace::Subspace):
(JSC::Subspace::initialize):
* Source/JavaScriptCore/heap/Subspace.h:
(JSC::Subspace::alignedMemoryAllocator const):
* Source/JavaScriptCore/runtime/DirectArguments.h:
* Source/JavaScriptCore/runtime/JSLexicalEnvironment.h:
(JSC::JSLexicalEnvironment::subspaceFor):
* Source/JavaScriptCore/runtime/VM.h:
(JSC::VM::cellSpace):
(JSC::VM::variableSizedCellSpace): Deleted.
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h:
* Source/WebCore/bindings/js/WebCoreJSClientData.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/edd7ee993e3d98aa50163477cc8842902bb9cb96

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28928 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114476 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59536 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111233 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29609 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37517 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83043 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112218 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23569 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98419 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63493 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22958 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16563 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59103 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/101782 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92938 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16603 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117593 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/107828 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36312 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26873 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92059 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36684 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94681 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91870 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36789 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14543 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32143 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36209 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41696 "Found 2 new failures in heap/MarkedBlock.cpp, heap/MarkedBlock.h") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/132096 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35893 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35798 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39225 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37585 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->