### PR TITLE
[GTK3] Fix build after 296427@main

### DIFF
--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLBaseElement.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLBaseElement.cpp
@@ -184,7 +184,7 @@ void webkit_dom_html_base_element_set_href(WebKitDOMHTMLBaseElement* self, const
     g_return_if_fail(WEBKIT_DOM_IS_HTML_BASE_ELEMENT(self));
     g_return_if_fail(value);
     WebCore::HTMLBaseElement* item = WebKit::core(self);
-    item->setHref(WTF::AtomString::fromUTF8(value));
+    item->setAttributeWithoutSynchronization(WebCore::HTMLNames::hrefAttr, WTF::AtomString::fromUTF8(value));
 }
 
 gchar* webkit_dom_html_base_element_get_target(WebKitDOMHTMLBaseElement* self)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLButtonElement.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLButtonElement.cpp
@@ -307,7 +307,7 @@ void webkit_dom_html_button_element_set_button_type(WebKitDOMHTMLButtonElement* 
     g_return_if_fail(WEBKIT_DOM_IS_HTML_BUTTON_ELEMENT(self));
     g_return_if_fail(value);
     WebCore::HTMLButtonElement* item = WebKit::core(self);
-    item->setType(WTF::AtomString::fromUTF8(value));
+    item->setAttributeWithoutSynchronization(WebCore::HTMLNames::typeAttr, WTF::AtomString::fromUTF8(value));
 }
 
 gchar* webkit_dom_html_button_element_get_name(WebKitDOMHTMLButtonElement* self)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLCanvasElement.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLCanvasElement.cpp
@@ -181,7 +181,7 @@ void webkit_dom_html_canvas_element_set_width(WebKitDOMHTMLCanvasElement* self, 
     WebCore::JSMainThreadNullState state;
     g_return_if_fail(WEBKIT_DOM_IS_HTML_CANVAS_ELEMENT(self));
     WebCore::HTMLCanvasElement* item = WebKit::core(self);
-    item->setWidth(value);
+    item->setIntegralAttribute(WebCore::HTMLNames::widthAttr, value);
 }
 
 glong webkit_dom_html_canvas_element_get_height(WebKitDOMHTMLCanvasElement* self)
@@ -198,7 +198,7 @@ void webkit_dom_html_canvas_element_set_height(WebKitDOMHTMLCanvasElement* self,
     WebCore::JSMainThreadNullState state;
     g_return_if_fail(WEBKIT_DOM_IS_HTML_CANVAS_ELEMENT(self));
     WebCore::HTMLCanvasElement* item = WebKit::core(self);
-    item->setHeight(value);
+    item->setUnsignedIntegralAttribute(WebCore::HTMLNames::heightAttr, value);
 }
 
 G_GNUC_END_IGNORE_DEPRECATIONS;

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLElement.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLElement.cpp
@@ -447,7 +447,7 @@ void webkit_dom_html_element_set_dir(WebKitDOMHTMLElement* self, const gchar* va
     g_return_if_fail(WEBKIT_DOM_IS_HTML_ELEMENT(self));
     g_return_if_fail(value);
     WebCore::HTMLElement* item = WebKit::core(self);
-    item->setDir(WTF::AtomString::fromUTF8(value));
+    item->setAttributeWithoutSynchronization(WebCore::HTMLNames::dirAttr, WTF::AtomString::fromUTF8(value));
 }
 
 glong webkit_dom_html_element_get_tab_index(WebKitDOMHTMLElement* self)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLEmbedElement.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLEmbedElement.cpp
@@ -260,7 +260,7 @@ glong webkit_dom_html_embed_element_get_height(WebKitDOMHTMLEmbedElement* self)
     WebCore::JSMainThreadNullState state;
     g_return_val_if_fail(WEBKIT_DOM_IS_HTML_EMBED_ELEMENT(self), 0);
     WebCore::HTMLEmbedElement* item = WebKit::core(self);
-    glong result = item->getIntegralAttribute(WebCore::HTMLNames::heightAttr);
+    glong result = item->integralAttribute(WebCore::HTMLNames::heightAttr);
     return result;
 }
 
