### PR TITLE
[Lockdown Mode] Disable XSLT parsing for WebKit in Lockdown Mode

### DIFF
--- a/LayoutTests/dom/xsl/lockdown-mode/XSLT-disabled-expected.txt
+++ b/LayoutTests/dom/xsl/lockdown-mode/XSLT-disabled-expected.txt
@@ -1,0 +1,14 @@
+This test ensures XSLT processing does not occur when loading an XML resource in LDM.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS xmlDocument.children.length is 1
+PASS xmlDocument.children[0].tagName is "doc"
+PASS xmlDocument.children[0].children.length is 1
+PASS xmlDocument.children[0].children[0].tagName is "example"
+PASS xmlDocument.children[0].children[0].innerHTML is "text"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/dom/xsl/lockdown-mode/XSLT-disabled.html
+++ b/LayoutTests/dom/xsl/lockdown-mode/XSLT-disabled.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("This test ensures XSLT processing does not occur when loading an XML resource in LDM.");
+
+var xmlDocument;
+
+function runTest() {
+
+    xmlDocument = document.getElementById("xml-iframe").contentDocument;
+
+    shouldBe("xmlDocument.children.length", "1");
+    shouldBeEqualToString("xmlDocument.children[0].tagName", "doc");
+    shouldBe("xmlDocument.children[0].children.length", "1");
+    shouldBeEqualToString("xmlDocument.children[0].children[0].tagName", "example");
+    shouldBeEqualToString("xmlDocument.children[0].children[0].innerHTML", "text");
+}
+</script>
+<iframe id="xml-iframe" src="resources/XSLT-disabled.xml" onload="runTest()"></iframe>
+</body>
+</html>

--- a/LayoutTests/dom/xsl/lockdown-mode/resources/XSLT-disabled.xml
+++ b/LayoutTests/dom/xsl/lockdown-mode/resources/XSLT-disabled.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="XSLT-disabled.xsl"?>
+<doc>
+   <example name="a">text</example>
+</doc>

--- a/LayoutTests/dom/xsl/lockdown-mode/resources/XSLT-disabled.xsl
+++ b/LayoutTests/dom/xsl/lockdown-mode/resources/XSLT-disabled.xsl
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <xsl:output method="text"/>
+
+  <xsl:template match="/">
+    Transform - <xsl:value-of select="."/>
+  </xsl:template>
+
+</xsl:stylesheet>
+

--- a/LayoutTests/js/dom/lockdown-mode/XSLTProcessor-disabled-expected.txt
+++ b/LayoutTests/js/dom/lockdown-mode/XSLTProcessor-disabled-expected.txt
@@ -1,0 +1,10 @@
+Ensures XSLTProcessor is unavailable to JavaScript in LDM.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS typeof(XSLTProcessor) === 'undefined' is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/js/dom/lockdown-mode/XSLTProcessor-disabled.html
+++ b/LayoutTests/js/dom/lockdown-mode/XSLTProcessor-disabled.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("Ensures XSLTProcessor is unavailable to JavaScript in LDM.");
+
+shouldBeTrue("typeof(XSLTProcessor) === 'undefined'");
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3227,6 +3227,11 @@ webkit.org/b/100238 fast/history/window-open.html [ Skip ]
 # WebXR is not fully supported yet
 webkit.org/b/208988 http/wpt/webxr [ Skip ]
 
