### PR TITLE
Stop using UncheckedKey containers in WebCore/dom

### DIFF
--- a/Source/WebCore/dom/ChildListMutationScope.cpp
+++ b/Source/WebCore/dom/ChildListMutationScope.cpp
@@ -39,7 +39,7 @@
 
 namespace WebCore {
 
-using AccumulatorMap = UncheckedKeyHashMap<WeakRef<ContainerNode, WeakPtrImplWithEventTargetData>, SingleThreadWeakRef<ChildListMutationAccumulator>>;
+using AccumulatorMap = HashMap<WeakRef<ContainerNode, WeakPtrImplWithEventTargetData>, SingleThreadWeakRef<ChildListMutationAccumulator>>;
 static AccumulatorMap& accumulatorMap()
 {
     static NeverDestroyed<AccumulatorMap> map;

--- a/Source/WebCore/dom/ConstantPropertyMap.h
+++ b/Source/WebCore/dom/ConstantPropertyMap.h
@@ -61,7 +61,7 @@ class ConstantPropertyMap {
 public:
     explicit ConstantPropertyMap(Document&);
 
-    using Values = UncheckedKeyHashMap<AtomString, Ref<const Style::CustomProperty>>;
+    using Values = HashMap<AtomString, Ref<const Style::CustomProperty>>;
     const Values& values() const;
 
     void didChangeSafeAreaInsets();

--- a/Source/WebCore/dom/CustomElementDefaultARIA.h
+++ b/Source/WebCore/dom/CustomElementDefaultARIA.h
@@ -55,7 +55,7 @@ public:
 
 private:
     using WeakElementPtr = WeakPtr<Element, WeakPtrImplWithEventTargetData>;
-    UncheckedKeyHashMap<QualifiedName, Variant<AtomString, WeakElementPtr, Vector<WeakElementPtr>>> m_map;
+    HashMap<QualifiedName, Variant<AtomString, WeakElementPtr, Vector<WeakElementPtr>>> m_map;
 };
 
 }; // namespace WebCore

--- a/Source/WebCore/dom/CustomElementRegistry.h
+++ b/Source/WebCore/dom/CustomElementRegistry.h
@@ -119,8 +119,8 @@ private:
     static WeakHashMap<Element, Ref<CustomElementRegistry>, WeakPtrImplWithEventTargetData>& scopedCustomElementRegistryMap();
 
     WeakPtr<LocalDOMWindow, WeakPtrImplWithEventTargetData> m_window;
-    UncheckedKeyHashMap<AtomString, Ref<JSCustomElementInterface>> m_nameMap;
-    UncheckedKeyHashMap<const JSC::JSObject*, JSCustomElementInterface*> m_constructorMap WTF_GUARDED_BY_LOCK(m_constructorMapLock);
+    HashMap<AtomString, Ref<JSCustomElementInterface>> m_nameMap;
+    HashMap<const JSC::JSObject*, JSCustomElementInterface*> m_constructorMap WTF_GUARDED_BY_LOCK(m_constructorMapLock);
     MemoryCompactRobinHoodHashMap<AtomString, Ref<DeferredPromise>> m_promiseMap;
     MemoryCompactRobinHoodHashSet<AtomString> m_disabledShadowSet;
     WeakListHashSet<Document, WeakPtrImplWithEventTargetData> m_associatedDocuments;

--- a/Source/WebCore/dom/DataTransfer.cpp
+++ b/Source/WebCore/dom/DataTransfer.cpp
@@ -436,7 +436,7 @@ struct PasteboardFileTypeReader final : PasteboardFileReader {
         types.add(type);
     }
 
-    UncheckedKeyHashSet<String, ASCIICaseInsensitiveHash> types;
+    HashSet<String, ASCIICaseInsensitiveHash> types;
 };
 
 bool DataTransfer::hasFileOfType(const String& type)

