### PR TITLE
[Liquid Glass] [macOS] Safari UI background fill is clipped when attaching web inspector view on the left or right side

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3123,6 +3123,30 @@ static WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::Fixe
 
 #endif // ENABLE(PDF_PAGE_NUMBER_INDICATOR)
 
+- (RetainPtr<WKWebView>)_horizontallyAttachedInspectorWebView
+{
+    RefPtr inspector = _page->inspector();
+    if (!inspector)
+        return nil;
+
+    if (!inspector->isAttached())
+        return nil;
+
+    switch (inspector->attachmentSide()) {
+    case WebKit::AttachmentSide::Bottom:
+        return nil;
+    case WebKit::AttachmentSide::Right:
+    case WebKit::AttachmentSide::Left:
+        break;
+    }
+
+    RefPtr inspectorPage = inspector->inspectorPage();
+    if (!inspectorPage)
+        return nil;
+
+    return inspectorPage->cocoaView();
+}
+
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
 
 - (void)_updateTopScrollPocketCaptureColor
@@ -3290,6 +3314,24 @@ static WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::Fixe
     _impl->updateScrollPocket();
 #endif
 }
+
+#if PLATFORM(MAC)
+
+- (BOOL)_alwaysPrefersSolidColorHardPocket
+{
+    return _alwaysPrefersSolidColorHardPocket;
+}
+
+- (void)_setAlwaysPrefersSolidColorHardPocket:(BOOL)value
+{
+    if (_alwaysPrefersSolidColorHardPocket == value)
+        return;
+
+    _alwaysPrefersSolidColorHardPocket = value;
+    _impl->updatePrefersSolidColorHardPocket();
+}
+
+#endif // PLATFORM(MAC)
 
 - (BOOL)_hasVisibleColorExtensionView:(WebCore::BoxSide)side
 {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -283,6 +283,7 @@ struct PerWebProcessState {
     BOOL _usesAutomaticContentInsetBackgroundFill;
     BOOL _shouldSuppressTopColorExtensionView;
 #if PLATFORM(MAC)
+    BOOL _alwaysPrefersSolidColorHardPocket;
     RetainPtr<NSColor> _overrideTopScrollEdgeEffectColor;
 #endif
 
@@ -587,7 +588,13 @@ struct PerWebProcessState {
 - (void)_updateHiddenScrollPocketEdges;
 #endif
 
+#if PLATFORM(MAC) && ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+@property (nonatomic, setter=_setAlwaysPrefersSolidColorHardPocket:) BOOL _alwaysPrefersSolidColorHardPocket;
+#endif
+
 @property (nonatomic, setter=_setHasActiveNowPlayingSession:) BOOL _hasActiveNowPlayingSession;
+
+@property (nonatomic, readonly) RetainPtr<WKWebView> _horizontallyAttachedInspectorWebView;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1624,6 +1624,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
     _impl->updateTopScrollPocketStyle();
     _impl->updateScrollPocketVisibilityWhenScrolledToTop();
+    _impl->updateTopScrollPocketCaptureColor();
 #endif
 }
 

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
@@ -34,6 +34,7 @@
 #include "APIUIClient.h"
 #include "InspectorBrowserAgent.h"
 #include "MessageSenderInlines.h"
+#include "PageClient.h"
 #include "WebAutomationSession.h"
 #include "WebFrameProxy.h"
 #include "WebInspectorInterruptDispatcherMessages.h"
@@ -344,6 +345,8 @@ void WebInspectorUIProxy::attach(AttachmentSide side)
     }
 
     platformAttach();
+
+    dispatchDidChangeLocalInspectorAttachment();
 }
 
 void WebInspectorUIProxy::detach()
@@ -360,6 +363,8 @@ void WebInspectorUIProxy::detach()
     protectedInspectorPage()->protectedLegacyMainFrameProcess()->send(Messages::WebInspectorUI::Detached(), m_inspectorPage->webPageIDInMainFrameProcess());
 
     platformDetach();
+
+    dispatchDidChangeLocalInspectorAttachment();
 }
 
 void WebInspectorUIProxy::setAttachedWindowHeight(unsigned height)
@@ -525,6 +530,8 @@ void WebInspectorUIProxy::openLocalInspectorFrontend()
             inspectorPageProcess->send(Messages::WebInspectorUI::Detached(), inspectorPage->webPageIDInMainFrameProcess());
 
         inspectorPageProcess->send(Messages::WebInspectorUI::SetDockingUnavailable(!m_canAttach), inspectorPage->webPageIDInMainFrameProcess());
+
+        dispatchDidChangeLocalInspectorAttachment();
     }
 
     // Notify clients when a local inspector attaches so that it may install delegates prior to the _WKInspector loading its frontend.
@@ -565,6 +572,8 @@ void WebInspectorUIProxy::open()
     }
 
     platformBringToFront();
+
+    dispatchDidChangeLocalInspectorAttachment();
 }
 
 void WebInspectorUIProxy::didClose()
@@ -627,6 +636,8 @@ void WebInspectorUIProxy::closeFrontendPageAndWindow()
     m_canAttach = false;
 
     platformCloseFrontendPageAndWindow();
