### PR TITLE
Stop using UncheckedKey containers in WebCore/style

### DIFF
--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -932,7 +932,7 @@ static AnchorsForAnchorName collectAnchorsForAnchorName(const Document& document
     return anchorsForAnchorName;
 }
 
-AnchorElements AnchorPositionEvaluator::findAnchorsForAnchorPositionedElement(const Element& anchorPositionedElement, const UncheckedKeyHashSet<ResolvedScopedName>& anchorNames, const AnchorsForAnchorName& anchorsForAnchorName)
+AnchorElements AnchorPositionEvaluator::findAnchorsForAnchorPositionedElement(const Element& anchorPositionedElement, const HashSet<ResolvedScopedName>& anchorNames, const AnchorsForAnchorName& anchorsForAnchorName)
 {
     AnchorElements anchorElements;
 

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -66,7 +66,7 @@ using AnchorElements = HashMap<ResolvedScopedName, WeakPtr<Element, WeakPtrImplW
 
 struct AnchorPositionedState {
     AnchorElements anchorElements;
-    UncheckedKeyHashSet<ResolvedScopedName> anchorNames;
+    HashSet<ResolvedScopedName> anchorNames;
     AnchorPositionResolutionStage stage;
 
     WTF_MAKE_STRUCT_TZONE_ALLOCATED(AnchorPositionedState);
@@ -130,7 +130,7 @@ public:
     static CheckedPtr<RenderBoxModelObject> defaultAnchorForBox(const RenderBox&);
 
 private:
-    static AnchorElements findAnchorsForAnchorPositionedElement(const Element&, const UncheckedKeyHashSet<ResolvedScopedName>& anchorNames, const AnchorsForAnchorName&);
+    static AnchorElements findAnchorsForAnchorPositionedElement(const Element&, const HashSet<ResolvedScopedName>& anchorNames, const AnchorsForAnchorName&);
     static RefPtr<const Element> anchorPositionedElementOrPseudoElement(BuilderState&);
     static AnchorPositionedKey keyForElementOrPseudoElement(const Element&);
 };

--- a/Source/WebCore/style/ChildChangeInvalidation.h
+++ b/Source/WebCore/style/ChildChangeInvalidation.h
@@ -45,7 +45,7 @@ private:
     void invalidateForHasAfterMutation();
     void invalidateAfterChange();
     void checkForSiblingStyleChanges();
-    using MatchingHasSelectors = UncheckedKeyHashSet<const CSSSelector*>;
+    using MatchingHasSelectors = HashSet<const CSSSelector*>;
     enum class ChangedElementRelation : uint8_t { SelfOrDescendant, Sibling };
     void invalidateForChangedElement(Element&, MatchingHasSelectors&, ChangedElementRelation);
     void invalidateForChangeOutsideHasScope();

--- a/Source/WebCore/style/InspectorCSSOMWrappers.h
+++ b/Source/WebCore/style/InspectorCSSOMWrappers.h
@@ -56,8 +56,8 @@ private:
     void collectFromStyleSheets(const Vector<RefPtr<CSSStyleSheet>>&);
     void maybeCollectFromStyleSheets(const Vector<RefPtr<CSSStyleSheet>>&);
 
-    UncheckedKeyHashMap<const StyleRule*, RefPtr<CSSStyleRule>> m_styleRuleToCSSOMWrapperMap;
-    UncheckedKeyHashSet<RefPtr<CSSStyleSheet>> m_styleSheetCSSOMWrapperSet;
+    HashMap<const StyleRule*, RefPtr<CSSStyleRule>> m_styleRuleToCSSOMWrapperMap;
+    HashSet<RefPtr<CSSStyleSheet>> m_styleSheetCSSOMWrapperSet;
 };
 
 } // namespace Style

--- a/Source/WebCore/style/MatchedDeclarationsCache.h
+++ b/Source/WebCore/style/MatchedDeclarationsCache.h
@@ -78,7 +78,7 @@ private:
     void sweep();
 
     SingleThreadWeakRef<const Resolver> m_owner;
