### PR TITLE
[HDR] Use ExtendedDisplayP3 as the HDR backing store colorSpace on iOS

### DIFF
--- a/Source/WebCore/platform/graphics/ContentsFormat.cpp
+++ b/Source/WebCore/platform/graphics/ContentsFormat.cpp
@@ -26,9 +26,6 @@
 #include "config.h"
 #include "ContentsFormat.h"
 
-#if USE(CG)
-#include "ColorSpaceCG.h"
-#endif
 #include "DestinationColorSpace.h"
 #include <wtf/text/TextStream.h>
 
@@ -39,13 +36,21 @@ std::optional<DestinationColorSpace> contentsFormatExtendedColorSpace(ContentsFo
     switch (contentsFormat) {
     case ContentsFormat::RGBA8:
         return std::nullopt;
-#if ENABLE(PIXEL_FORMAT_RGB10) && ENABLE(DESTINATION_COLOR_SPACE_EXTENDED_SRGB)
+
+#if ENABLE(PIXEL_FORMAT_RGB10)
     case ContentsFormat::RGBA10:
+#if ENABLE(DESTINATION_COLOR_SPACE_EXTENDED_SRGB)
         return DestinationColorSpace::ExtendedSRGB();
 #endif
-#if ENABLE(PIXEL_FORMAT_RGBA16F) && ENABLE(DESTINATION_COLOR_SPACE_EXTENDED_REC_2020)
+        break;
+#endif
+
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
     case ContentsFormat::RGBA16F:
-        return DestinationColorSpace::ExtendedRec2020();
+#if ENABLE(DESTINATION_COLOR_SPACE_DISPLAY_P3)
+        return DestinationColorSpace::ExtendedDisplayP3();
+#endif
+        break;
 #endif
     }
 


### PR DESCRIPTION
#### c52a198c22b69b7dc15b7b3d4eddedac0ac1d725
<pre>
[HDR] Use ExtendedDisplayP3 as the HDR backing store colorSpace on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=295118">https://bugs.webkit.org/show_bug.cgi?id=295118</a>
<a href="https://rdar.apple.com/153919243">rdar://153919243</a>

Reviewed by Mike Wyrzykowski and Simon Fraser.

For compositing HDR drawing on macOS, the DisplayColorSpace should be used to
avoid extra colorSpace conversion.

For compositing HDR drawing on iOS, using ExtendedDisplayP3 ensures any blending
operations happen in the same gamma space as the compositor.

For non compositing HDR drawing, ExtendedDisplayP3 will be used for everything
else on macOS and iOS.

* Source/WebCore/platform/graphics/ContentsFormat.cpp:
(WebCore::contentsFormatExtendedColorSpace):

Canonical link: <a href="https://commits.webkit.org/296814@main">https://commits.webkit.org/296814@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2364e5863945d9230d78cc6da9551c7c7a5a64cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109518 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29176 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19605 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114721 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59728 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111481 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37764 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83238 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112466 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23786 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98645 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63698 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23169 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16788 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59338 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93157 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16828 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117836 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36559 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27072 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92251 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36930 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94905 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92068 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23483 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37006 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14752 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32354 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36452 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41923 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36115 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39459 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37823 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->