### PR TITLE
Placeholder canvas does not always propagate HDR content format correctly to the layer

### DIFF
--- a/Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp
@@ -89,12 +89,11 @@ void PlaceholderRenderingContextSource::setPlaceholderBuffer(ImageBuffer& imageB
     });
 }
 
-void PlaceholderRenderingContextSource::setContentsToLayer(GraphicsLayer& layer, ContentsFormat contentsFormat, ImageBuffer* buffer)
+void PlaceholderRenderingContextSource::setContentsToLayer(GraphicsLayer& layer, ImageBuffer* buffer)
 {
     assertIsMainThread();
     Locker locker { m_lock };
     if ((m_delegate = layer.createAsyncContentsDisplayDelegate(m_delegate.get()))) {
-        m_delegate->setContentsFormat(contentsFormat);
         if (buffer) {
             m_delegate->tryCopyToLayer(*buffer);
             m_delegateBufferVersion = m_placeholderBufferVersion;
@@ -125,48 +124,24 @@ IntSize PlaceholderRenderingContext::size() const
     return canvas().size();
 }
 
-constexpr ContentsFormat pixelFormatToContentsFormat(ImageBufferPixelFormat format)
-{
-    switch (format) {
-    case ImageBufferPixelFormat::BGRX8:
-    case ImageBufferPixelFormat::BGRA8:
-        return ContentsFormat::RGBA8;
-#if ENABLE(PIXEL_FORMAT_RGB10)
-    case ImageBufferPixelFormat::RGB10:
-        return ContentsFormat::RGBA10;
-#endif
-#if ENABLE(PIXEL_FORMAT_RGB10A8)
-    case ImageBufferPixelFormat::RGB10A8:
-        return ContentsFormat::RGBA10;
-#endif
-#if ENABLE(PIXEL_FORMAT_RGBA16F)
-    case ImageBufferPixelFormat::RGBA16F:
-        return ContentsFormat::RGBA16F;
-#endif
-    default:
-        RELEASE_ASSERT_NOT_REACHED();
-        return ContentsFormat::RGBA8;
-    }
-}
-
 void PlaceholderRenderingContext::setContentsToLayer(GraphicsLayer& layer)
 {
     RefPtr<ImageBuffer> buffer;
-    Ref canvas = this->canvas();
-    if (canvas->hasCreatedImageBuffer())
+    if (Ref canvas = this->canvas(); canvas->hasCreatedImageBuffer())
         buffer = canvas->buffer();
-    m_source->setContentsToLayer(layer, pixelFormatToContentsFormat(m_pixelFormat), buffer.get());
+    m_source->setContentsToLayer(layer, buffer.get());
 }
 
 void PlaceholderRenderingContext::setPlaceholderBuffer(Ref<ImageBuffer>&& buffer)
 {
-    m_pixelFormat = buffer->pixelFormat();
     canvasBase().setImageBufferAndMarkDirty(WTFMove(buffer));
 }
 
 ImageBufferPixelFormat PlaceholderRenderingContext::pixelFormat() const
 {
-    return m_pixelFormat;
+    if (Ref canvas = this->canvas(); canvas->hasCreatedImageBuffer())
+        return Ref { *canvas->buffer() }->pixelFormat();
+    return CanvasRenderingContext::pixelFormat();
 }
 
 }

--- a/Source/WebCore/html/canvas/PlaceholderRenderingContext.h
+++ b/Source/WebCore/html/canvas/PlaceholderRenderingContext.h
@@ -36,8 +36,6 @@ namespace WebCore {
 
 class PlaceholderRenderingContext;
 
-enum class ContentsFormat : uint8_t;
-
 // Thread-safe interface to submit frames from worker to the placeholder rendering context.
 class PlaceholderRenderingContextSource : public ThreadSafeRefCounted<PlaceholderRenderingContextSource> {
     WTF_MAKE_TZONE_ALLOCATED(PlaceholderRenderingContextSource);
@@ -50,7 +48,7 @@ public:
     void setPlaceholderBuffer(ImageBuffer&);
 
     // Called by the placeholder context to attach to compositor layer.
-    void setContentsToLayer(GraphicsLayer&, ContentsFormat, ImageBuffer*);
+    void setContentsToLayer(GraphicsLayer&, ImageBuffer*);
 
 private:
     explicit PlaceholderRenderingContextSource(PlaceholderRenderingContext&);
@@ -81,7 +79,6 @@ private:
     ImageBufferPixelFormat pixelFormat() const final;
 
     const Ref<PlaceholderRenderingContextSource> m_source;
-    ImageBufferPixelFormat m_pixelFormat { ImageBufferPixelFormat::BGRA8 };
 };
 
 }

--- a/Source/WebCore/platform/graphics/GraphicsLayerContentsDisplayDelegate.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayerContentsDisplayDelegate.h
@@ -71,7 +71,6 @@ public:
 
     virtual bool isGraphicsLayerAsyncContentsDisplayDelegateCocoa() const { return false; }
     virtual bool isGraphicsLayerCARemoteAsyncContentsDisplayDelegate() const { return false; }
-    virtual void setContentsFormat(ContentsFormat) { }
 };
 
 }

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.h
@@ -39,6 +39,7 @@ public:
     
     static void applyHierarchyUpdates(RemoteLayerTreeNode&, const LayerProperties&, const RelatedLayerMap&);
     static void applyProperties(RemoteLayerTreeNode&, RemoteLayerTreeHost*, const LayerProperties&, const RelatedLayerMap&, LayerContentsType);
