### PR TITLE
Stop using UncheckedKey containers in WebCore/editing

### DIFF
--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -371,7 +371,7 @@ void ApplyStyleCommand::applyRelativeFontStyleChange(EditingStyle* style)
 
     // Store away font size before making any changes to the document.
     // This ensures that changes to one node won't effect another.
-    UncheckedKeyHashMap<Ref<Node>, float> startingFontSizes;
+    HashMap<Ref<Node>, float> startingFontSizes;
     for (auto node = startNode; node != beyondEnd; node = NodeTraversal::next(*node)) {
         RELEASE_ASSERT(node);
         startingFontSizes.set(*node, computedFontSize(node.get()));

--- a/Source/WebCore/editing/EditCommand.h
+++ b/Source/WebCore/editing/EditCommand.h
@@ -43,7 +43,7 @@ class Element;
 ASCIILiteral inputTypeNameForEditingAction(EditAction);
 bool isInputMethodComposingForEditingAction(EditAction);
 
-using NodeSet = UncheckedKeyHashSet<Ref<Node>>;
+using NodeSet = HashSet<Ref<Node>>;
 
 enum class AllowPasswordEcho : bool { No, Yes };
 

--- a/Source/WebCore/editing/EditorCommand.cpp
+++ b/Source/WebCore/editing/EditorCommand.cpp
@@ -83,7 +83,7 @@ public:
     bool (*allowExecutionWhenDisabled)(LocalFrame&, EditorCommandSource);
 };
 
-typedef UncheckedKeyHashMap<String, const EditorInternalCommand*, ASCIICaseInsensitiveHash> CommandMap;
+typedef HashMap<String, const EditorInternalCommand*, ASCIICaseInsensitiveHash> CommandMap;
 
 static const bool notTextInsertion = false;
 static const bool isTextInsertion = true;

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -505,7 +505,7 @@ void MarkupAccumulator::appendNamespace(StringBuilder& result, const AtomString&
         return;
     }
 
