### PR TITLE
When moving past a left-hand scrollbar, don't jump way outside the content box

### DIFF
--- a/LayoutTests/fast/scrolling/content-box-smaller-than-scrollbar-expected.txt
+++ b/LayoutTests/fast/scrolling/content-box-smaller-than-scrollbar-expected.txt
@@ -1,0 +1,6 @@
+
+PASS LTR scrollable with block-level child
+PASS RTL scrollable with block-level child
+PASS LTR scrollable with inline-level child
+FAIL RTL scrollable with inline-level child assert_equals: expected 502 but got 500
+

--- a/LayoutTests/fast/scrolling/content-box-smaller-than-scrollbar.html
+++ b/LayoutTests/fast/scrolling/content-box-smaller-than-scrollbar.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<style>
+    /* Avoid padding on the sides that have a scrollbar, since our current
+       behavior is inconsistent. */
+    .scrollable { overflow:scroll; width:2px; height:2px; border:solid; border-width:1px 2px 2px 1px; padding:1px 2px 0; }
+    .ltr { direction:ltr; padding-right:0; }
+    .rtl { direction:rtl; padding-left:0; }
+    .scrollable > div { width:500px; height:600px; }
+    .scrollable > div.inline-block { display:inline-block; vertical-align:top; }
+</style>
+<div class="scrollable ltr" id="ltrWithBlockLevel">
+    <div></div>
+</div>
+<div class="scrollable rtl" id="rtlWithBlockLevel">
+    <div></div>
+</div>
+<div class="scrollable ltr" id="ltrWithInlineLevel">
+    <div class="inline-block"></div>
+</div>
+<div class="scrollable rtl" id="rtlWithInlineLevel">
+    <div class="inline-block"></div>
+</div>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+    test(function() {
+        var elm = document.getElementById("ltrWithBlockLevel");
+        assert_equals(elm.scrollWidth, 502);
+        assert_equals(elm.scrollHeight, 601);
+    }, "LTR scrollable with block-level child");
+    test(function() {
+        var elm = document.getElementById("rtlWithBlockLevel");
+        assert_equals(elm.scrollWidth, 502);
+        assert_equals(elm.scrollHeight, 601);
+    }, "RTL scrollable with block-level child");
+    test(function() {
+        var elm = document.getElementById("ltrWithInlineLevel");
+        assert_equals(elm.scrollWidth, 502);
+        assert_equals(elm.scrollHeight, 601);
+    }, "LTR scrollable with inline-level child");
+    test(function() {
+        var elm = document.getElementById("rtlWithInlineLevel");
+        assert_equals(elm.scrollWidth, 502);
+        assert_equals(elm.scrollHeight, 601);
+    }, "RTL scrollable with inline-level child");
+</script>

--- a/LayoutTests/fast/table/cell-percent-padding-expected.txt
+++ b/LayoutTests/fast/table/cell-percent-padding-expected.txt
@@ -1,0 +1,3 @@
+
+PASS cell-percent-padding
+

--- a/LayoutTests/fast/table/cell-percent-padding.html
+++ b/LayoutTests/fast/table/cell-percent-padding.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<style>
+th {
+  overflow: scroll;
+  column-count: 3;
+  direction: rtl;
+  padding-left: 100%;
+  padding-right: 10px;
+}
+</style>
+<script src='../../resources/testharness.js'></script>
+<script src='../../resources/testharnessreport.js'></script>
+<script>
+async_test((t) => {
+  document.addEventListener("DOMContentLoaded", () => {
+    let th = document.createElement('th');
+    document.body.appendChild(th);
+    t.done();
+  });
+});
+</script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -1325,6 +1325,7 @@ fast/scrolling/rtl-scrollbars-text-selection.html [ Skip ]
 fast/scrolling/v-rl-scrollbars-initial-position-dynamic.html [ Skip ]
 fast/scrolling/v-rl-scrollbars-initial-position.html [ Skip ]
 fast/scrolling/vertical-scrollbar-position.html [ Skip ]