+    static void applyAsyncContentsUpdate(RemoteLayerTreeNode&, ImageBufferBackendHandle&&, ContentsFormat, const WebCore::RenderingResourceIdentifier& contentsIdentifier, LayerContentsType);
     static void applyPropertiesToLayer(CALayer *, RemoteLayerTreeNode*, RemoteLayerTreeHost*, const LayerProperties&, LayerContentsType);
 
 private:

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -378,6 +378,19 @@ static void updateCustomAppearance(CALayer *layer, GraphicsLayer::CustomAppearan
 #endif
 }
 
+static void applyContentsFormatToLayer(CALayer *layer, ContentsFormat contentsFormat)
+{
+    if (RetainPtr formatString = contentsFormatString(contentsFormat))
+        [layer setContentsFormat:formatString.get()];
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    if (contentsFormat == ContentsFormat::RGBA16F) {
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+        [layer setWantsExtendedDynamicRangeContent:true];
+        ALLOW_DEPRECATED_DECLARATIONS_END
+    }
+#endif
+}
+
 void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, RemoteLayerTreeNode* layerTreeNode, RemoteLayerTreeHost* layerTreeHost, const LayerProperties& properties, LayerContentsType layerContentsType)
 {
     if (properties.changedProperties & LayerChange::PositionChanged) {
@@ -549,18 +562,8 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, Remo
     }
 #endif
 
-    if (properties.changedProperties & LayerChange::ContentsFormatChanged) {
-        auto contentsFormat = properties.contentsFormat;
-        if (RetainPtr formatString = contentsFormatString(contentsFormat))
-            [layer setContentsFormat:formatString.get()];
-#if ENABLE(PIXEL_FORMAT_RGBA16F)
-        if (contentsFormat == ContentsFormat::RGBA16F) {
-            ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-            [layer setWantsExtendedDynamicRangeContent:true];
-            ALLOW_DEPRECATED_DECLARATIONS_END
-        }
-#endif
-    }
+    if (properties.changedProperties & LayerChange::ContentsFormatChanged)
+        applyContentsFormatToLayer(layer, properties.contentsFormat);
 
 #if HAVE(CORE_MATERIAL)
     if (properties.changedProperties & LayerChange::AppleVisualEffectChanged)
@@ -610,6 +613,15 @@ void RemoteLayerTreePropertyApplier::applyProperties(RemoteLayerTreeNode& node, 
 #endif
 
     END_BLOCK_OBJC_EXCEPTIONS
+}
+
+void RemoteLayerTreePropertyApplier::applyAsyncContentsUpdate(RemoteLayerTreeNode& node, ImageBufferBackendHandle&& contentsHandle, ContentsFormat contentsFormat, const WebCore::RenderingResourceIdentifier& contentsIdentifier, LayerContentsType layerContentsType)
+{
+    RetainPtr<id> contents = RemoteLayerBackingStoreProperties::layerContentsBufferFromBackendHandle(WTFMove(contentsHandle), layerContentsType, true);
+    RetainPtr layer = node.layer();
+    layer.get().contents = contents.get();
+    applyContentsFormatToLayer(layer.get(), contentsFormat);
+    node.setAsyncContentsIdentifier(contentsIdentifier);
 }
 
 void RemoteLayerTreePropertyApplier::applyHierarchyUpdates(RemoteLayerTreeNode& node, const LayerProperties& properties, const RelatedLayerMap& relatedLayers)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -174,7 +174,7 @@ private:
     void commitLayerTreeTransaction(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&);
     virtual void didCommitLayerTree(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&) { }
 
-    void asyncSetLayerContents(WebCore::PlatformLayerIdentifier, ImageBufferBackendHandle&&, const WebCore::RenderingResourceIdentifier&);
+    void asyncSetLayerContents(WebCore::PlatformLayerIdentifier, ImageBufferBackendHandle&&, WebCore::ContentsFormat, const WebCore::RenderingResourceIdentifier&);
 
     void sendUpdateGeometry();
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.messages.in
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.messages.in
@@ -30,5 +30,5 @@ messages -> RemoteLayerTreeDrawingAreaProxy : DrawingAreaProxy {
     void WillCommitLayerTree(WebKit::TransactionID transactionID)
     void CommitLayerTreeNotTriggered(WebKit::TransactionID nextCommitTransactionID)
     void CommitLayerTree(Vector<std::pair<WebKit::RemoteLayerTreeTransaction, WebKit::RemoteScrollingCoordinatorTransaction>> transactions, HashMap<WebKit::RemoteImageBufferSetIdentifier, std::unique_ptr<WebKit::BufferSetBackendHandle>> handlesMap) CanDispatchOutOfOrder
-    void AsyncSetLayerContents(WebCore::PlatformLayerIdentifier layer, WebKit::ImageBufferBackendHandle handle, WebCore::RenderingResourceIdentifier identifier)
+    void AsyncSetLayerContents(WebCore::PlatformLayerIdentifier layer, WebKit::ImageBufferBackendHandle handle, enum:uint8_t WebCore::ContentsFormat contentsFormat,  WebCore::RenderingResourceIdentifier identifier)
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -424,9 +424,9 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection
     }
 }
 
