### PR TITLE
Stop using UncheckedKey containers in more places in WebCore

### DIFF
--- a/Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp
+++ b/Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp
@@ -117,8 +117,8 @@ static Lock encodingRegistryLock;
 static TextEncodingNameMap* textEncodingNameMap WTF_GUARDED_BY_LOCK(encodingRegistryLock);
 static TextCodecMap* textCodecMap WTF_GUARDED_BY_LOCK(encodingRegistryLock);
 static bool didExtendTextCodecMaps;
-static UncheckedKeyHashSet<ASCIILiteral>* japaneseEncodings;
-static UncheckedKeyHashSet<ASCIILiteral>* nonBackslashEncodings;
+static HashSet<ASCIILiteral>* japaneseEncodings;
+static HashSet<ASCIILiteral>* nonBackslashEncodings;
 
 static constexpr ASCIILiteral textEncodingNameBlocklist[] = { "UTF-7"_s, "BOCU-1"_s, "SCSU"_s };
 
@@ -197,7 +197,7 @@ static void buildBaseTextCodecMaps() WTF_REQUIRES_LOCK(encodingRegistryLock)
     TextCodecUserDefined::registerCodecs(addToTextCodecMap);
 }
 
-static void addEncodingName(UncheckedKeyHashSet<ASCIILiteral>& set, ASCIILiteral name) WTF_REQUIRES_LOCK(encodingRegistryLock)
+static void addEncodingName(HashSet<ASCIILiteral>& set, ASCIILiteral name) WTF_REQUIRES_LOCK(encodingRegistryLock)
 {
     // We must not use atomCanonicalTextEncodingName() because this function is called in it.
     ASCIILiteral atomName = textEncodingNameMap->get(name);
@@ -213,7 +213,7 @@ static void buildQuirksSets() WTF_REQUIRES_LOCK(encodingRegistryLock)
     ASSERT(!japaneseEncodings);
     ASSERT(!nonBackslashEncodings);
 
-    japaneseEncodings = new UncheckedKeyHashSet<ASCIILiteral>;
+    japaneseEncodings = new HashSet<ASCIILiteral>;
     addEncodingName(*japaneseEncodings, "EUC-JP"_s);
     addEncodingName(*japaneseEncodings, "ISO-2022-JP"_s);
     addEncodingName(*japaneseEncodings, "ISO-2022-JP-1"_s);
@@ -229,7 +229,7 @@ static void buildQuirksSets() WTF_REQUIRES_LOCK(encodingRegistryLock)
     addEncodingName(*japaneseEncodings, "cp932"_s);
     addEncodingName(*japaneseEncodings, "x-mac-japanese"_s);
 
-    nonBackslashEncodings = new UncheckedKeyHashSet<ASCIILiteral>;
+    nonBackslashEncodings = new HashSet<ASCIILiteral>;
     // The text encodings below treat backslash as a currency symbol for IE compatibility.
     // See http://blogs.msdn.com/michkap/archive/2005/09/17/469941.aspx for more information.
     addEncodingName(*nonBackslashEncodings, "x-mac-japanese"_s);

--- a/Source/WebCore/bridge/IdentifierRep.cpp
+++ b/Source/WebCore/bridge/IdentifierRep.cpp
@@ -38,7 +38,7 @@ using namespace JSC;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(IdentifierRep);
 
-typedef UncheckedKeyHashSet<IdentifierRep*> IdentifierSet;
+using IdentifierSet = HashSet<IdentifierRep*>;
 
 static IdentifierSet& identifierSet()
 {

--- a/Source/WebCore/bridge/runtime_root.cpp
+++ b/Source/WebCore/bridge/runtime_root.cpp
@@ -44,7 +44,7 @@ namespace JSC { namespace Bindings {
 // comments in this file claimed that problem #1 was an issue in Java, in particular, 
 // because Java, allegedly, didn't always call finalize when collecting an object.
 
-typedef UncheckedKeyHashSet<RootObject*> RootObjectSet;
+using RootObjectSet = HashSet<RootObject*>;
 
 static RootObjectSet& rootObjectSet()
 {
@@ -117,8 +117,8 @@ void RootObject::invalidate()
     m_globalObject.clear();
 
     {
-        UncheckedKeyHashSet<InvalidationCallback*>::iterator end = m_invalidationCallbacks.end();
-        for (UncheckedKeyHashSet<InvalidationCallback*>::iterator iter = m_invalidationCallbacks.begin(); iter != end; ++iter)
+        HashSet<InvalidationCallback*>::iterator end = m_invalidationCallbacks.end();
+        for (auto iter = m_invalidationCallbacks.begin(); iter != end; ++iter)
             (**iter)(this);
 
         m_invalidationCallbacks.clear();

--- a/Source/WebCore/bridge/runtime_root.h
+++ b/Source/WebCore/bridge/runtime_root.h
@@ -92,7 +92,7 @@ private:
     ProtectCountSet m_protectCountSet;
     HashMap<RuntimeObject*, JSC::Weak<RuntimeObject>> m_runtimeObjects; // We use a map to implement a set.
 
-    UncheckedKeyHashSet<InvalidationCallback*> m_invalidationCallbacks;
+    HashSet<InvalidationCallback*> m_invalidationCallbacks;
 };
 
 } // namespace Bindings

--- a/Source/WebCore/fileapi/Blob.cpp
+++ b/Source/WebCore/fileapi/Blob.cpp
@@ -67,7 +67,7 @@ public:
     static URLRegistry& registry();
 
     Lock m_urlsPerContextLock;
-    HashMap<ScriptExecutionContextIdentifier, UncheckedKeyHashSet<URL>> m_urlsPerContext WTF_GUARDED_BY_LOCK(m_urlsPerContextLock);
+    HashMap<ScriptExecutionContextIdentifier, HashSet<URL>> m_urlsPerContext WTF_GUARDED_BY_LOCK(m_urlsPerContextLock);
 };
 
 void BlobURLRegistry::registerURL(const ScriptExecutionContext& context, const URL& publicURL, URLRegistrable& blob)
@@ -75,7 +75,7 @@ void BlobURLRegistry::registerURL(const ScriptExecutionContext& context, const U
     ASSERT(&blob.registry() == this);
     {
         Locker locker { m_urlsPerContextLock };
-        m_urlsPerContext.add(context.identifier(), UncheckedKeyHashSet<URL>()).iterator->value.add(publicURL.isolatedCopy());
+        m_urlsPerContext.add(context.identifier(), HashSet<URL>()).iterator->value.add(publicURL.isolatedCopy());
     }
     ThreadableBlobRegistry::registerBlobURL(context.protectedSecurityOrigin().get(), context.policyContainer(), publicURL, downcast<Blob>(blob).url(), context.topOrigin().data());
 }
@@ -102,7 +102,7 @@ void BlobURLRegistry::unregisterURL(const URL& url, const SecurityOriginData& to
 
 void BlobURLRegistry::unregisterURLsForContext(const ScriptExecutionContext& context)
 {
-    UncheckedKeyHashSet<URL> urlsForContext;
+    HashSet<URL> urlsForContext;
     {
         Locker locker { m_urlsPerContextLock };
         urlsForContext = m_urlsPerContext.take(context.identifier());

--- a/Source/WebCore/fileapi/Blob.h
+++ b/Source/WebCore/fileapi/Blob.h
@@ -163,7 +163,7 @@ private:
     // into an HTML or for FileRead'ing, public blob URLs must be used for those purposes.
     URL m_internalURL;
 
-    UncheckedKeyHashSet<std::unique_ptr<BlobLoader>> m_blobLoaders;
+    HashSet<std::unique_ptr<BlobLoader>> m_blobLoaders;
 };
 
 WebCoreOpaqueRoot root(Blob*);


### PR DESCRIPTION
#### a40735fe9cbf3239333f4e13a4c0d5d301811868
<pre>
Stop using UncheckedKey containers in more places in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=295142">https://bugs.webkit.org/show_bug.cgi?id=295142</a>

Reviewed by Darin Adler.

* Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp:
(PAL::WTF_REQUIRES_LOCK):
* Source/WebCore/bridge/IdentifierRep.cpp:
* Source/WebCore/bridge/runtime_root.cpp:
(JSC::Bindings::RootObject::invalidate):
* Source/WebCore/bridge/runtime_root.h:
* Source/WebCore/fileapi/Blob.cpp:
(WebCore::BlobURLRegistry::registerURL):
(WebCore::BlobURLRegistry::unregisterURLsForContext):
* Source/WebCore/fileapi/Blob.h:
* Source/WebCore/html/CanvasBase.cpp:
(WebCore:: const):
* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/inspector/InspectorCanvas.cpp:
(WebCore:: const):
* Source/WebCore/inspector/InspectorCanvas.h:

Canonical link: <a href="https://commits.webkit.org/296775@main">https://commits.webkit.org/296775@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89fd09f520d8707b8d78695d4e17ee0c75f59a11

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109542 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29200 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19629 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114745 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59745 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111505 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29878 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37788 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83263 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112490 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23806 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98668 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63723 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23185 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16811 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59361 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93179 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16851 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117857 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36581 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27088 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92271 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36954 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94928 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92088 "Found 2 new API test failures: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37028 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14775 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32379 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17678 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36475 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41946 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36134 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39478 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37845 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->