### PR TITLE
REGRESSION (279702@main): Incorrect use of sizeof() in checkJSStringOOBUTF8() from testapi.c

### DIFF
--- a/Source/JavaScriptCore/API/tests/testapi.c
+++ b/Source/JavaScriptCore/API/tests/testapi.c
@@ -1192,42 +1192,48 @@ void JSSynchronousGarbageCollectForDebugging(JSContextRef);
 static void checkJSStringOOBUTF8(void)
 {
     const size_t sourceCStringSize = 200;
-    const size_t outCStringSize = 10;
+    const size_t cStringSize = 10;
+    const size_t outCStringSize = cStringSize + sourceCStringSize;
 
-    char* sourceCString = (char*)malloc(sourceCStringSize);
-    memset(sourceCString, 0, sourceCStringSize);
+IGNORE_WARNINGS_BEGIN("vla")
+    char sourceCString[sourceCStringSize];
+IGNORE_WARNINGS_END
+    memset(sourceCString, 0, sizeof(sourceCString));
     for (size_t i = 0; i < sourceCStringSize - 1; ++i)
         sourceCString[i] = '0' + (i%10);
 
-    char* outCString = (char*)malloc(outCStringSize + sourceCStringSize);
-    memset(outCString, 0x13, outCStringSize + sourceCStringSize);
+IGNORE_WARNINGS_BEGIN("vla")
+    char outCString[outCStringSize];
+IGNORE_WARNINGS_END
+    memset(outCString, 0x13, sizeof(outCString));
 
     JSStringRef str = JSStringCreateWithUTF8CString(sourceCString);
-    size_t bytesWritten = JSStringGetUTF8CString(str, outCString, outCStringSize);
+    size_t bytesWritten = JSStringGetUTF8CString(str, outCString, cStringSize);
 
     assertTrue(bytesWritten == 10, "we report 10 bytes written precisely");
 
     for (size_t i = 0; i < sizeof(outCString); ++i) {
-        if (i == outCStringSize - 1)
+        if (i == cStringSize - 1)
             assertTrue(outCString[i] == '\0', "string terminated");
-        else if (i < outCStringSize - 1)
+        else if (i < cStringSize - 1)
             assertTrue(outCString[i] == sourceCString[i], "string copied");
         else
             assertTrue(outCString[i] == 0x13, "did not write past the end");
     }
 
     JSStringRelease(str);
-    free(outCString);
-    free(sourceCString);
 }
 
 static void checkJSStringOOBUTF16(void)
 {
     const size_t sourceCStringSize = 22;
-    const size_t outCStringSize = 20;
+    const size_t cStringSize = 20;
+    const size_t outCStringSize = cStringSize + sourceCStringSize;
 
-    char* sourceCString = (char*)malloc(sourceCStringSize);
-    memset(sourceCString, 0, sourceCStringSize);
+IGNORE_WARNINGS_BEGIN("vla")
+    char sourceCString[sourceCStringSize];
+IGNORE_WARNINGS_END
+    memset(sourceCString, 0, sizeof(sourceCString));
     for (size_t i = 0; i < sourceCStringSize - 1; ++i)
         sourceCString[i] = '0' + (i%10);
 
@@ -1236,35 +1242,38 @@ static void checkJSStringOOBUTF16(void)
     sourceCString[5] = '\x98';
     sourceCString[6] = '\x81';
 
-    char* outCString = (char*)malloc(outCStringSize + sourceCStringSize);
-    memset(outCString, 0x13, outCStringSize + sourceCStringSize);
+IGNORE_WARNINGS_BEGIN("vla")
+    char outCString[outCStringSize];
+IGNORE_WARNINGS_END
+    memset(outCString, 0x13, sizeof(outCString));
 
     JSStringRef str = JSStringCreateWithUTF8CString(sourceCString);
-    size_t bytesWritten = JSStringGetUTF8CString(str, outCString, outCStringSize);
+    size_t bytesWritten = JSStringGetUTF8CString(str, outCString, cStringSize);
 
     assertTrue(bytesWritten == 20, "we report 20 bytes written precisely");
 
     for (size_t i = 0; i < sizeof(outCString); ++i) {
-        if (i == outCStringSize - 1)
+        if (i == cStringSize - 1)
             assertTrue(outCString[i] == '\0', "string terminated");
-        else if (i < outCStringSize - 1)
+        else if (i < cStringSize - 1)
             assertTrue(outCString[i] == sourceCString[i], "string copied");
         else
             assertTrue(outCString[i] == 0x13, "did not write past the end");
     }
 
     JSStringRelease(str);
-    free(outCString);
-    free(sourceCString);
 }
 
 static void checkJSStringOOBUTF16AtEnd(void)
 {
     const size_t sourceCStringSize = 22;
-    const size_t outCStringSize = 20;
+    const size_t cStringSize = 20;
+    const size_t outCStringSize = cStringSize + sourceCStringSize;
 
-    char* sourceCString = (char*)malloc(sourceCStringSize);
-    memset(sourceCString, 0, sourceCStringSize);
+IGNORE_WARNINGS_BEGIN("vla")
+    char sourceCString[sourceCStringSize];
+IGNORE_WARNINGS_END
+    memset(sourceCString, 0, sizeof(sourceCString));
     for (size_t i = 0; i < sourceCStringSize - 1; ++i)
         sourceCString[i] = '0' + (i%10);
 
@@ -1273,11 +1282,13 @@ static void checkJSStringOOBUTF16AtEnd(void)
     sourceCString[19] = '\x98';
     sourceCString[20] = '\x81';
 
-    char* outCString = (char*)malloc(outCStringSize + sourceCStringSize);
-    memset(outCString, 0x13, outCStringSize + sourceCStringSize);
+IGNORE_WARNINGS_BEGIN("vla")
+    char outCString[outCStringSize];
+IGNORE_WARNINGS_END
+    memset(outCString, 0x13, sizeof(outCString));
 
     JSStringRef str = JSStringCreateWithUTF8CString(sourceCString);
-    size_t bytesWritten = JSStringGetUTF8CString(str, outCString, outCStringSize);
+    size_t bytesWritten = JSStringGetUTF8CString(str, outCString, cStringSize);
 
     assertTrue(bytesWritten == 18, "we report 18 bytes written precisely");
 
@@ -1291,8 +1302,6 @@ static void checkJSStringOOBUTF16AtEnd(void)
     }
 
     JSStringRelease(str);
