### PR TITLE
AX: Voice control not focusing inputs and textareas when not in a fieldset

### DIFF
--- a/LayoutTests/accessibility/mac/press-action-text-inputs-expected.txt
+++ b/LayoutTests/accessibility/mac/press-action-text-inputs-expected.txt
@@ -1,0 +1,13 @@
+This tests that performing a press action on text input types brings focus to those elements.
+
+Successfully focused text input.
+Successfully focused search input.
+Successfully focused content editable div.
+Successfully focused number input.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+Hello
+

--- a/LayoutTests/accessibility/mac/press-action-text-inputs.html
+++ b/LayoutTests/accessibility/mac/press-action-text-inputs.html
@@ -1,0 +1,49 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<input type="text" id="textInput"/>
+<input type="search" id="searchInput"/>
+<div contenteditable id="editableDiv">Hello</div>
+<input type="number" id="numberInput"/>
+
+<script>
+var output = "This tests that performing a press action on text input types brings focus to those elements.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var textInput = accessibilityController.accessibleElementById("textInput");
+    setTimeout(async function() {
+        textInput.press()
+        await waitFor(() => accessibilityController.focusedElement.role == "AXRole: AXTextField");
+        output += "Successfully focused text input.\n";
+
+        var searchInput = accessibilityController.accessibleElementById("searchInput");
+        searchInput.press();
+        await waitFor(() => accessibilityController.focusedElement.subrole == "AXSubrole: AXSearchField");
+        output += "Successfully focused search input.\n";
+
+        var contentEditable = accessibilityController.accessibleElementById("editableDiv");
+        contentEditable.press();
+        await waitFor(() => accessibilityController.focusedElement.role == "AXRole: AXTextArea");
+        output += "Successfully focused content editable div.\n";
+
+        var numberInput = accessibilityController.accessibleElementById("numberInput");
+        numberInput.press();
+        await waitFor(() => accessibilityController.focusedElement.role == "AXRole: AXTextField");
+        output += "Successfully focused number input.\n";
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+
+</script>
+
+</body>
+</html>

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -1224,10 +1224,16 @@ static RefPtr<Element> nodeActionElement(Node& node)
 {
     auto elementName = WebCore::elementName(node);
     if (RefPtr input = dynamicDowncast<HTMLInputElement>(node)) {
-        if (!input->isDisabledFormControl() && (input->isRadioButton() || input->isCheckbox() || input->isTextButton() || input->isFileUpload() || input->isImageButton()))
+        if (!input->isDisabledFormControl() && (input->isRadioButton() || input->isCheckbox() || input->isTextButton() || input->isFileUpload() || input->isImageButton() || input->isTextField()))
             return input;
     } else if (elementName == ElementName::HTML_button || elementName == ElementName::HTML_select)
         return &downcast<Element>(node);
+
+    // Content editable nodes should also be considered action elements, so they can accept presses.
+    if (RefPtr element = dynamicDowncast<Element>(node)) {
+        if (AccessibilityObject::contentEditableAttributeIsEnabled(*element))
+            return element;
+    }
 
     return nullptr;
 }


### PR DESCRIPTION
#### 09204fce5fa15194dbec6ce3ad2d0772be628ab8
<pre>
AX: Voice control not focusing inputs and textareas when not in a fieldset
<a href="https://bugs.webkit.org/show_bug.cgi?id=293974">https://bugs.webkit.org/show_bug.cgi?id=293974</a>
<a href="https://rdar.apple.com/152517222">rdar://152517222</a>

Reviewed by Tyler Wilcock.

We expose text inputs as supporting press actions in supportsPressAction, but did
not handle them at all when computing a node&apos;s action element. This would lead ATs
like Voice Control to try to invoke this action, with no result or change in focus.

To start supporting this, return text inputs and content editable nodes as action
elements.

* LayoutTests/accessibility/mac/press-action-text-inputs-expected.txt: Added.
* LayoutTests/accessibility/mac/press-action-text-inputs.html: Added.
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::nodeActionElement):

Canonical link: <a href="https://commits.webkit.org/296763@main">https://commits.webkit.org/296763@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e27b05fceaed31548ac21e8cf06e1049226cad9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109450 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29108 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114655 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59678 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111413 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29787 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37696 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83188 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112398 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23726 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98587 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63647 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23107 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16729 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59274 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93096 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16771 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117769 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36491 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27018 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92201 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36862 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94848 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92017 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23444 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36949 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14697 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32294 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36384 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41859 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36054 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39393 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37758 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->