### PR TITLE
Implement `hidden=until-found` HTML attribute and `beforematch` event

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7924,13 +7924,8 @@ webkit.org/b/290285 imported/w3c/web-platform-tests/svg/struct/reftests/use-data
 webkit.org/b/290285 imported/w3c/web-platform-tests/svg/struct/reftests/use-data-url.tentative.svg [ Skip ]
 webkit.org/b/290285 imported/w3c/web-platform-tests/svg/struct/scripted/use-load-error-events.tentative.html [ Skip ]
 
-# hidden=until-found
-imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-004.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-005.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-007.html [ ImageOnlyFailure ]
+# Investigate timeout on this test.
 imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-scroll-to-text-fragment.html [ Skip ]
-imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-text-fragment.html [ Skip ]
 
 # This test hits an assert in debug
 webkit.org/b/290133 [ Debug ] svg/dom/SVGGeometry-isPointInFill-with-null-path.html [ Skip ]

--- a/LayoutTests/editing/find/cocoa/find-in-page-in-hidden-until-found-expected.txt
+++ b/LayoutTests/editing/find/cocoa/find-in-page-in-hidden-until-found-expected.txt
@@ -1,0 +1,19 @@
+Verifies that find and replace can be used to replace words in an editable area. This test requires WebKitTestRunner.
+
+After replacing 'orange' with 'apricot':
+| "\n            "
+| <p>
+|   "Apple banana <#selection-anchor>apricot<#selection-focus>."
+| "\n        "
+
+First editor after replacing 'banana' with 'watermelon':
+| "\n            "
+| <p>
+|   "Apple <#selection-anchor>watermelon<#selection-focus> apricot."
+| "\n        "
+
+Second editor after replacing 'banana' with 'watermelon':
+| "\n                "
+| <p>
+|   "Kiwi watermelon pear."
+| "\n            "

--- a/LayoutTests/editing/find/cocoa/find-in-page-in-hidden-until-found.html
+++ b/LayoutTests/editing/find/cocoa/find-in-page-in-hidden-until-found.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/dump-as-markup.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+</head>
+<body>
+    <div id="hiddenUntilFound" hidden="until-found">
+        <div id="editor" contenteditable>
+            <p>Apple banana orange.</p>
+        </div>
+    </div>
+    <div id="otherHiddenUntilFound" hidden="until-found">
+        <div id="nestedHiddenUntilFound" hidden="until-found">
+            <div id="otherEditor" contenteditable>
+                <p>Kiwi banana pear.</p>
+            </div>
+        </div>
+    </div>
+    <div id="log"></div>
+</body>
+<script>
+Markup.waitUntilDone();
+Markup.description("Verifies that find and replace can be used to replace words in an editable area. This test requires WebKitTestRunner.");
+
+function waitForReveal(element) {
+    return new Promise((resolve, reject) => {
+        element.onbeforematch = () => {
+            if (!element.hidden)
+                reject();
+            setTimeout(() => {
+                if (!element.hidden)
+                    resolve();
+            }, 0);
+        }
+    });
+}
+
+onload = async () => {
+    testRunner.findStringMatchesInPage("orange", []);
+    testRunner.indicateFindMatch(0);
+    await Promise.all([waitForReveal(hiddenUntilFound), UIHelper.ensurePresentationUpdate()]);
+    testRunner.replaceFindMatchesAtIndices([0], "apricot", false);
+    Markup.dump("editor", "After replacing 'orange' with 'apricot'");
+
+    if (hiddenUntilFound.hidden) {
+        log.textContent += "FAIL because first element didn't expand after first replacement.\n";
+    }
+
+    if (!otherHiddenUntilFound.hidden || !nestedHiddenUntilFound.hidden) {
+        log.textContent += "FAIL because second element expanded after first replacement, despite word not matching in second element.\n";
+    }
+
+    hiddenUntilFound.hidden = "until-found";
+
+    testRunner.findStringMatchesInPage("banana", []);
+    testRunner.indicateFindMatch(0);
+    await Promise.all([waitForReveal(hiddenUntilFound), UIHelper.ensurePresentationUpdate()]);
+    testRunner.indicateFindMatch(1);
+    await Promise.all([waitForReveal(otherHiddenUntilFound), waitForReveal(nestedHiddenUntilFound), UIHelper.ensurePresentationUpdate()]);
+    testRunner.replaceFindMatchesAtIndices([0, 1], "watermelon", false);
+    Markup.dump("editor", "First editor after replacing 'banana' with 'watermelon'");
+    Markup.dump("otherEditor", "Second editor after replacing 'banana' with 'watermelon'");
+
+    if (hiddenUntilFound.hidden) {
+        log.textContent += "FAIL because first element didn't expand after second replacement.\n";
+    }
+
+    if (otherHiddenUntilFound.hidden || nestedHiddenUntilFound.hidden) {
+        log.textContent += "FAIL because second element didn't expand after second replacement.\n";
+    }
+
+    if (log.textContent)
+        Markup.dump("log");
+
+    Markup.notifyDone();
+};
+</script>
+</html>

