### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in FastFloat.cpp

### DIFF
--- a/Source/WTF/wtf/FastFloat.cpp
+++ b/Source/WTF/wtf/FastFloat.cpp
@@ -28,46 +28,42 @@
 
 #include "fast_float/fast_float.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 double parseDouble(std::span<const LChar> string, size_t& parsedLength)
 {
     double doubleValue = 0;
-    auto stringData = byteCast<char>(string.data());
-    auto result = fast_float::from_chars(stringData, stringData + string.size(), doubleValue);
-    parsedLength = result.ptr - stringData;
+    auto stringData = byteCast<char>(string);
+    auto result = fast_float::from_chars(std::to_address(stringData.begin()), std::to_address(stringData.end()), doubleValue);
+    parsedLength = result.ptr - stringData.data();
     return doubleValue;
 }
 
 double parseDouble(std::span<const char16_t> string, size_t& parsedLength)
 {
     double doubleValue = 0;
-    auto stringData = reinterpret_cast<const char16_t*>(string.data());
-    auto result = fast_float::from_chars(stringData, stringData + string.size(), doubleValue);
-    parsedLength = result.ptr - stringData;
+    auto stringData = spanReinterpretCast<const char16_t>(string);
+    auto result = fast_float::from_chars(std::to_address(stringData.begin()), std::to_address(stringData.end()), doubleValue);
+    parsedLength = result.ptr - stringData.data();
     return doubleValue;
 }
 
 double parseHexDouble(std::span<const LChar> string, size_t& parsedLength)
 {
     double doubleValue = 0;
-    auto stringData = byteCast<char>(string.data());
-    auto result = fast_float::from_chars(stringData, stringData + string.size(), doubleValue, fast_float::chars_format::hex);
-    parsedLength = result.ptr - stringData;
+    auto stringData = byteCast<char>(string);
+    auto result = fast_float::from_chars(std::to_address(stringData.begin()), std::to_address(stringData.end()), doubleValue, fast_float::chars_format::hex);
+    parsedLength = result.ptr - stringData.data();
     return doubleValue;
 }
 
 double parseHexDouble(std::span<const char16_t> string, size_t& parsedLength)
 {
     double doubleValue = 0;
-    auto stringData = reinterpret_cast<const char16_t*>(string.data());
-    auto result = fast_float::from_chars(stringData, stringData + string.size(), doubleValue, fast_float::chars_format::hex);
-    parsedLength = result.ptr - stringData;
+    auto stringData = spanReinterpretCast<const char16_t>(string);
+    auto result = fast_float::from_chars(std::to_address(stringData.begin()), std::to_address(stringData.end()), doubleValue, fast_float::chars_format::hex);
+    parsedLength = result.ptr - stringData.data();
     return doubleValue;
 }
 
 } // namespace WTF
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### 2bebd1537c897046c6043852e8c8ba7375c536f8
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in FastFloat.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=295183">https://bugs.webkit.org/show_bug.cgi?id=295183</a>

Reviewed by David Kilzer.

* Source/WTF/wtf/FastFloat.cpp:
(WTF::parseDouble):
(WTF::parseHexDouble):

Canonical link: <a href="https://commits.webkit.org/296810@main">https://commits.webkit.org/296810@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5144ec7e30219208805ab2e20523b0161ba730cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109667 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29325 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19754 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115688 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59901 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37913 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83334 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112615 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23907 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98765 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63793 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23288 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16909 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59482 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/102158 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/93282 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16947 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118480 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/108219 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36706 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27183 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92344 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37079 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95024 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92165 "Found 2 new API test failures: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23479 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37129 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14871 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32534 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36600 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42071 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/132495 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36261 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35873 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39603 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37970 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->