### PR TITLE
Stop using pointers to HashMap / HashSet in TextEncodingRegistry.cpp

### DIFF
--- a/Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp
+++ b/Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp
@@ -44,6 +44,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
 #include <wtf/MainThread.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/StringHash.h>
@@ -114,11 +115,29 @@ using TextCodecMap = HashMap<ASCIILiteral, NewTextCodecFunction>;
 
 static Lock encodingRegistryLock;
 
-static TextEncodingNameMap* textEncodingNameMap WTF_GUARDED_BY_LOCK(encodingRegistryLock);
-static TextCodecMap* textCodecMap WTF_GUARDED_BY_LOCK(encodingRegistryLock);
+static TextEncodingNameMap& textEncodingNameMap() WTF_REQUIRES_LOCK(encodingRegistryLock)
+{
+    static NeverDestroyed<TextEncodingNameMap> textEncodingNameMap;
+    return textEncodingNameMap;
+}
+static TextCodecMap& textCodecMap() WTF_REQUIRES_LOCK(encodingRegistryLock)
+{
+    static NeverDestroyed<TextCodecMap> textCodecMap;
+    return textCodecMap;
+}
 static bool didExtendTextCodecMaps;
-static HashSet<ASCIILiteral>* japaneseEncodings;
-static HashSet<ASCIILiteral>* nonBackslashEncodings;
+
+static HashSet<ASCIILiteral>& japaneseEncodings()
+{
+    static NeverDestroyed<HashSet<ASCIILiteral>> japaneseEncodings;
+    return japaneseEncodings;
+}
+
+static HashSet<ASCIILiteral>& nonBackslashEncodings()
+{
+    static NeverDestroyed<HashSet<ASCIILiteral>> nonBackslashEncodings;
+    return nonBackslashEncodings;
+}
 
 static constexpr ASCIILiteral textEncodingNameBlocklist[] = { "UTF-7"_s, "BOCU-1"_s, "SCSU"_s };
 
@@ -139,50 +158,51 @@ static void addToTextEncodingNameMap(ASCIILiteral alias, ASCIILiteral name) WTF_
     ASSERT(alias.length() <= maxEncodingNameLength);
     if (isUndesiredAlias(alias))
         return;
-    ASCIILiteral atomName = textEncodingNameMap->get(name);
+
+    auto& textEncodingNameMap = PAL::textEncodingNameMap();
+    ASCIILiteral atomName = textEncodingNameMap.get(name);
     ASSERT((alias == name) || !atomName.isNull());
     if (atomName.isNull())
         atomName = name;
 
-    ASSERT_WITH_MESSAGE(textEncodingNameMap->get(alias).isNull(), "Duplicate text encoding name %s for %s (previously registered as %s)", alias.characters(), atomName.characters(), textEncodingNameMap->get(alias).characters());
+    ASSERT_WITH_MESSAGE(textEncodingNameMap.get(alias).isNull(), "Duplicate text encoding name %s for %s (previously registered as %s)", alias.characters(), atomName.characters(), textEncodingNameMap.get(alias).characters());
 