-    free(outCString);
-    free(sourceCString);
 }
 
 static void checkJSStringOOB(void)


### PR DESCRIPTION
#### 8f23ef0c9c9d976ff401709ef3b3dcad12de7c5e
<pre>
REGRESSION (279702@main): Incorrect use of sizeof() in checkJSStringOOBUTF8() from testapi.c
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=295037">https://bugs.webkit.org/show_bug.cgi?id=295037</a>&gt;
&lt;<a href="https://rdar.apple.com/154311531">rdar://154311531</a>&gt;

Reviewed by Yusuke Suzuki.

Revert 279702@main and add a separate cStringSize variable for testing.

* Source/JavaScriptCore/API/tests/testapi.c:
(checkJSStringOOBUTF8):
(checkJSStringOOBUTF16):
(checkJSStringOOBUTF16AtEnd):
- Switch back to stack-allocated buffers by reverting 279702@main.
- Add IGNORE_WARNINGS_BEGIN(&quot;vla&quot;)/IGNORE_WARNINGS_END macros to avoid
  warnings in open source clang for the SaferCPP EWS bot.
- Add separate cStringSize variable so outCStringSize matches the size
  of the buffer.

Canonical link: <a href="https://commits.webkit.org/296699@main">https://commits.webkit.org/296699@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ddd7f1b9dbb797911b5c9f7e92830160cce15d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109323 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19410 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114528 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59577 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29660 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37570 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83085 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112271 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23610 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98474 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63539 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23004 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16616 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59155 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/101828 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92978 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16658 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117641 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/107881 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36364 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26913 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92096 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36736 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94735 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91908 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36834 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14592 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32185 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17640 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36260 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41743 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/132148 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35939 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35810 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39271 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37636 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->