--- a/LayoutTests/editing/text-iterator/find-in-page-in-hidden-until-found-expected.txt
+++ b/LayoutTests/editing/text-iterator/find-in-page-in-hidden-until-found-expected.txt
@@ -1,0 +1,9 @@
+
+PASS auto-expand on find-in-page match: div-simple
+PASS auto-expand on find-in-page match: nested-until-found
+PASS auto-expand on find-in-page match: nested-p
+PASS auto-expand on find-in-page match: nested-table
+PASS auto-expand on find-in-page match: details-nested-simple
+PASS auto-expand on find-in-page match: details-nested-target-in-p
+PASS auto-expand on find-in-page match: details-nested-target-in-table
+

--- a/LayoutTests/editing/text-iterator/find-in-page-in-hidden-until-found.html
+++ b/LayoutTests/editing/text-iterator/find-in-page-in-hidden-until-found.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html><html lang><meta charset="utf-8">
+<title>find-in-page with hidden=until-found elements</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<hr>
+<script>
+findStringInHiddenUntilFound = (id, contents) => {
+    promise_test(async () => {
+        document.body.insertAdjacentHTML("beforeend", `<div hidden="until-found" id=${id}>${contents}</div>`);
+        const div = document.getElementById(id);
+        assert_equals(div.hidden, "until-found", `div element is in hidden=until-found state: ${id}`);
+        assert_equals(getComputedStyle(div).contentVisibility, "hidden", `div element has c-v: hidden: ${id}`);
+        await new Promise((resolve) => {
+            div.addEventListener("beforematch", resolve, { once: true });
+            testRunner.findString(id, []);
+        });
+        assert_equals(div.hidden, "until-found", `div element is still in hidden=until-found state: ${id}`);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        assert_false(div.hidden, `div element is no longer hidden after a tick: ${id}`);
+
+        const detailsElements = div.querySelectorAll("details");
+        detailsElements.forEach((details) => {
+            assert_true(details.open, "details element got expanded");
+        });
+        div.remove();
+    }, `auto-expand on find-in-page match: ${id}`);
+}
+let target;
+target = "div-simple"; findStringInHiddenUntilFound(target, target);
+target = "nested-until-found"; findStringInHiddenUntilFound(target, `<div hidden=until-found>${target}</div>`);
+target = "nested-p"; findStringInHiddenUntilFound(target, `<p>${target}</p>`);
+target = "nested-table"; findStringInHiddenUntilFound(target, `<table><tr><td>${target}</table>`);
+target = "details-nested-simple"; findStringInHiddenUntilFound(target, `<details>${target}</details>`);
+target = "details-nested-target-in-p"; findStringInHiddenUntilFound(target, `<details><p>${target}</p></details>`);
+target = "details-nested-target-in-table"; findStringInHiddenUntilFound(target, `<details><table><tr><td>${target}</table></details>`);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-element-fragment-navigation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-element-fragment-navigation-expected.txt
@@ -1,13 +1,14 @@
+hello
 spacer
 
