### PR TITLE
Service Worker update requests have a malformed referer (referer: https:)

### DIFF
--- a/LayoutTests/http/wpt/service-workers/resources/soft-update-service-worker.py
+++ b/LayoutTests/http/wpt/service-workers/resources/soft-update-service-worker.py
@@ -1,0 +1,19 @@
+import json
+
+
+def main(request, response):
+    token = request.GET.first(b"token")
+    data = request.server.stash.take(token)
+    if not data:
+        data = ""
+
+    if b"get_referrer" in request.GET:
+        return 200, [(b"Content-Type", b"text/plain2")], data
+
+    request.server.stash.put(token, request.headers.get(b"Referer", None).decode("utf-8"))
+
+    headers = [(b"Content-Type", b"text/javascript"),
+               (b"Cache-Control", b"no-cache"),
+               (b"Pragma", b"no-cache")]
+
+    return 200, headers, u"onfetch = e => { }"

--- a/LayoutTests/http/wpt/service-workers/soft-update-referrer-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/soft-update-referrer-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Setup worker
+PASS Load iframe to do soft update
+

--- a/LayoutTests/http/wpt/service-workers/soft-update-referrer.html
+++ b/LayoutTests/http/wpt/service-workers/soft-update-referrer.html
@@ -1,0 +1,56 @@
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+</head>
+<body>
+<script>
+function with_iframe(url) {
+    return new Promise(function(resolve) {
+        var frame = document.createElement('iframe');
+        frame.className = 'test-iframe';
+        frame.src = url;
+        frame.onload = function() { resolve(frame); };
+        document.body.appendChild(frame);
+    });
+}
+
+const scriptURL = "resources/soft-update-service-worker.py?token=" + self.token();
+
+promise_test(async (test) => {
+    let registration = await navigator.serviceWorker.getRegistration("resources/");
+    if (registration)
+        await registration.unregister();
+    registration = await navigator.serviceWorker.register(scriptURL, { scope : "resources/" });
+    activeWorker = registration.active;
+    if (activeWorker)
+        return;
+    activeWorker = registration.installing;
+    await new Promise(resolve => {
+        activeWorker.addEventListener('statechange', () => {
+            if (activeWorker.state === "activated")
+                resolve();
+        });
+    });
+}, "Setup worker");
+
+promise_test(async (test) => {
+    let iframe = await with_iframe("resources/empty.html");
+    iframe.remove();
+
+    let counter = 0;
+    const expectedResult = window.location.origin + "/";
+    do {
+        await new Promise(resolve => setTimeout(resolve, 50));
+        const response = await fetch(scriptURL + "&get_referrer");
+        const text = await response.text();
+        if (text.length)
+            result = text;
+    } while (result != expectedResult && ++counter < 100);
+
+    assert_equals(result, expectedResult);
+}, "Load iframe to do soft update");
+</script>
+</body>
+</html>

--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -43,6 +43,7 @@
 #include "SWServerToContextConnection.h"
 #include "SWServerWorker.h"
 #include "SecurityOrigin.h"
+#include "SecurityPolicy.h"
 #include "ServiceWorkerClientType.h"
 #include "ServiceWorkerContextData.h"
 #include "ServiceWorkerJobData.h"
@@ -568,15 +569,6 @@ void SWServer::resolveUnregistrationJob(const ServiceWorkerJobData& jobData, con
     connection->resolveUnregistrationJobInClient(jobData.identifier().jobIdentifier, registrationKey, unregistrationResult);
 }
 
-URL static inline originURL(const SecurityOrigin& origin)
-{
-    URL url;
-    url.setProtocol(origin.protocol());
-    url.setHost(origin.host());
-    url.setPort(origin.port());
-    return url;
-}
-
 ResourceRequest SWServer::createScriptRequest(const URL& url, const ServiceWorkerJobData& jobData, SWServerRegistration& registration)
 {
     ResourceRequest request { URL { url } };
@@ -589,7 +581,7 @@ ResourceRequest SWServer::createScriptRequest(const URL& url, const ServiceWorke
     request.setFirstPartyForCookies(topOrigin->toURL());
 
     request.setHTTPHeaderField(HTTPHeaderName::Origin, origin->toString());
-    request.setHTTPReferrer(originURL(origin).string());
+    request.setHTTPReferrer(SecurityPolicy::referrerToOriginString(jobData.scriptURL));
     request.setHTTPUserAgent(serviceWorkerClientUserAgent(ClientOrigin { jobData.topOrigin, SecurityOrigin::create(jobData.scriptURL)->data() }));
     request.setPriority(ResourceLoadPriority::Low);
     request.setIsAppInitiated(registration.isAppInitiated());

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5307,7 +5307,6 @@
 		3AA994092B0B15CD00253533 /* WKExtrinsicButton.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKExtrinsicButton.h; path = ios/WKExtrinsicButton.h; sourceTree = "<group>"; };
 		3AA9940A2B0B15CE00253533 /* WKExtrinsicButton.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKExtrinsicButton.mm; path = ios/WKExtrinsicButton.mm; sourceTree = "<group>"; };
 		3AC4C04529D35D1500402716 /* WebSWRegistrationStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebSWRegistrationStore.h; sourceTree = "<group>"; };
-		3AC4C04629D35D1B00402716 /* ServiceWorker */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ServiceWorker; sourceTree = "<group>"; };
 		3AC6E5242A1C59AE0059F092 /* RemoteGraphicsContextGLInitializationState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteGraphicsContextGLInitializationState.h; sourceTree = "<group>"; };
 		3AE104BD29CBC8BA00661165 /* OriginQuotaManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OriginQuotaManager.cpp; sourceTree = "<group>"; };
 		3AE104BE29CBC8BB00661165 /* OriginQuotaManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OriginQuotaManager.h; sourceTree = "<group>"; };
@@ -14167,7 +14166,6 @@
 		93BA04D92151ADCD007F455F /* ServiceWorker */ = {
 			isa = PBXGroup;
 			children = (
-				3AC4C04629D35D1B00402716 /* ServiceWorker */,
 				41FFD2DA275A560B00501BBF /* ServiceWorkerDownloadTask.cpp */,
 				41FFD2DB275A560C00501BBF /* ServiceWorkerDownloadTask.h */,
 				41FFD2DC275A6A9400501BBF /* ServiceWorkerDownloadTask.messages.in */,


### PR DESCRIPTION
#### 7a0a88ad50affa5fe9f39629ad19bc0e7362a116
<pre>
Service Worker update requests have a malformed referer (referer: https:)
<a href="https://rdar.apple.com/154364616">rdar://154364616</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=294715">https://bugs.webkit.org/show_bug.cgi?id=294715</a>

Reviewed by Brady Eidson.

SWServer::createScriptRequest is using URL to create a valid referer but this does not give the expected result.
Instead reuse an existing routine to generate a referrer from an URL.

* LayoutTests/http/wpt/service-workers/resources/soft-update-service-worker.py: Added.
(main):
* LayoutTests/http/wpt/service-workers/soft-update-referrer-expected.txt: Added.
* LayoutTests/http/wpt/service-workers/soft-update-referrer.html: Added.
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::createScriptRequest):
(WebCore::originURL): Deleted.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/296710@main">https://commits.webkit.org/296710@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f20d6620541bf985d5320363fca21f55c7716cc0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28913 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19341 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114462 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59525 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111218 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29595 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37502 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83029 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112203 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23553 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98403 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63479 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22942 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16548 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59087 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92921 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16588 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117578 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36299 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26857 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92042 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36671 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94666 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91851 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23414 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36777 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14528 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32132 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36195 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41683 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35881 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39213 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37572 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->