### PR TITLE
REGRESSION(294049@main): Comic-Con website may show menu content partly offscreen

### DIFF
--- a/LayoutTests/webanimations/focus-accelerated-animated-element-initially-in-overflow-expected.txt
+++ b/LayoutTests/webanimations/focus-accelerated-animated-element-initially-in-overflow-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Calling 'focus()' on an element initially in overflow with a `transform` animation bringing it into view should not cause its container to scroll.
+

--- a/LayoutTests/webanimations/focus-accelerated-animated-element-initially-in-overflow.html
+++ b/LayoutTests/webanimations/focus-accelerated-animated-element-initially-in-overflow.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html>
+<head>
+    <title>Calling 'focus()' on an element initially in overflow with a `transform` animation bringing it into view should not cause its container to scroll.</title>
+    <style>
+
+div {
+    position: absolute;
+    left: 0;
+    top: 0;
+}
+
+#container {
+    width: 200px;
+    height: 200px;
+
+    background-color: blue;
+
+    overflow-x: hidden;
+}
+
+#target {
+    width: 100%;
+    height: 100%;
+
+    background-color: green;
+
+    transform: translateX(100%);
+    transition: transform 0.25s;
+}
+
+#target.showing {
+    transform: none;
+}
+
+button {
+    margin: 20px;
+}
+
+    </style>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+</head>
+
+<body>
+
+<div id="container">
+    <div id="target">
+        <button>Hello World!</button>
+    </div>
+</div>
+
+<script>
+
+const timeout = interval => new Promise(resolve => setTimeout(resolve, interval));
+
+const container = document.getElementById("container");
+const target = document.getElementById("target");
+const button = document.querySelector("button");
+
+promise_test(async test => {
+    // Initiate the transition.
+    await new Promise(requestAnimationFrame);
+    target.classList.add("showing");
+    
+    // 50ms later, focus the button which should no longer be in
+    // the overflow area.
+    await timeout(50);
+    button.focus();
+
+    // Wait a beat and check that the container was not scrolled
+    // as a result of calling focus().
+    await timeout(0);
+    assert_equals(container.scrollLeft, 0);
+
+    container.remove();
+}, "Calling 'focus()' on an element initially in overflow with a `transform` animation bringing it into view should not cause its container to scroll.");
+
+</script>
+
+</body>
+</html>

--- a/Source/WebCore/animation/AnimationEffect.cpp
+++ b/Source/WebCore/animation/AnimationEffect.cpp
@@ -77,7 +77,7 @@ EffectTiming AnimationEffect::getBindingsTiming() const
     return timing;
 }
 
-AnimationEffectTiming::ResolutionData AnimationEffect::resolutionData() const
+AnimationEffectTiming::ResolutionData AnimationEffect::resolutionData(UseCachedCurrentTime useCachedCurrentTime) const
 {
     if (!m_animation)
         return { };
@@ -85,10 +85,10 @@ AnimationEffectTiming::ResolutionData AnimationEffect::resolutionData() const
     RefPtr animation = m_animation.get();
     RefPtr timeline = animation->timeline();
     return {
-        timeline ? timeline->currentTime() : std::nullopt,
+        timeline ? timeline->currentTime(useCachedCurrentTime) : std::nullopt,
         timeline ? timeline->duration() : std::nullopt,
         animation->startTime(),
-        animation->currentTime(),
+        animation->currentTime(useCachedCurrentTime),
         animation->playbackRate()
     };
 }
@@ -106,11 +106,11 @@ ComputedEffectTiming AnimationEffect::getBindingsComputedTiming()
     return getComputedTiming();
 }
 
