### PR TITLE
[css-anchor-position-1] Scroll adjustment not applied for position:fixed anchored boxes

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7726,8 +7726,6 @@ webkit.org/b/282024 fast/text/text-box-edge-with-margin-padding-border-simple.ht
 # general failures
 webkit.org/b/289743 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-007.html [ ImageOnlyFailure ]
 webkit.org/b/289743 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-008.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-top-layer-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-top-layer-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-top-layer-005.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-top-layer-006.html [ ImageOnlyFailure ]
 webkit.org/b/289743 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scope-scroll.html [ ImageOnlyFailure ]
@@ -7736,7 +7734,6 @@ imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-chained-00
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-chained-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-chained-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-chained-fallback.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-fixedpos.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-012.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-004.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-006-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL #target1 is scroll-adjusted in x axis only assert_equals: expected 0 but got 50
-FAIL #target2 is scroll-adjusted in y axis only assert_equals: expected 200 but got 250
+FAIL #target1 is scroll-adjusted in x axis only assert_equals: expected 150 but got 100
+FAIL #target2 is scroll-adjusted in y axis only assert_equals: expected 150 but got 100
 PASS #target3 is scroll-adjusted in neither axis
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-002-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Should use the first fallback position at the initial scroll offset
-FAIL Should use the second fallback position after scrolling left assert_equals: Anchored element should be at the left of anchor expected 601 but got 700
+FAIL Should use the second fallback position after scrolling left assert_equals: Anchored element should be at the left of anchor expected 601 but got 801
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-004-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Should use the first fallback position at the initial scroll offsets
-FAIL Should use the second fallback position after scrolling viewport down assert_equals: Anchored element should be at the bottom of anchor expected 199 but got 100
+FAIL Should use the second fallback position after scrolling viewport down assert_equals: Anchored element should be at the bottom of anchor expected 199 but got -1
 FAIL Should use the third fallback position after scrolling the vrl scroller left assert_equals: Anchored element should be at the left of anchor expected 710 but got 810
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-005-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-005-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Should use the first fallback position at the initial scroll offset
-FAIL Should use the second fallback position after scrolling left assert_equals: Anchored element should be at the left of anchor expected 601 but got 700
+FAIL Should use the second fallback position after scrolling left assert_equals: Anchored element should be at the left of anchor expected 601 but got 801
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Should use the last (fourth) position option initially
-FAIL Should still use the last position option as long as it fits. assert_equals: Anchored element should be at the top of anchor expected 350 but got 600
-FAIL Should use the third position option with enough space below, and not enough above assert_equals: Anchored element should be at the bottom of anchor expected 199 but got 500
-FAIL Should use the second position option with enough space right assert_equals: Anchored element should be at the top of anchor expected 450 but got 600
-FAIL Should still use the second position option as long as it fits assert_equals: Anchored element should be at the top of anchor expected 350 but got 600
-FAIL Should use the first position option with enough space below and right assert_equals: Anchored element should be at the bottom of anchor expected 199 but got 500
+PASS Should still use the last position option as long as it fits.
+FAIL Should use the third position option with enough space below, and not enough above assert_equals: Anchored element should be at the bottom of anchor expected 199 but got -1
+FAIL Should use the second position option with enough space right assert_equals: Anchored element should be at the right of anchor expected 650 but got 450
+FAIL Should still use the second position option as long as it fits assert_equals: Anchored element should be at the right of anchor expected 650 but got 450
+FAIL Should use the first position option with enough space below and right assert_equals: Anchored element should be at the bottom of anchor expected 199 but got -1
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-007-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-007-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Should use the last position option initially
-FAIL Should stay at initial position, since it still fits assert_equals: Anchored element should be at the top of anchor expected 450 but got 600
-FAIL Should use the third position option with enough space left assert_equals: Anchored element should be at the left of anchor expected 586 but got 85
-FAIL Should use the first position option with enough space left and below assert_equals: Anchored element should be at the left of anchor expected 135 but got 85
-FAIL Should use the second position option with enough space below (and not enough above) assert_equals: Anchored element should be at the right of anchor expected 135 but got -15
+PASS Should stay at initial position, since it still fits
+FAIL Should use the third position option with enough space left assert_equals: Anchored element should be at the left of anchor expected 586 but got 786
+FAIL Should use the first position option with enough space left and below assert_equals: Anchored element should be at the left of anchor expected 135 but got 335
+FAIL Should use the second position option with enough space below (and not enough above) assert_equals: Anchored element should be at the bottom of anchor expected 199 but got -1
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-008-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-008-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Should use the last fallback position initially
-FAIL Should use the third fallback position with enough space left assert_equals: Anchored element should be at the left of anchor expected 135 but got 85
-FAIL Should use the second fallback position with enough space above assert_equals: Anchored element should be at the right of anchor expected 135 but got -15
-FAIL Should use the first fallback position with enough space left and above assert_equals: Anchored element should be at the left of anchor expected 586 but got 85
+FAIL Should use the third fallback position with enough space left assert_equals: Anchored element should be at the left of anchor expected 135 but got 335
+FAIL Should use the second fallback position with enough space above assert_equals: Anchored element should be at the top of anchor expected 135 but got 335
+FAIL Should use the first fallback position with enough space left and above assert_equals: Anchored element should be at the left of anchor expected 586 but got 786
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-009-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-009-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Should use the last fallback position initially
-FAIL Should use the third fallback position with enough space right assert_equals: Anchored element should be at the right of anchor expected 650 but got 700
-FAIL Should use the second fallback position with enough space below assert_equals: Anchored element should be at the left of anchor expected 650 but got 800
-FAIL Should use the first fallback position with enough space right and below assert_equals: Anchored element should be at the right of anchor expected 199 but got 700
+FAIL Should use the third fallback position with enough space right assert_equals: Anchored element should be at the right of anchor expected 650 but got 450
+FAIL Should use the second fallback position with enough space below assert_equals: Anchored element should be at the bottom of anchor expected 450 but got 250
+FAIL Should use the first fallback position with enough space right and below assert_equals: Anchored element should be at the right of anchor expected 199 but got -1
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-010-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-010-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Should use the last fallback position initially
-FAIL Should use the third fallback position with enough space right assert_equals: Anchored element should be at the right of anchor expected 650 but got 700
-FAIL Should use the second fallback position with enough space above assert_equals: Anchored element should be at the left of anchor expected 650 but got 800
-FAIL Should use the first fallback position with enough space right and above assert_equals: Anchored element should be at the right of anchor expected 199 but got 700
+FAIL Should use the third fallback position with enough space right assert_equals: Anchored element should be at the right of anchor expected 650 but got 450
+FAIL Should use the second fallback position with enough space above assert_equals: Anchored element should be at the top of anchor expected 135 but got 335
+FAIL Should use the first fallback position with enough space right and above assert_equals: Anchored element should be at the right of anchor expected 199 but got -1
 

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -358,6 +358,8 @@ public:
     void removeViewportConstrainedObject(RenderLayerModelObject&);
     const SingleThreadWeakHashSet<RenderLayerModelObject>* viewportConstrainedObjects() const { return m_viewportConstrainedObjects.get(); }
     WEBCORE_EXPORT bool hasViewportConstrainedObjects() const;
