### PR TITLE
[iOS 26] Using AutoFill in a password field echoes the last character

### DIFF
--- a/LayoutTests/editing/input/untrusted-textevent-does-not-echo-password-expected.html
+++ b/LayoutTests/editing/input/untrusted-textevent-does-not-echo-password-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+    <input style="font-size: 20px;" type="password" value="hello">
+</body>
+</html>

--- a/LayoutTests/editing/input/untrusted-textevent-does-not-echo-password.html
+++ b/LayoutTests/editing/input/untrusted-textevent-does-not-echo-password.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+    input {
+        caret-color: transparent;
+        outline: none;
+    }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+</head>
+<head>
+    <script>
+    window.testRunner?.waitUntilDone();
+    window.internals?.settings.setPasswordEchoEnabled(true);
+    addEventListener("load", async () => {
+        await UIHelper.setHardwareKeyboardAttached(false);
+        await UIHelper.ensurePresentationUpdate();
+        let input = document.querySelector("input");
+        input.focus();
+        [..."hello"].map(letter => {
+            const event = document.createEvent("TextEvent");
+            event.initTextEvent("textInput", true, true, null, letter);
+            input.dispatchEvent(event);
+        });
+        window.testRunner?.notifyDone();
+    });
+    </script>
+</head>
+<body>
+    <input style="font-size: 20px;" type="password">
+</body>
+</html>

