### PR TITLE
[WebKitSwift] Some files within the module unnecessarily import itself

### DIFF
--- a/Source/WebKit/WebKitSwift/IdentityDocumentServices/ISO18013MobileDocumentRequest+Extras.swift
+++ b/Source/WebKit/WebKitSwift/IdentityDocumentServices/ISO18013MobileDocumentRequest+Extras.swift
@@ -25,7 +25,6 @@
 
 internal import IdentityDocumentServices
 internal import IdentityDocumentServicesUI
-import WebKitSwift
 
 extension ISO18013MobileDocumentRequest.ElementInfo {
     init(_ source: WKIdentityDocumentPresentmentMobileDocumentElementInfo) {

--- a/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentController.swift
+++ b/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentController.swift
@@ -26,7 +26,6 @@
 internal import IdentityDocumentServices
 internal import IdentityDocumentServicesUI
 import os
-import WebKitSwift
 
 #if canImport(UIKit)
 import UIKit

--- a/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentMobileDocumentRequest+Extras.swift
+++ b/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentMobileDocumentRequest+Extras.swift
@@ -25,7 +25,6 @@
 
 internal import IdentityDocumentServices
 internal import IdentityDocumentServicesUI
-import WebKitSwift
 
 extension WKIdentityDocumentPresentmentMobileDocumentElementInfo {
     convenience init(_ source: ISO18013MobileDocumentRequest.ElementInfo) {

--- a/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentMobileDocumentRequest.swift
+++ b/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentMobileDocumentRequest.swift
@@ -25,7 +25,6 @@
 
 import Foundation
 import Security
-import WebKitSwift
 
 @objc @implementation extension WKIdentityDocumentPresentmentMobileDocumentRequest {
     var presentmentRequests: [WKIdentityDocumentPresentmentMobileDocumentPresentmentRequest]

--- a/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentRawRequest.swift
+++ b/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentRawRequest.swift
@@ -24,7 +24,6 @@
 #if HAVE_DIGITAL_CREDENTIALS_UI
 
 import Foundation
-import WebKitSwift
 
 @objc @implementation extension WKIdentityDocumentPresentmentRawRequest {
     let requestProtocol: String

--- a/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentRequest.swift
+++ b/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentRequest.swift
@@ -24,7 +24,6 @@
 #if HAVE_DIGITAL_CREDENTIALS_UI
 
 import Foundation
-import WebKitSwift
 
 @objc @implementation extension WKIdentityDocumentPresentmentRequest {
     // Used to workaround the fact that `@objc @implementation does not support stored properties whose size can change

--- a/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentResponse.swift
+++ b/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentResponse.swift
@@ -24,7 +24,6 @@
 #if HAVE_DIGITAL_CREDENTIALS_UI
 
 import Foundation
-import WebKitSwift
 
 @objc @implementation extension WKIdentityDocumentPresentmentResponse {
     let protocolString: String

--- a/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentRawRequestValidator.swift
+++ b/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentRawRequestValidator.swift
@@ -25,7 +25,6 @@
 
 internal import IdentityDocumentServices
 import os
-import WebKitSwift
 
 #if canImport(UIKit)
 import UIKit


### PR DESCRIPTION
#### 3c41afd934ce277f61f52f063fc35e3321686e8e
<pre>
[WebKitSwift] Some files within the module unnecessarily import itself
<a href="https://bugs.webkit.org/show_bug.cgi?id=295185">https://bugs.webkit.org/show_bug.cgi?id=295185</a>
<a href="https://rdar.apple.com/154631961">rdar://154631961</a>

Reviewed by Richard Robinson.

`import WebKitSwift` from files under `Source/WebKit/WebKitSwift/` is
redundant, so let&apos;s drop these imports in this patch.

* Source/WebKit/WebKitSwift/IdentityDocumentServices/ISO18013MobileDocumentRequest+Extras.swift:
* Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentController.swift:
* Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentMobileDocumentRequest+Extras.swift:
* Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentMobileDocumentRequest.swift:
* Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentRawRequest.swift:
* Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentRequest.swift:
* Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentResponse.swift:
* Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentRawRequestValidator.swift:

Canonical link: <a href="https://commits.webkit.org/296812@main">https://commits.webkit.org/296812@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b791a8edeb065b30c969df6687de668c41a2920

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109615 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19702 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115633 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59845 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29951 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37861 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83290 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112563 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23862 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98721 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63747 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23241 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59430 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93237 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16904 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118426 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36654 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27141 "Found 7 new test failures: http/tests/media/hls/hls-audio-tracks-language.html http/tests/media/hls/hls-webvtt-default.html http/tests/media/hls/hls-webvtt-style.html http/tests/media/hls/range-request-cross-origin.html http/tests/media/hls/track-in-band-multiple-cues.html http/tests/media/hls/track-webvtt-multitracks.html platform/mac/media/encrypted-media/fps-generateRequest.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92297 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37027 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94981 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92115 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23482 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37084 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14828 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32471 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36548 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42019 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36208 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39551 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37918 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->