### PR TITLE
Iframes with HDR images don't always become composited to show the HDR

### DIFF
--- a/LayoutTests/compositing/hdr/iframe-gains-hdr-image-expected.txt
+++ b/LayoutTests/compositing/hdr/iframe-gains-hdr-image-expected.txt
@@ -1,0 +1,48 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 8.00 8.00)
+          (bounds 504.00 404.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (position 2.00 2.00)
+              (children 1
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 500.00 400.00)
+                  (children 1
+                    (GraphicsLayer
+                      (anchor 0.00 0.00)
+                      (children 1
+                        (GraphicsLayer
+                          (anchor 0.00 0.00)
+                          (bounds 500.00 400.00)
+                          (children 1
+                            (GraphicsLayer
+                              (bounds 500.00 400.00)
+                              (drawsContent 1)
+                              (drawsHDRContent 1)
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/compositing/hdr/iframe-gains-hdr-image.html
+++ b/LayoutTests/compositing/hdr/iframe-gains-hdr-image.html
@@ -20,15 +20,11 @@
             testRunner.waitUntilDone();
         }
         
-        const iframe = document.getElementsByTagName('iframe')[0];
-        const frameLoadPromise = new Promise((resolve) => {
-            iframe.onload = resolve;
-        });
-
         const imageLoadPromise = new Promise((resolve) => {
             window.imageLoadResolve = resolve;
         });
         
+        const iframe = document.getElementsByTagName('iframe')[0];
         iframe.srcdoc = `
             <style>
             img {
@@ -36,22 +32,32 @@
                 height: 200px;
             }
             </style>
+            <script src="../../resources/ui-helper.js"></` + `script>
             <script>
-            function imageLoaded(image)
-            {
-                if (window.internals)
-                    internals.setHasHDRContentForTesting(image);
+                window.addEventListener('load', async () => {
+                    await UIHelper.renderingUpdate();
+
+                    const image = document.getElementsByTagName('img')[0];
+                    image.onload = (() => {
+                        if (window.internals)
+                            internals.setHasHDRContentForTesting(image);
             
-                parent.imageLoadResolve();
-            }
+                        parent.imageLoadResolve();
+                    });
+
+                    image.src = "../../fast/images/resources/green-400x400.png";
+                }, false);
             </` + `script>
             <body>
-            <img onload="imageLoaded(this)" src="../../fast/images/resources/green-400x400.png">
+            <img>
             </body>
             `;
 
         (async () => {
-            await Promise.all([frameLoadPromise, imageLoadPromise]);
+            await imageLoadPromise;
+            await UIHelper.renderingUpdate();
+            await UIHelper.renderingUpdate();
+            await UIHelper.renderingUpdate();
 
             if (window.testRunner) {
                 document.getElementById("layers").textContent = internals.layerTreeAsText(document);

--- a/LayoutTests/compositing/hdr/layer-gains-hdr-image-expected.txt
+++ b/LayoutTests/compositing/hdr/layer-gains-hdr-image-expected.txt
@@ -1,0 +1,19 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 8.00 100.00)
+          (bounds 222.00 222.00)
+          (drawsContent 1)
+          (drawsHDRContent 1)
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/compositing/hdr/layer-gains-hdr-image.html
+++ b/LayoutTests/compositing/hdr/layer-gains-hdr-image.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .container {
+            position: absolute;
+            will-change: transform;
+            border: 1px solid black;
+            padding: 10px;
+            top: 100px;
+        }
+    
+        .image-box {
+            display: block;
+            width: 200px;
+            height: 200px;
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        if (window.internals && window.testRunner) {
+            internals.clearMemoryCache();
+            internals.setScreenContentsFormatsForTesting(["RGBA8", "RGBA16F"]);
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+        
+        window.addEventListener('load', async () => {
+            await UIHelper.renderingUpdate();
+
+            const image = document.getElementsByTagName('img')[0];
+            const imageLoadPromise = new Promise((resolve) => {
+                image.onload = (() => {
+                    if (window.internals)
+                        internals.setHasHDRContentForTesting(image);
+                
+                    resolve();
+                });
+            });
+
+            image.src = "../../fast/images/resources/green-400x400.png";
+            await imageLoadPromise;
+
+            if (window.testRunner) {
+                document.getElementById("layers").textContent = internals.layerTreeAsText(document);
+                testRunner.notifyDone();
+            }
+        }, false);
+    </script>
+</head>
+<body>
+    <pre id="layers">Layer tree goes here in DRT</pre>
+    <div class="container"><img class="image-box"></div>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -36,6 +36,7 @@ fast/events/ios/ipad [ Skip ]
 fast/forms/ios [ Pass ]
 fast/forms/ios/ipad [ Skip ]
 fast/forms/switch [ Pass ]
+fast/snapshot [ Skip ]
 
 # Missing public painting code
 fast/forms/switch/click-animation-redundant-checked.html [ ImageOnlyFailure ]
@@ -7923,8 +7924,4 @@ webkit.org/b/294274 [ Debug ] platform/ios/mediastream/audio-muted-in-background
  webgl/1.0.x/conformance/textures/misc/gl-teximage.html [ Failure ]
  webgl/2.0.y/conformance/textures/misc/gl-teximage.html [ Failure ]
 
-fast/snapshot [ Skip ]
-
 imported/w3c/web-platform-tests/focus/focus-contenteditable-element-in-iframe-scroll-into-view.html [ Skip ]
-
-webkit.org/b/294873 compositing/hdr/iframe-with-hdr-image.html [ Skip ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2190,8 +2190,6 @@ webkit.org/b/293804 [ Debug ] pdf/annotations/checkbox-set-active.html [ Pass Ti
 # It fails only on debug build with '0.01%' difference
 [ Debug ] imported/w3c/web-platform-tests/css/css-fill-stroke/paint-order-001.html [ ImageOnlyFailure ]
 
-webkit.org/b/294873 compositing/hdr/iframe-with-hdr-image.html [ Skip ]
-
 webkit.org/b/295054 http/tests/webrtc/filtering-ice-candidate-cross-origin-frame.html [ Pass Failure ]
 
 webkit.org/b/295076 imported/w3c/web-platform-tests/css/css-pseudo/highlight-custom-properties-dynamic-001.html [ Pass ImageOnlyFailure ]

--- a/Source/WebCore/rendering/RenderBoxModelObject.h
+++ b/Source/WebCore/rendering/RenderBoxModelObject.h
@@ -43,6 +43,7 @@ enum class BleedAvoidance : uint8_t {
 
 enum class ContentChangeType : uint8_t {
     Image,
+    HDRImage,
     MaskImage,
     BackgroundIImage,
     Canvas,

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1727,9 +1727,15 @@ void RenderElement::imageContentChanged(CachedImage& cachedImage)
     }
 
     if (document().hasHDRContent()) {
-        if (CheckedPtr rendererLayer = enclosingLayer()) {
-            if (CheckedPtr layer = rendererLayer->enclosingCompositingLayer())
-                layer->contentChanged(ContentChangeType::Image);
+        if (cachedImage.hasHDRContent()) {
+            RefPtr element = this->element();
+            if (element)
+                element->invalidateStyleAndLayerComposition();
+        }
+
+        if (CheckedPtr layer = enclosingLayer()) {
+            auto changeType = cachedImage.hasHDRContent() ? ContentChangeType::HDRImage : ContentChangeType::Image;
+            layer->contentChanged(changeType);
         }
     }
 #else

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1007,7 +1007,7 @@ RenderLayerCompositor& RenderLayer::compositor() const
 
 void RenderLayer::contentChanged(ContentChangeType changeType)
 {
-    if (changeType == ContentChangeType::Canvas || changeType == ContentChangeType::Video || changeType == ContentChangeType::FullScreen || changeType == ContentChangeType::Model || (isComposited() && changeType == ContentChangeType::Image)) {
+    if (changeType == ContentChangeType::Canvas || changeType == ContentChangeType::Video || changeType == ContentChangeType::FullScreen || changeType == ContentChangeType::Model || changeType == ContentChangeType::HDRImage) {
         setNeedsPostLayoutCompositingUpdate();
         setNeedsCompositingConfigurationUpdate();
     }


### PR DESCRIPTION
#### 6f89b28dfb13595fbb09e8f3b955c156df53b191
<pre>
Iframes with HDR images don&apos;t always become composited to show the HDR
<a href="https://bugs.webkit.org/show_bug.cgi?id=294873">https://bugs.webkit.org/show_bug.cgi?id=294873</a>
<a href="https://rdar.apple.com/154137509">rdar://154137509</a>

Reviewed by Matt Woodrow.

296315@main wasn&apos;t quite complete; there&apos;s a race condition, revealed by `iframe-with-hdr-image.html`,
where the iframe may not actually do a compositing update after we detect the HDR image. The new
test, `iframe-gains-hdr-image.html`, targets this case.

When `RenderElement::imageContentChanged()` is called, we may not have any compositing layers in
the iframe yet, so we&apos;d never hit `layer-&gt;contentChanged()`. We also need to explicitly trigger
a compositing update for this image, via `invalidateStyleAndLayerComposition()`.

There&apos;s no need to find the `enclosingCompositingLayer()` to call `contentChanged()` on; we can just
call it on the enclosing RenderLayer.

`ContentChangeType::HDRImage` is added since HDR images are specifically a compositing trigger
which prevents us from needlessly triggering compositing updates for SDR images.

* LayoutTests/compositing/hdr/iframe-gains-hdr-image-expected.txt: Added.
* LayoutTests/compositing/hdr/iframe-gains-hdr-image.html: Added.
* LayoutTests/compositing/hdr/iframe-with-hdr-image.html:
* LayoutTests/compositing/hdr/layer-gains-hdr-image-expected.txt: Added.
* LayoutTests/compositing/hdr/layer-gains-hdr-image.html: Copied from LayoutTests/compositing/hdr/iframe-with-hdr-image.html.
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/rendering/RenderBoxModelObject.h:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::imageContentChanged):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::contentChanged):

Canonical link: <a href="https://commits.webkit.org/296835@main">https://commits.webkit.org/296835@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/929de7ccf01dbcd7f26c102136663d28dc012dd7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109691 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29349 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19778 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115712 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59925 "Failed to checkout and rebase branch from PR 47340") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111654 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30027 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37937 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83360 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/59925 "Failed to checkout and rebase branch from PR 47340") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112639 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23927 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98785 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63819 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23309 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16930 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59506 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93302 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16967 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118504 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36730 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27204 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92370 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37103 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95044 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92191 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23494 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37147 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14891 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32558 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36624 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42095 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36285 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39627 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37994 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->