-    textEncodingNameMap->add(alias, atomName);
+    textEncodingNameMap.add(alias, atomName);
 }
 
 static void addToTextCodecMap(ASCIILiteral name, NewTextCodecFunction&& function) WTF_REQUIRES_LOCK(encodingRegistryLock)
 {
-    ASCIILiteral atomName = textEncodingNameMap->get(name);
+    ASCIILiteral atomName = textEncodingNameMap().get(name);
     ASSERT(!atomName.isNull());
-    textCodecMap->add(atomName, WTFMove(function));
+    textCodecMap().add(atomName, WTFMove(function));
 }
 
 static void pruneBlocklistedCodecs() WTF_REQUIRES_LOCK(encodingRegistryLock)
 {
+    auto& textEncodingNameMap = PAL::textEncodingNameMap();
+    auto& textCodecMap = PAL::textCodecMap();
     for (auto& nameFromBlocklist : textEncodingNameBlocklist) {
-        ASCIILiteral atomName = textEncodingNameMap->get(nameFromBlocklist);
+        ASCIILiteral atomName = textEncodingNameMap.get(nameFromBlocklist);
         if (atomName.isNull())
             continue;
 
         Vector<ASCIILiteral> names;
-        for (auto& entry : *textEncodingNameMap) {
+        for (auto& entry : textEncodingNameMap) {
             if (entry.value == atomName)
                 names.append(entry.key);
         }
 
         for (auto& name : names)
-            textEncodingNameMap->remove(name);
+            textEncodingNameMap.remove(name);
 
-        textCodecMap->remove(atomName);
+        textCodecMap.remove(atomName);
     }
 }
 
 static void buildBaseTextCodecMaps() WTF_REQUIRES_LOCK(encodingRegistryLock)
 {
-    ASSERT(!textCodecMap);
-    ASSERT(!textEncodingNameMap);
-
-    textCodecMap = new TextCodecMap;
-    textEncodingNameMap = new TextEncodingNameMap;
+    ASSERT(textCodecMap().isEmpty());
+    ASSERT(textEncodingNameMap().isEmpty());
 
     TextCodecLatin1::registerEncodingNames(addToTextEncodingNameMap);
     TextCodecLatin1::registerCodecs(addToTextCodecMap);
@@ -200,7 +220,7 @@ static void buildBaseTextCodecMaps() WTF_REQUIRES_LOCK(encodingRegistryLock)
 static void addEncodingName(HashSet<ASCIILiteral>& set, ASCIILiteral name) WTF_REQUIRES_LOCK(encodingRegistryLock)
 {
     // We must not use atomCanonicalTextEncodingName() because this function is called in it.
-    ASCIILiteral atomName = textEncodingNameMap->get(name);
+    ASCIILiteral atomName = textEncodingNameMap().get(name);
     if (!atomName.isNull())
         set.add(atomName);
 }
@@ -210,44 +230,45 @@ static void buildQuirksSets() WTF_REQUIRES_LOCK(encodingRegistryLock)
     // FIXME: Having isJapaneseEncoding() and shouldShowBackslashAsCurrencySymbolIn()
     // and initializing the sets for them in TextEncodingRegistry.cpp look strange.
 
-    ASSERT(!japaneseEncodings);
-    ASSERT(!nonBackslashEncodings);
+    auto& japaneseEncodings = PAL::japaneseEncodings();
+    auto& nonBackslashEncodings = PAL::nonBackslashEncodings();
 
-    japaneseEncodings = new HashSet<ASCIILiteral>;
-    addEncodingName(*japaneseEncodings, "EUC-JP"_s);
-    addEncodingName(*japaneseEncodings, "ISO-2022-JP"_s);
-    addEncodingName(*japaneseEncodings, "ISO-2022-JP-1"_s);
-    addEncodingName(*japaneseEncodings, "ISO-2022-JP-2"_s);
-    addEncodingName(*japaneseEncodings, "ISO-2022-JP-3"_s);
-    addEncodingName(*japaneseEncodings, "JIS_C6226-1978"_s);
-    addEncodingName(*japaneseEncodings, "JIS_X0201"_s);
-    addEncodingName(*japaneseEncodings, "JIS_X0208-1983"_s);
-    addEncodingName(*japaneseEncodings, "JIS_X0208-1990"_s);
-    addEncodingName(*japaneseEncodings, "JIS_X0212-1990"_s);
-    addEncodingName(*japaneseEncodings, "Shift_JIS"_s);
-    addEncodingName(*japaneseEncodings, "Shift_JIS_X0213-2000"_s);
-    addEncodingName(*japaneseEncodings, "cp932"_s);
-    addEncodingName(*japaneseEncodings, "x-mac-japanese"_s);
+    ASSERT(japaneseEncodings.isEmpty());
+    ASSERT(nonBackslashEncodings.isEmpty());
 
-    nonBackslashEncodings = new HashSet<ASCIILiteral>;
+    addEncodingName(japaneseEncodings, "EUC-JP"_s);
+    addEncodingName(japaneseEncodings, "ISO-2022-JP"_s);
+    addEncodingName(japaneseEncodings, "ISO-2022-JP-1"_s);
+    addEncodingName(japaneseEncodings, "ISO-2022-JP-2"_s);
+    addEncodingName(japaneseEncodings, "ISO-2022-JP-3"_s);
+    addEncodingName(japaneseEncodings, "JIS_C6226-1978"_s);
+    addEncodingName(japaneseEncodings, "JIS_X0201"_s);
+    addEncodingName(japaneseEncodings, "JIS_X0208-1983"_s);
+    addEncodingName(japaneseEncodings, "JIS_X0208-1990"_s);
+    addEncodingName(japaneseEncodings, "JIS_X0212-1990"_s);
+    addEncodingName(japaneseEncodings, "Shift_JIS"_s);
+    addEncodingName(japaneseEncodings, "Shift_JIS_X0213-2000"_s);
+    addEncodingName(japaneseEncodings, "cp932"_s);
+    addEncodingName(japaneseEncodings, "x-mac-japanese"_s);
+
     // The text encodings below treat backslash as a currency symbol for IE compatibility.
     // See http://blogs.msdn.com/michkap/archive/2005/09/17/469941.aspx for more information.
-    addEncodingName(*nonBackslashEncodings, "x-mac-japanese"_s);
-    addEncodingName(*nonBackslashEncodings, "ISO-2022-JP"_s);
-    addEncodingName(*nonBackslashEncodings, "EUC-JP"_s);
+    addEncodingName(nonBackslashEncodings, "x-mac-japanese"_s);
+    addEncodingName(nonBackslashEncodings, "ISO-2022-JP"_s);
+    addEncodingName(nonBackslashEncodings, "EUC-JP"_s);
     // Shift_JIS_X0213-2000 is not the same encoding as Shift_JIS on Mac. We need to register both of them.
-    addEncodingName(*nonBackslashEncodings, "Shift_JIS"_s);
-    addEncodingName(*nonBackslashEncodings, "Shift_JIS_X0213-2000"_s);
+    addEncodingName(nonBackslashEncodings, "Shift_JIS"_s);
+    addEncodingName(nonBackslashEncodings, "Shift_JIS_X0213-2000"_s);
 }
 
 bool isJapaneseEncoding(ASCIILiteral canonicalEncodingName)
 {
-    return !canonicalEncodingName.isNull() && japaneseEncodings && japaneseEncodings->contains(canonicalEncodingName);
+    return !canonicalEncodingName.isNull() && japaneseEncodings().contains(canonicalEncodingName);
 }
 
 bool shouldShowBackslashAsCurrencySymbolIn(ASCIILiteral canonicalEncodingName)
 {
-    return !canonicalEncodingName.isNull() && nonBackslashEncodings && nonBackslashEncodings->contains(canonicalEncodingName);
+    return !canonicalEncodingName.isNull() && nonBackslashEncodings().contains(canonicalEncodingName);
 }
 
 static void extendTextCodecMaps() WTF_REQUIRES_LOCK(encodingRegistryLock)
@@ -272,13 +293,14 @@ std::unique_ptr<TextCodec> newTextCodec(const TextEncoding& encoding)
 {
     Locker locker { encodingRegistryLock };
 
-    ASSERT(textCodecMap);
+    auto& textCodecMap = PAL::textCodecMap();
+    ASSERT(!textCodecMap.isEmpty());
     if (!encoding.isValid()) {
         RELEASE_LOG_ERROR(TextEncoding, "Trying to create new text codec with invalid (null) encoding name. Will default to UTF-8.");
         return TextCodecUTF8::codec();
     }
-    auto result = textCodecMap->find(encoding.name());
-    if (result == textCodecMap->end()) {
+    auto result = textCodecMap.find(encoding.name());
+    if (result == textCodecMap.end()) {
         RELEASE_LOG_ERROR(TextEncoding, "Can't find codec for valid encoding %" PUBLIC_LOG_STRING ". Will default to UTF-8.", encoding.name().characters());
         return TextCodecUTF8::codec();
     }
@@ -296,17 +318,18 @@ static ASCIILiteral atomCanonicalTextEncodingName(std::span<const LChar> name)
 
     Locker locker { encodingRegistryLock };
 
-    if (!textEncodingNameMap)
+    if (textEncodingNameMap().isEmpty())
         buildBaseTextCodecMaps();
 
-    if (ASCIILiteral atomName = textEncodingNameMap->get<HashTranslatorTextEncodingName>(name))
+    auto& textEncodingNameMap = PAL::textEncodingNameMap();
+    if (ASCIILiteral atomName = textEncodingNameMap.get<HashTranslatorTextEncodingName>(name))
         return atomName;
     if (didExtendTextCodecMaps)
         return { };
 
     extendTextCodecMaps();
     didExtendTextCodecMaps = true;
-    return textEncodingNameMap->get<HashTranslatorTextEncodingName>(name);
+    return textEncodingNameMap.get<HashTranslatorTextEncodingName>(name);
 }
 
 static ASCIILiteral atomCanonicalTextEncodingName(std::span<const UChar> characters)


### PR DESCRIPTION
#### 25c204edc004c12a101256aaa66096038d3d0196
<pre>
Stop using pointers to HashMap / HashSet in TextEncodingRegistry.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=295166">https://bugs.webkit.org/show_bug.cgi?id=295166</a>

Reviewed by Darin Adler.

Stop using pointers to HashMap / HashSet in TextEncodingRegistry.cpp. This is a bit
of an anti-pattern since a HashMap/HashSet is already itself a pointer to a HashTable.

* Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp:
(PAL::WTF_REQUIRES_LOCK):
(PAL::japaneseEncodings):
(PAL::nonBackslashEncodings):
(PAL::isJapaneseEncoding):
(PAL::shouldShowBackslashAsCurrencySymbolIn):
(PAL::newTextCodec):
(PAL::atomCanonicalTextEncodingName):

Canonical link: <a href="https://commits.webkit.org/296783@main">https://commits.webkit.org/296783@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/815f51425e3d031c40f31af4d9926cf25beca097

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109593 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29251 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19680 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/115574 "Build was cancelled. Recent messages:Printed configuration") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/59819 "Build was cancelled. Recent messages:Printed configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111556 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29929 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37839 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/115574 "Build was cancelled. Recent messages:Printed configuration") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/59819 "Build was cancelled. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112541 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23840 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98703 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/115574 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23219 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16847 "Found 1 new test failure: imported/w3c/web-platform-tests/mimesniff/media/media-sniff.window.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59409 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93215 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16886 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/118372 "Build was cancelled. Recent messages:Failed to print configuration") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36632 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27122 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/118372 "Build was cancelled. Recent messages:Failed to print configuration") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37005 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94963 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/118372 "Build was cancelled. Recent messages:Failed to print configuration") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37063 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14810 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32444 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17681 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36526 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41997 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36186 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39529 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37896 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->