### PR TITLE
Change links from trac.webkit.org/browser/trunk to github.com/WebKit/WebKit/blob/main.

### DIFF
--- a/Tools/CISupport/build-webkit-org/public_html/TestFailures/scripts/ui.js
+++ b/Tools/CISupport/build-webkit-org/public_html/TestFailures/scripts/ui.js
@@ -41,7 +41,7 @@ ui.displayNameForBuilder = function(builderName)
 
 ui.urlForTest = function(testName)
 {
-    return 'https://trac.webkit.org/browser/trunk/LayoutTests/' + testName;
+    return 'https://github.com/WebKit/WebKit/blob/main/LayoutTests/' + testName;
 }
 
 ui.urlForFlakinessDashboard = function(opt_testNameList)

--- a/Tools/CISupport/ews-app/ews/views/statusbubble.py
+++ b/Tools/CISupport/ews-app/ews/views/statusbubble.py
@@ -40,7 +40,7 @@ _log = logging.getLogger(__name__)
 
 
 class StatusBubble(View):
-    # These queue names are from shortname in https://trac.webkit.org/browser/webkit/trunk/Tools/CISupport/ews-build/config.json
+    # These queue names are from shortname in https://github.com/webkit/webkit/blob/main/Tools/CISupport/ews-build/config.json
     # FIXME: Auto-generate this list https://bugs.webkit.org/show_bug.cgi?id=195640
     # Note: This list is sorted in the order of which bubbles appear in bugzilla.
     ALL_QUEUES = ['style', 'ios', 'ios-sim', 'mac', 'mac-AS-debug', 'vision', 'vision-sim', 'tv', 'tv-sim', 'watch', 'watch-sim', 'gtk', 'wpe', 'wpe-cairo', 'playstation', 'win', 'win-tests',

--- a/Tools/Scripts/webkitpy/common/config/urls.py
+++ b/Tools/Scripts/webkitpy/common/config/urls.py
@@ -31,7 +31,7 @@ import re
 
 
 def view_source_url(local_path):
-    return "https://trac.webkit.org/browser/trunk/%s" % local_path
+    return "https://github.com/WebKit/WebKit/blob/main/%s" % local_path
 
 
 def view_revision_url(revision_number):

--- a/Tools/Scripts/webkitpy/performance_tests/perftestsrunner_integrationtest.py
+++ b/Tools/Scripts/webkitpy/performance_tests/perftestsrunner_integrationtest.py
@@ -55,7 +55,7 @@ Finished: 0.1 s
 
 """
 
-    results = {'url': 'https://trac.webkit.org/browser/trunk/PerformanceTests/Bindings/event-target-wrapper.html',
+    results = {'url': 'https://github.com/WebKit/WebKit/blob/main/PerformanceTests/Bindings/event-target-wrapper.html',
         'metrics': {'Time': {'current': [[1486.0, 1471.0, 1510.0, 1505.0, 1478.0, 1490.0]] * 4}}}
 
 
@@ -70,7 +70,7 @@ Finished: 0.1 s
 
 """
 
-    results = {'url': 'https://trac.webkit.org/browser/trunk/PerformanceTests/Parser/some-parser.html',
+    results = {'url': 'https://github.com/WebKit/WebKit/blob/main/PerformanceTests/Parser/some-parser.html',
         'metrics': {'Time': {'current': [[1080.0, 1120.0, 1095.0, 1101.0, 1104.0]] * 4}}}
 
 
@@ -112,18 +112,18 @@ median= 1101.0 ms, stdev= 13.31402 ms, min= 1080.0 ms, max= 1120.0 ms
 Finished: 0.1 s
 """
 
-    results = {'url': 'https://trac.webkit.org/browser/trunk/PerformanceTests/Parser/test-with-subtests.html',
+    results = {'url': 'https://github.com/WebKit/WebKit/blob/main/PerformanceTests/Parser/test-with-subtests.html',
         'metrics': {'Time': {'current': [[1080.0, 1120.0, 1095.0, 1101.0, 1104.0]] * 4}},
         'tests': {
             'subtest': {
-                'url': 'https://trac.webkit.org/browser/trunk/PerformanceTests/Parser/test-with-subtests.html',
+                'url': 'https://github.com/WebKit/WebKit/blob/main/PerformanceTests/Parser/test-with-subtests.html',
                 'metrics': {'Time': {'current': [[1.0, 2.0, 3.0, 4.0, 5.0]] * 4}}},
             'total-test': {
-                'url': 'https://trac.webkit.org/browser/trunk/PerformanceTests/Parser/test-with-subtests.html',
+                'url': 'https://github.com/WebKit/WebKit/blob/main/PerformanceTests/Parser/test-with-subtests.html',
                 'metrics': {'Time': {'current': [[1.0, 2.0, 3.0, 4.0, 5.0]] * 4, "aggregators": ["Total"]}},
                 'tests': {
                     'subsubtest':
-                        {'url': 'https://trac.webkit.org/browser/trunk/PerformanceTests/Parser/test-with-subtests.html',
+                        {'url': 'https://github.com/WebKit/WebKit/blob/main/PerformanceTests/Parser/test-with-subtests.html',
                         'metrics': {'Time': {'current': [[1.0, 2.0, 3.0, 4.0, 5.0]] * 4}}}}}}}
 
 
@@ -309,10 +309,10 @@ class MainTest(unittest.TestCase):
 
     _event_target_wrapper_and_inspector_results = {
         "Bindings":
-            {"url": "https://trac.webkit.org/browser/trunk/PerformanceTests/Bindings",
+            {"url": "https://github.com/WebKit/WebKit/blob/main/PerformanceTests/Bindings",
             "tests": {"event-target-wrapper": EventTargetWrapperTestData.results}},
         "Parser":
-            {"url": "https://trac.webkit.org/browser/trunk/PerformanceTests/Parser",
+            {"url": "https://github.com/WebKit/WebKit/blob/main/PerformanceTests/Parser",
             "tests": {"some-parser": SomeParserTestData.results}}}
 
     def test_run_with_json_output(self):
@@ -508,10 +508,10 @@ class MainTest(unittest.TestCase):
         self.assertEqual(output['revisions'], {'WebKit': {'revision': '5678', 'timestamp': '2013-02-01 08:48:05 +0000'}})
         self.assertEqual(list(output['tests'].keys()), ['Bindings', 'Parser'])
         self.assertEqual(sorted(output['tests']['Bindings'].keys()), ['tests', 'url'])
-        self.assertEqual(output['tests']['Bindings']['url'], 'https://trac.webkit.org/browser/trunk/PerformanceTests/Bindings')
+        self.assertEqual(output['tests']['Bindings']['url'], 'https://github.com/WebKit/WebKit/blob/main/PerformanceTests/Bindings')
         self.assertEqual(list(output['tests']['Bindings']['tests'].keys()), ['event-target-wrapper'])
         self.assertEqual(output['tests']['Bindings']['tests']['event-target-wrapper'], {
-            'url': 'https://trac.webkit.org/browser/trunk/PerformanceTests/Bindings/event-target-wrapper.html',
+            'url': 'https://github.com/WebKit/WebKit/blob/main/PerformanceTests/Bindings/event-target-wrapper.html',
             'metrics': {'Time': {'current': [[1486.0, 1471.0, 1510.0, 1505.0, 1478.0, 1490.0]] * 4}}})
 
     def test_run_with_repeat(self):

--- a/Tools/Scripts/webkitpy/tool/servers/data/rebaselineserver/main.js
+++ b/Tools/Scripts/webkitpy/tool/servers/data/rebaselineserver/main.js
@@ -340,7 +340,7 @@ function selectTest()
                 baselinePath += 'platform/' + platform + '/';
             }
             baselinePath += testName + '-expected' + extension;
-            link.href = getTracUrl(baselinePath);
+            link.href = getRepoUrl(baselinePath);
             if (extension == '.checksum') {
                 link.textContent = 'chk';
             } else {
@@ -385,7 +385,7 @@ function updateState()
     $('next-test').disabled = testIndex == testCount - 1;
     $('previous-test').disabled = testIndex == 0;
 
-    $('test-link').href = getTracUrl(testName);
+    $('test-link').href = getRepoUrl(testName);
 
     var state = results.tests[testName].state;
     $('state').className = state;

--- a/Tools/Scripts/webkitpy/tool/servers/data/rebaselineserver/util.js
+++ b/Tools/Scripts/webkitpy/tool/servers/data/rebaselineserver/util.js
@@ -88,9 +88,9 @@ function toggle(id)
     }
 }
 
-function getTracUrl(layoutTestPath)
+function getRepoUrl(layoutTestPath)
 {
-  return 'https://trac.webkit.org/browser/trunk/LayoutTests/' + layoutTestPath;
+  return 'https://github.com/WebKit/WebKit/blob/main/LayoutTests/' + layoutTestPath;
 }
 
 function getSortedKeys(obj)


### PR DESCRIPTION
#### 2f67f454356413a702c53fdcaf5a8b007f034d63
<pre>
Change links from trac.webkit.org/browser/trunk to github.com/WebKit/WebKit/blob/main.
<a href="https://bugs.webkit.org/show_bug.cgi?id=295064">https://bugs.webkit.org/show_bug.cgi?id=295064</a>
<a href="https://rdar.apple.com/154434652">rdar://154434652</a>

Reviewed by Alexey Proskuryakov.

Some links to trac.webkit.org/browser/trunk/* still exist in the repo. This
makes tools like `webkit-patch rebaseline-server` generate a &quot;View test&quot; link
back to trac.webkit.org instead of GitHub.

So, this change replaces all instances of trac.webkit.org/browser/trunk with
github.com/WebKit/WebKit/blob/main.

* Tools/CISupport/build-webkit-org/public_html/TestFailures/scripts/ui.js:
    -&gt; (ui.urlForTest): Change URL to <a href="https://github.com/WebKit/WebKit/blob/main/*.">https://github.com/WebKit/WebKit/blob/main/*.</a>
* Tools/CISupport/ews-app/ews/views/statusbubble.py: Ditto.
* Tools/Scripts/webkitpy/common/config/urls.py: Ditto.
* Tools/Scripts/webkitpy/performance_tests/perftestsrunner_integrationtest.py: Ditto.
* Tools/Scripts/webkitpy/tool/servers/data/rebaselineserver/util.js:
    -&gt; (getTracUrl): Rename to `getRepoUrl`.
* Tools/Scripts/webkitpy/tool/servers/data/rebaselineserver/main.js:
    -&gt; (selectTest): Change invocation of `getTracUrl` to `getRepoUrl`.
    -&gt; (updateState): Ditto.

Canonical link: <a href="https://commits.webkit.org/296815@main">https://commits.webkit.org/296815@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a0b5de78bd411faab643570e4788fae22f5af13

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109330 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28988 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19417 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114535 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59583 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111293 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29667 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37577 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83090 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112278 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23616 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98470 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63545 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/108762 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23005 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16612 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59162 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92984 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16654 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117648 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36371 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26920 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92101 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/108826 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36743 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94731 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91914 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36843 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14589 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32191 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17698 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36267 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35945 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39278 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37643 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->