### PR TITLE
[Liquid Glass] [macOS] Top overhang color extension layer is clipped when rubber-banding against the top of the page while zoomed in

### DIFF
--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -552,6 +552,10 @@ void LocalFrameView::setContentsSize(const IntSize& size)
 
     if (m_frame->isMainFrame()) {
         page->pageOverlayController().didChangeDocumentSize();
+#if HAVE(RUBBER_BANDING)
+        if (CheckedPtr renderView = this->renderView())
+            renderView->compositor().updateSizeAndPositionForTopOverhangColorExtensionLayer();
+#endif
         BackForwardCache::singleton().markPagesForContentsSizeChanged(*page);
     }
     layoutContext().enableSetNeedsLayout();

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -2799,7 +2799,6 @@ void RenderLayerCompositor::frameViewDidChangeSize()
 
 #if HAVE(RUBBER_BANDING)
         updateSizeAndPositionForOverhangAreaLayer();
-        updateSizeAndPositionForTopOverhangColorExtensionLayer();
 #endif
     }
 }
@@ -3217,6 +3216,7 @@ void RenderLayerCompositor::updateRootLayerPosition()
     }
 
     updateLayerForTopOverhangColorExtension(m_layerForTopOverhangColorExtension);
+    updateSizeAndPositionForTopOverhangColorExtensionLayer();
     updateLayerForTopOverhangImage(m_layerForTopOverhangImage);
     updateLayerForBottomOverhangArea(m_layerForBottomOverhangArea);
     updateLayerForHeader(m_layerForHeader);
@@ -4969,9 +4969,11 @@ void RenderLayerCompositor::updateSizeAndPositionForTopOverhangColorExtensionLay
         return;
 
     Ref frameView = m_renderView.frameView();
-    auto insets = m_renderView.protectedFrameView()->obscuredContentInsets();
-    layer->setSize(frameView->frameRect().size());
-    layer->setPosition({ 0, insets.top() - layer->size().height() });
+    IntSize layerSize { frameView->contentsSize().width(), frameView->visibleSize().height() };
+    layer->setSize(layerSize);
+
+    auto rootLayerPosition = frameView->positionForRootContentLayer();
+    layer->setPosition({ rootLayerPosition.x(), rootLayerPosition.y() - layerSize.height() });
 }
 #endif // HAVE(RUBBER_BANDING)
 


### PR DESCRIPTION
#### 6cc2003d3fb639db259af595eb995dcd01c53f9a
<pre>
[Liquid Glass] [macOS] Top overhang color extension layer is clipped when rubber-banding against the top of the page while zoomed in
<a href="https://bugs.webkit.org/show_bug.cgi?id=295077">https://bugs.webkit.org/show_bug.cgi?id=295077</a>
Followup to <a href="https://rdar.apple.com/151482288">rdar://151482288</a>

Reviewed by Abrar Rahman Protyasha.

Small followup fix after the changes in 296667@main — the new top overhang color extension layer
should have been positioned right above the root content layer; the width should match that of the
root content layer (`frameView`&apos;s `contentsSize`), and the bottom edge should meet the root content
layer&apos;s top edge.

In particular, the existing logic (without this adjustment) causes the width of the color extension
layer to be shorter than required to span the full content width, when pinch-zooming into the web
view and scrolling against the top right edge of the screen.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::setContentsSize):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::frameViewDidChangeSize):

Move the call to `updateSizeAndPositionForTopOverhangColorExtensionLayer` into
`updateRootLayerPosition`, after the existing calls to update overhang layers.

(WebCore::RenderLayerCompositor::updateRootLayerPosition):
(WebCore::RenderLayerCompositor::updateSizeAndPositionForTopOverhangColorExtensionLayer):

See above. Note that the height of this color extension layer shouldn&apos;t really matter in practice —
as long as it&apos;s tall enough that it covers at least any vertical distance when rubber-banding. I
arbitrarily chose the visible height of the frame view here, assuming that users wouldn&apos;t need to
rubber-band the page so far, such that the page is not even visible.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/ObscuredContentInsets.mm:
(TestWebKitAPI::TEST(ObscuredContentInsets, TopOverhangColorExtensionLayer)):

Augment this API test to additionally sanity check the frame and background of the color extension
layer, both before and after zooming in. In both cases, the width should be consistent with the root
content layer, and it should be positioned such that the bottom of the layer is aligned to the top
of the root content layer.

Canonical link: <a href="https://commits.webkit.org/296704@main">https://commits.webkit.org/296704@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ba690022083a736280dccddadb6932437a6612d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109358 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29016 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19445 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114563 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59602 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111321 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29695 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37604 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83110 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112306 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23639 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98497 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63567 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23024 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16640 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59187 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93007 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16682 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117675 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36399 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/26939 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92119 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36770 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94759 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91934 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23410 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36864 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14610 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32210 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36292 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41768 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35966 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39303 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37668 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->