### PR TITLE
[macOS] Expose a KVO property for the top scroll pocket on WKWebView

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -152,6 +152,10 @@ typedef NS_ENUM(NSInteger, _WKImmediateActionType) {
 @class NSImage;
 #endif
 
+#if TARGET_OS_OSX
+@class NSScrollPocket;
+#endif
+
 @protocol WKHistoryDelegatePrivate;
 @protocol _WKAppHighlightDelegate;
 @protocol _WKDiagnosticLoggingDelegate;
@@ -883,6 +887,10 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 @property (nonatomic, readonly) NSEdgeInsets _obscuredContentInsets WK_API_AVAILABLE(macos(WK_MAC_TBA));
 @property (nonatomic, setter=_setUsesAutomaticContentInsetBackgroundFill:) BOOL _usesAutomaticContentInsetBackgroundFill WK_API_AVAILABLE(macos(WK_MAC_TBA));
 @property (nonatomic, copy, setter=_setOverrideTopScrollEdgeEffectColor:) NSColor *_overrideTopScrollEdgeEffectColor WK_API_AVAILABLE(macos(WK_MAC_TBA));
+
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 260000
+@property (nonatomic, readonly) NSScrollPocket *_topScrollPocket WK_API_AVAILABLE(macos(26.0));
+#endif
 
 - (void)_showWritingTools WK_API_AVAILABLE(macos(15.2));
 

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1605,6 +1605,15 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
 }
 
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+
+- (NSScrollPocket *)_topScrollPocket
+{
+    return _impl->topScrollPocket();
+}
+
+#endif
+
 - (void)_setUsesAutomaticContentInsetBackgroundFill:(BOOL)value
 {
     if (_usesAutomaticContentInsetBackgroundFill == value)

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewPrivateForTestingMac.h
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewPrivateForTestingMac.h
@@ -61,8 +61,6 @@
 - (void)_createFlagsChangedEventMonitorForTesting;
 - (BOOL)_hasFlagsChangedEventMonitorForTesting;
 
-@property (nonatomic, readonly) NSView *_scrollPocketForTesting;
-
 @end
 
 #endif // !TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewTestingMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewTestingMac.mm
@@ -154,15 +154,6 @@
     return _impl->hasFlagsChangedEventMonitor();
 }
 
-- (NSView *)_scrollPocketForTesting
-{
-#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
-    return _impl->topScrollPocket();
-#else
-    return nil;
-#endif
-}
-
 @end
 
 #endif // PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -6963,8 +6963,12 @@ void WebViewImpl::updateScrollPocket()
         && !view->_reasonsToHideTopScrollPocket
         && topContentInset > 0;
 
+    RetainPtr topScrollPocketSelector = NSStringFromSelector(@selector(_topScrollPocket));
     if (!needsTopView) {
-        if (RetainPtr scrollPocket = std::exchange(m_topScrollPocket, nil)) {
+        if (m_topScrollPocket) {
+            [view willChangeValueForKey:topScrollPocketSelector.get()];
+            RetainPtr scrollPocket = std::exchange(m_topScrollPocket, { });
+            [view didChangeValueForKey:topScrollPocketSelector.get()];
             [[scrollPocket captureView] removeFromSuperview];
             [scrollPocket removeFromSuperview];
         }
@@ -6973,7 +6977,9 @@ void WebViewImpl::updateScrollPocket()
 
     RetainPtr<NSView> captureView;
     if (!m_topScrollPocket) {
+        [view willChangeValueForKey:topScrollPocketSelector.get()];
         m_topScrollPocket = adoptNS([NSScrollPocket new]);
+        [view didChangeValueForKey:topScrollPocketSelector.get()];
         updateTopScrollPocketStyle();
         [m_topScrollPocket setEdge:NSScrollPocketEdgeTop];
         [m_topScrollPocket layout];

--- a/Tools/TestWebKitAPI/Tests/TestWebKitAPI/mac/AppKitSPI.h
+++ b/Tools/TestWebKitAPI/Tests/TestWebKitAPI/mac/AppKitSPI.h
@@ -35,9 +35,10 @@ DECLARE_SYSTEM_HEADER
 #import <AppKit/NSInspectorBarItemController.h>
 #import <AppKit/NSInspectorBar_Private.h>
 #import <AppKit/NSMenu_Private.h>
+#import <AppKit/NSScrollPocket_Private.h>
+#import <AppKit/NSScrollViewSeparatorTrackingAdapter_Private.h>
 #import <AppKit/NSTextInputClient_Private.h>
 #import <AppKit/NSWindow_Private.h>
-#import <AppKit/NSScrollViewSeparatorTrackingAdapter_Private.h>
 
 #else
 


### PR DESCRIPTION
#### 9ae715d4628e6343bcf7411adb6f719dceff80be
<pre>
[macOS] Expose a KVO property for the top scroll pocket on WKWebView
<a href="https://bugs.webkit.org/show_bug.cgi?id=295051">https://bugs.webkit.org/show_bug.cgi?id=295051</a>
<a href="https://rdar.apple.com/154419636">rdar://154419636</a>

Reviewed by Abrar Rahman Protyasha.

Add support for a new property, `-[WKWebView _topScrollPocket]`; additionally, add KVO support, so
clients can observe when the top scroll pocket is torn down or recreated.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _topScrollPocket]):
* Source/WebKit/UIProcess/API/mac/WKWebViewPrivateForTestingMac.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewTestingMac.mm:
(-[WKWebView _scrollPocketForTesting]): Deleted.
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::updateScrollPocket):

Call `-{will|did}ChangeValueForKey:` when setting `m_topScrollPocket`.

* Tools/TestWebKitAPI/Tests/TestWebKitAPI/mac/AppKitSPI.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ObscuredContentInsets.mm:
(-[TopScrollPocketObserver initWithWebView:]):
(-[TopScrollPocketObserver dealloc]):
(-[TopScrollPocketObserver observeValueForKeyPath:ofObject:change:context:]):
(-[TopScrollPocketObserver changeCount]):
(TestWebKitAPI::TEST(ObscuredContentInsets, ResizeScrollPocket)):
(TestWebKitAPI::TEST(ObscuredContentInsets, ScrollPocketCaptureColor)):

Replace the now-unnecessary `-_scrollPocketForTesting` testing helper with `-_topScrollPocket`.

(TestWebKitAPI::TEST(ObscuredContentInsets, TopScrollPocketKVO)):

Add a test for KVO on the new property.

Canonical link: <a href="https://commits.webkit.org/296686@main">https://commits.webkit.org/296686@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fdd1026e6bcd738d4249e4482c48a6d9abd28274

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109303 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28961 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19390 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114509 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/59562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111266 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29640 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37550 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/83070 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/59562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112251 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23594 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98452 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63522 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22984 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16595 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59135 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92962 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16637 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117623 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36344 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/26900 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/92082 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36717 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94714 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91893 "Found 2 new API test failures: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23400 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36820 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14574 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/32169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36240 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/41726 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35922 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39253 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37617 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->