### PR TITLE
Reduce scope of WTF_ALLOW_UNSAFE_BUFFER_USAGE macros in StringImpl.cpp

### DIFF
--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -44,8 +44,6 @@
 #include <wtf/DataLog.h>
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 using namespace Unicode;
@@ -333,6 +331,7 @@ Ref<StringImpl> StringImpl::substring(unsigned start, unsigned length)
     return create(span16().subspan(start, length));
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 char32_t StringImpl::characterStartingAt(unsigned i)
 {
     if (is8Bit())
@@ -513,6 +512,7 @@ Ref<StringImpl> StringImpl::convertToUppercaseWithoutLocaleStartingAtFailingInde
 
     return newImpl;
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 Ref<StringImpl> StringImpl::convertToUppercaseWithoutLocaleUpconvert()
 {
@@ -640,6 +640,7 @@ Ref<StringImpl> StringImpl::convertToUppercaseWithLocale(const AtomString& local
     return newString;
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 Ref<StringImpl> StringImpl::foldCase()
 {
     if (is8Bit()) {
@@ -722,6 +723,7 @@ SlowPath:
         return *this;
     return folded;
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 template<StringImpl::CaseConvertType type, typename CharacterType>
 ALWAYS_INLINE Ref<StringImpl> StringImpl::convertASCIICase(StringImpl& impl, std::span<const CharacterType> data)
@@ -766,6 +768,7 @@ Ref<StringImpl> StringImpl::convertToASCIIUppercase()
     return convertASCIICase<CaseConvertType::Upper>(*this, span16());
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 template<typename CodeUnitPredicate> inline Ref<StringImpl> StringImpl::trimMatchedCharacters(CodeUnitPredicate predicate)
 {
     if (!m_length)
@@ -792,12 +795,14 @@ template<typename CodeUnitPredicate> inline Ref<StringImpl> StringImpl::trimMatc
         return create(std::span { m_data8 + start, end + 1 - start });
     return create(std::span { m_data16 + start, end + 1 - start });
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 Ref<StringImpl> StringImpl::trim(CodeUnitMatchFunction predicate)
 {
     return trimMatchedCharacters(predicate);
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 template<typename CharacterType, class UCharPredicate> inline Ref<StringImpl> StringImpl::simplifyMatchedCharactersToSpace(UCharPredicate predicate)
 {
     StringBuffer<CharacterType> data(m_length);
@@ -831,6 +836,7 @@ template<typename CharacterType, class UCharPredicate> inline Ref<StringImpl> St
 
     return adopt(WTFMove(data));
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 Ref<StringImpl> StringImpl::simplifyWhiteSpace(CodeUnitMatchFunction isWhiteSpace)
 {
@@ -853,6 +859,7 @@ float StringImpl::toFloat(bool* ok)
     return charactersToFloat(span16(), ok);
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 size_t StringImpl::find(std::span<const LChar> matchString, size_t start)
 {
     ASSERT(!matchString.empty());
@@ -910,6 +917,7 @@ size_t StringImpl::find(std::span<const LChar> matchString, size_t start)
     }
     return start + i;
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 size_t StringImpl::reverseFind(std::span<const LChar> matchString, size_t start)
 {
@@ -1023,6 +1031,7 @@ size_t StringImpl::reverseFind(StringView matchString, size_t start)
     return reverseFindInner(span16(), matchString.span16(), start);
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 ALWAYS_INLINE static bool equalInner(const StringImpl& string, unsigned start, std::span<const char> matchString)
 {
     ASSERT(matchString.size() <= string.length());
@@ -1051,6 +1060,7 @@ ALWAYS_INLINE static bool equalInner(const StringImpl& string, unsigned start, S
         return equal(string.span16().data() + start, matchString.span8());
     return equal(string.span16().data() + start, matchString.span16());
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 bool StringImpl::startsWith(StringView string) const
 {
@@ -1102,6 +1112,7 @@ bool StringImpl::hasInfixEndingAt(StringView matchString, size_t end) const
     return end >= matchString.length() && equalInner(*this, end - matchString.length(), matchString);
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 Ref<StringImpl> StringImpl::replace(char16_t target, char16_t replacement)
 {
     if (target == replacement)
@@ -1170,6 +1181,7 @@ Ref<StringImpl> StringImpl::replace(size_t position, size_t lengthToReplace, Str
         copyCharacters(data.subspan(position + lengthToInsert), { m_data16 + position + lengthToReplace, length() - position - lengthToReplace });
     return newImpl;
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 Ref<StringImpl> StringImpl::replace(char16_t pattern, StringView replacement)
 {
@@ -1180,6 +1192,7 @@ Ref<StringImpl> StringImpl::replace(char16_t pattern, StringView replacement)
     return replace(pattern, replacement.span16());
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 Ref<StringImpl> StringImpl::replace(char16_t pattern, std::span<const LChar> replacement)
 {
     ASSERT(replacement.data());
@@ -1437,12 +1450,14 @@ Ref<StringImpl> StringImpl::replace(StringView pattern, StringView replacement)
 
     return newImpl;
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 bool equal(const StringImpl* a, const StringImpl* b)
 {
     return equalCommon(a, b);
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 template<typename CharacterType> inline bool equalInternal(const StringImpl* a, std::span<const CharacterType> b)
 {
     if (!a)
@@ -1458,6 +1473,7 @@ template<typename CharacterType> inline bool equalInternal(const StringImpl* a, 
         return a->span8().front() == b.front() && equal(a->span8().data() + 1, b.subspan(1));
     return a->span16().front() == b.front() && equal(a->span16().data() + 1, b.subspan(1));
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 bool equal(const StringImpl* a, std::span<const LChar> b)
 {
@@ -1469,6 +1485,7 @@ bool equal(const StringImpl* a, std::span<const char16_t> b)
     return equalInternal(a, b);
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 bool equal(const StringImpl* a, const LChar* b)
 {
     if (!a)
@@ -1503,6 +1520,7 @@ bool equal(const StringImpl* a, const LChar* b)
 
     return !b[length];
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 bool equal(const StringImpl& a, const StringImpl& b)
 {
@@ -1637,6 +1655,7 @@ unsigned StringImpl::concurrentHash() const
     return hash;
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 bool equalIgnoringNullity(std::span<const char16_t> a, StringImpl* b)
 {
     if (!b)
@@ -1653,7 +1672,6 @@ bool equalIgnoringNullity(std::span<const char16_t> a, StringImpl* b)
     }
     return equal(a, b->span16());
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 } // namespace WTF
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### ad9081b13d9065c12a88656ed621195822f90661
<pre>
Reduce scope of WTF_ALLOW_UNSAFE_BUFFER_USAGE macros in StringImpl.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=295085">https://bugs.webkit.org/show_bug.cgi?id=295085</a>

Reviewed by Ryosuke Niwa.

* Source/WTF/wtf/text/StringImpl.cpp:

Canonical link: <a href="https://commits.webkit.org/296733@main">https://commits.webkit.org/296733@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f490eadd821e73125e96c5a2d3b114e73f05dcd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109375 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29033 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19462 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114580 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59614 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29712 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37621 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83123 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112323 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98516 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63580 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23038 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16659 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59202 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/101875 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93024 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16701 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117692 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/107931 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36416 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26953 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92131 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36787 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94778 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91946 "Found 2 new API test failures: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23421 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36878 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14628 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32222 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36309 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41785 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/132197 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35981 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35820 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39319 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37684 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->