-    UncheckedKeyHashMap<unsigned, Vector<Entry>, AlreadyHashed> m_entries;
+    HashMap<unsigned, Vector<Entry>, AlreadyHashed> m_entries;
     Timer m_sweepTimer;
     unsigned m_additionsSinceLastSweep { 0 };
 };

--- a/Source/WebCore/style/PropertyCascade.h
+++ b/Source/WebCore/style/PropertyCascade.h
@@ -93,7 +93,7 @@ public:
     const Property& customProperty(const AtomString&) const;
 
     std::span<const CSSPropertyID> logicalGroupPropertyIDs() const;
-    const UncheckedKeyHashMap<AtomString, Property>& customProperties() const { return m_customProperties; }
+    const HashMap<AtomString, Property>& customProperties() const { return m_customProperties; }
 
     const HashSet<AnimatableCSSProperty> overriddenAnimatedProperties() const;
 
@@ -159,7 +159,7 @@ private:
     CSSPropertyID m_lowestSeenLogicalGroupProperty { lastLogicalGroupProperty };
     CSSPropertyID m_highestSeenLogicalGroupProperty { firstLogicalGroupProperty };
 
-    UncheckedKeyHashMap<AtomString, Property> m_customProperties;
+    HashMap<AtomString, Property> m_customProperties;
 };
 
 inline bool PropertyCascade::hasNormalProperty(CSSPropertyID id) const

