### PR TITLE
[SwiftUI] Cannot load any content if the return value of the loading APIs is discarded

### DIFF
--- a/Source/WebKit/UIProcess/API/Swift/WebPage.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage.swift
@@ -331,6 +331,9 @@ final public class WebPage {
     private var scopedNavigations: [ObjectIdentifier : AsyncThrowingStream<NavigationEvent, any Error>.Continuation] = [:]
 
     @ObservationIgnored
+    private var scopedStreams: [ObjectIdentifier : AsyncThrowingStream<NavigationEvent, any Error>] = [:]
+
+    @ObservationIgnored
     private var indefiniteNavigations: [UUID : AsyncThrowingStream<NavigationEvent, any Error>.Continuation] = [:]
 
     /// Loads the web content that the specified URL references and navigates to that content.
@@ -630,10 +633,12 @@ final public class WebPage {
                     stopLoading()
                 }
                 scopedNavigations[ObjectIdentifier(id)] = nil
+                scopedStreams[ObjectIdentifier(id)] = nil
             }
         }
 
         scopedNavigations[ObjectIdentifier(id)] = continuation
+        scopedStreams[ObjectIdentifier(id)] = stream
         return stream
     }
 

--- a/Tools/SwiftBrowser/Source/Views/ContentView.swift
+++ b/Tools/SwiftBrowser/Source/Views/ContentView.swift
@@ -235,7 +235,13 @@ struct ContentView: View {
                 .webViewElementFullscreenBehavior(.enabled)
                 .findNavigator(isPresented: $findNavigatorIsPresented)
                 .task {
-                    // FIXME: Observe navigation changes.
+                    do {
+                        for try await event in viewModel.page.navigations {
+                            print(event)
+                        }
+                    } catch {
+                        print(error)
+                    }
                 }
                 .onAppear {
                     viewModel.displayedURL = initialRequest.url!.absoluteString

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageNavigationTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageNavigationTests.swift
@@ -143,6 +143,19 @@ struct WebPageNavigationTests {
 
         #expect(actualEvents == expectedEvents)
     }
+
+    @Test
+    func navigationProceedsAfterDiscardingNavigationStream() async throws {
+        let page = WebPage()
+
+        let html = "<title>A title</title>"
+        page.load(html: html, baseURL: .aboutBlank)
+
+        // A timeout is used since observing the navigation sequence itself alters the outcome of this test.
+        try await Task.sleep(for: .seconds(10))
+
+        #expect(page.title == "A title")
+    }
 }
 
 #endif // ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.0)


### PR DESCRIPTION
#### 847b9725e347634c24739217b3dcdd40534ec7f0
<pre>
[SwiftUI] Cannot load any content if the return value of the loading APIs is discarded
<a href="https://bugs.webkit.org/show_bug.cgi?id=295133">https://bugs.webkit.org/show_bug.cgi?id=295133</a>
<a href="https://rdar.apple.com/154524118">rdar://154524118</a>

Reviewed by Aditya Keerthi.

The updated API added in 296486@main added functionality to facilitate cancelling a navigation
if the navigation stream that results from using the loading APIs is cancelled.

However, this had the unintended side effect of always immediately cancelling a navigation
if the return value is discarded, since the stream&apos;s lifetime will have ended instantly.

Fix by storing the streams internally like how the continuations are stored so that their lifetime
is tied to the lifetime of the WebPage except if the client explicitly cancels it.

Add a test, and address a FIXME in SwiftBrowser.

* Source/WebKit/UIProcess/API/Swift/WebPage.swift:
(scopedStreams):
(toNavigationSequence(_:)):
* Tools/SwiftBrowser/Source/Views/ContentView.swift:
(ContentView.body):
* Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageNavigationTests.swift:
(WebPageNavigationTests.navigationProceedsAfterDiscardingNavigationStream):

Canonical link: <a href="https://commits.webkit.org/296765@main">https://commits.webkit.org/296765@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6fc54292ba783d71250fc35f9444777bb02822e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29187 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19616 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114731 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59733 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111492 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29865 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37775 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/83250 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112477 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23793 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98660 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63710 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23173 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16803 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59348 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/93165 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16843 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117844 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36568 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27078 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/92258 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36941 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94920 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92075 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37018 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14767 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32361 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17675 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36462 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/41933 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36121 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39466 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37832 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->