### PR TITLE
Implement speculation rules - same origin conservative prefetch

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+<script src="/common/subset-tests-by-key.js"></script>
+
+<meta name="variant" content="?include=defaultPredicate">
+<meta name="variant" content="?include=hrefMatches">
+<meta name="variant" content="?include=and">
+<meta name="variant" content="?include=or">
+<meta name="variant" content="?include=not">
+<meta name="variant" content="?include=invalidPredicate">
+<meta name="variant" content="?include=linkInShadowTree">
+<meta name="variant" content="?include=linkHrefChanged">
+<meta name="variant" content="?include=newRuleSetAdded">
+<meta name="variant" content="?include=selectorMatches">
+<meta name="variant" content="?include=selectorMatchesScopingRoot">
+<meta name="variant" content="?include=selectorMatchesDisplayNone">
+<meta name="variant" content="?include=selectorMatchesDisplayLocked">
+<meta name="variant" content="?include=unslottedLink">
+<meta name="variant" content="?include=immediateMutation">
+<meta name="variant" content="?include=baseURLChangedBySameDocumentNavigation">
+<meta name="variant" content="?include=baseURLChangedByBaseElement">
+<meta name="variant" content="?include=linkToSelfFragment">
+
+<body>
+<script>
+  setup(() => assertSpeculationRulesIsSupported());
+
+  subsetTestByKey('defaultPredicate', promise_test, async t => {
+    const url = getPrefetchUrl();
+    addLink(url);
+    insertDocumentRule();
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+
+    assert_equals(await isUrlPrefetched(url), 1);
+  }, 'test document rule with no predicate');
+
+  subsetTestByKey('hrefMatches', promise_test, async t => {
+    insertDocumentRule({ href_matches: '*\\?uuid=*&foo=bar' });
+
+    const url_1 = getPrefetchUrl({foo: 'bar'});
+    addLink(url_1);
+    const url_2 = getPrefetchUrl({foo: 'buzz'});
+    addLink(url_2)
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+
+    assert_equals(await isUrlPrefetched(url_1), 1);
+    assert_equals(await isUrlPrefetched(url_2), 0);
+  }, 'test href_matches document rule');
+
+  subsetTestByKey('and', promise_test, async t => {
+    insertDocumentRule({
+      'and': [
+        { href_matches: '*\\?*foo=bar*' },
+        { href_matches: '*\\?*fizz=buzz*' }]
+    });
+
+    const url_1 = getPrefetchUrl({foo: 'bar'});
+    const url_2 = getPrefetchUrl({fizz: 'buzz'});
+    const url_3 = getPrefetchUrl({foo: 'bar', fizz: 'buzz'});
+    [url_1, url_2, url_3].forEach(url => addLink(url));
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+
+    assert_equals(await isUrlPrefetched(url_1), 0);
+    assert_equals(await isUrlPrefetched(url_2), 0);
+    assert_equals(await isUrlPrefetched(url_3), 1);
+  }, 'test document rule with conjunction predicate');
+
+  subsetTestByKey('or', promise_test, async t => {
+    insertDocumentRule({
+      'or': [
+        { href_matches: '*\\?*foo=bar*' },
+        { href_matches: '*\\?*fizz=buzz*' }]
+    });
+
+    const url_1 = getPrefetchUrl({ foo: 'buzz' });
+    const url_2 = getPrefetchUrl({ fizz: 'buzz' });
+    const url_3 = getPrefetchUrl({ foo: 'bar'});
+    [url_1, url_2, url_3].forEach(url => addLink(url));
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+
+    assert_equals(await isUrlPrefetched(url_1), 0);
+    assert_equals(await isUrlPrefetched(url_2), 1);
+    assert_equals(await isUrlPrefetched(url_3), 1);
+  }, 'test document rule with disjunction predicate');
+
+  subsetTestByKey('not', promise_test, async t => {
+    insertDocumentRule({ not: { href_matches: '*\\?uuid=*&foo=bar' } });
+
+    const url_1 = getPrefetchUrl({foo: 'bar'});
+    addLink(url_1);
+    const url_2 = getPrefetchUrl({foo: 'buzz'});
+    addLink(url_2)
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+
+    assert_equals(await isUrlPrefetched(url_1), 0);
+    assert_equals(await isUrlPrefetched(url_2), 1);
+  }, 'test document rule with negation predicate');
+
+  subsetTestByKey('invalidPredicate', promise_test, async t => {
+    const url = getPrefetchUrl();
+    addLink(url);
+    insertDocumentRule({invalid: 'predicate'});
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+
+    assert_equals(await isUrlPrefetched(url), 0);
+  }, 'invalid predicate should not throw error or start prefetch');
+
+  subsetTestByKey('linkInShadowTree', promise_test, async t => {
+    insertDocumentRule();
+
+    // Create shadow root.
+    const shadowHost = document.createElement('div');
+    document.body.appendChild(shadowHost);
+    const shadowRoot = shadowHost.attachShadow({mode: 'open'});
+
+    const url = getPrefetchUrl();
+    addLink(url, shadowRoot);
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+
+    assert_equals(await isUrlPrefetched(url), 1);
+  }, 'test that matching link in a shadow tree is prefetched');
+
+  subsetTestByKey('linkHrefChanged', promise_test, async t => {
+    insertDocumentRule({href_matches: "*\\?*foo=bar*"});
+
+    const url = getPrefetchUrl();
+    const link = addLink(url);
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+    assert_equals(await isUrlPrefetched(url), 0);
+
+    const matching_url = getPrefetchUrl({foo: 'bar'});
+    link.href = matching_url;
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+    assert_equals(await isUrlPrefetched(matching_url), 1);
+  }, 'test that changing the href of an invalid link to a matching value triggers a prefetch');
+
+  subsetTestByKey('newRuleSetAdded', promise_test, async t => {
+    insertDocumentRule({href_matches: "*\\?*foo=bar*"});
+    const url = getPrefetchUrl({fizz: "buzz"});
+    addLink(url);
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+    assert_equals(await isUrlPrefetched(url), 0);
+
+    insertDocumentRule({href_matches: "*\\?*fizz=buzz*"});
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+    assert_equals(await isUrlPrefetched(url), 1);
+  }, 'test that adding a second rule set triggers prefetch');
+
+  subsetTestByKey('selectorMatches', promise_test, async t => {
+    insertDocumentRule({ selector_matches: 'a.important-link' });
+
+    const url_1 = getPrefetchUrl({foo: 'bar'});
+    const importantLink = addLink(url_1);
+    importantLink.className = 'important-link';
+    const url_2 = getPrefetchUrl({foo: 'buzz'});
+    addLink(url_2)
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+
+    assert_equals(await isUrlPrefetched(url_1), 1);
+    assert_equals(await isUrlPrefetched(url_2), 0);
+  }, 'test selector_matches document rule');
+
+  subsetTestByKey('selectorMatchesScopingRoot', promise_test, async t => {
+    insertDocumentRule({ selector_matches: ':root > body > a' });
+
+    const url_1 = getPrefetchUrl({ foo: 'bar' });
+    addLink(url_1);
+
+    const url_2 = getPrefetchUrl({ foo: 'buzz' });
+    const extraContainer = document.createElement('div');
+    document.body.appendChild(extraContainer);
+    addLink(url_2, extraContainer);
+
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+
+    assert_equals(await isUrlPrefetched(url_1), 1);
+    assert_equals(await isUrlPrefetched(url_2), 0);
+  }, 'test selector_matches with :root');
+
+  subsetTestByKey('selectorMatchesDisplayNone', promise_test, async t => {
+    const style = document.createElement('style');
+    style.innerText = ".important-section { display: none; }";
+    document.head.appendChild(style);
+    insertDocumentRule();
+
+    const importantSection = document.createElement('div');
+    importantSection.className = 'important-section';
+    document.body.appendChild(importantSection);
+    const url = getPrefetchUrl();
+    addLink(url, importantSection);
+
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+    assert_equals(await isUrlPrefetched(url), 0);
+
+    style.remove();
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+    assert_equals(await isUrlPrefetched(url), 1);
+  }, 'test selector_matches with link inside display:none container');
+
+  subsetTestByKey('selectorMatchesDisplayLocked', promise_test, async t => {
+    const style = document.createElement('style');
+    style.innerText = ".important-section { content-visibility: hidden; }";
+    document.head.appendChild(style);
+    insertDocumentRule({ selector_matches: '.important-section a' });
+
+    const importantSection = document.createElement('div');
+    importantSection.className = 'important-section';
+    document.body.appendChild(importantSection);
+    const url = getPrefetchUrl();
+    addLink(url, importantSection);
+
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+    assert_equals(await isUrlPrefetched(url), 0);
+
+    style.remove();
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+    assert_equals(await isUrlPrefetched(url), 1);
+  }, 'test selector_matches with link inside display locked container');
+
+  subsetTestByKey('unslottedLink', promise_test, async t => {
+    insertDocumentRule();
+
+    // Create shadow root.
+    const shadowHost = document.createElement('div');
+    document.body.appendChild(shadowHost);
+    const shadowRoot = shadowHost.attachShadow({ mode: 'open' });
+
+    // Add unslotted link.
+    const url = getPrefetchUrl();
+    addLink(url, shadowHost);
+
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+    assert_equals(await isUrlPrefetched(url), 0);
+  }, 'test that unslotted link never matches document rule');
+
+  subsetTestByKey('immediateMutation', promise_test, async t => {
+    // Add a link and allow it to get its style computed.
+    // (Double RAF lets this happen normally.)
+    const url = getPrefetchUrl();
+    const link = addLink(url, document.body);
+    await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
+
+    // Add a document rule and then immediately change the DOM to make it match.
+    insertDocumentRule({ selector_matches: '.late-class *' });
+    document.body.className = 'late-class';
+
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+    assert_equals(await isUrlPrefetched(url), 1);
+  }, 'test that selector_matches predicates respect changes immediately');
+
+  const baseURLChangedTestFixture = (testName, modifyBaseURLFunc) => {
+    return subsetTestByKey(testName, promise_test, async t => {
+      const url = getPrefetchUrl();
+      const link = addLink(url);
+      const url_pattern_string = `prefetch.py${url.search}`;
+
+      // Insert a document rule with a url pattern predicate that uses a
+      // relative URL which will not match with |url|, due to |document.baseURI|
+      // being different from |url|'s path.
+      assert_false((new URLPattern(url_pattern_string, document.baseURI)).test(url));
+      insertDocumentRule({ href_matches: url_pattern_string });
+      await new Promise(resolve => t.step_timeout(resolve, 2000));
+      assert_equals(await isUrlPrefetched(url), 0);
+
+      // Change the baseURL of the document to |url|. |url| should now be
+      // prefetched.
+      modifyBaseURLFunc(url);
+      assert_true((new URLPattern(url_pattern_string, document.baseURI)).test(url));
+      await new Promise(resolve => t.step_timeout(resolve, 2000));
+      assert_equals(await isUrlPrefetched(url), 1);
+    });
+  }
+
+  baseURLChangedTestFixture('baseURLChangedBySameDocumentNavigation', url => {
+    history.pushState({}, "", url);
+  });
+
+  baseURLChangedTestFixture('baseURLChangedByBaseElement', url => {
+    const base = document.createElement('base');
+    base.href = url;
+    document.head.appendChild(base);
+  });
+
+  subsetTestByKey('linkToSelfFragment', promise_test, async t => {
+    const url = getPrefetchUrl();
+    history.pushState({}, "", url);
+    addLink(new URL('#fragment', url));
+    insertDocumentRule();
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+    assert_equals(await isUrlPrefetched(url), 0);
+  }, 'test that a fragment link to the current document does not prefetch');
+
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=and-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=and-expected.txt
@@ -1,0 +1,3 @@
+
+PASS test document rule with conjunction predicate
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=baseURLChangedByBaseElement-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=baseURLChangedByBaseElement-expected.txt
@@ -1,0 +1,3 @@
+
+PASS document-rules
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=baseURLChangedBySameDocumentNavigation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=baseURLChangedBySameDocumentNavigation-expected.txt
@@ -1,0 +1,3 @@
+
+PASS document-rules
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=defaultPredicate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=defaultPredicate-expected.txt
@@ -1,0 +1,3 @@
+
+PASS test document rule with no predicate
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=hrefMatches-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=hrefMatches-expected.txt
@@ -1,0 +1,3 @@
+
+PASS test href_matches document rule
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=immediateMutation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=immediateMutation-expected.txt
@@ -1,0 +1,3 @@
+
+PASS test that selector_matches predicates respect changes immediately
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=invalidPredicate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=invalidPredicate-expected.txt
@@ -1,0 +1,3 @@
+
+PASS invalid predicate should not throw error or start prefetch
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=linkHrefChanged-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=linkHrefChanged-expected.txt
@@ -1,0 +1,3 @@
+
+PASS test that changing the href of an invalid link to a matching value triggers a prefetch
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=linkInShadowTree-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=linkInShadowTree-expected.txt
@@ -1,0 +1,3 @@
+
+PASS test that matching link in a shadow tree is prefetched
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=linkToSelfFragment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=linkToSelfFragment-expected.txt
@@ -1,0 +1,3 @@
+
+PASS test that a fragment link to the current document does not prefetch
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=newRuleSetAdded-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=newRuleSetAdded-expected.txt
@@ -1,0 +1,3 @@
+
+PASS test that adding a second rule set triggers prefetch
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=not-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=not-expected.txt
@@ -1,0 +1,3 @@
+
+PASS test document rule with negation predicate
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=or-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=or-expected.txt
@@ -1,0 +1,3 @@
+
+PASS test document rule with disjunction predicate
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatches-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatches-expected.txt
@@ -1,0 +1,3 @@
+
+PASS test selector_matches document rule
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatchesDisplayLocked-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatchesDisplayLocked-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL test selector_matches with link inside display locked container assert_equals: expected 0 but got 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatchesDisplayNone-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatchesDisplayNone-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL test selector_matches with link inside display:none container assert_equals: expected 0 but got 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatchesScopingRoot-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatchesScopingRoot-expected.txt
@@ -1,0 +1,3 @@
+
+PASS test selector_matches with :root
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=unslottedLink-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=unslottedLink-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL test that unslotted link never matches document rule assert_equals: expected 0 but got 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/utils.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+
+<meta name="variant" content="?from_protocol=http&to_protocol=http">
+<meta name="variant" content="?from_protocol=http&to_protocol=https">
+<meta name="variant" content="?from_protocol=https&to_protocol=http">
+<meta name="variant" content="?from_protocol=https&to_protocol=https">
+
+<script>
+  setup(() => assertSpeculationRulesIsSupported());
+
+  // This is split across four test variants due to the test timeouts.
+  let { from_protocol, to_protocol } = Object.fromEntries(new URLSearchParams(location.search));
+  promise_test(async t => {
+    let agent = await spawnWindow(t, { protocol: from_protocol });
+    let nextUrl = agent.getExecutorURL({ protocol: to_protocol, page: 2 });
+    await agent.forceSinglePrefetch(nextUrl);
+    let result = agent.navigate(nextUrl);
+    await result;
+
+    if (to_protocol == "https") {
+      assert_prefetched(await agent.getRequestHeaders(), "Prefetch should work for HTTPS urls.");
+    } else {
+      assert_not_prefetched(await agent.getRequestHeaders(), "Prefetch should not work for HTTP urls.");
+    }
+  }, `test single ${to_protocol} url prefetch from a ${from_protocol} url`);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=http&to_protocol=http-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=http&to_protocol=http-expected.txt
@@ -1,0 +1,4 @@
+CONSOLE MESSAGE: Prefetch request denied: URL must be secure (HTTPS)
+
+PASS test single http url prefetch from a http url
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=http&to_protocol=https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=http&to_protocol=https-expected.txt
@@ -1,0 +1,4 @@
+CONSOLE MESSAGE: Prefetch request denied: not same origin as document
+
+FAIL test single https url prefetch from a http url assert_in_array: Prefetch should work for HTTPS urls. value undefined not in array ["prefetch", "prefetch;anonymous-client-ip"]
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=https&to_protocol=http-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=https&to_protocol=http-expected.txt
@@ -1,0 +1,4 @@
+CONSOLE MESSAGE: Prefetch request denied: not same origin as document
+
+PASS test single http url prefetch from a https url
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=https&to_protocol=https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=https&to_protocol=https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS test single https url prefetch from a https url
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/executor.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/executor.sub.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<script src="/common/dispatcher/dispatcher.js" nonce="abc"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="utils.sub.js" nonce="abc"></script>
+<script nonce="abc">
+// For a given string `str` that is escaped by WPT's `.sub.html` or
+// `pipe=sub(html)` functionality, return the original unescaped string.
+//
+// Concretely, for `str` as the result of `html.escape(x, quote=True)`,
+// return the original unescaped string `x`.
+// See `/tools/wptserve/wptserve/pipes.py` and
+// https://docs.python.org/3/library/html.html#html.escape.
+//
+// See https://crbug.com/404573971 for fixing the escaping issue.
+function reverse_html_escape(str) {
+  str = str.replaceAll('&lt;', '<');
+  str = str.replaceAll('&gt;', '>');
+  str = str.replaceAll('&quot;', '"');
+  str = str.replaceAll('&#x27;', "'");
+  str = str.replaceAll('&amp;', '&');
+  return str;
+}
+
+// To be consistent with https://fetch.spec.whatwg.org/#headers-class
+// (accessed via iterable),
+// - The keys are lower-cased header names, and
+// - The entries are removed when the corresponding headers are non-existent.
+window.requestHeaders = {
+  "purpose": "{{header_or_default(Purpose, NONEXISTENT)}}",
+  "sec-purpose": "{{header_or_default(Sec-Purpose, NONEXISTENT)}}",
+  "referer": "{{header_or_default(Referer, NONEXISTENT)}}",
+  "sec-fetch-dest": "{{header_or_default(Sec-Fetch-Dest, NONEXISTENT)}}",
+  "sec-fetch-mode": "{{header_or_default(Sec-Fetch-Mode, NONEXISTENT)}}",
+  "service-worker-navigation-preload":
+      "{{header_or_default(Service-Worker-Navigation-Preload, NONEXISTENT)}}",
+  // Convert to the raw string to avoid backslashes from being processed as
+  // escape sequences.
+  // TODO(crbug.com/404573971): Remove `header_or_default` to reflect
+  // `__no_tags__` properly.
+  sec_speculation_tags:
+      String.raw`{{header_or_default(Sec-Speculation-Tags, __no_tags__)}}`,
+};
+Object.keys(requestHeaders).forEach(key => {
+  if (requestHeaders[key] === "NONEXISTENT") {
+    delete requestHeaders[key];
+  } else {
+    requestHeaders[key] = reverse_html_escape(requestHeaders[key]);
+  }
+});
+
+// Add a link to the page in order to use during the test
+function add_link(id, url) {
+  const link_element = document.createElement("a");
+  const link_text = document.createTextNode(url);
+  link_element.setAttribute("href", url);
+  link_element.setAttribute("id", id);
+  link_element.appendChild(link_text);
+  document.body.appendChild(link_element);
+}
+
+// "id" is the id of the link that we need to hover on in order
+// to start the prefetch
+async function start_non_immediate_prefetch_on_hover(id) {
+  let target = document.getElementById(id);
+
+  test_driver.set_test_context(window.opener);
+  // Inject the inputs to run this test.
+  await new test_driver.Actions().addPointer("mouse").pointerMove(0, 0, {origin: target}).send();
+}
+
+// "id" is the id of the link that we need to press on in order
+// to start the prefetch
+async function start_non_immediate_prefetch_on_pointerdown(id) {
+  let target = document.getElementById(id);
+
+  test_driver.set_test_context(window.opener);
+  // Inject the inputs to run this test.
+  // Move mouse pointer outside of the anchor so that we don't start the
+  // navigation before making sure the prefetch request started server-side.
+  await new test_driver.Actions().addPointer("mouse").pointerMove(0, 0, {origin: target}).pointerDown().pointerMove(0, 0).pointerUp().send();
+}
+
+async function navigate_by_form_generated_post(url) {
+  let form = document.createElement('form');
+  form.method = 'POST';
+  form.action = url;
+  document.body.appendChild(form);
+  form.submit();
+}
+
+// The fetch request's URL sent to the server.
+window.requestUrl = reverse_html_escape(
+    "{{location[server]}}{{location[path]}}{{location[query]}}");
+
+const uuid = new URLSearchParams(location.search).get('uuid');
+window.executor = new Executor(uuid);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/executor.sub.html.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/executor.sub.html.headers
@@ -1,0 +1,1 @@
+Cache-Control: no-store

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/prefetch.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/prefetch.py
@@ -1,0 +1,17 @@
+from wptserve.handlers import json_handler
+
+@json_handler
+def main(request, response):
+  uuid = request.GET[b"uuid"]
+  prefetch = request.headers.get(
+      "Sec-Purpose", b"").decode("utf-8").startswith("prefetch")
+  response.headers.set("Cache-Control", "no-store")
+
+  n = request.server.stash.take(uuid)
+  if n is None:
+    n = 0
+  if prefetch:
+    n += 1
+    request.server.stash.put(uuid, n)
+
+  return n

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/utils.sub.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/utils.sub.js
@@ -1,0 +1,283 @@
+/**
+ * Utilities for initiating prefetch via speculation rules.
+ */
+
+// Resolved URL to find this script.
+const SR_PREFETCH_UTILS_URL = new URL(document.currentScript.src, document.baseURI);
+
+// If (and only if) you are writing a test that depends on
+// `requires: ["anonymous-client-ip-when-cross-origin"]`, then you must use this
+// host as the cross-origin host. (If you need a generic cross-origin host, use
+// `get_host_info().NOTSAMESITE_HOST` or similar instead.)
+//
+// TODO(domenic): document in the web platform tests server infrastructure that
+// such a host must exist, and possibly separate it from `{{hosts[alt][]}}`.
+const CROSS_ORIGIN_HOST_THAT_WORKS_WITH_ACIWCO = "{{hosts[alt][]}}";
+
+class PrefetchAgent extends RemoteContext {
+  constructor(uuid, t) {
+    super(uuid);
+    this.t = t;
+  }
+
+  getExecutorURL(options = {}) {
+    let {hostname, username, password, protocol, executor, ...extra} = options;
+    let params = new URLSearchParams({uuid: this.context_id, ...extra});
+    if(executor === undefined) {
+      executor = "executor.sub.html";
+    }
+    let url = new URL(`${executor}?${params}`, SR_PREFETCH_UTILS_URL);
+    if(hostname !== undefined) {
+      url.hostname = hostname;
+    }
+    if(username !== undefined) {
+      url.username = username;
+    }
+    if(password !== undefined) {
+      url.password = password;
+    }
+    if(protocol !== undefined) {
+      url.protocol = protocol;
+      url.port = protocol === "https" ? "{{ports[https][0]}}" : "{{ports[http][0]}}";
+    }
+    return url;
+  }
+
+  // Requests prefetch via speculation rules.
+  //
+  // In the future, this should also use browser hooks to force the prefetch to
+  // occur despite heuristic matching, etc., and await the completion of the
+  // prefetch.
+  async forceSinglePrefetch(url, extra = {}, wait_for_completion = true) {
+    return this.forceSpeculationRules(
+      {
+        prefetch: [{source: 'list', urls: [url], ...extra}]
+      }, wait_for_completion);
+  }
+
+  async forceSpeculationRules(rules, wait_for_completion = true) {
+    await this.execute_script((rules) => {
+      insertSpeculationRules(rules);
+    }, [rules]);
+    if (!wait_for_completion) {
+      return Promise.resolve();
+    }
+    return new Promise(resolve => this.t.step_timeout(resolve, 2000));
+  }
+
+  // `url` is the URL to navigate.
+  //
+  // `expectedDestinationUrl` is the expected URL after navigation.
+  // When omitted, `url` is used. When explicitly null, the destination URL is
+  // not validated.
+  async navigate(url, {expectedDestinationUrl} = {}) {
+    await this.execute_script((url) => {
+      window.executor.suspend(() => {
+        location.href = url;
+      });
+    }, [url]);
+    if (expectedDestinationUrl === undefined) {
+      expectedDestinationUrl = url;
+    }
+    if (expectedDestinationUrl) {
+      expectedDestinationUrl.username = '';
+      expectedDestinationUrl.password = '';
+      assert_equals(
+          await this.execute_script(() => location.href),
+          expectedDestinationUrl.toString(),
+          "expected navigation to reach destination URL");
+    }
+    await this.execute_script(() => {});
+  }
+
+  async getRequestHeaders() {
+    return this.execute_script(() => requestHeaders);
+  }
+
+  async getResponseCookies() {
+    return this.execute_script(() => {
+      let cookie = {};
+      document.cookie.split(/\s*;\s*/).forEach((kv)=>{
+        let [key, value] = kv.split(/\s*=\s*/);
+        cookie[key] = value;
+      });
+      return cookie;
+    });
+  }
+
+  async getRequestCookies() {
+    return this.execute_script(() => window.requestCookies);
+  }
+
+  async getRequestCredentials() {
+    return this.execute_script(() => window.requestCredentials);
+  }
+
+  async setReferrerPolicy(referrerPolicy) {
+    return this.execute_script(referrerPolicy => {
+      const meta = document.createElement("meta");
+      meta.name = "referrer";
+      meta.content = referrerPolicy;
+      document.head.append(meta);
+    }, [referrerPolicy]);
+  }
+
+  async getDeliveryType(){
+    return this.execute_script(() => {
+      return performance.getEntriesByType("navigation")[0].deliveryType;
+    });
+  }
+}
+
+// Produces a URL with a UUID which will record when it's prefetched.
+// |extra_params| can be specified to add extra search params to the generated
+// URL.
+function getPrefetchUrl(extra_params={}) {
+  let params = new URLSearchParams({ uuid: token(), ...extra_params });
+  return new URL(`prefetch.py?${params}`, SR_PREFETCH_UTILS_URL);
+}
+
+// Produces n URLs with unique UUIDs which will record when they are prefetched.
+function getPrefetchUrlList(n) {
+  return Array.from({ length: n }, () => getPrefetchUrl());
+}
+
+async function isUrlPrefetched(url) {
+  let response = await fetch(url, {redirect: 'follow'});
+  assert_true(response.ok);
+  return response.json();
+}
+
+// Must also include /common/utils.js and /common/dispatcher/dispatcher.js to use this.
+async function spawnWindowWithReference(t, options = {}, uuid = token()) {
+  let agent = new PrefetchAgent(uuid, t);
+  let w = window.open(agent.getExecutorURL(options), '_blank', options);
+  t.add_cleanup(() => w.close());
+  return {"agent":agent, "window":w};
+}
+
+// Must also include /common/utils.js and /common/dispatcher/dispatcher.js to use this.
+async function spawnWindow(t, options = {}, uuid = token()) {
+  let agent_window_pair = await spawnWindowWithReference(t, options, uuid);
+  return agent_window_pair.agent;
+}
+
+function insertSpeculationRules(body) {
+  let script = document.createElement('script');
+  script.type = 'speculationrules';
+  script.textContent = JSON.stringify(body);
+  document.head.appendChild(script);
+}
+
+// Creates and appends <a href=|href|> to |insertion point|. If
+// |insertion_point| is not specified, document.body is used.
+function addLink(href, insertion_point=document.body) {
+  const a = document.createElement('a');
+  a.href = href;
+  insertion_point.appendChild(a);
+  return a;
+}
+
+// Inserts a prefetch document rule with |predicate|. |predicate| can be
+// undefined, in which case the default predicate will be used (i.e. all links
+// in document will match).
+function insertDocumentRule(predicate, extra_options={}) {
+  insertSpeculationRules({
+    prefetch: [{
+      source: 'document',
+      eagerness: 'immediate',
+      where: predicate,
+      ...extra_options
+    }]
+  });
+}
+
+function assert_prefetched (requestHeaders, description) {
+  assert_in_array(requestHeaders.purpose, [undefined, "prefetch"], "The vendor-specific header Purpose, if present, must be 'prefetch'.");
+  assert_in_array(requestHeaders['sec-purpose'],
+                  ["prefetch", "prefetch;anonymous-client-ip"], description);
+}
+
+function assert_prefetched_anonymous_client_ip(requestHeaders, description) {
+  assert_in_array(requestHeaders.purpose, [undefined, "prefetch"], "The vendor-specific header Purpose, if present, must be 'prefetch'.");
+  assert_equals(requestHeaders['sec-purpose'],
+                "prefetch;anonymous-client-ip",
+                description);
+}
+
+function assert_not_prefetched (requestHeaders, description){
+  assert_equals(requestHeaders.purpose, undefined, description);
+  assert_equals(requestHeaders['sec-purpose'], undefined, description);
+}
+
+// If the prefetch request is intercepted and modified by ServiceWorker,
+// - "Sec-Purpose: prefetch" header is dropped in Step 33 of
+//   https://fetch.spec.whatwg.org/#dom-request
+//   because it's a https://fetch.spec.whatwg.org/#forbidden-request-header.
+// - "Purpose: prefetch" can still be sent.
+// Note that this check passes also for non-prefetch requests, so additional
+// checks are needed to distinguish from non-prefetch requests.
+function assert_prefetched_without_sec_purpose(requestHeaders, description) {
+  assert_in_array(requestHeaders.purpose, [undefined, "prefetch"],
+      "The vendor-specific header Purpose, if present, must be 'prefetch'.");
+  assert_equals(requestHeaders['sec-purpose'], undefined, description);
+}
+
+// For ServiceWorker tests.
+// `interceptedRequest` is an element of `interceptedRequests` in
+// `resources/basic-service-worker.js`.
+
+// The ServiceWorker fetch handler intercepted a prefetching request.
+function assert_intercept_prefetch(interceptedRequest, expectedUrl) {
+  assert_equals(interceptedRequest.request.url, expectedUrl.toString(),
+      "intercepted request URL.");
+
+  assert_prefetched(interceptedRequest.request.headers,
+      "Prefetch request should be intercepted.");
+
+  if (new URL(location.href).searchParams.has('clientId')) {
+    // https://github.com/WICG/nav-speculation/issues/346
+    // https://crbug.com/404294123
+    assert_equals(interceptedRequest.resultingClientId, "",
+        "resultingClientId shouldn't be exposed.");
+
+    // https://crbug.com/404286918
+    // `assert_not_equals()` isn't used for now to create stable failure diffs.
+    assert_false(interceptedRequest.clientId === "",
+        "clientId should be initiator.");
+  }
+}
+
+// The ServiceWorker fetch handler intercepted a non-prefetching request.
+function assert_intercept_non_prefetch(interceptedRequest, expectedUrl) {
+  assert_equals(interceptedRequest.request.url, expectedUrl.toString(),
+      "intercepted request URL.");
+
+  assert_not_prefetched(interceptedRequest.request.headers,
+      "Non-prefetch request should be intercepted.");
+
+  if (new URL(location.href).searchParams.has('clientId')) {
+    // Because this is an ordinal non-prefetch request, `resultingClientId`
+    // can be set as normal.
+    assert_not_equals(interceptedRequest.resultingClientId, "",
+        "resultingClientId can be exposed.");
+
+    assert_not_equals(interceptedRequest.clientId, "",
+        "clientId should be initiator.");
+  }
+}
+
+function assert_served_by_navigation_preload(requestHeaders) {
+  assert_equals(
+    requestHeaders['service-worker-navigation-preload'],
+    'true',
+    'Service-Worker-Navigation-Preload');
+}
+
+// Use nvs_header query parameter to ask the wpt server
+// to populate No-Vary-Search response header.
+function addNoVarySearchHeaderUsingQueryParam(url, value){
+  if(value){
+    url.searchParams.append("nvs_header", value);
+  }
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/resources/utils.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/resources/utils.js
@@ -1,0 +1,54 @@
+globalThis.assertSpeculationRulesIsSupported = () => {
+  assert_implements(
+      'supports' in HTMLScriptElement,
+      'HTMLScriptElement.supports must be supported');
+  assert_implements(
+      HTMLScriptElement.supports('speculationrules'),
+      '<script type="speculationrules"> must be supported');
+};
+
+// If you want access to these, be sure to include
+// /html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js.
+// So as to avoid requiring everyone to do that, we only conditionally define this infrastructure.
+if (globalThis.RemoteContextHelper) {
+  class PreloadingRemoteContextWrapper extends RemoteContextHelper.RemoteContextWrapper {
+    /**
+    * Starts preloading a page with this `PreloadingRemoteContextWrapper` as the
+    * referrer, using `<script type="speculationrules">`.
+    *
+    * @param {"prefetch"|"prerender"} preloadType - The preload type to use.
+    * @param {object} [extrasInSpeculationRule] - Additional properties to add
+    *     to the speculation rule JSON.
+    * @param {RemoteContextConfig|object} [extraConfig] - Additional remote
+    *     context configuration for the preloaded context.
+    * @returns {Promise<PreloadingRemoteContextWrapper>}
+    */
+    addPreload(preloadType, { extrasInSpeculationRule = {}, ...extraConfig } = {}) {
+      const referrerRemoteContext = this;
+
+      return this.helper.createContext({
+        executorCreator(url) {
+          return referrerRemoteContext.executeScript((url, preloadType, extrasInSpeculationRule) => {
+            const script = document.createElement("script");
+            script.type = "speculationrules";
+            script.textContent = JSON.stringify({
+              [preloadType]: [
+                {
+                  source: "list",
+                  urls: [url],
+                  ...extrasInSpeculationRule
+                }
+              ]
+            });
+            document.head.append(script);
+          }, [url, preloadType, extrasInSpeculationRule]);
+        },
+        extraConfig
+      });
+    }
+  }
+
+  globalThis.PreloadingRemoteContextHelper = class extends RemoteContextHelper {
+    static RemoteContextWrapper = PreloadingRemoteContextWrapper;
+  };
+}

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1218,6 +1218,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/SmallStrings.h
     runtime/SourceOrigin.h
     runtime/SparseArrayValueMap.h
+    runtime/SpeculationRules.h
     runtime/StableSort.h
     runtime/StackAlignment.h
     runtime/StackFrame.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1743,6 +1743,7 @@
 		ADE802991E08F1DE0058DE78 /* JSWebAssemblyLinkError.h in Headers */ = {isa = PBXBuildFile; fileRef = ADE802941E08F1C90058DE78 /* JSWebAssemblyLinkError.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		ADE8029A1E08F1DE0058DE78 /* WebAssemblyLinkErrorConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = ADE802951E08F1C90058DE78 /* WebAssemblyLinkErrorConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		ADE8029C1E08F1DE0058DE78 /* WebAssemblyLinkErrorPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = ADE802971E08F1C90058DE78 /* WebAssemblyLinkErrorPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BAED5D642E0CFFB8004787C9 /* SpeculationRules.h in Headers */ = {isa = PBXBuildFile; fileRef = BAED5D612E0CFA67004787C9 /* SpeculationRules.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC02E90D0E1839DB000F9297 /* ErrorConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = BC02E9050E1839DB000F9297 /* ErrorConstructor.h */; };
 		BC02E90F0E1839DB000F9297 /* ErrorPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = BC02E9070E1839DB000F9297 /* ErrorPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC02E9110E1839DB000F9297 /* NativeErrorConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = BC02E9090E1839DB000F9297 /* NativeErrorConstructor.h */; };
@@ -5386,6 +5387,8 @@
 		ADE802961E08F1C90058DE78 /* WebAssemblyLinkErrorPrototype.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblyLinkErrorPrototype.cpp; path = js/WebAssemblyLinkErrorPrototype.cpp; sourceTree = "<group>"; };
 		ADE802971E08F1C90058DE78 /* WebAssemblyLinkErrorPrototype.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WebAssemblyLinkErrorPrototype.h; path = js/WebAssemblyLinkErrorPrototype.h; sourceTree = "<group>"; };
 		ADE8029D1E08F2260058DE78 /* WebAssemblyLinkErrorConstructor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblyLinkErrorConstructor.cpp; path = js/WebAssemblyLinkErrorConstructor.cpp; sourceTree = "<group>"; };
+		BAED5D612E0CFA67004787C9 /* SpeculationRules.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SpeculationRules.h; sourceTree = "<group>"; };
+		BAED5D622E0CFA67004787C9 /* SpeculationRules.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SpeculationRules.cpp; sourceTree = "<group>"; };
 		BC021BF2136900C300FC5467 /* ToolExecutable.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = ToolExecutable.xcconfig; sourceTree = "<group>"; };
 		BC02E9040E1839DB000F9297 /* ErrorConstructor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ErrorConstructor.cpp; sourceTree = "<group>"; };
 		BC02E9050E1839DB000F9297 /* ErrorConstructor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ErrorConstructor.h; sourceTree = "<group>"; };
@@ -8848,6 +8851,8 @@
 				425BA1337E4344E1B269A671 /* SourceOrigin.h */,
 				0F0CD4C315F6B6B50032F1C0 /* SparseArrayValueMap.cpp */,
 				0FB7F39215ED8E3800F167B2 /* SparseArrayValueMap.h */,
+				BAED5D622E0CFA67004787C9 /* SpeculationRules.cpp */,
+				BAED5D612E0CFA67004787C9 /* SpeculationRules.h */,
 				E32EF01D2BD72AEF001675BA /* StableSort.h */,
 				0F3AC751183EA1040032029F /* StackAlignment.h */,
 				0F6DB7E71D6124B200CDBF8E /* StackFrame.cpp */,
@@ -11812,6 +11817,7 @@
 				0FB7F39E15ED8E4600F167B2 /* SparseArrayValueMap.h in Headers */,
 				A7386554118697B400540279 /* SpecializedThunkJIT.h in Headers */,
 				0FD82E54141DAEEE00179C94 /* SpeculatedType.h in Headers */,
+				BAED5D642E0CFFB8004787C9 /* SpeculationRules.h in Headers */,
 				A785F6BC18C553FE00F10626 /* SpillRegistersMode.h in Headers */,
 				E32EF01E2BD72AEF001675BA /* StableSort.h in Headers */,
 				0F3AC752183EA1040032029F /* StackAlignment.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -1040,6 +1040,7 @@ runtime/SideDataRepository.cpp
 runtime/SimpleTypedArrayController.cpp
 runtime/SmallStrings.cpp
 runtime/SparseArrayValueMap.cpp
+runtime/SpeculationRules.cpp
 runtime/StackFrame.cpp
 runtime/StrictEvalActivation.cpp
 runtime/StringConstructor.cpp

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -740,6 +740,7 @@ JSGlobalObject::JSGlobalObject(VM& vm, Structure* structure, const GlobalObjectM
     , m_customGetterFunctionSet(vm)
     , m_customSetterFunctionSet(vm)
     , m_importMap(ImportMap::create())
+    , m_speculationRules(SpeculationRules::create())
     , m_globalObjectMethodTable(globalObjectMethodTable ? globalObjectMethodTable : baseGlobalObjectMethodTable())
 {
 }

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -29,6 +29,7 @@
 #include "RegExpGlobalData.h"
 #include "RuntimeFlags.h"
 #include "SourceTaintedOrigin.h"
+#include "SpeculationRules.h"
 #include "StructureCache.h"
 #include "Watchpoint.h"
 #include "WeakGCSet.h"
@@ -623,6 +624,8 @@ public:
 
     const Ref<ImportMap> m_importMap;
 
+    const Ref<SpeculationRules> m_speculationRules;
+
     HashMap<String, JSCJSGlobalObjectSignpostIdentifier> m_signposts;
 
 #if ASSERT_ENABLED
@@ -1183,6 +1186,8 @@ public:
 
     const ImportMap& importMap() const { return m_importMap.get(); }
     ImportMap& importMap() { return m_importMap.get(); }
+    const SpeculationRules& speculationRules() const { return m_speculationRules.get(); }
+    SpeculationRules& speculationRules() { return m_speculationRules.get(); }
 
 protected:
     enum class HasSpeciesProperty : bool { No, Yes };

--- a/Source/JavaScriptCore/runtime/SpeculationRules.cpp
+++ b/Source/JavaScriptCore/runtime/SpeculationRules.cpp
@@ -1,0 +1,299 @@
+/*
+ * Copyright (C) 2025 Shopify Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SpeculationRules.h"
+
+#include "JSCInlines.h"
+#include "JSGlobalObject.h"
+#include "JSONObject.h"
+#include "SourceCode.h"
+#include <wtf/JSONValues.h>
+#include <wtf/URL.h>
+#include <wtf/URLHash.h>
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
+
+namespace JSC {
+
+static std::optional<Vector<String>> parseStringOrStringList(JSON::Object& object, const String& key)
+{
+    Vector<String> result;
+    String stringValue;
+    if (object.getString(key, stringValue)) {
+        result.append(stringValue);
+        return result;
+    }
+
+    RefPtr<JSON::Array> arrayValue;
+    if (object.getArray(key, arrayValue)) {
+        for (const auto& value : *arrayValue) {
+            String element;
+            if (!value->asString(element))
+                return std::nullopt;
+            result.append(element);
+        }
+        return result;
+    }
+
+    return Vector<String> { };
+}
+
+static std::optional<SpeculationRules::DocumentPredicate> parseDocumentPredicate(JSON::Object&);
+
+// https://wicg.github.io/nav-speculation/speculation-rules.html#parsing-a-document-rule-predicate-from-a-map
+static std::optional<SpeculationRules::DocumentPredicate> parseDocumentPredicate(JSON::Object& object)
+{
+    RefPtr<JSON::Array> array;
+    if (object.getArray("and"_s, array)) {
+        SpeculationRules::Conjunction conjunction;
+        for (auto& item : *array) {
+            RefPtr<JSON::Object> clauseObject = item->asObject();
+            if (!clauseObject)
+                return std::nullopt;
+            auto predicate = parseDocumentPredicate(*clauseObject);
+            if (!predicate)
+                return std::nullopt;
+            conjunction.clauses.append(WTFMove(*predicate));
+        }
+        return SpeculationRules::DocumentPredicate { Box<SpeculationRules::Conjunction>::create(WTFMove(conjunction)) };
+    }
+
+    if (object.getArray("or"_s, array)) {
+        SpeculationRules::Disjunction disjunction;
+        for (auto& item : *array) {
+            RefPtr<JSON::Object> clauseObject = item->asObject();
+            if (!clauseObject)
+                return std::nullopt;
+            auto predicate = parseDocumentPredicate(*clauseObject);
+            if (!predicate)
+                return std::nullopt;
+            disjunction.clauses.append(WTFMove(*predicate));
+        }
+        return SpeculationRules::DocumentPredicate { Box<SpeculationRules::Disjunction>::create(WTFMove(disjunction)) };
+    }
+
+    RefPtr<JSON::Object> clauseObject = object.getObject("not"_s);
+    if (clauseObject) {
+        auto predicate = parseDocumentPredicate(*clauseObject);
+        if (!predicate)
+            return std::nullopt;
+        SpeculationRules::Negation negation { Box<SpeculationRules::DocumentPredicate>::create(WTFMove(*predicate)) };
+        return SpeculationRules::DocumentPredicate { Box<SpeculationRules::Negation>::create(WTFMove(negation)) };
+    }
+
+    SpeculationRules::URLPatternPredicate urlPredicate;
+    auto urlMatches = parseStringOrStringList(object, "url_matches"_s);
+    if (urlMatches)
+        urlPredicate.patterns.appendVector(*urlMatches);
+    auto hrefMatches = parseStringOrStringList(object, "href_matches"_s);
+    if (hrefMatches)
+        urlPredicate.patterns.appendVector(*hrefMatches);
+
+    SpeculationRules::CSSSelectorPredicate selectorPredicate;
+    auto selectorMatches = parseStringOrStringList(object, "selector_matches"_s);
+    if (selectorMatches)
+        selectorPredicate.selectors.appendVector(*selectorMatches);
+
+    bool hasURLPredicate = !urlPredicate.patterns.isEmpty();
+    bool hasSelectorPredicate = !selectorPredicate.selectors.isEmpty();
+
+    if (hasURLPredicate && hasSelectorPredicate) {
+        SpeculationRules::Conjunction conjunction;
+        conjunction.clauses.append(SpeculationRules::DocumentPredicate { WTFMove(urlPredicate) });
+        conjunction.clauses.append(SpeculationRules::DocumentPredicate { WTFMove(selectorPredicate) });
+        return SpeculationRules::DocumentPredicate { Box<SpeculationRules::Conjunction>::create(WTFMove(conjunction)) };
+    }
+
+    if (hasURLPredicate)
+        return SpeculationRules::DocumentPredicate { WTFMove(urlPredicate) };
+
+    if (hasSelectorPredicate)
+        return SpeculationRules::DocumentPredicate { WTFMove(selectorPredicate) };
+
+    return std::nullopt;
+}
+
+// https://wicg.github.io/nav-speculation/speculation-rules.html#parse-a-speculation-rule
+static std::optional<SpeculationRules::Rule> parseSingleRule(JSON::Object& input, const String& rulesetLevelTag, const URL& rulesetBaseURL, const URL& documentBaseURL)
+{
+    const HashSet<String> allowedKeys = {
+        "source"_s, "urls"_s, "where"_s, "requires"_s, "target_hint"_s,
+        "referrer_policy"_s, "relative_to"_s, "eagerness"_s,
+        "expects_no_vary_search"_s, "tag"_s
+    };
+    for (const auto& key : input.keys()) {
+        if (!allowedKeys.contains(key))
+            return std::nullopt;
+    }
+
+    String source;
+    if (!input.getString("source"_s, source)) {
+        bool hasURLs = !!input.getValue("urls"_s);
+        bool hasWhere = !!input.getValue("where"_s);
+        if (hasURLs && !hasWhere)
+            source = "list"_s;
+        else if (hasWhere && !hasURLs)
+            source = "document"_s;
+        else
+            return std::nullopt;
+    }
+
+    if (source != "list"_s && source != "document"_s)
+        return std::nullopt;
+
+    SpeculationRules::Rule rule;
+
+    if (source == "list"_s) {
+        if (input.getValue("where"_s))
+            return std::nullopt;
+
+        RefPtr<JSON::Array> urlsArray;
+        if (!input.getArray("urls"_s, urlsArray))
+            return std::nullopt;
+
+        URL currentBaseURL = rulesetBaseURL;
+        String relativeTo;
+        if (input.getString("relative_to"_s, relativeTo)) {
+            if (relativeTo != "ruleset"_s && relativeTo != "document"_s)
+                return std::nullopt;
+            if (relativeTo == "document"_s)
+                currentBaseURL = documentBaseURL;
+        }
+
+        for (const auto& urlValue : *urlsArray) {
+            String urlString;
+            if (!urlValue->asString(urlString))
+                return std::nullopt;
+            URL parsedURL(currentBaseURL, urlString);
+            if (parsedURL.isValid() && (parsedURL.protocolIs("http"_s) || parsedURL.protocolIs("https"_s)))
+                rule.urls.append(parsedURL);
+        }
+        rule.eagerness = SpeculationRules::Eagerness::Immediate;
+
+    } else { // source == "document"_s
+        if (input.getValue("urls"_s) || input.getValue("relative_to"_s))
+            return std::nullopt;
+
+        RefPtr<JSON::Object> whereObject;
+        if (input.getObject("where"_s, whereObject)) {
+            auto predicate = parseDocumentPredicate(*whereObject);
+            if (!predicate)
+                return std::nullopt;
+            rule.predicate = WTFMove(*predicate);
+        } else {
+            // No "where" means match all links, which is an empty conjunction.
+            rule.predicate = SpeculationRules::DocumentPredicate { Box<SpeculationRules::Conjunction>::create() };
+        }
+        rule.eagerness = SpeculationRules::Eagerness::Conservative;
+    }
+
+    RefPtr<JSON::Array> requiresArray;
+    if (input.getArray("requires"_s, requiresArray)) {
+        for (const auto& reqValue : *requiresArray) {
+            String requirement;
+            if (!reqValue->asString(requirement) || requirement != "anonymous-client-ip-when-cross-origin"_s)
+                return std::nullopt;
+            rule.requirements.append(requirement);
+        }
+    }
+
+    input.getString("referrer_policy"_s, rule.referrerPolicy);
+
+    String eagernessString;
+    if (input.getString("eagerness"_s, eagernessString)) {
+        if (eagernessString == "immediate"_s)
+            rule.eagerness = SpeculationRules::Eagerness::Immediate;
+        else if (eagernessString == "eager"_s)
+            rule.eagerness = SpeculationRules::Eagerness::Eager;
+        else if (eagernessString == "moderate"_s)
+            rule.eagerness = SpeculationRules::Eagerness::Moderate;
+        else if (eagernessString == "conservative"_s)
+            rule.eagerness = SpeculationRules::Eagerness::Conservative;
+        else
+            return std::nullopt;
+    }
+
+    input.getString("expects_no_vary_search"_s, rule.noVarySearchHint);
+    // Note: Treating No-Vary-Search hint as a string for now.
+
+    if (!rulesetLevelTag.isNull())
+        rule.tags.append(rulesetLevelTag);
+
+    String ruleTag;
+    if (input.getString("tag"_s, ruleTag)) {
+        if (!ruleTag.containsOnlyASCII())
+            return std::nullopt;
+        rule.tags.append(WTFMove(ruleTag));
+    }
+
+    if (rule.tags.isEmpty())
+        rule.tags.append(String()); // Append null string
+
+    return rule;
+}
+
+static std::optional<Vector<SpeculationRules::Rule>> parseRules(JSON::Object& object, const String& key, const String& rulesetLevelTag, const URL& rulesetBaseURL, const URL& documentBaseURL)
+{
+    RefPtr<JSON::Array> array;
+    if (!object.getArray(key, array))
+        return Vector<SpeculationRules::Rule> { };
+
+    Vector<SpeculationRules::Rule> rules;
+    for (auto& value : *array) {
+        RefPtr<JSON::Object> ruleObject = value->asObject();
+        if (!ruleObject)
+            return std::nullopt;
+        if (auto rule = parseSingleRule(*ruleObject, rulesetLevelTag, rulesetBaseURL, documentBaseURL))
+            rules.append(WTFMove(*rule));
+        else
+            return std::nullopt; // Invalid rule in the list.
+    }
+    return rules;
+}
+
+// https://wicg.github.io/nav-speculation/speculation-rules.html#parse-speculation-rules
+void SpeculationRules::parseSpeculationRules(const StringView& text, const URL& rulesetBaseURL, const URL& documentBaseURL)
+{
+    auto jsonValue = JSON::Value::parseJSON(text);
+    if (!jsonValue)
+        return;
+
+    RefPtr<JSON::Object> jsonObject = jsonValue->asObject();
+    if (!jsonObject)
+        return;
+
+    auto speculationRules = SpeculationRules::create();
+
+    String rulesetLevelTag;
+    jsonObject->getString("tag"_s, rulesetLevelTag);
+
+    auto prefetch = parseRules(*jsonObject, "prefetch"_s, rulesetLevelTag, rulesetBaseURL, documentBaseURL);
+    if (!prefetch)
+        return;
+    m_prefetchRules.appendVector(WTFMove(*prefetch));
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/SpeculationRules.h
+++ b/Source/JavaScriptCore/runtime/SpeculationRules.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2025 Shopify Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Box.h>
+#include <wtf/RefCounted.h>
+#include <wtf/URL.h>
+#include <wtf/Variant.h>
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
+
+namespace JSC {
+
+class JSGlobalObject;
+
+// https://wicg.github.io/nav-speculation/speculation-rules.html
+class SpeculationRules : public RefCounted<SpeculationRules> {
+public:
+    // https://wicg.github.io/nav-speculation/speculation-rules.html#valid-eagerness-strings
+    enum class Eagerness {
+        Immediate,
+        Eager,
+        Moderate,
+        Conservative,
+    };
+
+    // https://wicg.github.io/nav-speculation/speculation-rules.html#document-rule-predicate
+    struct DocumentPredicate;
+
+    struct URLPatternPredicate {
+        Vector<String> patterns;
+    };
+
+    struct CSSSelectorPredicate {
+        Vector<String> selectors;
+    };
+
+    struct Conjunction {
+        Vector<DocumentPredicate> clauses;
+    };
+
+    struct Disjunction {
+        Vector<DocumentPredicate> clauses;
+    };
+
+    struct Negation {
+        Box<DocumentPredicate> clause;
+    };
+
+    struct DocumentPredicate {
+        WTF_MAKE_FAST_ALLOCATED;
+    public:
+        using PredicateVariant = WTF::Variant<URLPatternPredicate, CSSSelectorPredicate, Box<Conjunction>, Box<Disjunction>, Box<Negation>>;
+
+        DocumentPredicate(PredicateVariant&& value)
+            : m_value(WTFMove(value)) { }
+        DocumentPredicate(DocumentPredicate&&) = default;
+        DocumentPredicate& operator=(DocumentPredicate&&) = default;
+
+        const PredicateVariant& value() const { return m_value; }
+
+    private:
+        PredicateVariant m_value;
+    };
+
+    // https://wicg.github.io/nav-speculation/speculation-rules.html#speculation-rule
+    struct Rule {
+        Vector<URL> urls;
+        std::optional<DocumentPredicate> predicate;
+        Eagerness eagerness;
+        String referrerPolicy;
+        Vector<String> tags;
+        Vector<String> requirements;
+        String noVarySearchHint;
+    };
+
+    static Ref<SpeculationRules> create() { return adoptRef(*new SpeculationRules); }
+
+    // https://wicg.github.io/nav-speculation/speculation-rules.html#parse-speculation-rules
+    JS_EXPORT_PRIVATE void parseSpeculationRules(const StringView&, const URL& rulesetBaseURL, const URL& documentBaseURL);
+
+    const Vector<Rule>& prefetchRules() const { return m_prefetchRules; }
+
+private:
+    SpeculationRules() = default;
+
+    Vector<Rule> m_prefetchRules;
+};
+
+} // namespace JSC

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1219,6 +1219,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/SlotAssignmentMode.h
     dom/SpaceSplitString.h
     dom/SpatialBackdropSource.h
+    dom/SpeculationRulesMatcher.h
     dom/StartViewTransitionOptions.h
     dom/StaticRange.h
     dom/StyledElement.h
@@ -1566,6 +1567,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     loader/CustomHeaderFields.h
     loader/DocumentLoadTiming.h
     loader/DocumentLoader.h
+    loader/DocumentPrefetcher.h
     loader/DocumentWriter.h
     loader/EmptyClients.h
     loader/EmptyFrameLoaderClient.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1350,6 +1350,7 @@ dom/SimulatedClick.cpp
 dom/SlotAssignment.cpp
 dom/SpaceSplitString.cpp
 dom/SpatialBackdropSource.cpp
+dom/SpeculationRulesMatcher.cpp
 dom/StaticNodeList.cpp
 dom/StaticRange.cpp
 dom/StringCallback.cpp
@@ -1981,6 +1982,7 @@ loader/DefaultResourceLoadPriority.cpp
 loader/DocumentLoader.cpp
 loader/DocumentThreadableLoader.cpp
 loader/DocumentWriter.cpp
+loader/DocumentPrefetcher.cpp
 loader/EmptyClients.cpp
 loader/FTPDirectoryParser.cpp
 loader/FetchIdioms.cpp

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -73,6 +73,7 @@
 #include <JavaScriptCore/JSScriptFetchParameters.h>
 #include <JavaScriptCore/JSScriptFetcher.h>
 #include <JavaScriptCore/ScriptCallStack.h>
+#include <JavaScriptCore/SpeculationRules.h>
 #include <JavaScriptCore/StrongInlines.h>
 #include <JavaScriptCore/SyntheticModuleRecord.h>
 #include <JavaScriptCore/WeakGCMapInlines.h>
@@ -969,6 +970,15 @@ void ScriptController::registerImportMap(const ScriptSourceCode& sourceCode, con
 
     if (newImportMap)
         globalObject->importMap().mergeExistingAndNewImportMaps(WTFMove(newImportMap.value()), reporter);
+}
+
+void ScriptController::registerSpeculationRules(const ScriptSourceCode& sourceCode, const URL& baseURL)
+{
+    auto& world = mainThreadNormalWorldSingleton();
+    JSC::VM& vm = world.vm();
+    JSLockHolder lock(vm);
+    JSGlobalObject* globalObject = jsWindowProxy(world).window();
+    globalObject->speculationRules().parseSpeculationRules(sourceCode.source(), baseURL, baseURL);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/ScriptController.h
+++ b/Source/WebCore/bindings/js/ScriptController.h
@@ -175,6 +175,7 @@ public:
     void reportExceptionFromScriptError(LoadableScript::Error, bool);
 
     void registerImportMap(const ScriptSourceCode&, const URL& baseURL);
+    void registerSpeculationRules(const ScriptSourceCode&, const URL& baseURL);
 
 private:
     ValueOrException executeScriptInWorld(DOMWrapperWorld&, RunJavaScriptParameters&&);

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -81,6 +81,7 @@
 namespace JSC {
 class CallFrame;
 class InputCursor;
+class SpeculationRules;
 }
 
 namespace WTF {
@@ -839,6 +840,9 @@ public:
     const AtomString& baseTarget() const { return m_baseTarget; }
     HTMLBaseElement* firstBaseElement() const;
     void processBaseElement();
+
+    // https://wicg.github.io/nav-speculation/speculation-rules.html#consider-speculation
+    void considerSpeculationRules();
 
     URL baseURLForComplete(const URL& baseURLOverride) const;
     WEBCORE_EXPORT URL completeURL(const String&, ForceUTF8 = ForceUTF8::No) const final;
@@ -2003,6 +2007,7 @@ public:
     void attributeAddedToElement(const QualifiedName& attribute);
     void elementDisconnectedFromDocument(const Element&);
 
+    WEBCORE_EXPORT void prefetch(const URL&, const Vector<String>&, const String&, bool lowPriority = false);
 
 protected:
     enum class ConstructionFlag : uint8_t {
@@ -2184,6 +2189,9 @@ private:
     const Ref<const Settings> m_settings;
 
     const std::unique_ptr<Quirks> m_quirks;
+
+    // Speculation Rules
+    RefPtr<JSC::SpeculationRules> m_speculationRules;
 
     RefPtr<LocalDOMWindow> m_domWindow;
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_contextDocument;

--- a/Source/WebCore/dom/ScriptElement.h
+++ b/Source/WebCore/dom/ScriptElement.h
@@ -58,6 +58,7 @@ public:
     void executeClassicScript(const ScriptSourceCode&);
     void executeModuleScript(LoadableModuleScript&);
     void registerImportMap(const ScriptSourceCode&);
+    void registerSpeculationRules(const ScriptSourceCode&);
 
     void executePendingScript(PendingScript&);
 

--- a/Source/WebCore/dom/ScriptElementCachedScriptFetcher.h
+++ b/Source/WebCore/dom/ScriptElementCachedScriptFetcher.h
@@ -41,6 +41,7 @@ public:
     bool isClassicScript() const { return scriptType() == ScriptType::Classic; }
     bool isModuleScript() const { return scriptType() == ScriptType::Module; }
     bool isImportMap() const { return scriptType() == ScriptType::ImportMap; }
+    bool isSpeculationRules() const { return scriptType() == ScriptType::SpeculationRules; }
 
     const String& crossOriginMode() const { return m_crossOriginMode; }
 

--- a/Source/WebCore/dom/ScriptType.h
+++ b/Source/WebCore/dom/ScriptType.h
@@ -28,8 +28,8 @@
 namespace WebCore {
 
 // https://html.spec.whatwg.org/multipage/scripting.html#concept-script-type
-enum class ScriptType : uint8_t { Classic, Module, ImportMap };
-static constexpr unsigned bitWidthOfScriptType = 2;
-static_assert(static_cast<unsigned>(ScriptType::ImportMap) <= ((1U << bitWidthOfScriptType) - 1));
+enum class ScriptType : uint8_t { Classic, Module, ImportMap, SpeculationRules };
+static constexpr unsigned bitWidthOfScriptType = 3;
+static_assert(static_cast<unsigned>(ScriptType::SpeculationRules) <= ((1U << bitWidthOfScriptType) - 1));
 
 }

--- a/Source/WebCore/dom/SpeculationRulesMatcher.cpp
+++ b/Source/WebCore/dom/SpeculationRulesMatcher.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2025 Shopify Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SpeculationRulesMatcher.h"
+
+#include "Document.h"
+#include "Element.h"
+#include "HTMLAnchorElement.h"
+#include "JSDOMGlobalObject.h"
+#include "ScriptController.h"
+#include "SelectorQuery.h"
+#include "URLPattern.h"
+#include "URLPatternOptions.h"
+#include <JavaScriptCore/SpeculationRules.h>
+
+namespace WebCore {
+
+static bool matches(const JSC::SpeculationRules::DocumentPredicate&, Ref<Document>, Ref<HTMLAnchorElement>);
+
+static bool matches(const JSC::SpeculationRules::URLPatternPredicate& predicate, Ref<HTMLAnchorElement> anchor)
+{
+    for (const auto& patternString : predicate.patterns) {
+        ExceptionOr<Ref<URLPattern>> patternExceptionOr = URLPattern::create(anchor->protectedDocument(), patternString, String(anchor->document().baseURL().string()), URLPatternOptions());
+        if (!patternExceptionOr.hasException()) {
+            Ref<URLPattern> pattern = patternExceptionOr.returnValue();
+            auto result = pattern->test(anchor->protectedDocument(), anchor->href().string(), String(anchor->document().baseURL().string()));
+            if (!result.hasException() && result.returnValue())
+                return true;
+        }
+    }
+    return false;
+}
+
+static bool matches(const JSC::SpeculationRules::CSSSelectorPredicate& predicate, Ref<Element> element)
+{
+    for (const auto& selectorString : predicate.selectors) {
+        auto query = element->protectedDocument()->selectorQueryForString(selectorString);
+        if (query.hasException())
+            continue;
+        if (query.returnValue().matches(element.get()))
+            return true;
+    }
+    return false;
+}
+
+static bool matches(const Box<JSC::SpeculationRules::Conjunction>& predicate, Ref<Document> document, Ref<HTMLAnchorElement> anchor)
+{
+    for (const auto& clause : predicate->clauses) {
+        if (!matches(clause, document, anchor))
+            return false;
+    }
+    return true;
+}
+
+static bool matches(const Box<JSC::SpeculationRules::Disjunction>& predicate, Ref<Document> document, Ref<HTMLAnchorElement> anchor)
+{
+    if (predicate->clauses.isEmpty())
+        return false;
+
+    for (const auto& clause : predicate->clauses) {
+        if (matches(clause, document, anchor))
+            return true;
+    }
+    return false;
+}
+
+static bool matches(const Box<JSC::SpeculationRules::Negation>& predicate, Ref<Document> document, Ref<HTMLAnchorElement> anchor)
+{
+    return !matches(*predicate->clause, document, anchor);
+}
+
+static bool matches(const JSC::SpeculationRules::DocumentPredicate& predicate, Ref<Document> document, Ref<HTMLAnchorElement> anchor)
+{
+    return WTF::switchOn(predicate.value(),
+        [&] (const JSC::SpeculationRules::URLPatternPredicate& p) { return matches(p, anchor); },
+        [&] (const JSC::SpeculationRules::CSSSelectorPredicate& p) { return matches(p, anchor); },
+        [&] (const Box<JSC::SpeculationRules::Conjunction>& p) { return matches(p, document, anchor); },
+        [&] (const Box<JSC::SpeculationRules::Disjunction>& p) { return matches(p, document, anchor); },
+        [&] (const Box<JSC::SpeculationRules::Negation>& p) { return matches(p, document, anchor); }
+    );
+}
+
+// https://wicg.github.io/nav-speculation/speculation-rules.html#document-rule-predicate-matching
+std::optional<PrefetchRule> SpeculationRulesMatcher::hasMatchingRule(Ref<Document> document, Ref<HTMLAnchorElement> anchor)
+{
+    auto* globalObject = document->globalObject();
+    if (!globalObject)
+        return std::nullopt;
+
+    const auto& speculationRules = globalObject->speculationRules();
+    const auto& url = anchor->href();
+
+    for (const auto& rule : speculationRules.prefetchRules()) {
+        for (const auto& href : rule.urls) {
+            if (href == url)
+                return PrefetchRule { rule.tags, rule.referrerPolicy, rule.eagerness == JSC::SpeculationRules::Eagerness::Conservative };
+        }
+
+        if (rule.predicate && matches(rule.predicate.value(), document, anchor))
+            return PrefetchRule { rule.tags, rule.referrerPolicy, rule.eagerness == JSC::SpeculationRules::Eagerness::Conservative || rule.eagerness == JSC::SpeculationRules::Eagerness::Moderate };
+    }
+
+    return std::nullopt;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/SpeculationRulesMatcher.h
+++ b/Source/WebCore/dom/SpeculationRulesMatcher.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2025 Shopify Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
+
+namespace JSC {
+class SpeculationRules;
+} // namespace JSC
+
+namespace WTF {
+class URL;
+} // namespace WTF
+
+namespace WebCore {
+
+class Document;
+class HTMLAnchorElement;
+
+struct PrefetchRule {
+    Vector<String> tags;
+    String referrerPolicy;
+    bool conservative;
+};
+
+class SpeculationRulesMatcher {
+public:
+    static std::optional<PrefetchRule> hasMatchingRule(Ref<Document>, Ref<HTMLAnchorElement>);
+};
+
+} // namespace WebCore

--- a/Source/WebCore/dom/TextDecoderStreamDecoder.cpp
+++ b/Source/WebCore/dom/TextDecoderStreamDecoder.cpp
@@ -25,6 +25,8 @@
 #include "config.h"
 #include "TextDecoderStreamDecoder.h"
 
+#include "ExceptionOr.h"
+
 namespace WebCore {
 
 ExceptionOr<Ref<TextDecoderStreamDecoder>> TextDecoderStreamDecoder::create(const String& label, bool fatal, bool ignoreBOM)

--- a/Source/WebCore/dom/TrustedTypePolicy.cpp
+++ b/Source/WebCore/dom/TrustedTypePolicy.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "TrustedTypePolicy.h"
 
+#include "ExceptionCode.h"
+#include "ExceptionOr.h"
 #include "TrustedHTML.h"
 #include "TrustedScript.h"
 #include "TrustedScriptURL.h"

--- a/Source/WebCore/html/HTMLAnchorElement.h
+++ b/Source/WebCore/html/HTMLAnchorElement.h
@@ -83,6 +83,8 @@ public:
 
     Node::InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode& parentOfInsertedTree) override;
 
+    void setShouldBePrefetched(bool conservative, Vector<String>&& tags, String&& referrerPolicy);
+
 protected:
     HTMLAnchorElement(const QualifiedName&, Document&);
 
@@ -127,6 +129,13 @@ private:
 
     URL fullURL() const final { return href(); }
     void setFullURL(const URL&) final;
+
+    void checkForSpeculationRules();
+
+    bool m_shouldBeImmediatelyPrefetched { false };
+    bool m_shouldBeConservativelyPrefetched { false };
+    Vector<String> m_speculationRulesTags;
+    String m_prefetchReferrerPolicy;
 
     bool m_hasRootEditableElementForSelectionOnMouseDown { false };
     bool m_wasShiftKeyDownOnMouseDown { false };

--- a/Source/WebCore/html/HTMLScriptElement.h
+++ b/Source/WebCore/html/HTMLScriptElement.h
@@ -64,7 +64,7 @@ public:
     using HTMLElement::ref;
     using HTMLElement::deref;
 
-    static bool supports(StringView type) { return type == "classic"_s || type == "module"_s || type == "importmap"_s; }
+    static bool supports(StringView type) { return type == "classic"_s || type == "module"_s || type == "importmap"_s || type == "speculationrules"_s; }
 
     String fetchPriorityForBindings() const;
     RequestPriority fetchPriority() const final;

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -547,6 +547,8 @@ public:
 
     WEBCORE_EXPORT void setNewResultingClientId(ScriptExecutionContextIdentifier);
 
+    void setPrefetchedMainResource(CachedRawResource&);
+
 protected:
     WEBCORE_EXPORT DocumentLoader(ResourceRequest&&, SubstituteData&&);
 
@@ -584,6 +586,7 @@ private:
     WEBCORE_EXPORT void responseReceived(const CachedResource&, const ResourceResponse&, CompletionHandler<void()>&&) override;
     WEBCORE_EXPORT void dataReceived(CachedResource&, const SharedBuffer&) override;
     WEBCORE_EXPORT void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) override;
+
 #if USE(QUICK_LOOK)
     WEBCORE_EXPORT void previewResponseReceived(const CachedResource&, const ResourceResponse&) override;
 #endif

--- a/Source/WebCore/loader/DocumentPrefetcher.cpp
+++ b/Source/WebCore/loader/DocumentPrefetcher.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2025 Shopify Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DocumentPrefetcher.h"
+
+#include "CachedRawResource.h"
+#include "DocumentLoader.h"
+#include "Frame.h"
+#include "FrameLoader.h"
+#include "FrameLoaderClient.h"
+#include "ResourceRequest.h"
+#include "SubstituteData.h"
+
+namespace WebCore {
+
+DocumentPrefetcher::DocumentPrefetcher(FrameLoader& frameLoader)
+    : m_frameLoader(frameLoader)
+    , m_prefetchedResource(nullptr)
+{
+}
+
+DocumentPrefetcher::~DocumentPrefetcher()
+{
+    clear();
+}
+
+void DocumentPrefetcher::prefetch(ResourceRequest&& request, bool lowPriority)
+{
+
+    URL url = request.url();
+    if (m_prefetchedDocumentURL == url)
+        return;
+
+    ResourceLoaderOptions prefetchOptions(
+        SendCallbackPolicy::DoNotSendCallbacks,
+        ContentSniffingPolicy::DoNotSniffContent,
+        DataBufferingPolicy::BufferData,
+        StoredCredentialsPolicy::Use,
+        ClientCredentialPolicy::MayAskClientForCredentials,
+        FetchOptions::Credentials::Include,
+        SecurityCheckPolicy::DoSecurityCheck,
+        FetchOptions::Mode::Navigate,
+        CertificateInfoPolicy::IncludeCertificateInfo,
+        ContentSecurityPolicyImposition::DoPolicyCheck,
+        DefersLoadingPolicy::AllowDefersLoading,
+        CachingPolicy::AllowCaching
+    );
+
+    prefetchOptions.cachingPolicy = CachingPolicy::AllowCaching;
+
+    request.setHTTPHeaderField(HTTPHeaderName::SecPurpose, "prefetch"_s);
+    CachedResourceRequest prefetchRequest(WTFMove(request), prefetchOptions);
+    if (lowPriority)
+        prefetchRequest.setPriority(ResourceLoadPriority::Low);
+
+    WeakRef<FrameLoader> frameLoader = m_frameLoader;
+    if (!frameLoader.ptr())
+        return;
+    ResourceErrorOr<CachedResourceHandle<CachedRawResource>> resourceErrorOr = frameLoader->protectedDocumentLoader()->cachedResourceLoader().requestMainResource(WTFMove(prefetchRequest));
+    if (!resourceErrorOr)
+        return;
+    m_prefetchedResource = resourceErrorOr.value();
+    m_prefetchedDocumentURL = url.string();
+}
+
+CachedRawResource* DocumentPrefetcher::matchPrefetchedDocument(const URL& url)
+{
+    if (m_prefetchedDocumentURL == url.string())
+        return m_prefetchedResource.get();
+    return nullptr;
+}
+
+void DocumentPrefetcher::clear()
+{
+    m_prefetchedResource = nullptr;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/loader/DocumentPrefetcher.h
+++ b/Source/WebCore/loader/DocumentPrefetcher.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2025 Shopify Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CachedResourceHandle.h"
+
+#include <wtf/Forward.h>
+#include <wtf/HashMap.h>
+#include <wtf/URLHash.h>
+
+
+namespace WebCore {
+
+class CachedRawResource;
+class DocumentLoader;
+class FrameLoader;
+class ResourceRequest;
+
+class DocumentPrefetcher : public RefCounted<DocumentPrefetcher> {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    static Ref<DocumentPrefetcher> create(FrameLoader& frameLoader) { return adoptRef(*new DocumentPrefetcher(frameLoader)); }
+    explicit DocumentPrefetcher(FrameLoader&);
+    ~DocumentPrefetcher();
+
+    void prefetch(ResourceRequest&&, bool lowPriority = false);
+    CachedRawResource* matchPrefetchedDocument(const URL&);
+    void clear();
+
+private:
+    WeakRef<FrameLoader> m_frameLoader;
+    String m_prefetchedDocumentURL;
+    CachedResourceHandle<CachedRawResource> m_prefetchedResource;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -86,6 +86,7 @@ class ResourceRequest;
 class ResourceResponse;
 class SerializedScriptValue;
 class SubstituteData;
+class DocumentPrefetcher;
 
 enum class CachePolicy : uint8_t;
 enum class NewLoadInProgress : bool;
@@ -362,6 +363,8 @@ public:
 
     WEBCORE_EXPORT void prefetchDNSIfNeeded(const URL&);
 
+    void prefetch(const URL&, const Vector<String>&, const String&, bool lowPriority = false);
+
 private:
     enum FormSubmissionCacheLoadPolicy {
         MayAttemptCacheOnlyLoadForFormSubmissionItem,
@@ -548,6 +551,8 @@ private:
     bool m_errorOccurredInLoading { false };
     bool m_doNotAbortNavigationAPI { false };
     uint64_t m_requiredCookiesVersion { 0 };
+
+    RefPtr<DocumentPrefetcher> m_documentPrefetcher;
 };
 
 // This function is called by createWindow() in JSDOMWindowBase.cpp, for example, for

--- a/Source/WebCore/loader/LinkLoader.cpp
+++ b/Source/WebCore/loader/LinkLoader.cpp
@@ -41,6 +41,7 @@
 #include "CrossOriginAccessControl.h"
 #include "DefaultResourceLoadPriority.h"
 #include "DocumentInlines.h"
+#include "DocumentLoader.h"
 #include "FetchRequestDestination.h"
 #include "FrameLoader.h"
 #include "HTMLSrcsetParser.h"
@@ -63,6 +64,7 @@
 #include "SizesAttributeParser.h"
 #include "StyleResolver.h"
 #include "UserContentProvider.h"
+#include <JavaScriptCore/ConsoleTypes.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -610,6 +610,7 @@ bool CachedResourceLoader::allowedByContentSecurityPolicy(CachedResource::Type t
     case CachedResource::Type::Beacon:
     case CachedResource::Type::Ping:
     case CachedResource::Type::RawResource:
+    case CachedResource::Type::MainResource:
 #if ENABLE(MODEL_ELEMENT)
     case CachedResource::Type::EnvironmentMapResource:
     case CachedResource::Type::ModelResource:

--- a/Source/WebCore/platform/ReferrerPolicy.cpp
+++ b/Source/WebCore/platform/ReferrerPolicy.cpp
@@ -83,6 +83,7 @@ std::optional<ReferrerPolicy> parseReferrerPolicy(StringView policyString, Refer
     case ReferrerPolicySource::MetaTag:
         return parseReferrerPolicyToken(policyString, ShouldParseLegacyKeywords::Yes);
     case ReferrerPolicySource::ReferrerPolicyAttribute:
+    case ReferrerPolicySource::SpeculationRules:
         return parseReferrerPolicyToken(policyString, ShouldParseLegacyKeywords::No);
     }
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/ReferrerPolicy.h
+++ b/Source/WebCore/platform/ReferrerPolicy.h
@@ -50,7 +50,7 @@ enum class ReferrerPolicy : uint8_t {
     Default = StrictOriginWhenCrossOrigin
 };
 
-enum class ReferrerPolicySource : uint8_t { MetaTag, HTTPHeader, ReferrerPolicyAttribute };
+enum class ReferrerPolicySource : uint8_t { MetaTag, HTTPHeader, ReferrerPolicyAttribute, SpeculationRules };
 std::optional<ReferrerPolicy> parseReferrerPolicy(StringView, ReferrerPolicySource);
 String referrerPolicyToString(const ReferrerPolicy&);
 

--- a/Source/WebCore/platform/network/HTTPHeaderNames.in
+++ b/Source/WebCore/platform/network/HTTPHeaderNames.in
@@ -91,6 +91,7 @@ Sec-Fetch-Dest
 Sec-Fetch-Mode
 Sec-Fetch-Site
 Sec-Purpose
+Sec-Speculation-Tags
 Sec-WebSocket-Accept
 Sec-WebSocket-Extensions
 Sec-WebSocket-Key

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -1838,7 +1838,7 @@ def _check_parameter_name_against_text(parameter, text, error):
     # case insensitive while still retaining word breaks. (This ensures that
     # 'elate' doesn't look like it is duplicating of 'NateLate'.)
     canonical_parameter_name = parameter.lower_with_underscores_name()
-    if canonical_parameter_name == "]":
+    if canonical_parameter_name in (']', '<'):
         return True  # Work around a bug parsing some Objective-C code.
 
     # Appends "object" to all text to catch variables that did the same (but only


### PR DESCRIPTION
#### 7290f870cd7072c766b25f77424e628d6b34a38a
<pre>
Implement speculation rules - same origin conservative prefetch
<a href="https://bugs.webkit.org/show_bug.cgi?id=295193">https://bugs.webkit.org/show_bug.cgi?id=295193</a>

Reviewed by NOBODY (OOPS!).

This implements an initial version of same-origin conservative prefetch
speculation rules.

* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::JSGlobalObject):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::speculationRules const):
(JSC::JSGlobalObject::speculationRules):
* Source/JavaScriptCore/runtime/SpeculationRules.cpp: Added.
(JSC::parseStringOrStringList):
(JSC::parseDocumentPredicate):
(JSC::parseSingleRule):
(JSC::parseRules):
(JSC::SpeculationRules::parseSpeculationRules):
* Source/JavaScriptCore/runtime/SpeculationRules.h: Added.
(JSC::SpeculationRules::DocumentPredicate::DocumentPredicate):
(JSC::SpeculationRules::DocumentPredicate::value const):
(JSC::SpeculationRules::create):
(JSC::SpeculationRules::prefetchRules const):
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::registerSpeculationRules):
* Source/WebCore/bindings/js/ScriptController.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::canNavigateInternal):
(WebCore::Document::setNeedsDOMWindowResizeEvent):
(WebCore::Document::suspendScriptedAnimationControllerCallbacks):
(WebCore::Document::prefetch):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::determineScriptType):
(WebCore::ScriptElement::prepareScript):
(WebCore::ScriptElement::registerSpeculationRules):
* Source/WebCore/dom/ScriptElement.h:
* Source/WebCore/dom/ScriptElementCachedScriptFetcher.h:
(WebCore::ScriptElementCachedScriptFetcher::isSpeculationRules const):
* Source/WebCore/dom/ScriptType.h:
* Source/WebCore/dom/SpeculationRulesMatcher.cpp: Copied from Source/WebCore/dom/ScriptElementCachedScriptFetcher.h.
(WebCore::matches):
(WebCore::SpeculationRulesMatcher::hasMatchingRule):
* Source/WebCore/dom/SpeculationRulesMatcher.h: Copied from Source/WebCore/dom/ScriptElementCachedScriptFetcher.h.
* Source/WebCore/dom/TreeScope.h:
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::defaultEventHandler):
(WebCore::HTMLAnchorElement::insertedIntoAncestor):
(WebCore::HTMLAnchorElement::setShouldBeConservativelyPrefetched):
* Source/WebCore/html/HTMLAnchorElement.h:
* Source/WebCore/html/HTMLScriptElement.h:
* Source/WebCore/loader/DocumentPrefetcher.cpp: Copied from Source/WebCore/dom/ScriptType.h.
(WebCore::DocumentPrefetcher::DocumentPrefetcher):
(WebCore::DocumentPrefetcher::~DocumentPrefetcher):
(WebCore::DocumentPrefetcher::prefetch):
(WebCore::DocumentPrefetcher::matchPrefetchedDocument):
(WebCore::DocumentPrefetcher::clear):
* Source/WebCore/loader/DocumentPrefetcher.h: Copied from Source/WebCore/dom/ScriptType.h.
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::FrameLoader):
(WebCore::FrameLoader::load):
(WebCore::FrameLoader::loadWithNavigationAction):
(WebCore::FrameLoader::reloadWithOverrideEncoding):
(WebCore::FrameLoader::prefetch):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/LinkLoader.cpp:
* Source/WebCore/platform/ReferrerPolicy.cpp:
(WebCore::parseReferrerPolicy):
* Source/WebCore/platform/ReferrerPolicy.h:
* Source/WebCore/platform/network/HTTPHeaderNames.in:
* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(_check_parameter_name_against_text):
* Tools/SwiftBrowser/SwiftBrowser.xcodeproj/xcshareddata/xcschemes/SwiftBrowser.xcscheme:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa36ac49c44c37ad04a65ab5f5ab7dff4472246b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112525 "Failed to checkout and rebase branch from PR 47366") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32257 "Failed to checkout and rebase branch from PR 47366") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22735 "Failed to checkout and rebase branch from PR 47366") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118723 "Failed to checkout and rebase branch from PR 47366") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62976 "Failed to checkout and rebase branch from PR 47366") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114487 "Failed to checkout and rebase branch from PR 47366") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32909 "Failed to checkout and rebase branch from PR 47366") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40820 "Failed to checkout and rebase branch from PR 47366") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/118723 "Failed to checkout and rebase branch from PR 47366") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/62976 "Failed to checkout and rebase branch from PR 47366") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115472 "Failed to checkout and rebase branch from PR 47366") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/32909 "Failed to checkout and rebase branch from PR 47366") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/22735 "Failed to checkout and rebase branch from PR 47366") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/118723 "Failed to checkout and rebase branch from PR 47366") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/111957 "Failed to checkout and rebase branch from PR 47366") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/32909 "Failed to checkout and rebase branch from PR 47366") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/22735 "Failed to checkout and rebase branch from PR 47366") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62483 "Failed to checkout and rebase branch from PR 47366") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/105039 "Failed to checkout and rebase branch from PR 47366") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/32909 "Failed to checkout and rebase branch from PR 47366") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/22735 "Failed to checkout and rebase branch from PR 47366") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121945 "Failed to checkout and rebase branch from PR 47366") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/111139 "Failed to checkout and rebase branch from PR 47366") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39599 "Failed to checkout and rebase branch from PR 47366") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/40820 "Failed to checkout and rebase branch from PR 47366") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/121945 "Failed to checkout and rebase branch from PR 47366") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39981 "Failed to checkout and rebase branch from PR 47366") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/22735 "Failed to checkout and rebase branch from PR 47366") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/121945 "Failed to checkout and rebase branch from PR 47366") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/22735 "Failed to checkout and rebase branch from PR 47366") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35681 "Failed to checkout and rebase branch from PR 47366") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39487 "Failed to checkout and rebase branch from PR 47366") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44975 "Failed to checkout and rebase branch from PR 47366") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/135371 "Failed to checkout and rebase branch from PR 47366") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39124 "Failed to checkout and rebase branch from PR 47366") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/135371 "Failed to checkout and rebase branch from PR 47366") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42459 "Failed to checkout and rebase branch from PR 47366") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40865 "Failed to checkout and rebase branch from PR 47366") | | | 
<!--EWS-Status-Bubble-End-->