### PR TITLE
Unreviewed, reverting 296663@main (21fdaf35464f)

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -855,12 +855,10 @@ void WebProcessPool::registerNotificationObservers()
     }];
 #if HAVE(SUPPORT_HDR_DISPLAY_APIS)
     m_didBeginSuppressingHighDynamicRange = [[NSNotificationCenter defaultCenter] addObserverForName:NSApplicationShouldBeginSuppressingHighDynamicRangeContentNotification object:NSApp queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
-        m_suppressEDR = true;
-        screenPropertiesChanged();
+        suppressEDR(true);
     }];
     m_didEndSuppressingHighDynamicRange = [[NSNotificationCenter defaultCenter] addObserverForName:NSApplicationShouldEndSuppressingHighDynamicRangeContentNotification object:NSApp queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
-        m_suppressEDR = false;
-        screenPropertiesChanged();
+        suppressEDR(false);
     }];
 #endif
 
@@ -1367,6 +1365,19 @@ void WebProcessPool::didRefreshDisplay()
 #endif
 }
 #endif
+
+void WebProcessPool::suppressEDR(bool suppressEDR)
+{
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    if (m_suppressEDR == suppressEDR)
+        return;
+
+    m_suppressEDR = suppressEDR;
+    screenPropertiesChanged();
+#else
+    UNUSED_PARAM(m_suppressEDR);
+#endif
+}
 
 #if ENABLE(EXTENSION_CAPABILITIES)
 ExtensionCapabilityGranter& WebProcessPool::extensionCapabilityGranter()

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2815,6 +2815,10 @@ Color WebPageProxy::underlayColor() const
 
 void WebPageProxy::setShouldSuppressHDR(bool shouldSuppressHDR)
 {
+#if PLATFORM(IOS_FAMILY)
+    Ref processPool = m_configuration->processPool();
+    processPool->suppressEDR(shouldSuppressHDR);
+#endif
     if (hasRunningProcess())
         send(Messages::WebPage::SetShouldSuppressHDR(shouldSuppressHDR));
 }

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -640,6 +640,7 @@ public:
 #if PLATFORM(IOS_FAMILY)
     void didRefreshDisplay();
 #endif
+    void suppressEDR(bool);
 
 private:
     enum class NeedsGlobalStaticInitialization : bool { No, Yes };


### PR DESCRIPTION
#### e3f69f980c96869b898746b48e612daaa57ebc42
<pre>
Unreviewed, reverting 296663@main (21fdaf35464f)
<a href="https://bugs.webkit.org/show_bug.cgi?id=295030">https://bugs.webkit.org/show_bug.cgi?id=295030</a>
<a href="https://rdar.apple.com/154396798">rdar://154396798</a>

Re-land 296657@main with member function guard removed

Reverted change:

    Unreviewed, reverting 296657@main.
    <a href="https://bugs.webkit.org/show_bug.cgi?id=295028">https://bugs.webkit.org/show_bug.cgi?id=295028</a>
    296663@main (21fdaf35464f)

Canonical link: <a href="https://commits.webkit.org/296670@main">https://commits.webkit.org/296670@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb34fcc47876199bec19a4d2d04a3d0f46974a82

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109254 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19340 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114461 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59524 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29594 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37501 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83028 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112202 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23552 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98402 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63478 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22944 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59086 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92920 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16587 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117577 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36298 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26860 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92043 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36670 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94665 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91852 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23388 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36775 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14527 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32131 "Hash bb34fcc4 for PR 47239 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36194 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41682 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35880 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39212 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37571 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->