-    // Use emptyAtom()s's impl() for null strings since this UncheckedKeyHashMap can't handle nullptr as a key
+    // Use emptyAtom()s's impl() for null strings since this HashMap can't handle nullptr as a key
     auto addResult = namespaces.add(prefix.isNull() ? emptyAtom().impl() : prefix.impl(), namespaceURI.impl());
     if (!addResult.isNewEntry) {
         if (addResult.iterator->value == namespaceURI.impl())
@@ -880,7 +880,7 @@ static bool isElementExcludedByRule(const MarkupExclusionRule& rule, const Eleme
                 continue;
             }
 
-            // FIXME: We might optimize this by using a UncheckedKeyHashMap when there are too many attributes.
+            // FIXME: We might optimize this by using a HashMap when there are too many attributes.
             for (auto& attribute : element.attributes()) {
                 if (!equalIgnoringASCIICase(attribute.localName(), attributeLocalName))
                     continue;

--- a/Source/WebCore/editing/MarkupAccumulator.h
+++ b/Source/WebCore/editing/MarkupAccumulator.h
@@ -42,7 +42,7 @@ class Node;
 class Range;
 class ShadowRoot;
 
-typedef UncheckedKeyHashMap<AtomString, AtomStringImpl*> Namespaces;
+typedef HashMap<AtomString, AtomStringImpl*> Namespaces;
 
 enum class EntityMask : uint8_t {
     Amp = 1 << 0,

--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -126,7 +126,7 @@ public:
 
 private:
     const Vector<ExclusionRule>& m_rules;
-    UncheckedKeyHashMap<Ref<Element>, ExclusionRule::Type> m_cache;
+    HashMap<Ref<Element>, ExclusionRule::Type> m_cache;
 };
 
 TextManipulationController::TextManipulationController(Document& document)
@@ -839,7 +839,7 @@ auto TextManipulationController::replace(const ManipulationItemData& item, const
         return ManipulationFailure::Type::ContentChanged;
 
     size_t currentTokenIndex = 0;
-    UncheckedKeyHashMap<TextManipulationTokenIdentifier, TokenExchangeData> tokenExchangeMap;
+    HashMap<TextManipulationTokenIdentifier, TokenExchangeData> tokenExchangeMap;
     RefPtr<Node> commonAncestor;
     RefPtr<Node> firstContentNode;
     RefPtr<Node> lastChildOfCommonAncestorInRange;

--- a/Source/WebCore/editing/TextManipulationController.h
+++ b/Source/WebCore/editing/TextManipulationController.h
@@ -44,7 +44,7 @@ class Document;
 class Element;
 class VisiblePosition;
 
-using NodeSet = UncheckedKeyHashSet<Ref<Node>>;
+using NodeSet = HashSet<Ref<Node>>;
 
 class TextManipulationController final : public CanMakeWeakPtr<TextManipulationController>, public CanMakeCheckedPtr<TextManipulationController> {
     WTF_MAKE_TZONE_ALLOCATED(TextManipulationController);
@@ -111,7 +111,7 @@ private:
     WeakHashSet<Node, WeakPtrImplWithEventTargetData> m_manipulatedNodesWithNewContent;
     WeakHashSet<Node, WeakPtrImplWithEventTargetData> m_addedOrNewlyRenderedNodes;
 
-    UncheckedKeyHashMap<String, bool> m_cachedFontFamilyExclusionResults;
+    HashMap<String, bool> m_cachedFontFamilyExclusionResults;
 
     bool m_didScheduleObservationUpdate { false };
 
@@ -119,7 +119,7 @@ private:
     Vector<TextManipulationItem> m_pendingItemsForCallback;
 
     Vector<ExclusionRule> m_exclusionRules;
-    UncheckedKeyHashMap<TextManipulationItemIdentifier, ManipulationItemData> m_items;
+    HashMap<TextManipulationItemIdentifier, ManipulationItemData> m_items;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/editing/cocoa/AlternativeTextContextController.h
+++ b/Source/WebCore/editing/cocoa/AlternativeTextContextController.h
@@ -40,8 +40,8 @@ public:
     PlatformTextAlternatives *alternativesForContext(DictationContext) const;
 
 private:
-    UncheckedKeyHashMap<DictationContext, RetainPtr<PlatformTextAlternatives>> m_alternatives;
-    UncheckedKeyHashMap<RetainPtr<PlatformTextAlternatives>, DictationContext> m_contexts;
+    HashMap<DictationContext, RetainPtr<PlatformTextAlternatives>> m_alternatives;
+    HashMap<RetainPtr<PlatformTextAlternatives>, DictationContext> m_contexts;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -137,7 +137,7 @@ const unichar WebNextLineCharacter = 0x0085;
 static const CGFloat defaultFontSize = 12;
 static const CGFloat minimumFontSize = 1;
 
-using NodeSet = UncheckedKeyHashSet<Ref<Node>>;
+using NodeSet = HashSet<Ref<Node>>;
 
 class HTMLConverterCaches {
     WTF_MAKE_TZONE_ALLOCATED(HTMLConverterCaches);
@@ -156,7 +156,7 @@ public:
     bool isAncestorsOfStartToBeConverted(Node& node) const { return m_ancestorsUnderCommonAncestor.contains(&node); }
 
 private:
-    UncheckedKeyHashMap<Element*, std::unique_ptr<WebCore::Style::Extractor>> m_computedStyles;
+    HashMap<Element*, std::unique_ptr<WebCore::Style::Extractor>> m_computedStyles;
     NodeSet m_ancestorsUnderCommonAncestor;
 };
 
@@ -187,9 +187,9 @@ private:
     Position m_end;
     DocumentLoader* m_dataSource { nullptr };
     
-    UncheckedKeyHashMap<RefPtr<Element>, RetainPtr<NSDictionary>> m_attributesForElements;
-    UncheckedKeyHashMap<RetainPtr<CFTypeRef>, RefPtr<Element>> m_textTableFooters;
-    UncheckedKeyHashMap<RefPtr<Element>, RetainPtr<NSDictionary>> m_aggregatedAttributesForElements;
+    HashMap<RefPtr<Element>, RetainPtr<NSDictionary>> m_attributesForElements;
+    HashMap<RetainPtr<CFTypeRef>, RefPtr<Element>> m_textTableFooters;
+    HashMap<RefPtr<Element>, RetainPtr<NSDictionary>> m_aggregatedAttributesForElements;
 
     UserSelectNoneStateCache m_userSelectNoneStateCache;
     bool m_ignoreUserSelectNoneContent { false };

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -299,7 +299,7 @@ static void replaceRichContentWithAttachments(LocalFrame& frame, DocumentFragmen
         return;
 
     // FIXME: Handle resources in subframe archives.
-    UncheckedKeyHashMap<AtomString, Ref<ArchiveResource>> urlToResourceMap;
+    HashMap<AtomString, Ref<ArchiveResource>> urlToResourceMap;
     for (auto& subresource : subresources)
         urlToResourceMap.set(AtomString { subresource->url().string() }, subresource.copyRef());
 
@@ -495,7 +495,7 @@ RefPtr<DocumentFragment> createFragment(LocalFrame& frame, NSAttributedString *s
         return WTFMove(fragmentAndResources.fragment);
     }
 
-    UncheckedKeyHashMap<AtomString, AtomString> blobURLMap;
+    HashMap<AtomString, AtomString> blobURLMap;
     for (auto& subresource : fragmentAndResources.resources) {
         Ref data = subresource->data();
         Ref blob = Blob::create(document.get(), data->copyData(), subresource->mimeType());
@@ -545,7 +545,7 @@ static String sanitizeMarkupWithArchive(LocalFrame& frame, Document& destination
         return sanitizedMarkupForFragmentInDocument(WTFMove(fragment), *stagingDocument, msoListQuirks, markupAndArchive.markup);
     }
 
-    UncheckedKeyHashMap<AtomString, AtomString> blobURLMap;
+    HashMap<AtomString, AtomString> blobURLMap;
     for (const Ref<ArchiveResource>& subresource : markupAndArchive.archive->subresources()) {
         auto& subresourceURL = subresource->url();
         if (!shouldReplaceSubresourceURLWithBlobDuringSanitization(subresourceURL))

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -155,7 +155,7 @@ static void completeURLs(DocumentFragment* fragment, const String& baseURL)
         change.apply();
 }
 
-void replaceSubresourceURLs(Ref<DocumentFragment>&& fragment, UncheckedKeyHashMap<AtomString, AtomString>&& replacementMap)
+void replaceSubresourceURLs(Ref<DocumentFragment>&& fragment, HashMap<AtomString, AtomString>&& replacementMap)
 {
     Vector<AttributeChange> changes;
     for (Ref element : descendantsOfType<Element>(fragment)) {

--- a/Source/WebCore/editing/markup.h
+++ b/Source/WebCore/editing/markup.h
@@ -56,7 +56,7 @@ struct SimpleRange;
 
 template<typename> class ExceptionOr;
 
-void replaceSubresourceURLs(Ref<DocumentFragment>&&, UncheckedKeyHashMap<AtomString, AtomString>&&);
+void replaceSubresourceURLs(Ref<DocumentFragment>&&, HashMap<AtomString, AtomString>&&);
 void removeSubresourceURLAttributes(Ref<DocumentFragment>&&, Function<bool(const URL&)> shouldRemoveURL);
 
 Ref<Page> createPageForSanitizingWebContent();
@@ -78,7 +78,7 @@ private:
     enum class State : uint8_t { NotUserSelectNone, Mixed, OnlyUserSelectNone };
     State computeState(Node&);
 
-    UncheckedKeyHashMap<Ref<Node>, State> m_cache;
+    HashMap<Ref<Node>, State> m_cache;
     bool m_useComposedTree;
 };
 


### PR DESCRIPTION
#### ddbec7beb89b5056ea8a761530903cd9a516804e
<pre>
Stop using UncheckedKey containers in WebCore/editing
<a href="https://bugs.webkit.org/show_bug.cgi?id=295041">https://bugs.webkit.org/show_bug.cgi?id=295041</a>

Reviewed by Darin Adler.

Stop using UncheckedKey containers in WebCore/editing. This tested as
performance neutral on Speedometer.

* Source/WebCore/editing/ApplyStyleCommand.cpp:
(WebCore::ApplyStyleCommand::applyRelativeFontStyleChange):
* Source/WebCore/editing/EditCommand.h:
* Source/WebCore/editing/EditorCommand.cpp:
* Source/WebCore/editing/MarkupAccumulator.cpp:
(WebCore::MarkupAccumulator::appendNamespace):
(WebCore::isElementExcludedByRule):
* Source/WebCore/editing/MarkupAccumulator.h:
* Source/WebCore/editing/TextManipulationController.cpp:
(WebCore::TextManipulationController::replace):
* Source/WebCore/editing/TextManipulationController.h:
* Source/WebCore/editing/cocoa/AlternativeTextContextController.h:
* Source/WebCore/editing/cocoa/HTMLConverter.mm:
* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::replaceRichContentWithAttachments):
(WebCore::createFragment):
(WebCore::sanitizeMarkupWithArchive):
* Source/WebCore/editing/markup.cpp:
(WebCore::replaceSubresourceURLs):
* Source/WebCore/editing/markup.h:

Canonical link: <a href="https://commits.webkit.org/296689@main">https://commits.webkit.org/296689@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/773f276ecdd1b7d3a20996d132a12b8c64a6fa78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109282 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28940 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19368 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114488 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59546 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111245 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29620 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37529 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83052 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112230 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23579 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98432 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63524 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22968 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16576 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59115 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92948 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16616 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117604 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36324 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26881 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92067 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36696 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94694 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91878 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23402 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36802 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14555 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32153 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36220 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41708 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35904 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39235 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37597 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->