### PR TITLE
[SwiftUI] Remove outdated WebPage API symbols

### DIFF
--- a/Source/WebKit/UIProcess/API/Swift/WebPage+Navigation.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+Navigation.swift
@@ -26,16 +26,6 @@
 import Foundation
 
 extension WebPage {
-    @available(*, deprecated, message: "Navigations are now observed using async sequences directly.")
-    @_spi(_)
-    public struct NavigationID: Sendable, Hashable, Equatable {
-        let rawValue: ObjectIdentifier
-
-        init(_ cocoaNavigation: WKNavigation) {
-            self.rawValue = ObjectIdentifier(cocoaNavigation)
-        }
-    }
-
     /// A particular state that occurs during the progression of a navigation.
     @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
     @available(watchOS, unavailable)

--- a/Source/WebKit/UIProcess/API/Swift/WebPage.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage.swift
@@ -481,14 +481,6 @@ final public class WebPage {
         }
     }
 
-    @available(*, deprecated, message: "Navigations are now observed using async sequences directly.")
-    @_spi(_)
-    @_disfavoredOverload
-    @discardableResult
-    public func load(html: String, baseURL: URL) -> NavigationID? {
-        backingWebView.loadHTMLString(html, baseURL: baseURL).map(NavigationID.init(_:))
-    }
-
     /// Loads the web content from the data you provide as if the data were the response to the request.
     ///
     /// - Parameters:


### PR DESCRIPTION
#### e61ccbd10e7fa7455aa12aa68628b2ae7a3b3d15
<pre>
[SwiftUI] Remove outdated WebPage API symbols
<a href="https://bugs.webkit.org/show_bug.cgi?id=295112">https://bugs.webkit.org/show_bug.cgi?id=295112</a>
<a href="https://rdar.apple.com/154501829">rdar://154501829</a>

Reviewed by Abrar Rahman Protyasha.

Remove some old symbols.

* Source/WebKit/UIProcess/API/Swift/WebPage+Navigation.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage.swift:

Canonical link: <a href="https://commits.webkit.org/297344@main">https://commits.webkit.org/297344@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0480a5b3f049293e2e489d9818a4dbb29fe539e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109464 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114668 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59691 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29801 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37710 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83198 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112412 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23739 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98595 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63658 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23120 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59288 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93109 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16778 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117783 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36505 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27030 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92211 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36876 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94855 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92027 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23806 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36957 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14704 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32307 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36398 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41872 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36067 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39408 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37771 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->