### PR TITLE
blackrock.com: REGRESSION(283494@main): Timeouts observed with TLS upgrade

### DIFF
--- a/LayoutTests/ipc/serialized-type-info.html
+++ b/LayoutTests/ipc/serialized-type-info.html
@@ -4,7 +4,8 @@
         const firstTypeOnly = container == "std::span"
             || container == "Vector"
             || container == "std::array"
-            || container == "HashSet";
+            || container == "HashSet"
+            || container == "Markable";
         const firstTwoTypesOnly = container == "HashMap";
 
         const set = new Set();

--- a/Source/WTF/wtf/Markable.h
+++ b/Source/WTF/wtf/Markable.h
@@ -88,6 +88,18 @@ struct FloatMarkableTraits {
     }
 };
 
+struct DoubleMarkableTraits {
+    constexpr static bool isEmptyValue(double value)
+    {
+        return std::isnan(value);
+    }
+
+    constexpr static double emptyValue()
+    {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+};
+
 // The goal of Markable is offering Optional without sacrificing storage efficiency.
 // Markable takes Traits, which should have isEmptyValue and emptyValue functions. By using
 // one value of T as an empty value, we can remove bool flag in Optional. This strategy is

--- a/Source/WebCore/animation/WebAnimationTypes.h
+++ b/Source/WebCore/animation/WebAnimationTypes.h
@@ -50,18 +50,6 @@ class CSSTransition;
 class StyleOriginatedAnimation;
 class WebAnimation;
 
-struct WebAnimationsMarkableDoubleTraits {
-    static bool isEmptyValue(double value)
-    {
-        return std::isnan(value);
-    }
-
-    static constexpr double emptyValue()
-    {
-        return std::numeric_limits<double>::quiet_NaN();
-    }
-};
-
 enum class AnimationImpact : uint8_t {
     RequiresRecomposite     = 1 << 0,
     ForcesStackingContext   = 1 << 1
@@ -72,7 +60,7 @@ enum class UseCachedCurrentTime : bool { No, Yes };
 
 enum class WebAnimationType : uint8_t { CSSAnimation, CSSTransition, WebAnimation };
 
-using MarkableDouble = Markable<double, WebAnimationsMarkableDoubleTraits>;
+using MarkableDouble = Markable<double, WTF::DoubleMarkableTraits>;
 
 using WeakStyleOriginatedAnimations = Vector<WeakPtr<StyleOriginatedAnimation, WeakPtrImplWithEventTargetData>>;
 using AnimationCollection = ListHashSet<Ref<WebAnimation>>;

--- a/Source/WebCore/platform/network/ResourceRequestBase.cpp
+++ b/Source/WebCore/platform/network/ResourceRequestBase.cpp
@@ -287,6 +287,11 @@ void ResourceRequestBase::setTimeoutInterval(double timeoutInterval)
     m_platformRequestUpdated = false;
 }
 
+void ResourceRequestBase::resetTimeoutInterval()
+{
+    setTimeoutInterval(s_defaultTimeoutInterval);
+}
+
 const URL& ResourceRequestBase::firstPartyForCookies() const
 {
     updateResourceRequest(); 

--- a/Source/WebCore/platform/network/ResourceRequestBase.h
+++ b/Source/WebCore/platform/network/ResourceRequestBase.h
@@ -147,6 +147,7 @@ public:
     
     WEBCORE_EXPORT double timeoutInterval() const; // May return 0 when using platform default.
     WEBCORE_EXPORT void setTimeoutInterval(double);
+    WEBCORE_EXPORT void resetTimeoutInterval();
     
     WEBCORE_EXPORT const URL& firstPartyForCookies() const;
     WEBCORE_EXPORT void setFirstPartyForCookies(const URL&);

--- a/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
@@ -291,10 +291,10 @@ void ResourceRequest::doUpdatePlatformRequest()
     [nsRequest setCachePolicy:toPlatformRequestCachePolicy(cachePolicy())];
     _CFURLRequestSetProtocolProperty([nsRequest _CFURLRequest], kCFURLRequestAllowAllPOSTCaching, kCFBooleanTrue);
 
-    double timeoutInterval = ResourceRequestBase::timeoutInterval();
-    if (timeoutInterval)
-        [nsRequest setTimeoutInterval:timeoutInterval];
-    // Otherwise, respect NSURLRequest default timeout.
+    if (double newTimeoutInterval = timeoutInterval())
+        [nsRequest setTimeoutInterval:newTimeoutInterval];
+    else
+        [nsRequest setTimeoutInterval:defaultTimeoutInterval()];
 
     [nsRequest setMainDocumentURL:firstPartyForCookies().createNSURL().get()];
     if (!httpMethod().isEmpty())

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -355,6 +355,9 @@ void NetworkProcess::initializeNetworkProcess(NetworkProcessCreationParameters&&
 
     updateStorageAccessPromptQuirks(WTFMove(parameters.storageAccessPromptQuirksData));
 
+    if (parameters.defaultRequestTimeoutInterval)
+        setDefaultRequestTimeoutInterval(*parameters.defaultRequestTimeoutInterval);
+
     RELEASE_LOG(Process, "%p - NetworkProcess::initializeNetworkProcess: Presenting processPID=%d", this, legacyPresentingApplicationPID());
 }
 
@@ -3277,5 +3280,10 @@ void NetworkProcess::resetResourceMonitorThrottlerForTesting(PAL::SessionID sess
         completionHandler();
 }
 #endif
+
+void NetworkProcess::setDefaultRequestTimeoutInterval(double timeoutInterval)
+{
+    ResourceRequestBase::setDefaultTimeoutInterval(timeoutInterval);
+}
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -475,6 +475,8 @@ public:
 
     WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlockingForPage(std::optional<WebPageProxyIdentifier>) const;
 
+    void setDefaultRequestTimeoutInterval(double);
+
 private:
     void platformInitializeNetworkProcess(const NetworkProcessCreationParameters&);
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -278,4 +278,6 @@ messages -> NetworkProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
 #if ENABLE(CONTENT_EXTENSIONS)
     ResetResourceMonitorThrottlerForTesting(PAL::SessionID sessionID) -> ();
 #endif
+
+    SetDefaultRequestTimeoutInterval(double timeoutInterval)
 }

--- a/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.h
@@ -31,6 +31,7 @@
 #include <WebCore/Cookie.h>
 #include <WebCore/ProcessIdentifier.h>
 #include <WebCore/RegistrableDomain.h>
+#include <wtf/Markable.h>
 #include <wtf/ProcessID.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
@@ -82,6 +83,8 @@ struct NetworkProcessCreationParameters {
     Vector<std::pair<WebCore::ProcessIdentifier, WebCore::RegistrableDomain>> allowedFirstPartiesForCookies;
     HashSet<String> localhostAliasesForTesting;
     Vector<WebCore::OrganizationStorageAccessPromptQuirk> storageAccessPromptQuirksData;
+
+    Markable<double, WTF::DoubleMarkableTraits> defaultRequestTimeoutInterval;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.serialization.in
@@ -61,6 +61,8 @@ headers: "NetworkProcessCreationParameters.h" "AuxiliaryProcessCreationParameter
     Vector<std::pair<WebCore::ProcessIdentifier, WebCore::RegistrableDomain>> allowedFirstPartiesForCookies;
     HashSet<String> localhostAliasesForTesting;
     Vector<WebCore::OrganizationStorageAccessPromptQuirk> storageAccessPromptQuirksData;
+
+    Markable<double, WTF::DoubleMarkableTraits> defaultRequestTimeoutInterval;
 }
 
 enum class WebKit::LoadedWebArchive : bool

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -1304,6 +1304,12 @@ void NetworkResourceLoader::willSendRedirectedRequestInternal(ResourceRequest&& 
         redirectRequest.setHTTPHeaderField(WebCore::HTTPHeaderName::Authorization, authorization);
     }
 
+    if (request.wasSchemeOptimisticallyUpgraded()) {
+        LOADER_RELEASE_LOG("willSendRedirectedRequest: Resetting request timeout to the default value after redirect");
+
+        redirectRequest.resetTimeoutInterval();
+    }
+
     if (RefPtr networkLoadChecker = m_networkLoadChecker) {
         if (privateClickMeasurementAttributionTriggerData)
             networkLoadChecker->enableContentExtensionsCheck();

--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -854,7 +854,7 @@ template<typename T, typename Traits> struct ArgumentCoder<WTF::Markable<T, Trai
     }
 
     template<typename Decoder>
-    static std::optional<WTF::Markable<T>> decode(Decoder& decoder)
+    static std::optional<WTF::Markable<T, Traits>> decode(Decoder& decoder)
     {
         auto isEmpty = decoder.template decode<bool>();
         if (!isEmpty) [[unlikely]]

--- a/Source/WebKit/Shared/API/APIURLRequest.cpp
+++ b/Source/WebKit/Shared/API/APIURLRequest.cpp
@@ -27,6 +27,7 @@
 #include "APIURLRequest.h"
 
 #include "WebProcessPool.h"
+#include "WebsiteDataStore.h"
 
 namespace API {
 using namespace WebCore;
@@ -47,8 +48,11 @@ void URLRequest::setDefaultTimeoutInterval(double timeoutInterval)
 {
     ResourceRequest::setDefaultTimeoutInterval(timeoutInterval);
 
-    for (auto& processPool : WebProcessPool::allProcessPools())
+    for (Ref processPool : WebProcessPool::allProcessPools())
         processPool->setDefaultRequestTimeoutInterval(timeoutInterval);
+
+    for (Ref networkProcess : NetworkProcessProxy::allNetworkProcesses())
+        networkProcess->setDefaultRequestTimeoutInterval(timeoutInterval);
 }
 
 } // namespace API

--- a/Source/WebKit/Shared/WebProcessCreationParameters.h
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.h
@@ -37,6 +37,7 @@
 #include "WebProcessDataStoreParameters.h"
 #include <WebCore/CrossOriginMode.h>
 #include <wtf/HashMap.h>
+#include <wtf/Markable.h>
 #include <wtf/OptionSet.h>
 #include <wtf/ProcessID.h>
 #include <wtf/RetainPtr.h>
@@ -109,7 +110,7 @@ struct WebProcessCreationParameters {
 
     CacheModel cacheModel;
 
-    double defaultRequestTimeoutInterval { INT_MAX };
+    Markable<double, WTF::DoubleMarkableTraits> defaultRequestTimeoutInterval;
     unsigned backForwardCacheCapacity { 0 };
 
     bool shouldAlwaysUseComplexTextCodePath { false };

--- a/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
@@ -58,7 +58,7 @@
 
     WebKit::CacheModel cacheModel;
 
-    double defaultRequestTimeoutInterval;
+    Markable<double, WTF::DoubleMarkableTraits> defaultRequestTimeoutInterval;
     unsigned backForwardCacheCapacity;
 
     bool shouldAlwaysUseComplexTextCodePath;

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -33,6 +33,7 @@
 #include "APIHTTPCookieStore.h"
 #include "APINavigation.h"
 #include "APIPageConfiguration.h"
+#include "APIURLRequest.h"
 #include "AuthenticationChallengeProxy.h"
 #include "AuthenticationManager.h"
 #include "BackgroundFetchState.h"
@@ -230,6 +231,8 @@ void NetworkProcessProxy::sendCreationParametersToNewProcess()
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
     parameters.storageAccessPromptQuirksData = StorageAccessPromptQuirkController::sharedSingleton().cachedListData();
 #endif
+
+    parameters.defaultRequestTimeoutInterval = API::URLRequest::defaultTimeoutInterval();
 
     WebProcessPool::platformInitializeNetworkProcess(parameters);
     sendWithAsyncReply(Messages::NetworkProcess::InitializeNetworkProcess(WTFMove(parameters)), [weakThis = WeakPtr { *this }, initializationActivityAndGrant = initializationActivityAndGrant()] {
@@ -2037,6 +2040,12 @@ void NetworkProcessProxy::resetResourceMonitorThrottlerForTesting(PAL::SessionID
     sendWithAsyncReply(Messages::NetworkProcess::ResetResourceMonitorThrottlerForTesting(sessionID), WTFMove(completionHandler));
 }
 #endif
+
+void NetworkProcessProxy::setDefaultRequestTimeoutInterval(double timeoutInterval)
+{
+    if (canSendMessage())
+        send(Messages::NetworkProcess::SetDefaultRequestTimeoutInterval(timeoutInterval), 0);
+}
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -348,6 +348,8 @@ public:
     void resetResourceMonitorThrottlerForTesting(PAL::SessionID, CompletionHandler<void()>&&);
 #endif
 
+    void setDefaultRequestTimeoutInterval(double);
+
 private:
     explicit NetworkProcessProxy();
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -631,7 +631,8 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters,
         WebExtensionMatchPattern::registerCustomURLScheme(scheme);
 #endif
 
-    setDefaultRequestTimeoutInterval(parameters.defaultRequestTimeoutInterval);
+    if (parameters.defaultRequestTimeoutInterval)
+        setDefaultRequestTimeoutInterval(*parameters.defaultRequestTimeoutInterval);
 
     setBackForwardCacheCapacity(parameters.backForwardCacheCapacity);
 

--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -69,6 +69,7 @@
 #import <WebKit/DOMElement.h>
 #import <WebKit/DOMExtensions.h>
 #import <WebKit/DOMRange.h>
+#import <WebKit/WKURLRequest.h>
 #import <WebKit/WebArchive.h>
 #import <WebKit/WebBackForwardList.h>
 #import <WebKit/WebCache.h>
@@ -101,6 +102,7 @@
 #import <wtf/OSObjectPtr.h>
 #import <wtf/ProcessPrivilege.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/Seconds.h>
 #import <wtf/StdLibExtras.h>
 #import <wtf/Threading.h>
 #import <wtf/UniqueArray.h>
@@ -1985,6 +1987,8 @@ static void runTest(const std::string& inputLine)
 
     gTestRunner->clearAllDatabases();
     gTestRunner->clearNotificationPermissionState();
+
+    WKURLRequestSetDefaultTimeoutInterval((60_s).value());
 
     std::span pathOrURLSpan { pathOrURL };
     if (disallowedURLs)

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1389,6 +1389,8 @@ bool TestController::resetStateToConsistentValues(const TestOptions& options, Re
 
     WKWebsiteDataStoreResetResourceMonitorThrottler(websiteDataStore(), nullptr, nullptr);
 
+    WKURLRequestSetDefaultTimeoutInterval((60_s).value());
+
     // FIXME: This function should also ensure that there is only one page open.
 
     // Reset the EventSender for each test.


### PR DESCRIPTION
#### cde2625ebe14befd13b4a825f77b68645b5ddb12
<pre>
blackrock.com: REGRESSION(283494@main): Timeouts observed with TLS upgrade
<a href="https://bugs.webkit.org/show_bug.cgi?id=293286">https://bugs.webkit.org/show_bug.cgi?id=293286</a>
<a href="https://rdar.apple.com/151910984">rdar://151910984</a>

Reviewed by Matthew Finkel.

An HTTP request may be optimistically upgraded to an HTTPS request
when possible. The HTTPS request will be a redirect request from
the original HTTP request. In this event, the original HTTP request
will get a timeout interval of 3 seconds. This timeout currently
gets carried over to the redirect request. In cases where the
redirect is not completed within the 3 seconds, the redirect request
will timeout. This results in the site hanging and a terrible
customer experience.

We don&apos;t need to have the short timeout on the redirect request.

To fix this, we ensure that in cases where the request is scheme
upgraded, the redirect does not get the 3 second timeout. Instead,
it&apos;s timeout will be set at the platform&apos;s default value (this is
usually a large value--for example INT_MAX on iOS).

This change was causing a layout test to fail
(http/tests/xmlhttprequest/on-network-timeout-error-during-preflight.html):

The issue was two things:

1. Layout tests were implicitly relying on a different part of the
   code specifying a timeout value of 60 seconds. But with this change,
   the redirect request case will no longer implicitly rely on that,
   but rather explicity use ResourceRequestBase::defaultTimeoutInterval(),
   which is 0 for non-iOS platforms. From testing, it seems like this is
   interpreted as INT_MAX (or at least some high non-zero value) by
   lower level frameworks. So there is essentially no timeout. And this
   test is checking for a timeout. So we change TestController to explicity
   use 60 seconds as the default timeout for layout tests. We do the same
   for DumpRenderTree for WebKit1.

2. Even once we fixed this, the default value wasn&apos;t truly being
   updated to 60 seconds. The issue was that the WebKit C API to set
   the default value propagated the new value to all Web Processes
   but not to Network Processes. In this test, the value is accessed
   from the Network Process. Since the 60 seconds value wasn&apos;t set for
   Network Processes, it returned 0 seconds, which gets interpreted as
   INT_MAX (or some other higher non-zero value), and thus the test
   failed. We fix this by propagating the new default value from the
   API to Network Processes as well.

So we now explicitly set the default value to 60 seconds for each
layout test. And the WKURLRequestSetDefaultTimeoutInterval API
will propagate the value to Network Processes as well as Web Processes.

* LayoutTests/ipc/serialized-type-info.html:
* Source/WTF/wtf/Markable.h:
(WTF::DoubleMarkableTraits::isEmptyValue):
(WTF::DoubleMarkableTraits::emptyValue):
* Source/WebCore/animation/WebAnimationTypes.h:
(WebCore::WebAnimationsMarkableDoubleTraits::isEmptyValue): Deleted.
(WebCore::WebAnimationsMarkableDoubleTraits::emptyValue): Deleted.
* Source/WebCore/platform/network/ResourceRequestBase.cpp:
(WebCore::ResourceRequestBase::resetTimeoutInterval):

This will reset the timeout to the default value.

* Source/WebCore/platform/network/ResourceRequestBase.h:
* Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm:
(WebCore::ResourceRequest::doUpdatePlatformRequest):

This function updates the NSRequest with the current information
stored in the updated WebCore::ResourceRequest.

Before the update happens, in the case of the redirect, the NSRequest
will contain the timeout from the original request (the short
time interval). Currently, if the updated WebCore::ResourceRequest&apos;s
timeout interval is 0, we don&apos;t change the NSRequest&apos;s timeout, so
it remains as the short timeout.

We update this so that if the ResourceRequest&apos;s timeout is
0, we&apos;ll use the ResourceRequest&apos;s default timeout (generally a large
value, like INT_MAX on iOS).

* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::initializeNetworkProcess):
(WebKit::NetworkProcess::setDefaultRequestTimeoutInterval):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.h:

The default timeout for Network Processes can be set here.

* Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.serialization.in:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::willSendRedirectedRequestInternal):

If the original request was scheme upgraded, set the timeout on the
redirect request to the default value. If it&apos;s set it to 0, then when this
request is converted to an NSRequest, the default timeout will be used.

* Source/WebKit/Platform/IPC/ArgumentCoders.h:
* Source/WebKit/Shared/API/APIURLRequest.cpp:
(API::URLRequest::setDefaultTimeoutInterval):

When the default timeout is changed, this value gets propagated
to all the Web Processes. We make a change here to make sure the
value is propagated to all Network Processes as well (otherwise
the two are inconsistent).

* Source/WebKit/Shared/WebProcessCreationParameters.h:
* Source/WebKit/Shared/WebProcessCreationParameters.serialization.in:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::sendCreationParametersToNewProcess):
(WebKit::NetworkProcessProxy::setDefaultRequestTimeoutInterval):

We set the timeout for new Network Processes in exactly the same
way we do for WebProcesses.

* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::initializeWebProcess):
* Tools/DumpRenderTree/mac/DumpRenderTree.mm:
(runTest):

To make layout tests pass (as described above) we now explicitly
set the default value to 60 seconds for each layout test.

 Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm:
(TEST(WKNavigation, DISABLED_PreferredHTTPSPolicyAutomaticHTTPFallbackRedirectNo3SecondTimeout)):

New API test to test this behavior. This functionality depends on
a change made to a lower level system framework (libnetcore). That
change currently isn&apos;t on EWS, so this test is disabled for now.
We&apos;ll enable it once EWS is upgraded.

* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::resetStateToConsistentValues):

To make layout tests pass (as described above) we now explicitly
set the default value to 60 seconds for each layout test.

Canonical link: <a href="https://commits.webkit.org/297128@main">https://commits.webkit.org/297128@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3351f6562c0a9ca906101745312d9bd4a6d637bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110609 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30268 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20701 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116635 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60876 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112572 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30947 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38857 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84119 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113557 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24715 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99600 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64559 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24078 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17740 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60430 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/103100 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94101 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17799 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119425 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109163 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37649 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27964 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93085 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38023 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95871 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92908 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23672 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37917 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15660 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33626 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37544 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43015 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/133438 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37207 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36057 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40546 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38915 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->