### PR TITLE
AX: Downgrade various text marker asserts and logs to debug-only

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -3978,7 +3978,7 @@ std::optional<TextMarkerData> AXObjectCache::textMarkerDataForVisiblePosition(co
             previousEndDomOffset = textBox->maximumCaretOffset();
             previousLineIndex = newLineIndex;
         }
-        RELEASE_ASSERT(domOffset >= differenceBetweenDomAndRenderedOffsets);
+        ASSERT(domOffset >= differenceBetweenDomAndRenderedOffsets);
         unsigned renderedOffset = domOffset - differenceBetweenDomAndRenderedOffsets;
         return createFromRendererAndOffset(const_cast<RenderText&>(*renderText), renderedOffset);
     }

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -59,7 +59,7 @@ TextMarkerData::TextMarkerData(AXObjectCache& cache, const VisiblePosition& visi
 {
     ASSERT(isMainThread());
 #if ENABLE(AX_THREAD_TEXT_APIS)
-    RELEASE_ASSERT(!AXObjectCache::shouldCreateAXThreadCompatibleMarkers());
+    ASSERT(!AXObjectCache::shouldCreateAXThreadCompatibleMarkers());
 #endif
 
     zeroBytes(*this);
@@ -352,7 +352,7 @@ std::optional<CharacterRange> AXTextMarkerRange::characterRange() const
         return std::nullopt;
 
     if (m_start.m_data.characterOffset > m_end.m_data.characterOffset) {
-        TEXT_MARKER_ASSERT_NOT_REACHED("characterRange");
+        ASSERT_NOT_REACHED();
         return std::nullopt;
     }
     return { { m_start.m_data.characterOffset, m_end.m_data.characterOffset - m_start.m_data.characterOffset } };
@@ -629,7 +629,7 @@ String AXTextMarkerRange::toString() const
 #if ENABLE(AX_THREAD_TEXT_APIS)
 AXTextMarker AXTextMarker::convertToDomOffset() const
 {
-    RELEASE_ASSERT(!isMainThread());
+    ASSERT(!isMainThread());
 
     if (!isValid())
         return { };
@@ -696,7 +696,7 @@ int AXTextMarker::lineIndex() const
         // Start from a line end, so that subsequent calls to nextLineEnd() yield a new line.
         // Otherwise if we started from the middle of a line, we would count the the first line twice.
         auto nextLineEndMarker = currentMarker.nextLineEnd();
-        TEXT_MARKER_ASSERT_DOUBLE(nextLineEndMarker.lineID() == currentMarker.lineID(), "lineIndex", nextLineEndMarker, currentMarker);
+        TEXT_MARKER_ASSERT_DOUBLE(nextLineEndMarker.lineID() == currentMarker.lineID(), nextLineEndMarker, currentMarker);
         currentMarker = WTFMove(nextLineEndMarker);
     }
 
@@ -718,7 +718,7 @@ CharacterRange AXTextMarker::characterRangeForLine(unsigned lineIndex) const
     if (!object || !object->isTextControl())
         return { };
     // This implementation doesn't respect the offset as the only known callsite hardcodes zero. We'll need to make changes to support this if a usecase arrives for it.
-    TEXT_MARKER_ASSERT(!offset(), "characterRangeForLine");
+    TEXT_MARKER_ASSERT(!offset());
 
     std::optional stopAtID = object->idOfNextSiblingIncludingIgnoredOrParent();
     auto textRunMarker = toTextRunMarker(stopAtID);
@@ -745,7 +745,7 @@ CharacterRange AXTextMarker::characterRangeForLine(unsigned lineIndex) const
 AXTextMarkerRange AXTextMarker::markerRangeForLineIndex(unsigned lineIndex) const
 {
     // This implementation doesn't respect the offset as the only known callsite hardcodes zero. We'll need to make changes to support this if a usecase arrives for it.
-    TEXT_MARKER_ASSERT(!offset(), "markerRangeForLineIndex");
+    TEXT_MARKER_ASSERT(!offset());
 
     if (!isValid())
         return { };
@@ -798,7 +798,7 @@ bool AXTextMarker::atLineBoundaryForDirection(AXDirection direction) const
         return toTextRunMarker().atLineBoundaryForDirection(direction);
 
     size_t runIndex = runs()->indexForOffset(offset(), affinity());
-    TEXT_MARKER_ASSERT(runIndex != notFound, "atLineBoundaryForDirection (1)");
+    TEXT_MARKER_ASSERT(runIndex != notFound);
     if (runIndex == notFound)
         return false;
 
@@ -829,7 +829,7 @@ bool AXTextMarker::atLineBoundaryForDirection(AXDirection direction, const AXTex
     // The current line/containing block ends with the current object and runs. Now, check if we are at
     // the start/end of the line using the marker's position within its line.
     unsigned sumToRunIndex = runIndex ? runs->runLengthSumTo(runIndex - 1) : 0;
-    TEXT_MARKER_ASSERT(offset() >= sumToRunIndex, "atLineBoundaryForDirection (2)");
+    TEXT_MARKER_ASSERT(offset() >= sumToRunIndex);
     if (offset() < sumToRunIndex)
         return false;
 
@@ -839,7 +839,7 @@ bool AXTextMarker::atLineBoundaryForDirection(AXDirection direction, const AXTex
 
 unsigned AXTextMarker::offsetFromRoot() const
 {
-    RELEASE_ASSERT(!isMainThread());
+    ASSERT(!isMainThread());
 
     if (!isValid())
         return 0;
@@ -885,7 +885,7 @@ unsigned AXTextMarker::offsetFromRoot() const
         applyNewlineOffset();
 
         // If this assert fails, it means we couldn't navigate from root to `this`, which should never happen.
-        TEXT_MARKER_ASSERT_DOUBLE(hasSameObjectAndOffset(current), "offsetFromRoot", (*this), current);
+        TEXT_MARKER_ASSERT_DOUBLE(hasSameObjectAndOffset(current), (*this), current);
         return offset;
     }
     return 0;
@@ -893,7 +893,7 @@ unsigned AXTextMarker::offsetFromRoot() const
 
 AXTextMarker AXTextMarker::nextMarkerFromOffset(unsigned offset, ForceSingleOffsetMovement forceSingleOffsetMovement, std::optional<AXID> stopAtID) const
 {
-    RELEASE_ASSERT(!isMainThread());
+    ASSERT(!isMainThread());
 
     if (!isValid())
         return { };
@@ -914,7 +914,7 @@ AXTextMarker AXTextMarker::nextMarkerFromOffset(unsigned offset, ForceSingleOffs
 
 AXTextMarker AXTextMarker::findLastBefore(std::optional<AXID> stopAtID) const
 {
-    RELEASE_ASSERT(!isMainThread());
+    ASSERT(!isMainThread());
 
     if (!isValid())
         return { };
@@ -940,7 +940,7 @@ AXTextMarker AXTextMarker::findLastBefore(std::optional<AXID> stopAtID) const
 
 AXTextMarkerRange AXTextMarker::rangeWithSameStyle() const
 {
-    RELEASE_ASSERT(!isMainThread());
+    ASSERT(!isMainThread());
 
     if (!isValid())
         return { };
@@ -993,7 +993,7 @@ static FloatRect viewportRelativeFrameFromRuns(Ref<AXIsolatedObject> object, uns
 
 FloatRect AXTextMarkerRange::viewportRelativeFrame() const
 {
-    RELEASE_ASSERT(!isMainThread());
+    ASSERT(!isMainThread());
 
     auto start = m_start.toTextRunMarker();
     if (!start.isValid())
@@ -1023,7 +1023,7 @@ FloatRect AXTextMarkerRange::viewportRelativeFrame() const
 
 AXTextMarkerRange AXTextMarkerRange::convertToDomOffsetRange() const
 {
-    RELEASE_ASSERT(!isMainThread());
+    ASSERT(!isMainThread());
 
     return {
         m_start.convertToDomOffset(),
@@ -1101,7 +1101,7 @@ AXTextMarker AXTextMarker::findMarker(AXDirection direction, CoalesceObjectBreak
     object = findObjectWithRuns(*object, direction, stopAtID);
     if (object) {
         bool nextRunHasLength = direction == AXDirection::Next ? object->textRuns()->runLength(0) : object->textRuns()->lastRunLength();
-        TEXT_MARKER_ASSERT(nextRunHasLength, "findMarker");
+        TEXT_MARKER_ASSERT(nextRunHasLength);
         if (!nextRunHasLength)
             return { };
 
@@ -1123,7 +1123,7 @@ AXTextMarker AXTextMarker::findLine(AXDirection direction, AXTextUnitBoundary bo
         return toTextRunMarker(stopAtID).findLine(direction, boundary, includeTrailingLineBreak, stopAtID);
 
     size_t runIndex = runs()->indexForOffset(offset(), affinity());
-    TEXT_MARKER_ASSERT(runIndex != notFound, "findLine (1)");
+    TEXT_MARKER_ASSERT(runIndex != notFound);
     if (runIndex == notFound)
         return { };
 
@@ -1177,7 +1177,7 @@ AXTextMarker AXTextMarker::findLine(AXDirection direction, AXTextUnitBoundary bo
     auto startLineID = currentRuns->lineID(runIndex);
     // We found the start run and associated line, now iterate until we find a line boundary.
     while (currentObject) {
-        TEXT_MARKER_ASSERT_SINGLE(currentRuns->size(), "findLine (2)", (*this));
+        TEXT_MARKER_ASSERT_SINGLE(currentRuns->size(), (*this));
         if (!currentRuns->size())
             return { };
 
@@ -1224,7 +1224,7 @@ AXTextMarker AXTextMarker::findParagraph(AXDirection direction, AXTextUnitBounda
         return toTextRunMarker().findParagraph(direction, boundary);
 
     size_t runIndex = runs()->indexForOffset(offset(), affinity());
-    TEXT_MARKER_ASSERT(runIndex != notFound, "findParagraph");
+    TEXT_MARKER_ASSERT(runIndex != notFound);
     if (runIndex == notFound)
         return { };
 
@@ -1238,7 +1238,7 @@ AXTextMarker AXTextMarker::findParagraph(AXDirection direction, AXTextUnitBounda
     unsigned offsetInStartLine = offset() - sumToRunIndex;
 
     while (currentObject) {
-        TEXT_MARKER_ASSERT_SINGLE(currentRuns->size(), "findParagraph", (*this));
+        TEXT_MARKER_ASSERT_SINGLE(currentRuns->size(), (*this));
         if (!currentRuns->size())
             return { };
 
@@ -1305,7 +1305,7 @@ AXTextMarker AXTextMarker::findWordOrSentence(AXDirection direction, bool findWo
     // Functions to update resultMarker for word and sentence text units.
     auto updateWordResultMarker = [&] () {
         if (direction == AXDirection::Previous && boundary == AXTextUnitBoundary::Start) {
-            TEXT_MARKER_ASSERT_SINGLE(offset <= flattenedRuns.length(), "findWordOrSentence", (*this));
+            TEXT_MARKER_ASSERT_SINGLE(offset <= flattenedRuns.length(), (*this));
             int previousWordStart = findNextWordFromIndex(flattenedRuns, offset, false);
             if (previousWordStart <= objectBorder)
                 resultMarker = AXTextMarker(*currentObject, previousWordStart, origin);
@@ -1456,7 +1456,7 @@ AXTextMarker AXTextMarker::toTextRunMarker(std::optional<AXID> stopAtID) const
     if (!current)
         return { };
 
-    TEXT_MARKER_ASSERT(offset() >= precedingOffset, "toTextRunMarker (2)");
+    TEXT_MARKER_ASSERT(offset() >= precedingOffset);
     if (offset() < precedingOffset)
         return *this;
 

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -27,31 +27,17 @@
 #include "AccessibilityObject.h"
 #include <wtf/StdLibExtras.h>
 
-#define TEXT_MARKER_LOG(methodName) do { \
-    RELEASE_LOG(Accessibility, "[AX Thread Text Marker] hit assertion in %" PUBLIC_LOG_STRING, methodName); \
-} while (0)
-
-#define TEXT_MARKER_ASSERT(assertion, methodName) do { \
-    if (!(assertion)) \
-        TEXT_MARKER_LOG(methodName); \
+#define TEXT_MARKER_ASSERT(assertion) do { \
     std::string debugString = "Text marker origin: " + originToString(origin()).utf8().toStdString(); \
     ASSERT_WITH_MESSAGE(assertion, "%s", debugString.c_str()); \
 } while (0)
-#define TEXT_MARKER_ASSERT_SINGLE(assertion, methodName, marker) do { \
-    if (!(assertion)) \
-        TEXT_MARKER_LOG(methodName); \
+#define TEXT_MARKER_ASSERT_SINGLE(assertion, marker) do { \
     std::string debugString = "Text marker origin: " + originToString(marker.origin()).utf8().toStdString(); \
     ASSERT_WITH_MESSAGE(assertion, "%s", debugString.c_str()); \
 } while (0)
-#define TEXT_MARKER_ASSERT_DOUBLE(assertion, methodName, marker1, marker2) do { \
-    if (!(assertion)) \
-        TEXT_MARKER_LOG(methodName); \
+#define TEXT_MARKER_ASSERT_DOUBLE(assertion, marker1, marker2) do { \
     std::string debugString = "Text marker origins: " + originToString(marker1.origin()).utf8().toStdString() + ", " + originToString(marker2.origin()).utf8().data(); \
     ASSERT_WITH_MESSAGE(assertion, "%s", debugString.c_str()); \
-} while (0)
-#define TEXT_MARKER_ASSERT_NOT_REACHED(methodName) do { \
-    TEXT_MARKER_LOG(methodName); \
-    ASSERT_NOT_REACHED(); \
 } while (0)
 
 namespace WebCore {

--- a/Source/WebCore/accessibility/AXTextRun.cpp
+++ b/Source/WebCore/accessibility/AXTextRun.cpp
@@ -145,7 +145,7 @@ FloatRect AXTextRuns::localRect(unsigned start, unsigned end, FontOrientation or
         float totalAdvance = 0;
         unsigned startIndexInRun = startIndex - offsetOfFirstCharacterInRun;
         unsigned endIndexInRun = endIndex - offsetOfFirstCharacterInRun;
-        RELEASE_ASSERT(startIndexInRun <= endIndexInRun);
+        ASSERT(startIndexInRun <= endIndexInRun);
         for (size_t i = startIndexInRun; i < endIndexInRun; i++)
             totalAdvance += (float)characterAdvances[i];
         return totalAdvance;

--- a/Source/WebCore/accessibility/AXTextRun.h
+++ b/Source/WebCore/accessibility/AXTextRun.h
@@ -102,7 +102,7 @@ struct AXTextRun {
     {
         // Runs should have a non-zero length (i.e. endIndex should strictly be greater than startIndex).
         // This is important because several parts of AXTextMarker rely on this assumption.
-        RELEASE_ASSERT(endIndex > startIndex);
+        ASSERT(endIndex > startIndex);
     }
 
     const FixedVector<std::array<uint16_t, 2>>& domOffsets() const { return textRunDomOffsets; }

--- a/Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm
@@ -75,7 +75,7 @@ RetainPtr<PlatformTextMarkerData> AXTextMarker::platformData() const
 // FIXME: There's a lot of duplicated code between this function and AXTextMarkerRange::toString().
 RetainPtr<NSAttributedString> AXTextMarkerRange::toAttributedString(AXCoreObject::SpellCheck spellCheck) const
 {
-    RELEASE_ASSERT(!isMainThread());
+    ASSERT(!isMainThread());
 
     auto start = m_start.toTextRunMarker();
     if (!start.isValid())


### PR DESCRIPTION
#### e5d65510e96990b7963661b0e253476695797d14
<pre>
AX: Downgrade various text marker asserts and logs to debug-only
<a href="https://bugs.webkit.org/show_bug.cgi?id=295102">https://bugs.webkit.org/show_bug.cgi?id=295102</a>
<a href="https://rdar.apple.com/154493503">rdar://154493503</a>

Reviewed by Joshua Hoffman.

Making these asserts and logs run in release mode was useful when developing the feature, but we shouldn&apos;t continue
paying the cost.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::textMarkerDataForVisiblePosition):
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::TextMarkerData::TextMarkerData):
(WebCore::AXTextMarker::convertToDomOffset const):
(WebCore::AXTextMarker::offsetFromRoot const):
(WebCore::AXTextMarker::nextMarkerFromOffset const):
(WebCore::AXTextMarker::findLastBefore const):
(WebCore::AXTextMarker::rangeWithSameStyle const):
(WebCore::AXTextMarkerRange::viewportRelativeFrame const):
(WebCore::AXTextMarkerRange::convertToDomOffsetRange const):
* Source/WebCore/accessibility/AXTextMarker.h:
* Source/WebCore/accessibility/AXTextRun.cpp:
(WebCore::AXTextRuns::localRect const):
* Source/WebCore/accessibility/AXTextRun.h:
(WebCore::AXTextRun::AXTextRun):
* Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm:
(WebCore::AXTextMarkerRange::toAttributedString const):

Canonical link: <a href="https://commits.webkit.org/296747@main">https://commits.webkit.org/296747@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e49b124307c64f2de26f8ad42ef8f09fc75e9e21

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109453 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29111 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114658 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59681 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111416 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29790 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37699 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83190 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112401 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23728 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98585 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63650 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23109 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16727 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59277 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93098 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16769 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117772 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36494 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27021 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92203 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36865 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94846 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92019 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23432 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36952 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14695 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32297 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36387 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41862 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36057 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39396 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37761 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->