### PR TITLE
Reduce use of pointer arithmetic in TinyPtrSet and BitVector

### DIFF
--- a/Source/WTF/wtf/BitVector.h
+++ b/Source/WTF/wtf/BitVector.h
@@ -470,10 +470,10 @@ private:
         size_t numBits() const { return m_numBits; }
         size_t numWords() const { return (m_numBits + bitsInPointer() - 1) / bitsInPointer(); }
 
-        std::span<const uint8_t> byteSpan() const LIFETIME_BOUND { return unsafeMakeSpan(reinterpret_cast<const uint8_t*>(bits()), byteCount(numBits())); }
-        std::span<uint8_t> byteSpan() LIFETIME_BOUND { return unsafeMakeSpan(reinterpret_cast<uint8_t*>(bits()), byteCount(numBits())); }
-        std::span<const uintptr_t> wordsSpan() const LIFETIME_BOUND { return unsafeMakeSpan(bits(), numWords()); }
-        std::span<uintptr_t> wordsSpan() LIFETIME_BOUND { return unsafeMakeSpan(bits(), numWords()); }
+        std::span<const uint8_t> byteSpan() const LIFETIME_BOUND { return unsafeMakeSpan(reinterpret_cast<const uint8_t*>(m_words), byteCount(numBits())); }
+        std::span<uint8_t> byteSpan() LIFETIME_BOUND { return unsafeMakeSpan(reinterpret_cast<uint8_t*>(m_words), byteCount(numBits())); }
+        std::span<const uintptr_t> wordsSpan() const LIFETIME_BOUND { return unsafeMakeSpan(m_words, numWords()); }
+        std::span<uintptr_t> wordsSpan() LIFETIME_BOUND { return unsafeMakeSpan(m_words, numWords()); }
 
         static WTF_EXPORT_PRIVATE OutOfLineBits* create(size_t numBits);
         
@@ -485,12 +485,8 @@ private:
         {
         }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        uintptr_t* bits() { return std::bit_cast<uintptr_t*>(this + 1); }
-        const uintptr_t* bits() const { return std::bit_cast<const uintptr_t*>(this + 1); }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-
         size_t m_numBits;
+        uintptr_t m_words[0];
     };
     
     bool isInline() const { return m_bitsOrPointer >> maxInlineBits(); }

--- a/Source/WTF/wtf/TinyPtrSet.h
+++ b/Source/WTF/wtf/TinyPtrSet.h
@@ -451,7 +451,7 @@ private:
             fastFree(list);
         }
         
-        T* list() { return std::bit_cast<T*>(this + 1); }
+        T* list() { return m_list; }
         
         OutOfLineList(unsigned length, unsigned capacity)
             : m_length(length)
@@ -461,6 +461,7 @@ private:
 
         unsigned m_length;
         unsigned m_capacity;
+        T m_list[0];
     };
     
     ALWAYS_INLINE void deleteListIfNecessary()


### PR DESCRIPTION
#### fbcfad496da8f0e173102a88f9b7b3c51d1ff4c1
<pre>
Reduce use of pointer arithmetic in TinyPtrSet and BitVector
<a href="https://bugs.webkit.org/show_bug.cgi?id=295141">https://bugs.webkit.org/show_bug.cgi?id=295141</a>

Reviewed by Darin Adler.

Reduce use of pointer arithmetic in TinyPtrSet and BitVector by leveraging
flexible array members instead.

* Source/WTF/wtf/BitVector.h:
* Source/WTF/wtf/TinyPtrSet.h:
(WTF::TinyPtrSet::OutOfLineList::list):

Canonical link: <a href="https://commits.webkit.org/296776@main">https://commits.webkit.org/296776@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e18a10ba321b4115a710c3188121c0d4990fde28

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109541 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19628 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114743 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59744 "Built successfully") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111504 "Build is in progress. Recent messages:") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29877 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37787 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83261 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112489 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23805 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98667 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63721 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23184 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16810 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59360 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/102031 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93178 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16850 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117856 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/108093 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36580 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27086 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92272 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/109037 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36953 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94927 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92089 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23454 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37027 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14774 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32378 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36474 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41945 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/132358 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36133 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35845 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39477 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37844 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->