### PR TITLE
[Style] Convert border and outline values to use strong style types

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -199,6 +199,7 @@ set(WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/style"
     "${WEBCORE_DIR}/style/values"
     "${WEBCORE_DIR}/style/values/align"
+    "${WEBCORE_DIR}/style/values/backgrounds"
     "${WEBCORE_DIR}/style/values/borders"
     "${WEBCORE_DIR}/style/values/box"
     "${WEBCORE_DIR}/style/values/color-adjust"

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2751,6 +2751,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     style/values/align/StyleGapGutter.h
 
+    style/values/backgrounds/StyleLineWidth.h
+
     style/values/borders/StyleBorderRadius.h
     style/values/borders/StyleBoxShadow.h
     style/values/borders/StyleCornerShapeValue.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2939,10 +2939,11 @@ rendering/style/GridSpan.cpp
 rendering/style/GridTrackSize.cpp
 rendering/style/ListStyleType.cpp
 rendering/style/NinePieceImage.cpp
-rendering/style/QuotesData.cpp
+rendering/style/OutlineValue.cpp
 rendering/style/PositionArea.cpp
 rendering/style/PositionTryFallback.cpp
 rendering/style/PositionTryOrder.cpp
+rendering/style/QuotesData.cpp
 rendering/style/ReferenceFilterOperation.cpp
 rendering/style/RenderStyle.cpp
 rendering/style/RenderStyleConstants.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -4872,6 +4872,10 @@
 		BC2A0D912E089160003CBA0E /* StyleGapGutter.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2A0D6D2E08687E003CBA0E /* StyleGapGutter.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC2A0DAF2E08DFFD003CBA0E /* StyleBuilderChecking.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2A0DAE2E08DFFD003CBA0E /* StyleBuilderChecking.h */; };
 		BC2A0E332E0B6642003CBA0E /* StylePrimitiveNumeric+Forward.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2A0E322E0B6642003CBA0E /* StylePrimitiveNumeric+Forward.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC2A0EDF2E104D23003CBA0E /* StyleLineWidth.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2A0EDD2E104C90003CBA0E /* StyleLineWidth.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC2A0EE12E105274003CBA0E /* StyleLineWidth.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC2A0EE02E105274003CBA0E /* StyleLineWidth.cpp */; };
+		BC2A0EE22E11A47C003CBA0E /* StylePrimitiveNumericTypes+Evaluation.h in Headers */ = {isa = PBXBuildFile; fileRef = BCB271F42CC018F100265123 /* StylePrimitiveNumericTypes+Evaluation.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC2A0EE32E11A48B003CBA0E /* StylePrimitiveNumericTypes+Calculation.h in Headers */ = {isa = PBXBuildFile; fileRef = BC05ACC82CEE5C9600750CB1 /* StylePrimitiveNumericTypes+Calculation.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC2B41172732F41E00A2D191 /* ModelPlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2B41132732F06200A2D191 /* ModelPlayer.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC2B41182732F42300A2D191 /* ModelPlayerProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2B41152732F0C700A2D191 /* ModelPlayerProvider.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC2B41192732F42900A2D191 /* ModelPlayerClient.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2B410E2732EFE400A2D191 /* ModelPlayerClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -18023,7 +18027,10 @@
 		BC2A0DBA2E09AEEA003CBA0E /* StyleRayFunction.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleRayFunction.cpp; sourceTree = "<group>"; };
 		BC2A0DF02E0A2BCE003CBA0E /* StyleLengthWrapper+CSSValueConversion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "StyleLengthWrapper+CSSValueConversion.h"; sourceTree = "<group>"; };
 		BC2A0E322E0B6642003CBA0E /* StylePrimitiveNumeric+Forward.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "StylePrimitiveNumeric+Forward.h"; sourceTree = "<group>"; };
+		BC2A0E522E0C76ED003CBA0E /* OutlineValue.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = OutlineValue.cpp; sourceTree = "<group>"; };
 		BC2A0E782E0DAF88003CBA0E /* StylePrimitiveNumericTypes+CSSValueConversion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "StylePrimitiveNumericTypes+CSSValueConversion.h"; sourceTree = "<group>"; };
+		BC2A0EDD2E104C90003CBA0E /* StyleLineWidth.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleLineWidth.h; sourceTree = "<group>"; };
+		BC2A0EE02E105274003CBA0E /* StyleLineWidth.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleLineWidth.cpp; sourceTree = "<group>"; };
 		BC2B410E2732EFE400A2D191 /* ModelPlayerClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ModelPlayerClient.h; sourceTree = "<group>"; };
 		BC2B41122732F03C00A2D191 /* ModelPlayerClient.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ModelPlayerClient.cpp; sourceTree = "<group>"; };
 		BC2B41132732F06200A2D191 /* ModelPlayer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ModelPlayer.h; sourceTree = "<group>"; };
@@ -34818,6 +34825,15 @@
 			path = align;
 			sourceTree = "<group>";
 		};
+		BC2A0EDE2E104C90003CBA0E /* backgrounds */ = {
+			isa = PBXGroup;
+			children = (
+				BC2A0EE02E105274003CBA0E /* StyleLineWidth.cpp */,
+				BC2A0EDD2E104C90003CBA0E /* StyleLineWidth.h */,
+			);
+			path = backgrounds;
+			sourceTree = "<group>";
+		};
 		BC2B412227335E0C00A2D191 /* dummy */ = {
 			isa = PBXGroup;
 			children = (
@@ -35061,6 +35077,7 @@
 				1AB39CC62C98CEA100B8AD82 /* NameScope.h */,
 				BCEF43DF0E674110001C1287 /* NinePieceImage.cpp */,
 				BCEF43DC0E674012001C1287 /* NinePieceImage.h */,
+				BC2A0E522E0C76ED003CBA0E /* OutlineValue.cpp */,
 				BC5EB5DC0E81B8DD00B25965 /* OutlineValue.h */,
 				A363392C2A280D9C00C6EA56 /* PositionArea.cpp */,
 				A363392B2A280D8000C6EA56 /* PositionArea.h */,
@@ -35326,6 +35343,7 @@
 			isa = PBXGroup;
 			children = (
 				BC2A0D6F2E08687E003CBA0E /* align */,
+				BC2A0EDE2E104C90003CBA0E /* backgrounds */,
 				BC23BAAD2D6E345B0069A80B /* borders */,
 				BC9ABA142DECC1CA00F7E52D /* box */,
 				BC4AF4272CFA23040037C65C /* color */,
@@ -44888,6 +44906,7 @@
 				E47127CB163438AE00ED6F5A /* StyleInvalidator.h in Headers */,
 				BC2A0D5A2E0791C7003CBA0E /* StyleLengthWrapper.h in Headers */,
 				BC2387AC2D8744E100698102 /* StyleLineBoxContain.h in Headers */,
+				BC2A0EDF2E104D23003CBA0E /* StyleLineWidth.h in Headers */,
 				BC9ABA1A2DED228100F7E52D /* StyleMargin.h in Headers */,
 				BC5EB72A0E81DE8100B25965 /* StyleMarqueeData.h in Headers */,
 				BC675B6C2DEE8BB700AD4D79 /* StyleMaximumSize.h in Headers */,
@@ -44922,6 +44941,8 @@
 				BC6AFC742DFE70590065FA1D /* StylePrimitiveNumericAdaptors.h in Headers */,
 				BCD67C1C2D1F35840079EB9C /* StylePrimitiveNumericConcepts.h in Headers */,
 				BCE434672D4320630030D140 /* StylePrimitiveNumericOrKeyword.h in Headers */,
+				BC2A0EE32E11A48B003CBA0E /* StylePrimitiveNumericTypes+Calculation.h in Headers */,
+				BC2A0EE22E11A47C003CBA0E /* StylePrimitiveNumericTypes+Evaluation.h in Headers */,
 				BCB272042CC1EF9F00265123 /* StylePrimitiveNumericTypes.h in Headers */,
 				A80E6DFC0A199067007FB8C5 /* StyleProperties.h in Headers */,
 				930A76CB297FA2B30055B743 /* StylePropertiesInlines.h in Headers */,
@@ -46618,6 +46639,7 @@
 				A100D94F2AB251C400E00D67 /* SourceBufferParserAVFObjC.mm in Sources */,
 				CDC8B5AA18047FF10016E685 /* SourceBufferPrivateAVFObjC.mm in Sources */,
 				B9CA3B412CAB1D3E00B2607C /* SpatialImageControls.cpp in Sources */,
+				BC2A0EE12E105274003CBA0E /* StyleLineWidth.cpp in Sources */,
 				A833C7CA0A2CF06B00D57664 /* SVGNames.cpp in Sources */,
 				C1692DD223D23ABD006E88F7 /* SystemBattery.mm in Sources */,
 				329C0C2328BD96D600F187D2 /* TagName.cpp in Sources */,

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -117,6 +117,7 @@
 #include "SVGElementTypeHelpers.h"
 #include "SVGImage.h"
 #include "SVGSVGElement.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "Text.h"
 #include "TextControlInnerElements.h"
 #include "TextIterator.h"
@@ -938,8 +939,8 @@ Path AccessibilityRenderObject::elementPath() const
         if (!needsPath)
             return { };
 
-        float outlineOffset = style.outlineOffset();
-        float deviceScaleFactor = renderText->document().deviceScaleFactor();
+        auto outlineOffset = Style::to<float>(style.outlineOffset());
+        auto deviceScaleFactor = renderText->document().deviceScaleFactor();
         Vector<FloatRect> pixelSnappedRects;
         for (auto rect : rects) {
             rect.inflate(outlineOffset);

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -228,10 +228,14 @@ constexpr CSSValueID toCSSValueID(BorderStyle e)
 
 template<> constexpr BorderStyle fromCSSValueID(CSSValueID valueID)
 {
-    if (valueID == CSSValueAuto) // Valid for CSS outline-style
-        return BorderStyle::Dotted;
     return static_cast<BorderStyle>(valueID - CSSValueNone);
 }
+
+#define TYPE OutlineStyle
+#define FOR_EACH(CASE) CASE(Auto) CASE(None) CASE(Inset) CASE(Groove) CASE(Ridge) CASE(Outset) CASE(Dotted) CASE(Dashed) CASE(Solid) CASE(Double)
+DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
+#undef TYPE
+#undef FOR_EACH
 
 constexpr CSSValueID toCSSValueID(CompositeOperator e, CSSPropertyID propertyID)
 {

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -2121,7 +2121,7 @@
             "initial": "transparent",
             "codegen-properties": {
                 "accepts-quirky-color": true,
-                "animation-wrapper": "VisitedAffectedStyleTypeWrapper<Color>",
+                "animation-wrapper": "VisitedAffectedStyleTypeWrapper",
                 "visited-link-color-support": true,
                 "color-property": true,
                 "disables-native-appearance": true,
@@ -2675,7 +2675,7 @@
                     "resolver": "bottom"
                 },
                 "accepts-quirky-color": true,
-                "animation-wrapper": "VisitedAffectedStyleTypeWrapper<Color>",
+                "animation-wrapper": "VisitedAffectedStyleTypeWrapper",
                 "render-style-initial": "currentColor",
                 "visited-link-color-support": true,
                 "color-property": true,
@@ -2774,10 +2774,9 @@
                     "resolver": "bottom"
                 },
                 "accepts-quirky-length": true,
-                "animation-wrapper": "FloatWrapper",
-                "animation-wrapper-requires-additional-parameters": ["FloatWrapper::ValueRange::NonNegative"],
+                "animation-wrapper": "StyleTypeWrapper",
                 "render-style-initial": "initialBorderWidth",
-                "style-converter": "LineWidth<float>",
+                "style-converter": "StyleType<LineWidth>",
                 "disables-native-appearance": true,
                 "parser-grammar": "<line-width>"
             },
@@ -3256,7 +3255,7 @@
                     "resolver": "left"
                 },
                 "accepts-quirky-color": true,
-                "animation-wrapper": "VisitedAffectedStyleTypeWrapper<Color>",
+                "animation-wrapper": "VisitedAffectedStyleTypeWrapper",
                 "render-style-initial": "currentColor",
                 "visited-link-color-support": true,
                 "color-property": true,
@@ -3311,10 +3310,9 @@
                     "resolver": "left"
                 },
                 "accepts-quirky-length": true,
-                "animation-wrapper": "FloatWrapper",
-                "animation-wrapper-requires-additional-parameters": ["FloatWrapper::ValueRange::NonNegative"],
+                "animation-wrapper": "StyleTypeWrapper",
                 "render-style-initial": "initialBorderWidth",
-                "style-converter": "LineWidth<float>",
+                "style-converter": "StyleType<LineWidth>",
                 "disables-native-appearance": true,
                 "parser-grammar": "<line-width>"
             },
@@ -3365,7 +3363,7 @@
                     "resolver": "right"
                 },
                 "accepts-quirky-color": true,
-                "animation-wrapper": "VisitedAffectedStyleTypeWrapper<Color>",
+                "animation-wrapper": "VisitedAffectedStyleTypeWrapper",
                 "render-style-initial": "currentColor",
                 "visited-link-color-support": true,
                 "color-property": true,
@@ -3420,10 +3418,9 @@
                     "resolver": "right"
                 },
                 "accepts-quirky-length": true,
-                "animation-wrapper": "FloatWrapper",
-                "animation-wrapper-requires-additional-parameters": ["FloatWrapper::ValueRange::NonNegative"],
+                "animation-wrapper": "StyleTypeWrapper",
                 "render-style-initial": "initialBorderWidth",
-                "style-converter": "LineWidth<float>",
+                "style-converter": "StyleType<LineWidth>",
                 "disables-native-appearance": true,
                 "parser-grammar": "<line-width>"
             },
@@ -3529,7 +3526,7 @@
                     "resolver": "top"
                 },
                 "accepts-quirky-color": true,
-                "animation-wrapper": "VisitedAffectedStyleTypeWrapper<Color>",
+                "animation-wrapper": "VisitedAffectedStyleTypeWrapper",
                 "render-style-initial": "currentColor",
                 "visited-link-color-support": true,
                 "color-property": true,
@@ -3628,10 +3625,9 @@
                     "resolver": "top"
                 },
                 "accepts-quirky-length": true,
-                "animation-wrapper": "FloatWrapper",
-                "animation-wrapper-requires-additional-parameters": ["FloatWrapper::ValueRange::NonNegative"],
+                "animation-wrapper": "StyleTypeWrapper",
                 "render-style-initial": "initialBorderWidth",
-                "style-converter": "LineWidth<float>",
+                "style-converter": "StyleType<LineWidth>",
                 "disables-native-appearance": true,
                 "parser-grammar": "<line-width>"
             },
