### PR TITLE
Reduce scope of WTF_ALLOW_UNSAFE_BUFFER_USAGE macros in WTF::BitVector

### DIFF
--- a/Source/WTF/wtf/BitVector.cpp
+++ b/Source/WTF/wtf/BitVector.cpp
@@ -33,8 +33,6 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/SIMDHelpers.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER_AND_EXPORT(BitVector, WTF_INTERNAL);
@@ -276,5 +274,3 @@ void BitVector::dump(PrintStream& out) const
 }
 
 } // namespace WTF
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/BitVector.h
+++ b/Source/WTF/wtf/BitVector.h
@@ -37,8 +37,6 @@
 #include <CoreFoundation/CoreFoundation.h>
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace JSC {
 class CachedBitVector;
 }
@@ -140,13 +138,17 @@ public:
     bool quickGet(size_t bit) const
     {
         ASSERT_WITH_SECURITY_IMPLICATION(bit < size());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         return !!(bits()[bit / bitsInPointer()] & (static_cast<uintptr_t>(1) << (bit & (bitsInPointer() - 1))));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
     
     bool quickSet(size_t bit)
     {
         ASSERT_WITH_SECURITY_IMPLICATION(bit < size());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         uintptr_t& word = bits()[bit / bitsInPointer()];
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         uintptr_t mask = static_cast<uintptr_t>(1) << (bit & (bitsInPointer() - 1));
         bool result = !!(word & mask);
         word |= mask;
@@ -156,7 +158,9 @@ public:
     bool quickClear(size_t bit)
     {
         ASSERT_WITH_SECURITY_IMPLICATION(bit < size());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         uintptr_t& word = bits()[bit / bitsInPointer()];
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         uintptr_t mask = static_cast<uintptr_t>(1) << (bit & (bitsInPointer() - 1));
         bool result = !!(word & mask);
         word &= ~mask;
@@ -329,11 +333,7 @@ public:
     class iterator {
         WTF_MAKE_FAST_ALLOCATED;
     public:
-        iterator()
-            : m_bitVector(nullptr)
-            , m_index(0)
-        {
-        }
+        iterator() = default;
         
         iterator(const BitVector& bitVector, size_t index)
             : m_bitVector(&bitVector)
@@ -367,8 +367,8 @@ public:
         }
         
     private:
-        const BitVector* m_bitVector;
-        size_t m_index;
+        const BitVector* m_bitVector { nullptr };
+        size_t m_index { 0 };
     };
 
     // Use this to iterate over set bits.
@@ -485,9 +485,11 @@ private:
         {
         }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         uintptr_t* bits() { return std::bit_cast<uintptr_t*>(this + 1); }
         const uintptr_t* bits() const { return std::bit_cast<const uintptr_t*>(this + 1); }
-        
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
         size_t m_numBits;
     };
     
@@ -561,5 +563,3 @@ template<> struct HashTraits<BitVector> : public CustomHashTraits<BitVector> { }
 } // namespace WTF
 
 using WTF::BitVector;
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### 6852d68da5197c7899de5cda432e7153c1f28e40
<pre>
Reduce scope of WTF_ALLOW_UNSAFE_BUFFER_USAGE macros in WTF::BitVector
<a href="https://bugs.webkit.org/show_bug.cgi?id=295109">https://bugs.webkit.org/show_bug.cgi?id=295109</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/BitVector.cpp:
* Source/WTF/wtf/BitVector.h:

Canonical link: <a href="https://commits.webkit.org/296751@main">https://commits.webkit.org/296751@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06e60a33faffcb474c21b92ebbc62516a1140961

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109485 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19572 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114689 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/59708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29822 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37731 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/83217 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/59708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112433 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23759 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98616 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63677 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/23149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16758 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59307 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/101983 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/93130 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16799 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117803 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/108041 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36526 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/27046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/92233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36897 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94876 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/92049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23435 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36982 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14724 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/32325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36419 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41890 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/132305 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36086 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35837 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39426 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37790 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->