--- a/Source/WebCore/dom/DeviceOrientationAndMotionAccessController.h
+++ b/Source/WebCore/dom/DeviceOrientationAndMotionAccessController.h
@@ -59,7 +59,7 @@ public:
 
 private:
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_topDocument;
-    UncheckedKeyHashMap<SecurityOriginData, DeviceOrientationOrMotionPermissionState> m_accessStatePerOrigin;
+    HashMap<SecurityOriginData, DeviceOrientationOrMotionPermissionState> m_accessStatePerOrigin;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1206,8 +1206,8 @@ Element* Document::elementForAccessKey(const String& key)
 
 void Document::buildAccessKeyCache()
 {
-    m_accessKeyCache = makeUnique<UncheckedKeyHashMap<String, WeakPtr<Element, WeakPtrImplWithEventTargetData>, ASCIICaseInsensitiveHash>>([this] {
-        UncheckedKeyHashMap<String, WeakPtr<Element, WeakPtrImplWithEventTargetData>, ASCIICaseInsensitiveHash> map;
+    m_accessKeyCache = makeUnique<HashMap<String, WeakPtr<Element, WeakPtrImplWithEventTargetData>, ASCIICaseInsensitiveHash>>([this] {
+        HashMap<String, WeakPtr<Element, WeakPtrImplWithEventTargetData>, ASCIICaseInsensitiveHash> map;
         for (auto& node : composedTreeDescendants(*this)) {
             auto element = dynamicDowncast<Element>(node);
             if (!element)
@@ -5593,7 +5593,7 @@ void Document::runScrollSteps()
     if (RefPtr frameView = view()) {
         MonotonicTime now = MonotonicTime::now();
         bool scrollAnimationsInProgress = serviceScrollAnimationForScrollableArea(frameView.get(), now);
-        UncheckedKeyHashSet<CheckedPtr<ScrollableArea>> scrollableAreasToUpdate;
+        HashSet<CheckedPtr<ScrollableArea>> scrollableAreasToUpdate;
         if (auto userScrollableAreas = frameView->scrollableAreas()) {
             for (auto& area : *userScrollableAreas)
                 scrollableAreasToUpdate.add(CheckedPtr<ScrollableArea>(area));
@@ -5765,7 +5765,7 @@ void Document::sceneIdentifierDidChange()
 #endif
 
 #if ENABLE(MEDIA_STREAM) && ENABLE(MEDIA_SESSION)
-static bool hasRealtimeMediaSource(const UncheckedKeyHashSet<Ref<RealtimeMediaSource>>& sources, NOESCAPE const Function<bool(const RealtimeMediaSource&)>& filterSource)
+static bool hasRealtimeMediaSource(const HashSet<Ref<RealtimeMediaSource>>& sources, NOESCAPE const Function<bool(const RealtimeMediaSource&)>& filterSource)
 {
     for (Ref source : sources) {
         if (!source->isEnded() && filterSource(source.get()))
@@ -9445,7 +9445,7 @@ static Element* findNearestCommonComposedAncestor(Element* elementA, Element* el
     if (elementA == elementB)
         return elementA;
 
-    UncheckedKeyHashSet<Ref<Element>> ancestorChain;
+    HashSet<Ref<Element>> ancestorChain;
     for (auto* element = elementA; element; element = element->parentElementInComposedTree())
         ancestorChain.add(*element);
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -465,7 +465,7 @@ public:
 
     void removedLastRef();
 
-    using DocumentsMap = UncheckedKeyHashMap<ScriptExecutionContextIdentifier, WeakRef<Document, WeakPtrImplWithEventTargetData>>;
+    using DocumentsMap = HashMap<ScriptExecutionContextIdentifier, WeakRef<Document, WeakPtrImplWithEventTargetData>>;
     WEBCORE_EXPORT static DocumentsMap::ValuesIteratorRange allDocuments();
     WEBCORE_EXPORT static DocumentsMap& allDocumentsMap();
 
@@ -1832,7 +1832,7 @@ public:
     void didInsertAttachmentElement(HTMLAttachmentElement&);
     void didRemoveAttachmentElement(HTMLAttachmentElement&);
     WEBCORE_EXPORT RefPtr<HTMLAttachmentElement> attachmentForIdentifier(const String&) const;
-    const UncheckedKeyHashMap<String, Ref<HTMLAttachmentElement>>& attachmentElementsByIdentifier() const { return m_attachmentIdentifierToElementMap; }
+    const HashMap<String, Ref<HTMLAttachmentElement>>& attachmentElementsByIdentifier() const { return m_attachmentIdentifierToElementMap; }
 #endif
 
     void setServiceWorkerConnection(RefPtr<SWClientConnection>&&);
@@ -2236,7 +2236,7 @@ private:
     mutable String m_uniqueIdentifier;
 
     WeakHashSet<NodeIterator> m_nodeIterators;
-    UncheckedKeyHashSet<SingleThreadWeakRef<Range>> m_ranges;
+    HashSet<SingleThreadWeakRef<Range>> m_ranges;
 
     const UniqueRef<Style::Scope> m_styleScope;
     const std::unique_ptr<ExtensionStyleSheets> m_extensionStyleSheets;
@@ -2301,8 +2301,8 @@ private:
 
     RefPtr<TextResourceDecoder> m_decoder;
 
-    UncheckedKeyHashSet<LiveNodeList*> m_listsInvalidatedAtDocument;
-    UncheckedKeyHashSet<HTMLCollection*> m_collectionsInvalidatedAtDocument;
+    HashSet<LiveNodeList*> m_listsInvalidatedAtDocument;
+    HashSet<HTMLCollection*> m_collectionsInvalidatedAtDocument;
     std::array<unsigned, numNodeListInvalidationTypes> m_nodeListAndCollectionCounts = { };
 
     RefPtr<XPathEvaluator> m_xpathEvaluator;
@@ -2314,7 +2314,7 @@ private:
     // would be managed.
     WeakHashSet<CanvasRenderingContext> m_canvasContextsToPrepare;
 
-    UncheckedKeyHashMap<String, RefPtr<HTMLCanvasElement>> m_cssCanvasElements;
+    HashMap<String, RefPtr<HTMLCanvasElement>> m_cssCanvasElements;
 
     WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_documentSuspensionCallbackElements;
 
@@ -2328,12 +2328,12 @@ private:
 #endif
 
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_mainArticleElement;
-    UncheckedKeyHashSet<WeakRef<Element, WeakPtrImplWithEventTargetData>> m_articleElements;
+    HashSet<WeakRef<Element, WeakPtrImplWithEventTargetData>> m_articleElements;
 
     WeakHashSet<VisibilityChangeClient> m_visibilityStateCallbackClients;
     bool m_deferResizeEventForVisibilityChange { false };
 
-    std::unique_ptr<UncheckedKeyHashMap<String, WeakPtr<Element, WeakPtrImplWithEventTargetData>, ASCIICaseInsensitiveHash>> m_accessKeyCache;
+    std::unique_ptr<HashMap<String, WeakPtr<Element, WeakPtrImplWithEventTargetData>, ASCIICaseInsensitiveHash>> m_accessKeyCache;
 
     std::unique_ptr<ConstantPropertyMap> m_constantPropertyMap;
 
@@ -2423,7 +2423,7 @@ private:
 
     std::unique_ptr<DocumentSharedObjectPool> m_sharedObjectPool;
 
-    using LocaleIdentifierToLocaleMap = UncheckedKeyHashMap<AtomString, std::unique_ptr<Locale>>;
+    using LocaleIdentifierToLocaleMap = HashMap<AtomString, std::unique_ptr<Locale>>;
     LocaleIdentifierToLocaleMap m_localeCache;
 
     const RefPtr<Document> m_templateDocument;
@@ -2442,16 +2442,16 @@ private:
     RefPtr<CustomElementRegistry> m_activeCustomElementRegistry;
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
-    using TargetIdToClientMap = UncheckedKeyHashMap<PlaybackTargetClientContextIdentifier, WebCore::MediaPlaybackTargetClient*>;
+    using TargetIdToClientMap = HashMap<PlaybackTargetClientContextIdentifier, WebCore::MediaPlaybackTargetClient*>;
     TargetIdToClientMap m_idToClientMap;
-    using TargetClientToIdMap = UncheckedKeyHashMap<WebCore::MediaPlaybackTargetClient*, PlaybackTargetClientContextIdentifier>;
+    using TargetClientToIdMap = HashMap<WebCore::MediaPlaybackTargetClient*, PlaybackTargetClientContextIdentifier>;
     TargetClientToIdMap m_clientToIDMap;
 #endif
 
     RefPtr<IDBClient::IDBConnectionProxy> m_idbConnectionProxy;
 
 #if ENABLE(ATTACHMENT_ELEMENT)
-    UncheckedKeyHashMap<String, Ref<HTMLAttachmentElement>> m_attachmentIdentifierToElementMap;
+    HashMap<String, Ref<HTMLAttachmentElement>> m_attachmentIdentifierToElementMap;
 #endif
 
     Timer m_didAssociateFormControlsTimer;
@@ -2486,7 +2486,7 @@ private:
     std::optional<FixedVector<CSSPropertyID>> m_exposedComputedCSSPropertyIDs;
 
     const RefPtr<PaintWorklet> m_paintWorklet;
-    UncheckedKeyHashMap<String, Ref<PaintWorkletGlobalScope>> m_paintWorkletGlobalScopes;
+    HashMap<String, Ref<PaintWorkletGlobalScope>> m_paintWorkletGlobalScopes;
 
 #if ENABLE(CONTENT_CHANGE_OBSERVER)
     const std::unique_ptr<ContentChangeObserver> m_contentChangeObserver;
@@ -2530,7 +2530,7 @@ private:
 #if ENABLE(MEDIA_STREAM)
     String m_idHashSalt;
     size_t m_activeMediaElementsWithMediaStreamCount { 0 };
-    UncheckedKeyHashSet<Ref<RealtimeMediaSource>> m_captureSources;
+    HashSet<Ref<RealtimeMediaSource>> m_captureSources;
     bool m_isUpdatingCaptureAccordingToMutedState { false };
     bool m_shouldListenToVoiceActivity { false };
 #endif

--- a/Source/WebCore/dom/DocumentMarkerController.h
+++ b/Source/WebCore/dom/DocumentMarkerController.h
@@ -117,7 +117,7 @@ private:
     };
     Vector<TextRange> collectTextRanges(const SimpleRange&);
 
-    using MarkerMap = UncheckedKeyHashMap<Ref<Node>, std::unique_ptr<Vector<RenderedDocumentMarker>>>;
+    using MarkerMap = HashMap<Ref<Node>, std::unique_ptr<Vector<RenderedDocumentMarker>>>;
 
     bool possiblyHasMarkers(OptionSet<DocumentMarkerType>) const;
     OptionSet<DocumentMarkerType> removeMarkersFromList(MarkerMap::iterator, OptionSet<DocumentMarkerType>, NOESCAPE const Function<FilterMarkerResult(const RenderedDocumentMarker&)>& filterFunction = nullptr);

--- a/Source/WebCore/dom/DocumentSharedObjectPool.h
+++ b/Source/WebCore/dom/DocumentSharedObjectPool.h
@@ -44,7 +44,7 @@ public:
 
 private:
     struct ShareableElementDataHash;
-    using ShareableElementDataCache = UncheckedKeyHashSet<Ref<ShareableElementData>, ShareableElementDataHash>;
+    using ShareableElementDataCache = HashSet<Ref<ShareableElementData>, ShareableElementDataHash>;
     ShareableElementDataCache m_shareableElementDataCache;
 };
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -191,9 +191,9 @@ static_assert(sizeof(Element) == sizeof(SameSizeAsElement), "Element should stay
 using namespace HTMLNames;
 using namespace XMLNames;
 
-static UncheckedKeyHashMap<WeakRef<Element, WeakPtrImplWithEventTargetData>, Vector<RefPtr<Attr>>>& attrNodeListMap()
+static HashMap<WeakRef<Element, WeakPtrImplWithEventTargetData>, Vector<RefPtr<Attr>>>& attrNodeListMap()
 {
-    static NeverDestroyed<UncheckedKeyHashMap<WeakRef<Element, WeakPtrImplWithEventTargetData>, Vector<RefPtr<Attr>>>> map;
+    static NeverDestroyed<HashMap<WeakRef<Element, WeakPtrImplWithEventTargetData>, Vector<RefPtr<Attr>>>> map;
     return map;
 }
 
@@ -282,9 +282,9 @@ static bool shouldAutofocus(const Element& element)
     return allAncestorsAreSameOrigin;
 }
 
-static UncheckedKeyHashMap<WeakRef<Element, WeakPtrImplWithEventTargetData>, ElementIdentifier>& elementIdentifiersMap()
+static HashMap<WeakRef<Element, WeakPtrImplWithEventTargetData>, ElementIdentifier>& elementIdentifiersMap()
 {
-    static MainThreadNeverDestroyed<UncheckedKeyHashMap<WeakRef<Element, WeakPtrImplWithEventTargetData>, ElementIdentifier>> map;
+    static MainThreadNeverDestroyed<HashMap<WeakRef<Element, WeakPtrImplWithEventTargetData>, ElementIdentifier>> map;
     return map;
 }
 
@@ -1386,9 +1386,9 @@ static int adjustOffsetForZoomAndSubpixelLayout(RenderBoxModelObject& renderer, 
     return convertToNonSubpixelValue(offsetLeft / zoomFactor, Round);
 }
 
-static UncheckedKeyHashSet<TreeScope*> collectAncestorTreeScopeAsHashSet(Node& node)
+static HashSet<TreeScope*> collectAncestorTreeScopeAsHashSet(Node& node)
 {
-    UncheckedKeyHashSet<TreeScope*> ancestors;
+    HashSet<TreeScope*> ancestors;
     for (auto* currentScope = &node.treeScope(); currentScope; currentScope = currentScope->parentTreeScope())
         ancestors.add(currentScope);
     return ancestors;
@@ -6259,7 +6259,7 @@ TextStream& operator<<(TextStream& ts, ContentRelevancy relevancy)
 HTMLElement* Element::topmostPopoverAncestor(TopLayerElementType topLayerType)
 {
     // Store positions to avoid having to do O(n) search for every popover invoker.
-    UncheckedKeyHashMap<Ref<const Element>, size_t> topLayerPositions;
+    HashMap<Ref<const Element>, size_t> topLayerPositions;
     size_t i = 0;
     for (auto& element : document().autoPopoverList())
         topLayerPositions.add(element, i++);

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -148,7 +148,7 @@ using AnimatableCSSPropertyToTransitionMap = HashMap<AnimatableCSSProperty, Ref<
 using AnimationCollection = ListHashSet<Ref<WebAnimation>>;
 using CSSAnimationCollection = ListHashSet<Ref<CSSAnimation>>;
 using ElementName = NodeName;
-using ExplicitlySetAttrElementsMap = UncheckedKeyHashMap<QualifiedName, Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>>>;
+using ExplicitlySetAttrElementsMap = HashMap<QualifiedName, Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>>>;
 using TrustedTypeOrString = Variant<RefPtr<TrustedHTML>, RefPtr<TrustedScript>, RefPtr<TrustedScriptURL>, AtomString>;
 
 // https://drafts.csswg.org/css-contain/#relevant-to-the-user

--- a/Source/WebCore/dom/ExtensionStyleSheets.h
+++ b/Source/WebCore/dom/ExtensionStyleSheets.h
@@ -94,7 +94,7 @@ private:
 
     mutable Vector<RefPtr<CSSStyleSheet>> m_injectedUserStyleSheets;
     mutable Vector<RefPtr<CSSStyleSheet>> m_injectedAuthorStyleSheets;
-    mutable UncheckedKeyHashMap<Ref<CSSStyleSheet>, String> m_injectedStyleSheetToSource;
+    mutable HashMap<Ref<CSSStyleSheet>, String> m_injectedStyleSheetToSource;
     mutable bool m_injectedStyleSheetCacheValid { false };
 
     Vector<RefPtr<CSSStyleSheet>> m_userStyleSheets;

--- a/Source/WebCore/dom/IdTargetObserverRegistry.h
+++ b/Source/WebCore/dom/IdTargetObserverRegistry.h
@@ -60,10 +60,10 @@ private:
 
         ObserverSet();
         ~ObserverSet();
-        UncheckedKeyHashSet<CheckedRef<IdTargetObserver>> observers;
+        HashSet<CheckedRef<IdTargetObserver>> observers;
     };
 
-    using IdToObserverSetMap = UncheckedKeyHashMap<AtomString, std::unique_ptr<ObserverSet>>;
+    using IdToObserverSetMap = HashMap<AtomString, std::unique_ptr<ObserverSet>>;
     IdToObserverSetMap m_registry;
     CheckedPtr<ObserverSet> m_notifyingObserversInSet;
 };

--- a/Source/WebCore/dom/MessagePort.cpp
+++ b/Source/WebCore/dom/MessagePort.cpp
@@ -48,15 +48,15 @@ namespace WebCore {
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(MessagePort);
 
 static Lock allMessagePortsLock;
-static UncheckedKeyHashMap<MessagePortIdentifier, ThreadSafeWeakPtr<MessagePort>>& allMessagePorts() WTF_REQUIRES_LOCK(allMessagePortsLock)
+static HashMap<MessagePortIdentifier, ThreadSafeWeakPtr<MessagePort>>& allMessagePorts() WTF_REQUIRES_LOCK(allMessagePortsLock)
 {
-    static NeverDestroyed<UncheckedKeyHashMap<MessagePortIdentifier, ThreadSafeWeakPtr<MessagePort>>> map;
+    static NeverDestroyed<HashMap<MessagePortIdentifier, ThreadSafeWeakPtr<MessagePort>>> map;
     return map;
 }
 
-static UncheckedKeyHashMap<MessagePortIdentifier, ScriptExecutionContextIdentifier>& portToContextIdentifier() WTF_REQUIRES_LOCK(allMessagePortsLock)
+static HashMap<MessagePortIdentifier, ScriptExecutionContextIdentifier>& portToContextIdentifier() WTF_REQUIRES_LOCK(allMessagePortsLock)
 {
-    static NeverDestroyed<UncheckedKeyHashMap<MessagePortIdentifier, ScriptExecutionContextIdentifier>> map;
+    static NeverDestroyed<HashMap<MessagePortIdentifier, ScriptExecutionContextIdentifier>> map;
     return map;
 }
 
@@ -328,7 +328,7 @@ ExceptionOr<Vector<TransferredMessagePort>> MessagePort::disentanglePorts(Vector
         return Vector<TransferredMessagePort> { };
 
     // Walk the incoming array - if there are any duplicate ports, or null ports or cloned ports, throw an error (per section 8.3.3 of the HTML5 spec).
-    UncheckedKeyHashSet<Ref<MessagePort>> portSet;
+    HashSet<Ref<MessagePort>> portSet;
     for (auto& port : ports) {
         if (!port->m_entangled || !portSet.add(port).isNewEntry)
             return Exception { ExceptionCode::DataCloneError };

--- a/Source/WebCore/dom/MutationObserver.cpp
+++ b/Source/WebCore/dom/MutationObserver.cpp
@@ -194,8 +194,8 @@ void MutationObserver::deliver()
     // Calling takeTransientRegistrations() can modify m_registrations, so it's necessary
     // to make a copy of the transient registrations before operating on them.
     Vector<WeakPtr<MutationObserverRegistration>, 1> transientRegistrations;
-    Vector<UncheckedKeyHashSet<GCReachableRef<Node>>, 1> nodesToKeepAlive;
-    UncheckedKeyHashSet<GCReachableRef<Node>> pendingTargets;
+    Vector<HashSet<GCReachableRef<Node>>, 1> nodesToKeepAlive;
+    HashSet<GCReachableRef<Node>> pendingTargets;
     pendingTargets.swap(m_pendingTargets);
     for (auto& registration : m_registrations) {
         if (registration.hasTransientRegistrations())

--- a/Source/WebCore/dom/MutationObserver.h
+++ b/Source/WebCore/dom/MutationObserver.h
@@ -93,7 +93,7 @@ public:
     
     struct TakenRecords {
         Vector<Ref<MutationRecord>> records;
-        UncheckedKeyHashSet<GCReachableRef<Node>> pendingTargets;
+        HashSet<GCReachableRef<Node>> pendingTargets;
     };
     TakenRecords takeRecords();
     void disconnect();
@@ -125,7 +125,7 @@ private:
 
     const Ref<MutationCallback> m_callback;
     Vector<Ref<MutationRecord>> m_records;
-    UncheckedKeyHashSet<GCReachableRef<Node>> m_pendingTargets;
+    HashSet<GCReachableRef<Node>> m_pendingTargets;
     WeakHashSet<MutationObserverRegistration> m_registrations;
     unsigned m_priority;
 };

--- a/Source/WebCore/dom/MutationObserverInterestGroup.cpp
+++ b/Source/WebCore/dom/MutationObserverInterestGroup.cpp
@@ -40,7 +40,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MutationObserverInterestGroup);
 
-inline MutationObserverInterestGroup::MutationObserverInterestGroup(UncheckedKeyHashMap<Ref<MutationObserver>, MutationRecordDeliveryOptions>&& observers, MutationRecordDeliveryOptions oldValueFlag)
+inline MutationObserverInterestGroup::MutationObserverInterestGroup(HashMap<Ref<MutationObserver>, MutationRecordDeliveryOptions>&& observers, MutationRecordDeliveryOptions oldValueFlag)
     : m_observers(WTFMove(observers))
     , m_oldValueFlag(oldValueFlag)
 {

--- a/Source/WebCore/dom/MutationObserverInterestGroup.h
+++ b/Source/WebCore/dom/MutationObserverInterestGroup.h
@@ -43,7 +43,7 @@ class QualifiedName;
 class MutationObserverInterestGroup {
     WTF_MAKE_TZONE_ALLOCATED(MutationObserverInterestGroup);
 public:
-    MutationObserverInterestGroup(UncheckedKeyHashMap<Ref<MutationObserver>, MutationRecordDeliveryOptions>&&, MutationRecordDeliveryOptions);
+    MutationObserverInterestGroup(HashMap<Ref<MutationObserver>, MutationRecordDeliveryOptions>&&, MutationRecordDeliveryOptions);
 
     static std::unique_ptr<MutationObserverInterestGroup> createForChildListMutation(Node& target)
     {
@@ -78,7 +78,7 @@ private:
 
     bool hasOldValue(MutationRecordDeliveryOptions options) const { return options.containsAny(m_oldValueFlag); }
 
-    UncheckedKeyHashMap<Ref<MutationObserver>, MutationRecordDeliveryOptions> m_observers;
+    HashMap<Ref<MutationObserver>, MutationRecordDeliveryOptions> m_observers;
     MutationRecordDeliveryOptions m_oldValueFlag;
 };
 

--- a/Source/WebCore/dom/MutationObserverRegistration.cpp
+++ b/Source/WebCore/dom/MutationObserverRegistration.cpp
@@ -79,7 +79,7 @@ void MutationObserverRegistration::observedSubtreeNodeWillDetach(Node& node)
     m_transientRegistrationNodes.add(node);
 }
 
-UncheckedKeyHashSet<GCReachableRef<Node>> MutationObserverRegistration::takeTransientRegistrations()
+HashSet<GCReachableRef<Node>> MutationObserverRegistration::takeTransientRegistrations()
 {
     if (m_transientRegistrationNodes.isEmpty()) {
         ASSERT(!m_nodeKeptAlive);

--- a/Source/WebCore/dom/MutationObserverRegistration.h
+++ b/Source/WebCore/dom/MutationObserverRegistration.h
@@ -64,7 +64,7 @@ public:
 
     void resetObservation(MutationObserverOptions, const MemoryCompactLookupOnlyRobinHoodHashSet<AtomString>& attributeFilter);
     void observedSubtreeNodeWillDetach(Node&);
-    UncheckedKeyHashSet<GCReachableRef<Node>> takeTransientRegistrations();
+    HashSet<GCReachableRef<Node>> takeTransientRegistrations();
     bool hasTransientRegistrations() const { return !m_transientRegistrationNodes.isEmpty(); }
 
     bool shouldReceiveMutationFrom(Node&, MutationObserverOptionType, const QualifiedName* attributeName) const;
@@ -81,7 +81,7 @@ private:
     const Ref<MutationObserver> m_observer;
     WeakRef<Node, WeakPtrImplWithEventTargetData> m_node;
     RefPtr<Node> m_nodeKeptAlive;
-    UncheckedKeyHashSet<GCReachableRef<Node>> m_transientRegistrationNodes;
+    HashSet<GCReachableRef<Node>> m_transientRegistrationNodes;
     MutationObserverOptions m_options;
     MemoryCompactLookupOnlyRobinHoodHashSet<AtomString> m_attributeFilter;
 };

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -226,7 +226,7 @@ void Node::dumpStatistics()
     size_t fragmentNodes = 0;
     size_t shadowRootNodes = 0;
 
-    UncheckedKeyHashMap<String, size_t> perTagCount;
+    HashMap<String, size_t> perTagCount;
 
     size_t attributes = 0;
     size_t attributesWithAttr = 0;
@@ -234,7 +234,7 @@ void Node::dumpStatistics()
     size_t elementsWithRareData = 0;
     size_t elementsWithNamedNodeMap = 0;
 
-    UncheckedKeyHashMap<uint32_t, size_t> rareDataSingleUseTypeCounts;
+    HashMap<uint32_t, size_t> rareDataSingleUseTypeCounts;
     size_t mixedRareDataUseCount = 0;
 
     for (auto& node : liveNodeSet()) {
@@ -265,7 +265,7 @@ void Node::dumpStatistics()
 
                 // Tag stats
                 Element& element = uncheckedDowncast<Element>(node);
-                UncheckedKeyHashMap<String, size_t>::AddResult result = perTagCount.add(element.tagName(), 1);
+                HashMap<String, size_t>::AddResult result = perTagCount.add(element.tagName(), 1);
                 if (!result.isNewEntry)
                     result.iterator->value++;
 
@@ -583,9 +583,9 @@ ExceptionOr<void> Node::appendChild(Node& newChild)
     return Exception { ExceptionCode::HierarchyRequestError };
 }
 
-static UncheckedKeyHashSet<RefPtr<Node>> nodeSetPreTransformedFromNodeOrStringVector(const FixedVector<NodeOrString>& vector)
+static HashSet<RefPtr<Node>> nodeSetPreTransformedFromNodeOrStringVector(const FixedVector<NodeOrString>& vector)
 {
-    UncheckedKeyHashSet<RefPtr<Node>> nodeSet;
+    HashSet<RefPtr<Node>> nodeSet;
     for (const auto& variant : vector) {
         WTF::switchOn(variant,
             [&] (const RefPtr<Node>& node) { nodeSet.add(const_cast<Node*>(node.get())); },
@@ -595,7 +595,7 @@ static UncheckedKeyHashSet<RefPtr<Node>> nodeSetPreTransformedFromNodeOrStringVe
     return nodeSet;
 }
 
-static RefPtr<Node> firstPrecedingSiblingNotInNodeSet(Node& context, const UncheckedKeyHashSet<RefPtr<Node>>& nodeSet)
+static RefPtr<Node> firstPrecedingSiblingNotInNodeSet(Node& context, const HashSet<RefPtr<Node>>& nodeSet)
 {
     for (auto* sibling = context.previousSibling(); sibling; sibling = sibling->previousSibling()) {
         if (!nodeSet.contains(sibling))
@@ -604,7 +604,7 @@ static RefPtr<Node> firstPrecedingSiblingNotInNodeSet(Node& context, const Unche
     return nullptr;
 }
 
-static RefPtr<Node> firstFollowingSiblingNotInNodeSet(Node& context, const UncheckedKeyHashSet<RefPtr<Node>>& nodeSet)
+static RefPtr<Node> firstFollowingSiblingNotInNodeSet(Node& context, const HashSet<RefPtr<Node>>& nodeSet)
 {
     for (auto* sibling = context.nextSibling(); sibling; sibling = sibling->nextSibling()) {
         if (!nodeSet.contains(sibling))
@@ -2570,9 +2570,9 @@ WeakHashSet<MutationObserverRegistration>* Node::transientMutationObserverRegist
     return &data->transientRegistry;
 }
 
-UncheckedKeyHashMap<Ref<MutationObserver>, MutationRecordDeliveryOptions> Node::registeredMutationObservers(MutationObserverOptionType type, const QualifiedName* attributeName)
+HashMap<Ref<MutationObserver>, MutationRecordDeliveryOptions> Node::registeredMutationObservers(MutationObserverOptionType type, const QualifiedName* attributeName)
 {
-    UncheckedKeyHashMap<Ref<MutationObserver>, MutationRecordDeliveryOptions> observers;
+    HashMap<Ref<MutationObserver>, MutationRecordDeliveryOptions> observers;
     ASSERT((type == MutationObserverOptionType::Attributes && attributeName) || !attributeName);
 
     auto collectMatchingObserversForMutation = [&](MutationObserverRegistration& registration) {

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -574,7 +574,7 @@ public:
 
     inline void relaxAdoptionRequirement();
 
-    UncheckedKeyHashMap<Ref<MutationObserver>, MutationRecordDeliveryOptions> registeredMutationObservers(MutationObserverOptionType, const QualifiedName* attributeName);
+    HashMap<Ref<MutationObserver>, MutationRecordDeliveryOptions> registeredMutationObservers(MutationObserverOptionType, const QualifiedName* attributeName);
     void registerMutationObserver(MutationObserver&, MutationObserverOptions, const MemoryCompactLookupOnlyRobinHoodHashSet<AtomString>& attributeFilter);
     void unregisterMutationObserver(MutationObserverRegistration&);
     void registerTransientMutationObserver(MutationObserverRegistration&);

--- a/Source/WebCore/dom/NodeRareData.h
+++ b/Source/WebCore/dom/NodeRareData.h
@@ -104,9 +104,9 @@ public:
         static const bool safeToCompareToEmptyOrDeleted = DefaultHash<AtomString>::safeToCompareToEmptyOrDeleted;
     };
 
-    using NodeListCacheMap = UncheckedKeyHashMap<std::pair<unsigned char, AtomString>, LiveNodeList*, NodeListCacheMapEntryHash>;
-    using CollectionCacheMap = UncheckedKeyHashMap<std::pair<std::underlying_type_t<CollectionType>, AtomString>, HTMLCollection*, NodeListCacheMapEntryHash>;
-    using TagCollectionNSCache = UncheckedKeyHashMap<QualifiedName, TagCollectionNS*>;
+    using NodeListCacheMap = HashMap<std::pair<unsigned char, AtomString>, LiveNodeList*, NodeListCacheMapEntryHash>;
+    using CollectionCacheMap = HashMap<std::pair<std::underlying_type_t<CollectionType>, AtomString>, HTMLCollection*, NodeListCacheMapEntryHash>;
+    using TagCollectionNSCache = HashMap<QualifiedName, TagCollectionNS*>;
 
     template<typename T, typename ContainerType>
     ALWAYS_INLINE Ref<T> addCacheWithAtomName(ContainerType& container, const AtomString& name)

--- a/Source/WebCore/dom/QualifiedNameCache.h
+++ b/Source/WebCore/dom/QualifiedNameCache.h
@@ -68,7 +68,7 @@ private:
         static const int minimumTableSize = WTF::HashTableCapacityForSize<staticQualifiedNamesCount>::value;
     };
 
-    using QNameSet = UncheckedKeyHashSet<QualifiedName::QualifiedNameImpl*, QualifiedNameHash, QualifiedNameHashTraits>;
+    using QNameSet = HashSet<QualifiedName::QualifiedNameImpl*, QualifiedNameHash, QualifiedNameHashTraits>;
     QNameSet m_cache;
 };
 

--- a/Source/WebCore/dom/RadioButtonGroups.h
+++ b/Source/WebCore/dom/RadioButtonGroups.h
@@ -46,7 +46,7 @@ public:
     Vector<Ref<HTMLInputElement>> groupMembers(const HTMLInputElement&) const;
 
 private:
-    typedef UncheckedKeyHashMap<AtomString, std::unique_ptr<RadioButtonGroup>> NameToGroupMap;
+    typedef HashMap<AtomString, std::unique_ptr<RadioButtonGroup>> NameToGroupMap;
     NameToGroupMap m_nameToGroupMap;
 };
 

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -451,7 +451,7 @@ ExceptionOr<RefPtr<DocumentFragment>> Range::processContents(ActionType action)
                 return result.releaseException();
         }
 
-        UncheckedKeyHashSet<Ref<Element>> elementSet;
+        HashSet<Ref<Element>> elementSet;
         for (Ref element : customElementsReactionHoldingTank.takeElements())
             elementSet.add(element.get());
         if (!elementSet.isEmpty()) {

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -99,9 +99,9 @@ using namespace Inspector;
 static std::atomic<CrossOriginMode> globalCrossOriginMode { CrossOriginMode::Shared };
 
 static Lock allScriptExecutionContextsMapLock;
-static UncheckedKeyHashMap<ScriptExecutionContextIdentifier, ScriptExecutionContext*>& allScriptExecutionContextsMap() WTF_REQUIRES_LOCK(allScriptExecutionContextsMapLock)
+static HashMap<ScriptExecutionContextIdentifier, ScriptExecutionContext*>& allScriptExecutionContextsMap() WTF_REQUIRES_LOCK(allScriptExecutionContextsMapLock)
 {
-    static NeverDestroyed<UncheckedKeyHashMap<ScriptExecutionContextIdentifier, ScriptExecutionContext*>> contexts;
+    static NeverDestroyed<HashMap<ScriptExecutionContextIdentifier, ScriptExecutionContext*>> contexts;
     ASSERT(allScriptExecutionContextsMapLock.isLocked());
     return contexts;
 }

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -417,11 +417,11 @@ private:
     void checkConsistency() const;
     WEBCORE_EXPORT GuaranteedSerialFunctionDispatcher& nativePromiseDispatcher();
 
-    UncheckedKeyHashSet<MessagePort*> m_messagePorts;
-    UncheckedKeyHashSet<ContextDestructionObserver*> m_destructionObservers;
-    UncheckedKeyHashSet<ActiveDOMObject*> m_activeDOMObjects;
+    HashSet<MessagePort*> m_messagePorts;
+    HashSet<ContextDestructionObserver*> m_destructionObservers;
+    HashSet<ActiveDOMObject*> m_activeDOMObjects;
 
-    UncheckedKeyHashMap<int, RefPtr<DOMTimer>> m_timeouts;
+    HashMap<int, RefPtr<DOMTimer>> m_timeouts;
 
     struct PendingException;
     std::unique_ptr<Vector<std::unique_ptr<PendingException>>> m_pendingExceptions;
@@ -441,12 +441,12 @@ private:
 #endif
 
     RefPtr<ServiceWorker> m_activeServiceWorker;
-    UncheckedKeyHashMap<ServiceWorkerIdentifier, ServiceWorker*> m_serviceWorkers;
+    HashMap<ServiceWorkerIdentifier, ServiceWorker*> m_serviceWorkers;
 
     String m_domainForCachePartition;
     mutable ScriptExecutionContextIdentifier m_identifier;
 
-    UncheckedKeyHashMap<NotificationCallbackIdentifier, CompletionHandler<void()>> m_notificationCallbacks;
+    HashMap<NotificationCallbackIdentifier, CompletionHandler<void()>> m_notificationCallbacks;
 
     StorageBlockingPolicy m_storageBlockingPolicy;
     ReasonForSuspension m_reasonForSuspendingActiveDOMObjects { static_cast<ReasonForSuspension>(-1) };

--- a/Source/WebCore/dom/ScriptRunner.h
+++ b/Source/WebCore/dom/ScriptRunner.h
@@ -80,7 +80,7 @@ private:
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
     Vector<Ref<PendingScript>> m_scriptsToExecuteInOrder;
     Vector<RefPtr<PendingScript>> m_scriptsToExecuteSoon; // http://www.whatwg.org/specs/web-apps/current-work/#set-of-scripts-that-will-execute-as-soon-as-possible
-    UncheckedKeyHashSet<Ref<PendingScript>> m_pendingAsyncScripts;
+    HashSet<Ref<PendingScript>> m_pendingAsyncScripts;
     Timer m_timer;
 };
 

--- a/Source/WebCore/dom/SelectorQuery.h
+++ b/Source/WebCore/dom/SelectorQuery.h
@@ -129,7 +129,7 @@ public:
 
 private:
     using Key = std::tuple<String, CSSSelectorParserContext, SecurityOriginData>;
-    UncheckedKeyHashMap<Key, std::unique_ptr<SelectorQuery>> m_entries;
+    HashMap<Key, std::unique_ptr<SelectorQuery>> m_entries;
 };
 
 inline bool SelectorQuery::matches(Element& element) const

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -61,7 +61,7 @@ struct SameSizeAsShadowRoot : public DocumentFragment, public TreeScope {
     void* styleSheetList;
     void* styleScope;
     void* slotAssignment;
-    std::optional<UncheckedKeyHashMap<AtomString, AtomString>> partMappings;
+    std::optional<HashMap<AtomString, AtomString>> partMappings;
     AtomString referenceTarget;
 };
 

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -143,7 +143,7 @@ public:
     void moveShadowRootToNewParentScope(TreeScope&, Document&);
     void moveShadowRootToNewDocument(Document& oldDocument, Document& newDocument);
 
-    using PartMappings = UncheckedKeyHashMap<AtomString, Vector<AtomString, 1>>;
+    using PartMappings = HashMap<AtomString, Vector<AtomString, 1>>;
     const PartMappings& partMappings() const;
     void invalidatePartMappings();
 

--- a/Source/WebCore/dom/SimulatedClick.cpp
+++ b/Source/WebCore/dom/SimulatedClick.cpp
@@ -135,7 +135,7 @@ bool simulateClick(Element& element, Event* underlyingEvent, SimulatedClickMouse
     if (element.isDisabledFormControl())
         return false;
 
-    static MainThreadNeverDestroyed<UncheckedKeyHashSet<Ref<Element>>> elementsDispatchingSimulatedClicks;
+    static MainThreadNeverDestroyed<HashSet<Ref<Element>>> elementsDispatchingSimulatedClicks;
     if (!elementsDispatchingSimulatedClicks.get().add(element).isNewEntry)
         return false;
 

--- a/Source/WebCore/dom/SlotAssignment.cpp
+++ b/Source/WebCore/dom/SlotAssignment.cpp
@@ -45,7 +45,7 @@ using namespace HTMLNames;
 struct SameSizeAsNamedSlotAssignment {
     virtual ~SameSizeAsNamedSlotAssignment() = default;
     uint32_t values[4];
-    UncheckedKeyHashMap<void*, void*> pointer;
+    HashMap<void*, void*> pointer;
 #if ASSERT_ENABLED
     WeakHashSet<Element> hashSet;
 #endif
@@ -524,7 +524,7 @@ void ManualSlotAssignment::removeSlotElementByName(const AtomString&, HTMLSlotEl
 void ManualSlotAssignment::slotManualAssignmentDidChange(HTMLSlotElement& slot, Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>& previous, Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>& current, ShadowRoot& shadowRoot)
 {
     auto effectivePrevious = effectiveAssignedNodes(shadowRoot, previous);
-    UncheckedKeyHashSet<Ref<HTMLSlotElement>> affectedSlots;
+    HashSet<Ref<HTMLSlotElement>> affectedSlots;
     for (auto& node : current) {
         RefPtr protectedNode = node.get();
         if (RefPtr previousSlot = protectedNode->manuallyAssignedSlot()) {

--- a/Source/WebCore/dom/SlotAssignment.h
+++ b/Source/WebCore/dom/SlotAssignment.h
@@ -135,7 +135,7 @@ private:
     unsigned m_slotResolutionVersion { 0 };
     unsigned m_slotElementCount { 0 };
 
-    UncheckedKeyHashMap<AtomString, std::unique_ptr<Slot>> m_slots;
+    HashMap<AtomString, std::unique_ptr<Slot>> m_slots;
 
 #if ASSERT_ENABLED
     WeakHashSet<HTMLSlotElement, WeakPtrImplWithEventTargetData> m_slotElementsForConsistencyCheck;

--- a/Source/WebCore/dom/SpaceSplitString.cpp
+++ b/Source/WebCore/dom/SpaceSplitString.cpp
@@ -86,7 +86,7 @@ struct SpaceSplitStringTableKeyTraits : public HashTraits<AtomString>
     static const int minimumTableSize = WTF::HashTableCapacityForSize<typicalNumberOfSpaceSplitString>::value;
 };
 
-typedef UncheckedKeyHashMap<AtomString, SpaceSplitStringData*, AtomStringHash, SpaceSplitStringTableKeyTraits> SpaceSplitStringTable;
+typedef HashMap<AtomString, SpaceSplitStringData*, AtomStringHash, SpaceSplitStringTableKeyTraits> SpaceSplitStringTable;
 
 static SpaceSplitStringTable& spaceSplitStringTable()
 {

--- a/Source/WebCore/dom/TreeScopeOrderedMap.h
+++ b/Source/WebCore/dom/TreeScopeOrderedMap.h
@@ -86,11 +86,11 @@ private:
         unsigned count { 0 };
         Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>> orderedList;
 #if ASSERT_ENABLED || ENABLE(SECURITY_ASSERTIONS)
-        UncheckedKeyHashSet<WeakRef<Element, WeakPtrImplWithEventTargetData>> registeredElements;
+        HashSet<WeakRef<Element, WeakPtrImplWithEventTargetData>> registeredElements;
 #endif
     };
 
-    using Map = UncheckedKeyHashMap<AtomString, MapEntry>;
+    using Map = HashMap<AtomString, MapEntry>;
 
     mutable Map m_map;
 };

--- a/Source/WebCore/dom/VisitedLinkState.h
+++ b/Source/WebCore/dom/VisitedLinkState.h
@@ -54,7 +54,7 @@ private:
     InsideLink determineLinkStateSlowCase(const Element&);
 
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
-    UncheckedKeyHashSet<SharedStringHash, SharedStringHashHash> m_linksCheckedForVisitedState;
+    HashSet<SharedStringHash, SharedStringHashHash> m_linksCheckedForVisitedState;
 };
 
 inline InsideLink VisitedLinkState::determineLinkState(const Element& element)

--- a/Source/WebCore/dom/WindowEventLoop.h
+++ b/Source/WebCore/dom/WindowEventLoop.h
@@ -50,8 +50,8 @@ public:
 
     void queueMutationObserverCompoundMicrotask();
     Vector<GCReachableRef<HTMLSlotElement>>& signalSlotList() { return m_signalSlotList; }
-    UncheckedKeyHashSet<RefPtr<MutationObserver>>& activeMutationObservers() { return m_activeObservers; }
-    UncheckedKeyHashSet<RefPtr<MutationObserver>>& suspendedMutationObservers() { return m_suspendedObservers; }
+    HashSet<RefPtr<MutationObserver>>& activeMutationObservers() { return m_activeObservers; }
+    HashSet<RefPtr<MutationObserver>>& suspendedMutationObservers() { return m_suspendedObservers; }
 
     CustomElementQueue& backupElementQueue();
 
@@ -91,8 +91,8 @@ private:
     bool m_mutationObserverCompoundMicrotaskQueuedFlag { false };
     bool m_deliveringMutationRecords { false }; // FIXME: This flag doesn't exist in the spec.
     Vector<GCReachableRef<HTMLSlotElement>> m_signalSlotList; // https://dom.spec.whatwg.org/#signal-slot-list
-    UncheckedKeyHashSet<RefPtr<MutationObserver>> m_activeObservers;
-    UncheckedKeyHashSet<RefPtr<MutationObserver>> m_suspendedObservers;
+    HashSet<RefPtr<MutationObserver>> m_activeObservers;
+    HashSet<RefPtr<MutationObserver>> m_suspendedObservers;
 
     std::unique_ptr<CustomElementQueue> m_customElementQueue;
     bool m_processingBackupElementQueue { false };

--- a/Source/WebCore/dom/messageports/MessagePortChannel.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannel.h
@@ -75,7 +75,7 @@ private:
     std::array<std::optional<ProcessIdentifier>, 2> m_processes;
     std::array<RefPtr<MessagePortChannel>, 2> m_entangledToProcessProtectors;
     std::array<Vector<MessageWithMessagePorts>, 2> m_pendingMessages;
-    std::array<UncheckedKeyHashSet<RefPtr<MessagePortChannel>>, 2> m_pendingMessagePortTransfers;
+    std::array<HashSet<RefPtr<MessagePortChannel>>, 2> m_pendingMessagePortTransfers;
     std::array<RefPtr<MessagePortChannel>, 2> m_pendingMessageProtectors;
     uint64_t m_messageBatchesInFlight { 0 };
 

--- a/Source/WebCore/dom/messageports/MessagePortChannelRegistry.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannelRegistry.h
@@ -57,7 +57,7 @@ public:
     WEBCORE_EXPORT void messagePortChannelDestroyed(MessagePortChannel&);
 
 private:
-    UncheckedKeyHashMap<MessagePortIdentifier, WeakRef<MessagePortChannel>> m_openChannels;
+    HashMap<MessagePortIdentifier, WeakRef<MessagePortChannel>> m_openChannels;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.h
+++ b/Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.h
@@ -53,7 +53,7 @@ private:
     WeakRef<WorkerOrWorkletGlobalScope> m_scope;
 
     uint64_t m_lastCallbackIdentifier { 0 };
-    UncheckedKeyHashMap<uint64_t, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, Function<void()>&&)>> m_takeAllMessagesCallbacks;
+    HashMap<uint64_t, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, Function<void()>&&)>> m_takeAllMessagesCallbacks;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### ba42b5104760f99fd00fe830c31a506518a445fe
<pre>
Stop using UncheckedKey containers in WebCore/dom
<a href="https://bugs.webkit.org/show_bug.cgi?id=295179">https://bugs.webkit.org/show_bug.cgi?id=295179</a>

Reviewed by Anne van Kesteren.

Stop using UncheckedKey containers in WebCore/dom, for safety.
This tested as performance neutral on Speedometer.

* Source/WebCore/dom/ChildListMutationScope.cpp:
* Source/WebCore/dom/ConstantPropertyMap.h:
* Source/WebCore/dom/CustomElementDefaultARIA.h:
* Source/WebCore/dom/CustomElementRegistry.h:
* Source/WebCore/dom/DataTransfer.cpp:
* Source/WebCore/dom/DeviceOrientationAndMotionAccessController.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::buildAccessKeyCache):
(WebCore::Document::runScrollSteps):
(WebCore::hasRealtimeMediaSource):
(WebCore::findNearestCommonComposedAncestor):
* Source/WebCore/dom/Document.h:
(WebCore::Document::attachmentElementsByIdentifier const):
* Source/WebCore/dom/DocumentMarkerController.h:
* Source/WebCore/dom/DocumentSharedObjectPool.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::attrNodeListMap):
(WebCore::elementIdentifiersMap):
(WebCore::Element::topmostPopoverAncestor):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ExtensionStyleSheets.h:
* Source/WebCore/dom/IdTargetObserverRegistry.h:
* Source/WebCore/dom/MessagePort.cpp:
(WebCore::WTF_REQUIRES_LOCK):
(WebCore::MessagePort::disentanglePorts):
* Source/WebCore/dom/MutationObserver.cpp:
(WebCore::MutationObserver::deliver):
* Source/WebCore/dom/MutationObserver.h:
* Source/WebCore/dom/MutationObserverInterestGroup.cpp:
(WebCore::MutationObserverInterestGroup::MutationObserverInterestGroup):
* Source/WebCore/dom/MutationObserverInterestGroup.h:
* Source/WebCore/dom/MutationObserverRegistration.cpp:
(WebCore::MutationObserverRegistration::takeTransientRegistrations):
* Source/WebCore/dom/MutationObserverRegistration.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::dumpStatistics):
(WebCore::nodeSetPreTransformedFromNodeOrStringVector):
(WebCore::firstPrecedingSiblingNotInNodeSet):
(WebCore::firstFollowingSiblingNotInNodeSet):
(WebCore::Node::registeredMutationObservers):
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/NodeRareData.h:
* Source/WebCore/dom/QualifiedNameCache.h:
* Source/WebCore/dom/RadioButtonGroups.h:
* Source/WebCore/dom/Range.cpp:
(WebCore::Range::processContents):
* Source/WebCore/dom/ScriptExecutionContext.cpp:
* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/dom/ScriptRunner.h:
* Source/WebCore/dom/SelectorQuery.h:
* Source/WebCore/dom/ShadowRoot.cpp:
* Source/WebCore/dom/ShadowRoot.h:
* Source/WebCore/dom/SimulatedClick.cpp:
(WebCore::simulateClick):
* Source/WebCore/dom/SlotAssignment.cpp:
(WebCore::ManualSlotAssignment::slotManualAssignmentDidChange):
* Source/WebCore/dom/SlotAssignment.h:
* Source/WebCore/dom/SpaceSplitString.cpp:
* Source/WebCore/dom/TreeScopeOrderedMap.h:
* Source/WebCore/dom/VisitedLinkState.h:
* Source/WebCore/dom/WindowEventLoop.h:
* Source/WebCore/dom/messageports/MessagePortChannel.h:
* Source/WebCore/dom/messageports/MessagePortChannelRegistry.h:
* Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.h:

Canonical link: <a href="https://commits.webkit.org/296785@main">https://commits.webkit.org/296785@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f24c158dbe7c2a06ee9e44087704facd56c30ffa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-18-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-2-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 playstation ](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17683 "Built successfully and passed tests") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-18-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-11-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-11-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
<!--EWS-Status-Bubble-End-->