-ComputedEffectTiming AnimationEffect::getComputedTiming()
+ComputedEffectTiming AnimationEffect::getComputedTiming(UseCachedCurrentTime useCachedCurrentTime)
 {
     updateComputedTimingPropertiesIfNeeded();
 
-    auto data = resolutionData();
+    auto data = resolutionData(useCachedCurrentTime);
     auto resolvedTiming = m_timing.resolve(data);
 
     // https://drafts.csswg.org/web-animations-2/#dom-animationeffect-getcomputedtiming

--- a/Source/WebCore/animation/AnimationEffect.h
+++ b/Source/WebCore/animation/AnimationEffect.h
@@ -56,7 +56,7 @@ public:
     EffectTiming getBindingsTiming() const;
     BasicEffectTiming getBasicTiming();
     ComputedEffectTiming getBindingsComputedTiming();
-    ComputedEffectTiming getComputedTiming();
+    ComputedEffectTiming getComputedTiming(UseCachedCurrentTime = UseCachedCurrentTime::Yes);
     ExceptionOr<void> bindingsUpdateTiming(Document&, std::optional<OptionalEffectTiming>);
     ExceptionOr<void> updateTiming(Document&, std::optional<OptionalEffectTiming>);
 
@@ -116,7 +116,7 @@ protected:
     virtual std::optional<double> progressUntilNextStep(double) const;
 
 private:
-    AnimationEffectTiming::ResolutionData resolutionData() const;
+    AnimationEffectTiming::ResolutionData resolutionData(UseCachedCurrentTime = UseCachedCurrentTime::Yes) const;
     void updateComputedTimingPropertiesIfNeeded();
 
     AnimationEffectTiming m_timing;

--- a/Source/WebCore/animation/AnimationTimeline.h
+++ b/Source/WebCore/animation/AnimationTimeline.h
@@ -53,7 +53,7 @@ public:
     virtual void animationTimingDidChange(WebAnimation&);
     virtual void removeAnimation(WebAnimation&);
 
-    virtual std::optional<WebAnimationTime> currentTime() { return m_currentTime; }
+    virtual std::optional<WebAnimationTime> currentTime(UseCachedCurrentTime = UseCachedCurrentTime::Yes) { return m_currentTime; }
     virtual std::optional<WebAnimationTime> duration() const { return m_duration; }
 
     virtual void detachFromDocument();

--- a/Source/WebCore/animation/AnimationTimelinesController.cpp
+++ b/Source/WebCore/animation/AnimationTimelinesController.cpp
@@ -42,7 +42,6 @@
 #include "StyleOriginatedTimelinesController.h"
 #include "ViewTimeline.h"
 #include "WebAnimation.h"
-#include "WebAnimationTypes.h"
 #include <ranges>
 #include <wtf/HashSet.h>
 #include <wtf/Ref.h>
@@ -295,10 +294,13 @@ ReducedResolutionSeconds AnimationTimelinesController::liveCurrentTime() const
     return m_document->window()->nowTimestamp();
 }
 
-std::optional<Seconds> AnimationTimelinesController::currentTime()
+std::optional<Seconds> AnimationTimelinesController::currentTime(UseCachedCurrentTime useCachedCurrentTime)
 {
     if (!m_document->window())
         return std::nullopt;
+
+    if (useCachedCurrentTime == UseCachedCurrentTime::No && !m_isSuspended)
+        return liveCurrentTime();
 
     if (!m_cachedCurrentTime)
         cacheCurrentTime(liveCurrentTime());

--- a/Source/WebCore/animation/AnimationTimelinesController.h
+++ b/Source/WebCore/animation/AnimationTimelinesController.h
@@ -27,7 +27,7 @@
 
 #include "FrameRateAligner.h"
 #include "ReducedResolutionSeconds.h"
-#include "Timer.h"
+#include "WebAnimationTypes.h"
 #include <wtf/CancellableTask.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/Markable.h>
@@ -61,7 +61,7 @@ public:
     void updateStaleScrollTimelines();
     void addPendingAnimation(WebAnimation&);
 
-    std::optional<Seconds> currentTime();
+    std::optional<Seconds> currentTime(UseCachedCurrentTime = UseCachedCurrentTime::Yes);
     std::optional<FramesPerSecond> maximumAnimationFrameRate() const { return m_frameRateAligner.maximumFrameRate(); }
     std::optional<Seconds> timeUntilNextTickForAnimationsWithFrameRate(FramesPerSecond) const;
 

--- a/Source/WebCore/animation/DocumentTimeline.cpp
+++ b/Source/WebCore/animation/DocumentTimeline.cpp
@@ -127,10 +127,10 @@ unsigned DocumentTimeline::numberOfActiveAnimationsForTesting() const
     return count;
 }
 