+
+    dispatchDidChangeLocalInspectorAttachment();
 }
 
 void WebInspectorUIProxy::sendMessageToBackend(const String& message)
@@ -863,6 +874,19 @@ RefPtr<WebInspectorUIExtensionControllerProxy> WebInspectorUIProxy::protectedExt
     return extensionController();
 }
 #endif
+
+void WebInspectorUIProxy::dispatchDidChangeLocalInspectorAttachment()
+{
+    RefPtr inspectedPage = m_inspectedPage.get();
+    if (!inspectedPage)
+        return;
+
+    RefPtr pageClient = inspectedPage->pageClient();
+    if (!pageClient)
+        return;
+
+    pageClient->didChangeLocalInspectorAttachment();
+}
 
 // Unsupported configurations can use the stubs provided here.
 

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
@@ -84,7 +84,7 @@ class WebPreferences;
 class WebInspectorUIExtensionControllerProxy;
 #endif
 
-enum class AttachmentSide {
+enum class AttachmentSide : uint8_t {
     Bottom,
     Right,
     Left,
@@ -224,6 +224,8 @@ private:
     void createFrontendPage();
     void closeFrontendPageAndWindow();
 
+    void dispatchDidChangeLocalInspectorAttachment();
+
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
@@ -340,7 +342,7 @@ private:
     bool m_isOpening { false };
     bool m_closing { false };
 
-    AttachmentSide m_attachmentSide {AttachmentSide::Bottom};
+    AttachmentSide m_attachmentSide { AttachmentSide::Bottom };
 
 #if PLATFORM(MAC)
     RetainPtr<WKInspectorViewController> m_inspectorViewController;

--- a/Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm
@@ -93,6 +93,11 @@
     return self.protectedInspectorProxy->isUnderTest();
 }
 
+- (BOOL)inspectorViewControllerInspectorIsHorizontallyAttached:(WKInspectorViewController *)inspectorViewController
+{
+    return NO;
+}
+
 @end
 
 namespace WebKit {

--- a/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.h
+++ b/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.h
@@ -48,6 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (BOOL)viewIsInspectorWebView:(NSView *)view;
 + (NSURL * _Nullable)URLForInspectorResource:(NSString *)resource;
+- (void)didAttachOrDetach;
 
 @end
 
@@ -56,6 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)inspectorViewControllerDidBecomeActive:(WKInspectorViewController *)inspectorViewController;
 - (void)inspectorViewControllerInspectorDidCrash:(WKInspectorViewController *)inspectorViewController;
 - (BOOL)inspectorViewControllerInspectorIsUnderTest:(WKInspectorViewController *)inspectorViewController;
+- (BOOL)inspectorViewControllerInspectorIsHorizontallyAttached:(WKInspectorViewController *)inspectorViewController;
 - (void)inspectorViewController:(WKInspectorViewController *)inspectorViewController willMoveToWindow:(NSWindow *)newWindow;
 - (void)inspectorViewControllerDidMoveToWindow:(WKInspectorViewController *)inspectorViewController;
 - (void)inspectorViewController:(WKInspectorViewController *)inspectorViewController openURLExternally:(NSURL *)url;

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -706,6 +706,8 @@ public:
 
     virtual WebCore::UserInterfaceLayoutDirection userInterfaceLayoutDirection() = 0;
 
+    virtual void didChangeLocalInspectorAttachment() { }
+
 #if USE(QUICK_LOOK)
     virtual void requestPasswordForQuickLookDocument(const String& fileName, WTF::Function<void(const String&)>&&) = 0;
 #endif

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -119,6 +119,8 @@ private:
     void clearBrowsingWarningIfForMainFrameNavigation() override;
     bool hasBrowsingWarning() const override;
 
+    void didChangeLocalInspectorAttachment() final;
+
     bool showShareSheet(WebCore::ShareDataWithParsedURL&&, WTF::CompletionHandler<void(bool)>&&) override;
 
 #if HAVE(DIGITAL_CREDENTIALS_UI)

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -1145,6 +1145,13 @@ void PageClientImpl::cancelTextRecognitionForVideoInElementFullscreen()
     checkedImpl()->cancelTextRecognitionForVideoInElementFullscreen();
 }
 
+void PageClientImpl::didChangeLocalInspectorAttachment()
+{
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+    m_impl->updateScrollPocket();
+#endif
+}
+
 } // namespace WebKit
 
 #endif // PLATFORM(MAC)


### PR DESCRIPTION
#### 79d58a6856afda9361c92ad6aaad75a0a49f677d
<pre>
[Liquid Glass] [macOS] Safari UI background fill is clipped when attaching web inspector view on the left or right side
<a href="https://bugs.webkit.org/show_bug.cgi?id=295169">https://bugs.webkit.org/show_bug.cgi?id=295169</a>
<a href="https://rdar.apple.com/153388693">rdar://153388693</a>

Reviewed by Abrar Rahman Protyasha.

