### PR TITLE
[Model Element] Enforce a default memory limit on entity loads

### DIFF
--- a/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.cpp
+++ b/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.cpp
@@ -233,6 +233,11 @@ bool ModelConnectionToWebProcess::isAlwaysOnLoggingAllowed() const
     return m_sessionID.isAlwaysOnLoggingAllowed() || m_sharedPreferencesForWebProcess.allowPrivacySensitiveOperationsInNonPersistentDataStores;
 }
 
+std::optional<int> ModelConnectionToWebProcess::debugEntityMemoryLimit() const
+{
+    return m_modelProcess->debugEntityMemoryLimit();
+}
+
 } // namespace WebKit
 
 #undef MESSAGE_CHECK

--- a/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h
+++ b/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h
@@ -107,6 +107,7 @@ public:
     bool isAlwaysOnLoggingAllowed() const;
 
     const std::optional<String> attributionTaskID() const { return m_attributionTaskID; };
+    std::optional<int> debugEntityMemoryLimit() const;
 
 private:
     ModelConnectionToWebProcess(ModelProcess&, WebCore::ProcessIdentifier, PAL::SessionID, IPC::Connection::Handle&&, ModelProcessConnectionParameters&&, const std::optional<String>&);

--- a/Source/WebKit/ModelProcess/ModelProcess.cpp
+++ b/Source/WebKit/ModelProcess/ModelProcess.cpp
@@ -199,6 +199,7 @@ void ModelProcess::initializeModelProcess(ModelProcessCreationParameters&& param
 {
     CompletionHandlerCallingScope callCompletionHandler(WTFMove(completionHandler));
 
+    m_debugEntityMemoryLimit = parameters.debugEntityMemoryLimit;
     WKREEngine::enableRestrictiveRenderingMode(parameters.restrictiveRenderingMode);
 
     applyProcessCreationParameters(WTFMove(parameters.auxiliaryProcessParameters));

--- a/Source/WebKit/ModelProcess/ModelProcess.h
+++ b/Source/WebKit/ModelProcess/ModelProcess.h
@@ -80,6 +80,7 @@ public:
 #if PLATFORM(VISION) && ENABLE(GPU_PROCESS)
     void requestSharedSimulationConnection(WebCore::ProcessIdentifier, CompletionHandler<void(std::optional<IPC::SharedFileHandle>)>&&);
 #endif
+    std::optional<int> debugEntityMemoryLimit() const { return m_debugEntityMemoryLimit; }
 
     void webProcessConnectionCountForTesting(CompletionHandler<void(uint64_t)>&&);
     void modelPlayerCountForTesting(CompletionHandler<void(uint64_t)>&&);
@@ -118,6 +119,7 @@ private:
 
     WebCore::Timer m_idleExitTimer;
     String m_applicationVisibleName;
+    std::optional<int> m_debugEntityMemoryLimit;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/ModelProcess/ModelProcessCreationParameters.h
+++ b/Source/WebKit/ModelProcess/ModelProcessCreationParameters.h
@@ -37,6 +37,7 @@ struct ModelProcessCreationParameters {
     ProcessID parentPID;
     String applicationVisibleName;
     bool restrictiveRenderingMode { false };
+    std::optional<int> debugEntityMemoryLimit;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/ModelProcess/ModelProcessCreationParameters.serialization.in
+++ b/Source/WebKit/ModelProcess/ModelProcessCreationParameters.serialization.in
@@ -29,6 +29,7 @@ headers: "ModelProcessCreationParameters.h" "AuxiliaryProcessCreationParameters.
     ProcessID parentPID;
     String applicationVisibleName;
     bool restrictiveRenderingMode;
+    std::optional<int> debugEntityMemoryLimit;
 };
 
 #endif

--- a/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.cpp
+++ b/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.cpp
@@ -69,7 +69,7 @@ void ModelProcessModelPlayerManagerProxy::createModelPlayer(WebCore::ModelPlayer
     ASSERT(m_modelConnectionToWebProcess);
     ASSERT(!m_proxies.contains(identifier));
 
-    auto proxy = ModelProcessModelPlayerProxy::create(*this, identifier, m_modelConnectionToWebProcess->protectedConnection(), m_modelConnectionToWebProcess->attributionTaskID());
+    auto proxy = ModelProcessModelPlayerProxy::create(*this, identifier, m_modelConnectionToWebProcess->protectedConnection(), m_modelConnectionToWebProcess->attributionTaskID(), m_modelConnectionToWebProcess->debugEntityMemoryLimit());
     m_proxies.add(identifier, WTFMove(proxy));
 }
 

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -69,7 +69,7 @@ class ModelProcessModelPlayerProxy final
     , private IPC::MessageReceiver {
     WTF_MAKE_TZONE_ALLOCATED(ModelProcessModelPlayerProxy);
 public:
-    static Ref<ModelProcessModelPlayerProxy> create(ModelProcessModelPlayerManagerProxy&, WebCore::ModelPlayerIdentifier, Ref<IPC::Connection>&&, const std::optional<String>&);
+    static Ref<ModelProcessModelPlayerProxy> create(ModelProcessModelPlayerManagerProxy&, WebCore::ModelPlayerIdentifier, Ref<IPC::Connection>&&, const std::optional<String>&, std::optional<int> debugEntityMemoryLimit);
     ~ModelProcessModelPlayerProxy();
 
     void ref() const final { WebCore::ModelPlayer::ref(); }
@@ -148,7 +148,7 @@ public:
     static uint64_t objectCountForTesting() { return gObjectCountForTesting; }
 
 private:
-    ModelProcessModelPlayerProxy(ModelProcessModelPlayerManagerProxy&, WebCore::ModelPlayerIdentifier, Ref<IPC::Connection>&&, const std::optional<String>&);
+    ModelProcessModelPlayerProxy(ModelProcessModelPlayerManagerProxy&, WebCore::ModelPlayerIdentifier, Ref<IPC::Connection>&&, const std::optional<String>&, std::optional<int> debugEntityMemoryLimit);
 
     void computeTransform(bool);
     void updateTransform();
@@ -194,6 +194,7 @@ private:
     WebCore::StageModeOperation m_stageModeOperation { WebCore::StageModeOperation::None };
 
     std::optional<String> m_attributionTaskID;
+    std::optional<int> m_debugEntityMemoryLimit;
     std::optional<WebCore::TransformationMatrix> m_entityTransformToRestore;
     std::optional<WebCore::ModelPlayerAnimationState> m_animationStateToRestore;
     RunLoop::Timer m_unloadModelTimer;

--- a/Source/WebKit/UIProcess/Model/cocoa/ModelProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Model/cocoa/ModelProcessProxyCocoa.mm
@@ -47,6 +47,11 @@ void ModelProcessProxy::updateModelProcessCreationParameters(ModelProcessCreatio
     if ([value isKindOfClass:NSNumber.class] || [value isKindOfClass:NSString.class])
         enableRestrictiveRenderingMode = [NSUserDefaults.standardUserDefaults boolForKey:debugFlag];
     parameters.restrictiveRenderingMode = enableRestrictiveRenderingMode;
+
+    NSString * const memoryLimitFlag = @"WebKitDebugModelEntityMemoryLimit";
+    value = [NSUserDefaults.standardUserDefaults objectForKey:memoryLimitFlag];
+    if ([value isKindOfClass:NSNumber.class])
+        parameters.debugEntityMemoryLimit = [value integerValue];
 }
 
 void ModelProcessProxy::requestSharedSimulationConnection(WebCore::ProcessIdentifier webProcessIdentifier, CompletionHandler<void(std::optional<IPC::SharedFileHandle>)>&& completionHandler)

--- a/Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.h
+++ b/Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.h
@@ -67,7 +67,7 @@ NS_SWIFT_UI_ACTOR
 @property (nonatomic) NSTimeInterval currentTime;
 
 + (BOOL)isLoadFromDataAvailable;
-+ (void)loadFromData:(NSData *)data withAttributionTaskID:(nullable NSString *)attributionTaskId completionHandler:(NS_SWIFT_UI_ACTOR void (^)(WKRKEntity * _Nullable entity))completionHandler;
++ (void)loadFromData:(NSData *)data withAttributionTaskID:(nullable NSString *)attributionTaskId entityMemoryLimit:(NSInteger)entityMemoryLimit completionHandler:(NS_SWIFT_UI_ACTOR void (^)(WKRKEntity * _Nullable entity))completionHandler;
 - (instancetype)initWithCoreEntity:(REEntityRef)coreEntity;
 - (void)setParentCoreEntity:(REEntityRef)parentCoreEntity preservingWorldTransform:(BOOL)preservingWorldTransform;
 - (void)setUpAnimationWithAutoPlay:(BOOL)autoPlay;

--- a/Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.swift
+++ b/Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.swift
@@ -56,13 +56,17 @@ extension WKRKEntity {
 #endif
     }
 
-    @objc(loadFromData:withAttributionTaskID:completionHandler:)
-    class func load(from data: Data, withAttributionTaskID attributionTaskId: String?) async -> WKRKEntity? {
+    @objc(loadFromData:withAttributionTaskID:entityMemoryLimit:completionHandler:)
+    class func load(from data: Data, withAttributionTaskID attributionTaskId: String?, entityMemoryLimit: Int) async -> WKRKEntity? {
 #if canImport(RealityKit, _version: "403.0.3")
         do {
             var loadOptions = Entity.__LoadOptions()
             if let attributionTaskId {
                 loadOptions.memoryAttributionID = attributionTaskId
+            }
+            if entityMemoryLimit > 0 {
+                loadOptions.enforceMemoryConstraints = true
+                loadOptions.memoryLimit = entityMemoryLimit * 1024 * 1024
             }
 #if canImport(RealityKit, _version: "403.0.9")
             loadOptions.featuresToSkip = [.audio]


### PR DESCRIPTION
#### c0d5482e12f00b4dfb45eeadafe5ae738891cdc0
<pre>
[Model Element] Enforce a default memory limit on entity loads
<a href="https://bugs.webkit.org/show_bug.cgi?id=295167">https://bugs.webkit.org/show_bug.cgi?id=295167</a>
<a href="https://rdar.apple.com/145610624">rdar://145610624</a>

Reviewed by Mike Wyrzykowski.

Specify enforceMemoryConstraints and memoryLimit in load options when loading
the model entities. The default memory limit that ModelProcessModelPlayerProxy
uses is 100MB. For testing/debugging purposes, this memory limit can be
overridden with the WebKitDebugModelEntityMemoryLimit runtime default.

* Source/WebKit/ModelProcess/ModelConnectionToWebProcess.cpp:
(WebKit::ModelConnectionToWebProcess::debugEntityMemoryLimit const):
* Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h:
* Source/WebKit/ModelProcess/ModelProcess.cpp:
(WebKit::ModelProcess::initializeModelProcess):
Store the entity memory limit from the model process creation parameters.
* Source/WebKit/ModelProcess/ModelProcess.h:
* Source/WebKit/ModelProcess/ModelProcessCreationParameters.h:
* Source/WebKit/ModelProcess/ModelProcessCreationParameters.serialization.in:
* Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.cpp:
(WebKit::ModelProcessModelPlayerManagerProxy::createModelPlayer):
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::RKModelLoaderUSD::load):
Pass the entity memory limit to -[WKRKEntity loadFromData:...]. If no
memory limit is specified, pass in 0 to tell WKRKEntity to load without limit.
(WebKit::loadREModelUsingRKUSDLoader):
(WebKit::ModelProcessModelPlayerProxy::create):
(WebKit::ModelProcessModelPlayerProxy::ModelProcessModelPlayerProxy):
(WebKit::ModelProcessModelPlayerProxy::load):
Pass the entity memory limit to loadREModelUsingRKUSDLoader(). If no memory
limit is set, pass in the default which is 100MB.
* Source/WebKit/UIProcess/Model/cocoa/ModelProcessProxyCocoa.mm:
(WebKit::ModelProcessProxy::updateModelProcessCreationParameters):
* Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.h:
* Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.swift:
(WKRKEntity.load(from:withAttributionTaskID:entityMemoryLimit:)):
(WKRKEntity.load(from:withAttributionTaskID:)): Deleted.

Canonical link: <a href="https://commits.webkit.org/296796@main">https://commits.webkit.org/296796@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5eea27c10851c74880246ad34052b1810a05eeb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115643 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59856 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29927 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37837 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83298 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112539 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23837 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98700 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63757 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23216 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59407 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93212 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16883 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118436 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36630 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27120 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92306 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37003 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94960 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92127 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23471 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37060 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14807 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32440 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36524 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41995 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36184 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39527 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37894 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->