### PR TITLE
Web Extensions: Parsing for Create() Bookmark function

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIBookmarks.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIBookmarks.h
@@ -34,20 +34,33 @@ namespace WebKit {
 
 class WebExtensionAPIBookmarks : public WebExtensionAPIObject, public JSWebExtensionWrappable {
     WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIBookmarks, bookmarks, bookmarks);
-private:
+
+public:
+    enum class BookmarkTreeNodeType : uint8_t {
+        Bookmark,
+        Folder
+    };
+
+    struct CreateDetails {
+        std::optional<size_t> index;
+        String parentId;
+        String title;
+        std::optional<BookmarkTreeNodeType> type;
+        String url;
+    };
 
     struct MockBookmarkNode {
         String id;
+        String parentId;
         String title;
         String url;
+        size_t index;
         WallTime dateAdded;
+        BookmarkTreeNodeType type;
     };
 
     Vector<MockBookmarkNode> m_mockBookmarks;
 
-    NSDictionary *createDictionaryFromNode(const MockBookmarkNode& node);
-
-public:
 #if PLATFORM(COCOA)
     void createBookmark(NSDictionary *bookmark, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIBookmarks.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIBookmarks.mm
@@ -208,6 +208,23 @@ TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPIMockNodeWithgetRecent)
     Util::loadAndRunExtension(bookmarkOnManifest, @{ @"background.js": Util::constructScript(script) }, bookmarkConfig);
 }
 
+TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPICreateParse)
+{
+    auto *script = @[
+        @"let createdNode = await browser.bookmarks.create({title: 'My Test Bookmark', url: 'https://example.com/test1'})",
+        @"  browser.test.assertEq('My Test Bookmark', createdNode.title, 'Title should match');",
+        @"  browser.test.assertEq('https://example.com/test1', createdNode.url, 'URL should match');",
+        @"  browser.test.assertEq('bookmark', createdNode.type, 'Type should be bookmark');",
+        @"let createdNode2 = await browser.bookmarks.create({title: 'My Test Folder', parentId: '534'})",
+        @"  browser.test.assertEq('My Test Folder', createdNode2.title, 'Title should match');",
+        @"  browser.test.assertEq('folder', createdNode2.type, 'type should be folder because url is not specified');",
+        @"  browser.test.assertEq('534', createdNode2.parentId, 'parentId should match');",
+        @"  browser.test.notifyPass()",
+    ];
+
+    Util::loadAndRunExtension(bookmarkOnManifest, @{ @"background.js": Util::constructScript(script) }, bookmarkConfig);
+}
+
 }
 
 #endif


### PR DESCRIPTION
#### 7c3bccb28c9d00d450851dd40dcc5a3e4554f8ce
<pre>
Web Extensions: Parsing for Create() Bookmark function
<a href="https://rdar.apple.com/154231013">rdar://154231013</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=294932">https://bugs.webkit.org/show_bug.cgi?id=294932</a>

Reviewed by Timothy Hatcher.

Parses the create function using a CreateDetails Object which takes in the parameters
for the dictionary. For now this info from the dictionary is put into MockBookmarkNodes.
Also makes sure default type of a bookmark create request is assigned properly and
dateAdded is a parameter you can set only for testing purposes.
Created tests for these as well.

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIBookmarksCocoa.mm:
(WebKit::toWebAPI):
(WebKit::toTypeImpl):
(WebKit::WebExtensionAPIBookmarks::createBookmark):
(WebKit::WebExtensionAPIBookmarks::getRecent):
(WebKit::WebExtensionAPIBookmarks::createDictionaryFromNode):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIBookmarks.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIBookmarks.mm:
(TestWebKitAPI::TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPICreateParse)):

Canonical link: <a href="https://commits.webkit.org/296824@main">https://commits.webkit.org/296824@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2092a9f6dcff138b06cebf4b7d80ea972f2f99a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109692 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19779 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115713 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59926 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111655 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30028 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37938 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83355 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112640 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23924 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98781 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63814 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23306 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16926 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59507 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93299 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16963 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118505 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36731 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27203 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92364 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37104 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95040 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92185 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37143 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14887 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/32559 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17703 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36625 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42096 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36286 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39628 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37995 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->