### PR TITLE
Improve the output format of check-webkit-style

### DIFF
--- a/Tools/Scripts/webkitpy/style/checker_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checker_unittest.py
@@ -46,6 +46,7 @@ from webkitpy.style.checker import _all_categories
 from webkitpy.style.checker import check_webkit_style_configuration
 from webkitpy.style.checker import check_webkit_style_parser
 from webkitpy.style.checker import configure_logging
+from webkitpy.style.checker import ANSIColor
 from webkitpy.style.checker import CheckerDispatcher
 from webkitpy.style.checker import ProcessorBase
 from webkitpy.style.checker import StyleProcessor
@@ -687,12 +688,13 @@ class StyleProcessorConfigurationTest(LoggingTestCase):
     def test_write_style_error_emacs(self):
         """Test the write_style_error() method."""
         self._call_write_style_error("emacs")
-        self.assertLog(["ERROR: foo.h:100:  message  [whitespace/tab] [5]\n"])
+        expected = f"{ANSIColor.WHITE}foo.h:100:{ANSIColor.RESET} {ANSIColor.RED}error:{ANSIColor.RESET} {ANSIColor.YELLOW}[whitespace/tab]{ANSIColor.RESET} {ANSIColor.WHITE}message{ANSIColor.RESET}\n"
+        self.assertLog([expected])
 
     def test_write_style_error_vs7(self):
         """Test the write_style_error() method."""
         self._call_write_style_error("vs7")
-        self.assertLog(["ERROR: foo.h(100):  message  [whitespace/tab] [5]\n"])
+        self.assertLog(["foo.h(100): error: [whitespace/tab]  message\n"])
 
 
 class StyleProcessor_EndToEndTest(LoggingTestCase):
@@ -724,8 +726,8 @@ class StyleProcessor_EndToEndTest(LoggingTestCase):
                           file_path='foo.txt')
 
         self.assertEqual(processor.error_count, 1)
-        expected_messages = ['ERROR: foo.txt(2):  Line contains tab character.  '
-                             '[whitespace/tab] [5]\n']
+        expected_messages = ['foo.txt(2): error: [whitespace/tab]  '
+                             'Line contains tab character.\n']
         self.assertLog(expected_messages)
 
 
@@ -875,8 +877,8 @@ class StyleProcessor_CodeCoverageTest(LoggingTestCase):
 
         self.assertFalse(self._processor.should_process(file_path))
 
-        self.assertLog(['ERROR: foo/invalid_file.txt(-):  File type is unsupported by the WebKit '
-                        'project  [policy/language] [5]\n'.format(os.path.join('foo', 'skip_with_warning.txt'))])
+        self.assertLog(['foo/invalid_file.txt(-): error: [policy/language]  File type is unsupported by the WebKit '
+                        'project\n'.format(os.path.join('foo', 'skip_with_warning.txt'))])
 
     def test_process__checker_dispatched(self):
         """Test the process() method for a path with a dispatched checker."""

--- a/Tools/Scripts/webkitpy/style/error_handlers_unittest.py
+++ b/Tools/Scripts/webkitpy/style/error_handlers_unittest.py
@@ -142,14 +142,14 @@ class DefaultStyleErrorHandlerTest(LoggingTestCase):
         # First call: usual reporting.
         self._call_error_handler(error_handler, confidence)
         self.assertEqual(1, self._error_count)
-        self.assertLog(["ERROR: foo.h(100):  message  [whitespace/tab] [5]\n"])
+        self.assertLog(["foo.h(100): error: [whitespace/tab]  message\n"])
 
         # Second call: suppression message reported.
         self._call_error_handler(error_handler, confidence)
         # The "Suppressing further..." message counts as an additional
         # message (but not as an addition to the error count).
         self.assertEqual(2, self._error_count)
