### PR TITLE
Some smart pointer adoption in platform/mac

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -346,7 +346,6 @@ platform/graphics/cg/CGSubimageCacheWithTimer.cpp
 platform/graphics/mac/controls/ImageControlsButtonMac.mm
 platform/ios/PlaybackSessionInterfaceIOS.mm
 platform/ios/WebAVPlayerController.mm
-platform/mac/PlatformScreenMac.mm
 platform/mac/PlaybackSessionInterfaceMac.mm
 platform/mac/VideoPresentationInterfaceMac.mm
 platform/mac/WebPlaybackControlsManager.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -847,7 +847,6 @@ platform/graphics/mac/PDFDocumentImageMac.mm
 platform/graphics/opentype/OpenTypeMathData.cpp
 platform/graphics/transforms/TransformOperations.cpp
 platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp
-platform/mac/PasteboardMac.mm
 platform/mac/PasteboardWriter.mm
 platform/mac/ScrollbarsControllerMac.mm
 platform/mac/VideoPresentationInterfaceMac.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -411,9 +411,6 @@ platform/graphics/mac/controls/MeterMac.mm
 platform/graphics/mac/controls/ProgressBarMac.mm
 platform/graphics/mac/controls/SliderTrackMac.mm
 platform/graphics/transforms/RotateTransformOperation.cpp
-platform/mac/PlatformScreenMac.mm
-platform/mac/ScrollAnimatorMac.mm
-platform/mac/ScrollbarsControllerMac.mm
 platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm
 platform/mock/MockRealtimeMediaSourceCenter.cpp
 platform/mock/MockRealtimeVideoSource.cpp

--- a/Source/WebCore/platform/mac/PasteboardMac.mm
+++ b/Source/WebCore/platform/mac/PasteboardMac.mm
@@ -255,7 +255,7 @@ void Pasteboard::write(const Color& color)
 
 static NSFileWrapper* fileWrapper(const PasteboardImage& pasteboardImage)
 {
-    auto wrapper = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:pasteboardImage.resourceData->makeContiguous()->createNSData().get()]);
+    auto wrapper = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:Ref { *pasteboardImage.resourceData }->makeContiguous()->createNSData().get()]);
     [wrapper setPreferredFilename:suggestedFilenameWithMIMEType(pasteboardImage.url.url.createNSURL().get(), pasteboardImage.resourceMIMEType)];
     return wrapper.autorelease();
 }
