### PR TITLE
[JSC] Fold `RegExp#@@search` at DFG StrengthReduction phase

### DIFF
--- a/JSTests/microbenchmarks/regexp-prototype-search-no-strength-reduction.js
+++ b/JSTests/microbenchmarks/regexp-prototype-search-no-strength-reduction.js
@@ -1,0 +1,8 @@
+function shouldBe(a, b) {
+    if (a !== b) throw new Error(`Expected ${b} but got ${a}`);
+}
+
+for (let i = 0; i < 1e6; i++) {
+    shouldBe(new RegExp("wor" + "ld")[Symbol.search]("hello world"), 6);
+    shouldBe(/hello/[Symbol.search]("hello" + "world" + Math.random()), 0);
+}

--- a/JSTests/stress/regexp-prototype-search-strength-reduction.js
+++ b/JSTests/stress/regexp-prototype-search-strength-reduction.js
@@ -1,0 +1,20 @@
+function shouldBe(a, b) {
+    if (a !== b) throw new Error(`Expected ${b} but got ${a}`);
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    shouldBe(/world/[Symbol.search]("hello world"), 6);
+    shouldBe(/hello/[Symbol.search]("hello world"), 0);
+    shouldBe(/^hello/[Symbol.search]("hello world"), 0);
+    shouldBe(/world$/[Symbol.search]("hello world"), 6);
+
+    shouldBe(/xyz/[Symbol.search]("hello world"), -1);
+    shouldBe(/^world/[Symbol.search]("hello world"), -1);
+    shouldBe(/hello$/[Symbol.search]("hello world"), -1);
+
+    shouldBe(/l/g[Symbol.search]("hello world"), 2);
+    shouldBe(/o/g[Symbol.search]("hello world"), 4);
+
+    shouldBe(/hello/y[Symbol.search]("hello world"), 0);
+    shouldBe(/world/y[Symbol.search]("hello world"), -1);
+}


### PR DESCRIPTION
#### ec89a5102de07389efc7b31a277de2c8df6bf77b
<pre>
[JSC] Fold `RegExp#@@search` at DFG StrengthReduction phase
<a href="https://bugs.webkit.org/show_bug.cgi?id=295147">https://bugs.webkit.org/show_bug.cgi?id=295147</a>

Reviewed by Yusuke Suzuki.

JSC handles RegExp#exec, RegExp#test and RegExp#match in the DFG StrengthReduction
phase for constant folding optimization.

This patch changes to exted the same optimization to the `RegExpSearch` node that was
added in <a href="https://commits.webkit.org/296443@main.">https://commits.webkit.org/296443@main.</a>

                                                  TipOfTree                  Patched

regexp-prototype-search-no-strength-reduction
                                               93.2792+-1.0921     ?     93.4058+-0.9316        ?
regexp-prototype-search-short-string           32.7441+-1.0533     ^      5.0470+-0.0546        ^ definitely 6.4878x faster
regexp-prototype-search-complex-pattern        54.5425+-2.5405     ^      6.8118+-0.1985        ^ definitely 8.0071x faster
regexp-prototype-search-basic                 119.5020+-1.8881     ^     11.0128+-0.3870        ^ definitely 10.8512x faster
regexp-prototype-search-observable-side-effects2
                                                0.1547+-0.0286     ?      0.1674+-0.0140        ? might be 1.0821x slower
regexp-prototype-search-anchor                 59.0436+-3.4802     ^      6.9537+-0.2744        ^ definitely 8.4909x faster
regexp-prototype-search-observable-side-effects
                                                0.2566+-0.0065     ?      0.2590+-0.0054        ?

* JSTests/microbenchmarks/regexp-prototype-search-no-strength-reduction.js: Added.
(shouldBe):
* JSTests/stress/regexp-prototype-search-strength-reduction.js: Added.
(shouldBe):
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):

Canonical link: <a href="https://commits.webkit.org/297859@main">https://commits.webkit.org/297859@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72b0c17413a809051e42816e6eadc2e3c6d34859

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109551 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19638 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/115555 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/59795 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Failed to compile WebKit; Compiled WebKit (cancelled)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29887 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37797 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/115555 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/59795 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Failed to compile WebKit; Compiled WebKit (cancelled)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112499 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23814 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98676 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/115555 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23193 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16819 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59370 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/102041 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93188 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16859 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/118357 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/108103 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36590 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27096 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/118357 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36963 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94936 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/118357 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24169 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37037 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14783 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32390 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36484 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41955 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/132368 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36144 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35849 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39487 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37854 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->