### PR TITLE
Introduce a new WebKit Content Blocking condition to act on the current frame or ancestor frame URL

### DIFF
--- a/Source/WebCore/contentextensions/ContentExtensionCompiler.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionCompiler.cpp
@@ -347,6 +347,7 @@ std::error_code compileRuleList(ContentExtensionCompilationClient& client, Strin
                 break;
             case ActionCondition::IfFrameURL:
             case ActionCondition::UnlessFrameURL:
+            case ActionCondition::IfFrameOrAncestorsURL:
                 status = frameURLFilterParser.addPattern(condition, trigger.frameURLFilterIsCaseSensitive, actionLocationAndFlags);
                 if (status == URLFilterParser::MatchesEverything) {
                     frameURLUniversalActions.add(actionLocationAndFlags);

--- a/Source/WebCore/contentextensions/ContentExtensionParser.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionParser.cpp
@@ -210,6 +210,9 @@ static Expected<Trigger, std::error_code> loadTrigger(const JSON::Object& ruleOb
     if (auto error = checkCondition("unless-frame-url"_s, getStringList, ActionCondition::UnlessFrameURL))
         return makeUnexpected(error);
 
+    if (auto error = checkCondition("if-ancestor-frame-url"_s, getStringList, ActionCondition::IfFrameOrAncestorsURL))
+        return makeUnexpected(error);
+
     trigger.checkValidity();
     return trigger;
 }

--- a/Source/WebCore/contentextensions/ContentExtensionRule.h
+++ b/Source/WebCore/contentextensions/ContentExtensionRule.h
@@ -57,7 +57,7 @@ struct Trigger {
         if (topURLFilterIsCaseSensitive)
             ASSERT(actionCondition == ActionCondition::IfTopURL || actionCondition == ActionCondition::UnlessTopURL);
         if (frameURLFilterIsCaseSensitive)
-            ASSERT(actionCondition == ActionCondition::IfFrameURL || actionCondition == ActionCondition::UnlessFrameURL);
+            ASSERT(actionCondition == ActionCondition::IfFrameURL || actionCondition == ActionCondition::UnlessFrameURL || actionCondition == ActionCondition::IfFrameOrAncestorsURL);
     }
 
     bool isEmpty() const

--- a/Source/WebCore/loader/ResourceLoadInfo.h
+++ b/Source/WebCore/loader/ResourceLoadInfo.h
@@ -30,6 +30,7 @@
 #include "CachedResource.h"
 #include <wtf/OptionSet.h>
 #include <wtf/URL.h>
+#include <wtf/Vector.h>
 
 namespace WebCore::ContentExtensions {
 
@@ -38,7 +39,8 @@ enum class ActionCondition : uint32_t {
     IfTopURL = 0x40000,
     UnlessTopURL = 0x80000,
     IfFrameURL = 0x140000,
-    UnlessFrameURL = 0x180000
+    UnlessFrameURL = 0x180000,
+    IfFrameOrAncestorsURL = 0x1C0000
 };
 static constexpr uint32_t ActionConditionMask = 0x1C0000;
 
@@ -110,6 +112,7 @@ struct ResourceLoadInfo {
     OptionSet<ResourceType> type;
     bool mainFrameContext { false };
     RequestMethod requestMethod { RequestMethod::None };
+    Vector<URL> ancestorFrameURLs { };
 
     bool isThirdParty() const;
     ResourceFlags getResourceFlags() const;


### PR DESCRIPTION
#### 0d65d2e39211f8530206ac0d251c468d47cb1eaa
<pre>
Introduce a new WebKit Content Blocking condition to act on the current frame or ancestor frame URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=295036">https://bugs.webkit.org/show_bug.cgi?id=295036</a>
<a href="https://rdar.apple.com/154404658">rdar://154404658</a>

Reviewed by Brian Weinstein and Timothy Hatcher.

This patch introduces a new condition type for WebKit content blockers, if-
ancestor-frame-url. The condition makes it so that the rule applies if the
current frame&apos;s URL, or any of the ancestor frames URLs, are in the provided
array of URLs.

We need this functionality to be able to support dNR allowAllRequests rules for
sub frames.

Added a new test to validate the fix.

Note: the dNR fix is tracked with <a href="https://bugs.webkit.org/show_bug.cgi?id=295043">https://bugs.webkit.org/show_bug.cgi?id=295043</a>

* Source/WebCore/contentextensions/ContentExtensionCompiler.cpp:
(WebCore::ContentExtensions::compileRuleList):
* Source/WebCore/contentextensions/ContentExtensionParser.cpp:
(WebCore::ContentExtensions::loadTrigger):
* Source/WebCore/contentextensions/ContentExtensionRule.h:
(WebCore::ContentExtensions::Trigger::checkValidity):
* Source/WebCore/contentextensions/ContentExtensionsBackend.cpp:
(WebCore::ContentExtensions::ContentExtensionsBackend::actionsFromContentRuleList const):
(WebCore::ContentExtensions::ContentExtensionsBackend::processContentRuleListsForLoad):
* Source/WebCore/loader/ResourceLoadInfo.h:
* Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp:
(TestWebKitAPI::TEST_F(ContentExtensionTest, InvalidJSON)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, IfFrameOrAncestorsURL)):

Canonical link: <a href="https://commits.webkit.org/296754@main">https://commits.webkit.org/296754@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/864d003bc7a0c4eb273930b5dadb91ba0937b0d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109498 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29156 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114702 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/59715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111461 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29835 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37744 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/83225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/59715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112446 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/23769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/98626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/63685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/23147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/16768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59319 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/93140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/16809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117816 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36539 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/27054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/92244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36910 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/94886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/92061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/36994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/14733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/32333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17667 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36432 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/41903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/36096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/39439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37803 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->