### PR TITLE
[macOS] imported/w3c/web-platform-tests/mimesniff/media/media-sniff.window.html is a constant failure

### DIFF
--- a/LayoutTests/platform/mac-sonoma/imported/w3c/web-platform-tests/mimesniff/media/media-sniff.window-expected.txt
+++ b/LayoutTests/platform/mac-sonoma/imported/w3c/web-platform-tests/mimesniff/media/media-sniff.window-expected.txt
@@ -1,0 +1,44 @@
+
+PASS mp3-raw.mp3 loads when served with Content-Type
+PASS mp3-raw.mp3 loads when served with Content-Type bogus/mime
+PASS mp3-raw.mp3 loads when served with Content-Type application/octet-stream
+PASS mp3-raw.mp3 loads when served with Content-Type text/html
+PASS mp3-raw.mp3 loads when served with Content-Type audio/ogg; codec=vorbis
+PASS mp3-raw.mp3 loads when served with Content-Type application/pdf
+PASS mp3-with-id3.mp3 loads when served with Content-Type
+PASS mp3-with-id3.mp3 loads when served with Content-Type bogus/mime
+PASS mp3-with-id3.mp3 loads when served with Content-Type application/octet-stream
+PASS mp3-with-id3.mp3 loads when served with Content-Type text/html
+PASS mp3-with-id3.mp3 loads when served with Content-Type audio/ogg; codec=vorbis
+PASS mp3-with-id3.mp3 loads when served with Content-Type application/pdf
+PASS flac.flac loads when served with Content-Type
+PASS flac.flac loads when served with Content-Type bogus/mime
+PASS flac.flac loads when served with Content-Type application/octet-stream
+PASS flac.flac loads when served with Content-Type text/html
+PASS flac.flac loads when served with Content-Type audio/ogg; codec=vorbis
+PASS flac.flac loads when served with Content-Type application/pdf
+FAIL ogg.ogg loads when served with Content-Type  assert_unreached: No error expected frorm the HTMLMediaElement Reached unreachable code
+FAIL ogg.ogg loads when served with Content-Type bogus/mime assert_unreached: No error expected frorm the HTMLMediaElement Reached unreachable code
+FAIL ogg.ogg loads when served with Content-Type application/octet-stream assert_unreached: No error expected frorm the HTMLMediaElement Reached unreachable code
+FAIL ogg.ogg loads when served with Content-Type text/html assert_unreached: No error expected frorm the HTMLMediaElement Reached unreachable code
+FAIL ogg.ogg loads when served with Content-Type audio/ogg; codec=vorbis assert_unreached: No error expected frorm the HTMLMediaElement Reached unreachable code
+FAIL ogg.ogg loads when served with Content-Type application/pdf assert_unreached: No error expected frorm the HTMLMediaElement Reached unreachable code
+PASS mp4.mp4 loads when served with Content-Type
+PASS mp4.mp4 loads when served with Content-Type bogus/mime
+PASS mp4.mp4 loads when served with Content-Type application/octet-stream
+PASS mp4.mp4 loads when served with Content-Type text/html
+PASS mp4.mp4 loads when served with Content-Type audio/ogg; codec=vorbis
+PASS mp4.mp4 loads when served with Content-Type application/pdf
+PASS wav.wav loads when served with Content-Type
+PASS wav.wav loads when served with Content-Type bogus/mime
+PASS wav.wav loads when served with Content-Type application/octet-stream
+PASS wav.wav loads when served with Content-Type text/html
+PASS wav.wav loads when served with Content-Type audio/ogg; codec=vorbis
+PASS wav.wav loads when served with Content-Type application/pdf
+PASS webm.webm loads when served with Content-Type
+PASS webm.webm loads when served with Content-Type bogus/mime
+PASS webm.webm loads when served with Content-Type application/octet-stream
+PASS webm.webm loads when served with Content-Type text/html
+PASS webm.webm loads when served with Content-Type audio/ogg; codec=vorbis
+PASS webm.webm loads when served with Content-Type application/pdf
+

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2436,8 +2436,6 @@ fast/canvas/webgl/gl-teximage.html [ Failure ]
 #rdar://145604998 (REGRESSION(iOS 18.4, macOS Sequoia 15.4 ): fast/text/international/hindi-spacing.html is a constant text failure)
 fast/text/international/hindi-spacing.html [ Failure ]
 
