### PR TITLE
Upload wpt local-network-access tests

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6407,6 +6407,7 @@ imported/w3c/web-platform-tests/fetch/corb/script-html-correctly-labeled.tentati
 imported/w3c/web-platform-tests/fetch/corb/script-html-js-polyglot.sub.html [ Skip ]
 imported/w3c/web-platform-tests/fetch/corb/script-html-via-cross-origin-blob-url.sub.html [ Skip ]
 imported/w3c/web-platform-tests/fetch/corb/script-resource-with-json-parser-breaker.tentative.sub.html [ Skip ]
+imported/w3c/web-platform-tests/fetch/local-network-access/fetch.tentative.https.html [ Skip ]
 imported/w3c/web-platform-tests/fetch/metadata/generated/appcache-manifest.https.sub.html [ Skip ]
 imported/w3c/web-platform-tests/fetch/metadata/generated/css-images.sub.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/fetch/metadata/generated/element-a.https.sub.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/META.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/META.yml
@@ -1,0 +1,5 @@
+spec: https://wicg.github.io/local-network-access/
+suggested_reviewers:
+  - cthomp
+  - camillelamy
+  - hchao

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/README.md
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/README.md
@@ -1,0 +1,11 @@
+# Local Network Access tests
+
+This directory contains tests for Local Network Access' integration with
+the Fetch specification.
+
+See also:
+
+* [Explainer](https://github.com/explainers-by-googlers/local-network-access)
+
+Local Network Access replaced [Private Network
+Access](https://wicg.github.io/local-network-access/).

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/fetch.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/fetch.tentative.https-expected.txt
@@ -1,0 +1,6 @@
+
+FAIL LNA Public to local with permission Can't find variable: resolveUrl
+FAIL LNA Public to local with permission denied Can't find variable: resolveUrl
+FAIL LNA Public to local http mixed content bypass Can't find variable: resolveUrl
+FAIL LNA Public to public http mixed content bypass failure Can't find variable: resolveUrl
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/fetch.tentative.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/fetch.tentative.https.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>LNA Fetch tests: HTTPS </title>
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/support.sub.js"></script>
+<script>
+  "use strict";
+
+  promise_test(t => {
+    const sourceUrl = resolveUrl("resources/fetch-local.html",
+        sourceResolveOptions({ server: Server.HTTPS_PUBLIC }));
+
+    function checkResult(evt) {
+      checkTestResult(evt.data, FetchTestResult.SUCCESS);
+      t.done();
+    }
+
+    const promise = new Promise((resolve) => {
+                      window.addEventListener('message', resolve, {once: true});
+                    }).then(checkResult);
+    const popup = window.open(sourceUrl);
+    t.add_cleanup(() => popup.close());
+
+    return promise;
+  }, 'LNA Public to local with permission');
+
+  promise_test(t => {
+    // TODO(crbug.com/406991278): consider moving permission url param into
+    // options
+    const sourceUrl = resolveUrl("resources/fetch-local.html?permission=denied",
+        sourceResolveOptions({ server: Server.HTTPS_PUBLIC }));
+
+    function checkResult(evt) {
+      checkTestResult(evt.data, FetchTestResult.FAILURE);
+      t.done();
+    }
+
+    const promise = new Promise((resolve) => {
+                      window.addEventListener('message', resolve, {once: true});
+                    }).then(checkResult);
+    const popup = window.open(sourceUrl);
+    t.add_cleanup(() => popup.close());
+
+    return promise;
+  }, 'LNA Public to local with permission denied');
+
+  promise_test(t => {
+    const sourceUrl = resolveUrl("resources/fetch-local-http.html",
+        sourceResolveOptions({ server: Server.HTTPS_PUBLIC }));
+
+    function checkResult(evt) {
+      checkTestResult(evt.data, FetchTestResult.SUCCESS);
+      t.done();
+    }
+
+    const promise = new Promise((resolve) => {
+                      window.addEventListener('message', resolve, {once: true});
+                    }).then(checkResult);
+    const popup = window.open(sourceUrl);
+    t.add_cleanup(() => popup.close());
+
+    return promise;
+  }, 'LNA Public to local http mixed content bypass');
+
+  promise_test(t => {
+    const sourceUrl = resolveUrl("resources/fetch-public-http-wrong-address-space.html",
+        sourceResolveOptions({ server: Server.HTTPS_PUBLIC }));
+
+    function checkResult(evt) {
+      checkTestResult(evt.data, FetchTestResult.FAILURE);
+      t.done();
+    }
+
+    const promise = new Promise((resolve) => {
+                      window.addEventListener('message', resolve, {once: true});
+                    }).then(checkResult);
+    const popup = window.open(sourceUrl);
+    t.add_cleanup(() => popup.close());
+
+    return promise;
+  }, 'LNA Public to public http mixed content bypass failure');
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/fetch-local-http.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/fetch-local-http.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Fetch HTTP local with targetAddressSpace local </title>
+
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="support.sub.js"></script>
+<script>
+"use strict";
+
+// Fetch a local address over HTTP. Fetch is annotated with a
+// targetAddressSpace of local to allow for mixed content check bypassing.
+//
+// TODO(crbug.com/406991278): consolidate with fetch-local.html adding
+// options to minimize # of resources needed.
+Promise.resolve().then(async () => {
+  test_driver.set_test_context(opener);
+  await test_driver.set_permission({ name: 'local-network-access' }, 'granted');
+
+  const target = {
+    server: Server.HTTP_LOCAL,
+    behavior: { response: ResponseBehavior.allowCrossOrigin() },
+  };
+  const targetUrl = resolveTargetUrl(target);
+
+  fetch(targetUrl, {targetAddressSpace: 'local'})
+      .then(async function(response) {
+        const body = await response.text();
+        const message = {
+          ok: response.ok,
+          type: response.type,
+          body: body,
+        };
+        opener.postMessage(message, "*");
+      })
+      .catch(error => {
+        opener.postMessage({ error: error.toString() }, "*");
+      });
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/fetch-local.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/fetch-local.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Fetch Local resource</title>
+
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="support.sub.js"></script>
+<script>
+"use strict";
+
+// Set the 'local-network-access' permission then attempt to fetch a resource
+// in the local address space.
+//
+// By default, 'local-network-access' permission is set to 'granted'. This can
+// be changed by passing in a different value via the 'permission' URL parameter.
+// Valid values:
+//
+//    * granted
+//    * denied
+//    * prompt
+Promise.resolve().then(async () => {
+
+  const window_url = new URL(window.location.href);
+  let permission_value = 'granted';
+  if (window_url.searchParams.has('permission')) {
+     permission_value = window_url.searchParams.get('permission');
+  }
+
+  test_driver.set_test_context(opener);
+  await test_driver.set_permission({ name: 'local-network-access' }, permission_value);
+
+  const target = {
+    server: Server.HTTPS_LOCAL,
+    behavior: { response: ResponseBehavior.allowCrossOrigin() },
+  };
+  const targetUrl = resolveTargetUrl(target);
+
+  fetch(targetUrl)
+      .then(async function(response) {
+        const body = await response.text();
+        const message = {
+          ok: response.ok,
+          type: response.type,
+          body: body,
+        };
+        opener.postMessage(message, "*");
+      })
+      .catch(error => {
+        opener.postMessage({ error: error.toString() }, "*");
+      });
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/fetch-public-http-wrong-address-space.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/fetch-public-http-wrong-address-space.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Fetch HTTP public targetAddress local resource</title>
+
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="support.sub.js"></script>
+<script>
+"use strict";
+
+// Fetch a public address over HTTP. Fetch is annotated with a
+// targetAddressSpace of local to try to bypass mixed content, but should
+// fail because the address space of the resource does not match the target
+// address space.
+//
+// TODO(crbug.com/406991278): consolidate with fetch-local.html adding
+// options to minimize # of resources needed.
+Promise.resolve().then(async () => {
+  test_driver.set_test_context(opener);
+  await test_driver.set_permission({ name: 'local-network-access' }, 'granted');
+
+  const target = {
+    server: Server.HTTP_PUBLIC,
+    behavior: { response: ResponseBehavior.allowCrossOrigin() },
+  };
+  const targetUrl = resolveTargetUrl(target);
+
+  fetch(targetUrl, {targetAddressSpace: 'local'})
+      .then(async function(response) {
+        const body = await response.text();
+        const message = {
+          ok: response.ok,
+          type: response.type,
+          body: body,
+        };
+        opener.postMessage(message, "*");
+      })
+      .catch(error => {
+        opener.postMessage({ error: error.toString() }, "*");
+      });
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/support.sub.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/support.sub.js
@@ -1,0 +1,189 @@
+// Maps protocol (without the trailing colon) and address space to port.
+//
+// TODO(crbug.com/418737577): change keys to be consistent with new address
+// space names.
+const SERVER_PORTS = {
+  "http": {
+    "loopback": {{ports[http][0]}},
+    "local": {{ports[http-local][0]}},
+    "public": {{ports[http-public][0]}},
+  },
+  "https": {
+    "loopback": {{ports[https][0]}},
+    "other-loopback": {{ports[https][1]}},
+    "local": {{ports[https-local][0]}},
+    "public": {{ports[https-public][0]}},
+  },
+  "ws": {
+    "loopback": {{ports[ws][0]}},
+  },
+  "wss": {
+    "loopback": {{ports[wss][0]}},
+  },
+};
+
+// A `Server` is a web server accessible by tests. It has the following shape:
+//
+// {
+//   addressSpace: the IP address space of the server ("loopback", "local" or
+//     "public"),
+//   name: a human-readable name for the server,
+//   port: the port on which the server listens for connections,
+//   protocol: the protocol (including trailing colon) spoken by the server,
+// }
+//
+// Constants below define the available servers, which can also be accessed
+// programmatically with `get()`.
+class Server {
+  // Maps the given `protocol` (without a trailing colon) and `addressSpace` to
+  // a server. Returns null if no such server exists.
+  static get(protocol, addressSpace) {
+    const ports = SERVER_PORTS[protocol];
+    if (ports === undefined) {
+      return null;
+    }
+
+    const port = ports[addressSpace];
+    if (port === undefined) {
+      return null;
+    }
+
+    return {
+      addressSpace,
+      name: `${protocol}-${addressSpace}`,
+      port,
+      protocol: protocol + ':',
+    };
+  }
+
+  static HTTP_LOOPBACK = Server.get("http", "loopback");
+  static HTTP_LOCAL = Server.get("http", "local");
+  static HTTP_PUBLIC = Server.get("http", "public");
+  static HTTPS_LOOPBACK = Server.get("https", "loopback");
+  static OTHER_HTTPS_LOOPBACK = Server.get("https", "other-loopback");
+  static HTTPS_LOCAL = Server.get("https", "local");
+  static HTTPS_PUBLIC = Server.get("https", "public");
+  static WS_LOOPBACK = Server.get("ws", "loopback");
+  static WSS_LOOPBACK = Server.get("wss", "loopback");
+};
+
+// Resolves a URL relative to the current location, returning an absolute URL.
+//
+// `url` specifies the relative URL, e.g. "foo.html" or "http://foo.example".
+// `options`, if defined, should have the following shape:
+//
+//   {
+//     // Optional. Overrides the protocol of the returned URL.
+//     protocol,
+//
+//     // Optional. Overrides the port of the returned URL.
+//     port,
+//
+//     // Extra headers.
+//     headers,
+//
+//     // Extra search params.
+//     searchParams,
+//   }
+//
+function resolveUrl(url, options) {
+  const result = new URL(url, window.location);
+  if (options === undefined) {
+    return result;
+  }
+
+  const { port, protocol, headers, searchParams } = options;
+  if (port !== undefined) {
+    result.port = port;
+  }
+  if (protocol !== undefined) {
+    result.protocol = protocol;
+  }
+  if (headers !== undefined) {
+    const pipes = [];
+    for (key in headers) {
+      pipes.push(`header(${key},${headers[key]})`);
+    }
+    result.searchParams.append("pipe", pipes.join("|"));
+  }
+  if (searchParams !== undefined) {
+    for (key in searchParams) {
+      result.searchParams.append(key, searchParams[key]);
+    }
+  }
+
+  return result;
+}
+
+// Computes options to pass to `resolveUrl()` for a source document's URL.
+//
+// `server` identifies the server from which to load the document.
+// `treatAsPublic`, if set to true, specifies that the source document should
+// be artificially placed in the `public` address space using CSP.
+function sourceResolveOptions({ server, treatAsPublic }) {
+  const options = {...server};
+  if (treatAsPublic) {
+    options.headers = { "Content-Security-Policy": "treat-as-public-address" };
+  }
+  return options;
+}
+
+// Computes the URL of a target handler configured with the given options.
+//
+// `server` identifies the server from which to load the resource.
+// `behavior` specifies the behavior of the target server. It may contain:
+//   - `response`: The result of calling one of `ResponseBehavior`'s methods.
+//   - `redirect`: A URL to which the target should redirect GET requests.
+function resolveTargetUrl({ server, behavior }) {
+  if (server === undefined) {
+    throw new Error("no server specified.");
+  }
+  const options = {...server};
+  if (behavior) {
+    const { response, redirect } = behavior;
+    options.searchParams = {
+      ...response,
+    };
+    if (redirect !== undefined) {
+      options.searchParams.redirect = redirect;
+    }
+  }
+
+  return resolveUrl("target.py", options);
+}
+
+// Methods generate behavior specifications for how `resources/target.py`
+// should behave upon receiving a regular (non-preflight) request.
+const ResponseBehavior = {
+  // The response should succeed without CORS headers.
+  default: () => ({}),
+
+  // The response should succeed with CORS headers.
+  allowCrossOrigin: () => ({ "final-headers": "cors" }),
+};
+
+const FetchTestResult = {
+  SUCCESS: {
+    ok: true,
+    body: "success",
+  },
+  OPAQUE: {
+    ok: false,
+    type: "opaque",
+    body: "",
+  },
+  FAILURE: {
+    error: "TypeError: Failed to fetch",
+  },
+};
+
+// Helper function for checking results from fetch tests.
+function checkTestResult(actual, expected) {
+  assert_equals(actual.error, expected.error, "error mismatch");
+  assert_equals(actual.ok, expected.ok, "response ok mismatch");
+  assert_equals(actual.body, expected.body, "response body mismatch");
+
+  if (expected.type !== undefined) {
+    assert_equals(type, expected.type, "response type mismatch");
+  }
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/target.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/target.py
@@ -1,0 +1,105 @@
+# This endpoint responds to requests for a target of a (possible) LNA request.
+#
+# Its behavior can be configured with various search/GET parameters, all of
+# which are optional:
+#
+# - final-headers: Valid values are:
+#   - cors: this endpoint responds with valid CORS headers to CORS-enabled
+#     non-preflight requests. These should be sufficient for non-preflighted
+#     CORS-enabled requests to succeed.
+#   - sw: this endpoint responds with a valid Service-Worker header to allow
+#     for the request to serve as a Service worker script resource. This is
+#     only valid in conjunction with the cors value above.
+#   - unspecified: this endpoint responds with no CORS headers to non-preflight
+#     requests. This should fail CORS-enabled requests, but be sufficient for
+#     no-CORS requests.
+#
+# The following parameters only affect non-preflight responses:
+#
+# - redirect: If set, the response code is set to 301 and the `Location`
+#   response header is set to this value.
+# - mime-type: If set, the `Content-Type` response header is set to this value.
+# - file: Specifies a path (relative to this file's directory) to a file. If
+#   set, the response body is copied from this file.
+# - random-js-prefix: If set to any value, the response body is prefixed with
+#   a Javascript comment line containing a random value. This is useful in
+#   service worker tests, since service workers are only updated if the new
+#   script is not byte-for-byte identical with the old script.
+# - body: If set and `file` is not, the response body is set to this value.
+#
+
+import os
+import random
+
+from wptserve.utils import isomorphic_encode
+
+_ACAO = ("Access-Control-Allow-Origin", "*")
+_ACAH = ("Access-Control-Allow-Headers", "Service-Worker")
+
+def _get_response_headers(method, mode, origin):
+  acam = ("Access-Control-Allow-Methods", method)
+
+  if mode == b"cors":
+    return [acam, _ACAO]
+
+  if mode == b"cors+sw":
+    return [acam, _ACAO, _ACAH]
+
+  if mode == b"navigation":
+    return [
+        acam,
+        ("Access-Control-Allow-Origin", origin),
+        ("Access-Control-Allow-Credentials", "true"),
+    ]
+
+  return []
+
+
+def _is_loaded_in_fenced_frame(request):
+  return request.GET.get(b"is-loaded-in-fenced-frame")
+
+def _final_response_body(request):
+  file_name = None
+  if file_name is None:
+    file_name = request.GET.get(b"file")
+  if file_name is None:
+    return request.GET.get(b"body") or "success"
+
+  prefix = b""
+  if request.GET.get(b"random-js-prefix"):
+    value = random.randint(0, 1000000000)
+    prefix = isomorphic_encode("// Random value: {}\n\n".format(value))
+
+  path = os.path.join(os.path.dirname(isomorphic_encode(__file__)), file_name)
+  with open(path, 'rb') as f:
+    contents = f.read()
+
+  return prefix + contents
+
+def _handle_final_request(request, response):
+  mode = request.GET.get(b"final-headers")
+  origin = request.headers.get("Origin")
+  headers = _get_response_headers(request.method, mode, origin)
+
+  redirect = request.GET.get(b"redirect")
+  if redirect is not None:
+    headers.append(("Location", redirect))
+    return (301, headers, b"")
+
+  mime_type = request.GET.get(b"mime-type")
+  if mime_type is not None:
+    headers.append(("Content-Type", mime_type),)
+
+  if _is_loaded_in_fenced_frame(request):
+    headers.append(("Supports-Loading-Mode", "fenced-frame"))
+
+  body = _final_response_body(request)
+  return (headers, body)
+
+
+def main(request, response):
+  try:
+    return _handle_final_request(request, response)
+  except BaseException as e:
+    # Surface exceptions to the client, where they show up as assertion errors.
+    return (500, [("X-exception", str(e))], "exception: {}".format(e))

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/w3c-import.log
@@ -1,0 +1,21 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/fetch-local-http.html
+/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/fetch-local.html
+/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/fetch-public-http-wrong-address-space.html
+/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/support.sub.js
+/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/target.py

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/w3c-import.log
@@ -1,0 +1,19 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/META.yml
+/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/README.md
+/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/fetch.tentative.https.html


### PR DESCRIPTION
#### 04a08c1b1d1aaf8b59f258861d950127060b6068
<pre>
Upload WPT Local-Network Access Tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=295049">https://bugs.webkit.org/show_bug.cgi?id=295049</a>
<a href="https://rdar.apple.com/154416306">rdar://154416306</a>

Reviewed by NOBODY (OOPS!).

* LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/README.md:
* LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/iframe.tentative.https.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/iframe.tentative.https.window.js: Added.
(setup):
(makePermissionTests):
* LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/navigate.tentative.https.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/navigate.tentative.https.window.js: Added.
(setup):
* LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/navigate.tentative.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/navigate.tentative.window.js: Added.
(setup):
* LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/iframer.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/navigate.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/openee.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/support.sub.js:
(Server):
* LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/w3c-import.log:
* Tools/CISupport/build-webkit-org/steps.py:
(CompileWebKit.parseOutputLine):
</pre>