### PR TITLE
[JSC] Use BitSet for MarkedBlock::sweep

### DIFF
--- a/Source/JavaScriptCore/heap/MarkedBlock.cpp
+++ b/Source/JavaScriptCore/heap/MarkedBlock.cpp
@@ -170,6 +170,7 @@ void MarkedBlock::Handle::lastChanceToFinalize()
     m_directory->assertSweeperIsSuspended();
     m_directory->setIsAllocated(this, false);
     m_directory->setIsDestructible(this, true);
+    m_directory->setIsUnswept(this, true);
     blockHeader().m_marks.clearAll();
     block().clearHasAnyMarked();
     blockHeader().m_markingVersion = heap()->objectSpace().markingVersion();
@@ -483,12 +484,12 @@ void MarkedBlock::Handle::sweep(FreeList* freeList)
         return;
     }
 
-    if (m_isFreeListed) {
+    if (m_isFreeListed) [[unlikely]] {
         dataLog("FATAL: ", RawPointer(this), "->sweep: block is free-listed.\n");
         RELEASE_ASSERT_NOT_REACHED();
     }
     
-    if (isAllocated()) {
+    if (isAllocated()) [[unlikely]] {
         dataLog("FATAL: ", RawPointer(this), "->sweep: block is allocated.\n");
         RELEASE_ASSERT_NOT_REACHED();
     }

--- a/Source/JavaScriptCore/heap/MarkedBlock.h
+++ b/Source/JavaScriptCore/heap/MarkedBlock.h
@@ -220,7 +220,7 @@ public:
     private:
         Handle(Heap&, AlignedMemoryAllocator*, void*);
         
-        enum SweepDestructionMode { BlockHasNoDestructors, BlockHasDestructors, BlockHasDestructorsAndCollectorIsRunning };
+        enum SweepDestructionMode { BlockHasNoDestructors, BlockHasDestructors };
         enum ScribbleMode { DontScribble, Scribble };
         enum EmptyMode { IsEmpty, NotEmpty };
         enum NewlyAllocatedMode { HasNewlyAllocated, DoesNotHaveNewlyAllocated };

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -234,7 +234,6 @@ bool hasCapacityToUseLargeGigacage();
     v(Double, sizeClassProgression, 1.4, Normal, nullptr) \
     v(Unsigned, preciseAllocationCutoff, 100000, Normal, nullptr) \
     v(Bool, dumpSizeClasses, false, Normal, nullptr) \
-    v(Bool, useBumpAllocator, true, Normal, nullptr) \
     v(Bool, stealEmptyBlocksFromOtherAllocators, true, Normal, nullptr) \
     v(Bool, eagerlyUpdateTopCallFrame, false, Normal, nullptr) \
     v(Bool, dumpZappedCellCrashData, false, Normal, nullptr) \


### PR DESCRIPTION
#### e498e0debab264e2d840a9e74613b60c420d04f4
<pre>
[JSC] Use BitSet for MarkedBlock::sweep
<a href="https://bugs.webkit.org/show_bug.cgi?id=295083">https://bugs.webkit.org/show_bug.cgi?id=295083</a>
<a href="https://rdar.apple.com/154457450">rdar://154457450</a>

Reviewed by Yijia Huang.

This patch changes MarkedBlock::sweep by using BitSet.

1. Instead of iterating each cell, this patch uses BitSet.
   We construct these set from m_marks and m_newlyAllocated.
   These BitSet will answer liveness information super quickly,
   and iterating these bits are very efficient, in particular
   given that BitSet is already sparse (since atom size is smaller
   than cell size in most cases).
2. We copy BitSet before iterating them. So we can get snapshot of
   liveness information. We no longer need to push cells to the
   Vector for concurrent marking case since this liveness information
   is enough.
3. We construct FreeList in a forward direction. And we also call
   scribble / destructor too. So we can keep touching the same region
   well. Furthermore, we can do destroy calls in a bulk manner.
4. We leverage &quot;unswept&quot; bit and avoid calling destructors when unswept
   bit was not set. This happens when we call resumeAllocation
   (reconstructing FreeList to resume peripheral threads). In this case,
   we do not need to call destructors since our liveness condition is
   not changed from the previous sweeping, otherwise, unswept bit is
   updated.
5. We also remove useBumpAllocator option. Now we are always using
   interval based FreeList. So this option is meaningless.

* Source/JavaScriptCore/heap/MarkedBlock.cpp:
(JSC::MarkedBlock::Handle::sweep):
* Source/JavaScriptCore/heap/MarkedBlock.h:
* Source/JavaScriptCore/heap/MarkedBlockInlines.h:
(JSC::MarkedBlock::Handle::specializedSweep):
(JSC::MarkedBlock::Handle::sweepDestructionMode):
(JSC::DeadCellStorage::append): Deleted.
(): Deleted.
* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/296816@main">https://commits.webkit.org/296816@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26f65baf0d41a91ef745e8894c70772daa55e578

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109576 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29234 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19663 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/115565 "Build was cancelled. Recent messages:Printed configuration") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/59810 "Build was cancelled. Recent messages:Printed configuration") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29912 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37822 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/115565 "Build was cancelled. Recent messages:Printed configuration") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/59810 "Build was cancelled. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112524 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23829 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98691 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/115565 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23208 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16835 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59394 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/102066 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93204 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16874 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/118363 "Build was cancelled. Recent messages:Printed configuration") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/108128 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36615 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27111 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/118363 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36988 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94951 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/118363 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37051 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14798 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32422 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17699 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36509 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41980 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/132393 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36169 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35854 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39512 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37879 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->