@@ -4450,7 +4446,7 @@
                 }
             ],
             "codegen-properties": {
-                "animation-wrapper": "VisitedAffectedStyleTypeWrapper<SVGPaint>",
+                "animation-wrapper": "VisitedAffectedStyleTypeWrapper",
                 "animation-wrapper-requires-override-parameters": ["CSSPropertyID::CSSPropertyFill", "&RenderStyle::fill", "&RenderStyle::setFill", "&RenderStyle::visitedLinkFill", "&RenderStyle::setVisitedLinkFill"],
                 "style-builder-custom": "All",
                 "style-extractor-converter": "StyleType<SVGPaint>",
@@ -4528,7 +4524,7 @@
             "animation-type": "by computed value",
             "initial": "black",
             "codegen-properties": {
-                "animation-wrapper": "StyleTypeWrapper<Color>",
+                "animation-wrapper": "StyleTypeWrapper",
                 "animation-wrapper-requires-render-style": true,
                 "svg": true,
                 "color-property": true,
@@ -4959,7 +4955,7 @@
             "animation-type": "by computed value",
             "initial": "white",
             "codegen-properties": {
-                "animation-wrapper": "StyleTypeWrapper<Color>",
+                "animation-wrapper": "StyleTypeWrapper",
                 "animation-wrapper-requires-render-style": true,
                 "svg": true,
                 "color-property": true,
@@ -6623,7 +6619,7 @@
             "initial": "currentColor",
             "initial-comment": "Current spec initial value is 'auto'",
             "codegen-properties": {
-                "animation-wrapper": "VisitedAffectedStyleTypeWrapper<Color>",
+                "animation-wrapper": "VisitedAffectedStyleTypeWrapper",
                 "render-style-initial": "currentColor",
                 "visited-link-color-support": true,
                 "color-property": true,
@@ -6639,8 +6635,8 @@
             "animation-type": "by computed value",
             "initial": "0",
             "codegen-properties": {
-                "animation-wrapper": "Wrapper",
-                "style-converter": "ComputedLength<float>",
+                "animation-wrapper": "StyleTypeWrapper",
+                "style-converter": "StyleType<Length<>>",
                 "parser-grammar": "<length>"
             },
             "specification": {
@@ -6665,8 +6661,7 @@
                 "double"
             ],
             "codegen-properties": {
-                "style-builder-custom": "All",
-                "auto-functions": true,
+                "render-style-initial": "initialOutlineStyle",
                 "parser-grammar": "auto | <outline-line-style>"
             },
             "specification": {
@@ -6683,9 +6678,9 @@
                 "thick"
             ],
             "codegen-properties": {
-                "animation-wrapper": "FloatWrapper",
-                "animation-wrapper-requires-additional-parameters": ["FloatWrapper::ValueRange::NonNegative"],
-                "style-converter": "LineWidth<float>",
+                "animation-wrapper": "StyleTypeWrapper",
+                "render-style-initial": "initialOutlineWidth",
+                "style-converter": "StyleType<LineWidth>",
                 "parser-grammar": "<line-width>"
             },
             "specification": {
@@ -7483,7 +7478,7 @@
             "animation-type": "by computed value",
             "initial": "black",
             "codegen-properties": {
-                "animation-wrapper": "StyleTypeWrapper<Color>",
+                "animation-wrapper": "StyleTypeWrapper",
                 "animation-wrapper-requires-render-style": true,
                 "svg": true,
                 "color-property": true,
@@ -7525,7 +7520,7 @@
                 }
             ],
             "codegen-properties": {
-                "animation-wrapper": "VisitedAffectedStyleTypeWrapper<SVGPaint>",
+                "animation-wrapper": "VisitedAffectedStyleTypeWrapper",
                 "animation-wrapper-requires-override-parameters": ["CSSPropertyID::CSSPropertyStroke", "&RenderStyle::stroke", "&RenderStyle::setStroke", "&RenderStyle::visitedLinkStroke", "&RenderStyle::setVisitedLinkStroke"],
                 "style-builder-custom": "All",
                 "style-extractor-converter": "StyleType<SVGPaint>",
@@ -7664,8 +7659,8 @@
             "inherited": true,
             "initial": "transparent",
             "codegen-properties": {
-                "animation-wrapper": "StyleTypeWrapper<Color>",
-                "animation-wrapper-comment": "FIXME: Why doesn't this use VisitedAffectedStyleTypeWrapper<Color>",
+                "animation-wrapper": "StyleTypeWrapper",
+                "animation-wrapper-comment": "FIXME: Why doesn't this use VisitedAffectedStyleTypeWrapper",
                 "animation-wrapper-requires-override-parameters": ["CSSPropertyID::CSSPropertyStrokeColor", "&RenderStyle::strokeColor", "&RenderStyle::setStrokeColor"],
                 "style-builder-custom": "Value",
                 "visited-link-color-support": true,
@@ -9268,7 +9263,7 @@
                 "aliases": [
                     "-webkit-column-rule-color"
                 ],
-                "animation-wrapper": "VisitedAffectedStyleTypeWrapper<Color>",
+                "animation-wrapper": "VisitedAffectedStyleTypeWrapper",
                 "render-style-initial": "currentColor",
                 "visited-link-color-support": true,
                 "color-property": true,
@@ -9318,8 +9313,9 @@
                 "aliases": [
                     "-webkit-column-rule-width"
                 ],
-                "animation-wrapper": "Wrapper",
-                "style-converter": "LineWidth<unsigned short>",
+                "animation-wrapper": "StyleTypeWrapper",
+                "render-style-initial": "initialColumnRuleWidth",
+                "style-converter": "StyleType<LineWidth>",
                 "parser-grammar": "<line-width>"
             },
             "specification":  {
@@ -10877,7 +10873,7 @@
                 "aliases": [
                     "-webkit-text-decoration-color"
                 ],
-                "animation-wrapper": "VisitedAffectedStyleTypeWrapper<Color>",
+                "animation-wrapper": "VisitedAffectedStyleTypeWrapper",
                 "render-style-initial": "currentColor",
                 "visited-link-color-support": true,
                 "color-property": true,
@@ -11030,7 +11026,7 @@
                     "-epub-text-emphasis-color",
                     "-webkit-text-emphasis-color"
                 ],
-                "animation-wrapper": "VisitedAffectedStyleTypeWrapper<Color>",
+                "animation-wrapper": "VisitedAffectedStyleTypeWrapper",
                 "render-style-initial": "currentColor",
                 "visited-link-color-support": true,
                 "color-property": true,
@@ -11082,7 +11078,7 @@
             "inherited": true,
             "initial": "currentColor",
             "codegen-properties": {
-                "animation-wrapper": "VisitedAffectedStyleTypeWrapper<Color>",
+                "animation-wrapper": "VisitedAffectedStyleTypeWrapper",
                 "render-style-initial": "currentColor",
                 "visited-link-color-support": true,
                 "color-property": true,
@@ -11128,7 +11124,7 @@
             "inherited": true,
             "initial": "currentColor",
             "codegen-properties": {
-                "animation-wrapper": "VisitedAffectedStyleTypeWrapper<Color>",
+                "animation-wrapper": "VisitedAffectedStyleTypeWrapper",
                 "render-style-initial": "currentColor",
                 "visited-link-color-support": true,
                 "color-property": true,

--- a/Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp
+++ b/Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp
@@ -1175,8 +1175,8 @@ BoxGeometry::Edges FormattingGeometry::computedBorder(const Box& layoutBox) cons
     auto& style = layoutBox.style();
     LOG_WITH_STREAM(FormattingContextLayout, stream << "[Border] -> layoutBox: " << &layoutBox);
     return {
-        { LayoutUnit(style.borderLeftWidth()), LayoutUnit(style.borderRightWidth()) },
-        { LayoutUnit(style.borderTopWidth()), LayoutUnit(style.borderBottomWidth()) }
+        { Style::to<LayoutUnit>(style.borderLeftWidth()), Style::to<LayoutUnit>(style.borderRightWidth()) },
+        { Style::to<LayoutUnit>(style.borderTopWidth()), Style::to<LayoutUnit>(style.borderBottomWidth()) }
     };
 }
 

--- a/Source/WebCore/layout/formattingContexts/block/BlockFormattingGeometry.cpp
+++ b/Source/WebCore/layout/formattingContexts/block/BlockFormattingGeometry.cpp
@@ -327,10 +327,10 @@ IntrinsicWidthConstraints BlockFormattingGeometry::intrinsicWidthConstraints(con
     auto fixedMarginBorderAndPadding = [&](auto& layoutBox) {
         auto& style = layoutBox.style();
         return fixedValue(style.marginStart()).value_or(0)
-            + LayoutUnit { style.borderLeftWidth() }
+            + Style::to<LayoutUnit>(style.borderLeftWidth())
             + fixedValue(style.paddingLeft()).value_or(0)
             + fixedValue(style.paddingRight()).value_or(0)
-            + LayoutUnit { style.borderRightWidth() }
+            + Style::to<LayoutUnit>(style.borderRightWidth())
             + fixedValue(style.marginEnd()).value_or(0);
     };
 

--- a/Source/WebCore/layout/formattingContexts/block/BlockMarginCollapse.cpp
+++ b/Source/WebCore/layout/formattingContexts/block/BlockMarginCollapse.cpp
@@ -44,7 +44,7 @@ static bool hasBorder(const BorderValue& borderValue)
 {
     if (borderValue.style() == BorderStyle::None || borderValue.style() == BorderStyle::Hidden)
         return false;
-    return !!borderValue.width();
+    return !Style::isZero(borderValue.width());
 }
 
 static bool hasPadding(const Style::PaddingEdge& paddingValue)

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
@@ -34,6 +34,7 @@
 #include "LayoutInitialContainingBlock.h"
 #include "RenderStyleInlines.h"
 #include "RubyFormattingContext.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "TextUtil.h"
 #include <wtf/ListHashSet.h>
 #include <wtf/Range.h>
@@ -118,7 +119,7 @@ static inline bool computeInkOverflowForInlineLevelBox(const RenderStyle& style,
     auto inflateWithOutline = [&] {
         if (!style.hasOutlineInVisualOverflow())
             return;
-        inkOverflow.inflate(style.outlineSize());
+        inkOverflow.inflate(Style::to<float>(style.outlineSize()));
         hasInkOverflow = true;
     };
     inflateWithOutline();

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
@@ -231,10 +231,10 @@ Layout::BoxGeometry::Edges BoxGeometryUpdater::logicalBorder(const RenderBoxMode
 {
     auto& style = renderer.style();
 
-    auto borderLeft = LayoutUnit { style.borderLeftWidth() };
-    auto borderRight = LayoutUnit { style.borderRightWidth() };
-    auto borderTop = LayoutUnit { style.borderTopWidth() };
-    auto borderBottom = LayoutUnit { style.borderBottomWidth() };
+    auto borderLeft = Style::to<LayoutUnit>(style.borderLeftWidth());
+    auto borderRight = Style::to<LayoutUnit>(style.borderRightWidth());
+    auto borderTop = Style::to<LayoutUnit>(style.borderTopWidth());
+    auto borderBottom = Style::to<LayoutUnit>(style.borderBottomWidth());
 
     if (!isIntrinsicWidthMode)
         adjustBorderForTableAndFieldset(renderer, borderLeft, borderRight, borderTop, borderBottom);

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -254,7 +254,7 @@ static bool hasTransparentContainerStyle(const RenderStyle& style)
         && !style.hasExplicitlySetBorderRadius()
         // No visible borders or borders that do not create a complete box.
         && (!style.hasVisibleBorder()
-            || !(style.borderTopWidth() && style.borderRightWidth() && style.borderBottomWidth() && style.borderLeftWidth()));
+            || !(!Style::isZero(style.borderTopWidth()) && !Style::isZero(style.borderRightWidth()) && !Style::isZero(style.borderBottomWidth()) && !Style::isZero(style.borderLeftWidth())));
 }
 
 static bool canTweakShapeForStyle(const RenderStyle& style)

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -125,6 +125,7 @@
 #include "ScrollingCoordinator.h"
 #include "Settings.h"
 #include "ShadowRoot.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "StyleResolver.h"
 #include "StyleScope.h"
 #include "TextIndicator.h"
@@ -2237,7 +2238,7 @@ std::pair<FixedContainerEdges, WeakElementEdges> LocalFrameView::fixedContainerE
         if (!border->isVisible())
             return samplingRect;
 
-        auto borderWidth = border->width();
+        auto borderWidth = Style::to<float>(border->width());
         if (borderWidth > thinBorderWidth)
             return samplingRect;
 

--- a/Source/WebCore/page/SpatialNavigation.cpp
+++ b/Source/WebCore/page/SpatialNavigation.cpp
@@ -45,6 +45,7 @@
 #include "RenderLayerScrollableArea.h"
 #include "RenderStyleInlines.h"
 #include "Settings.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 
 namespace WebCore {
 
@@ -521,9 +522,9 @@ LayoutRect nodeRectInAbsoluteCoordinates(const ContainerNode& containerNode, boo
         // the rect of the focused element.
         if (ignoreBorder) {
             auto& style = renderer->style();
-            rect.move(style.borderLeftWidth(), style.borderTopWidth());
-            rect.setWidth(rect.width() - style.borderLeftWidth() - style.borderRightWidth());
-            rect.setHeight(rect.height() - style.borderTopWidth() - style.borderBottomWidth());
+            rect.move(Style::to<float>(style.borderLeftWidth()), Style::to<float>(style.borderTopWidth()));
+            rect.setWidth(rect.width() - Style::to<float>(style.borderLeftWidth()) - Style::to<float>(style.borderRightWidth()));
+            rect.setHeight(rect.height() - Style::to<float>(style.borderTopWidth()) - Style::to<float>(style.borderBottomWidth()));
         }
         return rect;
     }

--- a/Source/WebCore/platform/RectEdges.h
+++ b/Source/WebCore/platform/RectEdges.h
@@ -35,6 +35,8 @@ namespace WebCore {
 
 template<typename T> class RectEdges {
 public:
+    using value_type = T;
+
     RectEdges() requires (std::is_default_constructible_v<T>)
         : m_sides { }
     {
@@ -48,9 +50,9 @@ public:
     RectEdges(const RectEdges&) = default;
     RectEdges& operator=(const RectEdges&) = default;
 
-    template<typename U>
-    RectEdges(U&& top, U&& right, U&& bottom, U&& left)
-        : m_sides({ { std::forward<U>(top), std::forward<U>(right), std::forward<U>(bottom), std::forward<U>(left) } })
+    template<typename U, typename V, typename W, typename X>
+    RectEdges(U&& top, V&& right, W&& bottom, X&& left)
+        : m_sides({ { std::forward<U>(top), std::forward<V>(right), std::forward<W>(bottom), std::forward<X>(left) } })
     {
     }
 
@@ -129,6 +131,11 @@ public:
         return yFlippedCopy();
     }
 
+    RectEdges<T> transpose() const
+    {
+        return { left(), top(), right(), bottom() };
+    }
+
     template<typename F> bool anyOf(F&& functor) const
     {
         return std::ranges::any_of(m_sides, std::forward<F>(functor));
@@ -142,6 +149,11 @@ public:
     template<typename F> bool noneOf(F&& functor) const
     {
         return std::ranges::none_of(m_sides, std::forward<F>(functor));
+    }
+
+    template<typename F> RectEdges<std::invoke_result_t<F, T>> map(F&& functor) const
+    {
+        return { functor(top()), functor(right()), functor(bottom()), functor(left()) };
     }
 
     bool isZero() const

--- a/Source/WebCore/rendering/BorderEdge.cpp
+++ b/Source/WebCore/rendering/BorderEdge.cpp
@@ -30,6 +30,7 @@
 #include "LayoutUnit.h"
 #include "RenderObject.h"
 #include "RenderStyleInlines.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 
 namespace WebCore {
 
@@ -48,9 +49,9 @@ BorderEdge::BorderEdge(float edgeWidth, Color edgeColor, BorderStyle edgeStyle, 
 
 BorderEdges borderEdges(const RenderStyle& style, float deviceScaleFactor, RectEdges<bool> closedEdges, LayoutSize inflation, bool setColorsToBlack)
 {
-    auto constructBorderEdge = [&](float width, float inflation, CSSPropertyID borderColorProperty, BorderStyle borderStyle, bool isTransparent, bool isPresent) {
+    auto constructBorderEdge = [&](Style::LineWidth width, float inflation, CSSPropertyID borderColorProperty, BorderStyle borderStyle, bool isTransparent, bool isPresent) {
         auto color = setColorsToBlack ? Color::black : style.visitedDependentColorWithColorFilter(borderColorProperty);
-        auto inflatedWidth = width ? width + inflation : width;
+        auto inflatedWidth = !Style::isZero(width) ? Style::to<float>(width) + inflation : 0.0f;
         return BorderEdge(inflatedWidth, color, borderStyle, !setColorsToBlack && isTransparent, isPresent, deviceScaleFactor);
     };
 
@@ -62,17 +63,17 @@ BorderEdges borderEdges(const RenderStyle& style, float deviceScaleFactor, RectE
     };
 }
 
-BorderEdges borderEdgesForOutline(const RenderStyle& style, float deviceScaleFactor)
+BorderEdges borderEdgesForOutline(const RenderStyle& style, BorderStyle borderStyle, float deviceScaleFactor)
 {
     auto color = style.visitedDependentColorWithColorFilter(CSSPropertyOutlineColor);
     auto isTransparent = color.isValid() && !color.isVisible();
-    auto size = style.outlineWidth();
-    auto outlineStyle = style.outlineStyle();
+    auto size = Style::to<float>(style.outlineWidth());
+
     return {
-        BorderEdge { size, color, outlineStyle, isTransparent, true, deviceScaleFactor },
-        BorderEdge { size, color, outlineStyle, isTransparent, true, deviceScaleFactor },
-        BorderEdge { size, color, outlineStyle, isTransparent, true, deviceScaleFactor },
-        BorderEdge { size, color, outlineStyle, isTransparent, true, deviceScaleFactor } 
+        BorderEdge { size, color, borderStyle, isTransparent, true, deviceScaleFactor },
+        BorderEdge { size, color, borderStyle, isTransparent, true, deviceScaleFactor },
+        BorderEdge { size, color, borderStyle, isTransparent, true, deviceScaleFactor },
+        BorderEdge { size, color, borderStyle, isTransparent, true, deviceScaleFactor },
     };
 }
 

--- a/Source/WebCore/rendering/BorderEdge.h
+++ b/Source/WebCore/rendering/BorderEdge.h
@@ -69,9 +69,10 @@ private:
 };
 
 using BorderEdges = RectEdges<BorderEdge>;
+
 // inflation is only added to edges with non-zero widths.
 BorderEdges borderEdges(const RenderStyle&, float deviceScaleFactor, RectEdges<bool> closedEdges = { true }, LayoutSize inflation = { }, bool setColorsToBlack = false);
-BorderEdges borderEdgesForOutline(const RenderStyle&, float deviceScaleFactor);
+BorderEdges borderEdgesForOutline(const RenderStyle&, BorderStyle, float deviceScaleFactor);
 
 inline bool edgesShareColor(const BorderEdge& firstEdge, const BorderEdge& secondEdge) { return equalIgnoringSemanticColor(firstEdge.color(), secondEdge.color()); }
 inline BoxSideFlag edgeFlagForSide(BoxSide side) { return static_cast<BoxSideFlag>(1 << static_cast<unsigned>(side)); }

--- a/Source/WebCore/rendering/BorderPainter.cpp
+++ b/Source/WebCore/rendering/BorderPainter.cpp
@@ -291,7 +291,7 @@ void BorderPainter::paintOutline(const LayoutRect& paintRect) const
     auto& styleToUse = m_renderer->style();
 
     // Only paint the focus ring by hand if the theme isn't able to draw it.
-    if (styleToUse.hasAutoOutlineStyle() && !m_renderer->theme().supportsFocusRing(m_renderer, styleToUse)) {
+    if (styleToUse.outlineStyle() == OutlineStyle::Auto && !m_renderer->theme().supportsFocusRing(m_renderer, styleToUse)) {
         Vector<LayoutRect> focusRingRects;
         LayoutRect paintRectToUse { paintRect };
         if (CheckedPtr box = dynamicDowncast<RenderBox>(m_renderer.get()))
@@ -300,14 +300,15 @@ void BorderPainter::paintOutline(const LayoutRect& paintRect) const
         m_renderer->paintFocusRing(m_paintInfo, styleToUse, focusRingRects);
     }
 
-    if (m_renderer->hasOutlineAnnotation() && !styleToUse.hasAutoOutlineStyle() && !m_renderer->theme().supportsFocusRing(m_renderer, styleToUse))
+    if (m_renderer->hasOutlineAnnotation() && styleToUse.outlineStyle() != OutlineStyle::Auto && !m_renderer->theme().supportsFocusRing(m_renderer, styleToUse))
         m_renderer->addPDFURLRect(m_paintInfo, paintRect.location());
 
-    if (styleToUse.hasAutoOutlineStyle() || styleToUse.outlineStyle() == BorderStyle::None)
+    auto borderStyle = toBorderStyle(styleToUse.outlineStyle());
+    if (!borderStyle || *borderStyle == BorderStyle::None)
         return;
 
-    auto outlineWidth = LayoutUnit { styleToUse.outlineWidth() };
-    auto outlineOffset = LayoutUnit { styleToUse.outlineOffset() };
+    auto outlineWidth = Style::to<LayoutUnit>(styleToUse.outlineWidth());
+    auto outlineOffset = Style::to<LayoutUnit>(styleToUse.outlineOffset());
 
     auto outerRect = paintRect;
     outerRect.inflate(outlineOffset + outlineWidth);
@@ -323,7 +324,7 @@ void BorderPainter::paintOutline(const LayoutRect& paintRect) const
 
     auto bleedAvoidance = BleedAvoidance::ShrinkBackground;
     auto appliedClipAlready = false;
-    auto edges = borderEdgesForOutline(styleToUse, document().deviceScaleFactor());
+    auto edges = borderEdgesForOutline(styleToUse, *borderStyle, document().deviceScaleFactor());
     auto haveAllSolidEdges = decorationHasAllSolidEdges(edges);
 
     paintSides(outlineShape, {
@@ -348,8 +349,8 @@ void BorderPainter::paintOutline(const LayoutPoint& paintOffset, const Vector<La
     }
 
     auto& styleToUse = m_renderer->style();
-    auto outlineOffset = styleToUse.outlineOffset();
-    auto outlineWidth = styleToUse.outlineWidth();
+    auto outlineOffset = Style::to<float>(styleToUse.outlineOffset());
+    auto outlineWidth = Style::to<float>(styleToUse.outlineWidth());
     auto deviceScaleFactor = document().deviceScaleFactor();
 
     Vector<FloatRect> pixelSnappedRects;

--- a/Source/WebCore/rendering/BorderShape.cpp
+++ b/Source/WebCore/rendering/BorderShape.cpp
@@ -43,13 +43,7 @@ namespace WebCore {
 
 BorderShape BorderShape::shapeForBorderRect(const RenderStyle& style, const LayoutRect& borderRect, RectEdges<bool> closedEdges)
 {
-    auto borderWidths = RectEdges<LayoutUnit> {
-        LayoutUnit(style.borderTopWidth()),
-        LayoutUnit(style.borderRightWidth()),
-        LayoutUnit(style.borderBottomWidth()),
-        LayoutUnit(style.borderLeftWidth()),
-    };
-    return shapeForBorderRect(style, borderRect, borderWidths, closedEdges);
+    return shapeForBorderRect(style, borderRect, Style::to<LayoutBoxExtent>(style.borderWidth()), closedEdges);
 }
 
 BorderShape BorderShape::shapeForBorderRect(const RenderStyle& style, const LayoutRect& borderRect, const RectEdges<LayoutUnit>& overrideBorderWidths, RectEdges<bool> closedEdges)

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -1273,8 +1273,7 @@ void RenderBlock::paintObject(PaintInfo& paintInfo, const LayoutPoint& paintOffs
     if ((paintPhase == PaintPhase::Outline || paintPhase == PaintPhase::SelfOutline) && hasOutline() && style().usedVisibility() == Visibility::Visible) {
         // Don't paint focus ring for anonymous block continuation because the
         // inline element having outline-style:auto paints the whole focus ring.
-        bool hasOutlineStyleAuto = style().hasAutoOutlineStyle();
-        if (!hasOutlineStyleAuto || !isContinuation())
+        if (style().outlineStyle() != OutlineStyle::Auto || !isContinuation())
             paintOutline(paintInfo, LayoutRect(paintOffset, size()));
     }
 

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -4780,7 +4780,7 @@ LayoutRect RenderBox::applyVisualEffectOverflow(const LayoutRect& borderBox) con
     }
 
     if (outlineStyleForRepaint().hasOutlineInVisualOverflow()) {
-        LayoutUnit outlineSize { outlineStyleForRepaint().outlineSize() };
+        auto outlineSize = Style::to<LayoutUnit>(outlineStyleForRepaint().outlineSize());
         overflowMinX = std::min(overflowMinX, borderBox.x() - outlineSize);
         overflowMaxX = std::max(overflowMaxX, borderBox.maxX() + outlineSize);
         overflowMinY = std::min(overflowMinY, borderBox.y() - outlineSize);

--- a/Source/WebCore/rendering/RenderBoxModelObjectInlines.h
+++ b/Source/WebCore/rendering/RenderBoxModelObjectInlines.h
@@ -22,10 +22,11 @@
 
 #include "RenderBoxModelObject.h"
 #include "RenderStyleInlines.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 
 namespace WebCore {
 
-inline LayoutUnit RenderBoxModelObject::borderAfter() const { return LayoutUnit(style().borderAfterWidth()); }
+inline LayoutUnit RenderBoxModelObject::borderAfter() const { return Style::to<LayoutUnit>(style().borderAfterWidth()); }
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingAfter() const { return borderAfter() + paddingAfter(); }
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingBefore() const { return borderBefore() + paddingBefore(); }
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingLogicalHeight() const { return borderAndPaddingBefore() + borderAndPaddingAfter(); }
@@ -34,17 +35,17 @@ inline LayoutUnit RenderBoxModelObject::borderAndPaddingLogicalLeft() const { re
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingLogicalRight() const { return writingMode().isHorizontal() ? borderRight() + paddingRight() : borderBottom() + paddingBottom(); }
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingStart() const { return borderStart() + paddingStart(); }
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingEnd() const { return borderEnd() + paddingEnd(); }
-inline LayoutUnit RenderBoxModelObject::borderBefore() const { return LayoutUnit(style().borderBeforeWidth()); }
-inline LayoutUnit RenderBoxModelObject::borderBottom() const { return LayoutUnit(style().borderBottomWidth()); }
-inline LayoutUnit RenderBoxModelObject::borderEnd() const { return LayoutUnit(style().borderEndWidth()); }
-inline LayoutUnit RenderBoxModelObject::borderLeft() const { return LayoutUnit(style().borderLeftWidth()); }
+inline LayoutUnit RenderBoxModelObject::borderBefore() const { return Style::to<LayoutUnit>(style().borderBeforeWidth()); }
+inline LayoutUnit RenderBoxModelObject::borderBottom() const { return Style::to<LayoutUnit>(style().borderBottomWidth()); }
+inline LayoutUnit RenderBoxModelObject::borderEnd() const { return Style::to<LayoutUnit>(style().borderEndWidth()); }
+inline LayoutUnit RenderBoxModelObject::borderLeft() const { return Style::to<LayoutUnit>(style().borderLeftWidth()); }
 inline LayoutUnit RenderBoxModelObject::borderLogicalHeight() const { return borderBefore() + borderAfter(); }
 inline LayoutUnit RenderBoxModelObject::borderLogicalLeft() const { return writingMode().isHorizontal() ? borderLeft() : borderTop(); }
 inline LayoutUnit RenderBoxModelObject::borderLogicalRight() const { return writingMode().isHorizontal() ? borderRight() : borderBottom(); }
 inline LayoutUnit RenderBoxModelObject::borderLogicalWidth() const { return borderStart() + borderEnd(); }
-inline LayoutUnit RenderBoxModelObject::borderRight() const { return LayoutUnit(style().borderRightWidth()); }
-inline LayoutUnit RenderBoxModelObject::borderStart() const { return LayoutUnit(style().borderStartWidth()); }
-inline LayoutUnit RenderBoxModelObject::borderTop() const { return LayoutUnit(style().borderTopWidth()); }
+inline LayoutUnit RenderBoxModelObject::borderRight() const { return Style::to<LayoutUnit>(style().borderRightWidth()); }
+inline LayoutUnit RenderBoxModelObject::borderStart() const { return Style::to<LayoutUnit>(style().borderStartWidth()); }
+inline LayoutUnit RenderBoxModelObject::borderTop() const { return Style::to<LayoutUnit>(style().borderTopWidth()); }
 inline LayoutUnit RenderBoxModelObject::computedCSSPaddingAfter() const { return resolveLengthPercentageUsingContainerLogicalWidth(style().paddingAfter()); }
 inline LayoutUnit RenderBoxModelObject::computedCSSPaddingBefore() const { return resolveLengthPercentageUsingContainerLogicalWidth(style().paddingBefore()); }
 inline LayoutUnit RenderBoxModelObject::computedCSSPaddingBottom() const { return resolveLengthPercentageUsingContainerLogicalWidth(style().paddingBottom()); }
@@ -80,12 +81,7 @@ inline LayoutUnit RenderBoxModelObject::verticalBorderExtent() const { return bo
 
 inline RectEdges<LayoutUnit> RenderBoxModelObject::borderWidths() const
 {
-    return {
-        LayoutUnit(style().borderTopWidth()),
-        LayoutUnit(style().borderRightWidth()),
-        LayoutUnit(style().borderBottomWidth()),
-        LayoutUnit(style().borderLeftWidth())
-    };
+    return Style::to<RectEdges<LayoutUnit>>(style().borderWidth());
 }
 
 RectEdges<LayoutUnit> RenderBoxModelObject::padding() const

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1097,8 +1097,8 @@ void RenderElement::styleDidChange(StyleDifference diff, const RenderStyle* oldS
         protectedFrame()->eventHandler().scheduleCursorUpdate();
 #endif
 
-    bool hadOutlineAuto = oldStyle && oldStyle->hasAutoOutlineStyle();
-    bool hasOutlineAuto = outlineStyleForRepaint().hasAutoOutlineStyle();
+    bool hadOutlineAuto = oldStyle && oldStyle->outlineStyle() == OutlineStyle::Auto;
+    bool hasOutlineAuto = outlineStyleForRepaint().outlineStyle() == OutlineStyle::Auto;
     if (hasOutlineAuto != hadOutlineAuto) {
         updateOutlineAutoAncestor(hasOutlineAuto);
         issueRepaintForOutlineAuto(hasOutlineAuto ? outlineStyleForRepaint().outlineSize() : oldStyle->outlineSize());
@@ -1476,7 +1476,7 @@ bool RenderElement::repaintAfterLayoutIfNeeded(SingleThreadWeakPtr<const RenderL
 
     const RenderStyle& outlineStyle = outlineStyleForRepaint();
     auto& style = this->style();
-    auto outlineWidth = LayoutUnit { outlineStyle.outlineSize() };
+    auto outlineWidth = Style::to<LayoutUnit>(outlineStyle.outlineSize());
     auto insetShadowExtent = style.boxShadowInsetExtent();
     auto sizeDelta = LayoutSize { absoluteValue(newOutlineBoundsRect.width() - oldOutlineBoundsRect.width()), absoluteValue(newOutlineBoundsRect.height() - oldOutlineBoundsRect.height()) };
     if (sizeDelta.width()) {
@@ -1498,7 +1498,7 @@ bool RenderElement::repaintAfterLayoutIfNeeded(SingleThreadWeakPtr<const RenderL
                 });
             };
             auto outlineRightInsetExtent = [&]() -> LayoutUnit {
-                auto offset = LayoutUnit { outlineStyle.outlineOffset() };
+                auto offset = Style::to<LayoutUnit>(outlineStyle.outlineOffset());
                 return offset < 0 ? -offset : 0_lu;
             };
             auto boxShadowRightInsetExtent = [&] {
@@ -1544,7 +1544,7 @@ bool RenderElement::repaintAfterLayoutIfNeeded(SingleThreadWeakPtr<const RenderL
                 });
             };
             auto outlineBottomInsetExtent = [&]() -> LayoutUnit {
-                auto offset = LayoutUnit { outlineStyle.outlineOffset() };
+                auto offset = Style::to<LayoutUnit>(outlineStyle.outlineOffset());
                 return offset < 0 ? -offset : 0_lu;
             };
             auto boxShadowBottomInsetExtent = [&]() -> LayoutUnit {
@@ -2099,24 +2099,24 @@ static bool useShrinkWrappedFocusRingForOutlineStyleAuto()
 
 static void drawFocusRing(GraphicsContext& context, const Path& path, const RenderStyle& style, const Color& color)
 {
-    context.drawFocusRing(path, style.outlineWidth(), color);
+    context.drawFocusRing(path, Style::to<float>(style.outlineWidth()), color);
 }
 
 static void drawFocusRing(GraphicsContext& context, Vector<FloatRect> rects, const RenderStyle& style, const Color& color)
 {
 #if PLATFORM(MAC)
-    context.drawFocusRing(rects, 0, style.outlineWidth(), color);
+    context.drawFocusRing(rects, 0, Style::to<float>(style.outlineWidth()), color);
 #else
-    context.drawFocusRing(rects, style.outlineOffset(), style.outlineWidth(), color);
+    context.drawFocusRing(rects, Style::to<float>(style.outlineOffset()), Style::to<float>(style.outlineWidth()), color);
 #endif
 }
 
 void RenderElement::paintFocusRing(const PaintInfo& paintInfo, const RenderStyle& style, const Vector<LayoutRect>& focusRingRects) const
 {
-    ASSERT(style.hasAutoOutlineStyle());
-    float outlineOffset = style.outlineOffset();
+    ASSERT(style.outlineStyle() == OutlineStyle::Auto);
+    auto outlineOffset = Style::to<float>(style.outlineOffset());
     Vector<FloatRect> pixelSnappedFocusRingRects;
-    float deviceScaleFactor = document().deviceScaleFactor();
+    auto deviceScaleFactor = document().deviceScaleFactor();
     for (auto rect : focusRingRects) {
         rect.inflate(outlineOffset);
         pixelSnappedFocusRingRects.append(snapRectToDevicePixels(rect, deviceScaleFactor));
@@ -2146,13 +2146,13 @@ void RenderElement::paintOutline(PaintInfo& paintInfo, const LayoutRect& paintRe
     BorderPainter { *this, paintInfo }.paintOutline(paintRect);
 }
 
-void RenderElement::issueRepaintForOutlineAuto(float outlineSize)
+void RenderElement::issueRepaintForOutlineAuto(Style::Length<> outlineSize)
 {
     LayoutRect repaintRect;
     Vector<LayoutRect> focusRingRects;
     addFocusRingRects(focusRingRects, LayoutPoint(), containerForRepaint().renderer.get());
     for (auto rect : focusRingRects) {
-        rect.inflate(outlineSize);
+        rect.inflate(Style::to<float>(outlineSize));
         repaintRect.unite(rect);
     }
     repaintRectangle(repaintRect);
@@ -2170,7 +2170,7 @@ void RenderElement::updateOutlineAutoAncestor(bool hasOutlineAuto)
         if (hasOutlineAuto == child->hasOutlineAutoAncestor())
             continue;
         child->setHasOutlineAutoAncestor(hasOutlineAuto);
-        bool childHasOutlineAuto = child->outlineStyleForRepaint().hasAutoOutlineStyle();
+        bool childHasOutlineAuto = child->outlineStyleForRepaint().outlineStyle() == OutlineStyle::Auto;
         if (childHasOutlineAuto)
             continue;
         if (auto* element = dynamicDowncast<RenderElement>(child.get()))

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -432,7 +432,7 @@ private:
     void clearSubtreeLayoutRootIfNeeded() const;
     
     bool shouldWillChangeCreateStackingContext() const;
-    void issueRepaintForOutlineAuto(float outlineSize);
+    void issueRepaintForOutlineAuto(Style::Length<> outlineSize);
     
     void updateReferencedSVGResources();
     void clearReferencedSVGResources();

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -66,6 +66,7 @@
 #include "SVGElementTypeHelpers.h"
 #include "SVGImage.h"
 #include "Settings.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "TextPainter.h"
 #include <wtf/StackStats.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -684,7 +685,7 @@ void RenderImage::paintAreaElementFocusRing(PaintInfo& paintInfo, const LayoutPo
     if (!areaElementStyle)
         return;
 
-    float outlineWidth = areaElementStyle->outlineWidth();
+    auto outlineWidth = Style::to<float>(areaElementStyle->outlineWidth());
     if (!outlineWidth)
         return;
 

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -53,6 +53,7 @@
 #include "RenderView.h"
 #include "Settings.h"
 #include "StyleInheritedData.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "TransformState.h"
 #include "VisiblePosition.h"
 #include "WillChangeData.h"
@@ -611,7 +612,7 @@ LayoutRect RenderInline::clippedOverflowRect(const RenderLayerModelObject* repai
             repaintRect.move(renderInline->layer()->offsetForInFlowPosition());
     }
 
-    LayoutUnit outlineSize { style().outlineSize() };
+    auto outlineSize = Style::to<LayoutUnit>(style().outlineSize());
     repaintRect.inflate(outlineSize);
 
     if (hitRepaintContainer || !containingBlock)
@@ -935,20 +936,20 @@ void RenderInline::paintOutline(PaintInfo& paintInfo, const LayoutPoint& paintOf
 
     auto& styleToUse = style();
     // Only paint the focus ring by hand if the theme isn't able to draw it.
-    if (styleToUse.hasAutoOutlineStyle() && !theme().supportsFocusRing(*this, styleToUse)) {
+    if (styleToUse.outlineStyle() == OutlineStyle::Auto && !theme().supportsFocusRing(*this, styleToUse)) {
         Vector<LayoutRect> focusRingRects;
         addFocusRingRects(focusRingRects, paintOffset, paintInfo.paintContainer);
         paintFocusRing(paintInfo, styleToUse, focusRingRects);
     }
 
-    if (hasOutlineAnnotation() && !styleToUse.hasAutoOutlineStyle() && !theme().supportsFocusRing(*this, styleToUse))
+    if (hasOutlineAnnotation() && styleToUse.outlineStyle() != OutlineStyle::Auto && !theme().supportsFocusRing(*this, styleToUse))
         addPDFURLRect(paintInfo, paintOffset);
 
     GraphicsContext& graphicsContext = paintInfo.context();
     if (graphicsContext.paintingDisabled())
         return;
 
-    if (styleToUse.hasAutoOutlineStyle() || !styleToUse.hasOutline())
+    if (styleToUse.outlineStyle() == OutlineStyle::Auto || !styleToUse.hasOutline())
         return;
 
     if (!containingBlock()) {

--- a/Source/WebCore/rendering/RenderMultiColumnSet.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnSet.cpp
@@ -39,6 +39,7 @@
 #include "RenderMultiColumnSpannerPlaceholder.h"
 #include "RenderObjectInlines.h"
 #include "RenderView.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -627,13 +628,13 @@ void RenderMultiColumnSet::paintColumnRules(PaintInfo& paintInfo, const LayoutPo
     if (paintInfo.context().paintingDisabled())
         return;
 
-    RenderMultiColumnFlow* fragmentedFlow = multiColumnFlow();
-    const RenderStyle& blockStyle = parent()->style();
-    const Color& ruleColor = blockStyle.visitedDependentColorWithColorFilter(CSSPropertyColumnRuleColor);
+    auto* fragmentedFlow = multiColumnFlow();
+    const auto& blockStyle = parent()->style();
+    const auto& ruleColor = blockStyle.visitedDependentColorWithColorFilter(CSSPropertyColumnRuleColor);
     bool ruleTransparent = blockStyle.columnRuleIsTransparent();
-    BorderStyle ruleStyle = collapsedBorderStyle(blockStyle.columnRuleStyle());
-    LayoutUnit ruleThickness { blockStyle.columnRuleWidth() };
-    LayoutUnit colGap = columnGap();
+    auto ruleStyle = collapsedBorderStyle(blockStyle.columnRuleStyle());
+    auto ruleThickness = Style::to<LayoutUnit>(blockStyle.columnRuleWidth());
+    auto colGap = columnGap();
     bool renderRule = ruleStyle > BorderStyle::Hidden && !ruleTransparent;
     if (!renderRule)
         return;

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -983,7 +983,7 @@ void RenderObject::propagateRepaintToParentWithOutlineAutoIfNeeded(const RenderL
 
         bool rendererHasOutlineAutoAncestor = renderer->hasOutlineAutoAncestor() || originalRenderer->hasOutlineAutoAncestor();
         ASSERT(rendererHasOutlineAutoAncestor
-            || originalRenderer->outlineStyleForRepaint().hasAutoOutlineStyle()
+            || originalRenderer->outlineStyleForRepaint().outlineStyle() == OutlineStyle::Auto
             || (is<RenderBoxModelObject>(*renderer) && downcast<RenderBoxModelObject>(*renderer).isContinuation()));
         if (originalRenderer == &repaintContainer && rendererHasOutlineAutoAncestor)
             repaintRectNeedsConverting = true;
@@ -991,7 +991,7 @@ void RenderObject::propagateRepaintToParentWithOutlineAutoIfNeeded(const RenderL
             continue;
         // Issue repaint on the correct repaint container.
         LayoutRect adjustedRepaintRect = repaintRect;
-        adjustedRepaintRect.inflate(originalRenderer->outlineStyleForRepaint().outlineSize());
+        adjustedRepaintRect.inflate(Style::to<float>(originalRenderer->outlineStyleForRepaint().outlineSize()));
         if (!repaintRectNeedsConverting)
             repaintContainer.repaintRectangle(adjustedRepaintRect);
         else if (CheckedPtr rendererWithOutline = dynamicDowncast<RenderLayerModelObject>(originalRenderer.get())) {

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -299,7 +299,7 @@ void RenderReplaced::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
 
     LayoutRect paintRect = LayoutRect(adjustedPaintOffset, size());
     if (paintInfo.phase == PaintPhase::Outline || paintInfo.phase == PaintPhase::SelfOutline) {
-        if (style().outlineWidth())
+        if (!Style::isZero(style().outlineWidth()))
             paintOutline(paintInfo, paintRect);
         return;
     }

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -59,6 +59,7 @@
 #include "RenderView.h"
 #include "StyleBoxShadow.h"
 #include "StyleInheritedData.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 #include <wtf/SetForScope.h>
 #include <wtf/StackStats.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -1243,17 +1244,17 @@ LayoutUnit RenderTable::calcBorderStart() const
     if (!numEffCols())
         return 0;
 
-    float borderWidth = 0;
+    Style::LineWidth borderWidth = 0_css_px;
 
-    const BorderValue& tableStartBorder = style().borderStart();
+    auto& tableStartBorder = style().borderStart();
     if (tableStartBorder.style() == BorderStyle::Hidden)
         return 0;
     if (tableStartBorder.style() > BorderStyle::Hidden)
         borderWidth = tableStartBorder.width();
 
-    if (RenderTableCol* column = colElement(0)) {
+    if (auto* column = colElement(0)) {
         // FIXME: We don't account for direction on columns and column groups.
-        const BorderValue& columnAdjoiningBorder = column->style().borderStart();
+        auto& columnAdjoiningBorder = column->style().borderStart();
         if (columnAdjoiningBorder.style() == BorderStyle::Hidden)
             return 0;
         if (columnAdjoiningBorder.style() > BorderStyle::Hidden)
@@ -1261,21 +1262,21 @@ LayoutUnit RenderTable::calcBorderStart() const
         // FIXME: This logic doesn't properly account for the first column in the first column-group case.
     }
 
-    if (const RenderTableSection* topNonEmptySection = this->topNonEmptySection()) {
-        const BorderValue& sectionAdjoiningBorder = topNonEmptySection->borderAdjoiningTableStart();
+    if (auto* topNonEmptySection = this->topNonEmptySection()) {
+        auto& sectionAdjoiningBorder = topNonEmptySection->borderAdjoiningTableStart();
         if (sectionAdjoiningBorder.style() == BorderStyle::Hidden)
             return 0;
 
         if (sectionAdjoiningBorder.style() > BorderStyle::Hidden)
             borderWidth = std::max(borderWidth, sectionAdjoiningBorder.width());
 
-        if (const RenderTableCell* adjoiningStartCell = topNonEmptySection->cellAt(0, 0).primaryCell()) {
+        if (auto* adjoiningStartCell = topNonEmptySection->cellAt(0, 0).primaryCell()) {
             // FIXME: Make this work with perpendicular and flipped cells.
-            const BorderValue& startCellAdjoiningBorder = adjoiningStartCell->borderAdjoiningTableStart();
+            auto& startCellAdjoiningBorder = adjoiningStartCell->borderAdjoiningTableStart();
             if (startCellAdjoiningBorder.style() == BorderStyle::Hidden)
                 return 0;
 
-            const BorderValue& firstRowAdjoiningBorder = adjoiningStartCell->row()->borderAdjoiningTableStart();
+            auto& firstRowAdjoiningBorder = adjoiningStartCell->row()->borderAdjoiningTableStart();
             if (firstRowAdjoiningBorder.style() == BorderStyle::Hidden)
                 return 0;
 
@@ -1285,7 +1286,7 @@ LayoutUnit RenderTable::calcBorderStart() const
                 borderWidth = std::max(borderWidth, firstRowAdjoiningBorder.width());
         }
     }
-    return CollapsedBorderValue::adjustedCollapsedBorderWidth(borderWidth, document().deviceScaleFactor(), writingMode().isInlineFlipped());
+    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::to<float>(borderWidth), document().deviceScaleFactor(), writingMode().isInlineFlipped());
 }
 
 LayoutUnit RenderTable::calcBorderEnd() const
@@ -1297,18 +1298,18 @@ LayoutUnit RenderTable::calcBorderEnd() const
     if (!numEffCols())
         return 0;
 
-    float borderWidth = 0;
+    Style::LineWidth borderWidth = 0_css_px;
 
-    const BorderValue& tableEndBorder = style().borderEnd();
+    auto& tableEndBorder = style().borderEnd();
     if (tableEndBorder.style() == BorderStyle::Hidden)
         return 0;
     if (tableEndBorder.style() > BorderStyle::Hidden)
         borderWidth = tableEndBorder.width();
 
     unsigned endColumn = numEffCols() - 1;
-    if (RenderTableCol* column = colElement(endColumn)) {
+    if (auto* column = colElement(endColumn)) {
         // FIXME: We don't account for direction on columns and column groups.
-        const BorderValue& columnAdjoiningBorder = column->style().borderEnd();
+        auto& columnAdjoiningBorder = column->style().borderEnd();
         if (columnAdjoiningBorder.style() == BorderStyle::Hidden)
             return 0;
         if (columnAdjoiningBorder.style() > BorderStyle::Hidden)
@@ -1316,21 +1317,21 @@ LayoutUnit RenderTable::calcBorderEnd() const
         // FIXME: This logic doesn't properly account for the last column in the last column-group case.
     }
 
-    if (const RenderTableSection* topNonEmptySection = this->topNonEmptySection()) {
-        const BorderValue& sectionAdjoiningBorder = topNonEmptySection->borderAdjoiningTableEnd();
+    if (auto* topNonEmptySection = this->topNonEmptySection()) {
+        auto& sectionAdjoiningBorder = topNonEmptySection->borderAdjoiningTableEnd();
         if (sectionAdjoiningBorder.style() == BorderStyle::Hidden)
             return 0;
 
         if (sectionAdjoiningBorder.style() > BorderStyle::Hidden)
             borderWidth = std::max(borderWidth, sectionAdjoiningBorder.width());
 
-        if (const RenderTableCell* adjoiningEndCell = topNonEmptySection->cellAt(0, lastColumnIndex()).primaryCell()) {
+        if (auto* adjoiningEndCell = topNonEmptySection->cellAt(0, lastColumnIndex()).primaryCell()) {
             // FIXME: Make this work with perpendicular and flipped cells.
-            const BorderValue& endCellAdjoiningBorder = adjoiningEndCell->borderAdjoiningTableEnd();
+            auto& endCellAdjoiningBorder = adjoiningEndCell->borderAdjoiningTableEnd();
             if (endCellAdjoiningBorder.style() == BorderStyle::Hidden)
                 return 0;
 
-            const BorderValue& firstRowAdjoiningBorder = adjoiningEndCell->row()->borderAdjoiningTableEnd();
+            auto& firstRowAdjoiningBorder = adjoiningEndCell->row()->borderAdjoiningTableEnd();
             if (firstRowAdjoiningBorder.style() == BorderStyle::Hidden)
                 return 0;
 
@@ -1340,7 +1341,7 @@ LayoutUnit RenderTable::calcBorderEnd() const
                 borderWidth = std::max(borderWidth, firstRowAdjoiningBorder.width());
         }
     }
-    return CollapsedBorderValue::adjustedCollapsedBorderWidth(borderWidth, document().deviceScaleFactor(), !writingMode().isInlineFlipped());
+    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::to<float>(borderWidth), document().deviceScaleFactor(), !writingMode().isInlineFlipped());
 }
 
 void RenderTable::recalcBordersInRowDirection()
@@ -1373,16 +1374,16 @@ LayoutUnit RenderTable::outerBorderBefore() const
     if (!collapseBorders())
         return 0;
     LayoutUnit borderWidth;
-    if (RenderTableSection* topSection = this->topSection()) {
+    if (auto* topSection = this->topSection()) {
         borderWidth = topSection->outerBorderBefore();
         if (borderWidth < 0)
             return 0;   // Overridden by hidden
     }
-    const BorderValue& tb = style().borderBefore();
+    auto& tb = style().borderBefore();
     if (tb.style() == BorderStyle::Hidden)
         return 0;
     if (tb.style() > BorderStyle::Hidden) {
-        LayoutUnit collapsedBorderWidth = std::max(borderWidth, LayoutUnit(tb.width() / 2));
+        auto collapsedBorderWidth = std::max(borderWidth, LayoutUnit(Style::to<float>(tb.width()) / 2));
         borderWidth = floorToDevicePixel(collapsedBorderWidth, document().deviceScaleFactor());
     }
     return borderWidth;
@@ -1393,18 +1394,17 @@ LayoutUnit RenderTable::outerBorderAfter() const
     if (!collapseBorders())
         return 0;
     LayoutUnit borderWidth;
-
-    if (RenderTableSection* section = bottomSection()) {
+    if (auto* section = bottomSection()) {
         borderWidth = section->outerBorderAfter();
         if (borderWidth < 0)
             return 0; // Overridden by hidden
     }
-    const BorderValue& tb = style().borderAfter();
+    auto& tb = style().borderAfter();
     if (tb.style() == BorderStyle::Hidden)
         return 0;
     if (tb.style() > BorderStyle::Hidden) {
-        float deviceScaleFactor = document().deviceScaleFactor();
-        LayoutUnit collapsedBorderWidth = std::max(borderWidth, LayoutUnit((tb.width() + (1 / deviceScaleFactor)) / 2));
+        auto deviceScaleFactor = document().deviceScaleFactor();
+        auto collapsedBorderWidth = std::max(borderWidth, LayoutUnit((Style::to<float>(tb.width()) + (1 / deviceScaleFactor)) / 2));
         borderWidth = floorToDevicePixel(collapsedBorderWidth, deviceScaleFactor);
     }
     return borderWidth;
@@ -1415,17 +1415,16 @@ LayoutUnit RenderTable::outerBorderStart() const
     if (!collapseBorders())
         return 0;
 
-    LayoutUnit borderWidth;
-
-    const BorderValue& tb = style().borderStart();
+    auto& tb = style().borderStart();
     if (tb.style() == BorderStyle::Hidden)
         return 0;
     if (tb.style() > BorderStyle::Hidden)
-        return CollapsedBorderValue::adjustedCollapsedBorderWidth(tb.width(), document().deviceScaleFactor(), writingMode().isInlineFlipped());
+        return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::to<float>(tb.width()), document().deviceScaleFactor(), writingMode().isInlineFlipped());
 
+    LayoutUnit borderWidth;
     bool allHidden = true;
-    for (RenderTableSection* section = topSection(); section; section = sectionBelow(section)) {
-        LayoutUnit sw = section->outerBorderStart();
+    for (auto* section = topSection(); section; section = sectionBelow(section)) {
+        auto sw = section->outerBorderStart();
         if (sw < 0)
             continue;
         allHidden = false;
@@ -1442,17 +1441,16 @@ LayoutUnit RenderTable::outerBorderEnd() const
     if (!collapseBorders())
         return 0;
 
-    LayoutUnit borderWidth;
-
-    const BorderValue& tb = style().borderEnd();
+    auto& tb = style().borderEnd();
     if (tb.style() == BorderStyle::Hidden)
         return 0;
     if (tb.style() > BorderStyle::Hidden)
-        return CollapsedBorderValue::adjustedCollapsedBorderWidth(tb.width(), document().deviceScaleFactor(), !writingMode().isInlineFlipped());
+        return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::to<float>(tb.width()), document().deviceScaleFactor(), !writingMode().isInlineFlipped());
 
+    LayoutUnit borderWidth;
     bool allHidden = true;
-    for (RenderTableSection* section = topSection(); section; section = sectionBelow(section)) {
-        LayoutUnit sw = section->outerBorderEnd();
+    for (auto* section = topSection(); section; section = sectionBelow(section)) {
+        auto sw = section->outerBorderEnd();
         if (sw < 0)
             continue;
         allHidden = false;

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -46,6 +46,7 @@
 #include "RenderView.h"
 #include "Settings.h"
 #include "StyleBoxShadow.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "StyleProperties.h"
 #include "TransformState.h"
 #include <ranges>
@@ -435,11 +436,11 @@ auto RenderTableCell::localRectsForRepaint(RepaintOutlineBounds repaintOutlineBo
         return RenderBlockFlow::localRectsForRepaint(repaintOutlineBounds);
 
     bool flippedInline = tableWritingMode().isInlineFlipped();
-    LayoutUnit outlineSize { style().outlineSize() };
-    LayoutUnit left = std::max(borderHalfLeft(true), outlineSize);
-    LayoutUnit right = std::max(borderHalfRight(true), outlineSize);
-    LayoutUnit top = std::max(borderHalfTop(true), outlineSize);
-    LayoutUnit bottom = std::max(borderHalfBottom(true), outlineSize);
+    auto outlineSize = Style::to<LayoutUnit>(style().outlineSize());
+    auto left = std::max(borderHalfLeft(true), outlineSize);
+    auto right = std::max(borderHalfRight(true), outlineSize);
+    auto top = std::max(borderHalfTop(true), outlineSize);
+    auto bottom = std::max(borderHalfBottom(true), outlineSize);
     if ((left && !flippedInline) || (right && flippedInline)) {
         if (RenderTableCell* before = table()->cellBefore(this)) {
             top = std::max(top, before->borderHalfTop(true));
@@ -1039,7 +1040,7 @@ inline CollapsedBorderValue RenderTableCell::cachedCollapsedBottomBorder(const W
 
 RectEdges<LayoutUnit> RenderTableCell::borderWidths() const
 {
-    RenderTable* table = this->table();
+    auto* table = this->table();
     if (!table)
         return RenderBlockFlow::borderWidths();
 
@@ -1056,7 +1057,7 @@ RectEdges<LayoutUnit> RenderTableCell::borderWidths() const
 
 LayoutUnit RenderTableCell::borderLeft() const
 {
-    RenderTable* table = this->table();
+    auto* table = this->table();
     if (!table)
         return RenderBlockFlow::borderLeft();
     return table->collapseBorders() ? borderHalfLeft(false) : RenderBlockFlow::borderLeft();
@@ -1064,7 +1065,7 @@ LayoutUnit RenderTableCell::borderLeft() const
 
 LayoutUnit RenderTableCell::borderRight() const
 {
-    RenderTable* table = this->table();
+    auto* table = this->table();
     if (!table)
         return RenderBlockFlow::borderRight();
     return table->collapseBorders() ? borderHalfRight(false) : RenderBlockFlow::borderRight();
@@ -1072,7 +1073,7 @@ LayoutUnit RenderTableCell::borderRight() const
 
 LayoutUnit RenderTableCell::borderTop() const
 {
-    RenderTable* table = this->table();
+    auto* table = this->table();
     if (!table)
         return RenderBlockFlow::borderTop();
     return table->collapseBorders() ? borderHalfTop(false) : RenderBlockFlow::borderTop();
@@ -1080,7 +1081,7 @@ LayoutUnit RenderTableCell::borderTop() const
 
 LayoutUnit RenderTableCell::borderBottom() const
 {
-    RenderTable* table = this->table();
+    auto* table = this->table();
     if (!table)
         return RenderBlockFlow::borderBottom();
     return table->collapseBorders() ? borderHalfBottom(false) : RenderBlockFlow::borderBottom();
@@ -1090,7 +1091,7 @@ LayoutUnit RenderTableCell::borderBottom() const
 // work with different block flow values instead of being hard-coded to top-to-bottom.
 LayoutUnit RenderTableCell::borderStart() const
 {
-    RenderTable* table = this->table();
+    auto* table = this->table();
     if (!table)
         return RenderBlockFlow::borderStart();
     return table->collapseBorders() ? borderHalfStart(false) : RenderBlockFlow::borderStart();
@@ -1098,7 +1099,7 @@ LayoutUnit RenderTableCell::borderStart() const
 
 LayoutUnit RenderTableCell::borderEnd() const
 {
-    RenderTable* table = this->table();
+    auto* table = this->table();
     if (!table)
         return RenderBlockFlow::borderEnd();
     return table->collapseBorders() ? borderHalfEnd(false) : RenderBlockFlow::borderEnd();
@@ -1106,7 +1107,7 @@ LayoutUnit RenderTableCell::borderEnd() const
 
 LayoutUnit RenderTableCell::borderBefore() const
 {
-    RenderTable* table = this->table();
+    auto* table = this->table();
     if (!table)
         return RenderBlockFlow::borderBefore();
     return table->collapseBorders() ? borderHalfBefore(false) : RenderBlockFlow::borderBefore();
@@ -1114,7 +1115,7 @@ LayoutUnit RenderTableCell::borderBefore() const
 
 LayoutUnit RenderTableCell::borderAfter() const
 {
-    RenderTable* table = this->table();
+    auto* table = this->table();
     if (!table)
         return RenderBlockFlow::borderAfter();
     return table->collapseBorders() ? borderHalfAfter(false) : RenderBlockFlow::borderAfter();
@@ -1122,7 +1123,7 @@ LayoutUnit RenderTableCell::borderAfter() const
 
 LayoutUnit RenderTableCell::borderHalfLeft(bool outer) const
 {
-    WritingMode writingMode = this->tableWritingMode();
+    auto writingMode = this->tableWritingMode();
     if (writingMode.isHorizontal())
         return writingMode.isInlineLeftToRight() ? borderHalfStart(outer) : borderHalfEnd(outer);
     return writingMode.isBlockLeftToRight() ? borderHalfBefore(outer) : borderHalfAfter(outer);
@@ -1130,7 +1131,7 @@ LayoutUnit RenderTableCell::borderHalfLeft(bool outer) const
 
 LayoutUnit RenderTableCell::borderHalfRight(bool outer) const
 {
-    WritingMode writingMode = this->tableWritingMode();
+    auto writingMode = this->tableWritingMode();
     if (writingMode.isHorizontal())
         return writingMode.isInlineLeftToRight() ? borderHalfEnd(outer) : borderHalfStart(outer);
     return writingMode.isBlockLeftToRight() ? borderHalfAfter(outer) : borderHalfBefore(outer);
@@ -1138,7 +1139,7 @@ LayoutUnit RenderTableCell::borderHalfRight(bool outer) const
 
 LayoutUnit RenderTableCell::borderHalfTop(bool outer) const
 {
-    WritingMode writingMode = this->tableWritingMode();
+    auto writingMode = this->tableWritingMode();
     if (writingMode.isHorizontal())
         return writingMode.isBlockTopToBottom() ? borderHalfBefore(outer) : borderHalfAfter(outer);
     return writingMode.isInlineTopToBottom() ? borderHalfStart(outer) : borderHalfEnd(outer);
@@ -1146,7 +1147,7 @@ LayoutUnit RenderTableCell::borderHalfTop(bool outer) const
 
 LayoutUnit RenderTableCell::borderHalfBottom(bool outer) const
 {
-    WritingMode writingMode = this->tableWritingMode();
+    auto writingMode = this->tableWritingMode();
     if (writingMode.isHorizontal())
         return writingMode.isBlockTopToBottom() ? borderHalfAfter(outer) : borderHalfBefore(outer);
     return writingMode.isInlineTopToBottom() ? borderHalfEnd(outer) : borderHalfStart(outer);
@@ -1154,24 +1155,21 @@ LayoutUnit RenderTableCell::borderHalfBottom(bool outer) const
 
 LayoutUnit RenderTableCell::borderHalfStart(bool outer) const
 {
-    CollapsedBorderValue border = collapsedStartBorder(DoNotIncludeBorderColor);
-    if (border.exists())
+    if (auto border = collapsedStartBorder(DoNotIncludeBorderColor); border.exists())
         return CollapsedBorderValue::adjustedCollapsedBorderWidth(border.width(), document().deviceScaleFactor(), !(tableWritingMode().isInlineFlipped() ^ outer));
     return 0;
 }
     
 LayoutUnit RenderTableCell::borderHalfEnd(bool outer) const
 {
-    CollapsedBorderValue border = collapsedEndBorder(DoNotIncludeBorderColor);
-    if (border.exists())
+    if (auto border = collapsedEndBorder(DoNotIncludeBorderColor); border.exists())
         return CollapsedBorderValue::adjustedCollapsedBorderWidth(border.width(), document().deviceScaleFactor(), tableWritingMode().isInlineFlipped() ^ outer);
     return 0;
 }
 
 LayoutUnit RenderTableCell::borderHalfBefore(bool outer) const
 {
-    CollapsedBorderValue border = collapsedBeforeBorder(DoNotIncludeBorderColor);
-    if (border.exists())
+    if (auto border = collapsedBeforeBorder(DoNotIncludeBorderColor); border.exists())
         return CollapsedBorderValue::adjustedCollapsedBorderWidth(border.width(), document().deviceScaleFactor(), !(tableWritingMode().isBlockFlipped() ^ outer));
     return 0;
 }
@@ -1272,36 +1270,36 @@ void RenderTableCell::paintCollapsedBorders(PaintInfo& paintInfo, const LayoutPo
     if (!paintInfo.shouldPaintWithinRoot(*this) || style().usedVisibility() != Visibility::Visible)
         return;
 
-    LayoutRect localRepaintRect = paintInfo.rect;
-    LayoutRect paintRect = LayoutRect(paintOffset + location(), frameRect().size());
+    auto localRepaintRect = paintInfo.rect;
+    auto paintRect = LayoutRect(paintOffset + location(), frameRect().size());
     if (paintRect.y() - table()->outerBorderTop() >= localRepaintRect.maxY())
         return;
 
     if (paintRect.maxY() + table()->outerBorderBottom() <= localRepaintRect.y())
         return;
 
-    GraphicsContext& graphicsContext = paintInfo.context();
+    auto& graphicsContext = paintInfo.context();
     if (!table()->currentBorderValue() || graphicsContext.paintingDisabled())
         return;
 
-    WritingMode writingMode = tableWritingMode();
-    CollapsedBorderValue leftVal = cachedCollapsedLeftBorder(writingMode);
-    CollapsedBorderValue rightVal = cachedCollapsedRightBorder(writingMode);
-    CollapsedBorderValue topVal = cachedCollapsedTopBorder(writingMode);
-    CollapsedBorderValue bottomVal = cachedCollapsedBottomBorder(writingMode);
+    auto writingMode = tableWritingMode();
+    auto leftVal = cachedCollapsedLeftBorder(writingMode);
+    auto rightVal = cachedCollapsedRightBorder(writingMode);
+    auto topVal = cachedCollapsedTopBorder(writingMode);
+    auto bottomVal = cachedCollapsedBottomBorder(writingMode);
 
     // Adjust our x/y/width/height so that we paint the collapsed borders at the correct location.
-    LayoutUnit topWidth = topVal.width();
-    LayoutUnit bottomWidth = bottomVal.width();
-    LayoutUnit leftWidth = leftVal.width();
-    LayoutUnit rightWidth = rightVal.width();
+    auto topWidth = topVal.width();
+    auto bottomWidth = bottomVal.width();
+    auto leftWidth = leftVal.width();
+    auto rightWidth = rightVal.width();
 
-    float deviceScaleFactor = document().deviceScaleFactor();
-    LayoutUnit leftHalfCollapsedBorder = CollapsedBorderValue::adjustedCollapsedBorderWidth(leftWidth , deviceScaleFactor, false);
-    LayoutUnit topHalfCollapsedBorder = CollapsedBorderValue::adjustedCollapsedBorderWidth(topWidth, deviceScaleFactor, false);
-    LayoutUnit righHalftCollapsedBorder = CollapsedBorderValue::adjustedCollapsedBorderWidth(rightWidth, deviceScaleFactor, true);
-    LayoutUnit bottomHalfCollapsedBorder = CollapsedBorderValue::adjustedCollapsedBorderWidth(bottomWidth, deviceScaleFactor, true);
-    
+    auto deviceScaleFactor = document().deviceScaleFactor();
+    auto leftHalfCollapsedBorder = CollapsedBorderValue::adjustedCollapsedBorderWidth(leftWidth , deviceScaleFactor, false);
+    auto topHalfCollapsedBorder = CollapsedBorderValue::adjustedCollapsedBorderWidth(topWidth, deviceScaleFactor, false);
+    auto righHalftCollapsedBorder = CollapsedBorderValue::adjustedCollapsedBorderWidth(rightWidth, deviceScaleFactor, true);
+    auto bottomHalfCollapsedBorder = CollapsedBorderValue::adjustedCollapsedBorderWidth(bottomWidth, deviceScaleFactor, true);
+
     LayoutRect borderRect = LayoutRect(paintRect.x() - leftHalfCollapsedBorder,
         paintRect.y() - topHalfCollapsedBorder,
         paintRect.width() + leftHalfCollapsedBorder + righHalftCollapsedBorder,

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -697,15 +697,15 @@ LayoutUnit RenderTableSection::calcOuterBorderBefore() const
     if (!m_grid.size() || !totalCols)
         return 0;
 
-    LayoutUnit borderWidth;
+    Style::LineWidth borderWidth = 0_css_px;
 
-    const BorderValue& sb = style().borderBefore(table()->writingMode());
+    auto& sb = style().borderBefore(table()->writingMode());
     if (sb.style() == BorderStyle::Hidden)
         return -1;
     if (sb.style() > BorderStyle::Hidden)
         borderWidth = sb.width();
 
-    const BorderValue& rb = firstRow()->style().borderBefore(table()->writingMode());
+    auto& rb = firstRow()->style().borderBefore(table()->writingMode());
     if (rb.style() == BorderStyle::Hidden)
         return -1;
     if (rb.style() > BorderStyle::Hidden && rb.width() > borderWidth)
@@ -713,14 +713,14 @@ LayoutUnit RenderTableSection::calcOuterBorderBefore() const
 
     bool allHidden = true;
     for (unsigned c = 0; c < totalCols; c++) {
-        const CellStruct& current = cellAt(0, c);
+        auto& current = cellAt(0, c);
         if (current.inColSpan || !current.hasCells())
             continue;
-        const BorderValue& cb = current.primaryCell()->style().borderBefore(table()->writingMode()); // FIXME: Make this work with perpendicular and flipped cells.
+        auto& cb = current.primaryCell()->style().borderBefore(table()->writingMode()); // FIXME: Make this work with perpendicular and flipped cells.
         // FIXME: Don't repeat for the same col group
-        RenderTableCol* colGroup = table()->colElement(c);
+        auto* colGroup = table()->colElement(c);
         if (colGroup) {
-            const BorderValue& gb = colGroup->style().borderBefore(table()->writingMode());
+            auto& gb = colGroup->style().borderBefore(table()->writingMode());
             if (gb.style() == BorderStyle::Hidden || cb.style() == BorderStyle::Hidden)
                 continue;
             allHidden = false;
@@ -738,7 +738,7 @@ LayoutUnit RenderTableSection::calcOuterBorderBefore() const
     }
     if (allHidden)
         return -1;
-    return CollapsedBorderValue::adjustedCollapsedBorderWidth(borderWidth, document().deviceScaleFactor(), false);
+    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::to<float>(borderWidth), document().deviceScaleFactor(), false);
 }
 
 LayoutUnit RenderTableSection::calcOuterBorderAfter() const
@@ -747,15 +747,15 @@ LayoutUnit RenderTableSection::calcOuterBorderAfter() const
     if (!m_grid.size() || !totalCols)
         return 0;
 
-    LayoutUnit borderWidth;
+    Style::LineWidth borderWidth = 0_css_px;
 
-    const BorderValue& sb = style().borderAfter(table()->writingMode());
+    auto& sb = style().borderAfter(table()->writingMode());
     if (sb.style() == BorderStyle::Hidden)
         return -1;
     if (sb.style() > BorderStyle::Hidden)
         borderWidth = sb.width();
 
-    const BorderValue& rb = lastRow()->style().borderAfter(table()->writingMode());
+    auto& rb = lastRow()->style().borderAfter(table()->writingMode());
     if (rb.style() == BorderStyle::Hidden)
         return -1;
     if (rb.style() > BorderStyle::Hidden && rb.width() > borderWidth)
@@ -763,14 +763,14 @@ LayoutUnit RenderTableSection::calcOuterBorderAfter() const
 
     bool allHidden = true;
     for (unsigned c = 0; c < totalCols; c++) {
-        const CellStruct& current = cellAt(m_grid.size() - 1, c);
+        auto& current = cellAt(m_grid.size() - 1, c);
         if (current.inColSpan || !current.hasCells())
             continue;
-        const BorderValue& cb = current.primaryCell()->style().borderAfter(table()->writingMode()); // FIXME: Make this work with perpendicular and flipped cells.
+        auto& cb = current.primaryCell()->style().borderAfter(table()->writingMode()); // FIXME: Make this work with perpendicular and flipped cells.
         // FIXME: Don't repeat for the same col group
-        RenderTableCol* colGroup = table()->colElement(c);
+        auto* colGroup = table()->colElement(c);
         if (colGroup) {
-            const BorderValue& gb = colGroup->style().borderAfter(table()->writingMode());
+            auto& gb = colGroup->style().borderAfter(table()->writingMode());
             if (gb.style() == BorderStyle::Hidden || cb.style() == BorderStyle::Hidden)
                 continue;
             allHidden = false;
@@ -788,7 +788,7 @@ LayoutUnit RenderTableSection::calcOuterBorderAfter() const
     }
     if (allHidden)
         return -1;
-    return CollapsedBorderValue::adjustedCollapsedBorderWidth(borderWidth, document().deviceScaleFactor(), true);
+    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::to<float>(borderWidth), document().deviceScaleFactor(), true);
 }
 
 LayoutUnit RenderTableSection::calcOuterBorderStart() const
@@ -797,16 +797,16 @@ LayoutUnit RenderTableSection::calcOuterBorderStart() const
     if (!m_grid.size() || !totalCols)
         return 0;
 
-    LayoutUnit borderWidth;
+    Style::LineWidth borderWidth = 0_css_px;
 
-    const BorderValue& sb = style().borderStart(table()->writingMode());
+    auto& sb = style().borderStart(table()->writingMode());
     if (sb.style() == BorderStyle::Hidden)
         return -1;
     if (sb.style() > BorderStyle::Hidden)
         borderWidth = sb.width();
 
     if (RenderTableCol* colGroup = table()->colElement(0)) {
-        const BorderValue& gb = colGroup->style().borderStart(table()->writingMode());
+        auto& gb = colGroup->style().borderStart(table()->writingMode());
         if (gb.style() == BorderStyle::Hidden)
             return -1;
         if (gb.style() > BorderStyle::Hidden && gb.width() > borderWidth)
@@ -815,12 +815,12 @@ LayoutUnit RenderTableSection::calcOuterBorderStart() const
 
     bool allHidden = true;
     for (unsigned r = 0; r < m_grid.size(); r++) {
-        const CellStruct& current = cellAt(r, 0);
+        auto& current = cellAt(r, 0);
         if (!current.hasCells())
             continue;
         // FIXME: Don't repeat for the same cell
-        const BorderValue& cb = current.primaryCell()->style().borderStart(table()->writingMode()); // FIXME: Make this work with perpendicular and flipped cells.
-        const BorderValue& rb = current.primaryCell()->parent()->style().borderStart(table()->writingMode());
+        auto& cb = current.primaryCell()->style().borderStart(table()->writingMode()); // FIXME: Make this work with perpendicular and flipped cells.
+        auto& rb = current.primaryCell()->parent()->style().borderStart(table()->writingMode());
         if (cb.style() == BorderStyle::Hidden || rb.style() == BorderStyle::Hidden)
             continue;
         allHidden = false;
@@ -831,7 +831,7 @@ LayoutUnit RenderTableSection::calcOuterBorderStart() const
     }
     if (allHidden)
         return -1;
-    return CollapsedBorderValue::adjustedCollapsedBorderWidth(borderWidth, document().deviceScaleFactor(), table()->writingMode().isInlineFlipped());
+    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::to<float>(borderWidth), document().deviceScaleFactor(), table()->writingMode().isInlineFlipped());
 }
 
 LayoutUnit RenderTableSection::calcOuterBorderEnd() const
@@ -840,16 +840,16 @@ LayoutUnit RenderTableSection::calcOuterBorderEnd() const
     if (!m_grid.size() || !totalCols)
         return 0;
 
-    LayoutUnit borderWidth;
+    Style::LineWidth borderWidth = 0_css_px;
 
-    const BorderValue& sb = style().borderEnd(table()->writingMode());
+    auto& sb = style().borderEnd(table()->writingMode());
     if (sb.style() == BorderStyle::Hidden)
         return -1;
     if (sb.style() > BorderStyle::Hidden)
         borderWidth = sb.width();
 
     if (RenderTableCol* colGroup = table()->colElement(totalCols - 1)) {
-        const BorderValue& gb = colGroup->style().borderEnd(table()->writingMode());
+        auto& gb = colGroup->style().borderEnd(table()->writingMode());
         if (gb.style() == BorderStyle::Hidden)
             return -1;
         if (gb.style() > BorderStyle::Hidden && gb.width() > borderWidth)
@@ -858,12 +858,12 @@ LayoutUnit RenderTableSection::calcOuterBorderEnd() const
 
     bool allHidden = true;
     for (unsigned r = 0; r < m_grid.size(); r++) {
-        const CellStruct& current = cellAt(r, totalCols - 1);
+        auto& current = cellAt(r, totalCols - 1);
         if (!current.hasCells())
             continue;
         // FIXME: Don't repeat for the same cell
-        const BorderValue& cb = current.primaryCell()->style().borderEnd(table()->writingMode()); // FIXME: Make this work with perpendicular and flipped cells.
-        const BorderValue& rb = current.primaryCell()->parent()->style().borderEnd(table()->writingMode());
+        auto& cb = current.primaryCell()->style().borderEnd(table()->writingMode()); // FIXME: Make this work with perpendicular and flipped cells.
+        auto& rb = current.primaryCell()->parent()->style().borderEnd(table()->writingMode());
         if (cb.style() == BorderStyle::Hidden || rb.style() == BorderStyle::Hidden)
             continue;
         allHidden = false;
@@ -874,7 +874,7 @@ LayoutUnit RenderTableSection::calcOuterBorderEnd() const
     }
     if (allHidden)
         return -1;
-    return CollapsedBorderValue::adjustedCollapsedBorderWidth(borderWidth, document().deviceScaleFactor(), !table()->writingMode().isInlineFlipped());
+    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::to<float>(borderWidth), document().deviceScaleFactor(), !table()->writingMode().isInlineFlipped());
 }
 
 void RenderTableSection::recalcOuterBorder()
@@ -915,7 +915,7 @@ std::optional<LayoutUnit> RenderTableSection::baselineFromCellContentEdges(ItemP
     
     std::optional<LayoutUnit> result;
     for (size_t i = 0; i < row.size(); ++i) {
-        const CellStruct& cs = row.at(i);
+        auto& cs = row.at(i);
         const RenderTableCell* cell = cs.primaryCell();
         // Only cells with content have a baseline
         if (cell && cell->contentBoxLogicalHeight()) {
@@ -1177,18 +1177,18 @@ void RenderTableSection::paintRowGroupBorderIfRequired(const PaintInfo& paintInf
     switch (borderSide) {
     case BoxSide::Top:
         paintRowGroupBorder(paintInfo, antialias, LayoutRect(paintOffset.x() + offsetLeftForRowGroupBorder(cell, rowGroupRect, row), rowGroupRect.y(), 
-            horizontalRowGroupBorderWidth(cell, rowGroupRect, row, column), LayoutUnit(style.borderTop().width())), BoxSide::Top, CSSPropertyBorderTopColor, style.borderTopStyle(), table()->style().borderTopStyle());
+            horizontalRowGroupBorderWidth(cell, rowGroupRect, row, column), Style::to<LayoutUnit>(style.borderTop().width())), BoxSide::Top, CSSPropertyBorderTopColor, style.borderTopStyle(), table()->style().borderTopStyle());
         break;
     case BoxSide::Bottom:
         paintRowGroupBorder(paintInfo, antialias, LayoutRect(paintOffset.x() + offsetLeftForRowGroupBorder(cell, rowGroupRect, row), rowGroupRect.y() + rowGroupRect.height(), 
-            horizontalRowGroupBorderWidth(cell, rowGroupRect, row, column), LayoutUnit(style.borderBottom().width())), BoxSide::Bottom, CSSPropertyBorderBottomColor, style.borderBottomStyle(), table()->style().borderBottomStyle());
+            horizontalRowGroupBorderWidth(cell, rowGroupRect, row, column), Style::to<LayoutUnit>(style.borderBottom().width())), BoxSide::Bottom, CSSPropertyBorderBottomColor, style.borderBottomStyle(), table()->style().borderBottomStyle());
         break;
     case BoxSide::Left:
-        paintRowGroupBorder(paintInfo, antialias, LayoutRect(rowGroupRect.x(), rowGroupRect.y() + offsetTopForRowGroupBorder(cell, borderSide, row), LayoutUnit(style.borderLeft().width()),
+        paintRowGroupBorder(paintInfo, antialias, LayoutRect(rowGroupRect.x(), rowGroupRect.y() + offsetTopForRowGroupBorder(cell, borderSide, row), Style::to<LayoutUnit>(style.borderLeft().width()),
             verticalRowGroupBorderHeight(cell, rowGroupRect, row)), BoxSide::Left, CSSPropertyBorderLeftColor, style.borderLeftStyle(), table()->style().borderLeftStyle());
         break;
     case BoxSide::Right:
-        paintRowGroupBorder(paintInfo, antialias, LayoutRect(rowGroupRect.x() + rowGroupRect.width(), rowGroupRect.y() + offsetTopForRowGroupBorder(cell, borderSide, row), LayoutUnit(style.borderRight().width()),
+        paintRowGroupBorder(paintInfo, antialias, LayoutRect(rowGroupRect.x() + rowGroupRect.width(), rowGroupRect.y() + offsetTopForRowGroupBorder(cell, borderSide, row), Style::to<LayoutUnit>(style.borderRight().width()),
             verticalRowGroupBorderHeight(cell, rowGroupRect, row)), BoxSide::Right, CSSPropertyBorderRightColor, style.borderRightStyle(), table()->style().borderRightStyle());
         break;
     default:
@@ -1448,7 +1448,7 @@ unsigned RenderTableSection::numColumns() const
     
     for (unsigned r = 0; r < m_grid.size(); ++r) {
         for (unsigned c = result; c < table()->numEffCols(); ++c) {
-            const CellStruct& cell = cellAt(r, c);
+            auto& cell = cellAt(r, c);
             if (cell.hasCells() || cell.inColSpan)
                 result = c;
         }

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -761,7 +761,7 @@ OptionSet<ControlStyle::State> RenderTheme::extractControlStyleStatesForRenderer
         if (isSpinUpButtonPartPressed(renderer))
             states.add(ControlStyle::State::SpinUp);
     }
-    if (isFocused(renderer) && renderer.style().hasAutoOutlineStyle())
+    if (isFocused(renderer) && renderer.style().outlineStyle() == OutlineStyle::Auto)
         states.add(ControlStyle::State::Focused);
     if (isEnabled(renderer))
         states.add(ControlStyle::State::Enabled);
@@ -837,7 +837,7 @@ ControlStyle RenderTheme::extractControlStyleForRenderer(const RenderObject& ren
         style->usedZoom(),
         style->usedAccentColor(renderObject.styleColorOptions()),
         style->visitedDependentColorWithColorFilter(CSSPropertyColor),
-        style->borderWidth()
+        Style::to<FloatBoxExtent>(style->borderWidth()),
     };
 }
 
@@ -1362,7 +1362,7 @@ Style::MinimumSizePair RenderTheme::minimumControlSize(StyleAppearance appearanc
     return { WTFMove(resultWidth), WTFMove(resultHeight) };
 }
 
-LengthBox RenderTheme::controlBorder(StyleAppearance appearance, const FontCascade&, const LengthBox& zoomedBox, float, const Element*) const
+RectEdges<Style::LineWidth> RenderTheme::controlBorder(StyleAppearance appearance, const FontCascade&, const RectEdges<Style::LineWidth>& zoomedBox, float, const Element*) const
 {
     switch (appearance) {
     case StyleAppearance::PushButton:
@@ -1370,7 +1370,7 @@ LengthBox RenderTheme::controlBorder(StyleAppearance appearance, const FontCasca
     case StyleAppearance::SearchField:
     case StyleAppearance::Checkbox:
     case StyleAppearance::Radio:
-        return LengthBox(0);
+        return RectEdges<Style::LineWidth> { 0_css_px };
     default:
         return zoomedBox;
     }
@@ -1381,10 +1381,9 @@ LengthBox RenderTheme::controlBorder(StyleAppearance appearance, const FontCasca
 void RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle(RenderStyle& style, const Element* element) const
 {
     auto appearance = style.usedAppearance();
-
-    LengthBox borderBox(style.borderTopWidth(), style.borderRightWidth(), style.borderBottomWidth(), style.borderLeftWidth());
     CheckedRef fontCascade = style.fontCascade();
-    borderBox = controlBorder(appearance, fontCascade.get(), borderBox, style.usedZoom(), element);
+
+    auto borderBox = controlBorder(appearance, fontCascade.get(), style.borderWidth(), style.usedZoom(), element);
 
     auto supportsVerticalWritingMode = [](StyleAppearance appearance) {
         return appearance == StyleAppearance::Button
@@ -1395,31 +1394,31 @@ void RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle
     };
     // Transpose for vertical writing mode:
     if (!style.writingMode().isHorizontal() && supportsVerticalWritingMode(appearance))
-        borderBox = LengthBox(borderBox.left().value(), borderBox.top().value(), borderBox.right().value(), borderBox.bottom().value());
+        borderBox = borderBox.transpose();
 
-    if (borderBox.top().value() != static_cast<int>(style.borderTopWidth())) {
-        if (borderBox.top().value())
-            style.setBorderTopWidth(borderBox.top().value());
+    if (borderBox.top().value != Style::to<int>(style.borderTopWidth())) {
+        if (!Style::isZero(borderBox.top()))
+            style.setBorderTopWidth(borderBox.top());
         else
             style.resetBorderTop();
     }
-    if (borderBox.right().value() != static_cast<int>(style.borderRightWidth())) {
-        if (borderBox.right().value())
-            style.setBorderRightWidth(borderBox.right().value());
+    if (borderBox.right().value != Style::to<int>(style.borderRightWidth())) {
+        if (!Style::isZero(borderBox.right()))
+            style.setBorderRightWidth(borderBox.right());
         else
             style.resetBorderRight();
     }
-    if (borderBox.bottom().value() != static_cast<int>(style.borderBottomWidth())) {
-        style.setBorderBottomWidth(borderBox.bottom().value());
-        if (borderBox.bottom().value())
-            style.setBorderBottomWidth(borderBox.bottom().value());
+    if (borderBox.bottom().value != Style::to<int>(style.borderBottomWidth())) {
+        style.setBorderBottomWidth(borderBox.bottom());
+        if (!Style::isZero(borderBox.bottom()))
+            style.setBorderBottomWidth(borderBox.bottom());
         else
             style.resetBorderBottom();
     }
-    if (borderBox.left().value() != static_cast<int>(style.borderLeftWidth())) {
-        style.setBorderLeftWidth(borderBox.left().value());
-        if (borderBox.left().value())
-            style.setBorderLeftWidth(borderBox.left().value());
+    if (borderBox.left().value != Style::to<int>(style.borderLeftWidth())) {
+        style.setBorderLeftWidth(borderBox.left());
+        if (!Style::isZero(borderBox.left()))
+            style.setBorderLeftWidth(borderBox.left());
         else
             style.resetBorderLeft();
     }
@@ -2061,6 +2060,16 @@ Color RenderTheme::defaultButtonTextColor(OptionSet<StyleColorOptions> options) 
 Color RenderTheme::platformDefaultButtonTextColor(OptionSet<StyleColorOptions> options) const
 {
     return systemColor(CSSValueActivebuttontext, options);
+}
+
+Style::LineWidth RenderTheme::platformFocusRingWidth()
+{
+    return CSS::Keyword::Medium { };
+}
+
+Style::Length<> RenderTheme::platformFocusRingOffset(Style::LineWidth outlineWidth)
+{
+    return { std::max(Style::to<float>(outlineWidth) - Style::to<float>(platformFocusRingWidth()), 0.0f) };
 }
 
 #if ENABLE(TOUCH_EVENTS)

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -174,8 +174,8 @@ public:
 
     WEBCORE_EXPORT Color focusRingColor(OptionSet<StyleColorOptions>) const;
     virtual Color platformFocusRingColor(OptionSet<StyleColorOptions>) const { return Color::black; }
-    static float platformFocusRingWidth() { return 3; }
-    static float platformFocusRingOffset(float outlineWidth) { return std::max<float>(outlineWidth - platformFocusRingWidth(), 0); }
+    static Style::LineWidth platformFocusRingWidth();
+    static Style::Length<> platformFocusRingOffset(Style::LineWidth outlineWidth);
 #if ENABLE(TOUCH_EVENTS)
     static Color tapHighlightColor();
     virtual Color platformTapHighlightColor() const;
@@ -392,7 +392,7 @@ protected:
     Style::MinimumSizePair minimumControlSize(StyleAppearance, const FontCascade&, const Style::MinimumSizePair&, const Style::PreferredSizePair&, float zoomFactor) const;
 
     // Allows the theme to modify the existing border.
-    virtual LengthBox controlBorder(StyleAppearance, const FontCascade&, const LengthBox& zoomedBox, float zoomFactor, const Element*) const;
+    virtual RectEdges<Style::LineWidth> controlBorder(StyleAppearance, const FontCascade&, const RectEdges<Style::LineWidth>& zoomedBox, float zoomFactor, const Element*) const;
 
     // Whether or not whitespace: pre should be forced on always.
     virtual bool controlRequiresPreWhiteSpace(StyleAppearance) const { return false; }

--- a/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
+++ b/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014, 2020 Igalia S.L.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -430,7 +431,7 @@ Style::MinimumSizePair RenderThemeAdwaita::minimumControlSize(StyleAppearance, c
     return { WTFMove(resultWidth), WTFMove(resultHeight) };
 }
 
-LengthBox RenderThemeAdwaita::controlBorder(StyleAppearance appearance, const FontCascade& font, const LengthBox& zoomedBox, float zoomFactor, const Element* element) const
+RectEdges<Style::LineWidth> RenderThemeAdwaita::controlBorder(StyleAppearance appearance, const FontCascade& font, const RectEdges<Style::LineWidth>& zoomedBox, float zoomFactor, const Element* element) const
 {
     switch (appearance) {
     case StyleAppearance::PushButton:

--- a/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.h
+++ b/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2020 Igalia S.L.
  * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -97,7 +98,7 @@ private:
 
     Style::PreferredSizePair controlSize(StyleAppearance, const FontCascade&, const Style::PreferredSizePair&, float) const final;
     Style::MinimumSizePair minimumControlSize(StyleAppearance, const FontCascade&, const Style::MinimumSizePair&, float zoomFactor) const final;
-    LengthBox controlBorder(StyleAppearance, const FontCascade&, const LengthBox&, float, const Element*) const final;
+    RectEdges<Style::LineWidth> controlBorder(StyleAppearance, const FontCascade&, const RectEdges<Style::LineWidth>&, float, const Element*) const final;
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
     std::optional<Seconds> caretBlinkInterval() const override;

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
@@ -57,7 +57,7 @@ protected:
 
     void inflateRectForControlRenderer(const RenderObject&, FloatRect&) override;
 
-    LengthBox controlBorder(StyleAppearance, const FontCascade&, const LengthBox& zoomedBox, float zoomFactor, const Element*) const override;
+    RectEdges<Style::LineWidth> controlBorder(StyleAppearance, const FontCascade&, const RectEdges<Style::LineWidth>& zoomedBox, float zoomFactor, const Element*) const override;
 
     Color platformSpellingMarkerColor(OptionSet<StyleColorOptions>) const override;
     Color platformDictationAlternativesMarkerColor(OptionSet<StyleColorOptions>) const override;

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -497,7 +497,7 @@ void RenderThemeCocoa::inflateRectForControlRenderer(const RenderObject& rendere
     RenderTheme::inflateRectForControlRenderer(renderer, rect);
 }
 
-LengthBox RenderThemeCocoa::controlBorder(StyleAppearance appearance, const FontCascade& font, const LengthBox& zoomedBox, float zoomFactor, const Element* element) const
+RectEdges<Style::LineWidth> RenderThemeCocoa::controlBorder(StyleAppearance appearance, const FontCascade& font, const RectEdges<Style::LineWidth>& zoomedBox, float zoomFactor, const Element* element) const
 {
 #if ENABLE(FORM_CONTROL_REFRESH)
     if (formControlRefreshEnabled(element))
@@ -617,7 +617,7 @@ constexpr auto checkboxRadioBorderWidthForVectorBasedControls = 1.5f;
 
 static bool controlIsFocusedWithOutlineStyleAutoForVectorBasedControls(const RenderObject& renderer)
 {
-    return RenderTheme::singleton().isFocused(renderer) && renderer.style().hasAutoOutlineStyle();
+    return RenderTheme::singleton().isFocused(renderer) && renderer.style().outlineStyle() == OutlineStyle::Auto;
 }
 
 static constexpr auto checkboxRadioBorderDisabledOpacityForVectorBasedControls = 0.5f;
@@ -4092,8 +4092,8 @@ void RenderThemeCocoa::adjustSwitchStyle(RenderStyle& style, const Element* elem
 
     adjustSwitchStyleDisplay(style);
 
-    if (style.hasAutoOutlineStyle())
-        style.setOutlineStyle(BorderStyle::None);
+    if (style.outlineStyle() == OutlineStyle::Auto)
+        style.setOutlineStyle(OutlineStyle::None);
 #endif
 }
 

--- a/Source/WebCore/rendering/mac/RenderThemeMac.h
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.h
@@ -81,7 +81,7 @@ public:
     Style::PaddingBox controlPadding(StyleAppearance, const Style::PaddingBox&, float zoomFactor) const final;
     Style::PreferredSizePair controlSize(StyleAppearance, const FontCascade&, const Style::PreferredSizePair&, float zoomFactor) const final;
     Style::MinimumSizePair minimumControlSize(StyleAppearance, const FontCascade&, const Style::MinimumSizePair&, float zoomFactor) const final;
-    LengthBox controlBorder(StyleAppearance, const FontCascade&, const LengthBox&, float zoomFactor, const Element*) const final;
+    RectEdges<Style::LineWidth> controlBorder(StyleAppearance, const FontCascade&, const RectEdges<Style::LineWidth>&, float zoomFactor, const Element*) const final;
     bool controlRequiresPreWhiteSpace(StyleAppearance) const final;
 
     bool popsMenuByArrowKeys() const final { return true; }

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -1466,7 +1466,7 @@ void RenderThemeMac::adjustSearchFieldStyle(RenderStyle& style, const Element* e
 
     // Override border.
     style.resetBorder();
-    const short borderWidth = 2 * style.usedZoom();
+    auto borderWidth = 2_css_px * style.usedZoom();
     style.setBorderLeftWidth(borderWidth);
     style.setBorderLeftStyle(BorderStyle::Inset);
     style.setBorderRightWidth(borderWidth);
@@ -1689,7 +1689,7 @@ Style::MinimumSizePair RenderThemeMac::minimumControlSize(StyleAppearance appear
     }
 }
 
-LengthBox RenderThemeMac::controlBorder(StyleAppearance appearance, const FontCascade& font, const LengthBox& zoomedBox, float zoomFactor, const Element* element) const
+RectEdges<Style::LineWidth> RenderThemeMac::controlBorder(StyleAppearance appearance, const FontCascade& font, const RectEdges<Style::LineWidth>& zoomedBox, float zoomFactor, const Element* element) const
 {
 #if ENABLE(FORM_CONTROL_REFRESH)
     if (element && element->document().settings().formControlRefreshEnabled())
@@ -1701,7 +1701,7 @@ LengthBox RenderThemeMac::controlBorder(StyleAppearance appearance, const FontCa
     case StyleAppearance::ColorWell:
     case StyleAppearance::DefaultButton:
     case StyleAppearance::Button:
-        return LengthBox(0, zoomedBox.right().value(), 0, zoomedBox.left().value());
+        return { 0_css_px, zoomedBox.right(), 0_css_px, zoomedBox.left() };
     default:
         return RenderTheme::controlBorder(appearance, font, zoomedBox, zoomFactor, element);
     }

--- a/Source/WebCore/rendering/style/BorderData.cpp
+++ b/Source/WebCore/rendering/style/BorderData.cpp
@@ -27,7 +27,6 @@
 #include "config.h"
 #include "BorderData.h"
 
-#include "OutlineValue.h"
 #include "RenderStyle.h"
 #include "StylePrimitiveNumericTypes+Logging.h"
 #include <wtf/PointerComparison.h>
@@ -56,19 +55,6 @@ bool BorderData::isEquivalentForPainting(const BorderData& other, bool currentCo
         return true;
 
     return !containsCurrentColor();
-}
-
-TextStream& operator<<(TextStream& ts, const BorderValue& borderValue)
-{
-    ts << borderValue.width() << ' ' << borderValue.style() << ' ' << borderValue.color();
-    return ts;
-}
-
-TextStream& operator<<(TextStream& ts, const OutlineValue& outlineValue)
-{
-    ts << static_cast<const BorderValue&>(outlineValue);
-    ts.dumpProperty("outline-offset"_s, outlineValue.offset());
-    return ts;
 }
 
 void BorderData::dump(TextStream& ts, DumpStyleValues behavior) const

--- a/Source/WebCore/rendering/style/BorderData.h
+++ b/Source/WebCore/rendering/style/BorderData.h
@@ -35,8 +35,6 @@
 
 namespace WebCore {
 
-class OutlineValue;
-
 using namespace CSS::Literals;
 
 class BorderData {
@@ -65,28 +63,27 @@ public:
     }
 
     template<BoxSide side>
-    float borderEdgeWidth() const
+    Style::LineWidth borderEdgeWidth() const
     {
         if (m_edges[side].style() == BorderStyle::None || m_edges[side].style() == BorderStyle::Hidden)
-            return 0;
+            return 0_css_px;
         if (m_image.overridesBorderWidths() && m_image.borderSlices()[side].isFixed())
-            return m_image.borderSlices()[side].value();
+            return Style::LineWidth { m_image.borderSlices()[side].value() };
         return m_edges[side].width();
     }
 
-    float borderLeftWidth() const { return borderEdgeWidth<BoxSide::Left>(); }
-    float borderRightWidth() const { return borderEdgeWidth<BoxSide::Right>(); }
-    float borderTopWidth() const { return borderEdgeWidth<BoxSide::Top>(); }
-    float borderBottomWidth() const { return borderEdgeWidth<BoxSide::Bottom>(); }
+    Style::LineWidth borderLeftWidth() const { return borderEdgeWidth<BoxSide::Left>(); }
+    Style::LineWidth borderRightWidth() const { return borderEdgeWidth<BoxSide::Right>(); }
+    Style::LineWidth borderTopWidth() const { return borderEdgeWidth<BoxSide::Top>(); }
+    Style::LineWidth borderBottomWidth() const { return borderEdgeWidth<BoxSide::Bottom>(); }
 
-    FloatBoxExtent borderWidth() const
+    RectEdges<Style::LineWidth> borderWidth() const
     {
-        return FloatBoxExtent(borderTopWidth(), borderRightWidth(), borderBottomWidth(), borderLeftWidth());
+        return { borderTopWidth(), borderRightWidth(), borderBottomWidth(), borderLeftWidth() };
     }
 
     bool isEquivalentForPainting(const BorderData& other, bool currentColorDiffers) const;
 
-    friend bool operator==(const BorderData&, const BorderData&) = default;
 
     const BorderValue& left() const { return m_edges.left(); }
     const BorderValue& right() const { return m_edges.right(); }
@@ -108,6 +105,8 @@ public:
 
     void dump(TextStream&, DumpStyleValues = DumpStyleValues::All) const;
 
+    bool operator==(const BorderData&) const = default;
+
 private:
     bool containsCurrentColor() const;
 
@@ -117,8 +116,6 @@ private:
     Style::CornerShape m_cornerShapes { Style::CornerShapeValue::round() };
 };
 
-WTF::TextStream& operator<<(WTF::TextStream&, const BorderValue&);
-WTF::TextStream& operator<<(WTF::TextStream&, const OutlineValue&);
 WTF::TextStream& operator<<(WTF::TextStream&, const BorderData&);
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/BorderValue.cpp
+++ b/Source/WebCore/rendering/style/BorderValue.cpp
@@ -25,14 +25,10 @@
 #include "config.h"
 #include "BorderValue.h"
 
-namespace WebCore {
+#include "StylePrimitiveNumericTypes+Logging.h"
+#include <wtf/text/TextStream.h>
 
-BorderValue::BorderValue()
-    : m_color(Style::Color::currentColor())
-    , m_style(static_cast<unsigned>(BorderStyle::None))
-    , m_isAuto(static_cast<unsigned>(false))
-{
-}
+namespace WebCore {
 
 bool BorderValue::isTransparent() const
 {
@@ -42,6 +38,12 @@ bool BorderValue::isTransparent() const
 bool BorderValue::isVisible() const
 {
     return nonZero() && !isTransparent() && style() != BorderStyle::Hidden;
+}
+
+TextStream& operator<<(TextStream& ts, const BorderValue& borderValue)
+{
+    ts << borderValue.width() << ' ' << borderValue.style() << ' ' << borderValue.color();
+    return ts;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/CollapsedBorderValue.h
+++ b/Source/WebCore/rendering/style/CollapsedBorderValue.h
@@ -39,7 +39,7 @@ public:
     }
 
     CollapsedBorderValue(const BorderValue& border, const Color& color, BorderPrecedence precedence)
-        : m_width(LayoutUnit(border.nonZero() ? border.width() : 0))
+        : m_width(LayoutUnit(border.nonZero() ? border.width().value.value : 0))
         , m_color(color)
         , m_style(static_cast<unsigned>(border.style()))
         , m_precedence(static_cast<unsigned>(precedence))

--- a/Source/WebCore/rendering/style/NinePieceImage.cpp
+++ b/Source/WebCore/rendering/style/NinePieceImage.cpp
@@ -80,13 +80,13 @@ LayoutBoxExtent NinePieceImage::computeSlices(const LayoutSize& size, const Leng
     };
 }
 
-LayoutBoxExtent NinePieceImage::computeSlices(const LayoutSize& size, const LengthBox& lengths, const FloatBoxExtent& widths, const LayoutBoxExtent& slices)
+LayoutBoxExtent NinePieceImage::computeSlices(const LayoutSize& size, const LengthBox& lengths, const LayoutBoxExtent& widths, const LayoutBoxExtent& slices)
 {
     return {
-        computeSlice(lengths.top(), LayoutUnit(widths.top()), slices.top(), size.height()),
-        computeSlice(lengths.right(), LayoutUnit(widths.right()), slices.right(), size.width()),
-        computeSlice(lengths.bottom(), LayoutUnit(widths.bottom()), slices.bottom(), size.height()),
-        computeSlice(lengths.left(), LayoutUnit(widths.left()), slices.left(), size.width())
+        computeSlice(lengths.top(), widths.top(), slices.top(), size.height()),
+        computeSlice(lengths.right(), widths.right(), slices.right(), size.width()),
+        computeSlice(lengths.bottom(), widths.bottom(), slices.bottom(), size.height()),
+        computeSlice(lengths.left(), widths.left(), slices.left(), size.width())
     };
 }
 
@@ -201,20 +201,20 @@ Vector<FloatSize> NinePieceImage::computeTileScales(const Vector<FloatRect>& des
 
 void NinePieceImage::paint(GraphicsContext& graphicsContext, const RenderElement* renderer, const RenderStyle& style, const LayoutRect& destination, const LayoutSize& source, float deviceScaleFactor, CompositeOperator op) const
 {
-    StyleImage* styleImage = image();
+    auto* styleImage = image();
     ASSERT(styleImage);
     ASSERT(styleImage->isLoaded(renderer));
 
-    LayoutBoxExtent sourceSlices = computeSlices(source, imageSlices(), styleImage->imageScaleFactor());
-    LayoutBoxExtent destinationSlices = computeSlices(destination.size(), borderSlices(), style.borderWidth(), sourceSlices);
+    auto sourceSlices = computeSlices(source, imageSlices(), styleImage->imageScaleFactor());
+    auto destinationSlices = computeSlices(destination.size(), borderSlices(), Style::to<LayoutBoxExtent>(style.borderWidth()), sourceSlices);
 
     scaleSlicesIfNeeded(destination.size(), destinationSlices, deviceScaleFactor);
 
-    Vector<FloatRect> destinationRects = computeNineRects(destination, destinationSlices, deviceScaleFactor);
-    Vector<FloatRect> sourceRects = computeNineRects(FloatRect(FloatPoint(), source), sourceSlices, deviceScaleFactor);
-    Vector<FloatSize> tileScales = computeTileScales(destinationRects, sourceRects, horizontalRule(), verticalRule());
+    auto destinationRects = computeNineRects(destination, destinationSlices, deviceScaleFactor);
+    auto sourceRects = computeNineRects(FloatRect(FloatPoint(), source), sourceSlices, deviceScaleFactor);
+    auto tileScales = computeTileScales(destinationRects, sourceRects, horizontalRule(), verticalRule());
 
-    RefPtr<Image> image = styleImage->image(renderer, source);
+    auto image = styleImage->image(renderer, source);
     if (!image)
         return;
 

--- a/Source/WebCore/rendering/style/NinePieceImage.h
+++ b/Source/WebCore/rendering/style/NinePieceImage.h
@@ -174,7 +174,7 @@ public:
 
     static LayoutUnit computeSlice(Length, LayoutUnit width, LayoutUnit slice, LayoutUnit extent);
     static LayoutBoxExtent computeSlices(const LayoutSize&, const LengthBox& lengths, int scaleFactor);
-    static LayoutBoxExtent computeSlices(const LayoutSize&, const LengthBox& lengths, const FloatBoxExtent& widths, const LayoutBoxExtent& slices);
+    static LayoutBoxExtent computeSlices(const LayoutSize&, const LengthBox& lengths, const LayoutBoxExtent& widths, const LayoutBoxExtent& slices);
 
     static bool isEmptyPieceRect(ImagePiece, const LayoutBoxExtent& slices);
     static bool isEmptyPieceRect(ImagePiece, const Vector<FloatRect>& destinationRects, const Vector<FloatRect>& sourceRects);

--- a/Source/WebCore/rendering/style/OutlineValue.cpp
+++ b/Source/WebCore/rendering/style/OutlineValue.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2000 Lars Knoll (knoll@kde.org)
  *           (C) 2000 Antti Koivisto (koivisto@kde.org)
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2003, 2005, 2006, 2007, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2003, 2005, 2006, 2007, 2008, 2022 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Graham Dennis (graham.dennis@gmail.com)
  *
  * This library is free software; you can redistribute it and/or
@@ -22,47 +22,29 @@
  *
  */
 
-#pragma once
+#include "config.h"
+#include "OutlineValue.h"
 
-#include "RenderStyleConstants.h"
-#include "StyleColor.h"
-#include "StyleLineWidth.h"
+#include "StylePrimitiveNumericTypes+Logging.h"
+#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 
-class RenderStyle;
-
-class BorderValue {
-    friend class RenderStyle;
-public:
-    BorderValue()
-        : m_style(static_cast<unsigned>(BorderStyle::None))
-    {
-    }
-
-    const Style::Color& color() const { return m_color; }
-    Style::LineWidth width() const { return m_width; }
-    BorderStyle style() const { return static_cast<BorderStyle>(m_style); }
-
-    bool nonZero() const;
-    bool isTransparent() const;
-    bool isVisible() const;
-
-
-    bool operator==(const BorderValue&) const = default;
-
-protected:
-    Style::Color m_color { Style::Color::currentColor() };
-    Style::LineWidth m_width { CSS::Keyword::Medium { } };
-    PREFERRED_TYPE(BorderStyle) unsigned m_style : 4;
-};
-
-inline bool BorderValue::nonZero() const
+bool OutlineValue::isTransparent() const
 {
-    return !Style::isZero(width()) && style() != BorderStyle::None;
+    return m_color.isResolvedColor() && m_color.resolvedColor().isValid() && !m_color.resolvedColor().isVisible();
 }
 
+bool OutlineValue::isVisible() const
+{
+    return nonZero() && !isTransparent();
+}
 
-TextStream& operator<<(TextStream&, const BorderValue&);
+TextStream& operator<<(TextStream& ts, const OutlineValue& outlineValue)
+{
+    ts << outlineValue.width() << ' ' << outlineValue.style() << ' ' << outlineValue.color();
+    ts.dumpProperty("outline-offset"_s, outlineValue.offset());
+    return ts;
+}
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/OutlineValue.h
+++ b/Source/WebCore/rendering/style/OutlineValue.h
@@ -24,20 +24,77 @@
 
 #pragma once
 
-#include "BorderValue.h"
+#include "RenderStyleConstants.h"
+#include "StyleColor.h"
+#include "StyleLineWidth.h"
 
 namespace WebCore {
 
-class OutlineValue : public BorderValue {
-friend class RenderStyle;
+using namespace CSS::Literals;
+
+class RenderStyle;
+
+class OutlineValue final {
+    friend class RenderStyle;
 public:
-    float offset() const { return m_offset; }
-    bool isAuto() const { return static_cast<bool>(m_isAuto); }
+    OutlineValue()
+        : m_style(static_cast<unsigned>(OutlineStyle::None))
+    {
+    }
+
+    bool isVisible() const;
+
+    Style::Length<> size() const { return { m_width.value.value + m_offset.value }; }
+
+    const Style::Color& color() const { return m_color; }
+    Style::LineWidth width() const { return m_width; }
+    Style::Length<> offset() const { return m_offset; }
+    OutlineStyle style() const { return static_cast<OutlineStyle>(m_style); }
 
     bool operator==(const OutlineValue&) const = default;
 
 private:
-    float m_offset { 0 };
+    bool nonZero() const;
+    bool isTransparent() const;
+
+    Style::Color m_color { Style::Color::currentColor() };
+    Style::LineWidth m_width { CSS::Keyword::Medium { } };
+    Style::Length<> m_offset { 0_css_px };
+    PREFERRED_TYPE(OutlineStyle) unsigned m_style : 4;
 };
+
+inline bool OutlineValue::nonZero() const
+{
+    return !Style::isZero(width()) && style() != OutlineStyle::None;
+}
+
+inline std::optional<BorderStyle> toBorderStyle(OutlineStyle outlineStyle)
+{
+    switch (outlineStyle) {
+    case OutlineStyle::Auto:
+        break;
+    case OutlineStyle::None:
+        return BorderStyle::None;
+    case OutlineStyle::Inset:
+        return BorderStyle::Inset;
+    case OutlineStyle::Groove:
+        return BorderStyle::Groove;
+    case OutlineStyle::Outset:
+        return BorderStyle::Outset;
+    case OutlineStyle::Ridge:
+        return BorderStyle::Ridge;
+    case OutlineStyle::Dotted:
+        return BorderStyle::Dotted;
+    case OutlineStyle::Dashed:
+        return BorderStyle::Dashed;
+    case OutlineStyle::Solid:
+        return BorderStyle::Solid;
+    case OutlineStyle::Double:
+        return BorderStyle::Double;
+    }
+    return { };
+}
+
+TextStream& operator<<(TextStream&, const OutlineValue&);
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -54,6 +54,7 @@
 #include "StyleExtractor.h"
 #include "StyleImage.h"
 #include "StyleInheritedData.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "StyleResolver.h"
 #include "StyleScrollSnapPoints.h"
 #include "StyleSelfAlignmentData.h"
@@ -3135,7 +3136,7 @@ const BorderValue& RenderStyle::borderEnd(const WritingMode writingMode) const
     return writingMode.isInlineTopToBottom() ? borderBottom() : borderTop();
 }
 
-float RenderStyle::borderBeforeWidth(const WritingMode writingMode) const
+Style::LineWidth RenderStyle::borderBeforeWidth(const WritingMode writingMode) const
 {
     switch (writingMode.blockDirection()) {
     case FlowDirection::TopToBottom:
@@ -3151,7 +3152,7 @@ float RenderStyle::borderBeforeWidth(const WritingMode writingMode) const
     return borderTopWidth();
 }
 
-float RenderStyle::borderAfterWidth(const WritingMode writingMode) const
+Style::LineWidth RenderStyle::borderAfterWidth(const WritingMode writingMode) const
 {
     switch (writingMode.blockDirection()) {
     case FlowDirection::TopToBottom:
@@ -3167,14 +3168,14 @@ float RenderStyle::borderAfterWidth(const WritingMode writingMode) const
     return borderBottomWidth();
 }
 
-float RenderStyle::borderStartWidth(const WritingMode writingMode) const
+Style::LineWidth RenderStyle::borderStartWidth(const WritingMode writingMode) const
 {
     if (writingMode.isHorizontal())
         return writingMode.isInlineLeftToRight() ? borderLeftWidth() : borderRightWidth();
     return writingMode.isInlineTopToBottom() ? borderTopWidth() : borderBottomWidth();
 }
 
-float RenderStyle::borderEndWidth(const WritingMode writingMode) const
+Style::LineWidth RenderStyle::borderEndWidth(const WritingMode writingMode) const
 {
     if (writingMode.isHorizontal())
         return writingMode.isInlineLeftToRight() ? borderRightWidth() : borderLeftWidth();
@@ -3319,10 +3320,10 @@ Style::Color RenderStyle::initialTapHighlightColor()
 LayoutBoxExtent RenderStyle::imageOutsets(const NinePieceImage& image) const
 {
     return {
-        NinePieceImage::computeOutset(image.outset().top(), LayoutUnit(borderTopWidth())),
-        NinePieceImage::computeOutset(image.outset().right(), LayoutUnit(borderRightWidth())),
-        NinePieceImage::computeOutset(image.outset().bottom(), LayoutUnit(borderBottomWidth())),
-        NinePieceImage::computeOutset(image.outset().left(), LayoutUnit(borderLeftWidth()))
+        NinePieceImage::computeOutset(image.outset().top(), Style::to<LayoutUnit>(borderTopWidth())),
+        NinePieceImage::computeOutset(image.outset().right(), Style::to<LayoutUnit>(borderRightWidth())),
+        NinePieceImage::computeOutset(image.outset().bottom(), Style::to<LayoutUnit>(borderBottomWidth())),
+        NinePieceImage::computeOutset(image.outset().left(), Style::to<LayoutUnit>(borderLeftWidth()))
     };
 }
 
@@ -3752,21 +3753,21 @@ bool RenderStyle::hasReferenceFilterOnly() const
     return filterOperations.size() == 1 && filterOperations.at(0)->type() == FilterOperation::Type::Reference;
 }
 
-float RenderStyle::outlineWidth() const
+Style::LineWidth RenderStyle::outlineWidth() const
 {
     auto& outline = m_nonInheritedData->backgroundData->outline;
-    if (outline.style() == BorderStyle::None)
-        return 0;
-    if (hasAutoOutlineStyle())
+    if (outline.style() == OutlineStyle::None)
+        return 0_css_px;
+    if (outlineStyle() == OutlineStyle::Auto)
         return std::max(outline.width(), RenderTheme::platformFocusRingWidth());
     return outline.width();
 }
 
-float RenderStyle::outlineOffset() const
+Style::Length<> RenderStyle::outlineOffset() const
 {
     auto& outline = m_nonInheritedData->backgroundData->outline;
-    if (hasAutoOutlineStyle())
-        return (outline.offset() + RenderTheme::platformFocusRingOffset(outlineWidth()));
+    if (outlineStyle() == OutlineStyle::Auto)
+        return { Style::to<float>(outline.offset()) + Style::to<float>(RenderTheme::platformFocusRingOffset(outlineWidth())) };
     return outline.offset();
 }
 

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -74,6 +74,7 @@ class LayoutUnit;
 class LengthBox;
 class LineClampValue;
 class NinePieceImage;
+class OutlineValue;
 class PathOperation;
 class PositionArea;
 class PseudoIdSet;
@@ -181,6 +182,7 @@ enum class NinePieceImageRule : uint8_t;
 enum class NonCJKGlyphOrientation : bool;
 enum class ObjectFit : uint8_t;
 enum class Order : bool;
+enum class OutlineStyle : uint8_t;
 enum class Overflow : uint8_t;
 enum class OverflowAnchor : bool;
 enum class OverflowContinue : bool;
@@ -297,6 +299,7 @@ struct DynamicRangeLimit;
 struct FlexBasis;
 struct GapGutter;
 struct InsetEdge;
+struct LineWidth;
 struct MarginEdge;
 struct MaximumSize;
 struct MinimumSize;
@@ -561,28 +564,28 @@ public:
     inline bool hasExplicitlySetBorderTopRightRadius() const;
     inline bool hasExplicitlySetBorderRadius() const;
 
-    inline float borderLeftWidth() const;
+    inline Style::LineWidth borderLeftWidth() const;
     inline BorderStyle borderLeftStyle() const;
     inline bool borderLeftIsTransparent() const;
-    inline float borderRightWidth() const;
+    inline Style::LineWidth borderRightWidth() const;
     inline BorderStyle borderRightStyle() const;
     inline bool borderRightIsTransparent() const;
-    inline float borderTopWidth() const;
+    inline Style::LineWidth borderTopWidth() const;
     inline BorderStyle borderTopStyle() const;
     inline bool borderTopIsTransparent() const;
-    inline float borderBottomWidth() const;
+    inline Style::LineWidth borderBottomWidth() const;
     inline BorderStyle borderBottomStyle() const;
     inline bool borderBottomIsTransparent() const;
-    inline FloatBoxExtent borderWidth() const;
+    inline RectEdges<Style::LineWidth> borderWidth() const;
 
-    float borderBeforeWidth(const WritingMode) const;
-    float borderAfterWidth(const WritingMode) const;
-    float borderStartWidth(const WritingMode) const;
-    float borderEndWidth(const WritingMode) const;
-    float borderBeforeWidth() const { return borderBeforeWidth(writingMode()); }
-    float borderAfterWidth() const { return borderAfterWidth(writingMode()); }
-    float borderStartWidth() const { return borderStartWidth(writingMode()); }
-    float borderEndWidth() const { return borderEndWidth(writingMode()); }
+    Style::LineWidth borderBeforeWidth(const WritingMode) const;
+    Style::LineWidth borderAfterWidth(const WritingMode) const;
+    Style::LineWidth borderStartWidth(const WritingMode) const;
+    Style::LineWidth borderEndWidth(const WritingMode) const;
+    inline Style::LineWidth borderBeforeWidth() const;
+    inline Style::LineWidth borderAfterWidth() const;
+    inline Style::LineWidth borderStartWidth() const;
+    inline Style::LineWidth borderEndWidth() const;
 
     inline bool borderIsEquivalentForPainting(const RenderStyle&) const;
 
@@ -596,11 +599,12 @@ public:
     void setCornerTopLeftShape(Style::CornerShapeValue&&);
     void setCornerTopRightShape(Style::CornerShapeValue&&);
 
-    float outlineSize() const { return std::max<float>(0, outlineWidth() + outlineOffset()); }
-    float outlineWidth() const;
+    inline const OutlineValue& outline() const;
+    Style::Length<> outlineOffset() const;
+    Style::LineWidth outlineWidth() const;
+    inline Style::Length<> outlineSize() const;
     inline bool hasOutline() const;
-    inline BorderStyle outlineStyle() const;
-    inline bool hasAutoOutlineStyle() const;
+    inline OutlineStyle outlineStyle() const;
     inline bool hasOutlineInVisualOverflow() const;
     
     Overflow overflowX() const { return static_cast<Overflow>(m_nonInheritedFlags.overflowX); }
@@ -802,7 +806,6 @@ public:
 
     OptionSet<HangingPunctuation> hangingPunctuation() const;
 
-    float outlineOffset() const;
 
     inline float textStrokeWidth() const;
     inline float opacity() const;
@@ -976,8 +979,9 @@ public:
     inline ColumnFill columnFill() const;
     inline const Style::GapGutter& columnGap() const;
     inline const Style::GapGutter& rowGap() const;
+    inline const BorderValue& columnRule() const;
     inline BorderStyle columnRuleStyle() const;
-    inline unsigned short columnRuleWidth() const;
+    inline Style::LineWidth columnRuleWidth() const;
     inline bool columnRuleIsTransparent() const;
     inline ColumnSpan columnSpan() const;
     inline bool columnSpanEqual(const RenderStyle&) const;
@@ -1316,22 +1320,22 @@ public:
     inline void setHasExplicitlySetBorderTopLeftRadius(bool);
     inline void setHasExplicitlySetBorderTopRightRadius(bool);
 
-    inline void setBorderLeftWidth(float);
+    inline void setBorderLeftWidth(Style::LineWidth);
     inline void setBorderLeftStyle(BorderStyle);
     inline void setBorderLeftColor(Style::Color&&);
-    inline void setBorderRightWidth(float);
+    inline void setBorderRightWidth(Style::LineWidth);
     inline void setBorderRightStyle(BorderStyle);
     inline void setBorderRightColor(Style::Color&&);
-    inline void setBorderTopWidth(float);
+    inline void setBorderTopWidth(Style::LineWidth);
     inline void setBorderTopStyle(BorderStyle);
     inline void setBorderTopColor(Style::Color&&);
-    inline void setBorderBottomWidth(float);
+    inline void setBorderBottomWidth(Style::LineWidth);
     inline void setBorderBottomStyle(BorderStyle);
     inline void setBorderBottomColor(Style::Color&&);
 
-    inline void setOutlineWidth(float);
-    inline void setOutlineStyle(BorderStyle);
-    inline void setHasAutoOutlineStyle();
+    inline void setOutlineOffset(Style::Length<>);
+    inline void setOutlineWidth(Style::LineWidth);
+    inline void setOutlineStyle(OutlineStyle);
     inline void setOutlineColor(Style::Color&&);
 
     void setOverflowX(Overflow v) { m_nonInheritedFlags.overflowX =  static_cast<unsigned>(v); }
@@ -1527,7 +1531,6 @@ public:
     inline void setHasAutoOrphans();
     inline void setOrphans(unsigned short);
 
-    inline void setOutlineOffset(float);
     inline void setTextShadow(FixedVector<Style::TextShadow>&&);
     inline void setTextStrokeColor(Style::Color&&);
     inline void setTextStrokeWidth(float);
@@ -1614,7 +1617,7 @@ public:
     inline void setRowGap(Style::GapGutter&&);
     inline void setColumnRuleColor(Style::Color&&);
     inline void setColumnRuleStyle(BorderStyle);
-    inline void setColumnRuleWidth(unsigned short);
+    inline void setColumnRuleWidth(Style::LineWidth);
     inline void resetColumnRule();
     inline void setColumnSpan(ColumnSpan);
     inline void inheritColumnPropertiesFrom(const RenderStyle& parent);
@@ -2000,6 +2003,7 @@ public:
     static constexpr CaptionSide initialCaptionSide();
     static constexpr ColumnAxis initialColumnAxis();
     static constexpr ColumnProgression initialColumnProgression();
+    static inline Style::LineWidth initialColumnRuleWidth();
     static constexpr TextDirection initialDirection();
     static constexpr StyleWritingMode initialWritingMode();
     static constexpr TextCombine initialTextCombine();
@@ -2021,9 +2025,7 @@ public:
     static inline Style::Color initialTextStrokeColor();
     static inline Style::Color initialTextDecorationColor();
     static StyleImage* initialListStyleImage() { return 0; }
-    static float initialBorderWidth() { return 3; }
-    static unsigned short initialColumnRuleWidth() { return 3; }
-    static float initialOutlineWidth() { return 3; }
+    static inline Style::LineWidth initialBorderWidth();
     static inline Length initialLetterSpacing();
     static inline Length initialWordSpacing();
     static inline Style::PreferredSize initialSize();
@@ -2042,6 +2044,7 @@ public:
     static inline Length oneLength();
     static unsigned short initialWidows() { return 2; }
     static unsigned short initialOrphans() { return 2; }
+    static inline Style::LineWidth initialOutlineWidth();
     // Returning -100% percent here means the line-height is not set.
     static inline Length initialLineHeight();
     static constexpr TextAlignMode initialTextAlign();
@@ -2055,7 +2058,7 @@ public:
     static inline TextDecorationThickness initialTextDecorationThickness();
     static float initialZoom() { return 1.0f; }
     static constexpr TextZoom initialTextZoom();
-    static float initialOutlineOffset() { return 0; }
+    static constexpr Style::Length<> initialOutlineOffset();
     static float initialOpacity() { return 1.0f; }
     static constexpr BoxAlignment initialBoxAlign();
     static constexpr BoxDecorationBreak initialBoxDecorationBreak();
@@ -2090,6 +2093,7 @@ public:
     static constexpr TextWrapMode initialTextWrapMode();
     static constexpr TextWrapStyle initialTextWrapStyle();
     static constexpr WordBreak initialWordBreak();
+    static constexpr OutlineStyle initialOutlineStyle();
     static constexpr OverflowWrap initialOverflowWrap();
     static constexpr NBSPMode initialNBSPMode();
     static constexpr LineBreak initialLineBreak();

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -853,6 +853,23 @@ TextStream& operator<<(TextStream& ts, Order order)
     return ts;
 }
 
+TextStream& operator<<(TextStream& ts, OutlineStyle outlineStyle)
+{
+    switch (outlineStyle) {
+    case OutlineStyle::Auto: ts << "auto"_s; break;
+    case OutlineStyle::None: ts << "none"_s; break;
+    case OutlineStyle::Inset: ts << "inset"_s; break;
+    case OutlineStyle::Groove: ts << "groove"_s; break;
+    case OutlineStyle::Outset: ts << "outset"_s; break;
+    case OutlineStyle::Ridge: ts << "ridge"_s; break;
+    case OutlineStyle::Dotted: ts << "dotted"_s; break;
+    case OutlineStyle::Dashed: ts << "dashed"_s; break;
+    case OutlineStyle::Solid: ts << "solid"_s; break;
+    case OutlineStyle::Double: ts << "double"_s; break;
+    }
+    return ts;
+}
+
 TextStream& operator<<(TextStream& ts, Overflow overflow)
 {
     switch (overflow) {

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -243,6 +243,19 @@ enum class BorderPrecedence : uint8_t {
     Cell
 };
 
+enum class OutlineStyle : uint8_t {
+    Auto,
+    None,
+    Inset,
+    Groove,
+    Outset,
+    Ridge,
+    Dotted,
+    Dashed,
+    Solid,
+    Double
+};
+
 enum class PositionType : uint8_t {
     Static = 0,
     Relative = 1,
@@ -1311,6 +1324,7 @@ WTF::TextStream& operator<<(WTF::TextStream&, MaskMode);
 WTF::TextStream& operator<<(WTF::TextStream&, NBSPMode);
 WTF::TextStream& operator<<(WTF::TextStream&, ObjectFit);
 WTF::TextStream& operator<<(WTF::TextStream&, Order);
+WTF::TextStream& operator<<(WTF::TextStream&, OutlineStyle);
 WTF::TextStream& operator<<(WTF::TextStream&, WebCore::Overflow);
 WTF::TextStream& operator<<(WTF::TextStream&, OverflowAlignment);
 WTF::TextStream& operator<<(WTF::TextStream&, OverflowWrap);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -119,13 +119,17 @@ inline BlockStepInsert RenderStyle::blockStepInsert() const { return static_cast
 inline BlockStepRound RenderStyle::blockStepRound() const { return static_cast<BlockStepRound>(m_nonInheritedData->rareData->blockStepRound); }
 inline std::optional<Length> RenderStyle::blockStepSize() const { return m_nonInheritedData->rareData->blockStepSize; }
 inline const BorderData& RenderStyle::border() const { return m_nonInheritedData->surroundData->border; }
+inline Style::LineWidth RenderStyle::borderBeforeWidth() const { return borderBeforeWidth(writingMode()); }
+inline Style::LineWidth RenderStyle::borderAfterWidth() const { return borderAfterWidth(writingMode()); }
+inline Style::LineWidth RenderStyle::borderStartWidth() const { return borderStartWidth(writingMode()); }
+inline Style::LineWidth RenderStyle::borderEndWidth() const { return borderEndWidth(writingMode()); }
 inline const BorderValue& RenderStyle::borderBottom() const { return border().bottom(); }
 inline const Style::Color& RenderStyle::borderBottomColor() const { return border().bottom().color(); }
 inline bool RenderStyle::borderBottomIsTransparent() const { return border().bottom().isTransparent(); }
 inline const Style::BorderRadiusValue& RenderStyle::borderBottomLeftRadius() const { return border().bottomLeftRadius(); }
 inline const Style::BorderRadiusValue& RenderStyle::borderBottomRightRadius() const { return border().bottomRightRadius(); }
 inline BorderStyle RenderStyle::borderBottomStyle() const { return border().bottom().style(); }
-inline float RenderStyle::borderBottomWidth() const { return border().borderBottomWidth(); }
+inline Style::LineWidth RenderStyle::borderBottomWidth() const { return border().borderBottomWidth(); }
 inline const NinePieceImage& RenderStyle::borderImage() const { return border().image(); }
 inline NinePieceImageRule RenderStyle::borderImageHorizontalRule() const { return border().image().horizontalRule(); }
 inline const LengthBox& RenderStyle::borderImageOutset() const { return border().image().outset(); }
@@ -138,21 +142,21 @@ inline const BorderValue& RenderStyle::borderLeft() const { return border().left
 inline const Style::Color& RenderStyle::borderLeftColor() const { return border().left().color(); }
 inline bool RenderStyle::borderLeftIsTransparent() const { return border().left().isTransparent(); }
 inline BorderStyle RenderStyle::borderLeftStyle() const { return border().left().style(); }
-inline float RenderStyle::borderLeftWidth() const { return border().borderLeftWidth(); }
+inline Style::LineWidth RenderStyle::borderLeftWidth() const { return border().borderLeftWidth(); }
 inline const Style::BorderRadius& RenderStyle::borderRadii() const { return border().radii(); }
 inline const BorderValue& RenderStyle::borderRight() const { return border().right(); }
 inline const Style::Color& RenderStyle::borderRightColor() const { return border().right().color(); }
 inline bool RenderStyle::borderRightIsTransparent() const { return border().right().isTransparent(); }
 inline BorderStyle RenderStyle::borderRightStyle() const { return border().right().style(); }
-inline float RenderStyle::borderRightWidth() const { return border().borderRightWidth(); }
+inline Style::LineWidth RenderStyle::borderRightWidth() const { return border().borderRightWidth(); }
 inline const BorderValue& RenderStyle::borderTop() const { return border().top(); }
 inline const Style::Color& RenderStyle::borderTopColor() const { return border().top().color(); }
 inline bool RenderStyle::borderTopIsTransparent() const { return border().top().isTransparent(); }
 inline const Style::BorderRadiusValue& RenderStyle::borderTopLeftRadius() const { return border().topLeftRadius(); }
 inline const Style::BorderRadiusValue& RenderStyle::borderTopRightRadius() const { return border().topRightRadius(); }
 inline BorderStyle RenderStyle::borderTopStyle() const { return border().top().style(); }
-inline float RenderStyle::borderTopWidth() const { return border().borderTopWidth(); }
-inline FloatBoxExtent RenderStyle::borderWidth() const { return border().borderWidth(); }
+inline RectEdges<Style::LineWidth> RenderStyle::borderWidth() const { return border().borderWidth(); }
+inline Style::LineWidth RenderStyle::borderTopWidth() const { return border().borderTopWidth(); }
 inline const Style::InsetEdge& RenderStyle::bottom() const { return m_nonInheritedData->surroundData->inset.bottom(); }
 inline BoxAlignment RenderStyle::boxAlign() const { return static_cast<BoxAlignment>(m_nonInheritedData->miscData->deprecatedFlexibleBox->align); }
 inline float RenderStyle::boxFlex() const { return m_nonInheritedData->miscData->deprecatedFlexibleBox->flex; }
@@ -185,10 +189,11 @@ inline unsigned short RenderStyle::columnCount() const { return m_nonInheritedDa
 inline ColumnFill RenderStyle::columnFill() const { return static_cast<ColumnFill>(m_nonInheritedData->miscData->multiCol->fill); }
 inline const Style::GapGutter& RenderStyle::columnGap() const { return m_nonInheritedData->rareData->columnGap; }
 inline ColumnProgression RenderStyle::columnProgression() const { return static_cast<ColumnProgression>(m_nonInheritedData->miscData->multiCol->progression); }
-inline const Style::Color& RenderStyle::columnRuleColor() const { return m_nonInheritedData->miscData->multiCol->rule.color(); }
-inline bool RenderStyle::columnRuleIsTransparent() const { return m_nonInheritedData->miscData->multiCol->rule.isTransparent(); }
-inline BorderStyle RenderStyle::columnRuleStyle() const { return m_nonInheritedData->miscData->multiCol->rule.style(); }
-inline unsigned short RenderStyle::columnRuleWidth() const { return m_nonInheritedData->miscData->multiCol->ruleWidth(); }
+inline const BorderValue& RenderStyle::columnRule() const { return m_nonInheritedData->miscData->multiCol->rule; }
+inline const Style::Color& RenderStyle::columnRuleColor() const { return columnRule().color(); }
+inline bool RenderStyle::columnRuleIsTransparent() const { return columnRule().isTransparent(); }
+inline BorderStyle RenderStyle::columnRuleStyle() const { return columnRule().style(); }
+inline Style::LineWidth RenderStyle::columnRuleWidth() const { return m_nonInheritedData->miscData->multiCol->ruleWidth(); }
 inline ColumnSpan RenderStyle::columnSpan() const { return static_cast<ColumnSpan>(m_nonInheritedData->miscData->multiCol->columnSpan); }
 inline float RenderStyle::columnWidth() const { return m_nonInheritedData->miscData->multiCol->width; }
 inline const AtomString& RenderStyle::computedLocale() const { return fontDescription().computedLocale(); }
@@ -335,8 +340,8 @@ inline bool RenderStyle::hasInset() const { return !Style::isZero(insetBox()); }
 inline bool RenderStyle::hasOffsetPath() const { return !WTF::holdsAlternative<CSS::Keyword::None>(m_nonInheritedData->rareData->offsetPath); }
 inline bool RenderStyle::hasOpacity() const { return m_nonInheritedData->miscData->hasOpacity(); }
 inline bool RenderStyle::hasOutOfFlowPosition() const { return position() == PositionType::Absolute || position() == PositionType::Fixed; }
-inline bool RenderStyle::hasOutline() const { return outlineStyle() > BorderStyle::Hidden && outlineWidth() > 0; }
-inline bool RenderStyle::hasOutlineInVisualOverflow() const { return hasOutline() && outlineSize() > 0; }
+inline bool RenderStyle::hasOutline() const { return outlineStyle() != OutlineStyle::None && outlineWidth() > 0_css_px; }
+inline bool RenderStyle::hasOutlineInVisualOverflow() const { return hasOutline() && outlineSize() > 0_css_px; }
 inline bool RenderStyle::hasPadding() const { return !Style::isZero(paddingBox()); }
 inline bool RenderStyle::hasPerspective() const { return !perspective().isNone(); }
 inline bool RenderStyle::hasPositionedMask() const { return maskLayers().hasImage(); }
@@ -385,6 +390,7 @@ inline std::optional<Length> RenderStyle::initialBlockStepSize() { return std::n
 constexpr BorderCollapse RenderStyle::initialBorderCollapse() { return BorderCollapse::Separate; }
 inline Style::BorderRadiusValue RenderStyle::initialBorderRadius() { return { 0_css_px, 0_css_px }; }
 constexpr BorderStyle RenderStyle::initialBorderStyle() { return BorderStyle::None; }
+inline Style::LineWidth RenderStyle::initialBorderWidth() { return CSS::Keyword::Medium { }; }
 constexpr BoxAlignment RenderStyle::initialBoxAlign() { return BoxAlignment::Stretch; }
 constexpr BoxDecorationBreak RenderStyle::initialBoxDecorationBreak() { return BoxDecorationBreak::Slice; }
 constexpr BoxDirection RenderStyle::initialBoxDirection() { return BoxDirection::Normal; }
@@ -403,6 +409,7 @@ constexpr ColumnAxis RenderStyle::initialColumnAxis() { return ColumnAxis::Auto;
 constexpr ColumnFill RenderStyle::initialColumnFill() { return ColumnFill::Balance; }
 inline Style::GapGutter RenderStyle::initialColumnGap() { return CSS::Keyword::Normal { }; }
 constexpr ColumnProgression RenderStyle::initialColumnProgression() { return ColumnProgression::Normal; }
+inline Style::LineWidth RenderStyle::initialColumnRuleWidth() { return CSS::Keyword::Medium { }; }
 constexpr ColumnSpan RenderStyle::initialColumnSpan() { return ColumnSpan::None; }
 inline std::optional<Length> RenderStyle::initialContainIntrinsicHeight() { return std::nullopt; }
 constexpr ContainIntrinsicSizeType RenderStyle::initialContainIntrinsicHeightType() { return ContainIntrinsicSizeType::None; }
@@ -481,6 +488,9 @@ inline Style::OffsetPosition RenderStyle::initialOffsetPosition() { return CSS::
 constexpr Style::OffsetRotate RenderStyle::initialOffsetRotate() { return CSS::Keyword::Auto { }; }
 inline OrderedNamedGridLinesMap RenderStyle::initialOrderedNamedGridColumnLines() { return { }; }
 inline OrderedNamedGridLinesMap RenderStyle::initialOrderedNamedGridRowLines() { return { }; }
+constexpr Style::Length<> RenderStyle::initialOutlineOffset() { return 0_css_px; }
+constexpr OutlineStyle RenderStyle::initialOutlineStyle() { return OutlineStyle::None; }
+inline Style::LineWidth RenderStyle::initialOutlineWidth() { return CSS::Keyword::Medium { }; }
 constexpr OverflowAnchor RenderStyle::initialOverflowAnchor() { return OverflowAnchor::Auto; }
 inline OverflowContinue RenderStyle::initialOverflowContinue() { return OverflowContinue::Auto; }
 constexpr OverflowWrap RenderStyle::initialOverflowWrap() { return OverflowWrap::Normal; }
@@ -697,9 +707,10 @@ inline int RenderStyle::order() const { return m_nonInheritedData->miscData->ord
 inline const OrderedNamedGridLinesMap& RenderStyle::orderedNamedGridColumnLines() const { return m_nonInheritedData->rareData->grid->orderedNamedGridColumnLines(); }
 inline const OrderedNamedGridLinesMap& RenderStyle::orderedNamedGridRowLines() const { return m_nonInheritedData->rareData->grid->orderedNamedGridRowLines(); }
 inline unsigned short RenderStyle::orphans() const { return m_rareInheritedData->orphans; }
-inline const Style::Color& RenderStyle::outlineColor() const { return m_nonInheritedData->backgroundData->outline.color(); }
-inline BorderStyle RenderStyle::outlineStyle() const { return m_nonInheritedData->backgroundData->outline.style(); }
-inline bool RenderStyle::hasAutoOutlineStyle() const { return m_nonInheritedData->backgroundData->outline.isAuto(); }
+inline const OutlineValue& RenderStyle::outline() const { return m_nonInheritedData->backgroundData->outline; }
+inline const Style::Color& RenderStyle::outlineColor() const { return outline().color(); }
+inline Style::Length<> RenderStyle::outlineSize() const { return outline().size(); }
+inline OutlineStyle RenderStyle::outlineStyle() const { return outline().style(); }
 inline OverflowAnchor RenderStyle::overflowAnchor() const { return static_cast<OverflowAnchor>(m_nonInheritedData->rareData->overflowAnchor); }
 inline OverflowContinue RenderStyle::overflowContinue() const { return m_nonInheritedData->rareData->overflowContinue; }
 inline OverflowWrap RenderStyle::overflowWrap() const { return static_cast<OverflowWrap>(m_rareInheritedData->overflowWrap); }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -32,7 +32,6 @@ namespace WebCore {
 
 #define SET_STYLE_PROPERTY_BASE(read, value, write) do { if (!compareEqual(read, value)) write; } while (0)
 #define SET_STYLE_PROPERTY(read, write, value) SET_STYLE_PROPERTY_BASE(read, value, write = value)
-#define SET_STYLE_PROPERTY_WITH_FUNCTIONS(read, write, value) SET_STYLE_PROPERTY_BASE(read(), value, write(value))
 
 #define SET(group, variable, value) SET_STYLE_PROPERTY(group->variable, group.access().variable, value)
 #define SET_NESTED(group, parent, variable, value) SET_STYLE_PROPERTY(group->parent->variable, group.access().parent.access().variable, value)
@@ -43,9 +42,6 @@ namespace WebCore {
 #define SET_PAIR(group, variable1, value1, variable2, value2) SET_STYLE_PROPERTY_PAIR(group, group.access(), variable1, value1, variable2, value2)
 #define SET_NESTED_PAIR(group, parent, variable1, value1, variable2, value2) SET_STYLE_PROPERTY_PAIR(group->parent, group.access().parent.access(), variable1, value1, variable2, value2)
 #define SET_DOUBLY_NESTED_PAIR(group, grandparent, parent, variable1, value1, variable2, value2) SET_STYLE_PROPERTY_PAIR(group->grandparent->parent, group.access().grandparent.access().parent.access(), variable1, value1, variable2, value2)
-
-#define SET_BORDER_COLOR(group, variable, value) SET_STYLE_PROPERTY_WITH_FUNCTIONS(group->variable.color, group.access().variable.setColor, value)
-#define SET_NESTED_BORDER_COLOR(group, parentVariable, variable, value) SET_STYLE_PROPERTY_WITH_FUNCTIONS(group->parentVariable->variable.color, group.access().parentVariable.access().variable.setColor, value)
 
 template<typename T, typename U> inline bool compareEqual(const T& a, const U& b) { return a == b; }
 
@@ -100,23 +96,23 @@ inline void RenderStyle::setBlockStepAlign(BlockStepAlign value) { SET_NESTED(m_
 inline void RenderStyle::setBlockStepInsert(BlockStepInsert value) { SET_NESTED(m_nonInheritedData, rareData, blockStepInsert, static_cast<unsigned>(value)); }
 inline void RenderStyle::setBlockStepRound(BlockStepRound value) { SET_NESTED(m_nonInheritedData, rareData, blockStepRound, static_cast<unsigned>(value)); }
 inline void RenderStyle::setBlockStepSize(std::optional<Length> length) { SET_NESTED(m_nonInheritedData, rareData, blockStepSize, WTFMove(length)); }
-inline void RenderStyle::setBorderBottomColor(Style::Color&& value) { SET_NESTED_BORDER_COLOR(m_nonInheritedData, surroundData, border.m_edges.bottom(), WTFMove(value)); }
+inline void RenderStyle::setBorderBottomColor(Style::Color&& value) { SET_NESTED(m_nonInheritedData, surroundData, border.m_edges.bottom().m_color, WTFMove(value)); }
 inline void RenderStyle::setBorderBottomLeftRadius(Style::BorderRadiusValue&& size) { SET_NESTED(m_nonInheritedData, surroundData, border.m_radii.bottomLeft(), WTFMove(size)); }
 inline void RenderStyle::setBorderBottomRightRadius(Style::BorderRadiusValue&& size) { SET_NESTED(m_nonInheritedData, surroundData, border.m_radii.bottomRight(), WTFMove(size)); }
 inline void RenderStyle::setBorderBottomStyle(BorderStyle value) { SET_NESTED(m_nonInheritedData, surroundData, border.m_edges.bottom().m_style, static_cast<unsigned>(value)); }
-inline void RenderStyle::setBorderBottomWidth(float value) { SET_NESTED(m_nonInheritedData, surroundData, border.m_edges.bottom().m_width, value); }
+inline void RenderStyle::setBorderBottomWidth(Style::LineWidth value) { SET_NESTED(m_nonInheritedData, surroundData, border.m_edges.bottom().m_width, value); }
 inline void RenderStyle::setBorderImage(const NinePieceImage& image) { SET_NESTED(m_nonInheritedData, surroundData, border.m_image, image); }
-inline void RenderStyle::setBorderLeftColor(Style::Color&& value) { SET_NESTED_BORDER_COLOR(m_nonInheritedData, surroundData, border.m_edges.left(), WTFMove(value)); }
+inline void RenderStyle::setBorderLeftColor(Style::Color&& value) { SET_NESTED(m_nonInheritedData, surroundData, border.m_edges.left().m_color, WTFMove(value)); }
 inline void RenderStyle::setBorderLeftStyle(BorderStyle value) { SET_NESTED(m_nonInheritedData, surroundData, border.m_edges.left().m_style, static_cast<unsigned>(value)); }
-inline void RenderStyle::setBorderLeftWidth(float value) { SET_NESTED(m_nonInheritedData, surroundData, border.m_edges.left().m_width, value); }
-inline void RenderStyle::setBorderRightColor(Style::Color&& value) { SET_NESTED_BORDER_COLOR(m_nonInheritedData, surroundData, border.m_edges.right(), WTFMove(value)); }
+inline void RenderStyle::setBorderLeftWidth(Style::LineWidth value) { SET_NESTED(m_nonInheritedData, surroundData, border.m_edges.left().m_width, value); }
+inline void RenderStyle::setBorderRightColor(Style::Color&& value) { SET_NESTED(m_nonInheritedData, surroundData, border.m_edges.right().m_color, WTFMove(value)); }
 inline void RenderStyle::setBorderRightStyle(BorderStyle value) { SET_NESTED(m_nonInheritedData, surroundData, border.m_edges.right().m_style, static_cast<unsigned>(value)); }
-inline void RenderStyle::setBorderRightWidth(float value) { SET_NESTED(m_nonInheritedData, surroundData, border.m_edges.right().m_width, value); }
-inline void RenderStyle::setBorderTopColor(Style::Color&& value) { SET_NESTED_BORDER_COLOR(m_nonInheritedData, surroundData, border.m_edges.top(), WTFMove(value)); }
+inline void RenderStyle::setBorderRightWidth(Style::LineWidth value) { SET_NESTED(m_nonInheritedData, surroundData, border.m_edges.right().m_width, value); }
+inline void RenderStyle::setBorderTopColor(Style::Color&& value) { SET_NESTED(m_nonInheritedData, surroundData, border.m_edges.top().m_color, WTFMove(value)); }
 inline void RenderStyle::setBorderTopLeftRadius(Style::BorderRadiusValue&& size) { SET_NESTED(m_nonInheritedData, surroundData, border.m_radii.topLeft(), WTFMove(size)); }
 inline void RenderStyle::setBorderTopRightRadius(Style::BorderRadiusValue&& size) { SET_NESTED(m_nonInheritedData, surroundData, border.m_radii.topRight(), WTFMove(size)); }
 inline void RenderStyle::setBorderTopStyle(BorderStyle value) { SET_NESTED(m_nonInheritedData, surroundData, border.m_edges.top().m_style, static_cast<unsigned>(value)); }
-inline void RenderStyle::setBorderTopWidth(float value) { SET_NESTED(m_nonInheritedData, surroundData, border.m_edges.top().m_width, value); }
+inline void RenderStyle::setBorderTopWidth(Style::LineWidth value) { SET_NESTED(m_nonInheritedData, surroundData, border.m_edges.top().m_width, value); }
 inline void RenderStyle::setBottom(Style::InsetEdge&& edge) { SET_NESTED(m_nonInheritedData, surroundData, inset.bottom(), WTFMove(edge)); }
 inline void RenderStyle::setBoxAlign(BoxAlignment alignment) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, deprecatedFlexibleBox, align, static_cast<unsigned>(alignment)); }
 inline void RenderStyle::setBoxFlex(float flex) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, deprecatedFlexibleBox, flex, flex); }
@@ -142,9 +138,9 @@ inline void RenderStyle::setColumnAxis(ColumnAxis axis) { SET_DOUBLY_NESTED(m_no
 inline void RenderStyle::setColumnFill(ColumnFill fill) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, multiCol, fill, static_cast<unsigned>(fill)); }
 inline void RenderStyle::setColumnGap(Style::GapGutter&& gap) { SET_NESTED(m_nonInheritedData, rareData, columnGap, WTFMove(gap)); }
 inline void RenderStyle::setColumnProgression(ColumnProgression progression) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, multiCol, progression, static_cast<unsigned>(progression)); }
-inline void RenderStyle::setColumnRuleColor(Style::Color&& c) { SET_BORDER_COLOR(m_nonInheritedData.access().miscData.access().multiCol, rule, WTFMove(c)); }
+inline void RenderStyle::setColumnRuleColor(Style::Color&& c) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, multiCol, rule.m_color, c); }
 inline void RenderStyle::setColumnRuleStyle(BorderStyle b) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, multiCol, rule.m_style, static_cast<unsigned>(b)); }
-inline void RenderStyle::setColumnRuleWidth(unsigned short w) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, multiCol, rule.m_width, w); }
+inline void RenderStyle::setColumnRuleWidth(Style::LineWidth w) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, multiCol, rule.m_width, w); }
 inline void RenderStyle::setColumnSpan(ColumnSpan span) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, multiCol, columnSpan, static_cast<unsigned>(span)); }
 inline void RenderStyle::setColumnWidth(float width) { SET_DOUBLY_NESTED_PAIR(m_nonInheritedData, miscData, multiCol, width, width, autoWidth, false); }
 inline void RenderStyle::setContain(OptionSet<Containment> containment) { SET_NESTED(m_nonInheritedData, rareData, contain, containment); }
@@ -257,11 +253,10 @@ inline void RenderStyle::setOffsetPath(Style::OffsetPath&& path) { SET_NESTED(m_
 inline void RenderStyle::setOffsetPosition(Style::OffsetPosition&& position) { SET_NESTED(m_nonInheritedData, rareData, offsetPosition, WTFMove(position)); }
 inline void RenderStyle::setOffsetRotate(Style::OffsetRotate&& rotate) { SET_NESTED(m_nonInheritedData, rareData, offsetRotate, WTFMove(rotate)); }
 inline void RenderStyle::setOrder(int o) { SET_NESTED(m_nonInheritedData, miscData, order, o); }
-inline void RenderStyle::setOutlineColor(Style::Color&& color) { SET_NESTED_BORDER_COLOR(m_nonInheritedData, backgroundData, outline, WTFMove(color)); }
-inline void RenderStyle::setOutlineOffset(float offset) { SET_NESTED(m_nonInheritedData, backgroundData, outline.m_offset, offset); }
-inline void RenderStyle::setOutlineStyle(BorderStyle style) { SET_NESTED_PAIR(m_nonInheritedData, backgroundData, outline.m_isAuto, static_cast<unsigned>(false), outline.m_style, static_cast<unsigned>(style)); }
-inline void RenderStyle::setHasAutoOutlineStyle() { SET_NESTED_PAIR(m_nonInheritedData, backgroundData, outline.m_isAuto, static_cast<unsigned>(true), outline.m_style, static_cast<unsigned>(BorderStyle::Dotted)); }
-inline void RenderStyle::setOutlineWidth(float width) { SET_NESTED(m_nonInheritedData, backgroundData, outline.m_width, width); }
+inline void RenderStyle::setOutlineColor(Style::Color&& color) { SET_NESTED(m_nonInheritedData, backgroundData, outline.m_color, WTFMove(color)); }
+inline void RenderStyle::setOutlineOffset(Style::Length<> offset) { SET_NESTED(m_nonInheritedData, backgroundData, outline.m_offset, offset); }
+inline void RenderStyle::setOutlineStyle(OutlineStyle style) { SET_NESTED(m_nonInheritedData, backgroundData, outline.m_style, static_cast<unsigned>(style)); }
+inline void RenderStyle::setOutlineWidth(Style::LineWidth width) { SET_NESTED(m_nonInheritedData, backgroundData, outline.m_width, width); }
 inline void RenderStyle::setOverflowAnchor(OverflowAnchor a) { SET_NESTED(m_nonInheritedData, rareData, overflowAnchor, static_cast<unsigned>(a)); }
 inline void RenderStyle::setOverflowContinue(OverflowContinue value) { SET_NESTED(m_nonInheritedData, rareData, overflowContinue, value); }
 inline void RenderStyle::setOverflowWrap(OverflowWrap rule) { SET(m_rareInheritedData, overflowWrap, static_cast<unsigned>(rule)); }
@@ -687,17 +682,13 @@ inline void RenderStyle::setIsolation(Isolation isolation) { SET_NESTED(m_nonInh
 inline void RenderStyle::setAutoRevealsWhenFound() { SET(m_rareInheritedData, autoRevealsWhenFound, true); }
 
 #undef SET
-#undef SET_BORDER_COLOR
 #undef SET_DOUBLY_NESTED
 #undef SET_DOUBLY_NESTED_PAIR
 #undef SET_NESTED
-#undef SET_NESTED_BORDER_COLOR
-#undef SET_NESTED_BORDER_VALUE_COLOR
 #undef SET_NESTED_PAIR
 #undef SET_PAIR
 #undef SET_STYLE_PROPERTY
 #undef SET_STYLE_PROPERTY_BASE
 #undef SET_STYLE_PROPERTY_PAIR
-#undef SET_STYLE_PROPERTY_WITH_FUNCTIONS
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleMultiColData.h
+++ b/Source/WebCore/rendering/style/StyleMultiColData.h
@@ -34,6 +34,8 @@ class TextStream;
 
 namespace WebCore {
 
+using namespace CSS::Literals;
+
 // CSS3 Multi Column Layout
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleMultiColData);
@@ -49,10 +51,12 @@ public:
     void dumpDifferences(TextStream&, const StyleMultiColData&) const;
 #endif
 
-    unsigned short ruleWidth() const
+    // "Computed Value: absolute length, snapped as a border width; 0 if the column rule style is none or hidden"
+    // https://www.w3.org/TR/css-multicol-1/#propdef-column-rule-width
+    Style::LineWidth ruleWidth() const
     {
-        if (rule.style() == BorderStyle::None || rule.style() == BorderStyle::Hidden)
-            return 0; 
+        if (auto style = rule.style(); style == BorderStyle::None || style == BorderStyle::Hidden)
+            return 0_css_px;
         return rule.width();
     }
 

--- a/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp
+++ b/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021, 2022, 2023 Igalia S.L.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -39,6 +40,7 @@
 #include "RenderSVGText.h"
 #include "SVGClipPathElement.h"
 #include "SVGLayerTransformComputation.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 
 namespace WebCore {
 
@@ -289,7 +291,7 @@ void SVGBoundingBoxComputation::adjustBoxForClippingAndEffects(const SVGBounding
     }
 
     if (options.contains(DecorationOption::IncludeOutline))
-        box.inflate(m_renderer->outlineStyleForRepaint().outlineSize());
+        box.inflate(Style::to<float>(m_renderer->outlineStyleForRepaint().outlineSize()));
 }
 
 LayoutRect SVGBoundingBoxComputation::computeVisualOverflowRect(const RenderLayerModelObject& renderer)

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -59,6 +59,7 @@
 #include "SVGRenderStyle.h"
 #include "SVGResources.h"
 #include "SVGResourcesCache.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "TransformOperationData.h"
 #include "TransformState.h"
 #include <numbers>
@@ -85,7 +86,7 @@ std::optional<FloatRect> SVGRenderSupport::computeFloatVisibleRectInContainer(co
         return FloatRect();
 
     FloatRect adjustedRect = rect;
-    adjustedRect.inflate(renderer.style().outlineWidth());
+    adjustedRect.inflate(Style::to<float>(renderer.style().outlineWidth()));
 
     // Translate to coords in our parent renderer, and then call computeFloatVisibleRectInContainer() on our parent.
     adjustedRect = renderer.localToParentTransform().mapRect(adjustedRect);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
@@ -168,7 +168,7 @@ void LegacyRenderSVGContainer::paint(PaintInfo& paintInfo, const LayoutPoint&)
     // outline rect into parent coords before drawing.
     // FIXME: This means our focus ring won't share our rotation like it should.
     // We should instead disable our clip during PaintPhase::Outline
-    if (paintInfo.phase == PaintPhase::SelfOutline && style().outlineWidth() && style().usedVisibility() == Visibility::Visible) {
+    if (paintInfo.phase == PaintPhase::SelfOutline && !Style::isZero(style().outlineWidth()) && style().usedVisibility() == Visibility::Visible) {
         IntRect paintRectInParent = enclosingIntRect(localToParentTransform().mapRect(repaintRect));
         paintOutline(paintInfo, paintRectInParent);
     }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
@@ -211,7 +211,7 @@ void LegacyRenderSVGImage::paint(PaintInfo& paintInfo, const LayoutPoint&)
         }
     }
 
-    if (style().outlineWidth())
+    if (!Style::isZero(style().outlineWidth()))
         paintOutline(childPaintInfo, IntRect(boundingBox));
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
@@ -44,6 +44,7 @@
 #include "SVGNames.h"
 #include "SVGResourcesCache.h"
 #include "ShadowRoot.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -95,7 +96,7 @@ static void adjustRectForOutlineAndShadow(const LegacyRenderSVGModelObject& rend
         Style::adjustRectForShadow(shadowRect, boxShadow);
 
     auto outlineRect = rect;
-    auto outlineSize = LayoutUnit { renderer.outlineStyleForRepaint().outlineSize() };
+    auto outlineSize = Style::to<LayoutUnit>(renderer.outlineStyleForRepaint().outlineSize());
     if (outlineSize)
         outlineRect.inflate(outlineSize);
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
@@ -300,7 +300,7 @@ void LegacyRenderSVGShape::paint(PaintInfo& paintInfo, const LayoutPoint&)
         }
     }
 
-    if (style().outlineWidth())
+    if (!Style::isZero(style().outlineWidth()))
         paintOutline(childPaintInfo, IntRect(boundingBox));
 }
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -533,7 +533,7 @@ void RenderTreeBuilder::attachToRenderElementInternal(RenderElement& parent, Ren
     if (AXObjectCache* cache = parent.document().axObjectCache())
         cache->childrenChanged(parent, newChild);
 
-    if (parent.hasOutlineAutoAncestor() || parent.outlineStyleForRepaint().hasAutoOutlineStyle())
+    if (parent.hasOutlineAutoAncestor() || parent.outlineStyleForRepaint().outlineStyle() == OutlineStyle::Auto)
         if (!is<RenderMultiColumnSet>(newChild->previousSibling())) 
             newChild->setHasOutlineAutoAncestor();
 }

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -99,6 +99,7 @@
 #include "StylePathData.h"
 #include "StylePerspective.h"
 #include "StylePreferredSize.h"
+#include "StylePrimitiveNumericTypes+CSSValueConversion.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
 #include "StyleRayFunction.h"
 #include "StyleReflection.h"

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -564,27 +564,6 @@ inline void BuilderCustom::applyValueLineHeight(BuilderState& builderState, CSSV
 
 #endif
 
-inline void BuilderCustom::applyInheritOutlineStyle(BuilderState& builderState)
-{
-    if (builderState.parentStyle().hasAutoOutlineStyle())
-        builderState.style().setHasAutoOutlineStyle();
-    else
-        builderState.style().setOutlineStyle(forwardInheritedValue(builderState.parentStyle().outlineStyle()));
-}
-
-inline void BuilderCustom::applyInitialOutlineStyle(BuilderState& builderState)
-{
-    builderState.style().setOutlineStyle(RenderStyle::initialBorderStyle());
-}
-
-inline void BuilderCustom::applyValueOutlineStyle(BuilderState& builderState, CSSValue& value)
-{
-    if (value.valueID() == CSSValueAuto)
-        builderState.style().setHasAutoOutlineStyle();
-    else
-        builderState.style().setOutlineStyle(fromCSSValue<BorderStyle>(value));
-}
-
 inline void BuilderCustom::applyInitialCaretColor(BuilderState& builderState)
 {
     if (builderState.applyPropertyToRegularStyle())

--- a/Source/WebCore/style/StyleInterpolationWrappers.h
+++ b/Source/WebCore/style/StyleInterpolationWrappers.h
@@ -127,11 +127,11 @@ private:
 
 // MARK: - Typed Wrappers
 
-template<typename StyleType>
+template<typename StyleType, typename GetterType = StyleType, typename SetterType = StyleType>
 class StyleTypeWrapper : public WrapperBase {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Animation);
 public:
-    StyleTypeWrapper(CSSPropertyID property, const StyleType& (RenderStyle::*getter)() const, void (RenderStyle::*setter)(StyleType&&))
+    StyleTypeWrapper(CSSPropertyID property, GetterType (RenderStyle::*getter)() const, void (RenderStyle::*setter)(SetterType))
         : WrapperBase(property)
         , m_getter(getter)
         , m_setter(setter)
@@ -168,22 +168,31 @@ public:
 #endif
 
 private:
-    const StyleType& value(const RenderStyle& style) const
+    GetterType value(const RenderStyle& style) const
     {
         return (style.*m_getter)();
     }
 
-    const StyleType& (RenderStyle::*m_getter)() const;
-    void (RenderStyle::*m_setter)(StyleType&&);
+    GetterType (RenderStyle::*m_getter)() const;
+    void (RenderStyle::*m_setter)(SetterType);
 };
 
-template<typename T> class VisitedAffectedStyleTypeWrapper : public WrapperBase {
+// Deduction guide for getter/setters that return and take values.
+template<typename T>
+StyleTypeWrapper(CSSPropertyID, T (RenderStyle::*getter)() const, void (RenderStyle::*setter)(T)) -> StyleTypeWrapper<T, T, T>;
+
+// Deduction guide for getter/setters that return const references and take r-value references.
+template<typename T>
+StyleTypeWrapper(CSSPropertyID, const T& (RenderStyle::*getter)() const, void (RenderStyle::*setter)(T&&)) -> StyleTypeWrapper<T, const T&, T&&>;
+
+template<typename StyleType, typename GetterType = StyleType, typename SetterType = StyleType>
+class VisitedAffectedStyleTypeWrapper : public WrapperBase {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Animation);
 public:
-    VisitedAffectedStyleTypeWrapper(CSSPropertyID property, const T& (RenderStyle::*getter)() const, void (RenderStyle::*setter)(T&&), const T& (RenderStyle::*visitedGetter)() const, void (RenderStyle::*visitedSetter)(T&&))
+    VisitedAffectedStyleTypeWrapper(CSSPropertyID property, GetterType (RenderStyle::*getter)() const, void (RenderStyle::*setter)(SetterType), GetterType (RenderStyle::*visitedGetter)() const, void (RenderStyle::*visitedSetter)(SetterType))
         : WrapperBase(property)
-        , m_wrapper(StyleTypeWrapper<T>(property, getter, setter))
-        , m_visitedWrapper(StyleTypeWrapper<T>(property, visitedGetter, visitedSetter))
+        , m_wrapper(StyleTypeWrapper<StyleType, GetterType, SetterType>(property, getter, setter))
+        , m_visitedWrapper(StyleTypeWrapper<StyleType, GetterType, SetterType>(property, visitedGetter, visitedSetter))
     {
     }
 
@@ -211,9 +220,17 @@ public:
     }
 #endif
 
-    StyleTypeWrapper<T> m_wrapper;
-    StyleTypeWrapper<T> m_visitedWrapper;
+    StyleTypeWrapper<StyleType, GetterType, SetterType> m_wrapper;
+    StyleTypeWrapper<StyleType, GetterType, SetterType> m_visitedWrapper;
 };
+
+// Deduction guide for getter/setters that return and take values.
+template<typename T>
+VisitedAffectedStyleTypeWrapper(CSSPropertyID, T (RenderStyle::*getter)() const, void (RenderStyle::*setter)(T), T (RenderStyle::*visitedGetter)() const, void (RenderStyle::*visitedSetter)(T)) -> VisitedAffectedStyleTypeWrapper<T, T, T>;
+
+// Deduction guide for getter/setters that return const references and take r-value references.
+template<typename T>
+VisitedAffectedStyleTypeWrapper(CSSPropertyID, const T& (RenderStyle::*getter)() const, void (RenderStyle::*setter)(T&&), const T& (RenderStyle::*visitedGetter)() const, void (RenderStyle::*visitedSetter)(T&&)) -> VisitedAffectedStyleTypeWrapper<T, const T&, T&&>;
 
 template<typename T>
 class AutoWrapper final : public Wrapper<T> {
@@ -1278,10 +1295,12 @@ private:
 class ScrollbarColorWrapper final : public WrapperBase {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Animation);
 public:
+    using Underlying = StyleTypeWrapper<Color, const Color&, Color&&>;
+
     ScrollbarColorWrapper()
         : WrapperBase(CSSPropertyScrollbarColor)
-        , m_thumbWrapper(StyleTypeWrapper<Color>(CSSPropertyScrollbarColor, &RenderStyle::scrollbarThumbColor, &RenderStyle::setScrollbarThumbColor))
-        , m_trackWrapper(StyleTypeWrapper<Color>(CSSPropertyScrollbarColor, &RenderStyle::scrollbarTrackColor, &RenderStyle::setScrollbarTrackColor))
+        , m_thumbWrapper(Underlying { CSSPropertyScrollbarColor, &RenderStyle::scrollbarThumbColor, &RenderStyle::setScrollbarThumbColor })
+        , m_trackWrapper(Underlying { CSSPropertyScrollbarColor, &RenderStyle::scrollbarTrackColor, &RenderStyle::setScrollbarTrackColor })
     {
     }
 
@@ -1324,8 +1343,8 @@ public:
 #endif
 
 private:
-    StyleTypeWrapper<Color> m_thumbWrapper;
-    StyleTypeWrapper<Color> m_trackWrapper;
+    Underlying m_thumbWrapper;
+    Underlying m_trackWrapper;
 };
 
 class VisitedAffectedColorWrapper final : public WrapperBase {
@@ -1366,18 +1385,20 @@ public:
     ColorWrapper m_visitedWrapper;
 };
 
-class AccentColorWrapper final : public StyleTypeWrapper<Color> {
+class AccentColorWrapper final : public StyleTypeWrapper<Color, const Color&, Color&&> {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Animation);
 public:
+    using Base = StyleTypeWrapper<Color, const Color&, Color&&>;
+
     AccentColorWrapper()
-        : StyleTypeWrapper<Color>(CSSPropertyAccentColor, &RenderStyle::accentColor, &RenderStyle::setAccentColor)
+        : Base { CSSPropertyAccentColor, &RenderStyle::accentColor, &RenderStyle::setAccentColor }
     {
     }
 
     bool equals(const RenderStyle& a, const RenderStyle& b) const final
     {
         return a.hasAutoAccentColor() == b.hasAutoAccentColor()
-            && StyleTypeWrapper<Color>::equals(a, b);
+            && Base::equals(a, b);
     }
 
     bool canInterpolate(const RenderStyle& from, const RenderStyle& to, CompositeOperation) const final
@@ -1388,7 +1409,7 @@ public:
     void interpolate(RenderStyle& destination, const RenderStyle& from, const RenderStyle& to, const Context& context) const final
     {
         if (canInterpolate(from, to, context.compositeOperation)) {
-            StyleTypeWrapper<Color>::interpolate(destination, from, to, context);
+            Base::interpolate(destination, from, to, context);
             return;
         }
 
@@ -1401,11 +1422,13 @@ public:
     }
 };
 
-class CaretColorWrapper final : public VisitedAffectedStyleTypeWrapper<Color> {
+class CaretColorWrapper final : public VisitedAffectedStyleTypeWrapper<Color, const Color&, Color&&> {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Animation);
 public:
+    using Base = VisitedAffectedStyleTypeWrapper<Color, const Color&, Color&&>;
+
     CaretColorWrapper()
-        : VisitedAffectedStyleTypeWrapper<Color>(CSSPropertyCaretColor, &RenderStyle::caretColor, &RenderStyle::setCaretColor, &RenderStyle::visitedLinkCaretColor, &RenderStyle::setVisitedLinkCaretColor)
+        : Base { CSSPropertyCaretColor, &RenderStyle::caretColor, &RenderStyle::setCaretColor, &RenderStyle::visitedLinkCaretColor, &RenderStyle::setVisitedLinkCaretColor }
     {
     }
 
@@ -1413,7 +1436,7 @@ public:
     {
         return a.hasAutoCaretColor() == b.hasAutoCaretColor()
             && a.hasVisitedLinkAutoCaretColor() == b.hasVisitedLinkAutoCaretColor()
-            && VisitedAffectedStyleTypeWrapper<Color>::equals(a, b);
+            && Base::equals(a, b);
     }
 
     bool canInterpolate(const RenderStyle& from, const RenderStyle& to, CompositeOperation) const final

--- a/Source/WebCore/style/values/StyleValueTypes.h
+++ b/Source/WebCore/style/values/StyleValueTypes.h
@@ -466,6 +466,48 @@ struct ToPlatformInvoker {
 };
 inline constexpr ToPlatformInvoker toPlatform{};
 
+// MARK: - Conversion directly from "Style" to "[any type]"
+
+// All leaf types must implement the following:
+//
+//    template<> struct WebCore::Style::To<[any type], StyleType> {
+//        [any type] operator()(const StyleType&);
+//    };
+
+template<typename Target, typename From> struct To;
+
+template<typename Target> struct ToInvoker {
+    template<typename StyleType, typename... Rest> auto operator()(const StyleType& value, Rest&&... rest) const -> Target
+    {
+        return To<Target, StyleType>{}(value, std::forward<Rest>(rest)...);
+    }
+};
+template<typename Target> inline constexpr ToInvoker<Target> to{};
+
+// Constrained for `TreatAsVariantLike`.
+template<typename Target, VariantLike StyleType> struct To<Target, StyleType> {
+    template<typename... Rest> auto operator()(const StyleType& value, Rest&&... rest) -> Target
+    {
+        return WTF::switchOn(value, [&](const auto& alternative) -> Target { return to<Target>(alternative, std::forward<Rest>(rest)...); });
+    }
+};
+
+// Specialization for `TupleLike` (wrapper).
+template<typename Target, TupleLike StyleType> requires (std::tuple_size_v<StyleType> == 1) struct To<Target, StyleType> {
+    template<typename... Rest> auto operator()(const StyleType& value, Rest&&... rest) -> Target
+    {
+        return to<Target>(get<0>(value), std::forward<Rest>(rest)...);
+    }
+};
+
+// Specialization for `RectEdges`
+template<typename Target, typename StyleType> struct To<Target, RectEdges<StyleType>> {
+    template<typename... Rest> auto operator()(const RectEdges<StyleType>& value, Rest&&... rest) -> Target
+    {
+        return value.map([&](auto value) -> typename Target::value_type { return to<typename Target::value_type>(value, rest...); });
+    }
+};
+
 // MARK: - Serialization
 
 // All leaf types must implement the following:

--- a/Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp
+++ b/Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2024-2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleLineWidth.h"
+
+#include "CSSPrimitiveValue.h"
+#include "CSSValuePair.h"
+#include "RenderStyleInlines.h"
+#include "StyleBuilderChecking.h"
+#include "StylePrimitiveNumericTypes+CSSValueConversion.h"
+#include "StylePrimitiveNumericTypes+Conversions.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
+
+namespace WebCore {
+namespace Style {
+
+using namespace CSS::Literals;
+
+// MARK: - Conversion
+
+auto CSSValueConversion<LineWidth>::operator()(BuilderState& state, const CSSValue& value) -> LineWidth
+{
+    auto* primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
+    if (!primitiveValue)
+        return CSS::Keyword::Medium { };
+
+    switch (primitiveValue->valueID()) {
+    case CSSValueThin:
+        return CSS::Keyword::Thin { };
+    case CSSValueMedium:
+        return CSS::Keyword::Medium { };
+    case CSSValueThick:
+        return CSS::Keyword::Thick { };
+    case CSSValueInvalid: {
+        // Any original result that was >= 1 should not be allowed to fall below 1.
+        // This keeps border lines from vanishing.
+        auto result = primitiveValue->resolveAsLength<float>(state.cssToLengthConversionData());
+        if (state.style().usedZoom() < 1.0f && result < 1.0) {
+            auto originalLength = primitiveValue->resolveAsLength<float>(state.cssToLengthConversionData().copyWithAdjustedZoom(1.0));
+            if (originalLength >= 1.0f)
+                return 1_css_px;
+        }
+        auto minimumLineWidth = 1.0f / state.document().deviceScaleFactor();
+        if (result > 0.0f && result < minimumLineWidth)
+            return { minimumLineWidth };
+        return { floorToDevicePixel(result, state.document().deviceScaleFactor()) };
+    }
+    default:
+        ASSERT_NOT_REACHED();
+        state.setCurrentPropertyInvalidAtComputedValueTime();
+        return CSS::Keyword::Medium { };
+    }
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/backgrounds/StyleLineWidth.h
+++ b/Source/WebCore/style/values/backgrounds/StyleLineWidth.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "LayoutUnit.h"
+#include "StylePrimitiveNumeric.h"
+
+namespace WebCore {
+namespace Style {
+
+using namespace CSS::Literals;
+
+// <'line-width'> = <length [0,∞]> | thin@(1px) | medium@(3px) | thick@(5px)
+// https://drafts.csswg.org/css-backgrounds-3/#typedef-line-width
+struct LineWidth {
+    Length<CSS::Nonnegative> value;
+
+    constexpr LineWidth(Length<CSS::Nonnegative> value) : value { value } { }
+    constexpr LineWidth(CSS::Keyword::Thin) : value { 1_css_px } { }
+    constexpr LineWidth(CSS::Keyword::Medium) : value { 3_css_px } { }
+    constexpr LineWidth(CSS::Keyword::Thick) : value { 5_css_px } { }
+
+    constexpr LineWidth(CSS::ValueLiteral<CSS::LengthUnit::Px> value) : value { value } { }
+
+    constexpr bool operator==(const LineWidth&) const = default;
+    constexpr auto operator<=>(const LineWidth&) const = default;
+    constexpr auto operator<=>(const CSS::ValueLiteral<CSS::LengthUnit::Px>& other) { return value <=> other; }
+    constexpr auto operator<=>(const LayoutUnit& other) { return value.value <=> other; }
+};
+DEFINE_TYPE_WRAPPER_GET(LineWidth, value);
+
+// MARK: - Conversion
+
+template<> struct CSSValueConversion<LineWidth> { auto operator()(BuilderState&, const CSSValue&) -> LineWidth; };
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_TUPLE_LIKE_CONFORMANCE_FOR_TYPE_WRAPPER(WebCore::Style::LineWidth)

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h
@@ -72,6 +72,11 @@ template<CSS::Numeric CSSType> struct PrimitiveNumeric {
 
     constexpr bool operator==(const PrimitiveNumeric&) const = default;
     constexpr bool operator==(ResolvedValueType other) const { return value == other; };
+    constexpr bool operator==(const WebCore::CSS::ValueLiteral<UnitTraits::canonical>& other) const { return value == clampTo<ResolvedValueType>(other.value); };
+
+    constexpr auto operator<=>(const PrimitiveNumeric&) const = default;
+    constexpr auto operator<=>(ResolvedValueType other) const { return value == other; };
+    constexpr auto operator<=>(const WebCore::CSS::ValueLiteral<UnitTraits::canonical>& other) const { return value <=> clampTo<ResolvedValueType>(other.value); };
 
 private:
     template<typename> friend struct PrimitiveNumericMarkableTraits;

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h
@@ -30,6 +30,7 @@
 #include "LayoutPoint.h"
 #include "LayoutSize.h"
 #include "LayoutUnit.h"
+#include "Length.h"
 #include "StylePrimitiveNumericTypes+Calculation.h"
 #include "StylePrimitiveNumericTypes.h"
 #include "StyleValueTypes.h"
@@ -61,14 +62,27 @@ template<auto R, typename V> constexpr LayoutUnit evaluate(const Percentage<R, V
 // MARK: - Numeric
 
 template<NonCompositeNumeric StyleType> struct Evaluation<StyleType> {
-    constexpr double operator()(const StyleType& value)
+    constexpr auto operator()(const StyleType& value) -> typename StyleType::ResolvedValueType
     {
-        return static_cast<double>(value.value);
+        return static_cast<typename StyleType::ResolvedValueType>(value.value);
     }
     template<typename Reference> constexpr auto operator()(const StyleType& value, Reference) -> Reference
     {
         return static_cast<Reference>(value.value);
     }
+};
+
+template<NonCompositeNumeric StyleType> struct To<LayoutUnit, StyleType> {
+    auto operator()(const StyleType& value) -> LayoutUnit { return LayoutUnit(value.value); }
+};
+template<NonCompositeNumeric StyleType> struct To<WebCore::Length, StyleType> {
+    auto operator()(const StyleType& value) -> WebCore::Length { return WebCore::Length(value.value, WebCore::LengthType::Fixed); }
+};
+template<std::integral Target, NonCompositeNumeric StyleType> struct To<Target, StyleType> {
+    auto operator()(const StyleType& value) -> Target { return static_cast<Target>(value.value); }
+};
+template<std::floating_point Target, NonCompositeNumeric StyleType> struct To<Target, StyleType> {
+    auto operator()(const StyleType& value) -> Target { return static_cast<Target>(value.value); }
 };
 
 // MARK: - Calculation


### PR DESCRIPTION
#### 6ef2758a97a7a0f013c9f35721ee13e2bf547108
<pre>
[Style] Convert border and outline values to use strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=295178">https://bugs.webkit.org/show_bug.cgi?id=295178</a>

Reviewed by NOBODY (OOPS!).

WIP FOR BOTS.

* Source/WTF/wtf/Compiler.h:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp:
* Source/WebCore/layout/formattingContexts/block/BlockFormattingGeometry.cpp:
* Source/WebCore/layout/formattingContexts/block/BlockMarginCollapse.cpp:
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
* Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp:
* Source/WebCore/page/InteractionRegion.cpp:
* Source/WebCore/page/LocalFrameView.cpp:
* Source/WebCore/page/SpatialNavigation.cpp:
* Source/WebCore/platform/RectEdges.h:
* Source/WebCore/rendering/BorderEdge.cpp:
* Source/WebCore/rendering/BorderEdge.h:
* Source/WebCore/rendering/BorderPainter.cpp:
* Source/WebCore/rendering/BorderShape.cpp:
* Source/WebCore/rendering/RenderBlock.cpp:
* Source/WebCore/rendering/RenderBox.cpp:
* Source/WebCore/rendering/RenderBoxModelObjectInlines.h:
* Source/WebCore/rendering/RenderElement.cpp:
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderImage.cpp:
* Source/WebCore/rendering/RenderInline.cpp:
* Source/WebCore/rendering/RenderMultiColumnSet.cpp:
* Source/WebCore/rendering/RenderObject.cpp:
* Source/WebCore/rendering/RenderReplaced.cpp:
* Source/WebCore/rendering/RenderTable.cpp:
* Source/WebCore/rendering/RenderTableCell.cpp:
* Source/WebCore/rendering/RenderTableSection.cpp:
* Source/WebCore/rendering/RenderTheme.cpp:
* Source/WebCore/rendering/RenderTheme.h:
* Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp:
* Source/WebCore/rendering/adwaita/RenderThemeAdwaita.h:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.h:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
* Source/WebCore/rendering/mac/RenderThemeMac.h:
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
* Source/WebCore/rendering/style/BorderData.cpp:
* Source/WebCore/rendering/style/BorderData.h:
* Source/WebCore/rendering/style/BorderValue.cpp:
* Source/WebCore/rendering/style/BorderValue.h:
* Source/WebCore/rendering/style/CollapsedBorderValue.h:
* Source/WebCore/rendering/style/NinePieceImage.cpp:
* Source/WebCore/rendering/style/NinePieceImage.h:
* Source/WebCore/rendering/style/OutlineValue.cpp: Added.
* Source/WebCore/rendering/style/OutlineValue.h:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:
* Source/WebCore/rendering/style/StyleMultiColData.h:
* Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp:
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleBuilderCustom.h:
* Source/WebCore/style/StyleInterpolationWrappers.h:
* Source/WebCore/style/values/StyleValueTypes.h:
* Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp: Added.
* Source/WebCore/style/values/backgrounds/StyleLineWidth.h: Added.
* Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ef2758a97a7a0f013c9f35721ee13e2bf547108

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109624 "16 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29282 "Hash 6ef2758a for PR 47353 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19711 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115642 "Hash 6ef2758a for PR 47353 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59855 "Hash 6ef2758a for PR 47353 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111587 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29960 "Hash 6ef2758a for PR 47353 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37870 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/115642 "Hash 6ef2758a for PR 47353 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/59855 "Hash 6ef2758a for PR 47353 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112572 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/29960 "Hash 6ef2758a for PR 47353 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98730 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/115642 "Hash 6ef2758a for PR 47353 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/29960 "Hash 6ef2758a for PR 47353 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16875 "Found 60 new test failures: compositing/repaint/invalidations-on-composited-layers.html compositing/repaint/resize-repaint.html compositing/tiling/huge-layer-canvas-resize.html compositing/tiling/huge-layer-img-resize.html compositing/transforms/transformed-replaced-with-shadow-children.html fast/block/basic/015.html fast/box-shadow/negative-shadow-box-expand.html fast/box-shadow/negative-shadow-box-shrink.html fast/repaint/4776765.html fast/repaint/align-items-change.html ... (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59439 "Hash 6ef2758a for PR 47353 does not build (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/102115 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/29960 "Hash 6ef2758a for PR 47353 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16913 "Found 60 new test failures: compositing/repaint/invalidations-on-composited-layers.html compositing/repaint/resize-repaint.html compositing/tiling/huge-layer-canvas-resize.html compositing/tiling/huge-layer-img-resize.html fast/box-shadow/negative-shadow-box-expand.html fast/box-shadow/negative-shadow-box-shrink.html fast/repaint/4776765.html fast/repaint/align-items-change.html fast/repaint/border-radius-repaint-2.html fast/repaint/focus-ring-repaint.html ... (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118435 "Hash 6ef2758a for PR 47353 does not build (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/108176 "Built successfully and passed tests") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36663 "Hash 6ef2758a for PR 47353 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27150 "Found 60 new test failures: accessibility/mac/abbr-acronym-tags.html compositing/repaint/invalidations-on-composited-layers.html compositing/repaint/resize-repaint.html compositing/tiling/huge-layer-canvas-resize.html compositing/tiling/huge-layer-img-resize.html css2.1/20110323/dynamic-top-change-005.htm fast/box-shadow/negative-shadow-box-expand.html fast/box-shadow/negative-shadow-box-shrink.html fast/css/relative-positioned-block-nested-with-inline-parent-dynamic-removed.html fast/css/relative-positioned-block-nested-with-inline-parent-dynamic.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/118435 "Hash 6ef2758a for PR 47353 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37036 "Hash 6ef2758a for PR 47353 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94990 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/118435 "Hash 6ef2758a for PR 47353 does not build (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14837 "Found 60 new test failures: compositing/repaint/invalidations-on-composited-layers.html compositing/repaint/resize-repaint.html compositing/tiling/huge-layer-canvas-resize.html compositing/tiling/huge-layer-img-resize.html compositing/transforms/transformed-replaced-with-shadow-children.html fast/box-shadow/negative-shadow-box-expand.html fast/box-shadow/negative-shadow-box-shrink.html fast/multicol/tall-float.html fast/repaint/4776765.html fast/repaint/align-items-change.html ... (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32480 "Hash 6ef2758a for PR 47353 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36557 "Hash 6ef2758a for PR 47353 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42028 "Found 1 new failure in style/values/backgrounds/StyleLineWidth.cpp and found 1 fixed file: style/values/primitives/StyleLengthWrapper.h") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/132441 "Built successfully") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36217 "Hash 6ef2758a for PR 47353 does not build (failure)") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35863 "Passed tests") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39560 "Hash 6ef2758a for PR 47353 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37927 "Hash 6ef2758a for PR 47353 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->