--- a/Source/WebCore/style/RuleFeature.h
+++ b/Source/WebCore/style/RuleFeature.h
@@ -106,23 +106,23 @@ struct RuleFeatureSet {
     bool usesMatchElement(MatchElement matchElement) const { return usedMatchElements[enumToUnderlyingType(matchElement)]; }
     void setUsesMatchElement(MatchElement matchElement) { usedMatchElements[enumToUnderlyingType(matchElement)] = true; }
 
-    UncheckedKeyHashSet<AtomString> idsInRules;
-    UncheckedKeyHashSet<AtomString> idsMatchingAncestorsInRules;
-    UncheckedKeyHashSet<AtomString> attributeLowercaseLocalNamesInRules;
-    UncheckedKeyHashSet<AtomString> attributeLocalNamesInRules;
-    UncheckedKeyHashSet<AtomString> contentAttributeNamesInRules;
+    HashSet<AtomString> idsInRules;
+    HashSet<AtomString> idsMatchingAncestorsInRules;
+    HashSet<AtomString> attributeLowercaseLocalNamesInRules;
+    HashSet<AtomString> attributeLocalNamesInRules;
+    HashSet<AtomString> contentAttributeNamesInRules;
 
-    UncheckedKeyHashMap<AtomString, std::unique_ptr<RuleFeatureVector>> idRules;
-    UncheckedKeyHashMap<AtomString, std::unique_ptr<RuleFeatureVector>> classRules;
-    UncheckedKeyHashMap<AtomString, std::unique_ptr<Vector<RuleFeatureWithInvalidationSelector>>> attributeRules;
-    UncheckedKeyHashMap<PseudoClassInvalidationKey, std::unique_ptr<RuleFeatureVector>> pseudoClassRules;
-    UncheckedKeyHashMap<PseudoClassInvalidationKey, std::unique_ptr<Vector<RuleFeatureWithInvalidationSelector>>> hasPseudoClassRules;
+    HashMap<AtomString, std::unique_ptr<RuleFeatureVector>> idRules;
+    HashMap<AtomString, std::unique_ptr<RuleFeatureVector>> classRules;
+    HashMap<AtomString, std::unique_ptr<Vector<RuleFeatureWithInvalidationSelector>>> attributeRules;
+    HashMap<PseudoClassInvalidationKey, std::unique_ptr<RuleFeatureVector>> pseudoClassRules;
+    HashMap<PseudoClassInvalidationKey, std::unique_ptr<Vector<RuleFeatureWithInvalidationSelector>>> hasPseudoClassRules;
     Vector<RuleAndSelector> scopeBreakingHasPseudoClassRules;
 
-    UncheckedKeyHashSet<AtomString> classesAffectingHost;
-    UncheckedKeyHashSet<AtomString> attributesAffectingHost;
-    UncheckedKeyHashSet<CSSSelector::PseudoClass, IntHash<CSSSelector::PseudoClass>, WTF::StrongEnumHashTraits<CSSSelector::PseudoClass>> pseudoClassesAffectingHost;
-    UncheckedKeyHashSet<CSSSelector::PseudoClass, IntHash<CSSSelector::PseudoClass>, WTF::StrongEnumHashTraits<CSSSelector::PseudoClass>> pseudoClasses;
+    HashSet<AtomString> classesAffectingHost;
+    HashSet<AtomString> attributesAffectingHost;
+    HashSet<CSSSelector::PseudoClass, IntHash<CSSSelector::PseudoClass>, WTF::StrongEnumHashTraits<CSSSelector::PseudoClass>> pseudoClassesAffectingHost;
+    HashSet<CSSSelector::PseudoClass, IntHash<CSSSelector::PseudoClass>, WTF::StrongEnumHashTraits<CSSSelector::PseudoClass>> pseudoClasses;
 
     std::array<bool, matchElementCount> usedMatchElements { };
 

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -465,7 +465,7 @@ RuleSet::CollectedMediaQueryChanges RuleSet::evaluateDynamicMediaQueryRules(cons
 {
     CollectedMediaQueryChanges collectedChanges;
 
-    UncheckedKeyHashMap<size_t, bool, DefaultHash<size_t>, WTF::UnsignedWithZeroKeyHashTraits<size_t>> affectedRulePositionsAndResults;
+    HashMap<size_t, bool, DefaultHash<size_t>, WTF::UnsignedWithZeroKeyHashTraits<size_t>> affectedRulePositionsAndResults;
 
     for (size_t i = startIndex; i < m_dynamicMediaQueryRules.size(); ++i) {
         auto& dynamicRules = m_dynamicMediaQueryRules[i];

--- a/Source/WebCore/style/RuleSet.h
+++ b/Source/WebCore/style/RuleSet.h
@@ -80,7 +80,7 @@ public:
     ~RuleSet();
 
     typedef Vector<RuleData, 1> RuleDataVector;
-    typedef UncheckedKeyHashMap<AtomString, std::unique_ptr<RuleDataVector>> AtomRuleMap;
+    typedef HashMap<AtomString, std::unique_ptr<RuleDataVector>> AtomRuleMap;
 
     void addRule(const StyleRule&, unsigned selectorIndex, unsigned selectorListIndex);
     void addPageRule(StyleRulePage&);
@@ -217,7 +217,7 @@ private:
     RefPtr<StyleRuleViewTransition> m_viewTransitionRule;
     RuleFeatureSet m_features;
     Vector<DynamicMediaQueryRules> m_dynamicMediaQueryRules;
-    UncheckedKeyHashMap<Vector<size_t>, Ref<const RuleSet>> m_mediaQueryInvalidationRuleSetCache;
+    HashMap<Vector<size_t>, Ref<const RuleSet>> m_mediaQueryInvalidationRuleSetCache;
     unsigned m_ruleCount { 0 };
 
     Vector<CascadeLayer> m_cascadeLayers;

--- a/Source/WebCore/style/RuleSetBuilder.h
+++ b/Source/WebCore/style/RuleSetBuilder.h
@@ -67,7 +67,7 @@ private:
         struct DynamicContext {
             const MQ::MediaQueryList& queries;
             Vector<size_t> affectedRulePositions { };
-            UncheckedKeyHashSet<Ref<const StyleRule>> affectedRules { };
+            HashSet<Ref<const StyleRule>> affectedRules { };
         };
         Vector<DynamicContext> dynamicContextStack { };
 
@@ -85,7 +85,7 @@ private:
     const ShrinkToFit m_shrinkToFit { ShrinkToFit::Enable };
 
     CascadeLayerName m_resolvedCascadeLayerName;
-    UncheckedKeyHashMap<CascadeLayerName, RuleSet::CascadeLayerIdentifier> m_cascadeLayerIdentifierMap;
+    HashMap<CascadeLayerName, RuleSet::CascadeLayerIdentifier> m_cascadeLayerIdentifierMap;
     RuleSet::CascadeLayerIdentifier m_currentCascadeLayerIdentifier { 0 };
     Vector<const CSSSelectorList*> m_selectorListStack;
     Vector<CSSParserEnum::NestedContextType> m_ancestorStack;

--- a/Source/WebCore/style/SelectorMatchingState.h
+++ b/Source/WebCore/style/SelectorMatchingState.h
@@ -42,8 +42,8 @@ struct SelectorMatchingState {
 
     ContainerQueryEvaluationState containerQueryEvaluationState;
 
-    UncheckedKeyHashMap<HasPseudoClassCacheKey, HasPseudoClassMatch> hasPseudoClassMatchCache;
-    UncheckedKeyHashMap<HasPseudoClassFilterKey, std::unique_ptr<HasSelectorFilter>> hasPseudoClassSelectorFilters;
+    HashMap<HasPseudoClassCacheKey, HasPseudoClassMatch> hasPseudoClassMatchCache;
+    HashMap<HasPseudoClassFilterKey, std::unique_ptr<HasSelectorFilter>> hasPseudoClassSelectorFilters;
 };
 
 inline HasPseudoClassCacheKey makeHasPseudoClassCacheKey(const Element& element, const CSSSelector& selector)

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -87,7 +87,7 @@ private:
 
     const PropertyCascade m_cascade;
     // Rollback cascades are build on demand to resolve 'revert' and 'revert-layer' keywords.
-    UncheckedKeyHashMap<RollbackCascadeKey, std::unique_ptr<const PropertyCascade>> m_rollbackCascades;
+    HashMap<RollbackCascadeKey, std::unique_ptr<const PropertyCascade>> m_rollbackCascades;
 
     BuilderState m_state;
 };

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -225,9 +225,9 @@ private:
 
     const CSSToLengthConversionData m_cssToLengthConversionData;
 
-    UncheckedKeyHashSet<AtomString> m_appliedCustomProperties;
-    UncheckedKeyHashSet<AtomString> m_inProgressCustomProperties;
-    UncheckedKeyHashSet<AtomString> m_inCycleCustomProperties;
+    HashSet<AtomString> m_appliedCustomProperties;
+    HashSet<AtomString> m_inProgressCustomProperties;
+    HashSet<AtomString> m_inCycleCustomProperties;
     WTF::BitSet<cssPropertyIDEnumValueCount> m_inProgressProperties;
     WTF::BitSet<cssPropertyIDEnumValueCount> m_invalidAtComputedValueTimeProperties;
 

--- a/Source/WebCore/style/StyleInvalidator.h
+++ b/Source/WebCore/style/StyleInvalidator.h
@@ -63,7 +63,7 @@ public:
 
     static void invalidateShadowParts(ShadowRoot&);
 
-    using MatchElementRuleSets = UncheckedKeyHashMap<MatchElement, InvalidationRuleSetVector, IntHash<MatchElement>, WTF::StrongEnumHashTraits<MatchElement>>;
+    using MatchElementRuleSets = HashMap<MatchElement, InvalidationRuleSetVector, IntHash<MatchElement>, WTF::StrongEnumHashTraits<MatchElement>>;
     static void addToMatchElementRuleSets(Invalidator::MatchElementRuleSets&, const InvalidationRuleSet&);
     static void addToMatchElementRuleSetsRespectingNegation(Invalidator::MatchElementRuleSets&, const InvalidationRuleSet&);
     static void invalidateWithMatchElementRuleSets(Element&, const MatchElementRuleSets&);

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -475,7 +475,7 @@ Vector<Ref<StyleRuleKeyframe>> Resolver::keyframeRulesForName(const AtomString& 
         return &CubicBezierTimingFunction::defaultTimingFunction();
     };
 
-    UncheckedKeyHashSet<RefPtr<const TimingFunction>> timingFunctions;
+    HashSet<RefPtr<const TimingFunction>> timingFunctions;
     auto uniqueTimingFunctionForKeyframe = [&](Ref<StyleRuleKeyframe> keyframe) -> RefPtr<const TimingFunction> {
         auto timingFunction = timingFunctionForKeyframe(keyframe);
         for (auto existingTimingFunction : timingFunctions) {
@@ -491,7 +491,7 @@ Vector<Ref<StyleRuleKeyframe>> Resolver::keyframeRulesForName(const AtomString& 
 
     using KeyframeUniqueKey = std::tuple<StyleRuleKeyframe::Key, RefPtr<const TimingFunction>, CompositeOperation>;
     auto hasDuplicateKeys = [&]() -> bool {
-        UncheckedKeyHashSet<KeyframeUniqueKey> uniqueKeyframeKeys;
+        HashSet<KeyframeUniqueKey> uniqueKeyframeKeys;
         for (auto& keyframe : *keyframes) {
             auto compositeOperation = compositeOperationForKeyframe(keyframe);
             auto timingFunction = uniqueTimingFunctionForKeyframe(keyframe);
@@ -509,7 +509,7 @@ Vector<Ref<StyleRuleKeyframe>> Resolver::keyframeRulesForName(const AtomString& 
     // Merge keyframes with a similar offset and timing function ensuring that merged keyframes
     // move to the end of the list if the offset is a timeline range.
     Vector<Ref<StyleRuleKeyframe>> deduplicatedKeyframes;
-    UncheckedKeyHashMap<KeyframeUniqueKey, Ref<StyleRuleKeyframe>> keyframesMap;
+    HashMap<KeyframeUniqueKey, Ref<StyleRuleKeyframe>> keyframesMap;
     for (auto& originalKeyframe : *keyframes) {
         auto compositeOperation = compositeOperationForKeyframe(originalKeyframe);
         auto timingFunction = uniqueTimingFunctionForKeyframe(originalKeyframe);

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -89,7 +89,7 @@ struct ResolutionContext {
     bool isSVGUseTreeRoot { false };
 };
 
-using KeyframesRuleMap = UncheckedKeyHashMap<AtomString, RefPtr<StyleRuleKeyframes>>;
+using KeyframesRuleMap = HashMap<AtomString, RefPtr<StyleRuleKeyframes>>;
 
 class Resolver : public RefCounted<Resolver>, public CanMakeSingleThreadWeakPtr<Resolver> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(Resolver);

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -153,8 +153,8 @@ public:
     static const Scope* forOrdinal(const Element&, ScopeOrdinal);
 
     struct LayoutDependencyUpdateContext {
-        UncheckedKeyHashSet<CheckedRef<const Element>> invalidatedContainers;
-        UncheckedKeyHashSet<CheckedRef<const Element>> invalidatedAnchorPositioned;
+        HashSet<CheckedRef<const Element>> invalidatedContainers;
+        HashSet<CheckedRef<const Element>> invalidatedAnchorPositioned;
     };
     bool invalidateForLayoutDependencies(LayoutDependencyUpdateContext&);
 
@@ -179,7 +179,7 @@ private:
     void updateActiveStyleSheets(UpdateType);
     void scheduleUpdate(UpdateType);
 
-    using ResolverScopes = UncheckedKeyHashMap<Ref<Resolver>, Vector<WeakPtr<Scope>>>;
+    using ResolverScopes = HashMap<Ref<Resolver>, Vector<WeakPtr<Scope>>>;
     ResolverScopes collectResolverScopes();
     template <typename TestFunction> void evaluateMediaQueries(TestFunction&&);
 
@@ -236,7 +236,7 @@ private:
 
     Timer m_pendingUpdateTimer;
 
-    mutable UncheckedKeyHashSet<SingleThreadWeakRef<const CSSStyleSheet>> m_weakCopyOfActiveStyleSheetListForFastLookup;
+    mutable HashSet<SingleThreadWeakRef<const CSSStyleSheet>> m_weakCopyOfActiveStyleSheetListForFastLookup;
 
     // Track the currently loading top-level stylesheets needed for rendering.
     // Sheets loaded using the @import directive are not included in this count.
@@ -274,7 +274,7 @@ private:
     const UniqueRef<CSSCounterStyleRegistry> m_counterStyleRegistry;
 
     // FIXME: These (and some things above) are only relevant for the root scope.
-    UncheckedKeyHashMap<ResolverSharingKey, Ref<Resolver>> m_sharedShadowTreeResolvers;
+    HashMap<ResolverSharingKey, Ref<Resolver>> m_sharedShadowTreeResolvers;
 
     AnchorPositionedToAnchorMap m_anchorPositionedToAnchorMap;
 };

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -304,14 +304,14 @@ void ScopeRuleSets::collectFeatures() const
 }
 
 template<typename KeyType, typename RuleFeatureVectorType, typename Hash, typename HashTraits>
-static Vector<InvalidationRuleSet>* ensureInvalidationRuleSets(const KeyType& key, UncheckedKeyHashMap<KeyType, std::unique_ptr<Vector<InvalidationRuleSet>>, Hash, HashTraits>& ruleSetMap, const UncheckedKeyHashMap<KeyType, std::unique_ptr<RuleFeatureVectorType>, Hash, HashTraits>& ruleFeatures)
+static Vector<InvalidationRuleSet>* ensureInvalidationRuleSets(const KeyType& key, HashMap<KeyType, std::unique_ptr<Vector<InvalidationRuleSet>>, Hash, HashTraits>& ruleSetMap, const HashMap<KeyType, std::unique_ptr<RuleFeatureVectorType>, Hash, HashTraits>& ruleFeatures)
 {
     return ruleSetMap.ensure(key, [&] () -> std::unique_ptr<Vector<InvalidationRuleSet>> {
         auto* features = ruleFeatures.get(key);
         if (!features)
             return nullptr;
 
-        UncheckedKeyHashMap<std::tuple<uint8_t, bool, bool>, InvalidationRuleSet> invalidationRuleSetMap;
+        HashMap<std::tuple<uint8_t, bool, bool>, InvalidationRuleSet> invalidationRuleSetMap;
 
         for (auto& feature : *features) {
             auto key = std::tuple { static_cast<uint8_t>(feature.matchElement), static_cast<bool>(feature.isNegation), true };
@@ -363,10 +363,10 @@ const Vector<InvalidationRuleSet>* ScopeRuleSets::hasPseudoClassInvalidationRule
     return ensureInvalidationRuleSets(key, m_hasPseudoClassInvalidationRuleSets, m_features.hasPseudoClassRules);
 }
 
-const UncheckedKeyHashSet<AtomString>& ScopeRuleSets::customPropertyNamesInStyleContainerQueries() const
+const HashSet<AtomString>& ScopeRuleSets::customPropertyNamesInStyleContainerQueries() const
 {
     if (!m_customPropertyNamesInStyleContainerQueries) {
-        UncheckedKeyHashSet<AtomString> propertyNames;
+        HashSet<AtomString> propertyNames;
 
         auto collectPropertyNames = [&](auto* ruleSet) {
             if (!ruleSet)

--- a/Source/WebCore/style/StyleScopeRuleSets.h
+++ b/Source/WebCore/style/StyleScopeRuleSets.h
@@ -80,7 +80,7 @@ public:
     const Vector<InvalidationRuleSet>* pseudoClassInvalidationRuleSets(const PseudoClassInvalidationKey&) const;
     const Vector<InvalidationRuleSet>* hasPseudoClassInvalidationRuleSets(const PseudoClassInvalidationKey&) const;
 
-    const UncheckedKeyHashSet<AtomString>& customPropertyNamesInStyleContainerQueries() const;
+    const HashSet<AtomString>& customPropertyNamesInStyleContainerQueries() const;
 
     SelectorsForStyleAttribute selectorsForStyleAttribute() const;
 
@@ -124,13 +124,13 @@ private:
     Resolver& m_styleResolver;
     mutable RuleFeatureSet m_features;
     mutable RefPtr<RuleSet> m_scopeBreakingHasPseudoClassInvalidationRuleSet;
-    mutable UncheckedKeyHashMap<AtomString, std::unique_ptr<Vector<InvalidationRuleSet>>> m_idInvalidationRuleSets;
-    mutable UncheckedKeyHashMap<AtomString, std::unique_ptr<Vector<InvalidationRuleSet>>> m_classInvalidationRuleSets;
-    mutable UncheckedKeyHashMap<AtomString, std::unique_ptr<Vector<InvalidationRuleSet>>> m_attributeInvalidationRuleSets;
-    mutable UncheckedKeyHashMap<PseudoClassInvalidationKey, std::unique_ptr<Vector<InvalidationRuleSet>>> m_pseudoClassInvalidationRuleSets;
-    mutable UncheckedKeyHashMap<PseudoClassInvalidationKey, std::unique_ptr<Vector<InvalidationRuleSet>>> m_hasPseudoClassInvalidationRuleSets;
+    mutable HashMap<AtomString, std::unique_ptr<Vector<InvalidationRuleSet>>> m_idInvalidationRuleSets;
+    mutable HashMap<AtomString, std::unique_ptr<Vector<InvalidationRuleSet>>> m_classInvalidationRuleSets;
+    mutable HashMap<AtomString, std::unique_ptr<Vector<InvalidationRuleSet>>> m_attributeInvalidationRuleSets;
+    mutable HashMap<PseudoClassInvalidationKey, std::unique_ptr<Vector<InvalidationRuleSet>>> m_pseudoClassInvalidationRuleSets;
+    mutable HashMap<PseudoClassInvalidationKey, std::unique_ptr<Vector<InvalidationRuleSet>>> m_hasPseudoClassInvalidationRuleSets;
 
-    mutable std::optional<UncheckedKeyHashSet<AtomString>> m_customPropertyNamesInStyleContainerQueries;
+    mutable std::optional<HashSet<AtomString>> m_customPropertyNamesInStyleContainerQueries;
 
     mutable std::optional<SelectorsForStyleAttribute> m_cachedSelectorsForStyleAttribute;
 

--- a/Source/WebCore/style/StyleSheetContentsCache.h
+++ b/Source/WebCore/style/StyleSheetContentsCache.h
@@ -52,7 +52,7 @@ private:
 
     StyleSheetContentsCache();
 
-    UncheckedKeyHashMap<Key, Ref<StyleSheetContents>> m_cache;
+    HashMap<Key, Ref<StyleSheetContents>> m_cache;
 };
 
 }

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -199,14 +199,14 @@ private:
         OptionSet<Change> changes;
         DescendantsToResolve descendantsToResolve { DescendantsToResolve::None };
     };
-    UncheckedKeyHashMap<Ref<Element>, DeferredDescendantResolutionState> m_deferredDescendantResolutionStates;
+    HashMap<Ref<Element>, DeferredDescendantResolutionState> m_deferredDescendantResolutionStates;
     bool m_needsInterleavedLayout { false };
     bool m_didFirstInterleavedLayout { false };
 
     struct QueryContainerState {
         bool invalidated { false };
     };
-    UncheckedKeyHashMap<Ref<Element>, QueryContainerState> m_queryContainerStates;
+    HashMap<Ref<Element>, QueryContainerState> m_queryContainerStates;
 
     // This state gets passes to the style builder and holds state for a single tree resolution, including over any interleaving.
     TreeResolutionState m_treeResolutionState;

--- a/Source/WebCore/style/StyleUpdate.h
+++ b/Source/WebCore/style/StyleUpdate.h
@@ -94,8 +94,8 @@ private:
     const Ref<Document> m_document;
     ListHashSet<RefPtr<ContainerNode>> m_roots;
     ListHashSet<RefPtr<Element>> m_rebuildRoots;
-    UncheckedKeyHashMap<RefPtr<const Element>, ElementUpdate> m_elements;
-    UncheckedKeyHashMap<RefPtr<const Text>, TextUpdate> m_texts;
+    HashMap<RefPtr<const Element>, ElementUpdate> m_elements;
+    HashMap<RefPtr<const Text>, TextUpdate> m_texts;
     std::unique_ptr<RenderStyle> m_initialContainingBlockUpdate;
 };
 

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -517,7 +517,7 @@ static bool transitionMatchesProperty(const Animation& transition, const Animata
     return false;
 }
 
-static void compileTransitionPropertiesInStyle(const RenderStyle& style, CSSPropertiesBitSet& transitionProperties, UncheckedKeyHashSet<AtomString>& transitionCustomProperties, bool& transitionPropertiesContainAll)
+static void compileTransitionPropertiesInStyle(const RenderStyle& style, CSSPropertiesBitSet& transitionProperties, HashSet<AtomString>& transitionCustomProperties, bool& transitionPropertiesContainAll)
 {
     auto* transitions = style.transitions();
     if (!transitions) {
@@ -798,7 +798,7 @@ void Styleable::updateCSSTransitions(const RenderStyle& currentStyle, const Rend
     // First, let's compile the list of all CSS properties found in the current style and the after-change style.
     bool transitionPropertiesContainAll = false;
     CSSPropertiesBitSet transitionProperties;
-    UncheckedKeyHashSet<AtomString> transitionCustomProperties;
+    HashSet<AtomString> transitionCustomProperties;
     compileTransitionPropertiesInStyle(currentStyle, transitionProperties, transitionCustomProperties, transitionPropertiesContainAll);
     compileTransitionPropertiesInStyle(newStyle, transitionProperties, transitionCustomProperties, transitionPropertiesContainAll);
 


### PR DESCRIPTION
#### ad6c74826afd48b8d1dc589ab5786639426d336b
<pre>
Stop using UncheckedKey containers in WebCore/style
<a href="https://bugs.webkit.org/show_bug.cgi?id=295042">https://bugs.webkit.org/show_bug.cgi?id=295042</a>

Reviewed by Darin Adler.

Stop using UncheckedKey containers in WebCore/style, for safety. This tested as
performance neutral on Speedometer.

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::findAnchorsForAnchorPositionedElement):
* Source/WebCore/style/AnchorPositionEvaluator.h:
* Source/WebCore/style/ChildChangeInvalidation.h:
* Source/WebCore/style/InspectorCSSOMWrappers.h:
* Source/WebCore/style/MatchedDeclarationsCache.h:
* Source/WebCore/style/PropertyCascade.h:
(WebCore::Style::PropertyCascade::customProperties const):
* Source/WebCore/style/RuleFeature.h:
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::evaluateDynamicMediaQueryRules):
* Source/WebCore/style/RuleSet.h:
* Source/WebCore/style/RuleSetBuilder.h:
* Source/WebCore/style/SelectorMatchingState.h:
* Source/WebCore/style/StyleBuilder.h:
* Source/WebCore/style/StyleBuilderState.h:
* Source/WebCore/style/StyleInvalidator.h:
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::keyframeRulesForName const):
* Source/WebCore/style/StyleResolver.h:
* Source/WebCore/style/StyleScope.h:
* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::ensureInvalidationRuleSets):
(WebCore::Style::ScopeRuleSets::customPropertyNamesInStyleContainerQueries const):
* Source/WebCore/style/StyleScopeRuleSets.h:
* Source/WebCore/style/StyleSheetContentsCache.h:
* Source/WebCore/style/StyleTreeResolver.h:
* Source/WebCore/style/StyleUpdate.h:
* Source/WebCore/style/Styleable.cpp:
(WebCore::compileTransitionPropertiesInStyle):
(WebCore::Styleable::updateCSSTransitions const):

Canonical link: <a href="https://commits.webkit.org/296679@main">https://commits.webkit.org/296679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8015407703952f7ca99716abdbdaefe77965177

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109283 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28941 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19369 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114489 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/59547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111246 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29621 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37530 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83058 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/59547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112231 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23576 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98430 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63508 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22965 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16574 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59116 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92945 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16614 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117605 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36325 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26885 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/92073 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36697 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94692 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91883 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23397 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36800 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14553 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/32154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36221 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41709 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35905 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39236 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37598 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->