--- a/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -746,7 +746,7 @@ void CompositeEditCommand::inputText(const String& text, bool selectInsertedText
         newline = text.find('\n', offset);
         if (newline != offset) {
             int substringLength = newline == notFound ? length - offset : newline - offset;
-            applyCommandToComposite(InsertTextCommand::create(document(), text.substring(offset, substringLength), false));
+            applyCommandToComposite(InsertTextCommand::create(document(), text.substring(offset, substringLength), AllowPasswordEcho::Yes, false));
         }
         if (newline != notFound) {
             VisiblePosition caret(endingSelection().visibleStart());
@@ -773,10 +773,10 @@ void CompositeEditCommand::inputText(const String& text, bool selectInsertedText
         setEndingSelection(VisibleSelection(visiblePositionForIndex(startIndex, scope.get()), visiblePositionForIndex(startIndex + length, scope.get())));
 }
 
-void CompositeEditCommand::insertTextIntoNode(Text& node, unsigned offset, const String& text)
+void CompositeEditCommand::insertTextIntoNode(Text& node, unsigned offset, const String& text, AllowPasswordEcho allowPasswordEcho)
 {
     if (!text.isEmpty())
-        applyCommandToComposite(InsertIntoTextNodeCommand::create(node, offset, text, editingAction()));
+        applyCommandToComposite(InsertIntoTextNodeCommand::create(node, offset, text, allowPasswordEcho, editingAction()));
 }
 
 void CompositeEditCommand::deleteTextFromNode(Text& node, unsigned offset, unsigned count)
@@ -784,11 +784,11 @@ void CompositeEditCommand::deleteTextFromNode(Text& node, unsigned offset, unsig
     applyCommandToComposite(DeleteFromTextNodeCommand::create(node, offset, count, editingAction()));
 }
 
-void CompositeEditCommand::replaceTextInNode(Text& node, unsigned offset, unsigned count, const String& replacementText)
+void CompositeEditCommand::replaceTextInNode(Text& node, unsigned offset, unsigned count, const String& replacementText, AllowPasswordEcho allowPasswordEcho)
 {
     applyCommandToComposite(DeleteFromTextNodeCommand::create(node, offset, count));
     if (!replacementText.isEmpty())
-        applyCommandToComposite(InsertIntoTextNodeCommand::create(node, offset, replacementText, editingAction()));
+        applyCommandToComposite(InsertIntoTextNodeCommand::create(node, offset, replacementText, allowPasswordEcho, editingAction()));
 }
 
 Position CompositeEditCommand::replaceSelectedTextInNode(const String& text)

--- a/Source/WebCore/editing/CompositeEditCommand.h
+++ b/Source/WebCore/editing/CompositeEditCommand.h
@@ -168,7 +168,7 @@ protected:
     void insertParagraphSeparatorAtPosition(const Position&, bool useDefaultParagraphElement = false, bool pasteBlockqutoeIntoUnquotedArea = false);
     void insertParagraphSeparator(bool useDefaultParagraphElement = false, bool pasteBlockqutoeIntoUnquotedArea = false);
     void insertLineBreak();
-    void insertTextIntoNode(Text&, unsigned offset, const String& text);
+    void insertTextIntoNode(Text&, unsigned offset, const String& text, AllowPasswordEcho = AllowPasswordEcho::Yes);
     void mergeIdenticalElements(Element&, Element&);
     void rebalanceWhitespace();
     void rebalanceWhitespaceAt(const Position&);
@@ -186,7 +186,7 @@ protected:
     void moveRemainingSiblingsToNewParent(Node*, Node* pastLastNodeToMove, Element& newParent);
     void updatePositionForNodeRemovalPreservingChildren(Position&, Node&);
     void prune(Node*);
-    void replaceTextInNode(Text&, unsigned offset, unsigned count, const String& replacementText);
+    void replaceTextInNode(Text&, unsigned offset, unsigned count, const String& replacementText, AllowPasswordEcho = AllowPasswordEcho::Yes);
     Position replaceSelectedTextInNode(const String&);
     void replaceTextInNodePreservingMarkers(Text&, unsigned offset, unsigned count, const String& replacementText);
     Position positionOutsideTabSpan(const Position&);

--- a/Source/WebCore/editing/EditCommand.h
+++ b/Source/WebCore/editing/EditCommand.h
@@ -45,6 +45,8 @@ bool isInputMethodComposingForEditingAction(EditAction);
 
 using NodeSet = UncheckedKeyHashSet<Ref<Node>>;
 
+enum class AllowPasswordEcho : bool { No, Yes };
+
 class EditCommand : public RefCounted<EditCommand> {
 public:
     virtual ~EditCommand();

--- a/Source/WebCore/editing/InsertIntoTextNodeCommand.h
+++ b/Source/WebCore/editing/InsertIntoTextNodeCommand.h
@@ -33,15 +33,15 @@ class Text;
 
 class InsertIntoTextNodeCommand : public SimpleEditCommand {
 public:
-    static Ref<InsertIntoTextNodeCommand> create(Ref<Text>&& node, unsigned offset, const String& text, EditAction editingAction = EditAction::Insert)
+    static Ref<InsertIntoTextNodeCommand> create(Ref<Text>&& node, unsigned offset, const String& text, AllowPasswordEcho allowPasswordEcho = AllowPasswordEcho::Yes, EditAction editingAction = EditAction::Insert)
     {
-        return adoptRef(*new InsertIntoTextNodeCommand(WTFMove(node), offset, text, editingAction));
+        return adoptRef(*new InsertIntoTextNodeCommand(WTFMove(node), offset, text, allowPasswordEcho, editingAction));
     }
 
     const String& insertedText();
 
 protected:
-    InsertIntoTextNodeCommand(Ref<Text>&& node, unsigned offset, const String& text, EditAction editingAction);
+    InsertIntoTextNodeCommand(Ref<Text>&& node, unsigned offset, const String& text, AllowPasswordEcho, EditAction editingAction);
 
 private:
     void doApply() override;
@@ -51,10 +51,13 @@ private:
 #ifndef NDEBUG
     void getNodesInCommand(NodeSet&) override;
 #endif
+
+    bool shouldEnablePasswordEcho() const;
     
     const Ref<Text> m_node;
     unsigned m_offset;
     String m_text;
+    AllowPasswordEcho m_allowPasswordEcho { AllowPasswordEcho::Yes };
 };
 
 inline const String& InsertIntoTextNodeCommand::insertedText()

--- a/Source/WebCore/editing/InsertTextCommand.cpp
+++ b/Source/WebCore/editing/InsertTextCommand.cpp
@@ -39,9 +39,10 @@
 
 namespace WebCore {
 
-InsertTextCommand::InsertTextCommand(Ref<Document>&& document, const String& text, bool selectInsertedText, RebalanceType rebalanceType, EditAction editingAction)
+InsertTextCommand::InsertTextCommand(Ref<Document>&& document, const String& text, AllowPasswordEcho allowPasswordEcho, bool selectInsertedText, RebalanceType rebalanceType, EditAction editingAction)
     : CompositeEditCommand(WTFMove(document), editingAction)
     , m_text(text)
+    , m_allowPasswordEcho(allowPasswordEcho)
     , m_selectInsertedText(selectInsertedText)
     , m_rebalanceType(rebalanceType)
 {
@@ -208,7 +209,7 @@ void InsertTextCommand::doApply()
         RefPtr<Text> textNode = startPosition.containerText();
         const unsigned offset = startPosition.offsetInContainerNode();
 
-        insertTextIntoNode(*textNode, offset, m_text);
+        insertTextIntoNode(*textNode, offset, m_text, m_allowPasswordEcho);
         endPosition = Position(textNode.get(), offset + m_text.length());
         if (m_markerSupplier)
             m_markerSupplier->addMarkersToTextNode(*textNode, offset, m_text);

--- a/Source/WebCore/editing/InsertTextCommand.h
+++ b/Source/WebCore/editing/InsertTextCommand.h
@@ -47,10 +47,10 @@ public:
         RebalanceAllWhitespaces
     };
 
-    static Ref<InsertTextCommand> create(Ref<Document>&& document, const String& text, bool selectInsertedText = false,
-        RebalanceType rebalanceType = RebalanceLeadingAndTrailingWhitespaces, EditAction editingAction = EditAction::Insert)
+    static Ref<InsertTextCommand> create(Ref<Document>&& document, const String& text, AllowPasswordEcho allowPasswordEcho
+        , bool selectInsertedText = false, RebalanceType rebalanceType = RebalanceLeadingAndTrailingWhitespaces, EditAction editingAction = EditAction::Insert)
     {
-        return adoptRef(*new InsertTextCommand(WTFMove(document), text, selectInsertedText, rebalanceType, editingAction));
+        return adoptRef(*new InsertTextCommand(WTFMove(document), text, allowPasswordEcho, selectInsertedText, rebalanceType, editingAction));
     }
 
     static Ref<InsertTextCommand> createWithMarkerSupplier(Ref<Document>&& document, const String& text, Ref<TextInsertionMarkerSupplier>&& markerSupplier, EditAction editingAction = EditAction::Insert)
@@ -60,7 +60,7 @@ public:
 
 protected:
     InsertTextCommand(Ref<Document>&&, const String& text, Ref<TextInsertionMarkerSupplier>&&, EditAction);
-    InsertTextCommand(Ref<Document>&&, const String& text, bool selectInsertedText, RebalanceType, EditAction);
+    InsertTextCommand(Ref<Document>&&, const String& text, AllowPasswordEcho, bool selectInsertedText, RebalanceType, EditAction);
 
 private:
 
@@ -78,6 +78,7 @@ private:
     friend class TypingCommand;
 
     String m_text;
+    AllowPasswordEcho m_allowPasswordEcho { AllowPasswordEcho::Yes };
     bool m_selectInsertedText;
     RebalanceType m_rebalanceType;
     RefPtr<TextInsertionMarkerSupplier> m_markerSupplier;

--- a/Source/WebCore/editing/TypingCommand.cpp
+++ b/Source/WebCore/editing/TypingCommand.cpp
@@ -556,8 +556,9 @@ void TypingCommand::insertTextRunWithoutNewlines(const String& text, bool select
     if (!willAddTypingToOpenCommand(Type::InsertText, TextGranularity::CharacterGranularity, text))
         return;
 
-    auto command = InsertTextCommand::create(document(), text, selectInsertedText,
-        m_compositionType == TextCompositionType::None ? InsertTextCommand::RebalanceLeadingAndTrailingWhitespaces : InsertTextCommand::RebalanceAllWhitespaces, EditAction::TypingInsertText);
+    auto allowPasswordEcho = triggeringEventIsUntrusted() ? AllowPasswordEcho::No : AllowPasswordEcho::Yes;
+    auto rebalanceWhitespaces = m_compositionType == TextCompositionType::None ? InsertTextCommand::RebalanceLeadingAndTrailingWhitespaces : InsertTextCommand::RebalanceAllWhitespaces;
+    auto command = InsertTextCommand::create(document(), text, allowPasswordEcho, selectInsertedText, rebalanceWhitespaces, EditAction::TypingInsertText);
 
     applyCommandToComposite(WTFMove(command), endingSelection());
     typingAddedToOpenCommand(Type::InsertText);


### PR DESCRIPTION
#### 84f5cba186ee78db4d9a484d2a327d463d207124
<pre>
[iOS 26] Using AutoFill in a password field echoes the last character
<a href="https://bugs.webkit.org/show_bug.cgi?id=295032">https://bugs.webkit.org/show_bug.cgi?id=295032</a>
<a href="https://rdar.apple.com/148549180">rdar://148549180</a>

Reviewed by Abrar Rahman Protyasha and Ryosuke Niwa.

Safari AutoFill in macOS Tahoe / iOS 26 now creates and dispatches `TextEvent`s to simulate user
input. While this more closely simulates some typing behaviors (and improves compatibility on some
websites), it also has the byproduct of triggering password echo on iOS (flashing the last typed
character in a password field).

Fix this by not echoing the last character in a password field, when the triggering text event is
untrusted. See below for more details.

* LayoutTests/editing/input/untrusted-textevent-does-not-echo-password-expected.html: Added.
* LayoutTests/editing/input/untrusted-textevent-does-not-echo-password.html: Added.

Add a layout test to exercise the change by verifying that the password does not echo when creating
and dispatching TextEvents in a password field. This test simply ref&apos;s against a password field with
a `value` attribute set to the same string.

* Source/WebCore/editing/CompositeEditCommand.cpp:
(WebCore::CompositeEditCommand::inputText):
(WebCore::CompositeEditCommand::insertTextIntoNode):
(WebCore::CompositeEditCommand::replaceTextInNode):

Add more plumbing for the `AllowPasswordEcho` flag.

* Source/WebCore/editing/CompositeEditCommand.h:
* Source/WebCore/editing/EditCommand.h:

Add a new enum type, representing whether or not we should allow password echo when inserting text.
This enum is plumbed from `TypingCommand` -&gt; `InsertTextCommand` -&gt; `InsertIntoTextNodeCommand` when
typing, and finally checked in `InsertIntoTextNodeCommand::shouldEnablePasswordEcho`.

* Source/WebCore/editing/InsertIntoTextNodeCommand.cpp:
(WebCore::InsertIntoTextNodeCommand::InsertIntoTextNodeCommand):
(WebCore::InsertIntoTextNodeCommand::shouldEnablePasswordEcho const):

Pull this logic out into a private helper method, for better readability.

(WebCore::InsertIntoTextNodeCommand::doApply):
* Source/WebCore/editing/InsertIntoTextNodeCommand.h:

Store the `AllowPasswordEcho` flag as a member.

(WebCore::InsertIntoTextNodeCommand::create):
* Source/WebCore/editing/InsertTextCommand.cpp:
(WebCore::InsertTextCommand::InsertTextCommand):
(WebCore::InsertTextCommand::doApply):

Plumb the `AllowPasswordEcho` state into `InsertIntoTextNodeCommand`.

* Source/WebCore/editing/InsertTextCommand.h:

Store the `AllowPasswordEcho` flag as a member.

(WebCore::InsertTextCommand::create):
* Source/WebCore/editing/TypingCommand.cpp:
(WebCore::TypingCommand::insertTextRunWithoutNewlines):

Plumb the value of `AllowPasswordEcho` into `InsertTextCommand` when typing; this value is derived
from `triggeringEventIsUntrusted()`, which is in turn derived from whether or not the dispatched
text event is trusted.

Canonical link: <a href="https://commits.webkit.org/296673@main">https://commits.webkit.org/296673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2f519223cd685ae61a048e09e93526c4bee3bf3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109268 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28926 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114474 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59534 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111231 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29607 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37515 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83037 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112216 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23565 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98418 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63487 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22954 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16562 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59101 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92934 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16602 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117591 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36310 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26868 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92053 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36682 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94680 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91864 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23390 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36784 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14542 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32141 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36207 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41694 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35891 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39223 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37583 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->