### PR TITLE
[WPE] Log messages to the Android log where appropriate

### DIFF
--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -3606,9 +3606,11 @@ int main(int argc, char** argv)
     // yet, since that would do somethings that we'd like to defer until after we
     // have a chance to parse options.
     WTF::initialize();
-#if PLATFORM(COCOA)
+#if PLATFORM(COCOA) || OS(ANDROID)
     WTF::disableForwardingVPrintfStdErrToOSLog();
+#endif
 
+#if PLATFORM(COCOA)
     if (getenv("JSCTEST_CrashReportArgV")) {
         StringPrintStream out;
         CommaPrinter space(" "_s);

--- a/Source/WTF/wtf/PlatformWPE.cmake
+++ b/Source/WTF/wtf/PlatformWPE.cmake
@@ -72,6 +72,10 @@ if (ENABLE_JOURNALD_LOG)
     list(APPEND WTF_LIBRARIES Journald::Journald)
 endif ()
 
+if (ANDROID)
+    list(APPEND WTF_LIBRARIES Android::Log)
+endif ()
+
 list(APPEND WTF_SYSTEM_INCLUDE_DIRECTORIES
     ${GIO_UNIX_INCLUDE_DIRS}
     ${GLIB_INCLUDE_DIRS}

--- a/Source/WTF/wtf/WTFConfig.h
+++ b/Source/WTF/wtf/WTFConfig.h
@@ -91,7 +91,7 @@ struct Config {
     bool isPermanentlyFrozen;
     bool disabledFreezingForTesting;
     bool useSpecialAbortForExtraSecurityImplications;
-#if PLATFORM(COCOA)
+#if PLATFORM(COCOA) || OS(ANDROID)
     bool disableForwardingVPrintfStdErrToOSLog;
 #endif
 

--- a/Source/cmake/FindAndroid.cmake
+++ b/Source/cmake/FindAndroid.cmake
@@ -1,0 +1,139 @@
+# Copyright (C) 2025 Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND ITS CONTRIBUTORS ``AS
+# IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR ITS
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#[=======================================================================[.rst:
+FindAndroid
+-----------
+
+Find Android NDK headers and libraries.
+
+This module supports checking for the following components:
+
+``Android``
+  The base ``libandroid`` library. If no components are specified, this
+  will the only one to search for.
+``Log``
+  The logging ``liblog`` library.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+For each supported component, the corresponding `Android::<name>` target
+will be defined, for example `Android::Android`, if found.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables in your project, for each
+component given its `<name>`:
+
+``Android_<name>_FOUND``
+  True if the component `<name>` is available.
+
+#]=======================================================================]
+
+if (NOT ANDROID)
+    return()
+endif ()
+
+include(CMakePushCheckState)
+include(CheckFunctionExists)
+include(CheckIncludeFile)
+
+function(_AndroidHandleComponent target)
+    if (TARGET Android::${target})
+        message(DEBUG "Android::${target} already checked, skipping")
+        return()
+    endif ()
+
+    if (NOT Android_COMPONENT_${target}_LIBRARY)
+        message(CHECK_FAIL "Invalid component name")
+        return()
+    endif ()
+
+    set(libname "${Android_COMPONENT_${target}_LIBRARY}")
+    set(header "${Android_COMPONENT_${target}_HEADER}")
+    set(symbol "${Android_COMPONENT_${target}_SYMBOL}")
+    set(deps "${Android_COMPONENT_${target}_DEPS}")
+    set(deplibs "${libname}")
+
+    foreach (dep IN LISTS deps)
+        if (Android_FIND_REQUIRED_${target} AND NOT Android_FIND_REQUIRED_${dep})
+            set(Android_FIND_REQUIRED_${dep} TRUE PARENT_SCOPE)
+        endif ()
+        _AndroidHandleComponent(${dep})
+        list(APPEND deplibs Android::${dep})
+    endforeach ()
+
+    check_include_file("${header}" Android_COMPONENT_${target}_HAS_HEADER)
+    if (NOT Android_COMPONENT_${target}_HAS_HEADER)
+        return()
+    endif ()
+
+    cmake_push_check_state(RESET)
+    set(CMAKE_REQUIRED_LIBRARIES "${libname}")
+    check_function_exists("${symbol}" Android_COMPONENT_${target}_HAS_SYMBOL)
+    cmake_pop_check_state()
+    if (NOT Android_COMPONENT_${target}_HAS_SYMBOL)
+        return()
+    endif ()
+
+    add_library(Android::${target} INTERFACE IMPORTED)
+    set_target_properties(Android::${target} PROPERTIES
+        INTERFACE_LINK_LIBRARIES "${deplibs}")
+    set(Android_${target}_FOUND TRUE PARENT_SCOPE)
+endfunction()
+
+function(_AndroidDefineComponent target libname header symbol)
+    if (Android_COMPONENT_${target}_LIBRARY)
+        message(FATAL_ERROR "Android::${target} component already defined")
+    endif ()
+    cmake_parse_arguments(PARSE_ARGV 4 opt "" "" "")
+    set(Android_COMPONENT_${target}_LIBRARY "${libname}" PARENT_SCOPE)
+    set(Android_COMPONENT_${target}_HEADER "${header}" PARENT_SCOPE)
+    set(Android_COMPONENT_${target}_SYMBOL "${symbol}" PARENT_SCOPE)
+    set(Android_COMPONENT_${target}_DEPS "${opt_UNPARSED_ARGUMENTS}" PARENT_SCOPE)
+endfunction()
+
+_AndroidDefineComponent(Android
+    android
+    android/hardware_buffer.h
+    AHardwareBuffer_allocate
+)
+_AndroidDefineComponent(Log
+    log
+    android/log.h
+    __android_log_print
+)
+
+if (NOT Android_FIND_COMPONENTS)
+    set(Android_FIND_COMPONENTS Android)
+    set(Android_FIND_REQUIRED_Android ${Android_FIND_REQUIRED})
+endif ()
+
+foreach (component IN LISTS Android_FIND_COMPONENTS)
+    _AndroidHandleComponent(${component})
+endforeach ()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Android HANDLE_COMPONENTS)

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -23,6 +23,10 @@ find_package(WebP REQUIRED COMPONENTS demux)
 find_package(WPE REQUIRED)
 find_package(ZLIB REQUIRED)
 
+if (ANDROID)
+    find_package(Android REQUIRED COMPONENTS Log)
+endif ()
+
 WEBKIT_OPTION_BEGIN()
 
 SET_AND_EXPOSE_TO_BUILD(ENABLE_DEVELOPER_MODE ${DEVELOPER_MODE})


### PR DESCRIPTION
#### d52459e42f870cd1b42ad406f87071f981944b70
<pre>
[WPE] Log messages to the Android log where appropriate
<a href="https://bugs.webkit.org/show_bug.cgi?id=295155">https://bugs.webkit.org/show_bug.cgi?id=295155</a>

Reviewed by Nikolas Zimmermann and Sergio Villar Senin.

Add an Android-specific version of the logging macros. Those use
__android_log_print() to get the messages sent to the system log
facility. LogChannel is also augmented with calls to the Android
logging functions where appropriate.

Also, on actual devices Android closes the standard error stream of
processes by default, therefore it is handy to have messages send to
the standard error stream forwarded to the system log.

In all cases, the name of the LogChannel subsystem is set as the
Android logging tag, which means that the corresponding system
property (i.e. &quot;log.tag.&lt;name&gt;&quot;) needs to be set in order for logs
to be sent to the system log. This can be achieved for example with
the following command using ADB:

  adb shell setprop log.tag.WPEWebKit VERBOSE

Or, to save the setting:

  adb shell setprop persist.log.tag.WPEWebKit VERBOSE

The logging level may be set to VERBOSE, DEBUG, INFO, WARN, ERROR,
or FATAL. Those correspond to the log levels defined in &lt;android/log.h&gt;.
More information about how to configure the logger can be found at:

  <a href="https://android.googlesource.com/platform/system/core/+/66607ebc0e451/logd/README.property">https://android.googlesource.com/platform/system/core/+/66607ebc0e451/logd/README.property</a>

Setting environment variables on Android is a bit of a chore, so in
the future it may be desirable to read the list of enabled logging
channels from a system property instead.

* Source/JavaScriptCore/jsc.cpp:
(main):
* Source/WTF/wtf/Assertions.cpp:
* Source/WTF/wtf/Assertions.h:
* Source/WTF/wtf/Logger.h:
(WTF::Logger::willLog const):
(WTF::Logger::log):
(WTF::Logger::logVerbose):
* Source/WTF/wtf/PlatformWPE.cmake:
* Source/WTF/wtf/WTFConfig.h:
* Source/cmake/FindAndroid.cmake: Added.
* Source/cmake/OptionsWPE.cmake:

Canonical link: <a href="https://commits.webkit.org/297472@main">https://commits.webkit.org/297472@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc7d865578c5c164e9793c28b92beecb8defb2e4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111897 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31560 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22037 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117915 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62125 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32241 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40141 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/85006 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35694 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114844 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25746 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/100697 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65446 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25067 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18832 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61759 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/104385 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95125 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18903 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121197 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/110456 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38924 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28947 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/93875 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39305 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96954 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93699 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23911 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38881 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16669 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34942 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38822 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44317 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/134717 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38459 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36264 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41784 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40174 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->