-FAIL Verifies that fragment navigation reveals hidden=until-found elements. assert_false: expected false got true
-FAIL Verifies that fragment navigation reveals all parent hidden=until-found elements. assert_false: parentid should not have the hidden attribute. expected false got true
-FAIL Verifies that the beforematch event is fired synchronously and bubbles after fragment navigation. assert_true: beforematch should have been fired on parentid. expected true got false
-FAIL Verifies that when a beforematch event handler moves a matching element, we scroll to its final location. assert_true: The beforematch event should have been fired. expected true got false
-FAIL Verifies that the beforematch event is fired on the right element when there are multiple hidden=until-found elements. assert_true: bar was navigated to, so it should get the beforematch event. expected true got false
-FAIL Verifies that no scrolling occurs when an element selected by the fragment identifier is detached by the beforematch event handler. assert_true: beforematch should be called when window.location.hash is set to #detach. expected true got false
-FAIL No scrolling should occur when the beforematch event handler sets the target element's style to display: none. assert_true: beforematch should be called when window.location.hash is set to #displaynone. expected true got false
-FAIL Scrolling should still occur when beforematch sets visiblity:hidden on the target element. assert_true: beforematch should be called when window.location.hash is set to #visibilityhidden. expected true got false
+PASS Verifies that fragment navigation reveals hidden=until-found elements.
+PASS Verifies that fragment navigation reveals all parent hidden=until-found elements.
+PASS Verifies that the beforematch event is fired synchronously and bubbles after fragment navigation.
+PASS Verifies that when a beforematch event handler moves a matching element, we scroll to its final location.
+PASS Verifies that the beforematch event is fired on the right element when there are multiple hidden=until-found elements.
+PASS Verifies that no scrolling occurs when an element selected by the fragment identifier is detached by the beforematch event handler.
+PASS No scrolling should occur when the beforematch event handler sets the target element's style to display: none.
+PASS Scrolling should still occur when beforematch sets visiblity:hidden on the target element.
 PASS Verifies that the beforematch event is not fired on elements without hidden=until-found.
-FAIL The hidden attribute should still be set inside the beforematch event handler. assert_true: expected true got false
+PASS The hidden attribute should still be set inside the beforematch event handler.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-ua-stylesheet-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-ua-stylesheet-expected.txt
@@ -3,8 +3,8 @@ PASS hidden-ua-stylesheet
 PASS div.removeAttribute('hidden')
 PASS div.setAttribute('hidden', '')
 PASS div.setAttribute('hidden', 'asdf')
-FAIL div.setAttribute('hidden', 'until-found') assert_equals: div.setAttribute('hidden', 'until-found') should not affect the div's display property. expected "block" but got "none"
-FAIL div.setAttribute('hidden', 'UNTIL-FOUND') assert_equals: div.setAttribute('hidden', 'UNTIL-FOUND') should not affect the div's display property. expected "block" but got "none"
-FAIL div.setAttribute('hidden', 'UnTiL-FoUnD') assert_equals: div.setAttribute('hidden', 'UnTiL-FoUnD') should not affect the div's display property. expected "block" but got "none"
+PASS div.setAttribute('hidden', 'until-found')
+PASS div.setAttribute('hidden', 'UNTIL-FOUND')
+PASS div.setAttribute('hidden', 'UnTiL-FoUnD')
 PASS div.setAttribute('hidden', '0')
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-event-handlers-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-event-handlers-expected.txt
@@ -198,6 +198,8 @@ CONSOLE MESSAGE: This requires a TrustedScript value else it violates the follow
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 
 PASS Event handler onclick should be blocked.
 PASS Event handler onchange should be blocked.
