### PR TITLE
dNR: fix sub_frame resourceType allowAllRequests rules

### DIFF
--- a/Source/WebCore/contentextensions/ContentExtensionCompiler.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionCompiler.cpp
@@ -347,7 +347,7 @@ std::error_code compileRuleList(ContentExtensionCompilationClient& client, Strin
                 break;
             case ActionCondition::IfFrameURL:
             case ActionCondition::UnlessFrameURL:
-            case ActionCondition::IfFrameOrAncestorsURL:
+            case ActionCondition::IfAncestorSubframeURL:
                 status = frameURLFilterParser.addPattern(condition, trigger.frameURLFilterIsCaseSensitive, actionLocationAndFlags);
                 if (status == URLFilterParser::MatchesEverything) {
                     frameURLUniversalActions.add(actionLocationAndFlags);

--- a/Source/WebCore/contentextensions/ContentExtensionParser.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionParser.cpp
@@ -210,7 +210,7 @@ static Expected<Trigger, std::error_code> loadTrigger(const JSON::Object& ruleOb
     if (auto error = checkCondition("unless-frame-url"_s, getStringList, ActionCondition::UnlessFrameURL))
         return makeUnexpected(error);
 
-    if (auto error = checkCondition("if-ancestor-frame-url"_s, getStringList, ActionCondition::IfFrameOrAncestorsURL))
+    if (auto error = checkCondition("if-ancestor-subframe-url"_s, getStringList, ActionCondition::IfAncestorSubframeURL))
         return makeUnexpected(error);
 
     trigger.checkValidity();

--- a/Source/WebCore/contentextensions/ContentExtensionRule.h
+++ b/Source/WebCore/contentextensions/ContentExtensionRule.h
@@ -57,7 +57,7 @@ struct Trigger {
         if (topURLFilterIsCaseSensitive)
             ASSERT(actionCondition == ActionCondition::IfTopURL || actionCondition == ActionCondition::UnlessTopURL);
         if (frameURLFilterIsCaseSensitive)
-            ASSERT(actionCondition == ActionCondition::IfFrameURL || actionCondition == ActionCondition::UnlessFrameURL || actionCondition == ActionCondition::IfFrameOrAncestorsURL);
+            ASSERT(actionCondition == ActionCondition::IfFrameURL || actionCondition == ActionCondition::UnlessFrameURL || actionCondition == ActionCondition::IfAncestorSubframeURL);
     }
 
     bool isEmpty() const

--- a/Source/WebCore/loader/ResourceLoadInfo.h
+++ b/Source/WebCore/loader/ResourceLoadInfo.h
@@ -40,7 +40,7 @@ enum class ActionCondition : uint32_t {
     UnlessTopURL = 0x80000,
     IfFrameURL = 0x140000,
     UnlessFrameURL = 0x180000,
-    IfFrameOrAncestorsURL = 0x1C0000
+    IfAncestorSubframeURL = 0x1C0000
 };
 static constexpr uint32_t ActionConditionMask = 0x1C0000;
 
@@ -112,7 +112,7 @@ struct ResourceLoadInfo {
     OptionSet<ResourceType> type;
     bool mainFrameContext { false };
     RequestMethod requestMethod { RequestMethod::None };
-    Vector<URL> ancestorFrameURLs { };
+    Vector<URL> ancestorSubframeURLs { };
 
     bool isThirdParty() const;
     ResourceFlags getResourceFlags() const;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm
@@ -863,6 +863,12 @@ static BOOL isArrayOfRequestMethodsValid(NSArray<NSString *> *requestMethods)
 
     [convertedRules addObject:[self _webKitRuleWithWebKitActionType:webKitActionType chromeActionType:chromeActionType condition:condition]];
 
+    if ([condition[declarativeNetRequestRuleConditionResourceTypeKey] containsObject:@"main_frame"] && [condition[declarativeNetRequestRuleConditionResourceTypeKey] containsObject:@"sub_frame"]) {
+        NSMutableDictionary *modifiedCondition = [condition mutableCopy];
+        modifiedCondition[declarativeNetRequestRuleConditionResourceTypeKey] = @[ @"sub_frame" ];
+        [convertedRules addObject:[self _webKitRuleWithWebKitActionType:webKitActionType chromeActionType:chromeActionType condition:modifiedCondition]];
+    }
+
     if ([webKitActionType isEqualToString:@"make-https"])
         [convertedRules addObject:[self _webKitRuleWithWebKitActionType:@"ignore-following-rules" chromeActionType:chromeActionType condition:condition]];
 
@@ -884,11 +890,8 @@ static BOOL isArrayOfRequestMethodsValid(NSArray<NSString *> *requestMethods)
 
         if ([condition[declarativeNetRequestRuleConditionResourceTypeKey] containsObject:@"main_frame"])
             triggerDictionary[@"if-top-url"] = @[ [self _regexURLFilterForChromeURLFilter:condition[declarativeNetRequestRuleConditionURLFilterKey]] ?: condition[declarativeNetRequestRuleConditionRegexFilterKey] ?: @".*" ];
-        else {
-            // FIXME: rdar://154124673 (dNR: fix sub_frame resourceType allowAllRequests rules)
-            triggerDictionary[@"if-frame-url"] = @[ [self _regexURLFilterForChromeURLFilter:condition[declarativeNetRequestRuleConditionURLFilterKey]] ?: condition[declarativeNetRequestRuleConditionRegexFilterKey] ?: @".*" ];
-            triggerDictionary[@"load-context"] = @[ @"child-frame" ];
-        }
+        else
+            triggerDictionary[@"if-ancestor-subframe-url"] = @[ [self _regexURLFilterForChromeURLFilter:condition[declarativeNetRequestRuleConditionURLFilterKey]] ?: condition[declarativeNetRequestRuleConditionRegexFilterKey] ?: @".*" ];
 
         return [convertedRule copy];
     }

--- a/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
@@ -1587,12 +1587,12 @@ TEST_F(ContentExtensionTest, InvalidJSON)
     checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"if-domain\":[\"a\"],\"if-top-url\":[\"a\"]}}]"_s, ContentExtensionError::JSONMultipleConditions);
     checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"if-top-url\":[],\"unless-domain\":[\"a\"]}}]"_s, ContentExtensionError::JSONMultipleConditions);
     checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"if-top-url\":[\"a\"],\"if-domain\":[\"a\"]}}]"_s, ContentExtensionError::JSONMultipleConditions);
