### PR TITLE
REGRESSION(294049@main): `document.timeline.currentTime` never advances

### DIFF
--- a/LayoutTests/webanimations/document-timeline-current-time-updates-without-running-animations-expected.txt
+++ b/LayoutTests/webanimations/document-timeline-current-time-updates-without-running-animations-expected.txt
@@ -1,0 +1,3 @@
+
+PASS The document timeline's current time should increase when the page rendering does not update.
+

--- a/LayoutTests/webanimations/document-timeline-current-time-updates-without-running-animations.html
+++ b/LayoutTests/webanimations/document-timeline-current-time-updates-without-running-animations.html
@@ -1,0 +1,57 @@
+<html>
+<head>
+    <title>The document timeline's current time should increase when the page rendering does not update.</title>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+</head>
+
+<body>
+
+<script>
+
+const pageRenderingUpdate = () => new Promise(requestAnimationFrame);
+
+const timeout = interval => new Promise(resolve => setTimeout(resolve, interval));
+
+const timelineTimeBetweenPageRenderingUpdates = () => {
+    return new Promise(async (resolve, reject) => {
+        // Wait for an initial page rendering update to make sure we have a full
+        // page rendering update interval before we wait for a run loop that falls
+        // within a page rendering update interval.
+        await pageRenderingUpdate();
+
+        const maxAttempts = 10;
+        for (let numAttempts = 0; numAttempts < maxAttempts; numAttempts++) {
+            const pageRenderingUpdateTime = await pageRenderingUpdate();
+            const timelineTime = document.timeline.currentTime;
+
+            // Wait for the next run loop.
+            await timeout(0);
+
+            // If that run loop was run less than 10ms after the page rendering update,
+            // we are in between two page rendering updates.
+            if (performance.now() - pageRenderingUpdateTime < 10) {
+                resolve(timelineTime);
+                break;
+            }
+        }
+
+        reject(-1);
+    });
+}
+
+promise_test(async test => {
+    const initialTimelineTime = await timelineTimeBetweenPageRenderingUpdates();
+    assert_equals(document.timeline.currentTime, initialTimelineTime,
+        "The timeline time should be the same during a page rendering update and in a run loop before the next page rendering update");
+
+    // Wait for 20ms which is more than the typical interval between two page rendering updates.
+    await timeout(20);
+    assert_greater_than(document.timeline.currentTime, initialTimelineTime,
+        "The timeline time should increase after waiting for over the typical duration between two page rendering updates");
+}, "The document timeline's current time should increase when the page rendering does not update.");
+
+</script>
+
+</body>
+</html>

--- a/Source/WebCore/animation/AnimationTimelinesController.h
+++ b/Source/WebCore/animation/AnimationTimelinesController.h
@@ -78,6 +78,7 @@ private:
 
     ReducedResolutionSeconds liveCurrentTime() const;
     void cacheCurrentTime(ReducedResolutionSeconds);
+    void clearCachedCurrentTime();
     void processPendingAnimations();
     bool isPendingTimelineAttachment(const WebAnimation&) const;
 
@@ -87,6 +88,7 @@ private:
     std::unique_ptr<AcceleratedEffectStackUpdater> m_acceleratedEffectStackUpdater;
 #endif
 
+    Timer m_cachedCurrentTimeClearanceTimer;
     Vector<Ref<ScrollTimeline>> m_updatedScrollTimelines;
     HashMap<FramesPerSecond, ReducedResolutionSeconds> m_animationFrameRateToLastTickTimeMap;
     WeakHashSet<AnimationTimeline> m_timelines;


### PR DESCRIPTION
#### 64e4b813611284f83426e5540758eb80faee07dd
<pre>
REGRESSION(294049@main): `document.timeline.currentTime` never advances
<a href="https://bugs.webkit.org/show_bug.cgi?id=295177">https://bugs.webkit.org/show_bug.cgi?id=295177</a>
<a href="https://rdar.apple.com/problem/154607696">rdar://problem/154607696</a>

Reviewed by Simon Fraser.

Prior to 294049@main, when the current time would be requested from `AnimationTimelinesController`,
most likely through `DocumentTimeline::currentTime()`, we would either use the cached current time,
if available, or compute a new one. In the case where we would compute a new one, we would also
enqueue a task (using `EventLoop::queueTask()`) to clear it after the current run loop had completed,
ensuring that any code ran within that loop would use the same current time.

That changed in 294049@main where we made it so that the document timeline&apos;s current time was cached
throughout the duration of the animation frame, matching the behavior of Chrome and Firefox. In effect,
this meant that that current time was updated every 16ms or so (assuming a display update cadence of 60Hz).

However, we neglected to preserve the mechanism to clear that cached current time, instead relying on
the fact that animations would cause animations to be updated and for that current time to be cached
as the page rendering updated at 60Hz.

When we cache the current time, we now clear it after a delay matching the page&apos;s preferred rendering
update interval.

We also add a test which checks that the document timeline&apos;s current time is correctly updated
after 20ms even with no page rendering updates scheduled. This test would have reliably failed
prior to this patch.

* LayoutTests/webanimations/document-timeline-current-time-updates-without-running-animations-expected.txt: Added.
* LayoutTests/webanimations/document-timeline-current-time-updates-without-running-animations.html: Added.
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::AnimationTimelinesController):
(WebCore::AnimationTimelinesController::suspendAnimations):
(WebCore::AnimationTimelinesController::resumeAnimations):
(WebCore::AnimationTimelinesController::cacheCurrentTime):
(WebCore::AnimationTimelinesController::clearCachedCurrentTime):
* Source/WebCore/animation/AnimationTimelinesController.h:

Canonical link: <a href="https://commits.webkit.org/296903@main">https://commits.webkit.org/296903@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46f7d91049aba9684065249585e8a6d35eda25e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109886 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29544 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19974 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115907 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60123 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111849 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30222 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38132 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83538 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112834 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24094 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98957 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63979 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23468 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17105 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59702 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93465 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17147 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118699 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36925 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27368 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92514 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37298 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95223 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92337 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37312 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15054 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32776 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17742 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36820 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42290 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36480 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39822 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38189 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->