@@ -331,7 +331,7 @@ glong webkit_dom_html_embed_element_get_width(WebKitDOMHTMLEmbedElement* self)
     WebCore::JSMainThreadNullState state;
     g_return_val_if_fail(WEBKIT_DOM_IS_HTML_EMBED_ELEMENT(self), 0);
     WebCore::HTMLEmbedElement* item = WebKit::core(self);
-    glong result = item->getIntegralAttribute(WebCore::HTMLNames::widthAttr);
+    glong result = item->integralAttribute(WebCore::HTMLNames::widthAttr);
     return result;
 }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLFormElement.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLFormElement.cpp
@@ -349,7 +349,7 @@ void webkit_dom_html_form_element_set_enctype(WebKitDOMHTMLFormElement* self, co
     g_return_if_fail(WEBKIT_DOM_IS_HTML_FORM_ELEMENT(self));
     g_return_if_fail(value);
     WebCore::HTMLFormElement* item = WebKit::core(self);
-    item->setEnctype(WTF::AtomString::fromUTF8(value));
+    item->setAttributeWithoutSynchronization(WebCore::HTMLNames::enctypeAttr, WTF::AtomString::fromUTF8(value));
 }
 
 gchar* webkit_dom_html_form_element_get_encoding(WebKitDOMHTMLFormElement* self)
@@ -367,7 +367,7 @@ void webkit_dom_html_form_element_set_encoding(WebKitDOMHTMLFormElement* self, c
     g_return_if_fail(WEBKIT_DOM_IS_HTML_FORM_ELEMENT(self));
     g_return_if_fail(value);
     WebCore::HTMLFormElement* item = WebKit::core(self);
-    item->setEnctype(WTF::AtomString::fromUTF8(value));
+    item->setAttributeWithoutSynchronization(WebCore::HTMLNames::enctypeAttr, WTF::AtomString::fromUTF8(value));
 }
 
 gchar* webkit_dom_html_form_element_get_method(WebKitDOMHTMLFormElement* self)
@@ -385,7 +385,7 @@ void webkit_dom_html_form_element_set_method(WebKitDOMHTMLFormElement* self, con
     g_return_if_fail(WEBKIT_DOM_IS_HTML_FORM_ELEMENT(self));
     g_return_if_fail(value);
     WebCore::HTMLFormElement* item = WebKit::core(self);
-    item->setMethod(WTF::AtomString::fromUTF8(value));
+    item->setAttributeWithoutSynchronization(WebCore::HTMLNames::methodAttr, WTF::AtomString::fromUTF8(value));
 }
 
 gchar* webkit_dom_html_form_element_get_name(WebKitDOMHTMLFormElement* self)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLImageElement.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLImageElement.cpp
@@ -512,7 +512,7 @@ void webkit_dom_html_image_element_set_height(WebKitDOMHTMLImageElement* self, g
     WebCore::JSMainThreadNullState state;
     g_return_if_fail(WEBKIT_DOM_IS_HTML_IMAGE_ELEMENT(self));
     WebCore::HTMLImageElement* item = WebKit::core(self);
-    item->setHeight(value);
+    item->setUnsignedIntegralAttribute(WebCore::HTMLNames::heightAttr, value);
 }
 
 glong webkit_dom_html_image_element_get_hspace(WebKitDOMHTMLImageElement* self)
@@ -520,7 +520,7 @@ glong webkit_dom_html_image_element_get_hspace(WebKitDOMHTMLImageElement* self)
     WebCore::JSMainThreadNullState state;
     g_return_val_if_fail(WEBKIT_DOM_IS_HTML_IMAGE_ELEMENT(self), 0);
     WebCore::HTMLImageElement* item = WebKit::core(self);
-    glong result = item->getIntegralAttribute(WebCore::HTMLNames::hspaceAttr);
+    glong result = item->integralAttribute(WebCore::HTMLNames::hspaceAttr);
     return result;
 }
 
@@ -608,7 +608,7 @@ glong webkit_dom_html_image_element_get_vspace(WebKitDOMHTMLImageElement* self)
     WebCore::JSMainThreadNullState state;
     g_return_val_if_fail(WEBKIT_DOM_IS_HTML_IMAGE_ELEMENT(self), 0);
     WebCore::HTMLImageElement* item = WebKit::core(self);
