### PR TITLE
CSS borders should not be applied to checkboxes with native appearance

### DIFF
--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
@@ -156,10 +156,8 @@ protected:
 
     Color checkboxRadioBackgroundColorForVectorBasedControls(const RenderStyle&, OptionSet<ControlStyle::State>, OptionSet<StyleColorOptions>) const;
 
-    bool adjustCheckboxStyleForVectorBasedControls(RenderStyle&, const Element*) const;
     bool paintCheckboxForVectorBasedControls(const RenderObject&, const PaintInfo&, const FloatRect&);
 
-    bool adjustRadioStyleForVectorBasedControls(RenderStyle&, const Element*) const;
     bool paintRadioForVectorBasedControls(const RenderObject&, const PaintInfo&, const FloatRect&);
 
     bool adjustButtonStyleForVectorBasedControls(RenderStyle&, const Element*) const;

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -809,11 +809,6 @@ Color RenderThemeCocoa::checkboxRadioBackgroundColorForVectorBasedControls(const
     return backgroundColor;
 }
 
-bool RenderThemeCocoa::adjustCheckboxStyleForVectorBasedControls(RenderStyle&, const Element*) const
-{
-    return false;
-}
-
 bool RenderThemeCocoa::paintCheckboxForVectorBasedControls(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect)
 {
     // FIXME: A pre-existing flicker issue caused by a delay between the pressed state ending
@@ -924,11 +919,6 @@ bool RenderThemeCocoa::paintCheckboxForVectorBasedControls(const RenderObject& b
     context.fillPath(glyphPath);
 
     return true;
-}
-
-bool RenderThemeCocoa::adjustRadioStyleForVectorBasedControls(RenderStyle&, const Element*) const
-{
-    return false;
 }
 
 bool RenderThemeCocoa::paintRadioForVectorBasedControls(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect)
@@ -3595,8 +3585,8 @@ bool RenderThemeCocoa::adjustTextControlInnerTextStyleForVectorBasedControls(Ren
 void RenderThemeCocoa::adjustCheckboxStyle(RenderStyle& style, const Element* element) const
 {
 #if ENABLE(FORM_CONTROL_REFRESH)
-    if (adjustCheckboxStyleForVectorBasedControls(style, element))
-        return;
+    if (formControlRefreshEnabled(box))
+        style.resetBorder();
 #endif
 
     RenderTheme::adjustCheckboxStyle(style, element);
@@ -3615,8 +3605,8 @@ bool RenderThemeCocoa::paintCheckbox(const RenderObject& box, const PaintInfo& p
 void RenderThemeCocoa::adjustRadioStyle(RenderStyle& style, const Element* element) const
 {
 #if ENABLE(FORM_CONTROL_REFRESH)
-    if (adjustRadioStyleForVectorBasedControls(style, element))
-        return;
+    if (formControlRefreshEnabled(box))
+        style.resetBorder();
 #endif
 
     RenderTheme::adjustRadioStyle(style, element);


### PR DESCRIPTION
#### eac29b3f4223635ab77600018881bd0423395a97
<pre>
CSS borders should not be applied to checkboxes with native appearance
<a href="https://bugs.webkit.org/show_bug.cgi?id=295063">https://bugs.webkit.org/show_bug.cgi?id=295063</a>
<a href="https://rdar.apple.com/154434054">rdar://154434054</a>

Reviewed by Aditya Keerthi and Wenson Hsieh.

Reset the border for radio buttons and checkboxes during style adjustment so
that border-widths set by authors do not result in an altered control size. This
behavior is consistent with the behavior prior to the form control refresh, and
consistent with Firefox and Chrome.

Removed unnecessary methods &quot;adjustCheckboxStyleForVectorBasedControls&quot; and
&quot;adjustRadioStyleForVectorBasedControls&quot;.

* Source/WebCore/rendering/cocoa/RenderThemeCocoa.h:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::RenderThemeCocoa::adjustCheckboxStyle const):
(WebCore::RenderThemeCocoa::adjustRadioStyle const):
(WebCore::RenderThemeCocoa::adjustCheckboxStyleForVectorBasedControls const): Deleted.
(WebCore::RenderThemeCocoa::adjustRadioStyleForVectorBasedControls const): Deleted.

Canonical link: <a href="https://commits.webkit.org/296698@main">https://commits.webkit.org/296698@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cfaee9743b151023f66b560c86bf3794380ab90c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109321 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28979 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19408 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114526 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59575 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111284 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29658 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37568 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83084 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112269 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23608 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98476 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63537 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22998 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16618 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59153 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92976 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16660 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117639 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36362 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/26925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92095 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36734 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94737 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91907 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23407 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36833 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14594 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32183 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36258 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41741 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35937 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39269 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37633 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->