-void RemoteLayerTreeDrawingAreaProxy::asyncSetLayerContents(WebCore::PlatformLayerIdentifier layerID, ImageBufferBackendHandle&& handle, const WebCore::RenderingResourceIdentifier& identifier)
+void RemoteLayerTreeDrawingAreaProxy::asyncSetLayerContents(WebCore::PlatformLayerIdentifier layerID, ImageBufferBackendHandle&& handle, WebCore::ContentsFormat contentsFormat, const WebCore::RenderingResourceIdentifier& identifier)
 {
-    m_remoteLayerTreeHost->asyncSetLayerContents(layerID, WTFMove(handle), identifier);
+    m_remoteLayerTreeHost->asyncSetLayerContents(layerID, WTFMove(handle), contentsFormat, identifier);
 }
 
 void RemoteLayerTreeDrawingAreaProxy::acceleratedAnimationDidStart(WebCore::PlatformLayerIdentifier layerID, const String& key, MonotonicTime startTime)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -67,7 +67,7 @@ public:
 
     // Returns true if the root layer changed.
     bool updateLayerTree(const IPC::Connection&, const RemoteLayerTreeTransaction&, float indicatorScaleFactor  = 1);
-    void asyncSetLayerContents(WebCore::PlatformLayerIdentifier, ImageBufferBackendHandle&&, const WebCore::RenderingResourceIdentifier&);
+    void asyncSetLayerContents(WebCore::PlatformLayerIdentifier, ImageBufferBackendHandle&&, WebCore::ContentsFormat, const WebCore::RenderingResourceIdentifier&);
 
     void setIsDebugLayerTreeHost(bool flag) { m_isDebugLayerTreeHost = flag; }
     bool isDebugLayerTreeHost() const { return m_isDebugLayerTreeHost; }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -271,15 +271,12 @@ bool RemoteLayerTreeHost::updateLayerTree(const IPC::Connection& connection, con
     return rootLayerChanged;
 }
 