-    glong result = item->getIntegralAttribute(WebCore::HTMLNames::vspaceAttr);
+    glong result = item->integralAttribute(WebCore::HTMLNames::vspaceAttr);
     return result;
 }
 
@@ -634,7 +634,7 @@ void webkit_dom_html_image_element_set_width(WebKitDOMHTMLImageElement* self, gl
     WebCore::JSMainThreadNullState state;
     g_return_if_fail(WEBKIT_DOM_IS_HTML_IMAGE_ELEMENT(self));
     WebCore::HTMLImageElement* item = WebKit::core(self);
-    item->setWidth(value);
+    item->setIntegralAttribute(WebCore::HTMLNames::widthAttr, value);
 }
 
 gboolean webkit_dom_html_image_element_get_complete(WebKitDOMHTMLImageElement* self)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLInputElement.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLInputElement.cpp
@@ -692,7 +692,7 @@ void webkit_dom_html_input_element_set_height(WebKitDOMHTMLInputElement* self, g
     WebCore::JSMainThreadNullState state;
     g_return_if_fail(WEBKIT_DOM_IS_HTML_INPUT_ELEMENT(self));
     WebCore::HTMLInputElement* item = WebKit::core(self);
-    item->setHeight(value);
+    item->setUnsignedIntegralAttribute(WebCore::HTMLNames::heightAttr, value);
 }
 
 gboolean webkit_dom_html_input_element_get_indeterminate(WebKitDOMHTMLInputElement* self)
@@ -841,7 +841,7 @@ void webkit_dom_html_input_element_set_input_type(WebKitDOMHTMLInputElement* sel
     g_return_if_fail(WEBKIT_DOM_IS_HTML_INPUT_ELEMENT(self));
     g_return_if_fail(value);
     WebCore::HTMLInputElement* item = WebKit::core(self);
-    item->setType(WTF::AtomString::fromUTF8(value));
+    item->setAttributeWithoutSynchronization(WebCore::HTMLNames::typeAttr, WTF::AtomString::fromUTF8(value));
 }
 
 gchar* webkit_dom_html_input_element_get_default_value(WebKitDOMHTMLInputElement* self)
@@ -849,7 +849,7 @@ gchar* webkit_dom_html_input_element_get_default_value(WebKitDOMHTMLInputElement
     WebCore::JSMainThreadNullState state;
     g_return_val_if_fail(WEBKIT_DOM_IS_HTML_INPUT_ELEMENT(self), 0);
     WebCore::HTMLInputElement* item = WebKit::core(self);
-    gchar* result = convertToUTF8String(item->defaultValue());
+    gchar* result = convertToUTF8String(item->attributeWithoutSynchronization(WebCore::HTMLNames::valueAttr));
     return result;
 }
 
@@ -859,7 +859,7 @@ void webkit_dom_html_input_element_set_default_value(WebKitDOMHTMLInputElement* 
     g_return_if_fail(WEBKIT_DOM_IS_HTML_INPUT_ELEMENT(self));
     g_return_if_fail(value);
     WebCore::HTMLInputElement* item = WebKit::core(self);
-    item->setDefaultValue(WTF::AtomString::fromUTF8(value));
+    item->setAttributeWithoutSynchronization(WebCore::HTMLNames::valueAttr, WTF::AtomString::fromUTF8(value));
 }
 
 gchar* webkit_dom_html_input_element_get_value(WebKitDOMHTMLInputElement* self)
@@ -895,7 +895,7 @@ void webkit_dom_html_input_element_set_width(WebKitDOMHTMLInputElement* self, gu
     WebCore::JSMainThreadNullState state;
     g_return_if_fail(WEBKIT_DOM_IS_HTML_INPUT_ELEMENT(self));
     WebCore::HTMLInputElement* item = WebKit::core(self);
-    item->setWidth(value);
+    item->setIntegralAttribute(WebCore::HTMLNames::widthAttr, value);
 }
 
 gboolean webkit_dom_html_input_element_get_will_validate(WebKitDOMHTMLInputElement* self)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLLIElement.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLLIElement.cpp
@@ -192,7 +192,7 @@ glong webkit_dom_html_li_element_get_value(WebKitDOMHTMLLIElement* self)
     WebCore::JSMainThreadNullState state;
     g_return_val_if_fail(WEBKIT_DOM_IS_HTML_LI_ELEMENT(self), 0);
     WebCore::HTMLLIElement* item = WebKit::core(self);