-    checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"if-ancestor-frame-url\":[\"a\"],\"if-frame-url\":[\"a\"]}}]"_s, ContentExtensionError::JSONMultipleConditions);
-    checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"if-ancestor-frame-url\":[\"a\"],\"unless-frame-url\":[\"a\"]}}]"_s, ContentExtensionError::JSONMultipleConditions);
-    checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"if-ancestor-frame-url\":[\"a\"],\"if-domain\":[\"a\"]}}]"_s, ContentExtensionError::JSONMultipleConditions);
-    checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"if-ancestor-frame-url\":[\"a\"],\"unless-domain\":[\"a\"]}}]"_s, ContentExtensionError::JSONMultipleConditions);
-    checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"if-ancestor-frame-url\":[\"a\"],\"if-top-url\":[\"a\"]}}]"_s, ContentExtensionError::JSONMultipleConditions);
-    checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"if-ancestor-frame-url\":[\"a\"],\"unless-top-url\":[\"a\"]}}]"_s, ContentExtensionError::JSONMultipleConditions);
+    checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"if-ancestor-subframe-url\":[\"a\"],\"if-frame-url\":[\"a\"]}}]"_s, ContentExtensionError::JSONMultipleConditions);
+    checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"if-ancestor-subframe-url\":[\"a\"],\"unless-frame-url\":[\"a\"]}}]"_s, ContentExtensionError::JSONMultipleConditions);
+    checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"if-ancestor-subframe-url\":[\"a\"],\"if-domain\":[\"a\"]}}]"_s, ContentExtensionError::JSONMultipleConditions);
+    checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"if-ancestor-subframe-url\":[\"a\"],\"unless-domain\":[\"a\"]}}]"_s, ContentExtensionError::JSONMultipleConditions);
+    checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"if-ancestor-subframe-url\":[\"a\"],\"if-top-url\":[\"a\"]}}]"_s, ContentExtensionError::JSONMultipleConditions);
+    checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"if-ancestor-subframe-url\":[\"a\"],\"unless-top-url\":[\"a\"]}}]"_s, ContentExtensionError::JSONMultipleConditions);
     checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"if-top-url\":[\"a\"]}}, {\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"if-domain\":[\"a\"]}}]"_s, { });
     checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"if-top-url\":[\"a\"]}}, {\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"unless-domain\":[\"a\"]}}]"_s, { });
     checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"test\\\\.html\", \"unless-top-url\":[\"[\"]}}]"_s, ContentExtensionError::JSONInvalidRegex);