-void RemoteLayerTreeHost::asyncSetLayerContents(PlatformLayerIdentifier layerID, ImageBufferBackendHandle&& handle, const WebCore::RenderingResourceIdentifier& identifier)
+void RemoteLayerTreeHost::asyncSetLayerContents(PlatformLayerIdentifier layerID, ImageBufferBackendHandle&& contentsHandle, ContentsFormat contentsFormat, const WebCore::RenderingResourceIdentifier& contentsIdentifier)
 {
     RefPtr node = nodeForID(layerID);
     if (!node)
         return;
-
-    RetainPtr<id> contents = RemoteLayerBackingStoreProperties::layerContentsBufferFromBackendHandle(WTFMove(handle), layerContentsType(), true);
-    node->layer().contents = contents.get();
-    node->setAsyncContentsIdentifier(identifier);
+    RemoteLayerTreePropertyApplier::applyAsyncContentsUpdate(*node, WTFMove(contentsHandle), contentsFormat, contentsIdentifier, layerContentsType());
 }
 
 RemoteLayerTreeNode* RemoteLayerTreeHost::nodeForID(std::optional<PlatformLayerIdentifier> layerID) const

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
@@ -48,6 +48,31 @@
 namespace WebKit {
 using namespace WebCore;
 
+constexpr ContentsFormat pixelFormatToContentsFormat(ImageBufferPixelFormat format)
+{
+    switch (format) {
+    case ImageBufferPixelFormat::BGRX8:
+    case ImageBufferPixelFormat::BGRA8:
+        return ContentsFormat::RGBA8;
+#if ENABLE(PIXEL_FORMAT_RGB10)
+    case ImageBufferPixelFormat::RGB10:
+        return ContentsFormat::RGBA10;
+#endif
+#if ENABLE(PIXEL_FORMAT_RGB10A8)
+    case ImageBufferPixelFormat::RGB10A8:
+        return ContentsFormat::RGBA10;
+#endif
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    case ImageBufferPixelFormat::RGBA16F:
+        return ContentsFormat::RGBA16F;
+#endif
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+        return ContentsFormat::RGBA8;
+    }
+}
+
+
 WTF_MAKE_TZONE_ALLOCATED_IMPL(GraphicsLayerCARemote);
 
 GraphicsLayerCARemote::GraphicsLayerCARemote(Type layerType, GraphicsLayerClient& client, RemoteLayerTreeContext& context)
@@ -162,9 +187,10 @@ public:
             Locker locker { m_surfaceLock };
             m_surfaceBackendHandle = ImageBufferBackendHandle { *backendHandle };
             m_surfaceIdentifier = clone->renderingResourceIdentifier();
+            m_contentsFormat = pixelFormatToContentsFormat(clone->pixelFormat());
         }
 
-        m_connection->send(Messages::RemoteLayerTreeDrawingAreaProxy::AsyncSetLayerContents(*m_layerID, WTFMove(*backendHandle), clone->renderingResourceIdentifier()), m_drawingArea.toUInt64());
+        m_connection->send(Messages::RemoteLayerTreeDrawingAreaProxy::AsyncSetLayerContents(*m_layerID, WTFMove(*backendHandle), m_contentsFormat, clone->renderingResourceIdentifier()), m_drawingArea.toUInt64());
 
         return true;
     }