-std::optional<WebAnimationTime> DocumentTimeline::currentTime()
+std::optional<WebAnimationTime> DocumentTimeline::currentTime(UseCachedCurrentTime useCachedCurrentTime)
 {
     if (auto* controller = this->controller()) {
-        if (auto currentTime = controller->currentTime())
+        if (auto currentTime = controller->currentTime(useCachedCurrentTime))
             return *currentTime - m_originTime;
         return std::nullopt;
     }

--- a/Source/WebCore/animation/DocumentTimeline.h
+++ b/Source/WebCore/animation/DocumentTimeline.h
@@ -57,7 +57,7 @@ public:
 
     Document* document() const { return m_document.get(); }
 
-    std::optional<WebAnimationTime> currentTime() override;
+    std::optional<WebAnimationTime> currentTime(UseCachedCurrentTime = UseCachedCurrentTime::Yes) override;
     ExceptionOr<Ref<WebAnimation>> animate(Ref<CustomEffectCallback>&&, std::optional<Variant<double, CustomAnimationOptions>>&&);
 
     void animationTimingDidChange(WebAnimation&) override;

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1824,7 +1824,12 @@ void KeyframeEffect::getAnimatedStyle(std::unique_ptr<RenderStyle>& animatedStyl
     if (!renderer() || !animation())
         return;
 
-    auto computedTiming = getComputedTiming();
+    // In case we are running accelerated, we want to use a live, non-cached current time so that any geometry
+    // computation that may rely on this computed style has the most current information. Indeed, when using
+    // accelerated effects, we may not update animations in WebCore and thus will fail to have a meaningful
+    // cached current time.
+    auto useCachedCurrentTime = isRunningAccelerated() ? UseCachedCurrentTime::No : UseCachedCurrentTime::Yes;
+    auto computedTiming = getComputedTiming(useCachedCurrentTime);
     LOG_WITH_STREAM(Animations, stream << "KeyframeEffect " << this << " getAnimatedStyle - progress " << computedTiming.progress);
     if (!computedTiming.progress)
         return;

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -360,7 +360,7 @@ std::pair<WebAnimationTime, WebAnimationTime> ScrollTimeline::intervalForAttachm
     };
 }
 
