### PR TITLE
Digital Credentials: implement userAgentAllowsProtocol()

### DIFF
--- a/LayoutTests/http/wpt/identity/formats/ISO18013/mobiledocument.https-expected.txt
+++ b/LayoutTests/http/wpt/identity/formats/ISO18013/mobiledocument.https-expected.txt
@@ -1,4 +1,5 @@
 
+PASS Check that the user agent knows about the ISO-18013 Mobile Document protocol.
 PASS Conversion to ISO-18013 Mobile Document Request.
 PASS Validation of ISO-18013 Mobile Document Request.
 

--- a/LayoutTests/http/wpt/identity/formats/ISO18013/mobiledocument.https.html
+++ b/LayoutTests/http/wpt/identity/formats/ISO18013/mobiledocument.https.html
@@ -17,6 +17,21 @@
         assert_equals(document.visibilityState, "visible", "should be visible");
     });
 
+    promise_test(async ()=>{
+        assert_true(
+            DigitalCredential.userAgentAllowsProtocol("org-iso-mdoc"),
+            "Check that the user agent allows the ISO-18013 Mobile Document protocol."
+        );
+        assert_false(
+            DigitalCredential.userAgentAllowsProtocol(""),
+            "Check that the user agent does not allow an empty protocol."
+        );
+        assert_false(
+            DigitalCredential.userAgentAllowsProtocol("org-iso-mdoc-unknown"),
+            "Check that the user agent does not allow an unknown protocol."
+        );
+    }, "Check that the user agent knows about the ISO-18013 Mobile Document protocol.");
+
     promise_test(async (t) => {
         const invalidData = [
             "",

--- a/LayoutTests/http/wpt/identity/idl.https-expected.txt
+++ b/LayoutTests/http/wpt/identity/idl.https-expected.txt
@@ -82,4 +82,5 @@ PASS DigitalCredential interface: existence and properties of interface prototyp
 PASS DigitalCredential interface: existence and properties of interface prototype object's @@unscopables property
 PASS DigitalCredential interface: attribute protocol
 PASS DigitalCredential interface: attribute data
+PASS DigitalCredential interface: operation userAgentAllowsProtocol(DOMString)
 

--- a/LayoutTests/http/wpt/identity/idl.https.html
+++ b/LayoutTests/http/wpt/identity/idl.https.html
@@ -21,6 +21,7 @@ dictionary DigitalCredentialRequest {
 interface DigitalCredential : Credential {
     readonly attribute DOMString protocol;
     readonly attribute Uint8Array data;
+    static boolean userAgentAllowsProtocol(DOMString protocol);
 };
 </script>
 <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/META.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/META.yml
@@ -1,7 +1,8 @@
-spec: https://github.com/wicg/digital-credentials
+spec: https://github.com/w3c-fedid/digital-credentials/
 suggested_reviewers:
   - marcoscaceres
   - samuelgoto
   - tplooker
   - pkotwicz
   - mohamedamir
+  - timcappalli

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/dc-types.ts
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/dc-types.ts
@@ -8,7 +8,7 @@ export type CredentialMediationRequirement =
   | "silent";
 
 /**
- * @see https://wicg.github.io/digital-credentials/#dom-digitalcredentialrequest
+ * @see https://w3c-fedid.github.io/digital-credentials/#dom-digitalcredentialrequest
  */
 export interface DigitalCredentialGetRequest {
   protocol: string;
@@ -16,7 +16,7 @@ export interface DigitalCredentialGetRequest {
 }
 
 /**
- * @see https://wicg.github.io/digital-credentials/#dom-digitalcredentialrequestoptions
+ * @see https://w3c-fedid.github.io/digital-credentials/#dom-digitalcredentialrequestoptions
  */
 export interface DigitalCredentialRequestOptions {
   /**
@@ -26,7 +26,7 @@ export interface DigitalCredentialRequestOptions {
 }
 
 /**
- * @see https://wicg.github.io/digital-credentials/#extensions-to-credentialrequestoptions
+ * @see https://w3c-fedid.github.io/digital-credentials/#extensions-to-credentialrequestoptions
  */
 export interface CredentialRequestOptions {
   digital: DigitalCredentialRequestOptions;

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/digital-credential-user-agent-allows-protocol.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/digital-credential-user-agent-allows-protocol.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS User agent does not allow invalid protocol identifiers.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/digital-credential-user-agent-allows-protocol.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/digital-credential-user-agent-allows-protocol.https.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>Tests for DigitalCredential's userAgentAllowsProtocol() static method.</title>
+<link rel="help" href="https://github.com/w3c-fedid/digital-credentials/pull/221" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body></body>
+<script type="module">
+
+  const invalidIdentifiers = ["", " ", "a b", "a,b", "AB", "a.B", "a.b", " foo-bar", " foo-bar ", "foo-bar ", "fooBar"];
+
+  promise_test(async (t) => {
+    for (const invalidIdentifier of invalidIdentifiers) {
+      const result = DigitalCredential.userAgentAllowsProtocol(invalidIdentifier);
+      assert_equals(result, false, `Incorrect result for ${invalidIdentifier}.`);
+    }
+  }, "User agent does not allow invalid protocol identifiers.");
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/w3c-import.log
@@ -22,6 +22,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/digital-credentials/create.tentative.https.html
 /LayoutTests/imported/w3c/web-platform-tests/digital-credentials/dc-types.ts
 /LayoutTests/imported/w3c/web-platform-tests/digital-credentials/default-permissions-policy.https.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/digital-credential-user-agent-allows-protocol.https.html
 /LayoutTests/imported/w3c/web-platform-tests/digital-credentials/digital-credentials-static-methods.tentative.https.html
 /LayoutTests/imported/w3c/web-platform-tests/digital-credentials/enabled-on-self-origin-by-permissions-policy.https.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/digital-credentials/enabled-on-self-origin-by-permissions-policy.https.sub.html.headers

--- a/Source/WebCore/Modules/identity/DigitalCredential.h
+++ b/Source/WebCore/Modules/identity/DigitalCredential.h
@@ -66,6 +66,11 @@ public:
 
     static void discoverFromExternalSource(const Document&, CredentialPromise&&, CredentialRequestOptions&&);
 
+    static bool userAgentAllowsProtocol(const String& protocol)
+    {
+        return protocol == "org-iso-mdoc"_s;
+    }
+
 private:
     DigitalCredential(JSC::Strong<JSC::JSObject>&&, IdentityCredentialProtocol);
 

--- a/Source/WebCore/Modules/identity/DigitalCredential.idl
+++ b/Source/WebCore/Modules/identity/DigitalCredential.idl
@@ -31,4 +31,5 @@
 ] interface DigitalCredential : BasicCredential {
     [SameObject] readonly attribute object data;
     readonly attribute IdentityCredentialProtocol protocol;
+    static boolean userAgentAllowsProtocol(DOMString protocol);
 };


### PR DESCRIPTION
#### 13d1709c2ffe886e469ecad874d12c06b91b2428
<pre>
Digital Credentials: implement userAgentAllowsProtocol()
<a href="https://rdar.apple.com/153776127">rdar://153776127</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=294352">https://bugs.webkit.org/show_bug.cgi?id=294352</a>

Reviewed by Anne van Kesteren.

This implements the userAgentAllowsProtocol() method, which allows
user agents to indicate whether they support a given protocol for
digital credentials. This is useful for sites to determine if they can
request a digital credential with a specific protocol.

Spec:
<a href="https://w3c-fedid.github.io/digital-credentials/#dom-digitalcredential-useragentallowsprotocol">https://w3c-fedid.github.io/digital-credentials/#dom-digitalcredential-useragentallowsprotocol</a>

WebKit only supports the &quot;org-iso-mdoc&quot; protocol, so this method
returns true only for that protocol.

Imports relevent Web Platform Tests. Upstream commit:

<a href="https://github.com/web-platform-tests/wpt/commit/c7fd2ce174cbc79b1e8d9b86c448d709a0e3f427">https://github.com/web-platform-tests/wpt/commit/c7fd2ce174cbc79b1e8d9b86c448d709a0e3f427</a>
Canonical link: <a href="https://commits.webkit.org/296786@main">https://commits.webkit.org/296786@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed3f83f434129fdad3e22575f31aa8b20ae25e79

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109390 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29048 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114595 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59629 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111353 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29727 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37636 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83139 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112338 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23671 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98527 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63596 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23055 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16670 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59217 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93039 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16712 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117707 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36431 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26966 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92147 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36802 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94789 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91962 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23460 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36893 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14639 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32241 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36324 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41800 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35996 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39334 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37699 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->