-    glong result = item->getIntegralAttribute(WebCore::HTMLNames::valueAttr);
+    glong result = item->integralAttribute(WebCore::HTMLNames::valueAttr);
     return result;
 }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLOListElement.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLOListElement.cpp
@@ -217,7 +217,7 @@ void webkit_dom_html_o_list_element_set_start(WebKitDOMHTMLOListElement* self, g
     WebCore::JSMainThreadNullState state;
     g_return_if_fail(WEBKIT_DOM_IS_HTML_O_LIST_ELEMENT(self));
     WebCore::HTMLOListElement* item = WebKit::core(self);
-    item->setStartForBindings(value);
+    item->setIntegralAttribute(WebCore::HTMLNames::startAttr, value);
 }
 
 gchar* webkit_dom_html_o_list_element_get_type_attr(WebKitDOMHTMLOListElement* self)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLObjectElement.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLObjectElement.cpp
@@ -612,7 +612,7 @@ glong webkit_dom_html_object_element_get_hspace(WebKitDOMHTMLObjectElement* self
     WebCore::JSMainThreadNullState state;
     g_return_val_if_fail(WEBKIT_DOM_IS_HTML_OBJECT_ELEMENT(self), 0);
     WebCore::HTMLObjectElement* item = WebKit::core(self);
-    glong result = item->getIntegralAttribute(WebCore::HTMLNames::hspaceAttr);
+    glong result = item->integralAttribute(WebCore::HTMLNames::hspaceAttr);
     return result;
 }
 
@@ -694,7 +694,7 @@ glong webkit_dom_html_object_element_get_vspace(WebKitDOMHTMLObjectElement* self
     WebCore::JSMainThreadNullState state;
     g_return_val_if_fail(WEBKIT_DOM_IS_HTML_OBJECT_ELEMENT(self), 0);
     WebCore::HTMLObjectElement* item = WebKit::core(self);
-    glong result = item->getIntegralAttribute(WebCore::HTMLNames::vspaceAttr);
+    glong result = item->integralAttribute(WebCore::HTMLNames::vspaceAttr);
     return result;
 }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLOptionElement.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLOptionElement.cpp
@@ -304,7 +304,7 @@ void webkit_dom_html_option_element_set_label(WebKitDOMHTMLOptionElement* self, 
     g_return_if_fail(WEBKIT_DOM_IS_HTML_OPTION_ELEMENT(self));
     g_return_if_fail(value);
     WebCore::HTMLOptionElement* item = WebKit::core(self);
-    item->setLabel(WTF::AtomString::fromUTF8(value));
+    item->setAttributeWithoutSynchronization(WebCore::HTMLNames::labelAttr, WTF::AtomString::fromUTF8(value));
 }
 
 gboolean webkit_dom_html_option_element_get_default_selected(WebKitDOMHTMLOptionElement* self)
@@ -356,7 +356,7 @@ void webkit_dom_html_option_element_set_value(WebKitDOMHTMLOptionElement* self, 
     g_return_if_fail(WEBKIT_DOM_IS_HTML_OPTION_ELEMENT(self));
     g_return_if_fail(value);
     WebCore::HTMLOptionElement* item = WebKit::core(self);
-    item->setValue(WTF::AtomString::fromUTF8(value));
+    item->setAttributeWithoutSynchronization(WebCore::HTMLNames::valueAttr, WTF::AtomString::fromUTF8(value));
 }
 
 gchar* webkit_dom_html_option_element_get_text(WebKitDOMHTMLOptionElement* self)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLPreElement.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLPreElement.cpp
@@ -174,7 +174,7 @@ glong webkit_dom_html_pre_element_get_width(WebKitDOMHTMLPreElement* self)
     WebCore::JSMainThreadNullState state;
     g_return_val_if_fail(WEBKIT_DOM_IS_HTML_PRE_ELEMENT(self), 0);
     WebCore::HTMLPreElement* item = WebKit::core(self);
-    glong result = item->getIntegralAttribute(WebCore::HTMLNames::widthAttr);
+    glong result = item->integralAttribute(WebCore::HTMLNames::widthAttr);
     return result;
 }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLTableCellElement.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLTableCellElement.cpp