Currently, when Liquid Glass is enabled, revealing Web Inspector attached to the left or right of
the web view in Safari causes the background color fill in the tab bar to become clipped (the color
in the tab bar above the web view is either the background color or top fixed color, while the color
above the inspector web view is the system background color). This happens because the scroll pocket
(scroll edge effect) in the obscured inset area of the web view only matches the width of the web
view, and is additionally clipped by the web view&apos;s parent view.

To fix this, we add a mechanism to let the inspector web view pull a solid scroll pocket capture
color directly from the attached inspected web view, and keep the capture color up to date if it
changes in the original web view. See below for more details.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _horizontallyAttachedInspectorWebView]):

Add a helper method to get the attached web inspector web view from the inspected `WKWebView`.

(-[WKWebView _alwaysPrefersSolidColorHardPocket]):
(-[WKWebView _setAlwaysPrefersSolidColorHardPocket:]):

Add a property to force `-[NSScrollPocket prefersSolidColorHardPocket]` to `YES` on the inspected
web view&apos;s pocket, only when it&apos;s docked to the left or right. This allows the magic pocket (and
thus, the background of the tab bar) to be a solid color equal to the inspected web view&apos;s pocket
capture color.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _setUsesAutomaticContentInsetBackgroundFill:]):

Drive-by fix: update the scroll pocket capture color when the pocket style (hard vs. soft) changes.
This currently gets stale when changing from soft -&gt; hard pocket style.

* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp:
(WebKit::WebInspectorUIProxy::attach):
(WebKit::WebInspectorUIProxy::detach):
(WebKit::WebInspectorUIProxy::openLocalInspectorFrontend):
(WebKit::WebInspectorUIProxy::open):
(WebKit::WebInspectorUIProxy::closeFrontendPageAndWindow):
(WebKit::WebInspectorUIProxy::dispatchDidChangeLocalInspectorAttachment):

Add a mechanism to call into the inspected page when the local inspector&apos;s attachment state (i.e.
attachment side, or whether it&apos;s attached at all) changes. This is necessary to expand the pocket
bounds of the inspected web view to encompass the inspector web view as well; despite being inside
of a clipped parent view, this is necessary for glass elements above the web view&apos;s scroll pocket to
adapt correctly to the background color of the scroll pocket in the Safari UI.

* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h:
* Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm:
(-[WKRemoteWebInspectorUIProxyObjCAdapter inspectorViewControllerInspectorIsHorizontallyAttached:]):

Add a delegate hook that returns whether or not the inspector web view is attached to the left or
right of the inspected web view.

* Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.h:
* Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm:
(-[WKInspectorViewController didAttachOrDetach]):

Whenever the inspector view is attached or detached, update the inspector web view&apos;s scroll pocket
state so that it pulls the initial color of the inspected web view&apos;s scroll pocket capture color,
using the capture color override, as well as the new `_alwaysPrefersSolidColorHardPocket` property.

(-[WKInspectorViewController _horizontallyAttachedInspectedWebView]):

Add a helper method to get the attached inspected web view, from the inspector web view.

* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
(-[WKWebInspectorUIProxyObjCAdapter inspectorViewControllerInspectorIsHorizontallyAttached:]):
(WebKit::WebInspectorUIProxy::platformCreateFrontendPage):
(WebKit::WebInspectorUIProxy::inspectedViewFrameDidChange):

When &quot;content inset background fill&quot; is enabled (i.e. the Liquid Glass runtime flag), allow the
bounds of the web inspector view to extend to match the full height of the inspected web view. The
existing infrastructure of applying safe area insets to the obscured content insets of the web view
allows the inspector web view to still dodge the Safari UI, even when it&apos;s full height.

(WebKit::WebInspectorUIProxy::platformAttach):
(WebKit::WebInspectorUIProxy::platformDetach):

Call `-didAttachOrDetach`.

* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::didChangeLocalInspectorAttachment):
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::didChangeLocalInspectorAttachment):

Update the scroll pocket&apos;s layout bounds when the web inspector attachment mode changes; see below.

* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::updateTopScrollPocketCaptureColor):

Update the attached web inspector web view whenever the inspected web view&apos;s scroll pocket capture
color changes.

(WebKit::WebViewImpl::updatePrefersSolidColorHardPocket):

Add support for `-_alwaysPrefersSolidColorHardPocket`, by returning `YES` if the new flag is set.

(WebKit::WebViewImpl::updateScrollPocket):

Expand the bounds of the scroll pocket to include the area underneath the attached web inspector
view. This is necessary in order to ensure that glass above the scroll pocket adapts correctly and
consistently to the updated capture color, even if the scroll pocket is clipped.

Canonical link: <a href="https://commits.webkit.org/296782@main">https://commits.webkit.org/296782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c6e650236a1c4269c16cbe2525b4575c54496fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109611 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29269 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19698 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115629 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59841 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29947 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37857 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/83289 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112559 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23858 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98718 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63743 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23237 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59426 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93233 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16901 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118422 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36650 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27137 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92293 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37023 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94978 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92111 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23459 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37080 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14825 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32466 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36544 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42015 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36204 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39547 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37914 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->