@@ -273,7 +273,7 @@ static void writeFileWrapperAsRTFDAttachment(NSFileWrapper *wrapper, const Strin
 
 void Pasteboard::write(const PasteboardImage& pasteboardImage)
 {
-    CFDataRef imageData = pasteboardImage.image->adapter().tiffRepresentation();
+    CFDataRef imageData = Ref { *pasteboardImage.image }->adapter().tiffRepresentation();
     if (!imageData)
         return;
 
@@ -860,7 +860,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         return pasteboardBuffer.data;
 ALLOW_DEPRECATED_DECLARATIONS_END
 
-    auto sourceData = pasteboardBuffer.data->createCFData();
+    auto sourceData = Ref { *pasteboardBuffer.data }->createCFData();
     auto sourceType = pasteboardBuffer.type.createCFString();
 
     const void* key = kCGImageSourceTypeIdentifierHint;

--- a/Source/WebCore/platform/mac/PlatformScreenMac.mm
+++ b/Source/WebCore/platform/mac/PlatformScreenMac.mm
@@ -63,7 +63,7 @@ static PlatformDisplayID displayID(Widget* widget)
     if (!widget)
         return 0;
 
-    auto* view = widget->root();
+    RefPtr view = widget->root();
     if (!view)
         return 0;
 

--- a/Source/WebCore/platform/mac/ScrollAnimatorMac.mm
+++ b/Source/WebCore/platform/mac/ScrollAnimatorMac.mm
@@ -113,8 +113,8 @@ bool ScrollAnimatorMac::allowsVerticalStretching(const PlatformWheelEvent& wheel
     
     switch (m_scrollableArea.verticalScrollElasticity()) {
     case ScrollElasticity::Automatic: {
-        Scrollbar* hScroller = m_scrollableArea.horizontalScrollbar();
-        Scrollbar* vScroller = m_scrollableArea.verticalScrollbar();
+        RefPtr hScroller = m_scrollableArea.horizontalScrollbar();
+        RefPtr vScroller = m_scrollableArea.verticalScrollbar();
         bool scrollbarsAllowStretching = ((vScroller && vScroller->enabled()) || (!hScroller || !hScroller->enabled()));
         auto relevantSide = ScrollableArea::targetSideForScrollDelta(-wheelEvent.delta(), ScrollEventAxis::Vertical);
         bool eventPreventsStretching = m_scrollableArea.hasScrollableOrRubberbandableAncestor() && wheelEvent.isGestureStart() && relevantSide && m_scrollableArea.isPinnedOnSide(*relevantSide);
@@ -139,8 +139,8 @@ bool ScrollAnimatorMac::allowsHorizontalStretching(const PlatformWheelEvent& whe
     
     switch (m_scrollableArea.horizontalScrollElasticity()) {
     case ScrollElasticity::Automatic: {
-        Scrollbar* hScroller = m_scrollableArea.horizontalScrollbar();
-        Scrollbar* vScroller = m_scrollableArea.verticalScrollbar();
+        RefPtr hScroller = m_scrollableArea.horizontalScrollbar();
+        RefPtr vScroller = m_scrollableArea.verticalScrollbar();
         bool scrollbarsAllowStretching = ((hScroller && hScroller->enabled()) || (!vScroller || !vScroller->enabled()));
         auto relevantSide = ScrollableArea::targetSideForScrollDelta(-wheelEvent.delta(), ScrollEventAxis::Horizontal);
         bool eventPreventsStretching = m_scrollableArea.hasScrollableOrRubberbandableAncestor() && wheelEvent.isGestureStart() && relevantSide && m_scrollableArea.isPinnedOnSide(*relevantSide);

--- a/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
@@ -128,7 +128,7 @@ static NSScrollerImp *scrollerImpForScrollbar(Scrollbar& scrollbar)
     if (!scrollableArea || !scrollerImp)
         return NSZeroPoint;
 
-    WebCore::Scrollbar* scrollbar = 0;
+    RefPtr<WebCore::Scrollbar> scrollbar;
     if ([scrollerImp isHorizontal])
         scrollbar = scrollableArea->horizontalScrollbar();
     else
@@ -382,7 +382,7 @@ using WebCore::LogOverlayScrollbars;
     if (!WebCore::ScrollbarThemeMac::isCurrentlyDrawingIntoLayer())
         return nil;
 
-    WebCore::GraphicsLayer* layer;
+    RefPtr<WebCore::GraphicsLayer> layer;
     if (_scrollbar->orientation() == WebCore::ScrollbarOrientation::Vertical)
         layer = _scrollbar->scrollableArea().layerForVerticalScrollbar();
     else
@@ -626,7 +626,7 @@ void ScrollbarsControllerMac::cancelAnimations()
 void ScrollbarsControllerMac::setVisibleScrollerThumbRect(const IntRect& scrollerThumb)
 {
     auto rectInViewCoordinates = scrollerThumb;
-    if (auto* verticalScrollbar = scrollableArea().verticalScrollbar())
+    if (RefPtr verticalScrollbar = scrollableArea().verticalScrollbar())
         rectInViewCoordinates = verticalScrollbar->convertToContainingView(scrollerThumb);
 
     if (rectInViewCoordinates == m_visibleScrollerThumbRect)
@@ -765,7 +765,7 @@ void ScrollbarsControllerMac::didBeginScrollGesture()
 
     [m_scrollerImpPair beginScrollGesture];
 
-    if (auto* monitor = wheelEventTestMonitor())
+    if (RefPtr monitor = wheelEventTestMonitor())
         monitor->deferForReason(scrollableArea().scrollingNodeIDForTesting(), WheelEventTestMonitor::DeferReason::ContentScrollInProgress);
 
     ScrollbarsController::didBeginScrollGesture();
@@ -780,7 +780,7 @@ void ScrollbarsControllerMac::didEndScrollGesture()
 
     [m_scrollerImpPair endScrollGesture];
 
-    if (auto* monitor = wheelEventTestMonitor())
+    if (RefPtr monitor = wheelEventTestMonitor())
         monitor->removeDeferralForReason(scrollableArea().scrollingNodeIDForTesting(), WheelEventTestMonitor::DeferReason::ContentScrollInProgress);
 
     ScrollbarsController::didEndScrollGesture();
@@ -828,7 +828,7 @@ void ScrollbarsControllerMac::didAddVerticalScrollbar(Scrollbar* scrollbar)
     m_verticalScrollerImpDelegate = adoptNS([[WebScrollerImpDelegate alloc] initWithScrollbar:scrollbar]);
 
     [painter setDelegate:m_verticalScrollerImpDelegate.get()];
-    if (GraphicsLayer* layer = scrollbar->scrollableArea().layerForVerticalScrollbar())
+    if (RefPtr layer = scrollbar->scrollableArea().layerForVerticalScrollbar())
         [painter setLayer:layer->platformLayer()];
 
     [m_scrollerImpPair setVerticalScrollerImp:painter];
@@ -860,7 +860,7 @@ void ScrollbarsControllerMac::didAddHorizontalScrollbar(Scrollbar* scrollbar)
     m_horizontalScrollerImpDelegate = adoptNS([[WebScrollerImpDelegate alloc] initWithScrollbar:scrollbar]);
 
     [painter setDelegate:m_horizontalScrollerImpDelegate.get()];
-    if (GraphicsLayer* layer = scrollbar->scrollableArea().layerForHorizontalScrollbar())
+    if (RefPtr layer = scrollbar->scrollableArea().layerForHorizontalScrollbar())
         [painter setLayer:layer->platformLayer()];
 
     [m_scrollerImpPair setHorizontalScrollerImp:painter];
@@ -889,8 +889,8 @@ void ScrollbarsControllerMac::invalidateScrollbarPartLayers(Scrollbar* scrollbar
 
 void ScrollbarsControllerMac::verticalScrollbarLayerDidChange()
 {
-    GraphicsLayer* layer = scrollableArea().layerForVerticalScrollbar();
-    Scrollbar* scrollbar = scrollableArea().verticalScrollbar();
+    RefPtr layer = scrollableArea().layerForVerticalScrollbar();
+    RefPtr scrollbar = scrollableArea().verticalScrollbar();
     if (!scrollbar)
         return;
 
@@ -903,8 +903,8 @@ void ScrollbarsControllerMac::verticalScrollbarLayerDidChange()
 
 void ScrollbarsControllerMac::horizontalScrollbarLayerDidChange()
 {
-    GraphicsLayer* layer = scrollableArea().layerForHorizontalScrollbar();
-    Scrollbar* scrollbar = scrollableArea().horizontalScrollbar();
+    RefPtr layer = scrollableArea().layerForHorizontalScrollbar();
+    RefPtr scrollbar = scrollableArea().horizontalScrollbar();
     if (!scrollbar)
         return;
 
@@ -944,22 +944,22 @@ void ScrollbarsControllerMac::notifyContentAreaScrolled(const FloatSize& delta)
 
 void ScrollbarsControllerMac::updateScrollerImps()
 {
-    Scrollbar* verticalScrollbar = scrollableArea().verticalScrollbar();
+    RefPtr verticalScrollbar = scrollableArea().verticalScrollbar();
     if (verticalScrollbar && !verticalScrollbar->isCustomScrollbar()) {
         verticalScrollbar->invalidate();
 
         NSScrollerImp *oldVerticalPainter = [m_scrollerImpPair verticalScrollerImp];
-        auto* verticalScrollbarMac = dynamicDowncast<ScrollbarMac>(verticalScrollbar);
+        RefPtr verticalScrollbarMac = dynamicDowncast<ScrollbarMac>(verticalScrollbar);
         verticalScrollbarMac->createScrollerImp(WTFMove(oldVerticalPainter));
         [m_scrollerImpPair setVerticalScrollerImp:verticalScrollbarMac->scrollerImp()];
     }
 
-    Scrollbar* horizontalScrollbar = scrollableArea().horizontalScrollbar();
+    RefPtr horizontalScrollbar = scrollableArea().horizontalScrollbar();
     if (horizontalScrollbar && !horizontalScrollbar->isCustomScrollbar()) {
         horizontalScrollbar->invalidate();
 
         NSScrollerImp *oldHorizontalPainter = [m_scrollerImpPair horizontalScrollerImp];
-        auto* horizontalScrollbarMac = dynamicDowncast<ScrollbarMac>(horizontalScrollbar);
+        RefPtr horizontalScrollbarMac = dynamicDowncast<ScrollbarMac>(horizontalScrollbar);
         horizontalScrollbarMac->createScrollerImp(WTFMove(oldHorizontalPainter));
         [m_scrollerImpPair setHorizontalScrollerImp:horizontalScrollbarMac->scrollerImp()];
     }
@@ -1026,7 +1026,7 @@ void ScrollbarsControllerMac::sendContentAreaScrolledTimerFired()
     sendContentAreaScrolled(m_contentAreaScrolledTimerScrollDelta);
     m_contentAreaScrolledTimerScrollDelta = { };
 
-    if (auto* monitor = wheelEventTestMonitor())
+    if (RefPtr monitor = wheelEventTestMonitor())
         monitor->removeDeferralForReason(scrollableArea().scrollingNodeIDForTesting(), WheelEventTestMonitor::DeferReason::ContentScrollInProgress);
 }
 
@@ -1037,7 +1037,7 @@ void ScrollbarsControllerMac::sendContentAreaScrolledSoon(const FloatSize& delta
     if (!m_sendContentAreaScrolledTimer.isActive())
         m_sendContentAreaScrolledTimer.startOneShot(0_s);
 
-    if (auto* monitor = wheelEventTestMonitor())
+    if (RefPtr monitor = wheelEventTestMonitor())
         monitor->deferForReason(scrollableArea().scrollingNodeIDForTesting(), WheelEventTestMonitor::DeferReason::ContentScrollInProgress);
 }
 


### PR DESCRIPTION
#### 4a9b4121bc2eb68a70df8de623e2587f5c736986
<pre>
Some smart pointer adoption in platform/mac
<a href="https://bugs.webkit.org/show_bug.cgi?id=295196">https://bugs.webkit.org/show_bug.cgi?id=295196</a>

Reviewed by Charlie Wolfe.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/296805@main">https://commits.webkit.org/296805@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6b074ff410b3e930721ccb7172c8cc8c60660f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29336 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115699 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59912 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111641 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37924 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83346 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112626 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23917 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98775 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63805 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23298 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16920 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59493 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/93292 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16957 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118491 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36717 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27193 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92354 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37090 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95034 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92175 "Found 2 new API test failures: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37132 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14881 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32545 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17694 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36611 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42082 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36272 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39614 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37981 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->