-        expected_message = ["ERROR: foo.h(100):  message  [whitespace/tab] [5]\n",
+        expected_message = ["foo.h(100): error: [whitespace/tab]  message\n",
                             "ERROR: Suppressing further [whitespace/tab] reports for this file.\n"]
         self.assertLog(expected_message)
 
@@ -174,11 +174,11 @@ class DefaultStyleErrorHandlerTest(LoggingTestCase):
         # Error on modified line: error.
         self._call_error_handler(error_handler, confidence, line_number=50)
         self.assertEqual(1, self._error_count)
-        self.assertLog(["ERROR: foo.h(50):  message  [whitespace/tab] [5]\n"])
+        self.assertLog(["foo.h(50): error: [whitespace/tab]  message\n"])
 
         # Error on non-modified line after turning off line filtering: error.
         error_handler.turn_off_line_filtering()
         self._call_error_handler(error_handler, confidence, line_number=60)
         self.assertEqual(2, self._error_count)
-        self.assertLog(['ERROR: foo.h(60):  message  [whitespace/tab] [5]\n',
+        self.assertLog(['foo.h(60): error: [whitespace/tab]  message\n',
                         'ERROR: Suppressing further [whitespace/tab] reports for this file.\n'])

--- a/Tools/Scripts/webkitpy/style/main_unittest.py
+++ b/Tools/Scripts/webkitpy/style/main_unittest.py
@@ -30,6 +30,7 @@ import webkitpy.style.checker as checker
 from webkitpy.common.host import Host
 from webkitpy.common.system.filesystem_mock import MockFileSystem
 from webkitpy.common.system.logtesting import LogTesting
+from webkitpy.style.checker import ANSIColor
 from webkitpy.style.checker import StyleProcessor
 from webkitpy.style.filereader import TextFileReader
 from webkitpy.style.main import change_directory
@@ -144,9 +145,11 @@ class ExpectationLinterInStyleCheckerTest(unittest.TestCase):
             file_reader.do_association_check('/mock-checkout', host)
         self.assertEqual(captured.stdout.getvalue(), '')
         self.assertEqual(captured.stderr.getvalue(), '')
+
+        expected = f"{ANSIColor.WHITE}/mock-checkout/LayoutTests/TestExpectations:3:{ANSIColor.RESET} {ANSIColor.RED}error:{ANSIColor.RESET} {ANSIColor.YELLOW}[test/expectations]{ANSIColor.RESET} {ANSIColor.WHITE}Duplicate or ambiguous entry lines LayoutTests/TestExpectations:2 and LayoutTests/TestExpectations:3.{ANSIColor.RESET}\n"
         self.assertEqual(
             captured.root.log.getvalue(),
-            '/mock-checkout/LayoutTests/TestExpectations:3:  Duplicate or ambiguous entry lines LayoutTests/TestExpectations:2 and LayoutTests/TestExpectations:3.  [test/expectations] [5]\n',
+            expected,
         )
 
     def test_linter_duplicate_line_no_edit(self):
@@ -203,9 +206,11 @@ class ExpectationLinterInStyleCheckerTest(unittest.TestCase):
             file_reader.do_association_check('/mock-checkout', host)
         self.assertEqual(captured.stdout.getvalue(), '')
         self.assertEqual(captured.stderr.getvalue(), '')
+
+        expected = f"{ANSIColor.WHITE}/mock-checkout/LayoutTests/TestExpectations:3:{ANSIColor.RESET} {ANSIColor.RED}error:{ANSIColor.RESET} {ANSIColor.YELLOW}[test/expectations]{ANSIColor.RESET} {ANSIColor.WHITE}Duplicate or ambiguous entry lines LayoutTests/TestExpectations:2 and LayoutTests/TestExpectations:3.{ANSIColor.RESET}\n"
         self.assertEqual(
             captured.root.log.getvalue(),
-            '/mock-checkout/LayoutTests/TestExpectations:3:  Duplicate or ambiguous entry lines LayoutTests/TestExpectations:2 and LayoutTests/TestExpectations:3.  [test/expectations] [5]\n',
+            expected,
         )
 
     def test_linter_deleted_file(self):
@@ -220,9 +225,11 @@ class ExpectationLinterInStyleCheckerTest(unittest.TestCase):
             file_reader.do_association_check('/mock-checkout', host)
         self.assertEqual(captured.stdout.getvalue(), '')
         self.assertEqual(captured.stderr.getvalue(), '')
+
+        expected = f"{ANSIColor.WHITE}/mock-checkout/LayoutTests/TestExpectations:2:{ANSIColor.RESET} {ANSIColor.RED}error:{ANSIColor.RESET} {ANSIColor.YELLOW}[test/expectations]{ANSIColor.RESET} {ANSIColor.WHITE}Path does not exist.{ANSIColor.RESET}\n"
         self.assertEqual(
             captured.root.log.getvalue(),
-            '/mock-checkout/LayoutTests/TestExpectations:2:  Path does not exist.  [test/expectations] [5]\n',
+            expected,
         )
 
     def test_linter_deleted_file_no_edit(self):


### PR DESCRIPTION
#### d7aca415c23a1b5d182ba4359077378edafe04d4
<pre>
Improve the output format of check-webkit-style
<a href="https://bugs.webkit.org/show_bug.cgi?id=295140">https://bugs.webkit.org/show_bug.cgi?id=295140</a>
<a href="https://rdar.apple.com/154540370">rdar://154540370</a>

Reviewed by Brianna Fan.

Make the output formatted a bit nicer, and also with color. The format is inspired by swift-format.

A screenshot of after vs. before will be attached to the PR.

* Tools/Scripts/webkitpy/common/system/logtesting.py:
(LogTesting.setUp):

Adjust the testing logger to match the updated logic of the normal logging mechanism.

* Tools/Scripts/webkitpy/style/checker.py:
(_create_log_handlers):
(StyleProcessorConfiguration.write_style_error):

Introduce a new logging level &quot;style&quot; (with value 41, which is 1 greater than &quot;error&quot;). This is so
that code style related errors are formatted in a unique way; specifically, the level is not logged
at the beginning of the string.

Consequently, a new handler is introduced to differentiate between style errors and other errors.

* Tools/Scripts/webkitpy/style/checker_unittest.py:
(StyleProcessorConfigurationTest.test_write_style_error_emacs):
(StyleProcessorConfigurationTest.test_write_style_error_vs7):
(StyleProcessor_EndToEndTest.test_process):
(StyleProcessor_CodeCoverageTest.test_invalid_file):
* Tools/Scripts/webkitpy/style/error_handlers_unittest.py:
(DefaultStyleErrorHandlerTest.test_max_reports_per_category):
(DefaultStyleErrorHandlerTest.test_line_numbers):
* Tools/Scripts/webkitpy/style/main_unittest.py:

Adjust test expectations for the new format.

Canonical link: <a href="https://commits.webkit.org/296935@main">https://commits.webkit.org/296935@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1f6d2247956635299ea3f75531944033461a5fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110007 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29666 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20098 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116029 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60255 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111970 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30344 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38253 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83634 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112955 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24193 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99064 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64076 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/109439 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23565 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17212 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59824 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93566 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17255 "Found 1 new test failure: imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-timing.https.sub.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118820 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37047 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27463 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92607 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37419 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95330 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92431 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23555 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37423 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15151 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32929 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36941 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36603 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39943 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38312 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->