+fast/scrolling/content-box-smaller-than-scrollbar.html [ Skip ]
 
 imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-root-both-edges.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-root.html [ ImageOnlyFailure ]

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -1212,8 +1212,9 @@ void RenderBlockFlow::determineLogicalLeftPositionForChild(RenderBox& child, App
 {
     LayoutUnit startPosition = borderAndPaddingStart();
     LayoutUnit initialStartPosition = startPosition;
+    auto verticalScrollbarWidthClampedToContentBox = std::min<LayoutUnit>(verticalScrollbarWidth(), std::max(0_lu, logicalWidth() - borderAndPaddingLogicalWidth()));
     if ((shouldPlaceVerticalScrollbarOnLeft() || style().scrollbarGutter().isStableBothEdges()) && isHorizontalWritingMode())
-        startPosition += (writingMode().isLogicalLeftInlineStart() ? 1 : -1) * verticalScrollbarWidth();
+        startPosition += (writingMode().isLogicalLeftInlineStart() ? 1 : -1) * verticalScrollbarWidthClampedToContentBox;
     if (style().scrollbarGutter().isStableBothEdges() && !isHorizontalWritingMode())
         startPosition += (writingMode().isLogicalLeftInlineStart() ? 1 : -1) * horizontalScrollbarHeight();
     LayoutUnit totalAvailableLogicalWidth = borderAndPaddingLogicalWidth() + contentBoxLogicalWidth();


### PR DESCRIPTION
#### be03a3a56787f1a44f1d8f79d868cba8af782d46
<pre>
When moving past a left-hand scrollbar, don&apos;t jump way outside the content box
<a href="https://bugs.webkit.org/show_bug.cgi?id=279324">https://bugs.webkit.org/show_bug.cgi?id=279324</a>
<a href="https://rdar.apple.com/136040116">rdar://136040116</a>

Reviewed by Alan Baradlay.

Merge (non-inline fix): <a href="https://source.chromium.org/chromium/chromium/src/+/d457f863f78941ed376b463ee39476b1a1852797">https://source.chromium.org/chromium/chromium/src/+/d457f863f78941ed376b463ee39476b1a1852797</a>
&amp; <a href="https://chromium.googlesource.com/chromium/src.git/+/49858cc9147612da1e54a673147e8020c5d7b9f9">https://chromium.googlesource.com/chromium/src.git/+/49858cc9147612da1e54a673147e8020c5d7b9f9</a>

This patch fixes edge cases where scrollWidth can be messed up by left-hand
scroller leading to be outside of content box in case of a scrollbar being
wider than its containing block.

* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::determineLogicalLeftPositionForChild):
* LayoutTests/fast/scrolling/content-box-smaller-than-scrollbar.html:
* LayoutTests/fast/table/cell-percent-padding-expected.txt:
* LayoutTests/fast/table/cell-percent-padding.html:
* LayoutTests/fast/scrolling/content-box-smaller-than-scrollbar-expected.txt:
* LayoutTests/platform/ios/TestExpectations: Add Platform Specific Expectation due to RTL scrollbars

Canonical link: <a href="https://commits.webkit.org/297945@main">https://commits.webkit.org/297945@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e93d570a5727b9381aa1591c32d8c5b91979d0c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113142 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32877 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23355 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119350 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64276 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115104 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33529 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41440 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86115 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41356 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116089 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26779 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101782 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66434 "Found 145 new API test failures: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration, /WPE/TestBackForwardList:/webkit/WebKitWebView/navigation-after-session-restore, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/reset, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /WPE/TestLoaderClient:/webkit/WebKitURIResponse/http-headers, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone-worker, /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/injected-script, /WPE/TestLoaderClient:/webkit/WebKitWebView/unfinished-subresource-load, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/cookies ... (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26052 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19910 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63104 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96164 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19985 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122567 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40220 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30002 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94964 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40604 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97998 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94706 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24229 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39856 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17662 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36350 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40106 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45605 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39747 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43080 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41484 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->