### PR TITLE
AX: When navigating by-line with VoiceOver, sometimes lines are double-read and others are skipped

### DIFF
--- a/LayoutTests/accessibility/mac/line-navigation-skipped-content-expected.txt
+++ b/LayoutTests/accessibility/mac/line-navigation-skipped-content-expected.txt
@@ -1,0 +1,10 @@
+This test ensures we don't skip any content when using the text marker APIs to navigate by line (like VoiceOver).
+
+PASS: Was able to navigate through all lines of text.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+Game Boy, platform of Donkey Kong Land
+

--- a/LayoutTests/accessibility/mac/line-navigation-skipped-content.html
+++ b/LayoutTests/accessibility/mac/line-navigation-skipped-content.html
@@ -1,0 +1,61 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<!-- Note that this bug reproduces in real pages without contenteditable too, it's just easier to write the test with contenteditable. -->
+<div style="display: flex; font-family: sans-serif;" tabindex=0 id="container" contenteditable="true">
+    <div style="flex: 1 1 55%; float: left; max-width: 127px">
+        <a href="#foo">
+            <img alt="foo image" src="../resources/cake.png" decoding=async width=127 height=154>
+        </a>
+        <div>Game Boy, platform of <i>Donkey Kong Land</i></div>
+    </div>
+    <div style="flex: 1 1 45%;"></div>
+</div>
+<script>
+var output = "This test ensures we don't skip any content when using the text marker APIs to navigate by line (like VoiceOver).\n\n";
+
+document.getElementById("container").focus();
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var expectStringAtIndex = 0;
+    var expectedStrings = [
+        "Game Boy,",
+        "platform of",
+        "Donkey Kong",
+        "Land",
+    ];
+
+    var markerRange, resultString;
+    var webarea = accessibilityController.rootElement.childAtIndex(0);
+    setTimeout(async function() {
+        while (expectStringAtIndex < expectedStrings.length) {
+            eventSender.keyDown("downArrow");
+
+            await waitFor(() => {
+                endMarker = webarea.endTextMarkerForTextMarkerRange(webarea.selectedTextMarkerRange());
+                markerRange = webarea.lineTextMarkerRangeForTextMarker(endMarker);
+
+                resultString = webarea.stringForTextMarkerRange(markerRange)?.trim();
+                if (resultString !== expectedStrings[expectStringAtIndex])
+                    return false;
+
+                ++expectStringAtIndex;
+                return true;
+            });
+        }
+        output += "PASS: Was able to navigate through all lines of text.\n";
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -3945,17 +3945,18 @@ std::optional<TextMarkerData> AXObjectCache::textMarkerDataForVisiblePosition(co
         if (isRendererReplacedElement(node->renderer()) || is<RenderLineBreak>(node->renderer()))
             return createFromRendererAndOffset(*node->renderer(), domOffset);
 
-        CheckedPtr<const RenderText> renderText = dynamicDowncast<RenderText>(node ? node->renderer() : nullptr);
+        CheckedPtr<const RenderText> renderText = nullptr;
+
+        auto boxAndOffset = visiblePosition.inlineBoxAndOffset();
+        if (boxAndOffset.box) {
+            renderText = dynamicDowncast<RenderText>(boxAndOffset.box->renderer());
+            domOffset = boxAndOffset.offset;
+        }
 
         if (!renderText) {
-            auto boxAndOffset = visiblePosition.inlineBoxAndOffset();
-            if (!boxAndOffset.box)
-                return std::nullopt;
-
-            renderText = dynamicDowncast<RenderText>(boxAndOffset.box->renderer());
+            renderText = dynamicDowncast<RenderText>(node ? node->renderer() : nullptr);
             if (!renderText)
                 return std::nullopt;
-            domOffset = boxAndOffset.offset;
         }
 
         auto [textBox, orderCache] = InlineIterator::firstTextBoxInLogicalOrderFor(*renderText);

--- a/Source/WebCore/accessibility/AXTextRun.h
+++ b/Source/WebCore/accessibility/AXTextRun.h
@@ -179,7 +179,7 @@ struct AXTextRuns {
 
     // Convenience methods for TextUnit movement.
     bool runStartsWithLineBreak(size_t runIndex) const { return text[runs[runIndex].startIndex] == '\n'; }
-    bool runEndsWithLineBreak(size_t runIndex) const { return text[runs[runIndex].endIndex] == '\n'; }
+    bool runEndsWithLineBreak(size_t runIndex) const { return text[runs[runIndex].endIndex - 1] == '\n'; }
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### d059afda93f6ee4b9b9ad306bc27f349fa92d7e1
<pre>
AX: When navigating by-line with VoiceOver, sometimes lines are double-read and others are skipped
<a href="https://bugs.webkit.org/show_bug.cgi?id=295060">https://bugs.webkit.org/show_bug.cgi?id=295060</a>
<a href="https://rdar.apple.com/154432630">rdar://154432630</a>

Reviewed by Joshua Hoffman.

This happened because when moving up and down lines via character navigation, we would end up at a text position at the
very end of a line (but still within bounds of the text element), then post this position as a text marker to VoiceOver.
This resulted in us computing the same line-range twice for two different markers across two different up / down movements,
resulting in one line being read twice and the next one being skipped.

The main-thread implementation avoids this using RenderedPosition, which was built to avoid these ambiguities when it comes
to DOM text vs. actual rendered text (e.g. post whitespace collapsing and trimming). RenderedPosition is in turn constructed
using VisiblePosition::inlineBoxAndOffset, which is what has the smarts on when to move off of these ambiguous positions.

This commit fixes the bug by changing AXObjectCache::textMarkerDataForVisiblePosition to lean on VisiblePosition::inlineBoxAndOffset
when constructing an AX-thread text marker. New layout test added (accessibility/mac/line-navigation-skipped-content.html)
that fails without this change.

This commit also includes a fix in AXTextRuns::runEndsWithLineBreak to address a regression introduced by <a href="https://commits.webkit.org/296681@main.">https://commits.webkit.org/296681@main.</a>
When initially working on that change, AXTextRun::endIndex was inclusive, but I later made it exclusive, and forgot to
update runEndsWithLineBreak appropriately (with a `- 1`).

* LayoutTests/accessibility/mac/line-navigation-skipped-content-expected.txt: Added.
* LayoutTests/accessibility/mac/line-navigation-skipped-content.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::textMarkerDataForVisiblePosition):
* Source/WebCore/accessibility/AXTextRun.h:
(WebCore::AXTextRuns::runEndsWithLineBreak const):

Canonical link: <a href="https://commits.webkit.org/296702@main">https://commits.webkit.org/296702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd0a55c82d48d45108d5344a93c458d4bc2bc069

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109328 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19415 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114533 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59581 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111291 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29665 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37575 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83088 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112276 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23618 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98471 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63543 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23007 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16613 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59160 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92986 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16655 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117646 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36369 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26917 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92099 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36741 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94732 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91912 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23409 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36840 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14590 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32189 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36265 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41747 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35943 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39276 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37641 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->