@@ -642,7 +642,7 @@ void webkit_dom_html_table_cell_element_set_scope(WebKitDOMHTMLTableCellElement*
     g_return_if_fail(WEBKIT_DOM_IS_HTML_TABLE_CELL_ELEMENT(self));
     g_return_if_fail(value);
     WebCore::HTMLTableCellElement* item = WebKit::core(self);
-    item->setScope(WTF::AtomString::fromUTF8(value));
+    item->setAttributeWithoutSynchronization(WebCore::HTMLNames::scopeAttr, WTF::AtomString::fromUTF8(value));
 }
 
 G_GNUC_END_IGNORE_DEPRECATIONS;

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLTextAreaElement.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLTextAreaElement.cpp
@@ -502,7 +502,7 @@ void webkit_dom_html_text_area_element_set_default_value(WebKitDOMHTMLTextAreaEl
     g_return_if_fail(WEBKIT_DOM_IS_HTML_TEXT_AREA_ELEMENT(self));
     g_return_if_fail(value);
     WebCore::HTMLTextAreaElement* item = WebKit::core(self);
-    item->setDefaultValue(WTF::String::fromUTF8(value));
+    item->setAttributeWithoutSynchronization(WebCore::HTMLNames::valueAttr, WTF::AtomString::fromUTF8(value));
 }
 
 gchar* webkit_dom_html_text_area_element_get_value(WebKitDOMHTMLTextAreaElement* self)


### PR DESCRIPTION
#### bbbf39e5eddd5334df2f9f72f97c8661fc59f593
<pre>
[GTK3] Fix build after 296427@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=289440">https://bugs.webkit.org/show_bug.cgi?id=289440</a>

Reviewed by Michael Catanzaro.

Rename setter/getter functions, according to changes in 296427@main.

* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLBaseElement.cpp:
(webkit_dom_html_base_element_set_href):
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLButtonElement.cpp:
(webkit_dom_html_button_element_set_button_type):
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLCanvasElement.cpp:
(webkit_dom_html_canvas_element_set_width):
(webkit_dom_html_canvas_element_set_height):
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLElement.cpp:
(webkit_dom_html_element_set_dir):
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLEmbedElement.cpp:
(webkit_dom_html_embed_element_get_height):
(webkit_dom_html_embed_element_get_width):
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLFormElement.cpp:
(webkit_dom_html_form_element_set_enctype):
(webkit_dom_html_form_element_set_encoding):
(webkit_dom_html_form_element_set_method):
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLImageElement.cpp:
(webkit_dom_html_image_element_set_height):
(webkit_dom_html_image_element_get_hspace):
(webkit_dom_html_image_element_get_vspace):
(webkit_dom_html_image_element_set_width):
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLInputElement.cpp:
(webkit_dom_html_input_element_set_height):
(webkit_dom_html_input_element_set_input_type):
(webkit_dom_html_input_element_get_default_value):
(webkit_dom_html_input_element_set_default_value):
(webkit_dom_html_input_element_set_width):
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLLIElement.cpp:
(webkit_dom_html_li_element_get_value):
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLOListElement.cpp:
(webkit_dom_html_o_list_element_set_start):
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLObjectElement.cpp:
(webkit_dom_html_object_element_get_hspace):
(webkit_dom_html_object_element_get_vspace):
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLOptionElement.cpp:
(webkit_dom_html_option_element_set_label):
(webkit_dom_html_option_element_set_value):
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLPreElement.cpp:
(webkit_dom_html_pre_element_get_width):
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLTableCellElement.cpp:
(webkit_dom_html_table_cell_element_set_scope):
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLTextAreaElement.cpp:
(webkit_dom_html_text_area_element_set_default_value):

Canonical link: <a href="https://commits.webkit.org/296732@main">https://commits.webkit.org/296732@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31e27a58c3e3fe92faee345e0f626cf70070f422

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109447 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29105 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19534 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114652 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/59676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29784 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37693 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/83186 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/59676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112395 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/23724 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98577 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63644 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23105 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59271 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93092 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16762 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117766 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36488 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/27017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/92195 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36859 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94839 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92011 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23420 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36943 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14688 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32292 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36381 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/41857 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36052 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39391 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37756 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->