+    bool hasAnchorPositionedViewportConstrainedObjects() const;
+    void clearCachedHasAnchorPositionedViewportConstrainedObjects();
 
     float frameScaleFactor() const;
 
@@ -739,6 +741,8 @@ public:
     void invalidateScrollAnchoringElement() final;
     ScrollAnchoringController* scrollAnchoringController() { return m_scrollAnchoringController.get(); }
 
+    void updateAnchorPositionedAfterScroll() final;
+
     WEBCORE_EXPORT void scrollbarStyleDidChange();
 
     void scrollbarWidthChanged(ScrollbarWidth) override;
@@ -1049,6 +1053,7 @@ private:
     std::unique_ptr<ScrollableAreaSet> m_scrollableAreas;
     std::unique_ptr<ScrollableAreaSet> m_scrollableAreasForAnimatedScroll;
     std::unique_ptr<SingleThreadWeakHashSet<RenderLayerModelObject>> m_viewportConstrainedObjects;
+    mutable std::optional<bool> m_hasAnchorPositionedViewportConstrainedObjects;
 
     OptionSet<LayoutMilestone> m_milestonesPendingPaint;
 

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -266,6 +266,7 @@ void ScrollableArea::scrollPositionChanged(const ScrollPosition& position)
         scrollbarsController().notifyContentAreaScrolled(scrollPosition() - oldPosition);
         invalidateScrollAnchoringElement();
         updateScrollAnchoringElement();