@@ -3176,20 +3176,20 @@ TEST_F(ContentExtensionTest, UnlessFrameURL)
     testRequest(matchingNothing, requestInTopAndFrameURLs("http://example.com/"_s, "https://webkit.org/"_s, "https://webkit.org/"_s), { });
 }
 
-TEST_F(ContentExtensionTest, IfFrameOrAncestorsURL)
+TEST_F(ContentExtensionTest, IfAncestorSubframeURL)
 {
-    auto basic = makeBackend("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\".*\", \"if-ancestor-frame-url\":[\"whatwg\"]}}]"_s);
+    auto basic = makeBackend("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\".*\", \"if-ancestor-subframe-url\":[\"whatwg\"]}}]"_s);
     testRequest(basic, requestInTopAndFrameURLs("https://whatwg.org/"_s, "https://whatwg.org/"_s, "https://whatwg.org/"_s, ResourceType::TopDocument, { URL { "https://whatwg.org/"_s } }), { variantIndex<BlockLoadAction> });
     testRequest(basic, requestInTopAndFrameURLs("https://example.com/"_s, "https://example.com/"_s, "https://example.com/"_s, ResourceType::TopDocument, { URL { "https://example.com/"_s } }), { });
     testRequest(basic, requestInTopAndFrameURLs("https://example.com/"_s, "https://webkit.org/"_s, "https://whatwg.org/"_s, ResourceType::ChildDocument, { URL { "https://webkit.org/"_s }, URL { "https://whatwg.org/"_s } }), { variantIndex<BlockLoadAction> });
     testRequest(basic, requestInTopAndFrameURLs("https://example.com/"_s, "https://webkit.org/"_s, "https://apple.com/"_s, ResourceType::ChildDocument, { URL { "https://webkit.org/"_s }, URL { "https://apple.com/"_s } }), { });
 
-    auto caseSensitivity = makeBackend("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\".*\", \"if-ancestor-frame-url\":[\"whatwg\"],\"frame-url-filter-is-case-sensitive\":true}}]"_s);
+    auto caseSensitivity = makeBackend("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\".*\", \"if-ancestor-subframe-url\":[\"whatwg\"],\"frame-url-filter-is-case-sensitive\":true}}]"_s);
     auto caseSensitivityRequest = requestInTopAndFrameURLs("https://example.com/"_s, "https://webkit.org/"_s, "https://example.com/wHaTwG"_s);
     testRequest(basic, caseSensitivityRequest, { variantIndex<BlockLoadAction> });
     testRequest(caseSensitivity, caseSensitivityRequest, { });
 
-    auto otherFlags = makeBackend("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\".*\", \"if-ancestor-frame-url\":[\"whatwg\"],\"resource-type\":[\"image\"]}}]"_s);
+    auto otherFlags = makeBackend("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\".*\", \"if-ancestor-subframe-url\":[\"whatwg\"],\"resource-type\":[\"image\"]}}]"_s);
     testRequest(otherFlags, requestInTopAndFrameURLs("https://example.com/"_s, "https://webkit.org/"_s, "https://whatwg.org/"_s, ResourceType::TopDocument, { URL { "https://webkit.org/"_s }, URL { "https://whatwg.org/"_s } }), { });
     testRequest(otherFlags, requestInTopAndFrameURLs("https://example.com/"_s, "https://webkit.org/"_s, "https://whatwg.org/"_s, ResourceType::Image, { URL { "https://webkit.org/"_s }, URL { "https://whatwg.org/"_s } }), { variantIndex<BlockLoadAction> });
 


### PR DESCRIPTION
#### 34e4b871322e872acaed32b6cec020679fac098a
<pre>
dNR: fix sub_frame resourceType allowAllRequests rules
<a href="https://bugs.webkit.org/show_bug.cgi?id=295043">https://bugs.webkit.org/show_bug.cgi?id=295043</a>
<a href="https://rdar.apple.com/154124673">rdar://154124673</a>

Reviewed by Timothy Hatcher.

This patch fixes allowAllRequests rules for sub_frame resource types.

First, I renamed the recently added if-ancestor-frame-url content blocker
condition to be if-ancestor-subframe-url and made it exclude the main frame.
While working on that patch (see <a href="https://github.com/WebKit/WebKit/pull/47251)">https://github.com/WebKit/WebKit/pull/47251)</a>,
it was thought that it&apos;d be better to include the main frame in the condition,
but it turns out that it&apos;s not. It&apos;s better to split main_frame and sub_frame
rules out into their own rules using if-top-url and if-ancestor-subframe-url,
respectively.

Therefore, dNR allowAllRequests rules convert into the following content blocker
rules:

// dNR
{
  &quot;id&quot;: 1,
  &quot;action&quot;: {
    &quot;type&quot;: &quot;allowAllRequests&quot;
  },
  &quot;condition&quot;: {
    &quot;urlFilter&quot;: &quot;apple.com&quot;,
    &quot;resourceTypes&quot;: [ &quot;main_frame&quot;, &quot;sub_frame&quot; ]
  }
}

// WebKit content blocking

{
  &quot;action&quot;: {
    &quot;type&quot;: &quot;ignore-following-rules&quot;,
  },
  &quot;trigger&quot;: {
    &quot;url-filter&quot;: &quot;.*&quot;,
    &quot;if-top-url&quot;: [ &quot;apple\\.com&quot; ],
  }
},
{
  &quot;action&quot;: {
    &quot;type&quot;: &quot;ignore-following-rules&quot;,
  },
  &quot;trigger&quot;: {
    &quot;url-filter&quot;: &quot;.*&quot;,
    &quot;if-ancestor-subframe-url&quot;: [ &quot;apple\\.com&quot; ],
  }
}

I wrote new tests to validate the rule conversions and functionality.

* Source/WebCore/contentextensions/ContentExtensionCompiler.cpp:
(WebCore::ContentExtensions::compileRuleList):
* Source/WebCore/contentextensions/ContentExtensionParser.cpp:
(WebCore::ContentExtensions::loadTrigger):
* Source/WebCore/contentextensions/ContentExtensionRule.h:
(WebCore::ContentExtensions::Trigger::checkValidity):
* Source/WebCore/contentextensions/ContentExtensionsBackend.cpp:
(WebCore::ContentExtensions::ContentExtensionsBackend::actionsFromContentRuleList const):
(WebCore::ContentExtensions::ContentExtensionsBackend::processContentRuleListsForLoad):
* Source/WebCore/loader/ResourceLoadInfo.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm:
(-[_WKWebExtensionDeclarativeNetRequestRule _convertRulesWithModifiedCondition:webKitActionType:chromeActionType:]):
(-[_WKWebExtensionDeclarativeNetRequestRule _webKitRuleWithWebKitActionType:chromeActionType:condition:]):
* Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp:
(TestWebKitAPI::TEST_F(ContentExtensionTest, InvalidJSON)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, IfAncestorSubframeURL)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, IfFrameOrAncestorsURL)): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, MainFrameAllowAllRequests)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, SubFrameAllowAllRequests)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithMainFrameAllowAllRequests)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithSubFrameAllowAllRequests)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithMainFrameAndSubFrameAllowAllRequests)):

Canonical link: <a href="https://commits.webkit.org/296799@main">https://commits.webkit.org/296799@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a14d249075edc06c0408c16fc44fe01aae16258a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109521 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29179 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19608 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114724 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59729 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111484 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37767 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83248 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112469 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23788 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98649 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63708 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23167 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16792 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59341 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93159 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16832 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117837 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36562 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27071 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92257 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36933 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94909 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92074 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37007 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14756 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32355 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17685 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36455 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41926 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36116 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39462 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37826 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->