-webkit.org/b/293981 [ Sequoia ] imported/w3c/web-platform-tests/mimesniff/media/media-sniff.window.html [ Failure ]
-
 webkit.org/b/294043 [ Sequoia ] platform/mac/fast/text/line-break-locale.html [ Failure ]
 
 webkit.org/b/294152 [ Sequoia ] http/tests/misc/timer-vs-loading.html [ Timeout ]

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/mimesniff/media/media-sniff.window-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/mimesniff/media/media-sniff.window-expected.txt
@@ -1,0 +1,44 @@
+
+PASS mp3-raw.mp3 loads when served with Content-Type
+PASS mp3-raw.mp3 loads when served with Content-Type bogus/mime
+PASS mp3-raw.mp3 loads when served with Content-Type application/octet-stream
+PASS mp3-raw.mp3 loads when served with Content-Type text/html
+PASS mp3-raw.mp3 loads when served with Content-Type audio/ogg; codec=vorbis
+PASS mp3-raw.mp3 loads when served with Content-Type application/pdf
+PASS mp3-with-id3.mp3 loads when served with Content-Type
+PASS mp3-with-id3.mp3 loads when served with Content-Type bogus/mime
+PASS mp3-with-id3.mp3 loads when served with Content-Type application/octet-stream
+PASS mp3-with-id3.mp3 loads when served with Content-Type text/html
+PASS mp3-with-id3.mp3 loads when served with Content-Type audio/ogg; codec=vorbis
+PASS mp3-with-id3.mp3 loads when served with Content-Type application/pdf
+PASS flac.flac loads when served with Content-Type
+PASS flac.flac loads when served with Content-Type bogus/mime
+PASS flac.flac loads when served with Content-Type application/octet-stream
+PASS flac.flac loads when served with Content-Type text/html
+PASS flac.flac loads when served with Content-Type audio/ogg; codec=vorbis
+PASS flac.flac loads when served with Content-Type application/pdf
+PASS ogg.ogg loads when served with Content-Type
+PASS ogg.ogg loads when served with Content-Type bogus/mime
+PASS ogg.ogg loads when served with Content-Type application/octet-stream
+PASS ogg.ogg loads when served with Content-Type text/html
+PASS ogg.ogg loads when served with Content-Type audio/ogg; codec=vorbis
+PASS ogg.ogg loads when served with Content-Type application/pdf
+PASS mp4.mp4 loads when served with Content-Type
+PASS mp4.mp4 loads when served with Content-Type bogus/mime
+PASS mp4.mp4 loads when served with Content-Type application/octet-stream
+PASS mp4.mp4 loads when served with Content-Type text/html
+PASS mp4.mp4 loads when served with Content-Type audio/ogg; codec=vorbis
+PASS mp4.mp4 loads when served with Content-Type application/pdf
+PASS wav.wav loads when served with Content-Type
+PASS wav.wav loads when served with Content-Type bogus/mime
+PASS wav.wav loads when served with Content-Type application/octet-stream
+PASS wav.wav loads when served with Content-Type text/html
+PASS wav.wav loads when served with Content-Type audio/ogg; codec=vorbis
+PASS wav.wav loads when served with Content-Type application/pdf
+PASS webm.webm loads when served with Content-Type
+PASS webm.webm loads when served with Content-Type bogus/mime
+PASS webm.webm loads when served with Content-Type application/octet-stream
+PASS webm.webm loads when served with Content-Type text/html
+PASS webm.webm loads when served with Content-Type audio/ogg; codec=vorbis
+PASS webm.webm loads when served with Content-Type application/pdf
+


### PR DESCRIPTION
#### 9955bfe040cc8ec42ba301fa7a86c52b52247f65
<pre>
[macOS] imported/w3c/web-platform-tests/mimesniff/media/media-sniff.window.html is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=293981">https://bugs.webkit.org/show_bug.cgi?id=293981</a>
<a href="https://rdar.apple.com/152524059">rdar://152524059</a>

Reviewed by Jonathan Bedard.

Rebaseline the test

* LayoutTests/platform/mac-sonoma/imported/w3c/web-platform-tests/mimesniff/media/media-sniff.window-expected.txt: Added.
* LayoutTests/platform/mac/TestExpectations:
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/mimesniff/media/media-sniff.window-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/296772@main">https://commits.webkit.org/296772@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f4fd04ee07bb5fd73bada211d24dd8606227eff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109522 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29180 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114725 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59730 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29859 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37768 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83242 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112470 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23787 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98644 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63702 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23166 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16787 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59342 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93158 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16827 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117838 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36563 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27073 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92253 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36934 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94904 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92070 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23451 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37008 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14751 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32356 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36456 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36117 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39463 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37827 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->