### PR TITLE
Fix the build after 296600@main

### DIFF
--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift
@@ -97,12 +97,24 @@
     }
 
     @nonobjc final var playable: (any Playable)? {
-        get { base.playable }
+        get {
+            #if USE_APPLE_INTERNAL_SDK
+            base.playable
+            #else
+            nil
+            #endif
+        }
         set { base.playable = newValue }
     }
 
     @nonobjc final var prefersAutoDimming: Bool {
-        get { base.prefersAutoDimming }
+        get {
+            #if USE_APPLE_INTERNAL_SDK
+            base.prefersAutoDimming
+            #else
+            false
+            #endif
+        }
         set { base.prefersAutoDimming = newValue }
     }
 }


### PR DESCRIPTION
#### dd9bf16cd3995f89a44871d8338927691b0ee68c
<pre>
Fix the build after 296600@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=295098">https://bugs.webkit.org/show_bug.cgi?id=295098</a>
<a href="https://rdar.apple.com/154437528">rdar://154437528</a>

Unreviewed build fix.

* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift:
(WKSPlayableViewControllerHost.playable):
(WKSPlayableViewControllerHost.prefersAutoDimming):

Canonical link: <a href="https://commits.webkit.org/296728@main">https://commits.webkit.org/296728@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89bfdb7e8184d8302abda6e814e1a7cf009f19b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109429 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29087 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19516 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114634 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59662 "Failed to checkout and rebase branch from PR 47296") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29766 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37675 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83173 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/59662 "Failed to checkout and rebase branch from PR 47296") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112377 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23706 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98562 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63631 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23087 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59254 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93074 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16747 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117748 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36470 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27000 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92185 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36841 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94824 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92000 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36928 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14673 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32276 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17657 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36363 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41839 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36034 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39373 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37738 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->