@@ -216,6 +218,7 @@ PASS Non-event handler div.inert should not be blocked.
 PASS Event handler div.onabort should be blocked.
 PASS Event handler div.onauxclick should be blocked.
 PASS Event handler div.onbeforeinput should be blocked.
+PASS Event handler div.onbeforematch should be blocked.
 PASS Event handler div.onbeforetoggle should be blocked.
 PASS Event handler div.onblur should be blocked.
 PASS Event handler div.oncancel should be blocked.

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1801,6 +1801,7 @@ http/tests/download/convert-cached-load-to-download.html [ Skip ]
 http/tests/mime/html-with-nosniff-html.html [ Skip ]
 
 # testRunner.findString function is WK2-only, not implemented for WK1.
+editing/text-iterator/find-in-page-in-hidden-until-found.html [ Skip ]
 editing/text-iterator/find-in-page-in-closed-details.html [ Skip ]
 editing/text-iterator/find-in-page-in-summary-of-closed-details.html [ Skip ]
 

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -648,6 +648,7 @@ namespace WebCore {
     macro(onbackgroundfetchfail) \
     macro(onbackgroundfetchabort) \
     macro(onbackgroundfetchclick) \
+    macro(onbeforematch) \
     macro(oncommand) \
     macro(oncookiechange) \
     macro(onnotificationclick) \

--- a/Source/WebCore/dom/EventNames.json
+++ b/Source/WebCore/dom/EventNames.json
@@ -32,6 +32,7 @@
     "beforecut": { },
     "beforeinput": { },
     "beforeload": { },
+    "beforematch": { },
     "beforepaste": { },
     "beforeprint": { },
     "beforetoggle": { },

--- a/Source/WebCore/dom/FindRevealAlgorithms.h
+++ b/Source/WebCore/dom/FindRevealAlgorithms.h
@@ -29,6 +29,9 @@ namespace WebCore {
 
 class Node;
 
-WEBCORE_EXPORT void revealClosedDetailsAncestors(Node&);
+void revealClosedDetailsAncestors(Node&);
+void revealHiddenUntilFoundAncestors(Node&);
+
+WEBCORE_EXPORT void revealClosedDetailsAndHiddenUntilFoundAncestors(Node&);
 
 } // namespace WebCore

--- a/Source/WebCore/dom/GlobalEventHandlers.idl
+++ b/Source/WebCore/dom/GlobalEventHandlers.idl
@@ -32,7 +32,7 @@ interface mixin GlobalEventHandlers {
     attribute EventHandler onabort;
     attribute EventHandler onauxclick;
     attribute EventHandler onbeforeinput;
-    // attribute EventHandler onbeforematch;
+    [EnabledBySetting=HiddenUntilFoundEnabled] attribute EventHandler onbeforematch;
     attribute EventHandler onbeforetoggle;
     attribute EventHandler onblur;
     attribute EventHandler oncancel;

--- a/Source/WebCore/html/HTMLAttributeNames.in
+++ b/Source/WebCore/html/HTMLAttributeNames.in
@@ -219,6 +219,7 @@ onbeforecopy
 onbeforecut
 onbeforeinput
 onbeforeload
+onbeforematch
 onbeforepaste
 onbeforeprint
 onbeforetoggle

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -237,7 +237,10 @@ void HTMLElement::collectPresentationalHintsForAttribute(const QualifiedName& na
         break;
     }
     case AttributeNames::hiddenAttr:
-        addPropertyToPresentationalHintStyle(style, CSSPropertyDisplay, CSSValueNone);
+        if (document().settings().hiddenUntilFoundEnabled() && equalIgnoringASCIICase(value, "until-found"_s))
+            addPropertyToPresentationalHintStyle(style, CSSPropertyContentVisibility, CSSValueHidden);
+        else
+            addPropertyToPresentationalHintStyle(style, CSSPropertyDisplay, CSSValueNone);
         break;
     case AttributeNames::draggableAttr:
         if (equalLettersIgnoringASCIICase(value, "true"_s))
@@ -979,6 +982,13 @@ EnterKeyHint HTMLElement::canonicalEnterKeyHint() const
 String HTMLElement::enterKeyHint() const
 {
     return attributeValueForEnterKeyHint(canonicalEnterKeyHint());
+}
+
+bool HTMLElement::isHiddenUntilFound() const
+{
+    if (!document().settings().hiddenUntilFoundEnabled())
+        return false;
+    return equalIgnoringASCIICase(attributeWithoutSynchronization(HTMLNames::hiddenAttr), "until-found"_s);
 }
 
 // https://html.spec.whatwg.org/#dom-hidden

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -133,6 +133,7 @@ public:
     WEBCORE_EXPORT EnterKeyHint canonicalEnterKeyHint() const;
     String enterKeyHint() const;
 
+    bool isHiddenUntilFound() const;
     std::optional<Variant<bool, double, String>> hidden() const;
     void setHidden(const std::optional<Variant<bool, double, String>>&);
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2771,13 +2771,15 @@ bool LocalFrameView::scrollToFragmentInternal(StringView fragmentIdentifier)
         return false;
     }
 
+    if (anchorElement)
+        revealClosedDetailsAndHiddenUntilFoundAncestors(*anchorElement);
+
     RefPtr<ContainerNode> scrollPositionAnchor = anchorElement;
     if (!scrollPositionAnchor)
         scrollPositionAnchor = m_frame->document();
     maintainScrollPositionAtAnchor(scrollPositionAnchor.get());
-    
+
     if (anchorElement) {
-        revealClosedDetailsAncestors(*anchorElement);
         // If the anchor accepts keyboard focus, move focus there to aid users relying on keyboard navigation.
         if (anchorElement->isFocusable())
             document.setFocusedElement(anchorElement.get(), { { }, { }, { }, { }, FocusVisibility::Visible });

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -653,6 +653,9 @@ void Adjuster::adjust(RenderStyle& style) const
 
         if (m_document->settings().detailsAutoExpandEnabled() && is<HTMLDetailsElement>(element))
             style.setAutoRevealsWhenFound();
+
+        if (RefPtr htmlElement = dynamicDowncast<HTMLElement>(element); htmlElement && htmlElement->isHiddenUntilFound())
+            style.setAutoRevealsWhenFound();
     }
 
     if (shouldInheritTextDecorationsInEffect(style, m_element.get()))

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -507,7 +507,7 @@ void FindController::didFindString()
 
     CheckedRef selection = selectedFrame->selection();
     selection->revealSelection();
-    revealClosedDetailsAncestors(*selection->selection().start().protectedAnchorNode());
+    revealClosedDetailsAndHiddenUntilFoundAncestors(*selection->selection().start().protectedAnchorNode());
 }
 
 void FindController::didHideFindIndicator()

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -161,7 +161,7 @@ void WebFoundTextRangeController::decorateTextRangeWithStyle(const WebFoundTextR
         case FindDecorationStyle::Highlighted: {
             m_highlightedRange = range;
 
-            revealClosedDetailsAncestors(simpleRange->protectedStartContainer());
+            revealClosedDetailsAndHiddenUntilFoundAncestors(simpleRange->protectedStartContainer());
 
             if (m_findPageOverlay)
                 setTextIndicatorWithRange(*simpleRange);

--- a/Source/WebKit/WebProcess/WebPage/ios/FindControllerIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/FindControllerIOS.mm
@@ -181,7 +181,7 @@ void FindController::didFindString()
     // text, so we reveal the text at the center of the viewport.
     // FIXME: Find a better way to estimate the obscured area (https://webkit.org/b/183889).
     frame->selection().revealSelection(SelectionRevealMode::RevealUpToMainFrame, ScrollAlignment::alignCenterAlways, WebCore::RevealExtentOption::DoNotRevealExtent);
-    revealClosedDetailsAncestors(*frame->selection().selection().start().anchorNode());
+    revealClosedDetailsAndHiddenUntilFoundAncestors(*frame->selection().selection().start().anchorNode());
 }
 
 void FindController::didFailToFindString()


### PR DESCRIPTION
#### 4f12f2494d1ca0a52e7bee8a94bbc94194faf48a
<pre>
Implement `hidden=until-found` HTML attribute and `beforematch` event
<a href="https://bugs.webkit.org/show_bug.cgi?id=238266">https://bugs.webkit.org/show_bug.cgi?id=238266</a>
<a href="https://rdar.apple.com/90706206">rdar://90706206</a>

Reviewed by Darin Adler.

Spec: <a href="https://html.spec.whatwg.org/#the-hidden-attribute">https://html.spec.whatwg.org/#the-hidden-attribute</a>

* LayoutTests/TestExpectations:
* LayoutTests/editing/find/cocoa/find-in-page-in-hidden-until-found-expected.txt: Added.
* LayoutTests/editing/find/cocoa/find-in-page-in-hidden-until-found.html: Added.
* LayoutTests/editing/text-iterator/find-in-page-in-hidden-until-found-expected.txt: Added.
* LayoutTests/editing/text-iterator/find-in-page-in-hidden-until-found.html: Added.
Find in page tests.

* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-element-fragment-navigation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-ua-stylesheet-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-event-handlers-expected.txt:
Rebaseline test passes.

* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/dom/EventNames.json:
* Source/WebCore/dom/FindRevealAlgorithms.cpp:
(WebCore::revealHiddenUntilFoundAncestors): Implement <a href="https://html.spec.whatwg.org/#ancestor-hidden-until-found-revealing-algorithm">https://html.spec.whatwg.org/#ancestor-hidden-until-found-revealing-algorithm</a>
(WebCore::revealClosedDetailsAndHiddenUntilFoundAncestors):
* Source/WebCore/dom/FindRevealAlgorithms.h:

* Source/WebCore/dom/GlobalEventHandlers.idl:
* Source/WebCore/html/HTMLAttributeNames.in:
Add beforematch event.

* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::collectPresentationalHintsForAttribute): `hidden=until-found` uses `content-visibility: hidden`
(WebCore::HTMLElement::isHiddenUntilFound const): Helper method to avoid duplication
* Source/WebCore/html/HTMLElement.h:

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scrollToFragmentInternal): Follow <a href="https://html.spec.whatwg.org/#scrolling-to-a-fragment">https://html.spec.whatwg.org/#scrolling-to-a-fragment</a>

* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const): Make sure autoRevealsWhenFound bit is set so that TextIterator doesn&apos;t skip these subtrees.

* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::didFindString):
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::decorateTextRangeWithStyle):
* Source/WebKit/WebProcess/WebPage/ios/FindControllerIOS.mm:
(WebKit::FindController::didFindString):

3 different codepaths for find-in-page on different configurations.

Canonical link: <a href="https://commits.webkit.org/297073@main">https://commits.webkit.org/297073@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7cffa86b1a5dae32eaa89d25ee98df688efe38c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110501 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/30160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20593 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/116526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/60768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112464 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30839 "Failed to checkout and rebase branch from PR 47284") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38748 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/116526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/60768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113449 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/30839 "Failed to checkout and rebase branch from PR 47284") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/116526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/30839 "Failed to checkout and rebase branch from PR 47284") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK1-Tests-EWS "Waiting to run tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/60322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/30839 "Failed to checkout and rebase branch from PR 47284") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/17695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/119317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/37541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/27860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/119317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/37915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/95767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/119317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/33514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17818 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/37436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/42907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/37098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/40438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/38807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->