-std::optional<WebAnimationTime> ScrollTimeline::currentTime()
+std::optional<WebAnimationTime> ScrollTimeline::currentTime(UseCachedCurrentTime)
 {
     // https://drafts.csswg.org/scroll-animations-1/#scroll-timeline-progress
     // Progress (the current time) for a scroll progress timeline is calculated as:

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -72,7 +72,7 @@ public:
 
     AnimationTimelinesController* controller() const override;
 
-    std::optional<WebAnimationTime> currentTime() override;
+    std::optional<WebAnimationTime> currentTime(UseCachedCurrentTime = UseCachedCurrentTime::Yes) override;
     TimelineRange defaultRange() const override;
     WeakPtr<Element, WeakPtrImplWithEventTargetData> timelineScopeDeclaredElement() const { return m_timelineScopeElement; }
     void setTimelineScopeElement(const Element&);

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -469,12 +469,12 @@ ExceptionOr<void> WebAnimation::setBindingsCurrentTime(const std::optional<WebAn
     return setCurrentTime(currentTime);
 }
 
-std::optional<WebAnimationTime> WebAnimation::currentTime() const
+std::optional<WebAnimationTime> WebAnimation::currentTime(UseCachedCurrentTime useCachedCurrentTime) const
 {
-    return currentTime(RespectHoldTime::Yes);
+    return currentTime(RespectHoldTime::Yes, useCachedCurrentTime);
 }
 
-std::optional<WebAnimationTime> WebAnimation::currentTime(RespectHoldTime respectHoldTime) const
+std::optional<WebAnimationTime> WebAnimation::currentTime(RespectHoldTime respectHoldTime, UseCachedCurrentTime useCachedCurrentTime) const
 {
     // 3.4.4. The current time of an animation
     // https://drafts.csswg.org/web-animations-1/#the-current-time-of-an-animation
@@ -490,11 +490,11 @@ std::optional<WebAnimationTime> WebAnimation::currentTime(RespectHoldTime respec
     //     2. the associated timeline is inactive, or
     //     3. the animation's start time is unresolved.
     // The current time is an unresolved time value.
-    if (!m_timeline || !m_timeline->currentTime() || !m_startTime)
+    if (!m_timeline || !m_timeline->currentTime(useCachedCurrentTime) || !m_startTime)
         return std::nullopt;
 
     // Otherwise, current time = (timeline time - start time) * playback rate
-    return (*m_timeline->currentTime() - *m_startTime) * m_playbackRate;
+    return (*m_timeline->currentTime(useCachedCurrentTime) - *m_startTime) * m_playbackRate;
 }
 
 ExceptionOr<void> WebAnimation::silentlySetCurrentTime(std::optional<WebAnimationTime> seekTime)

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -90,7 +90,7 @@ public:
     AnimationTimeline* timeline() const { return m_timeline.get(); }
     virtual void setTimeline(RefPtr<AnimationTimeline>&&);
 
-    std::optional<WebAnimationTime> currentTime() const;
+    std::optional<WebAnimationTime> currentTime(UseCachedCurrentTime = UseCachedCurrentTime::Yes) const;
     ExceptionOr<void> setCurrentTime(std::optional<WebAnimationTime>);
 
     double playbackRate() const { return m_playbackRate + 0; }
@@ -205,7 +205,7 @@ private:
     WebAnimationTime effectEndTime() const;
     WebAnimation& readyPromiseResolve();
     WebAnimation& finishedPromiseResolve();
-    std::optional<WebAnimationTime> currentTime(RespectHoldTime) const;
+    std::optional<WebAnimationTime> currentTime(RespectHoldTime, UseCachedCurrentTime = UseCachedCurrentTime::Yes) const;
     ExceptionOr<void> silentlySetCurrentTime(std::optional<WebAnimationTime>);
     void finishNotificationSteps();
     bool hasPendingPauseTask() const { return m_timeToRunPendingPauseTask != TimeToRunPendingTask::NotScheduled; }

--- a/Source/WebCore/animation/WebAnimationTypes.h
+++ b/Source/WebCore/animation/WebAnimationTypes.h
@@ -68,6 +68,7 @@ enum class AnimationImpact : uint8_t {
 };
 
 enum class UseAcceleratedAction : bool { No, Yes };
+enum class UseCachedCurrentTime : bool { No, Yes };
 
 enum class WebAnimationType : uint8_t { CSSAnimation, CSSTransition, WebAnimation };
 


### PR DESCRIPTION
#### 8fd5ab7bf0260ad28d50e10b8a66a0b1bf9eac07
<pre>
REGRESSION(294049@main): Comic-Con website may show menu content partly offscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=295184">https://bugs.webkit.org/show_bug.cgi?id=295184</a>
<a href="https://rdar.apple.com/152375667">rdar://152375667</a>

Reviewed by Simon Fraser.

Prior to 294049@main, when the current time would be requested from `AnimationTimelinesController`,
most likely through `DocumentTimeline::currentTime()`, we would either use the cached current time,
if available, or compute a new one. In the case where we would compute a new one, we would also
enqueue a task (using `EventLoop::queueTask()`) to clear it after the current run loop had completed,
ensuring that any code ran within that loop would use the same current time.

That changed in 294049@main where we made it so that the document timeline&apos;s current time was cached
throughout the duration of the animation frame, matching the behavior of Chrome and Firefox. In effect,
this meant that that current time was updated every 16ms or so (assuming a display update cadence of 60Hz).

However, we neglected to preserve the mechanism to clear that cached current time, instead relying on
the fact that animations would cause animations to be updated and for that current time to be cached
as the page rendering updated at 60Hz.

The Comic-Con website has a menu which, in a narrow window or on a narrow display such as an iPhone,
animates an element which is the width of the window over 150ms from right to left, taking it from
being completely offscreen to completely onscreen. That element is contained within an element that
has `overflow-x: hidden`, meaning that the animated element animates from being completely in the
overflow part of its container to. That element has a title wrapped in a &lt;button&gt; element which has
its `focus()` method called on it 50ms into the animated transition using a `setTimeout()` call.

Sometimes, this transition would appear to end up partly offscreen on the left of the window. The
reason this would happen is that the animated transition in question was performed using the `transform`
property, meaning that acceleration was used. In that scenario, we don&apos;t schedule animation updates
while the transition is in-flight, letting Core Animation update the animated time and interpolate
the transform property of the composited layer backing the target element. This meant that we would have
no chance, within WebCore, to update the transition&apos;s timeline&apos;s (ie. the document timeline) current time
while the transition would be in-flight.

However, when `focus()` is called on an element within a scrollable container, WebCore will scroll
that element into view if it deems this necessary (ie. it&apos;s partially invisible). To achieve this,
the method `RenderLayerScrollableArea::updateScrollPositionForScrollIntoView()` is called. This method
will eventually call into `RenderElement::absoluteAnchorRectWithScrollMargin()` which itself will call
into `KeyframeEffect::getAnimatedStyle()`. The purpose of that last method is to compute the animated
style for this keyframe effect on demand when the target element&apos;s renderer&apos;s style has not been updated
during the traditional process of updating animations during page rendering updates, as is the case
for accelerated animations.

However, since we would fail to update the document timeline&apos;s current time past the start of the
transition, we would compute the bounds incorrectly and assume the element was contained in the overflow
area. This would lead to the container with `overflow-x: hidden` to scroll to reveal the `&lt;button&gt;`
element.

In this patch we address this particular issue by adding a way to *not* use the cached current time
when computing an animation&apos;s current time, which relies on the document timeline&apos;s current time. We
elect to do so in the case where `KeyframeEffect::getAnimatedStyle()` is called for an effect that
is running with acceleration.

Note that this doesn&apos;t fix the problem of not clearing the cached current time in the absence of
repeated page rendering updates. This will be addressed separately in bug 295177.

Finally, to ensure we don&apos;t encounter this issue going forward, we add a test that replicates the
behavior of the Comic-Con website. This test would reliably fail prior to this patch.

* LayoutTests/webanimations/focus-accelerated-animated-element-initially-in-overflow-expected.txt: Added.
* LayoutTests/webanimations/focus-accelerated-animated-element-initially-in-overflow.html: Added.
* Source/WebCore/animation/AnimationEffect.cpp:
(WebCore::AnimationEffect::resolutionData const):
(WebCore::AnimationEffect::getComputedTiming):
* Source/WebCore/animation/AnimationEffect.h:
* Source/WebCore/animation/AnimationTimeline.h:
(WebCore::AnimationTimeline::currentTime):
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::currentTime):
* Source/WebCore/animation/AnimationTimelinesController.h:
* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::currentTime):
* Source/WebCore/animation/DocumentTimeline.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::getAnimatedStyle):
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::currentTime):
* Source/WebCore/animation/ScrollTimeline.h:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::currentTime const):
* Source/WebCore/animation/WebAnimation.h:
* Source/WebCore/animation/WebAnimationTypes.h:

Canonical link: <a href="https://commits.webkit.org/296833@main">https://commits.webkit.org/296833@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef5683dc8d0958bfabbb02767c72186ff9751ed3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109744 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19832 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/115765 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/59978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/111707 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30080 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37990 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/115765 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/59978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112692 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/23968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/98833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/115765 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/23348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/16978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/59559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/93342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/17019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118557 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36783 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/27245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/92401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37156 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/95095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/92223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/37189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/14932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/32611 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17710 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36678 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42148 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/36338 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39680 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38047 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->