+        updateAnchorPositionedAfterScroll();
     }
 }
 

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -428,6 +428,7 @@ public:
     virtual void updateScrollAnchoringElement() { }
     virtual void updateScrollPositionForScrollAnchoringController() { }
     virtual void invalidateScrollAnchoringElement() { }
+    virtual void updateAnchorPositionedAfterScroll() { }
     virtual std::optional<FrameIdentifier> rootFrameID() const { return std::nullopt; }
 
     WEBCORE_EXPORT void setScrollbarsController(std::unique_ptr<ScrollbarsController>&&);

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -305,6 +305,9 @@ void RenderBox::styleWillChange(StyleDifference diff, const RenderStyle& newStyl
     else if (oldStyle && !oldStyle->positionTryFallbacks().isEmpty() && oldStyle->hasOutOfFlowPosition())
         view().unregisterPositionTryBox(*this);
 
+    if (oldStyle && Style::AnchorPositionEvaluator::isAnchorPositioned(newStyle) != Style::AnchorPositionEvaluator::isAnchorPositioned(*oldStyle))
+        view().frameView().clearCachedHasAnchorPositionedViewportConstrainedObjects();
+
     RenderBoxModelObject::styleWillChange(diff, newStyle);
 }
 

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -366,8 +366,6 @@ void RenderLayerScrollableArea::scrollTo(const ScrollPosition& position)
     // Update the positions of our child layers (if needed as only fixed layers should be impacted by a scroll).
     // We don't update compositing layers, because we need to do a deep update from the compositing ancestor.
     if (!view.frameView().layoutContext().isInRenderTreeLayout()) {
-        Style::AnchorPositionEvaluator::updateAfterOverflowScroll(m_layer.renderer().protectedDocument());
-
         // If we're in the middle of layout, we'll just update layers once layout has finished.
         view.protectedFrameView()->updateLayerPositionsAfterOverflowScroll(m_layer);
 
@@ -2032,6 +2030,11 @@ void RenderLayerScrollableArea::invalidateScrollAnchoringElement()
 {
     if (m_scrollAnchoringController)
         m_scrollAnchoringController->invalidateAnchorElement();
+}
+
+void RenderLayerScrollableArea::updateAnchorPositionedAfterScroll()
+{
+    Style::AnchorPositionEvaluator::updatePositionsAfterScroll(m_layer.renderer().document());
 }
 
 std::optional<FrameIdentifier> RenderLayerScrollableArea::rootFrameID() const

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -267,6 +267,8 @@ public:
     void invalidateScrollAnchoringElement() final;
     ScrollAnchoringController* scrollAnchoringController() { return m_scrollAnchoringController.get(); }
 
+    void updateAnchorPositionedAfterScroll() final;
+
     void createScrollbarsController() final;
 
     std::optional<FrameIdentifier> rootFrameID() const final;

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -110,14 +110,16 @@ public:
 
     static void updateAnchorPositioningStatesAfterInterleavedLayout(Document&, AnchorPositionedStates&);
     static void updateSnapshottedScrollOffsets(Document&);
-    static void updateAfterOverflowScroll(Document&);
+    static void updatePositionsAfterScroll(Document&);
     static void updateAnchorPositionedStateForLayoutTimePositioned(Element&, const RenderStyle&, AnchorPositionedStates&);
 
     static LayoutRect computeAnchorRectRelativeToContainingBlock(CheckedRef<const RenderBoxModelObject> anchorBox, const RenderBlock& containingBlock);
 
     static AnchorToAnchorPositionedMap makeAnchorPositionedForAnchorMap(AnchorPositionedToAnchorMap&);
 
+    static bool isAnchorPositioned(const RenderStyle&);
     static bool isLayoutTimeAnchorPositioned(const RenderStyle&);
+
     static CSSPropertyID resolvePositionTryFallbackProperty(CSSPropertyID, WritingMode, const BuilderPositionTryFallback&);
 
     static bool overflowsInsetModifiedContainingBlock(const RenderBox& anchoredBox);


### PR DESCRIPTION
#### de4580fe7eeedb0b8582ce8ea85919b788e1d58b
<pre>
[css-anchor-position-1] Scroll adjustment not applied for position:fixed anchored boxes
<a href="https://bugs.webkit.org/show_bug.cgi?id=295002">https://bugs.webkit.org/show_bug.cgi?id=295002</a>
<a href="https://rdar.apple.com/154348421">rdar://154348421</a>

Reviewed by Simon Fraser.

Compute scroll adjustment correctly for fixed positioned anchored boxes.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-006-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-004-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-005-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-007-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-008-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-009-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-010-expected.txt:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::addViewportConstrainedObject):
(WebCore::LocalFrameView::removeViewportConstrainedObject):
(WebCore::LocalFrameView::hasAnchorPositionedViewportConstrainedObjects const):

