### PR TITLE
(New-test)TestWebKitAPI.WKWebExtensionAPITabs.CreateTabsOverflowIndex is a constant failure

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -35,6 +35,7 @@
 #import "CocoaHelpers.h"
 #import "Logging.h"
 #import "MessageSenderInlines.h"
+#import <JavaScriptCore/MathCommon.h>
 #import "WebExtensionAPINamespace.h"
 #import "WebExtensionAPIPort.h"
 #import "WebExtensionContext.h"
@@ -195,7 +196,7 @@ NSDictionary *toWebAPI(const WebExtensionTabParameters& parameters)
 
 static inline size_t clampIndex(double index)
 {
-    return static_cast<size_t>(std::max(0.0, std::min(index, static_cast<double>(std::numeric_limits<size_t>::max()))));
+    return static_cast<size_t>(std::max(0.0, std::min(index, static_cast<double>(JSC::maxSafeInteger()))));
 }
 
 bool WebExtensionAPITabs::parseTabCreateOptions(NSDictionary *options, WebExtensionTabParameters& parameters, NSString *sourceKey, NSString **outExceptionString)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
@@ -30,6 +30,7 @@
 #import "HTTPServer.h"
 #import "TestWKWebView.h"
 #import "WebExtensionUtilities.h"
+#import <JavaScriptCore/MathCommon.h>
 
 namespace TestWebKitAPI {
 
@@ -258,12 +259,7 @@ TEST(WKWebExtensionAPITabs, Create)
     [manager run];
 }
 
-// FIXME: rdar://152666936
-#if PLATFORM(MAC)
-TEST(WKWebExtensionAPITabs, DISABLED_CreateTabsOverflowIndex)
-#else
 TEST(WKWebExtensionAPITabs, CreateTabsOverflowIndex)
-#endif
 {
     auto *backgroundScript = Util::constructScript(@[
         @"var allWindows = await browser.windows.getAll({ populate: true })",
@@ -286,7 +282,7 @@ TEST(WKWebExtensionAPITabs, CreateTabsOverflowIndex)
 
     manager.get().internalDelegate.openNewTab = ^(WKWebExtensionTabConfiguration *configuration, WKWebExtensionContext *context, void (^completionHandler)(id<WKWebExtensionTab>, NSError *)) {
         EXPECT_NS_EQUAL(configuration.window, window);
-        EXPECT_EQ(configuration.index, NSUIntegerMax);
+        EXPECT_EQ(configuration.index, JSC::maxSafeIntegerAsUInt64());
 
         originalOpenNewTab(configuration, context, completionHandler);
     };


### PR DESCRIPTION
#### fcf76aadbe80fdf6cac217fde133c5c084675eb7
<pre>
(New-test)TestWebKitAPI.WKWebExtensionAPITabs.CreateTabsOverflowIndex is a constant failure
<a href="https://rdar.apple.com/152666936">rdar://152666936</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=294077">https://bugs.webkit.org/show_bug.cgi?id=294077</a>

Reviewed by Timothy Hatcher.

Changed std::min to MIN in order have a larger max range. Changed the expected max value to the max safe integer instead of NSUIntegerMax.

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::clampIndex):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, CreateTabsOverflowIndex)):

Canonical link: <a href="https://commits.webkit.org/296705@main">https://commits.webkit.org/296705@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24ab2973a287940df44fc862a1893a12f93fad20

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109346 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114551 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59594 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111309 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29683 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37592 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83101 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112294 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23633 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98487 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63558 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23020 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16630 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59176 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93001 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16672 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117663 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36387 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26932 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92111 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36759 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94749 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91926 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36855 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14603 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/32202 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17643 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36281 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41760 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35957 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39292 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37657 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->