### PR TITLE
REGRESSION(294902@main): shape-margin and vertical-align do not report the correct computed values when zoomed

### DIFF
--- a/LayoutTests/fast/css/zoom-shape-margin-expected.txt
+++ b/LayoutTests/fast/css/zoom-shape-margin-expected.txt
@@ -1,0 +1,6 @@
+
+PASS 'shape-margin: 16px' at zoom level 1
+PASS 'shape-margin: calc(16px)' at zoom level 1
+PASS 'shape-margin: 16px' at zoom level 2
+PASS 'shape-margin: calc(16px)' at zoom level 2
+

--- a/LayoutTests/fast/css/zoom-shape-margin.html
+++ b/LayoutTests/fast/css/zoom-shape-margin.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+<div id="container">
+</div>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+  let container = document.getElementById('container')
+  const test_property_with_zoom = (property, specified, zoom, expected) => {
+      test(() => {
+        try {
+          document.body.style.zoom = zoom;
+
+          let target = document.createElement("div");
+          target.className = 'target';
+          target.appendChild(new Text("test"));
+          container.appendChild(target)
+
+          target.style[property] = specified;
+          const computed = window.getComputedStyle(target)[property]
+          assert_equals(computed, expected);
+        } finally {
+          document.body.style.zoom = 1;
+        }
+      }, `'${property}: ${specified}' at zoom level ${zoom}`)
+  }
+
+  test_property_with_zoom("shape-margin", "16px", 1, '16px');
+  test_property_with_zoom("shape-margin", "calc(16px)", 1, '16px');
+
+  test_property_with_zoom("shape-margin", "16px", 2, '16px');
+  test_property_with_zoom("shape-margin", "calc(16px)", 2, '16px');
+
+  container.remove();
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/css/zoom-vertical-align-expected.txt
+++ b/LayoutTests/fast/css/zoom-vertical-align-expected.txt
@@ -1,0 +1,6 @@
+
+PASS 'vertical-align: 16px' at zoom level 1
+PASS 'vertical-align: calc(16px)' at zoom level 1
+PASS 'vertical-align: 16px' at zoom level 2
+PASS 'vertical-align: calc(16px)' at zoom level 2
+

--- a/LayoutTests/fast/css/zoom-vertical-align.html
+++ b/LayoutTests/fast/css/zoom-vertical-align.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+<div id="container">
+</div>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+  let container = document.getElementById('container')
+  const test_property_with_zoom = (property, specified, zoom, expected) => {
+      test(() => {
+        try {
+          document.body.style.zoom = zoom;
+
+          let target = document.createElement("div");
+          target.className = 'target';
+          target.appendChild(new Text("test"));
+          container.appendChild(target)
+
+          target.style[property] = specified;
+          const computed = window.getComputedStyle(target)[property]
+          assert_equals(computed, expected);
+        } finally {
+          document.body.style.zoom = 1;
+        }
+      }, `'${property}: ${specified}' at zoom level ${zoom}`)
+  }
+
+  test_property_with_zoom("vertical-align", "16px", 1, '16px');
+  test_property_with_zoom("vertical-align", "calc(16px)", 1, '16px');
+
+  test_property_with_zoom("vertical-align", "16px", 2, '16px');
+  test_property_with_zoom("vertical-align", "calc(16px)", 2, '16px');
+
+  container.remove();
+</script>
+</body>
+</html>

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -12048,9 +12048,7 @@
                 ],
                 "animation-wrapper": "LengthWrapper",
                 "animation-wrapper-requires-additional-parameters": ["{ LengthWrapper::Flags::IsLengthPercentage, LengthWrapper::Flags::NegativeLengthsAreInvalid }"],
-                "style-builder-converter": "Length",
-                "style-extractor-converter": "LengthWithoutApplyingZoom",
-                "style-extractor-converter-comment": "FIXME: Add explanation (or remove) for why extractor does not apply zoom",
+                "style-converter": "Length",
                 "parser-grammar": "<length-percentage [0,inf]>"
             },
             "specification": {

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -152,7 +152,6 @@ public:
     static Ref<CSSPrimitiveValue> convertLength(const RenderStyle&, const WebCore::Length&);
     static Ref<CSSPrimitiveValue> convertLengthAllowingNumber(ExtractorState&, const WebCore::Length&);
     static Ref<CSSPrimitiveValue> convertLengthOrAuto(ExtractorState&, const WebCore::Length&);
-    static Ref<CSSPrimitiveValue> convertLengthWithoutApplyingZoom(ExtractorState&, const WebCore::Length&);
 
     template<typename T> static Ref<CSSPrimitiveValue> convertNumber(ExtractorState&, T);
     template<typename T> static Ref<CSSPrimitiveValue> convertNumberAsPixels(ExtractorState&, T);
@@ -396,11 +395,6 @@ inline Ref<CSSPrimitiveValue> ExtractorConverter::convertLengthOrAuto(ExtractorS
     if (length.isAuto())
         return CSSPrimitiveValue::create(CSSValueAuto);
     return convertLength(state, length);
-}
-
-inline Ref<CSSPrimitiveValue> ExtractorConverter::convertLengthWithoutApplyingZoom(ExtractorState& state, const WebCore::Length& length)
-{
-    return CSSPrimitiveValue::create(length, state.style);
 }
 
 template<typename T> Ref<CSSPrimitiveValue> ExtractorConverter::convertNumber(ExtractorState& state, T number)

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -1445,7 +1445,7 @@ inline Ref<CSSValue> ExtractorCustom::extractVerticalAlign(ExtractorState& state
     case VerticalAlign::BaselineMiddle:
         return CSSPrimitiveValue::create(CSSValueWebkitBaselineMiddle);
     case VerticalAlign::Length:
-        return ExtractorConverter::convertLengthWithoutApplyingZoom(state, state.style.verticalAlignLength());
+        return ExtractorConverter::convertLength(state, state.style.verticalAlignLength());
     }
     RELEASE_ASSERT_NOT_REACHED();
 }