@@ -172,9 +198,10 @@ public:
     void display(PlatformCALayer& layer) final
     {
         Locker locker { m_surfaceLock };
-        layer.setContentsFormat(m_contentsFormat);
-        if (m_surfaceBackendHandle)
+        if (m_surfaceBackendHandle) {
+            downcast<PlatformCALayerRemote>(layer).setContentsFormat(m_contentsFormat);
             downcast<PlatformCALayerRemote>(layer).setRemoteDelegatedContents({ ImageBufferBackendHandle { *m_surfaceBackendHandle }, { }, std::optional<RenderingResourceIdentifier>(m_surfaceIdentifier) });
+        }
     }
 
     void setDestinationLayerID(WebCore::PlatformLayerIdentifier layerID)
@@ -185,11 +212,6 @@ public:
     bool isGraphicsLayerCARemoteAsyncContentsDisplayDelegate() const final { return true; }
 
 private:
-    void setContentsFormat(ContentsFormat contentsFormat) final
-    {
-        m_contentsFormat = contentsFormat;
-    }
-
     const Ref<IPC::Connection> m_connection;
     DrawingAreaIdentifier m_drawingArea;
     Markable<WebCore::PlatformLayerIdentifier> m_layerID;


### PR DESCRIPTION
#### 0fa785e8db04d313aca5d3509a8550bbb3c79cf2
<pre>
Placeholder canvas does not always propagate HDR content format correctly to the layer
<a href="https://bugs.webkit.org/show_bug.cgi?id=295095">https://bugs.webkit.org/show_bug.cgi?id=295095</a>
<a href="https://rdar.apple.com/154478292">rdar://154478292</a>

Reviewed by NOBODY (OOPS!).

Propagate the HDR content format from the image buffer.
Fixes a race where the content format was not set if the buffer had
not reached the main thread when the delegate was created.

* Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp:
(WebCore::PlaceholderRenderingContextSource::setContentsToLayer):
(WebCore::PlaceholderRenderingContext::setContentsToLayer):
(WebCore::PlaceholderRenderingContext::setPlaceholderBuffer):
(WebCore::PlaceholderRenderingContext::pixelFormat const):
(WebCore::pixelFormatToContentsFormat): Deleted.
* Source/WebCore/html/canvas/PlaceholderRenderingContext.h:
* Source/WebCore/platform/graphics/GraphicsLayerContentsDisplayDelegate.h:
(WebCore::GraphicsLayerAsyncContentsDisplayDelegate::isGraphicsLayerCARemoteAsyncContentsDisplayDelegate const):
(WebCore::GraphicsLayerAsyncContentsDisplayDelegate::setContentsFormat): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::applyContentsFormatToLayer):
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
(WebKit::RemoteLayerTreePropertyApplier::applyAsyncContentsUpdate):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.messages.in:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::asyncSetLayerContents):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::asyncSetLayerContents):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm:
(WebKit::pixelFormatToContentsFormat):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fa785e8db04d313aca5d3509a8550bbb3c79cf2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109417 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29075 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19504 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114622 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59650 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111380 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29754 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37663 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83160 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112365 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23695 "Found 2 new test failures: fast/filter-image/clipped-filter.html fast/mediacapturefromelement/CanvasCaptureMediaStream-offscreencanvas.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98550 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63618 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23077 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16693 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59242 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93063 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16735 "Found 1 new test failure: fast/mediacapturefromelement/CanvasCaptureMediaStream-offscreencanvas.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117734 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36458 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26989 "Found 1 new test failure: fast/mediacapturefromelement/CanvasCaptureMediaStream-offscreencanvas.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92171 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36829 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94812 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91986 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36917 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14661 "Found 1 new test failure: fast/mediacapturefromelement/CanvasCaptureMediaStream-offscreencanvas.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32262 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36351 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41827 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36022 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39361 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37726 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->