+# Lockdown Mode does not apply
+dom/xsl/lockdown-mode [ Skip ]
+http/tests/lockdown-mode [ Skip ]
+js/dom/lockdown-mode [ Skip ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of UNSUPPORTED tests.
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -3185,8 +3185,6 @@ http/tests/websocket/tests/hybi/websocket-allowed-setting-cookie-as-third-party-
 
 webkit.org/b/294301 http/tests/media/hls/hls-audio-tracks-language.html [ Pass Failure ]
 
-http/tests/lockdown-mode [ Skip ]
-
 imported/w3c/web-platform-tests/css/css-transforms/individual-transform/individual-transform-3.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-images/gradient/conic-gradient-001.html [ ImageOnlyFailure ]
 
@@ -3205,3 +3203,8 @@ webkit.org/b/295119  imported/w3c/web-platform-tests/css/css-fonts/font-size-adj
 
 # setSinkId is not enabled on WK1
 media/video-setSinkId-default.html [ Skip ]
+
+# Lockdown Mode does not apply
+dom/xsl/lockdown-mode [ Skip ]
+http/tests/lockdown-mode [ Skip ]
+js/dom/lockdown-mode [ Skip ]

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -4483,4 +4483,7 @@ imported/w3c/web-platform-tests/wasm/core/simd/simd_f64x2_pmin_pmax.wast.js.html
 
 http/tests/iframe-memory-monitor/media-video-autoplay-in-frames.html [ Skip ]
 
+# Lockdown Mode does not apply
+dom/xsl/lockdown-mode [ Skip ]
 http/tests/lockdown-mode [ Skip ]
+js/dom/lockdown-mode [ Skip ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -448,6 +448,11 @@ webkit.org/b/252954 imported/w3c/web-platform-tests/html/rendering/replaced-elem
 
 webkit.org/b/264660 imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled-keyboard.tentative.html [ Failure ]
 
+# Lockdown Mode does not apply
+dom/xsl/lockdown-mode [ Skip ]
+http/tests/lockdown-mode [ Skip ]
+js/dom/lockdown-mode [ Skip ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # 3. UNRESOLVED TESTS
 #////////////////////////////////////////////////////////////////////////////////////////
@@ -507,8 +512,6 @@ imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes.html?pen-n
 imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes.html?pen-right [ Skip ]
 imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes.html?pen-right-nonstandard [ Skip ]
 imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes.html?touch-nonstandard [ Skip ]
-
-http/tests/lockdown-mode [ Skip ]
 
 css3/scroll-snap/resnap-after-layout.html [ Skip ] # Timeout.
 
@@ -1361,3 +1364,7 @@ webkit.org/b/292841 fullscreen/exit-full-screen-video-crash.html [ Timeout ]
 webkit.org/b/254518 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/autoplay-allowed-by-feature-policy.https.sub.html [ Crash Failure Pass ]
 
 webkit.org/b/267992 imported/w3c/web-platform-tests/html/anonymous-iframe/initial-empty-document.tentative.https.window.html [ Crash Pass ]
+
+# The Digital Credentials API is not supported on WPE port.
+http/wpt/identity/ [ Skip ]
+imported/w3c/web-platform-tests/digital-credentials/ [ Skip ]

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -9427,6 +9427,23 @@ WritingSuggestionsAttributeEnabled:
     WebCore:
       default: true
 
+XSLTEnabled:
+  type: bool
+  status: internal
+  webcoreName: "xsltEnabled"
+  webcoreGetter: "isXSLTEnabled"
+  condition: ENABLE(XSLT)
+  humanReadableName: "XSLT Support Enabled"
+  humanReadableDescription: "Enables support for XSLT"
+  defaultValue:
+    WebKitLegacy:
+      default: true
+    WebKit:
+      default: true
+    WebCore:
+      default: true
+  disableInLockdownMode: true
+
 ZoomOnDoubleTapWhenRoot:
   type: bool
   status: internal

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -556,6 +556,7 @@ namespace WebCore {
     macro(XRWebGLBinding) \
     macro(XRWebGLLayer) \
     macro(XRWebGLSubImage) \
+    macro(XSLTProcessor) \
     macro(VideoTrackGenerator) \
     macro(abortAlgorithm) \
     macro(abortSteps) \

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7743,6 +7743,8 @@ bool Document::shouldDeferAsynchronousScriptsUntilParsingFinishes() const
 
 void Document::scheduleToApplyXSLTransforms()
 {
+    ASSERT(settings().isXSLTEnabled());
+
     m_hasPendingXSLTransforms = true;
     if (!m_applyPendingXSLTransformsTimer.isActive())
         m_applyPendingXSLTransformsTimer.startOneShot(0_s);
@@ -7758,6 +7760,8 @@ void Document::applyPendingXSLTransformsNowIfScheduled()
 
 void Document::applyPendingXSLTransformsTimerFired()
 {
+    ASSERT(settings().isXSLTEnabled());
+
     if (parsing())
         return;
 

--- a/Source/WebCore/dom/ProcessingInstruction.cpp
+++ b/Source/WebCore/dom/ProcessingInstruction.cpp
@@ -100,7 +100,8 @@ void ProcessingInstruction::checkStyleSheet()
 
         m_isCSS = type.isEmpty() || type == cssContentTypeAtom();
 #if ENABLE(XSLT)
-        m_isXSL = type == "text/xml"_s || type == "text/xsl"_s || type == "application/xml"_s || type == "application/xhtml+xml"_s || type == "application/rss+xml"_s || type == "application/atom+xml"_s;
+        bool isXSLTSupported = document->settings().isXSLTEnabled();
+        m_isXSL = isXSLTSupported && (type == "text/xml"_s || type == "text/xsl"_s || type == "application/xml"_s || type == "application/xhtml+xml"_s || type == "application/rss+xml"_s || type == "application/atom+xml"_s);
         if (!m_isCSS && !m_isXSL)
 #else
         if (!m_isCSS)

--- a/Source/WebCore/xml/XSLTProcessor.idl
+++ b/Source/WebCore/xml/XSLTProcessor.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,7 @@
 
 // https://dom.spec.whatwg.org/#xsltprocessor
 [
+    EnabledBySetting=XsltEnabled,
     Conditional=XSLT,
     Exposed=Window
 ] interface XSLTProcessor {


### PR DESCRIPTION
#### 261b24ff1774bf055cd4378f1bd12ca926417b35
<pre>
[Lockdown Mode] Disable XSLT parsing for WebKit in Lockdown Mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=295107">https://bugs.webkit.org/show_bug.cgi?id=295107</a>
&lt;<a href="https://rdar.apple.com/problem/151845594">rdar://problem/151845594</a>&gt;

Reviewed by Ryosuke Niwa.

This patch disables XSLT support when in Lockdown Mode by removing
access to the XSLTProcessor constructor to prevent JavaScript usage,
and preventing detection of a stylesheet as XSL unless a newly
introduced feature flag is enabled.

The feature flag is enabled by default and disabled in LDM to prevent
any change in current behaviour.

Added LayoutTests that ensure XSLTProcessor is inaccessible, and suitably
check an XML document with a stylesheet is not processed when in LDM.

* LayoutTests/dom/xsl/lockdown-mode/XSLT-disabled-expected.txt: Added.
* LayoutTests/dom/xsl/lockdown-mode/XSLT-disabled.html: Added.
* LayoutTests/dom/xsl/lockdown-mode/resources/XSLT-disabled.xml: Added.
* LayoutTests/dom/xsl/lockdown-mode/resources/XSLT-disabled.xsl: Added.
* LayoutTests/js/dom/lockdown-mode/XSLTProcessor-disabled-expected.txt: Added.
* LayoutTests/js/dom/lockdown-mode/XSLTProcessor-disabled.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/win/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::scheduleToApplyXSLTransforms):
(WebCore::Document::applyPendingXSLTransformsTimerFired):
* Source/WebCore/dom/ProcessingInstruction.cpp:
(WebCore::ProcessingInstruction::checkStyleSheet):
* Source/WebCore/xml/XSLTProcessor.idl:

Canonical link: <a href="https://commits.webkit.org/297851@main">https://commits.webkit.org/297851@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28df4ec56d66f0e8be1364900b7f130f862a83e4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113069 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32804 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23282 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119273 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63663 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115031 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33456 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41367 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86058 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36726 "Build was cancelled. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116016 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26714 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101712 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66368 "Found 139 new API test failures: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration, /WPE/TestBackForwardList:/webkit/WebKitWebView/navigation-after-session-restore, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/reset, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /WPE/TestLoaderClient:/webkit/WebKitURIResponse/http-headers, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone-worker, /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/injected-script, /WPE/TestLoaderClient:/webkit/WebKitWebView/unfinished-subresource-load, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/cookies ... (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25992 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19843 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63031 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/105586 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96101 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19916 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122494 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/111685 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40147 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29941 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94909 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40531 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97931 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94651 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24164 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39792 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17601 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/36272 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40033 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45532 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/135915 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39674 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/36490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43007 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41411 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->