@@ -1481,7 +1481,7 @@ inline void ExtractorCustom::extractVerticalAlignSerialization(ExtractorState& s
         CSS::serializationForCSS(builder, context, CSS::Keyword::WebkitBaselineMiddle { });
         return;
     case VerticalAlign::Length:
-        ExtractorSerializer::serializeLengthWithoutApplyingZoom(state, builder, context, state.style.verticalAlignLength());
+        ExtractorSerializer::serializeLength(state, builder, context, state.style.verticalAlignLength());
         return;
     }
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebCore/style/StyleExtractorSerializer.h
+++ b/Source/WebCore/style/StyleExtractorSerializer.h
@@ -60,7 +60,6 @@ public:
     static void serializeLength(const RenderStyle&, StringBuilder&, const CSS::SerializationContext&, const WebCore::Length&);
     static void serializeLengthAllowingNumber(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const WebCore::Length&);
     static void serializeLengthOrAuto(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const WebCore::Length&);
-    static void serializeLengthWithoutApplyingZoom(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const WebCore::Length&);
 
     template<typename T> static void serializeNumber(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, T);
     template<typename T> static void serializeNumberAsPixels(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, T);
@@ -341,52 +340,6 @@ inline void ExtractorSerializer::serializeLengthAllowingNumber(ExtractorState& s
 inline void ExtractorSerializer::serializeLengthOrAuto(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const WebCore::Length& length)
 {
     serializeLength(state, builder, context, length);
-}
-
-inline void ExtractorSerializer::serializeLengthWithoutApplyingZoom(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const WebCore::Length& length)
-{
-    switch (length.type()) {
-    case LengthType::Auto:
-        serializationForCSS(builder, context, state.style, CSS::Keyword::Auto { });
-        return;
-    case LengthType::Content:
-        serializationForCSS(builder, context, state.style, CSS::Keyword::Content { });
-        return;
-    case LengthType::FillAvailable:
-        serializationForCSS(builder, context, state.style, CSS::Keyword::WebkitFillAvailable { });
-        return;
-    case LengthType::FitContent:
-        serializationForCSS(builder, context, state.style, CSS::Keyword::FitContent { });
-        return;
-    case LengthType::Intrinsic:
-        serializationForCSS(builder, context, state.style, CSS::Keyword::Intrinsic { });
-        return;
-    case LengthType::MinIntrinsic:
-        serializationForCSS(builder, context, state.style, CSS::Keyword::MinIntrinsic { });
-        return;
-    case LengthType::MinContent:
-        serializationForCSS(builder, context, state.style, CSS::Keyword::MinContent { });
-        return;
-    case LengthType::MaxContent:
-        serializationForCSS(builder, context, state.style, CSS::Keyword::MaxContent { });
-        return;
-    case LengthType::Normal:
-        serializationForCSS(builder, context, state.style, CSS::Keyword::Normal { });
-        return;
-    case LengthType::Fixed:
-        CSS::serializationForCSS(builder, context, CSS::LengthRaw<> { CSS::LengthUnit::Px, length.value() });
-        return;
-    case LengthType::Percent:
-        CSS::serializationForCSS(builder, context, CSS::PercentageRaw<> { length.value() });
-        return;
-    case LengthType::Calculated:
-        builder.append(CSSCalcValue::create(length.protectedCalculationValue(), state.style)->customCSSText(context));
-        return;
-    case LengthType::Relative:
-    case LengthType::Undefined:
-        break;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
 }
 
 template<typename T> void ExtractorSerializer::serializeNumber(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, T number)


### PR DESCRIPTION
#### 7eeb199e2df8621af8dc660abe1e4bc51e2837e7
<pre>
REGRESSION(294902@main): shape-margin and vertical-align do not report the correct computed values when zoomed
<a href="https://bugs.webkit.org/show_bug.cgi?id=295128">https://bugs.webkit.org/show_bug.cgi?id=295128</a>

Reviewed by Darin Adler.

Fix regression where zoom was not taken into account for &apos;shape-margin&apos; and &apos;vertical-align&apos;
computed values.

* LayoutTests/fast/css/zoom-shape-margin-expected.txt: Added.
* LayoutTests/fast/css/zoom-shape-margin.html: Added.
* LayoutTests/fast/css/zoom-vertical-align-expected.txt: Added.
* LayoutTests/fast/css/zoom-vertical-align.html: Added.
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/style/StyleExtractorConverter.h:
(WebCore::Style::ExtractorConverter::convertLengthWithoutApplyingZoom): Deleted.
* Source/WebCore/style/StyleExtractorCustom.h:
(WebCore::Style::ExtractorCustom::extractVerticalAlign):
(WebCore::Style::ExtractorCustom::extractVerticalAlignSerialization):
* Source/WebCore/style/StyleExtractorSerializer.h:
(WebCore::Style::ExtractorSerializer::serializeLengthWithoutApplyingZoom): Deleted.

Canonical link: <a href="https://commits.webkit.org/296767@main">https://commits.webkit.org/296767@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63496ba472317cfbee0eb898a8bff36e4173a00d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109512 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19599 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114716 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59724 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111475 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29849 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37758 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83236 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112460 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98639 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63696 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23157 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16781 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59332 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93149 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16822 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117830 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36553 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27065 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92247 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36924 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94899 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92064 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23447 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37000 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14746 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32346 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36446 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41917 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36109 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39453 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37817 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->