### PR TITLE
Address recent Safer CPP regressions

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -116,7 +116,6 @@ platform/mediastream/libwebrtc/LibWebRTCDav1dDecoder.cpp
 platform/mediastream/mac/CoreAudioSharedUnit.h
 platform/network/cocoa/CredentialCocoa.h
 platform/network/cocoa/ProtectionSpaceCocoa.h
-platform/network/mac/FormDataStreamMac.mm
 rendering/AccessibilityRegionContext.h
 rendering/BreakLines.h
 rendering/RenderLayerBacking.cpp

--- a/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
@@ -52,7 +52,6 @@ platform/graphics/ca/TileCoverageMap.h
 platform/mac/VideoPresentationInterfaceMac.mm
 platform/mock/DeviceOrientationClientMock.h
 rendering/BackgroundPainter.h
-rendering/BidiRun.h
 rendering/GlyphDisplayListCache.cpp
 rendering/GridTrackSizingAlgorithm.h
 rendering/ImageQualityController.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1044,7 +1044,6 @@ style/Styleable.cpp
 style/Styleable.h
 style/TransformOperationsBuilder.cpp
 style/UserAgentStyle.cpp
-style/values/svg/StyleSVGPaint.cpp
 style/values/transforms/StyleRotate.cpp
 style/values/transforms/StyleScale.cpp
 style/values/transforms/StyleTranslate.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -275,7 +275,6 @@ html/PluginDocument.cpp
 html/ValidatedFormListedElement.cpp
 html/canvas/CanvasRenderingContext2D.cpp
 html/canvas/CanvasRenderingContext2DBase.cpp
-html/canvas/ImageBitmapRenderingContext.cpp
 html/canvas/OffscreenCanvasRenderingContext2D.cpp
 html/parser/HTMLConstructionSite.cpp
 html/shadow/DateTimeEditElement.cpp
@@ -451,7 +450,6 @@ rendering/RenderLayerFilters.cpp
 rendering/RenderLayerModelObject.cpp
 rendering/RenderListBox.cpp
 rendering/RenderListItem.cpp
-rendering/RenderListMarker.cpp
 rendering/RenderMenuList.cpp
 rendering/RenderObject.cpp
 rendering/RenderProgress.cpp

--- a/Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp
@@ -56,12 +56,12 @@ ImageBitmapRenderingContext::~ImageBitmapRenderingContext() = default;
 
 ImageBitmapCanvas ImageBitmapRenderingContext::canvas()
 {
-    auto& base = canvasBase();
+    WeakRef base = canvasBase();
 #if ENABLE(OFFSCREEN_CANVAS)
-    if (auto* offscreenCanvas = dynamicDowncast<OffscreenCanvas>(base))
+    if (RefPtr offscreenCanvas = dynamicDowncast<OffscreenCanvas>(base.get()))
         return offscreenCanvas;
 #endif
-    return &downcast<HTMLCanvasElement>(base);
+    return &downcast<HTMLCanvasElement>(base.get());
 }
 
 void ImageBitmapRenderingContext::setOutputBitmap(RefPtr<ImageBitmap> imageBitmap)

--- a/Source/WebCore/platform/network/mac/FormDataStreamMac.mm
+++ b/Source/WebCore/platform/network/mac/FormDataStreamMac.mm
@@ -29,6 +29,7 @@
 #import "config.h"
 #import "FormDataStreamMac.h"
 
+#import "FormData.h"
 #import "FormDataStreamCFNet.h"
 #import <pal/spi/cf/CFNetworkSPI.h>
 

--- a/Source/WebCore/rendering/BidiRun.h
+++ b/Source/WebCore/rendering/BidiRun.h
@@ -46,7 +46,7 @@ public:
     void setBox(LegacyInlineBox* box) { m_box = box; }
 
 private:
