### PR TITLE
Remove dynamic-range-limit:no-limit override for videos

### DIFF
--- a/LayoutTests/fast/css/dynamic-range-limit-default.html
+++ b/LayoutTests/fast/css/dynamic-range-limit-default.html
@@ -21,13 +21,13 @@ if (CSS.supports("dynamic-range-limit", "standard") && CSS.supports("dynamic-ran
     shouldBe('document.getElementById("div").style["dynamic-range-limit"]', '""', quiet);
     shouldBe('getComputedStyle(document.getElementById("div"))["dynamic-range-limit"]', 'defaultLimit', quiet);
     shouldBe('document.getElementById("video").style["dynamic-range-limit"]', '""', quiet);
-    shouldBe('getComputedStyle(document.getElementById("video"))["dynamic-range-limit"]', '"no-limit"', quiet);
+    shouldBe('getComputedStyle(document.getElementById("video"))["dynamic-range-limit"]', 'defaultLimit', quiet);
     shouldBe('document.getElementById("div-standard").style["dynamic-range-limit"]', '"standard"', quiet);
     shouldBe('getComputedStyle(document.getElementById("div-standard"))["dynamic-range-limit"]', '"standard"', quiet);
     shouldBe('document.getElementById("div-under-standard").style["dynamic-range-limit"]', '""', quiet);
     shouldBe('getComputedStyle(document.getElementById("div-under-standard"))["dynamic-range-limit"]', '"standard"', quiet);
     shouldBe('document.getElementById("video-under-standard").style["dynamic-range-limit"]', '""', quiet);
-    shouldBe('getComputedStyle(document.getElementById("video-under-standard"))["dynamic-range-limit"]', '"no-limit"', quiet);
+    shouldBe('getComputedStyle(document.getElementById("video-under-standard"))["dynamic-range-limit"]', '"standard"', quiet);
 
     if (CSS.supports("dynamic-range-limit", "constrained")) {
         shouldBe('document.getElementById("video-constrained").style["dynamic-range-limit"]', '"constrained"', quiet);

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -158,7 +158,6 @@ video {
     -webkit-tap-highlight-color: transparent;
 #endif
     content: normal !important;
-    dynamic-range-limit: no-limit;
 }
 
 audio {


### PR DESCRIPTION
#### 08f06e1d5e805b23a7e0a80dbed518f97212067d
<pre>
Remove dynamic-range-limit:no-limit override for videos
<a href="https://bugs.webkit.org/show_bug.cgi?id=295190">https://bugs.webkit.org/show_bug.cgi?id=295190</a>
<a href="https://rdar.apple.com/154647207">rdar://154647207</a>

Reviewed by Anne van Kesteren.

Since the dynamic-range-limit default is no-limit for all elements, we
don&apos;t need the now-redundant override for videos in the UA style sheet.
As a bonus, it means that videos will now respect any explicit
dynamic-range-limit from its ancestors.

* LayoutTests/fast/css/dynamic-range-limit-default.html:
* Source/WebCore/css/html.css:
(video):

Canonical link: <a href="https://commits.webkit.org/296790@main">https://commits.webkit.org/296790@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/085768eed17bb6456c5065591d5fc4025e6eee45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109630 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19717 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115649 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59863 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111593 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29966 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37876 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83302 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112578 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23877 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98736 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63761 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23258 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16881 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59445 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93252 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16919 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118442 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36669 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27157 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92310 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37042 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94996 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92131 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23464 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37098 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14843 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32491 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36563 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42034 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36223 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39566 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37933 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->