See if any of the viewport constrained objects are anchor positioned.

(WebCore::LocalFrameView::clearCachedHasAnchorPositionedViewportConstrainedObjects):
(WebCore::LocalFrameView::shouldUpdateCompositingLayersAfterScrolling const):

We need to update compositing layers on every frame if there are fixed anchor positioned boxes.

(WebCore::LocalFrameView::updateAnchorPositionedAfterScroll):

We need to update anchor positions after document scroll too.

* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::ScrollableArea::scrollPositionChanged):
* Source/WebCore/platform/ScrollableArea.h:
(WebCore::ScrollableArea::updateAnchorPositionedAfterScroll):

Factor into a separate virtual function, invoked from ScrollableArea::scrollPositionChanged.

* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::styleWillChange):

Clear the cached fixed-with-anchor bit if anchor positioned style changes.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::updateLayerPositionsAfterOverflowScroll):
(WebCore::RenderLayer::updateLayerPositionsAfterDocumentScroll):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::scrollTo):

Move to RenderLayer::updateLayerPositionsAfterOverflowScroll.

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::scrollOffsetFromAnchor):

Take fixed position into account when computing scroll offset.

(WebCore::Style::AnchorPositionEvaluator::updateSnapshottedScrollOffsets):

Use defaultAnchorForBox() to figure out if we need scroll compensation.

(WebCore::Style::AnchorPositionEvaluator::updatePositionsAfterScroll):
(WebCore::Style::AnchorPositionEvaluator::isAnchorPositioned):
(WebCore::Style::scrollOffsetFromAncestorContainer): Deleted.
(WebCore::Style::AnchorPositionEvaluator::updateAfterOverflowScroll): Deleted.
* Source/WebCore/style/AnchorPositionEvaluator.h:

Canonical link: <a href="https://commits.webkit.org/296811@main">https://commits.webkit.org/296811@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e52b786be56ab506342d4909281a6db3075d3e67

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109660 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29318 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19747 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115680 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59894 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111623 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37906 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83333 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112608 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23898 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98759 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63792 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23279 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16903 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59475 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93273 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16941 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118473 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36699 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27177 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92340 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37072 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95018 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92161 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23480 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37117 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14865 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32527 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36593 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42064 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36253 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39596 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37963 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->