-    RenderObject& m_renderer;
+    CheckedRef<RenderObject> m_renderer;
     LegacyInlineBox* m_box;
 };
 

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -508,8 +508,8 @@ std::pair<int, int> RenderListMarker::layoutBoundForTextContent(String text) con
     if (style.lineHeight().isNormal()) {
         auto maxAscentAndDescent = ascentAndDescent(metricsOfPrimaryFont);
 
-        for (auto& fallbackFont : Layout::TextUtil::fallbackFontsForText(text, style, Layout::TextUtil::IncludeHyphen::No)) {
-            auto& fontMetrics = fallbackFont.fontMetrics();
+        for (Ref fallbackFont : Layout::TextUtil::fallbackFontsForText(text, style, Layout::TextUtil::IncludeHyphen::No)) {
+            auto& fontMetrics = fallbackFont->fontMetrics();
             if (primaryFontHeight >= floorf(fontMetrics.height())) {
                 // FIXME: Figure out why certain symbols (e.g. disclosure-open) would initiate fallback fonts with just slightly different (subpixel) metrics.
                 // This is mainly about preserving legacy behavior.

--- a/Source/WebCore/style/values/svg/StyleSVGPaint.cpp
+++ b/Source/WebCore/style/values/svg/StyleSVGPaint.cpp
@@ -42,7 +42,7 @@ auto CSSValueConversion<SVGPaint>::operator()(BuilderState& state, const CSSValu
     // <paint> = none | <color> | <url> [none | <color>]? 
 
     if (RefPtr list = dynamicDowncast<CSSValueList>(value)) {
-        RefPtr firstValue = list->protectedItem(0);
+        RefPtr firstValue = list->item(0);
         RefPtr urlValue = requiredDowncast<CSSURLValue>(state, *firstValue);
         if (!urlValue) {
             return {
@@ -61,7 +61,7 @@ auto CSSValueConversion<SVGPaint>::operator()(BuilderState& state, const CSSValu
             };
         }
 
-        RefPtr secondItem = list->protectedItem(1);
+        RefPtr secondItem = list->item(1);
         if (RefPtr primitiveValue = dynamicDowncast<const CSSPrimitiveValue>(secondItem)) {
             switch (primitiveValue->valueID()) {
             case CSSValueNone:
@@ -85,7 +85,7 @@ auto CSSValueConversion<SVGPaint>::operator()(BuilderState& state, const CSSValu
         return {
             .type = SVGPaintType::URIRGBColor,
             .url = WTFMove(url),
-            .color = toStyleFromCSSValue<Color>(state, *list->item(1), forVisitedLink)
+            .color = toStyleFromCSSValue<Color>(state, *list->protectedItem(1), forVisitedLink)
         };
     }
 


### PR DESCRIPTION
#### 12457977bdd9e259b6fb4ced82654951c802a3d6
<pre>
Address recent Safer CPP regressions
<a href="https://bugs.webkit.org/show_bug.cgi?id=295033">https://bugs.webkit.org/show_bug.cgi?id=295033</a>

Reviewed by Ryosuke Niwa.

Incidentally also fixes redundant uses of the protectedX() idiom.

* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp:
(WebCore::ImageBitmapRenderingContext::canvas):
* Source/WebCore/platform/network/mac/FormDataStreamMac.mm:
* Source/WebCore/rendering/BidiRun.h:
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::RenderListMarker::layoutBoundForTextContent const):
* Source/WebCore/style/values/svg/StyleSVGPaint.cpp:
(WebCore::Style::CSSValueConversion&lt;SVGPaint&gt;::operator):

Canonical link: <a href="https://commits.webkit.org/296750@main">https://commits.webkit.org/296750@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2302ee74bd6aaed247e47c5ff27fd8a32f8ea4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109454 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19541 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114659 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59682 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111417 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29791 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37700 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83192 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112402 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23730 "Found 2 new test failures: fast/filter-image/clipped-filter.html media/video-unmuted-after-play-holds-sleep-assertion.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98586 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63652 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23111 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16728 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59278 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93100 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16770 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117773 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36495 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27020 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92202 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36866 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94847 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92018 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23437 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36953 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14696 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32298 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36388 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41863 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36058 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39397 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37762 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->