### PR TITLE
Implement speculation rules - same origin conservative prefetch

### DIFF
--- a/LayoutTests/imported/w3c/resources/import-expectations.json
+++ b/LayoutTests/imported/w3c/resources/import-expectations.json
@@ -308,6 +308,8 @@
     "web-platform-tests/signed-exchange": "skip",
     "web-platform-tests/soft-navigation-heuristics": "skip",
     "web-platform-tests/speculation-rules": "skip",
+    "web-platform-tests/speculation-rules/prefetch": "import",
+    "web-platform-tests/speculation-rules/resources": "import",
     "web-platform-tests/speech-api": "import",
     "web-platform-tests/storage": "import",
     "web-platform-tests/storage-access-api": "import",

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/anonymous-client.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/anonymous-client.https-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/anonymous-client.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/anonymous-client.https.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/utils.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+<script>
+  setup(() => assertSpeculationRulesIsSupported());
+
+  promise_test(async t => {
+    let agent = await spawnWindow(t);
+    let nextUrl = agent.getExecutorURL({ hostname: CROSS_ORIGIN_HOST_THAT_WORKS_WITH_ACIWCO, page: 2 });
+    await agent.forceSinglePrefetch(nextUrl, { requires: ["anonymous-client-ip-when-cross-origin"] });
+    await agent.navigate(nextUrl);
+
+    let requestHeaders = await agent.getRequestHeaders();
+    assert_prefetched_anonymous_client_ip(requestHeaders);
+  }, "test anonymous-client url prefetch for cross origin pages");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/clear-prefetch-cache-after-clear-site-data-cache.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/clear-prefetch-cache-after-clear-site-data-cache.https-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/clear-prefetch-cache-after-clear-site-data-cache.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/clear-prefetch-cache-after-clear-site-data-cache.https.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/utils.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+<script>
+  setup(() => assertSpeculationRulesIsSupported());
+
+  // Test that Clear-Site-Data header value "prefetchCache" clears prefetch cache
+  promise_test(async t => {
+    let agent = await spawnWindow(t, { protocol: 'https' });
+    let nextUrl = agent.getExecutorURL({protocol: 'https', page: 2 });
+    await agent.forceSinglePrefetch(nextUrl);
+
+    // Open new window with url to clear cache data through Clear-Site-Data header.
+    // Ensure that the cache is cleared before the navigation.
+    const gotMessage = new Promise(resolve => {
+      window.addEventListener('message', e => {
+        resolve(e.data);
+      }, {
+        once: true
+      });
+    });
+    window.open("/../../clear-site-data/support/clear-site-data-prefetchCache.py");
+    await gotMessage;
+
+    await agent.navigate(nextUrl);
+    // Because Clear-Site-Data response header is sent, prefetches are expected
+    // to be evicted.
+    // The navigation to nextURL is not expected to use the prefetch cache.
+    assert_not_prefetched(await agent.getRequestHeaders());
+  }, "clear-site-data prefetchCache headers should prevent it from being fetched");
+
+    // Test that Clear-Site-Data header value "cache" clears prefetch cache
+  promise_test(async t => {
+    let agent = await spawnWindow(t, { protocol: 'https' });
+    let nextUrl = agent.getExecutorURL({protocol: 'https', page: 2 });
+    await agent.forceSinglePrefetch(nextUrl);
+
+    // Open new window with url to clear cache data through Clear-Site-Data header.
+    // Ensure that the cache is cleared before the navigation.
+    const gotMessage = new Promise(resolve => {
+      window.addEventListener('message', e => {
+        resolve(e.data);
+      }, {
+        once: true
+      });
+    });
+    let cache_helper = "cache_helper=" + self.crypto.randomUUID() + "&";
+    window.open("/../../clear-site-data/support/clear-site-data-cache.py?" + cache_helper + "response=single_html&cache&clear_first=all");
+    await gotMessage;
+
+    await agent.navigate(nextUrl);
+    // Because Clear-Site-Data response header is sent, prefetches are expected
+    // to be evicted.
+    // The navigation to nextURL is not expected to use the prefetch cache.
+    assert_not_prefetched(await agent.getRequestHeaders());
+  }, "clear-site-data cache headers should prevent it from being fetched");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src='/resources/testdriver-vendor.js'></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/subset-tests-by-key.js"></script>
+<script src="/common/utils.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+<meta name="variant" content="?include=unchanged">
+<meta name="variant" content="?include=changed">
+<meta name="variant" content="?include=unchangedWithRedirect">
+<meta name="variant" content="?include=changedWithRedirect">
+<meta name="variant" content="?include=changedWithRedirect2">
+<meta name="variant" content="?include=changedWithRedirect3">
+<script>
+setup(() => assertSpeculationRulesIsSupported());
+
+subsetTestByKey("unchanged", promise_test, async t => {
+  await test_driver.delete_all_cookies();
+  document.cookie = 'vary1=hello';
+
+  let agent = await spawnWindow(t);
+
+  let nextUrl = agent.getExecutorURL({ executor: "cookies.py", cookieindices: "1" });
+  await agent.forceSinglePrefetch(nextUrl);
+  await agent.navigate(nextUrl);
+
+  assert_prefetched(await agent.getRequestHeaders());
+  let request_cookies = await agent.getRequestCookies();
+  let response_cookies = await agent.getResponseCookies();
+  assert_equals(request_cookies.vary1, "hello");
+  assert_equals(request_cookies.vary2, undefined);
+  assert_equals(response_cookies.vary1, "hello");
+  assert_equals(response_cookies.vary2, undefined);
+}, "Cookie-Indices should not prevent a prefetch from succeeding if the cookie has not changed.");
+
+subsetTestByKey("changed", promise_test, async t => {
+  await test_driver.delete_all_cookies();
+  document.cookie = 'vary1=hello';
+
+  let agent = await spawnWindow(t);
+
+  let nextUrl = agent.getExecutorURL({ executor: "cookies.py", cookieindices: "1" });
+  await agent.forceSinglePrefetch(nextUrl);
+  document.cookie = 'vary1=two';
+  await agent.navigate(nextUrl);
+
+  assert_not_prefetched(await agent.getRequestHeaders());
+  let request_cookies = await agent.getRequestCookies();
+  let response_cookies = await agent.getResponseCookies();
+  assert_equals(request_cookies.vary1, "two");
+  assert_equals(request_cookies.vary2, undefined);
+  assert_equals(response_cookies.vary1, "two");
+  assert_equals(response_cookies.vary2, undefined);
+}, "Cookie-Indices should prevent a prefetch from being used if the cookie has changed.");
+
+subsetTestByKey("unchangedWithRedirect", promise_test, async t => {
+  await test_driver.delete_all_cookies();
+
+  document.cookie = 'vary1=hello';
+
+  let agent = await spawnWindow(t);
+
+  let finalUrl = agent.getExecutorURL({ executor: "cookies.py", cookieindices: "1" });
+  let nextUrl = new URL("/common/redirect.py?location=" + encodeURIComponent(finalUrl), document.baseURI);
+  await agent.forceSinglePrefetch(nextUrl);
+  await agent.navigate(nextUrl, {expectedDestinationUrl: finalUrl});
+
+  assert_prefetched(await agent.getRequestHeaders());
+  let request_cookies = await agent.getRequestCookies();
+  let response_cookies = await agent.getResponseCookies();
+  assert_equals(request_cookies.vary1, "hello");
+  assert_equals(request_cookies.vary2, undefined);
+  assert_equals(response_cookies.vary1, "hello");
+  assert_equals(response_cookies.vary2, undefined);
+}, "Cookie-Indices should not prevent a prefetch from succeeding with unchanged cookies, even with redirect");
+
+subsetTestByKey("changedWithRedirect", promise_test, async t => {
+  await test_driver.delete_all_cookies();
+
+  document.cookie = 'vary1=hello';
+
+  let agent = await spawnWindow(t);
+
+  let finalUrl = agent.getExecutorURL({ executor: "cookies.py", cookieindices: "1" });
+  let nextUrl = new URL("/common/redirect.py?location=" + encodeURIComponent(finalUrl), document.baseURI);
+  await agent.forceSinglePrefetch(nextUrl);
+  document.cookie = 'vary1=two';
+  await agent.navigate(nextUrl, {expectedDestinationUrl: finalUrl});
+
+  assert_not_prefetched(await agent.getRequestHeaders());
+  let request_cookies = await agent.getRequestCookies();
+  let response_cookies = await agent.getResponseCookies();
+  assert_equals(request_cookies.vary1, "two");
+  assert_equals(request_cookies.vary2, undefined);
+  assert_equals(response_cookies.vary1, "two");
+  assert_equals(response_cookies.vary2, undefined);
+}, "Cookie-Indices should prevent a prefetch from succeeding if the cookie changed, with a redirect");
+
+subsetTestByKey("changedWithRedirect2", promise_test, async t => {
+  await test_driver.delete_all_cookies();
+
+  document.cookie = 'vary1=hello';
+
+  let agent = await spawnWindow(t);
+
+  // One subtlety here: the wptserve pipe parser doesn't allow commas inside
+  // the header value (since that delimits the pipe arguments).
+  // There is currently no way around this, so we simply don't use a value with a comma.
+  let finalUrl = agent.getExecutorURL({ executor: "cookies.py" });
+  let pipe = "header(Cache-Control,no-store)|header(Vary,Cookie)|header(Cookie-Indices,\"vary1\")";
+  let nextUrl = new URL(`/common/redirect.py?location=${encodeURIComponent(finalUrl)}&pipe=${encodeURIComponent(pipe)}`, document.baseURI);
+  await agent.forceSinglePrefetch(nextUrl);
+  document.cookie = 'vary1=two';
+  await agent.navigate(nextUrl, {expectedDestinationUrl: finalUrl});
+
+  assert_prefetched(await agent.getRequestHeaders());
+  let request_cookies = await agent.getRequestCookies();
+  let response_cookies = await agent.getResponseCookies();
+  assert_equals(request_cookies.vary1, "hello");
+  assert_equals(request_cookies.vary2, undefined);
+  assert_equals(response_cookies.vary1, "two");
+  assert_equals(response_cookies.vary2, undefined);
+}, "If the redirect needs to be rerequested but goes to the same place and that one doesn't vary, we actually can use the prefetched final response.");
+
+subsetTestByKey("changedWithRedirect3", promise_test, async t => {
+  await test_driver.delete_all_cookies();
+
+  document.cookie = 'vary1=hello';
+
+  let agent = await spawnWindow(t);
+
+  // One subtlety here: the wptserve pipe parser doesn't allow commas inside
+  // the header value (since that delimits the pipe arguments).
+  // There is currently no way around this, so we simply don't use a value with a comma.
+  let finalUrl = agent.getExecutorURL({ executor: "cookies.py" });
+  let pipe = "header(Cache-Control,no-store)|header(Vary,Cookie)|header(Cookie-Indices,\"vary1\")";
+  let nextUrl = new URL(`resources/random_redirect.py?location=${encodeURIComponent(finalUrl)}&pipe=${encodeURIComponent(pipe)}`, document.baseURI);
+  await agent.forceSinglePrefetch(nextUrl);
+  document.cookie = 'vary1=two';
+  await agent.navigate(nextUrl, {expectedDestinationUrl: null});
+
+  assert_not_prefetched(await agent.getRequestHeaders());
+  let request_cookies = await agent.getRequestCookies();
+  let response_cookies = await agent.getResponseCookies();
+  assert_equals(request_cookies.vary1, "two");
+  assert_equals(request_cookies.vary2, undefined);
+  assert_equals(response_cookies.vary1, "two");
+  assert_equals(response_cookies.vary2, undefined);
+}, "If the redirect needs to be rerequested and goes elsewhere, we cannot can use the prefetched final response.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https_include=changed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https_include=changed-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https_include=changedWithRedirect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https_include=changedWithRedirect-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https_include=changedWithRedirect2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https_include=changedWithRedirect2-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https_include=changedWithRedirect3-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https_include=changedWithRedirect3-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https_include=unchanged-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https_include=unchanged-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https_include=unchangedWithRedirect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https_include=unchangedWithRedirect-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cross-origin-cookies-anonymous-client-ip-duplicate.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cross-origin-cookies-anonymous-client-ip-duplicate.https-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cross-origin-cookies-anonymous-client-ip-duplicate.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cross-origin-cookies-anonymous-client-ip-duplicate.https.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src='/resources/testdriver-vendor.js'></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/utils.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+<script>
+  setup(() => assertSpeculationRulesIsSupported());
+
+  promise_test(async t => {
+    await test_driver.delete_all_cookies();
+
+    let executor = 'cookies.py';
+    let agent = await spawnWindow(t, { executor });
+    let response_cookies = await agent.getResponseCookies();
+    let request_cookies = await agent.getRequestCookies();
+    assert_equals(request_cookies["count"], undefined);
+    assert_equals(request_cookies["type"], undefined);
+    assert_equals(response_cookies["count"], "1");
+    assert_equals(response_cookies["type"], "navigate");
+
+    let nextUrl = agent.getExecutorURL({ executor, hostname: CROSS_ORIGIN_HOST_THAT_WORKS_WITH_ACIWCO, page: 2 });
+    await agent.forceSinglePrefetch(nextUrl, { requires: ["anonymous-client-ip-when-cross-origin"] });
+    await agent.forceSinglePrefetch(nextUrl);
+    await agent.navigate(nextUrl);
+
+    response_cookies = await agent.getResponseCookies();
+    request_cookies = await agent.getRequestCookies();
+    assert_equals(request_cookies["count"], undefined);
+    assert_equals(request_cookies["type"], undefined);
+    assert_equals(response_cookies["count"], "1");
+    assert_equals(response_cookies["type"], "prefetch");
+
+    let requestHeaders = await agent.getRequestHeaders();
+    assert_prefetched_anonymous_client_ip(requestHeaders);
+  }, "speculation rules based prefetch should not use cookies for cross origin urls and should issue only the IP-anonymized request if that one is first.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cross-origin-cookies.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cross-origin-cookies.https-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cross-origin-cookies.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cross-origin-cookies.https.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src='/resources/testdriver-vendor.js'></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/utils.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+<script>
+  setup(() => assertSpeculationRulesIsSupported());
+
+  promise_test(async t => {
+    await test_driver.delete_all_cookies();
+
+    let executor = 'cookies.py';
+    let agent = await spawnWindow(t, { executor });
+    let response_cookies = await agent.getResponseCookies();
+    let request_cookies = await agent.getRequestCookies();
+    assert_equals(request_cookies["count"], undefined);
+    assert_equals(request_cookies["type"], undefined);
+    assert_equals(response_cookies["count"], "1");
+    assert_equals(response_cookies["type"], "navigate");
+
+    let nextUrl = agent.getExecutorURL({ executor, hostname: get_host_info().NOTSAMESITE_HOST, page: 2 });
+    await agent.forceSinglePrefetch(nextUrl);
+    await agent.navigate(nextUrl);
+
+    response_cookies = await agent.getResponseCookies();
+    request_cookies = await agent.getRequestCookies();
+    assert_equals(request_cookies["count"], undefined);
+    assert_equals(request_cookies["type"], undefined);
+    assert_equals(response_cookies["count"], "1");
+    assert_equals(response_cookies["type"], "prefetch");
+
+    let requestHeaders = await agent.getRequestHeaders();
+    assert_prefetched(requestHeaders);
+  }, "speculation rules based prefetch should not use cookies for cross origin urls.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators-2.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators-2.https-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators-2.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators-2.https.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
+<script>
+setup(() => assertSpeculationRulesIsSupported());
+
+// Regression test for https://crbug.com/1431804.
+promise_test(async t => {
+  const win = await spawnWindow(t, { protocol: 'https' });
+  const nextUrl = win.getExecutorURL({ protocol: 'https', page: 2 });
+
+  // Navigate `win` from Document #1 -> #2 (nextUrl) -> #3 (tempUrl) ->
+  // #4 (nextUrl),
+  // Start speculation rules prefetch from #1, and
+  // Try using the prefetched result for the navigation #3 -> #4.
+  // The Documents #2 and #4 are different, but the same RenderFrameHost is
+  // used before https://crbug.com/936696 is done.
+
+  await win.forceSinglePrefetch(nextUrl);
+
+  // Register a SW for `nextUrl` -- this is a trick to make the prefetched
+  // result to put in `PrefetchService::prefetches_ready_to_serve_` in
+  // Chromium implementation but actually not used by this navigation.
+  const r = await service_worker_unregister_and_register(
+      t, 'resources/sw.js', nextUrl);
+  await wait_for_state(t, r.installing, 'activated');
+
+  // Navigate #1 -> #2.
+  // This doesn't use the prefetched result due to the ServiceWorker.
+  await win.navigate(nextUrl);
+
+  // Unregister the SW.
+  await service_worker_unregister(t, nextUrl);
+
+  // Navigate #2 -> #3 -> #4.
+  const tempUrl = win.getExecutorURL({ protocol: 'https', page: 3 });
+  await win.navigate(tempUrl);
+  await win.navigate(nextUrl);
+
+  const headers = await win.execute_script(() => {
+    return requestHeaders;
+  }, []);
+  assert_not_prefetched(headers,
+      "Prefetch should not work for different initiators.");
+}, "Prefetches from different initiator Documents with same RenderFrameHost");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators.sub.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators.sub.https.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
+
+<meta name="variant" content="?cross-site-1">
+<meta name="variant" content="?cross-site-2">
+<meta name="variant" content="?same-site">
+
+<script>
+setup(() => assertSpeculationRulesIsSupported());
+
+// Regression test for https://crbug.com/1423234.
+promise_test(async t => {
+  // Open 2 windows.
+  const hostname1 =
+      location.search === '?cross-site-1' ? '{{hosts[alt][www]}}' : undefined;
+  const hostname2 =
+      location.search === '?cross-site-2' ? '{{hosts[alt][www]}}' : undefined;
+  const initiator1 = await spawnWindow(
+      t, { protocol: 'https', hostname: hostname1 });
+  const initiator2 = await spawnWindow(
+      t, { protocol: 'https', hostname: hostname2 });
+
+  // Start speculation rules prefetch from `initiator1`.
+  const nextUrl = initiator1.getExecutorURL({ protocol: 'https', page: 2 });
+  await initiator1.forceSinglePrefetch(nextUrl);
+
+  // Register a SW for `nextUrl` -- this is a trick to make the prefetched
+  // result to put in `PrefetchService::prefetches_ready_to_serve_` in
+  // Chromium implementation but actually not used by this navigation.
+  const r = await service_worker_unregister_and_register(
+      t, 'resources/sw.js', nextUrl);
+  await wait_for_state(t, r.installing, 'activated');
+
+  // Navigate `initiator1`.
+  // This doesn't use the prefetched result due to the ServiceWorker.
+  await initiator1.navigate(nextUrl);
+
+  // Navigate `initiator1` away from `nextUrl`.
+  const headers1 = await initiator1.execute_script(() => {
+    window.executor.suspend(() => {
+      location.href = 'about:blank';
+    });
+    return requestHeaders;
+  }, []);
+
+  // Unregister the SW.
+  await service_worker_unregister(t, nextUrl);
+
+  // Navigate `initiator2`.
+  // This shouldn't use the prefetched result because the initiator Documents
+  // (even sites) are different.
+  await initiator2.execute_script((url) => {
+    window.executor.suspend(() => {
+      location.href = url;
+    });
+  }, [nextUrl]);
+
+  // Note: while the Window for `initiator2` remains open, the executor ID of
+  // the page is the ID of `nextUrl`, which is `initiator1.context_id`.
+  // So `initiator1` is used below for manipulating the Window for `initiator2`.
+  assert_equals(
+      await initiator1.execute_script(() => location.href),
+      nextUrl.toString(),
+      "expected navigation to reach destination URL");
+
+  const headers2 = await initiator1.execute_script(() => {
+    return requestHeaders;
+  }, []);
+
+  assert_not_prefetched(headers1,
+      "Prefetch should not work due to ServiceWorker.");
+
+  assert_not_prefetched(headers2,
+      "Prefetch should not work for different initiators.");
+}, "Cross-initiator prefetches using ServiceWorker tricks");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators.sub.https_cross-site-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators.sub.https_cross-site-1-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators.sub.https_cross-site-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators.sub.https_cross-site-2-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators.sub.https_same-site-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators.sub.https_same-site-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+<script src="/common/subset-tests-by-key.js"></script>
+
+<meta name="variant" content="?include=defaultPredicate">
+<meta name="variant" content="?include=hrefMatches">
+<meta name="variant" content="?include=and">
+<meta name="variant" content="?include=or">
+<meta name="variant" content="?include=not">
+<meta name="variant" content="?include=invalidPredicate">
+<meta name="variant" content="?include=linkInShadowTree">
+<meta name="variant" content="?include=linkHrefChanged">
+<meta name="variant" content="?include=newRuleSetAdded">
+<meta name="variant" content="?include=selectorMatches">
+<meta name="variant" content="?include=selectorMatchesScopingRoot">
+<meta name="variant" content="?include=selectorMatchesDisplayNone">
+<meta name="variant" content="?include=selectorMatchesDisplayLocked">
+<meta name="variant" content="?include=unslottedLink">
+<meta name="variant" content="?include=immediateMutation">
+<meta name="variant" content="?include=baseURLChangedBySameDocumentNavigation">
+<meta name="variant" content="?include=baseURLChangedByBaseElement">
+<meta name="variant" content="?include=linkToSelfFragment">
+
+<body>
+<script>
+  setup(() => assertSpeculationRulesIsSupported());
+
+  subsetTestByKey('defaultPredicate', promise_test, async t => {
+    const url = getPrefetchUrl();
+    addLink(url);
+    insertDocumentRule();
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+
+    assert_equals(await isUrlPrefetched(url), 1);
+  }, 'test document rule with no predicate');
+
+  subsetTestByKey('hrefMatches', promise_test, async t => {
+    insertDocumentRule({ href_matches: '*\\?uuid=*&foo=bar' });
+
+    const url_1 = getPrefetchUrl({foo: 'bar'});
+    addLink(url_1);
+    const url_2 = getPrefetchUrl({foo: 'buzz'});
+    addLink(url_2)
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+
+    assert_equals(await isUrlPrefetched(url_1), 1);
+    assert_equals(await isUrlPrefetched(url_2), 0);
+  }, 'test href_matches document rule');
+
+  subsetTestByKey('and', promise_test, async t => {
+    insertDocumentRule({
+      'and': [
+        { href_matches: '*\\?*foo=bar*' },
+        { href_matches: '*\\?*fizz=buzz*' }]
+    });
+
+    const url_1 = getPrefetchUrl({foo: 'bar'});
+    const url_2 = getPrefetchUrl({fizz: 'buzz'});
+    const url_3 = getPrefetchUrl({foo: 'bar', fizz: 'buzz'});
+    [url_1, url_2, url_3].forEach(url => addLink(url));
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+
+    assert_equals(await isUrlPrefetched(url_1), 0);
+    assert_equals(await isUrlPrefetched(url_2), 0);
+    assert_equals(await isUrlPrefetched(url_3), 1);
+  }, 'test document rule with conjunction predicate');
+
+  subsetTestByKey('or', promise_test, async t => {
+    insertDocumentRule({
+      'or': [
+        { href_matches: '*\\?*foo=bar*' },
+        { href_matches: '*\\?*fizz=buzz*' }]
+    });
+
+    const url_1 = getPrefetchUrl({ foo: 'buzz' });
+    const url_2 = getPrefetchUrl({ fizz: 'buzz' });
+    const url_3 = getPrefetchUrl({ foo: 'bar'});
+    [url_1, url_2, url_3].forEach(url => addLink(url));
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+
+    assert_equals(await isUrlPrefetched(url_1), 0);
+    assert_equals(await isUrlPrefetched(url_2), 1);
+    assert_equals(await isUrlPrefetched(url_3), 1);
+  }, 'test document rule with disjunction predicate');
+
+  subsetTestByKey('not', promise_test, async t => {
+    insertDocumentRule({ not: { href_matches: '*\\?uuid=*&foo=bar' } });
+
+    const url_1 = getPrefetchUrl({foo: 'bar'});
+    addLink(url_1);
+    const url_2 = getPrefetchUrl({foo: 'buzz'});
+    addLink(url_2)
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+
+    assert_equals(await isUrlPrefetched(url_1), 0);
+    assert_equals(await isUrlPrefetched(url_2), 1);
+  }, 'test document rule with negation predicate');
+
+  subsetTestByKey('invalidPredicate', promise_test, async t => {
+    const url = getPrefetchUrl();
+    addLink(url);
+    insertDocumentRule({invalid: 'predicate'});
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+
+    assert_equals(await isUrlPrefetched(url), 0);
+  }, 'invalid predicate should not throw error or start prefetch');
+
+  subsetTestByKey('linkInShadowTree', promise_test, async t => {
+    insertDocumentRule();
+
+    // Create shadow root.
+    const shadowHost = document.createElement('div');
+    document.body.appendChild(shadowHost);
+    const shadowRoot = shadowHost.attachShadow({mode: 'open'});
+
+    const url = getPrefetchUrl();
+    addLink(url, shadowRoot);
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+
+    assert_equals(await isUrlPrefetched(url), 1);
+  }, 'test that matching link in a shadow tree is prefetched');
+
+  subsetTestByKey('linkHrefChanged', promise_test, async t => {
+    insertDocumentRule({href_matches: "*\\?*foo=bar*"});
+
+    const url = getPrefetchUrl();
+    const link = addLink(url);
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+    assert_equals(await isUrlPrefetched(url), 0);
+
+    const matching_url = getPrefetchUrl({foo: 'bar'});
+    link.href = matching_url;
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+    assert_equals(await isUrlPrefetched(matching_url), 1);
+  }, 'test that changing the href of an invalid link to a matching value triggers a prefetch');
+
+  subsetTestByKey('newRuleSetAdded', promise_test, async t => {
+    insertDocumentRule({href_matches: "*\\?*foo=bar*"});
+    const url = getPrefetchUrl({fizz: "buzz"});
+    addLink(url);
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+    assert_equals(await isUrlPrefetched(url), 0);
+
+    insertDocumentRule({href_matches: "*\\?*fizz=buzz*"});
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+    assert_equals(await isUrlPrefetched(url), 1);
+  }, 'test that adding a second rule set triggers prefetch');
+
+  subsetTestByKey('selectorMatches', promise_test, async t => {
+    insertDocumentRule({ selector_matches: 'a.important-link' });
+
+    const url_1 = getPrefetchUrl({foo: 'bar'});
+    const importantLink = addLink(url_1);
+    importantLink.className = 'important-link';
+    const url_2 = getPrefetchUrl({foo: 'buzz'});
+    addLink(url_2)
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+
+    assert_equals(await isUrlPrefetched(url_1), 1);
+    assert_equals(await isUrlPrefetched(url_2), 0);
+  }, 'test selector_matches document rule');
+
+  subsetTestByKey('selectorMatchesScopingRoot', promise_test, async t => {
+    insertDocumentRule({ selector_matches: ':root > body > a' });
+
+    const url_1 = getPrefetchUrl({ foo: 'bar' });
+    addLink(url_1);
+
+    const url_2 = getPrefetchUrl({ foo: 'buzz' });
+    const extraContainer = document.createElement('div');
+    document.body.appendChild(extraContainer);
+    addLink(url_2, extraContainer);
+
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+
+    assert_equals(await isUrlPrefetched(url_1), 1);
+    assert_equals(await isUrlPrefetched(url_2), 0);
+  }, 'test selector_matches with :root');
+
+  subsetTestByKey('selectorMatchesDisplayNone', promise_test, async t => {
+    const style = document.createElement('style');
+    style.innerText = ".important-section { display: none; }";
+    document.head.appendChild(style);
+    insertDocumentRule();
+
+    const importantSection = document.createElement('div');
+    importantSection.className = 'important-section';
+    document.body.appendChild(importantSection);
+    const url = getPrefetchUrl();
+    addLink(url, importantSection);
+
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+    assert_equals(await isUrlPrefetched(url), 0);
+
+    style.remove();
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+    assert_equals(await isUrlPrefetched(url), 1);
+  }, 'test selector_matches with link inside display:none container');
+
+  subsetTestByKey('selectorMatchesDisplayLocked', promise_test, async t => {
+    const style = document.createElement('style');
+    style.innerText = ".important-section { content-visibility: hidden; }";
+    document.head.appendChild(style);
+    insertDocumentRule({ selector_matches: '.important-section a' });
+
+    const importantSection = document.createElement('div');
+    importantSection.className = 'important-section';
+    document.body.appendChild(importantSection);
+    const url = getPrefetchUrl();
+    addLink(url, importantSection);
+
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+    assert_equals(await isUrlPrefetched(url), 0);
+
+    style.remove();
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+    assert_equals(await isUrlPrefetched(url), 1);
+  }, 'test selector_matches with link inside display locked container');
+
+  subsetTestByKey('unslottedLink', promise_test, async t => {
+    insertDocumentRule();
+
+    // Create shadow root.
+    const shadowHost = document.createElement('div');
+    document.body.appendChild(shadowHost);
+    const shadowRoot = shadowHost.attachShadow({ mode: 'open' });
+
+    // Add unslotted link.
+    const url = getPrefetchUrl();
+    addLink(url, shadowHost);
+
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+    assert_equals(await isUrlPrefetched(url), 0);
+  }, 'test that unslotted link never matches document rule');
+
+  subsetTestByKey('immediateMutation', promise_test, async t => {
+    // Add a link and allow it to get its style computed.
+    // (Double RAF lets this happen normally.)
+    const url = getPrefetchUrl();
+    const link = addLink(url, document.body);
+    await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
+
+    // Add a document rule and then immediately change the DOM to make it match.
+    insertDocumentRule({ selector_matches: '.late-class *' });
+    document.body.className = 'late-class';
+
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+    assert_equals(await isUrlPrefetched(url), 1);
+  }, 'test that selector_matches predicates respect changes immediately');
+
+  const baseURLChangedTestFixture = (testName, modifyBaseURLFunc) => {
+    return subsetTestByKey(testName, promise_test, async t => {
+      const url = getPrefetchUrl();
+      const link = addLink(url);
+      const url_pattern_string = `prefetch.py${url.search}`;
+
+      // Insert a document rule with a url pattern predicate that uses a
+      // relative URL which will not match with |url|, due to |document.baseURI|
+      // being different from |url|'s path.
+      assert_false((new URLPattern(url_pattern_string, document.baseURI)).test(url));
+      insertDocumentRule({ href_matches: url_pattern_string });
+      await new Promise(resolve => t.step_timeout(resolve, 2000));
+      assert_equals(await isUrlPrefetched(url), 0);
+
+      // Change the baseURL of the document to |url|. |url| should now be
+      // prefetched.
+      modifyBaseURLFunc(url);
+      assert_true((new URLPattern(url_pattern_string, document.baseURI)).test(url));
+      await new Promise(resolve => t.step_timeout(resolve, 2000));
+      assert_equals(await isUrlPrefetched(url), 1);
+    });
+  }
+
+  baseURLChangedTestFixture('baseURLChangedBySameDocumentNavigation', url => {
+    history.pushState({}, "", url);
+  });
+
+  baseURLChangedTestFixture('baseURLChangedByBaseElement', url => {
+    const base = document.createElement('base');
+    base.href = url;
+    document.head.appendChild(base);
+  });
+
+  subsetTestByKey('linkToSelfFragment', promise_test, async t => {
+    const url = getPrefetchUrl();
+    history.pushState({}, "", url);
+    addLink(new URL('#fragment', url));
+    insertDocumentRule();
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+    assert_equals(await isUrlPrefetched(url), 0);
+  }, 'test that a fragment link to the current document does not prefetch');
+
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=and-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=and-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=baseURLChangedByBaseElement-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=baseURLChangedByBaseElement-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=baseURLChangedBySameDocumentNavigation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=baseURLChangedBySameDocumentNavigation-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=defaultPredicate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=defaultPredicate-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=hrefMatches-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=hrefMatches-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=immediateMutation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=immediateMutation-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=invalidPredicate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=invalidPredicate-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=linkHrefChanged-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=linkHrefChanged-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=linkInShadowTree-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=linkInShadowTree-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=linkToSelfFragment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=linkToSelfFragment-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=newRuleSetAdded-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=newRuleSetAdded-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=not-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=not-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=or-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=or-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatches-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatches-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatchesDisplayLocked-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatchesDisplayLocked-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatchesDisplayNone-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatchesDisplayNone-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatchesScopingRoot-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatchesScopingRoot-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=unslottedLink-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=unslottedLink-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/duplicate-urls.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/duplicate-urls.https-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/duplicate-urls.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/duplicate-urls.https.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/utils.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+
+<script>
+  setup(() => assertSpeculationRulesIsSupported());
+
+  promise_test(async t => {
+    let urls = Array(5).fill(getPrefetchUrlList(1)[0]);
+    insertSpeculationRules({ prefetch: [{ source: 'list', urls: urls }] });
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+
+    let prefetched_count = await isUrlPrefetched(urls[0]);
+    assert_equals(prefetched_count, 1, "url should be prefetched just once.");
+  }, "browser should remove duplicate urls from prefetch buffer.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/fragment.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/fragment.https-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/fragment.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/fragment.https.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/utils.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+<script>
+setup(() => assertSpeculationRulesIsSupported());
+
+promise_test(async t => {
+  const testUrl = document.URL;
+  const [prefetchUrl, anotherPrefetchUrl] = getPrefetchUrlList(2);
+  try {
+    history.pushState({}, '', prefetchUrl);
+    const urls = [
+      new URL('#fragment', prefetchUrl),
+      new URL('#fragment', anotherPrefetchUrl),
+    ];
+    insertSpeculationRules({prefetch: [{source: 'list', urls}]});
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+    assert_equals(await isUrlPrefetched(prefetchUrl), 0);
+    assert_equals(await isUrlPrefetched(anotherPrefetchUrl), 1);
+  } finally {
+    // We needed to temporarily change the document URL to do the previous
+    // test. Undo that to avoid breaking any other test cases.
+    history.back();
+    await new Promise(resolve => {
+      addEventListener('popstate', () => resolve(), {once: true});
+    });
+    await new Promise(resolve => t.step_timeout(resolve, 0));
+    assert_equals(document.URL, testUrl);
+  }
+}, "fragment links to the current document URL are not prefetched");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/implicit-source.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/implicit-source.https-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/implicit-source.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/implicit-source.https.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/utils.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+<body>
+<script>
+  setup(() => assertSpeculationRulesIsSupported());
+
+  promise_test(async t => {
+    let urls = getPrefetchUrlList(2);
+
+    let a = document.createElement('a');
+    a.className = 'prefetch-me';
+    a.href = urls[1];
+    a.textContent = 'prefetch me!';
+    document.body.appendChild(a);
+    t.add_cleanup(() => a.remove());
+
+    insertSpeculationRules({prefetch: [
+      {urls: [urls[0]]},
+      {where: {selector_matches: '.prefetch-me'}, eagerness: 'immediate'},
+    ]});
+
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+
+    let wasPrefetched = urls.map(isUrlPrefetched);
+    assert_true(!!(await wasPrefetched[0]), 'implicit list rule should have worked');
+    assert_true(!!(await wasPrefetched[1]), 'implicit document rule should have worked');
+  }, 'rules should be accepted without an explicit source');
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-a-element.sub.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-a-element.sub.https.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/utils.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+
+<meta name="variant" content="?cross-site">
+<meta name="variant" content="?same-site">
+
+<script>
+  setup(() => assertSpeculationRulesIsSupported());
+
+  // In https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate,
+  // `sourceDocument` (instead of `navigable`'s active document) should be
+  // used as the referring document for prefetch.
+  promise_test(async t => {
+    const win = await spawnWindow(t, { protocol: 'https' });
+
+    const hostname =
+      location.search === '?cross-site' ? '{{hosts[alt][www]}}' : undefined;
+    const nextUrl = win.getExecutorURL({ protocol: 'https', hostname, page: 2 });
+
+    await win.forceSinglePrefetch(nextUrl);
+
+    // sourceDocument == `win`'s Document == active document of window being
+    // navigated.
+    await win.execute_script((url) => {
+      window.executor.suspend(() => {
+        const a = document.createElement('a');
+        a.setAttribute('href', url);
+        document.body.appendChild(a);
+        a.click();
+      });
+    }, [nextUrl]);
+
+    assert_equals(
+        await win.execute_script(() => location.href),
+        nextUrl.toString(),
+        "expected navigation to reach destination URL");
+
+    assert_prefetched(await win.getRequestHeaders());
+  }, `<a>`);
+
+  promise_test(async t => {
+    const win = await spawnWindow(t, { protocol: 'https' });
+
+    const hostname =
+      location.search === '?cross-site' ? '{{hosts[alt][www]}}' : undefined;
+    const nextUrl = win.getExecutorURL({ protocol: 'https', hostname, page: 2 });
+
+    await win.forceSinglePrefetch(nextUrl);
+
+    // sourceDocument == `win`'s Document != active document of window being
+    // navigated, since the window being navigated is a new window.
+    await win.execute_script((url) => {
+      window.executor.suspend(() => {
+        const a = document.createElement('a');
+        a.setAttribute('href', url);
+        a.setAttribute('target', '_blank');
+        document.body.appendChild(a);
+        a.click();
+      });
+    }, [nextUrl]);
+
+    // Below, the scripts given to `win.execute_script()` are executed on the
+    // `nextUrl` page in the new window, because `window.executor.suspend()`
+    // above made `win`'s original page stop processing `execute_script()`,
+    // while the new page of `nextUrl` in the new window starts processing
+    // `execute_script()` for the same ID.
+    assert_equals(
+        await win.execute_script(() => location.href),
+        nextUrl.toString(),
+        "expected navigation to reach destination URL");
+
+    assert_prefetched(await win.getRequestHeaders());
+  }, `<a target="blank">`);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-a-element.sub.https_cross-site-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-a-element.sub.https_cross-site-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-a-element.sub.https_same-site-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-a-element.sub.https_same-site-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-iframe-location-href.sub.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-iframe-location-href.sub.https.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/utils.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+
+<meta name="variant" content="?cross-site">
+<meta name="variant" content="?same-site">
+
+<script>
+  setup(() => assertSpeculationRulesIsSupported());
+
+  // In https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate,
+  // `sourceDocument` (instead of `navigable`'s active document) should be
+  // used as the referring document for prefetch.
+  //
+  // Nonetheless, a prefetch in a top-level window is not suitable to use in an iframe.
+  // In particular, browsers partition storage and cache by top-level site.
+  // If a browser does start allowing these in narrower cases where the partition
+  // would nonetheless be the same, this test might need tweaking.
+  promise_test(async t => {
+    const win = await spawnWindow(t, { protocol: 'https' });
+
+    const hostname =
+      location.search === '?cross-site' ? '{{hosts[alt][www]}}' : undefined;
+    const nextUrl = win.getExecutorURL({ protocol: 'https', hostname, page: 2 });
+
+    await win.forceSinglePrefetch(nextUrl);
+
+    // In https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate,
+    // `sourceDocument` is the incumbent Document and thus `win`'s Document.
+    // `navigable`'s active document is `iframe`'s Document.
+    await win.execute_script((url) => {
+      window.executor.suspend(() => {
+        const iframe = document.createElement('iframe');
+        document.body.appendChild(iframe);
+        iframe.contentWindow.location.href = url;
+      });
+    }, [nextUrl]);
+
+    // Below, the scripts given to `win.execute_script()` are executed on the
+    // `nextUrl` page in the iframe, because `window.executor.suspend()` above
+    // made `win`'s original page stop processing `execute_script()`,
+    // while the new page of `nextUrl` in the iframe starts processing
+    // `execute_script()` for the same ID.
+    assert_equals(
+        await win.execute_script(() => location.href),
+        nextUrl.toString(),
+        "expected navigation to reach destination URL");
+
+    assert_not_prefetched(await win.getRequestHeaders());
+  }, `location.href across iframe`);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-iframe-location-href.sub.https_cross-site-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-iframe-location-href.sub.https_cross-site-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-iframe-location-href.sub.https_same-site-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-iframe-location-href.sub.https_same-site-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-window-open.sub.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-window-open.sub.https.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/utils.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+
+<meta name="variant" content="?cross-site">
+<meta name="variant" content="?same-site">
+
+<script>
+  setup(() => assertSpeculationRulesIsSupported());
+
+  // In https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate,
+  // `sourceDocument` (instead of `navigable`'s active document) should be
+  // used as the referring document for prefetch.
+  promise_test(async t => {
+    const win = await spawnWindow(t, { protocol: 'https' });
+
+    const hostname =
+      location.search === '?cross-site' ? '{{hosts[alt][www]}}' : undefined;
+    const nextUrl = win.getExecutorURL({ protocol: 'https', hostname, page: 2 });
+
+    await win.forceSinglePrefetch(nextUrl);
+
+    await win.execute_script((url) => {
+      window.executor.suspend(() => {
+        window.open(url, "_blank");
+      });
+    }, [nextUrl]);
+
+    // Below, the scripts given to `win.execute_script()` are executed on the
+    // `nextUrl` page in the new window, because `window.executor.suspend()`
+    // above made `win`'s original page stop processing `execute_script()`,
+    // while the new page of `nextUrl` in the new window starts processing
+    // `execute_script()` for the same ID. Same for below.
+    assert_equals(
+        await win.execute_script(() => location.href),
+        nextUrl.toString(),
+        "expected navigation to reach destination URL");
+
+    assert_prefetched(await win.getRequestHeaders());
+  }, `window.open()`);
+
+  promise_test(async t => {
+    const win = await spawnWindow(t, { protocol: 'https' });
+
+    const hostname =
+      location.search === '?cross-site' ? '{{hosts[alt][www]}}' : undefined;
+    const nextUrl = win.getExecutorURL({ protocol: 'https', hostname, page: 2 });
+
+    await win.forceSinglePrefetch(nextUrl);
+
+    await win.execute_script((url) => {
+      window.executor.suspend(() => {
+        window.open(url, "_blank", "noopener");
+      });
+    }, [nextUrl]);
+
+    assert_equals(
+        await win.execute_script(() => location.href),
+        nextUrl.toString(),
+        "expected navigation to reach destination URL");
+
+    assert_prefetched(await win.getRequestHeaders());
+  }, `window.open(noopener)`);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-window-open.sub.https_cross-site-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-window-open.sub.https_cross-site-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-window-open.sub.https_same-site-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-window-open.sub.https_same-site-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/multiple-url.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/multiple-url.https-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/multiple-url.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/multiple-url.https.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/utils.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+
+<script>
+  setup(() => assertSpeculationRulesIsSupported());
+
+  promise_test(async t => {
+    let urls = getPrefetchUrlList(5);
+    insertSpeculationRules({ prefetch: [{ source: 'list', urls: urls }] });
+    await new Promise(resolve => t.step_timeout(resolve, 3000));
+
+    let prefetched_count = (await Promise.all(urls.map(isUrlPrefetched))).reduce(
+      (count, was_prefetched) => count + (was_prefetched ? 1 : 0), 0);
+
+    assert_greater_than_equal(prefetched_count, 2, "At least two urls should be prefetched to pass the test.");
+  }, "browser should be able to prefetch multiple urls");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/utils.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+
+<meta name="variant" content="?prefetch=true&bypass_cache=true">
+<meta name="variant" content="?prefetch=false&bypass_cache=true">
+<meta name="variant" content="?prefetch=true&bypass_cache=false">
+<meta name="variant" content="?prefetch=false&bypass_cache=false">
+
+<script>
+setup(() => assertSpeculationRulesIsSupported());
+
+const prefetchEnabled = (Object.fromEntries(
+  new URLSearchParams(location.search)).prefetch === "true");
+const bypassCache = (Object.fromEntries(
+  new URLSearchParams(location.search)).bypass_cache === "true");
+
+promise_test(async t => {
+    const agent = await spawnWindow(t);
+    // Some meaningless query param to avoid cached response.
+    const prefetchUrl =
+      bypassCache ? agent.getExecutorURL({ a: "b" }) : agent.getExecutorURL();
+
+    if (prefetchEnabled)
+      await agent.forceSinglePrefetch(prefetchUrl);
+
+    await agent.navigate(prefetchUrl);
+
+    if (prefetchEnabled)
+      assert_prefetched(await agent.getRequestHeaders(),
+        `Prefetch ${prefetchUrl.href} should work.`);
+    else
+      assert_not_prefetched(await agent.getRequestHeaders(),
+        `${prefetchUrl.href} should not be prefetched.`);
+
+    await agent.execute_script(
+      () => window.entries = performance.getEntriesByType('navigation'));
+
+    // Expects one entry, whose `deliveryType` is "navigational-prefetch" for
+    // the prefetched request, and "" for the non-prefetched.
+    //
+    // TODO(crbug/1317756): Currently the initial prefetch request bypasses the
+    // HTTP cache, making `deliveryType` always an empty string for non-prefetch
+    // request. Expand test coverage when `net::LOAD_DISABLE_CACHE` is removed.
+    assert_equals(await agent.execute_script(() => window.entries.length), 1,
+      'Wrong number of entries');
+    const deliveryType =
+      await agent.execute_script(() => window.entries[0].deliveryType);
+    const expectedDeliveryType = prefetchEnabled ? 'navigational-prefetch' : '';
+    assert_equals(deliveryType, expectedDeliveryType);
+
+  }, `PerformanceNavigationTiming.deliveryType test, same origin prefetch.`);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=false&bypass_cache=false-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=false&bypass_cache=false-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=false&bypass_cache=true-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=false&bypass_cache=true-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=true&bypass_cache=false-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=true&bypass_cache=false-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=true&bypass_cache=true-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=true&bypass_cache=true-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/utils.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+<script src="/common/subset-tests-by-key.js"></script>
+
+<meta name="variant" content="?include=noPrefetch">
+<meta name="variant" content="?include=afterResponse">
+<meta name="variant" content="?include=waitingForResponse">
+<meta name="variant" content="?include=waitingForRedirect">
+
+<script>
+const setupProperties = {};
+if (shouldRunSubTest('waitingForResponse') || shouldRunSubTest('waitingForRedirect')) {
+  // These tests rely on the relationship between these timeouts, the delays
+  // on the server, and any vendor specific timeouts. Force a multiplier of 1,
+  // since using setTimeout directly incurs the wrath of `wpt lint`.
+  setupProperties.timeout_multiplier = 1;
+}
+setup(() => assertSpeculationRulesIsSupported(), setupProperties);
+
+subsetTestByKey('noPrefetch', promise_test, async t => {
+  const agent = await spawnWindow(t);
+  const landingUrl = agent.getExecutorURL({page: 2});
+
+  await agent.navigate(landingUrl);
+  assert_not_prefetched(await agent.getRequestHeaders(), `${landingUrl} should not be prefetched.`);
+
+  // It's generally expected that events occur in this order:
+  //   ... -> connectEnd --> requestStart --> responseStart --> ...
+  const [entry] = await agent.execute_script(
+      () => performance.getEntriesByType('navigation'));
+  assert_less_than_equal(entry.connectEnd, entry.requestStart);
+  assert_less_than_equal(entry.requestStart, entry.responseStart);
+}, "PerformanceNavigationTiming data should be in the correct order (no prefetch)");
+
+subsetTestByKey('afterResponse', promise_test, async t => {
+  const agent = await spawnWindow(t);
+  const landingUrl = agent.getExecutorURL({page: 2});
+  await agent.forceSinglePrefetch(landingUrl);
+
+  await agent.navigate(landingUrl);
+  assert_prefetched(await agent.getRequestHeaders(), `${landingUrl} should have been prefetched.`);
+
+  // Since the response should have started before the navigation, these should
+  // all have the same value (i.e., the start of the fetch).
+  const [entry] = await agent.execute_script(
+      () => performance.getEntriesByType('navigation'));
+  assert_equals(entry.connectEnd, entry.requestStart);
+  assert_equals(entry.requestStart, entry.responseStart);
+}, "PerformanceNavigationTiming data should show 'instantaneous' events completed beforehand");
+
+subsetTestByKey('waitingForResponse', promise_test, async t => {
+  const agent = await spawnWindow(t);
+  const landingUrl = agent.getExecutorURL({executor: 'slow-executor.py', delay: '3', page: 2});
+  await agent.forceSinglePrefetch(landingUrl, {}, /*wait_for_completion=*/false);
+
+  // Chromium, at least, will give up the prefetch if the response head doesn't
+  // come back within 1 second of navigation. So since the server will take
+  // 3 seconds to respond, we wait 2.5 seconds before navigating, to ensure the
+  // response comes back within about 0.5 seconds.
+  await new Promise(resolve => t.step_timeout(resolve, 2_500));
+
+  await agent.navigate(landingUrl);
+  assert_prefetched(await agent.getRequestHeaders(), `${landingUrl} should have been prefetched.`);
+
+  // Unlike the `afterResponse` test, we expect delays between `requestStart`
+  // and `responseStart` here. If our timing was perfect and server round-trips
+  // were instantaneous, that delay would be 0.5 seconds. To give ourselves a
+  // bit of wiggle room, instead we assert that it's at least 0.1 seconds.
+  const [entry] = await agent.execute_script(
+      () => performance.getEntriesByType('navigation'));
+  assert_less_than_equal(entry.connectEnd, entry.requestStart, "connectEnd must be before requestStart");
+  assert_greater_than(entry.responseStart, entry.requestStart + 100, "responseStart must be > 100 ms after requestStart");
+}, "PerformanceNavigationTiming data should show noticeable TTFB if the response is slow");
+
+subsetTestByKey('waitingForRedirect', promise_test, async t => {
+  const agent = await spawnWindow(t);
+  const landingUrl = agent.getExecutorURL({page: 2});
+  const slowRedirectUrl = new URL(`/common/slow-redirect.py?delay=3&location=${encodeURIComponent(landingUrl)}`, document.baseURI);
+  await agent.forceSinglePrefetch(slowRedirectUrl, {}, /*wait_for_completion=*/false);
+
+  // Considerations here are the same as for `waitingForResponse`.
+  await new Promise(resolve => t.step_timeout(resolve, 2_500));
+
+  await agent.navigate(slowRedirectUrl, {expectedDestinationUrl: landingUrl});
+  assert_prefetched(await agent.getRequestHeaders(), `${landingUrl} should have been prefetched.`);
+
+  // As in `waitingForResponse`, we expect at least 0.1 seconds TTFB. Unlike in
+  // that test, the delta isn't captured by `requestStart` vs. `responseStart`,
+  // because these stats only measure the final request/response pair, which is
+  // not delayed.
+  const [entry] = await agent.execute_script(
+      () => performance.getEntriesByType('navigation'));
+  assert_less_than_equal(entry.connectEnd, entry.requestStart, "connectEnd must be before requestStart");
+  assert_less_than_equal(entry.requestStart, entry.responseStart, "requestStart must be before responseStart");
+  assert_greater_than(entry.connectEnd, 100, "connectEnd must be > 100 ms");
+}, "PerformanceNavigationTiming data should show noticeable TTFB if the response is slow");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https_include=afterResponse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https_include=afterResponse-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https_include=noPrefetch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https_include=noPrefetch-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https_include=waitingForRedirect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https_include=waitingForRedirect-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https_include=waitingForResponse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https_include=waitingForResponse-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/utils.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+
+<meta name="variant" content="?default">
+<meta name="variant" content="?bypass_cache=true">
+<meta name="variant" content="?prefetch=true">
+<meta name="variant" content="?prefetch=true&bypass_cache=true">
+
+<script>
+setup(() => assertSpeculationRulesIsSupported());
+
+const searchParams = new URLSearchParams(location.search);
+const prefetchEnabled = searchParams.has('prefetch');
+const bypassCache = searchParams.has('bypass_cache');
+
+// Header size: https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-transfersize
+const headerSize = 300;
+
+promise_test(async t => {
+    const agent = await spawnWindow(t);
+    // Some meaningless query param to avoid cached response.
+    const prefetchUrl =
+      bypassCache ? agent.getExecutorURL({ a: "b" }) : agent.getExecutorURL();
+
+    if (prefetchEnabled)
+      await agent.forceSinglePrefetch(prefetchUrl);
+
+    await agent.navigate(prefetchUrl);
+
+    if (prefetchEnabled)
+      assert_prefetched(await agent.getRequestHeaders(),
+        `Prefetch ${prefetchUrl.href} should work.`);
+    else
+      assert_not_prefetched(await agent.getRequestHeaders(),
+        `${prefetchUrl.href} should not be prefetched.`);
+
+    await agent.execute_script(
+      () => window.entries = performance.getEntriesByType('navigation'));
+
+    // TODO(crbug/1317756): Currently the initial prefetch request bypasses the
+    // HTTP cache. Expand test coverage for cache and cache+revalidation cases.
+    //
+    // We do not assert the exact size of `resources/executor.sub.html` since it
+    // would be a headache to update this test everytime executor.sub.html
+    // changes.
+    assert_equals(await agent.execute_script(() => window.entries.length), 1,
+      'Wrong number of entries');
+    const entry =
+      await agent.execute_script(() => window.entries[0]);
+    const bodySize = entry.encodedBodySize;
+    assert_greater_than(bodySize, 0);
+    assert_equals(entry.transferSize, headerSize + bodySize);
+    assert_equals(entry.decodedBodySize, bodySize);
+  }, `PerformanceNavigationTiming.transferSize/encodedBodySize/decodedBodySize test, same origin prefetch.`);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https_bypass_cache=true-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https_bypass_cache=true-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https_default-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https_default-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https_prefetch=true&bypass_cache=true-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https_prefetch=true&bypass_cache=true-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https_prefetch=true-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https_prefetch=true-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-http-cache-interference.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-http-cache-interference.https-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-http-cache-interference.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-http-cache-interference.https.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/utils.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+<!-- Regression test for https://issues.chromium.org/issues/381099745 -->
+
+<script>
+  setup(() => assertSpeculationRulesIsSupported());
+
+  promise_test(async t => {
+    let agent = await spawnWindow(t);
+    let nextUrl = agent.getExecutorURL({ executor: "conditional-status.py" });
+    await agent.forceSinglePrefetch(nextUrl);
+    await agent.navigate(nextUrl);
+
+    const result = await agent.execute_script(() => {
+      return document.body.textContent;
+    });
+
+    assert_equals(result, "200", "Should use the non-prefetched 200, instead of the prefetched 503");
+  }, "Check that the HTTP cache doesn't cache when the server conditionally responds with 503 for prefetch requests.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-prefetch-for-post.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-prefetch-for-post.https-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-prefetch-for-post.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-prefetch-for-post.https.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/utils.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+<script>
+  setup(() => assertSpeculationRulesIsSupported());
+
+  promise_test(async t => {
+    let agent = await spawnWindow(t);
+    let nextUrl = agent.getExecutorURL({ executor: 'post-navigation-handler.py', protocol: 'https', page: 2 });
+    await agent.forceSinglePrefetch(nextUrl);
+
+  await agent.execute_script(async (nextUrl) => {
+    window.executor.suspend(() => {
+        navigate_by_form_generated_post(nextUrl);
+    });
+  }, [nextUrl]);
+
+    assert_not_prefetched(await agent.getRequestHeaders());
+  }, "post navigations should not use cached prefetch");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/README.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/README.txt
@@ -1,0 +1,1 @@
+Web Platform Tests for No-Vary-Search support in prefetch cache.

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/hint-test-inputs.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/hint-test-inputs.js
@@ -1,0 +1,306 @@
+// Test inputs:
+// - description: a description of the test.
+// - noVarySearch: No-Vary-Search header value for the response.
+// - noVarySearchHint: No-Vary-Search hint to include in prefetch
+//   speculation rules
+// - prefetchQuery: added to query part of prefetch-executor when prefetching
+// - navigateQuery: added to query part of prefetch-executor when navigating
+// - shouldUse: if the test case expects the prefetched entry to be used or not.
+const hint_test_inputs = [
+  {
+    description:
+        'Use in-flight prefetch as query parameter b has the same value.',
+    noVarySearch: 'params=("a")',
+    noVarySearchHint: 'params=("a")',
+    prefetchQuery: 'a=2&b=3',
+    navigateQuery: 'b=3',
+    shouldUse: true
+  },
+
+  {
+    description:
+        'Don\'t use in-flight prefetch as there is no No-Vary-Search hint.',
+    noVarySearch: 'params=("a")',
+    noVarySearchHint: '',
+    prefetchQuery: 'a=2&b=3',
+    navigateQuery: 'b=3',
+    shouldUse: false
+  },
+
+  {
+    description:
+        'Don\'t use in-flight prefetch as the prefetched URL has the extra "a" query parameter.',
+    noVarySearch: 'params=("b")',
+    noVarySearchHint: 'params=("b")',
+    prefetchQuery: 'a=2&b=3',
+    navigateQuery: 'b=2',
+    shouldUse: false
+  },
+
+  {
+    description: 'Use in-flight prefetch as the URLs do not vary by a and b.',
+    noVarySearch: 'params=("a" "b")',
+    noVarySearchHint: 'params=("a" "b")',
+    prefetchQuery: 'a=2&b=3',
+    navigateQuery: 'b=2',
+    shouldUse: true
+  },
+
+  {
+    description: 'Do not use in-flight prefetch as the navigation URL has' +
+        ' a different value for the "b" query parameter.',
+    noVarySearch: 'params=("a" "b")',
+    noVarySearchHint: 'params=("a")',
+    prefetchQuery: 'a=2&b=3',
+    navigateQuery: 'b=2',
+    shouldUse: false
+  },
+
+  {
+    description:
+        'Use in-flight prefetch as the URLs have the same values for all keys, only differing by order.',
+    noVarySearch: 'key-order',
+    noVarySearchHint: 'key-order',
+    prefetchQuery: 'b=5&a=3&a=4&d=6&c=5&b=3',
+    navigateQuery: 'd=6&a=3&b=5&b=3&c=5&a=4',
+    shouldUse: true
+  },
+
+  {
+    description:
+        'Use in-flight prefetch as the URLs have the same values for all keys, only differing by order and using ?1 for specifying a true value.',
+    noVarySearch: 'key-order=?1',
+    noVarySearchHint: 'key-order=?1',
+    prefetchQuery: 'b=5&a=3&a=4&d=6&c=5&b=3',
+    navigateQuery: 'd=6&a=3&b=5&b=3&c=5&a=4',
+    shouldUse: true
+  },
+
+  {
+    description:
+        'Don\'t use in-flight prefetch as key-order is set to false and the URLs are not identical.',
+    noVarySearch: 'key-order=?0',
+    noVarySearchHint: 'key-order=?1',
+    prefetchQuery: 'b=5&a=3&a=4&d=6&c=5&b=3',
+    navigateQuery: 'd=6&a=3&b=5&b=3&c=5&a=4',
+    shouldUse: false
+  },
+
+  {
+    description:
+        'Use in-flight prefetch as all query parameters except c can be ignored.',
+    noVarySearch: 'params, except=("c")',
+    noVarySearchHint: 'params, except=("c")',
+    prefetchQuery: 'b=5&a=3&d=6&c=3',
+    navigateQuery: 'a=1&b=2&c=3',
+    shouldUse: true
+  },
+
+  {
+    description:
+        'Use in-flight prefetch as all query parameters except c can be ignored.' +
+        ' Only the last except matters.',
+    noVarySearch: 'params, except=("b"), except=("c")',
+    noVarySearchHint: 'params, except=("b"), except=("c")',
+    prefetchQuery: 'b=5&a=3&d=6&c=3',
+    navigateQuery: 'a=1&b=2&c=3',
+    shouldUse: true
+  },
+
+  {
+    description:
+        'Don\'t use in-flight prefetch as even though all query parameters' +
+        ' except c can be ignored, c has different value.',
+    noVarySearch: 'params, except=("c")',
+    noVarySearchHint: 'params',
+    prefetchQuery: 'b=5&a=3&d=6&c=3',
+    navigateQuery: 'a=1&b=2&c=5',
+    shouldUse: false
+  },
+
+  {
+    description: 'Use in-flight prefetch as even though all query parameters' +
+        ' except c and d can be ignored, c value matches and d value matches.',
+    noVarySearch: 'params, except=("c" "d")',
+    noVarySearchHint: 'params, except=("c" "d")',
+    prefetchQuery: 'b=5&a=3&d=6&c=5',
+    navigateQuery: 'd=6&a=1&b=2&c=5',
+    shouldUse: true
+  },
+
+  {
+    description:
+        'Use in-flight prefetch as even though all query parameters except' +
+        ' c and d can be ignored, c value matches and d value matches.' +
+        ' Some query parameters to be ignored appear multiple times in the query.',
+    noVarySearch: 'params, except=("c" "d")',
+    noVarySearchHint: 'params',
+    prefetchQuery: 'b=5&a=3&a=4&d=6&c=5',
+    navigateQuery: 'd=6&a=1&a=2&b=2&b=3&c=5',
+    shouldUse: true
+  },
+
+  {
+    description:
+        'Use in-flight prefetch as all query parameters except c can be ignored.' +
+        ' Allow extension via parameters.',
+    noVarySearch: 'params, except=("c";unknown)',
+    noVarySearchHint: 'params, except=("c";unknown)',
+    prefetchQuery: 'b=5&a=3&d=6&c=3',
+    navigateQuery: 'a=1&b=2&c=3',
+    shouldUse: true
+  },
+
+  {
+    description: 'Use in-flight prefetch as query parameter c can be ignored.' +
+        ' Allow extension via parameters.',
+    noVarySearch: 'params=("c";unknown)',
+    noVarySearchHint: 'params=("c";unknown)',
+    prefetchQuery: 'a=2&b=2&c=5',
+    navigateQuery: 'a=2&c=3&b=2',
+    shouldUse: true
+  },
+
+  {
+    description:
+        'Use in-flight prefetch as the URLs have the values in different order for a.' +
+        ' Allow extension via parameters.',
+    noVarySearch: 'key-order;unknown',
+    noVarySearchHint: 'key-order;unknown',
+    prefetchQuery: 'b=5&a=3&a=4&d=6&c=5&b=3',
+    navigateQuery: 'd=6&a=3&b=5&b=3&c=5&a=4',
+    shouldUse: true
+  },
+
+  {
+    description:
+        'Use in-flight prefetch as the URLs do not vary on any query parameters.' +
+        ' Allow extension via parameters.',
+    noVarySearch: 'params;unknown',
+    noVarySearchHint: 'params;unknown',
+    prefetchQuery: '',
+    navigateQuery: 'b=4&c=5',
+    shouldUse: true
+  },
+
+  {
+    description:
+        'Use in-flight prefetch as all query parameters except c can be ignored.' +
+        ' Allow extension via parameters.',
+    noVarySearch: 'params;unknown, except=("c");unknown',
+    noVarySearchHint: 'params;unknown, except=("c");unknown',
+    prefetchQuery: 'b=5&a=3&d=6&c=3',
+    navigateQuery: 'a=1&b=2&c=3',
+    shouldUse: true
+  },
+
+  {
+    description:
+        'Don\'t use the in-flight prefetched URL. Empty No-Vary-Search means default URL variance.' +
+        ' The prefetched and the navigated URLs have to be the same.',
+    noVarySearch: '',
+    noVarySearchHint: 'params',
+    prefetchQuery: 'b=5&a=3&d=6&c=3',
+    navigateQuery: 'a=1&b=2&c=3',
+    shouldUse: false
+  },
+
+  {
+    description:
+        'Use the in-flight prefetch. Empty No-Vary-Search means default URL variance.' +
+        ' The prefetched and the navigated URLs have to be the same.',
+    noVarySearch: '',
+    noVarySearchHint: '',
+    prefetchQuery: 'b=5&a=3&d=6&c=3',
+    navigateQuery: 'b=5&a=3&d=6&c=3',
+    shouldUse: true
+  },
+
+  {
+    description:
+        'Use the in-flight prefetch. Invalid No-Vary-Search means default URL variance.' +
+        ' The prefetched and the navigated URLs have to be the same.',
+    noVarySearch: '',
+    noVarySearchHint: 'params=(a)',
+    prefetchQuery: 'b=5&a=3&d=6&c=3',
+    navigateQuery: 'b=5&a=3&d=6&c=3',
+    shouldUse: true
+  },
+
+  {
+    description:
+        'Don\'t use the in-flight prefetch. Invalid No-Vary-Search means default URL variance.' +
+        ' The prefetched and the navigated URLs are not the same.',
+    noVarySearch: '',
+    noVarySearchHint: 'params=(a)',
+    prefetchQuery: 'b=5&a=3&d=6&c=3',
+    navigateQuery: 'b=5&a=4&d=6&c=3',
+    shouldUse: false
+  },
+
+  {
+    description:
+        'No-Vary-Search hint must be a string so the speculation rule will be ignored.' +
+        ' There is no prefetch happening.',
+    noVarySearch: '',
+    noVarySearchHint: 0,
+    prefetchQuery: 'b=5&a=3&d=6&c=3',
+    navigateQuery: 'b=5&a=3&d=6&c=3',
+    shouldUse: false
+  },
+
+  {
+    description:
+        'Use the in-flight prefetch. Empty No-Vary-Search means default URL variance.' +
+        ' The prefetched and the navigated URLs have to be the same.',
+    noVarySearch: '',
+    noVarySearchHint: '',
+    prefetchQuery: '',
+    navigateQuery: '',
+    shouldUse: true
+  },
+
+  {
+    description:
+        'Use the in-flight prefetch. Non-ASCII key - 2 UTF-8 code units.' +
+        ' Don\'t vary the response on the non-ASCII key.',
+    noVarySearch: 'params=("%C2%A2")',
+    noVarySearchHint: 'params=("%C2%A2")',
+    prefetchQuery: '¢=3',
+    navigateQuery: '¢=4',
+    shouldUse: true
+  },
+
+  {
+    description:
+        'Use the in-flight prefetch. Non-ASCII key - 2 UTF-8 code units.' +
+        ' Don\'t vary the response on the non-ASCII key.',
+    noVarySearch: 'params=("%C2%A2")',
+    noVarySearchHint: 'params=("%C2%A2")',
+    prefetchQuery: 'a=2&¢=3',
+    navigateQuery: '¢=4&a=2',
+    shouldUse: true
+  },
+
+  {
+    description:
+        'Don\'t use the in-flight prefetch. Non-ASCII key - 2 UTF-8 code units.' +
+        ' Vary the response on the non-ASCII key.',
+    noVarySearch: 'params, except=("%C2%A2")',
+    noVarySearchHint: 'params',
+    prefetchQuery: '¢=3',
+    navigateQuery: '¢=4',
+    shouldUse: false
+  },
+
+  {
+    description:
+        'Use the in-flight prefetch. Non-ASCII key - 2 UTF-8 code units.' +
+        ' Vary the response on the non-ASCII key.',
+    noVarySearch: 'params, except=("%C2%A2")',
+    noVarySearchHint: 'params, except=("%C2%A2")',
+    prefetchQuery: '¢=3&a=4',
+    navigateQuery: 'a=5&¢=3',
+    shouldUse: true
+  },
+];

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<title>Use for navigation the requested prefetched response annotated with No-Vary-Search hint, if
+No-Vary-Search headers also match during navigation</title>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/utils.js"></script>
+<script src="../../resources/utils.js"></script>
+<script src="../resources/utils.sub.js"></script>
+<script src="/common/subset-tests.js"></script>
+<script src="hint-test-inputs.js"></script>
+
+<meta name="variant" content="?1-1">
+<meta name="variant" content="?2-2">
+<meta name="variant" content="?3-3">
+<meta name="variant" content="?4-4">
+<meta name="variant" content="?5-5">
+<meta name="variant" content="?6-6">
+<meta name="variant" content="?7-7">
+<meta name="variant" content="?8-8">
+<meta name="variant" content="?9-9">
+<meta name="variant" content="?10-10">
+<meta name="variant" content="?11-11">
+<meta name="variant" content="?12-12">
+<meta name="variant" content="?13-13">
+<meta name="variant" content="?14-14">
+<meta name="variant" content="?15-15">
+<meta name="variant" content="?16-16">
+<meta name="variant" content="?17-17">
+<meta name="variant" content="?18-18">
+<meta name="variant" content="?19-19">
+<meta name="variant" content="?20-20">
+<meta name="variant" content="?21-21">
+<meta name="variant" content="?22-22">
+<meta name="variant" content="?23-23">
+<meta name="variant" content="?24-24">
+<meta name="variant" content="?25-25">
+<meta name="variant" content="?26-26">
+<meta name="variant" content="?27-27">
+<meta name="variant" content="?28-last">
+
+<script>
+  setup(() => assertSpeculationRulesIsSupported());
+
+  /*
+    remoteAgent: the RemoteContext instance used to communicate between the
+      test and the window where prefetch/navigation is happening
+    noVarySearchHeaderValue: the value of No-Vary-Search header to be populated
+      for the prefetched response
+    noVarySearchHintValue: the value of No-Vary-Search hint passed in
+      as expects_no_vary_search hint in prefetch speculation rules.
+    prefetchQuery: query params to be added to prefetchExecutor url and prefetched
+    navigateQuery: query params to be added to prefetchExecutor url and navigated to
+  */
+  async function prefetchAndNavigate(remoteAgent, noVarySearchHeaderValue, noVarySearchHintValue, prefetchQuery, navigateQuery){
+    /*
+    Flow:
+      * prefetch prefetch_nvs_hint.py?uuid=...&nvs_header=...&otherqueryparams
+      * the prefetch request above includes no_vary_search_hint in the speculation
+        rules
+      * the server blocks progress on this prefetch request on the server side so
+        from the browser perspective the server is "thinking"
+      * the test starts navigation to
+        prefetch_nvs_hint.py?uuid=...&nvs_header=...&otherdifferentqueryparams.
+        This navigation matches by No-Vary-Search hint the above in
+        progress prefetch.
+      * the test fetches prefetch_nvs_hint.py?uuid=...&unblock="unblock"
+        which unblocks the in progress prefetch so that the in-progress
+        navigation can continue
+    */
+    const prefetch_nvs_hint_server_page = "prefetch_nvs_hint.py";
+    const prefetchUrl = remoteAgent.getExecutorURL({executor:prefetch_nvs_hint_server_page});
+    const navigateToUrl = new URL(prefetchUrl);
+    // Add query params to the url to be prefetched.
+    const additionalPrefetchedUrlSearchParams = new URLSearchParams(prefetchQuery);
+    addNoVarySearchHeaderUsingQueryParam(prefetchUrl, noVarySearchHeaderValue);
+    additionalPrefetchedUrlSearchParams.forEach((value, key) => {
+      prefetchUrl.searchParams.append(key, value);
+    });
+
+    await remoteAgent.forceSinglePrefetch(prefetchUrl,
+        {expects_no_vary_search:noVarySearchHintValue});
+
+    // Add new query params to navigateToUrl to match No-Vary-Search test case.
+    const additionalNavigateToUrlSearchParams = new URLSearchParams(navigateQuery);
+    addNoVarySearchHeaderUsingQueryParam(navigateToUrl, noVarySearchHeaderValue);
+    additionalNavigateToUrlSearchParams.forEach((value, key) => {
+      navigateToUrl.searchParams.append(key, value);
+    });
+    // Url used by fetch in order to unblock the prefetched url
+    const nvshint_unblock_url = remoteAgent.getExecutorURL(
+      {executor:prefetch_nvs_hint_server_page, unblock:"unblock"});
+    await remoteAgent.execute_script((unblock_url) => {
+      onbeforeunload = (event) => {
+          fetch(unblock_url);
+      };
+    }, [nvshint_unblock_url]);
+
+    // Try navigating to a non-exact prefetched URL that matches by
+    // No-Vary-Search hint
+    // Wait for the navigation to finish
+    await remoteAgent.navigate(navigateToUrl);
+  }
+
+  function prefetch_no_vary_search_test(description, noVarySearch, noVarySearchHint, prefetchQuery, navigateQuery, shouldUse){
+    promise_test(async t => {
+      const agent = await spawnWindow(t, {});
+      await prefetchAndNavigate(agent,
+        noVarySearch,
+        noVarySearchHint,
+        prefetchQuery,
+        navigateQuery);
+
+      if (shouldUse) {
+        assert_prefetched(await agent.getRequestHeaders(),
+          "Navigation didn't use the prefetched response!");
+      }
+      else{
+        assert_not_prefetched(await agent.getRequestHeaders(),
+          "Navigation used the prefetched response!");
+      }
+     }, description);
+  }
+
+  hint_test_inputs.forEach(({description, noVarySearch, noVarySearchHint, prefetchQuery, navigateQuery, shouldUse}) => {
+    subsetTest(prefetch_no_vary_search_test,
+      description, noVarySearch, noVarySearchHint, prefetchQuery, navigateQuery,
+      shouldUse);
+  });
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_1-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_1-1-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_10-10-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_10-10-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_11-11-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_11-11-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_12-12-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_12-12-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_13-13-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_13-13-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_14-14-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_14-14-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_15-15-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_15-15-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_16-16-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_16-16-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_17-17-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_17-17-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_18-18-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_18-18-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_19-19-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_19-19-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_2-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_2-2-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_20-20-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_20-20-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_21-21-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_21-21-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_22-22-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_22-22-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_23-23-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_23-23-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_24-24-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_24-24-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_25-25-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_25-25-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_26-26-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_26-26-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_27-27-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_27-27-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_28-last-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_28-last-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_3-3-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_3-3-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_4-4-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_4-4-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_5-5-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_5-5-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_6-6-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_6-6-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_7-7-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_7-7-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_8-8-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_8-8-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_9-9-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https_9-9-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<title>Prefetched response including No-Vary-Search headers is used during navigation</title>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/utils.js"></script>
+<script src="../../resources/utils.js"></script>
+<script src="../resources/utils.sub.js"></script>
+<script src="/common/subset-tests.js"></script>
+<script src="test-utils.js"></script>
+<script src="test-inputs.js"></script>
+
+<meta name="variant" content="?1-1">
+<meta name="variant" content="?2-2">
+<meta name="variant" content="?3-3">
+<meta name="variant" content="?4-4">
+<meta name="variant" content="?5-5">
+<meta name="variant" content="?6-6">
+<meta name="variant" content="?7-7">
+<meta name="variant" content="?8-8">
+<meta name="variant" content="?9-9">
+<meta name="variant" content="?10-10">
+<meta name="variant" content="?11-11">
+<meta name="variant" content="?12-12">
+<meta name="variant" content="?13-13">
+<meta name="variant" content="?14-14">
+<meta name="variant" content="?15-15">
+<meta name="variant" content="?16-16">
+<meta name="variant" content="?17-17">
+<meta name="variant" content="?18-18">
+<meta name="variant" content="?19-19">
+<meta name="variant" content="?20-20">
+<meta name="variant" content="?21-21">
+<meta name="variant" content="?22-22">
+<meta name="variant" content="?23-23">
+<meta name="variant" content="?24-24">
+<meta name="variant" content="?25-25">
+<meta name="variant" content="?26-26">
+<meta name="variant" content="?27-27">
+<meta name="variant" content="?28-28">
+<meta name="variant" content="?29-29">
+<meta name="variant" content="?30-last">
+
+<script>
+  setup(() => assertSpeculationRulesIsSupported());
+
+  /*
+    remoteAgent: the RemoteContext instance used to communicate between the
+      test and the window where prefetch/navigation is happening
+    noVarySearchHeaderValue: the value of No-Vary-Search header to be populated
+      for the prefetched response
+    prefetchQuery: query params to be added to prefetchExecutor url and prefetched
+    navigateQuery: query params to be added to prefetchExecutor url and navigated to
+  */
+  async function prefetchAndNavigate(remoteAgent, noVarySearchHeaderValue, prefetchQuery, navigateQuery){
+    const nextUrl = remoteAgent.getExecutorURL();
+    const navigateToUrl = new URL(nextUrl);
+    // Add query params to the url to be prefetched.
+    const additionalPrefetchedUrlSearchParams = new URLSearchParams(prefetchQuery);
+    addNoVarySearchHeaderUsingPipe(additionalPrefetchedUrlSearchParams, noVarySearchHeaderValue);
+    additionalPrefetchedUrlSearchParams.forEach((value, key) => {
+      nextUrl.searchParams.append(key, value);
+    });
+
+    await remoteAgent.forceSinglePrefetch(nextUrl);
+
+    // Add new query params to navigateToUrl to match No-Vary-Search test case.
+    const additionalNavigateToUrlSearchParams = new URLSearchParams(navigateQuery);
+    addNoVarySearchHeaderUsingPipe(additionalNavigateToUrlSearchParams, noVarySearchHeaderValue);
+    additionalNavigateToUrlSearchParams.forEach((value, key) => {
+      navigateToUrl.searchParams.append(key, value);
+    });
+    await remoteAgent.navigate(navigateToUrl);
+  }
+
+  function prefetch_no_vary_search_test(description, noVarySearch, prefetchQuery, navigateQuery, shouldUse){
+    promise_test(async t => {
+      const agent = await spawnWindow(t, {});
+      await prefetchAndNavigate(agent,
+        noVarySearch,
+        prefetchQuery,
+        navigateQuery);
+
+      if(shouldUse){
+        assert_prefetched(await agent.getRequestHeaders(),
+          "Navigation didn't use the prefetched response!");
+      }
+      else{
+        assert_not_prefetched(await agent.getRequestHeaders(),
+          "Navigation used the prefetched response!");
+      }
+     }, description);
+  }
+
+  test_inputs.forEach(({description, noVarySearch, prefetchQuery, navigateQuery, shouldUse}) => {
+    subsetTest(prefetch_no_vary_search_test,
+      description, noVarySearch, prefetchQuery, navigateQuery,
+      shouldUse);
+  });
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_1-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_1-1-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_10-10-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_10-10-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_11-11-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_11-11-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_12-12-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_12-12-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_13-13-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_13-13-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_14-14-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_14-14-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_15-15-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_15-15-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_16-16-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_16-16-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_17-17-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_17-17-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_18-18-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_18-18-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_19-19-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_19-19-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_2-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_2-2-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_20-20-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_20-20-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_21-21-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_21-21-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_22-22-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_22-22-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_23-23-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_23-23-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_24-24-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_24-24-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_25-25-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_25-25-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_26-26-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_26-26-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_27-27-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_27-27-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_28-28-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_28-28-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_29-29-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_29-29-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_3-3-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_3-3-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_30-last-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_30-last-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_4-4-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_4-4-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_5-5-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_5-5-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_6-6-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_6-6-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_7-7-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_7-7-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_8-8-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_8-8-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_9-9-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https_9-9-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/test-inputs.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/test-inputs.js
@@ -1,0 +1,204 @@
+// Test inputs:
+// - description: a description of the test.
+// - noVarySearch: No-Vary-Search header value for the response.
+// - prefetchQuery: added to query part of prefetch-executor when prefetching
+// - navigateQuery: added to query part of prefetch-executor when navigating
+// - shouldUse: if the test case expects the prefetched entry to be used or not.
+const test_inputs = [
+   {description:"Use prefetched response as query parameter b has the same value.",
+    noVarySearch: 'params=("a")',
+    prefetchQuery: "a=2&b=3",
+    navigateQuery: "b=3",
+    shouldUse: true},
+
+   {description:"Don't use prefetched response as query parameter b has different value.",
+    noVarySearch: 'params("a")',
+    prefetchQuery: "a=2&b=3",
+    navigateQuery: "b=2",
+    shouldUse: false},
+
+   {description:"Use prefetched response as the URLs do not vary by a and b.",
+    noVarySearch: 'params=("a" "b")',
+    prefetchQuery: "a=2&b=3",
+    navigateQuery: "b=2",
+    shouldUse: true},
+
+   {description:"Use prefetched response as the URLs do not vary on any query parameters.",
+    noVarySearch: "params",
+    prefetchQuery: "a=2&b=3",
+    navigateQuery: "b=4&c=5",
+    shouldUse: true},
+
+   {description:"Use prefetched response as the URLs do not vary on any query parameters.",
+    noVarySearch: "params",
+    prefetchQuery: "",
+    navigateQuery: "b=4&c=5",
+    shouldUse: true},
+
+   {description:"Don't use prefetched response as the URLs have different value for c.",
+    noVarySearch: "key-order",
+    prefetchQuery: "c=4&b=3&a=2",
+    navigateQuery: "a=2&c=5&b=3",
+    shouldUse: false},
+
+   {description:"Don't use prefetched response as the URLs have the values in different order for a.",
+    noVarySearch: "key-order",
+    prefetchQuery: "b=5&a=3&a=4&d=6&c=5&b=3",
+    navigateQuery: "d=6&a=4&b=5&b=3&c=5&a=3",
+    shouldUse: false},
+
+   {description:"Use prefetched response as the URLs have the same values for a.",
+    noVarySearch: "key-order",
+    prefetchQuery: "b=5&a=3&a=4&d=6&c=5&b=3",
+    navigateQuery: "d=6&a=3&b=5&b=3&c=5&a=4",
+    shouldUse: true},
+
+   {description:"Use prefetched response as the URLs have the same values for a.",
+    noVarySearch: "key-order=?1",
+    prefetchQuery: "b=5&a=3&a=4&d=6&c=5&b=3",
+    navigateQuery: "d=6&a=3&b=5&b=3&c=5&a=4",
+    shouldUse: true},
+
+   {description:"Don't use prefetched response as key-order is set to false and the URLs are not identical.",
+    noVarySearch: "key-order=?0",
+    prefetchQuery: "b=5&a=3&a=4&d=6&c=5&b=3",
+    navigateQuery: "d=6&a=3&b=5&b=3&c=5&a=4",
+    shouldUse: false},
+
+   {description:"Use prefetched response as query parameter c can be ignored.",
+    noVarySearch: 'params=("c")',
+    prefetchQuery: "a=2&b=2&c=5",
+    navigateQuery: "a=2&c=3&b=2",
+    shouldUse: true},
+
+   {description:"Use prefetched response as query parameter a can be ignored.",
+    noVarySearch: 'params=("a")',
+    prefetchQuery: "a=2",
+    navigateQuery: "",
+    shouldUse: true},
+
+   {description:"Use prefetched response as query parameter a can be ignored.",
+    noVarySearch: 'params=("a")',
+    prefetchQuery: "",
+    navigateQuery: "a=2",
+    shouldUse: true},
+
+   {description:"Use prefetched response as all query parameters except c can be ignored.",
+    noVarySearch: 'params, except=("c")',
+    prefetchQuery: "b=5&a=3&d=6&c=3",
+    navigateQuery: "a=1&b=2&c=3",
+    shouldUse: true},
+
+   {description:"Use prefetched response as all query parameters except c can be ignored." +
+                " Only the last except matters.",
+    noVarySearch: 'params, except=("b"), except=("c")',
+    prefetchQuery: "b=5&a=3&d=6&c=3",
+    navigateQuery: "a=1&b=2&c=3",
+    shouldUse: true},
+
+   {description:"Don't use prefetched response as even though all query parameters" +
+                " except c can be ignored, c has different value.",
+    noVarySearch: 'params, except=("c")',
+    prefetchQuery: "b=5&a=3&d=6&c=3",
+    navigateQuery: "a=1&b=2&c=5",
+    shouldUse: false},
+
+   {description:"Use prefetched response as even though all query parameters" +
+                " except c and d can be ignored, c value matches and d value matches.",
+    noVarySearch: 'params, except=("c" "d")',
+    prefetchQuery: "b=5&a=3&d=6&c=5",
+    navigateQuery: "d=6&a=1&b=2&c=5",
+    shouldUse: true},
+
+   {description:"Use prefetched response as even though all query parameters except" +
+                " c and d can be ignored, c value matches and d value matches." +
+                " Some query parameters to be ignored appear multiple times in the query.",
+    noVarySearch: 'params, except=("c" "d")',
+    prefetchQuery: "b=5&a=3&a=4&d=6&c=5",
+    navigateQuery: "d=6&a=1&a=2&b=2&b=3&c=5",
+    shouldUse: true},
+
+   {description:"Use prefetched response as all query parameters except c can be ignored." +
+                " Allow extension via parameters.",
+    noVarySearch: 'params, except=("c";unknown)',
+    prefetchQuery: "b=5&a=3&d=6&c=3",
+    navigateQuery: "a=1&b=2&c=3",
+    shouldUse: true},
+
+   {description:"Use prefetched response as query parameter c can be ignored." +
+                " Allow extension via parameters.",
+    noVarySearch: 'params=("c";unknown)',
+    prefetchQuery: "a=2&b=2&c=5",
+    navigateQuery: "a=2&c=3&b=2",
+    shouldUse: true},
+
+   {description:"Use prefetched response as the URLs have the values in different order for a." +
+                " Allow extension via parameters.",
+    noVarySearch: "key-order;unknown",
+    prefetchQuery: "b=5&a=3&a=4&d=6&c=5&b=3",
+    navigateQuery: "d=6&a=3&b=5&b=3&c=5&a=4",
+    shouldUse: true},
+
+   {description:"Use prefetched response as the URLs do not vary on any query parameters." +
+                " Allow extension via parameters.",
+    noVarySearch: "params;unknown",
+    prefetchQuery: "",
+    navigateQuery: "b=4&c=5",
+    shouldUse: true},
+
+   {description:"Use prefetched response as all query parameters except c can be ignored." +
+                " Allow extension via parameters.",
+    noVarySearch: 'params;unknown, except=("c");unknown',
+    prefetchQuery: "b=5&a=3&d=6&c=3",
+    navigateQuery: "a=1&b=2&c=3",
+    shouldUse: true},
+
+   {description:"Don't use the prefetched URL. Empty No-Vary-Search means default URL variance." +
+                " The prefetched and the navigated URLs have to be the same.",
+    noVarySearch: "",
+    prefetchQuery: "b=5&a=3&d=6&c=3",
+    navigateQuery: "a=1&b=2&c=3",
+    shouldUse: false},
+
+   {description:"Use the prefetched URL. Empty No-Vary-Search means default URL variance." +
+                " The prefetched and the navigated URLs have to be the same.",
+    noVarySearch: "",
+    prefetchQuery: "b=5&a=3&d=6&c=3",
+    navigateQuery: "b=5&a=3&d=6&c=3",
+    shouldUse: true},
+
+   {description:"Use the prefetched URL. Empty No-Vary-Search means default URL variance." +
+                " The prefetched and the navigated URLs have to be the same.",
+    noVarySearch: "",
+    prefetchQuery: "",
+    navigateQuery: "",
+    shouldUse: true},
+
+   {description:"Use the prefetched URL. Non-ASCII key - 2 UTF-8 code units." +
+                " Don't vary the response on the non-ASCII key.",
+    noVarySearch: 'params=("%C2%A2")',
+    prefetchQuery: "¢=3",
+    navigateQuery: "¢=4",
+    shouldUse: true},
+
+    {description:"Use the prefetched URL. Non-ASCII key - 2 UTF-8 code units." +
+                 " Don't vary the response on the non-ASCII key.",
+    noVarySearch: 'params=("%C2%A2")',
+    prefetchQuery: "a=2&¢=3",
+    navigateQuery: "¢=4&a=2",
+    shouldUse: true},
+
+    {description:"Don't use the prefetched URL. Non-ASCII key - 2 UTF-8 code units." +
+                 " Vary the response on the non-ASCII key.",
+    noVarySearch: 'params, except=("%C2%A2")',
+    prefetchQuery: "¢=3",
+    navigateQuery: "¢=4",
+    shouldUse: false},
+
+    {description:"Use the prefetched URL. Non-ASCII key - 2 UTF-8 code units." +
+                 " Vary the response on the non-ASCII key.",
+    noVarySearch: 'params, except=("%C2%A2")',
+    prefetchQuery: "¢=3&a=4",
+    navigateQuery: "a=5&¢=3",
+    shouldUse: true},
+];

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/test-utils.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/test-utils.js
@@ -1,0 +1,12 @@
+function addNoVarySearchHeaderUsingPipe(searchParams, headerValue) {
+  // Use server pipes
+  // https://web-platform-tests.org/writing-tests/server-pipes.html to populate
+  // No-Vary-Search response header. The "," and ")" characters need to be
+  // escaped by using backslash (see
+  // https://web-platform-tests.org/writing-tests/server-pipes.html). E.g.
+  // params=("a") becomes params=("a"\), params=("a"),key-order becomes
+  // params=("a"\)\,key-order etc.
+  searchParams.append(
+      'pipe',
+      `header(No-Vary-Search,${headerValue.replaceAll(/[,)]/g, '\\$&')})`);
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/w3c-import.log
@@ -1,0 +1,22 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/README.txt
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/hint-test-inputs.js
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single-with-hint.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/prefetch-single.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/test-inputs.js
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-vary-search/test-utils.js

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/subset-tests-by-key.js"></script>
+<script src="/common/utils.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+
+<meta name="variant" content="?include=BaseCase">
+<meta name="variant" content="?include=FollowRedirect">
+<meta name="variant" content="?include=RelativeUrlForSpeculationRulesSet">
+<meta name="variant" content="?include=RelativeUrlForCandidate">
+<meta name="variant" content="?include=UseNonUTF8EncodingForSpeculationRulesSet">
+<meta name="variant" content="?include=FailCORS">
+<meta name="variant" content="?include=FailToParseSpeculationRulesHeader">
+<meta name="variant" content="?include=InnerListInSpeculationRulesHeader">
+<meta name="variant" content="?include=EmptyRuleSet">
+<meta name="variant" content="?include=FailToParseRuleSet">
+<meta name="variant" content="?include=InvalidUrlForSpeculationRulesSet">
+<meta name="variant" content="?include=StatusCode199">
+<meta name="variant" content="?include=StatusCode404">
+<meta name="variant" content="?include=InvalidMimeType">
+<meta name="variant" content="?include=CSPExemption">
+
+<script>
+  setup(() => assertSpeculationRulesIsSupported());
+
+  async function runSpeculationRulesFetchTest(t, options) {
+    options = {
+      // Whether a prefetch is expected to succeed.
+      shouldPrefetch: true,
+      // Status code to be returned in the response.
+      status: 200,
+      // Whether a redirect must be followed to reach the rule set.
+      redirect: false,
+      // Whether to use relative URLs for the candidates in the rule set.
+      useRelativeUrlForCandidate: false,
+      // Whether to use relative URL for the rule set in SpeculationRules header.
+      useRelativeUrlForSpeculationRulesSet: false,
+      // Whether to use UTF-8 encoding for the rule set.
+      useUtf8EncodingForSpeculationRulesSet: true,
+      // Whether to force the response to cause a CORS failure.
+      failCors: false,
+      // Whether to use a valid SpeculationRules header format.
+      useValidSpeculationRulesHeaderValue: true,
+      // Whether to use an inner list of URLS in SpeculationRules header.
+      useInnerListInSpeculationRulesHeaderValue: false,
+      // Whether to return an empty response.
+      useEmptySpeculationRulesSet: false,
+      // Wheter to return a rule set with valid JSON format
+      useValidJsonForSpeculationRulesSet: true,
+      // Wheter to use a valid URL for the rule set in SpeculationRules header.
+      useValidUrlForSpeculationRulesSet: true,
+      // Wheter to use the valid "application/speculationrules-json" MIME type for the rule set.
+      useValidMimeTypeForSpeculationRulesSet: true,
+      // Whether to use a strict CSP for the main page.
+      strictCSP: false,
+      ...options
+    };
+
+    let page = 2;
+    let uuid = token();
+    let executor_url = new URL(`executor.sub.html`, SR_PREFETCH_UTILS_URL).toString();
+    if (options.useRelativeUrlForCandidate) {
+      executor_url = `executor.sub.html`;
+    }
+    let speculation_rule_set_url = `ruleset.py?url=${executor_url}&uuid=${uuid}&page=${page}&status=${options.status}&valid_mime=${options.useValidMimeTypeForSpeculationRulesSet}&valid_json=${options.useValidJsonForSpeculationRulesSet}&empty_json=${options.useEmptySpeculationRulesSet}&fail_cors=${options.failCors}&valid_encoding=${options.useUtf8EncodingForSpeculationRulesSet}&redirect=${options.redirect}`;
+    if (!options.useRelativeUrlForSpeculationRulesSet) {
+      let base_url = new URL(SR_PREFETCH_UTILS_URL);
+      base_url.hostname = get_host_info().NOTSAMESITE_HOST;
+      speculation_rule_set_url = new URL(speculation_rule_set_url, base_url).toString();
+    }
+    if (!options.useValidUrlForSpeculationRulesSet) {
+      speculation_rule_set_url = "http://:80/";
+    }
+
+    let speculation_rules_header = `header(Speculation-Rules,"${speculation_rule_set_url}")`;
+    if (!options.useValidSpeculationRulesHeaderValue) {
+      speculation_rules_header = `header(Speculation-Rules, x y z)`;
+    }
+    else if (options.useInnerListInSpeculationRulesHeaderValue) {
+      speculation_rules_header =  `header(Speculation-Rules, \\("${speculation_rule_set_url}" "xyz.com/rule-set.json"\\))`;
+    }
+    if (options.strictCSP) {
+      speculation_rules_header = speculation_rules_header + `|header(Content-Security-Policy, script-src 'strict-dynamic' 'nonce-abc' 'unsafe-eval')`;
+    }
+
+    let agent = await spawnWindow(t, {pipe: speculation_rules_header}, uuid);
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+    // Passing non-ascii character '÷' as part of the next URL to check if we always decode the speculation rules set using utf-8 or not. This character is encoded differently in utf-8 and windows-1250
+    let nextUrl = agent.getExecutorURL({ page, str: decodeURIComponent('%C3%B7')});
+    await agent.navigate(nextUrl);
+
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+
+    let test_case_desc = JSON.stringify(options);
+    if (options.shouldPrefetch)
+      assert_prefetched(await agent.getRequestHeaders(), `Prefetch should work for request ${test_case_desc}.`);
+    else
+      assert_not_prefetched(await agent.getRequestHeaders(), `Prefetch should not work for request ${test_case_desc}.`);
+  }
+
+  subsetTestByKey('BaseCase', promise_test, async t => {
+    return runSpeculationRulesFetchTest(t, {});
+  }, "Base case.");
+
+  subsetTestByKey('FollowRedirect', promise_test, async t => {
+    return runSpeculationRulesFetchTest(t, {redirect: true});
+  }, "It should follow redirects and fetch the speculation rules set.");
+
+  subsetTestByKey('RelativeUrlForSpeculationRulesSet', promise_test, async t => {
+    return runSpeculationRulesFetchTest(t, {useRelativeUrlForSpeculationRulesSet: true});
+  }, "It should fetch a speculation rules set using its relative URL.");
+
+  subsetTestByKey('RelativeUrlForCandidate', promise_test, async t => {
+    return runSpeculationRulesFetchTest(t, {useRelativeUrlForCandidate: true, shouldPrefetch: false});
+  }, "It should resolve the relative candidate URLs in the speculation rules set based on the speculation rules set's URL");
+
+  subsetTestByKey('UseNonUTF8EncodingForSpeculationRulesSet', promise_test, async t => {
+    return runSpeculationRulesFetchTest(t, {useUtf8EncodingForSpeculationRulesSet: false, shouldPrefetch: false});
+  }, "The speculation rules set should always be encoded using UTF-8.");
+
+  subsetTestByKey('FailCORS', promise_test, async t => {
+    return runSpeculationRulesFetchTest(t, {failCors: true, shouldPrefetch: false});
+  }, "It should reject the speculation rules set if CORS fails.");
+
+  subsetTestByKey('FailToParseSpeculationRulesHeader', promise_test, async t => {
+    return runSpeculationRulesFetchTest(t, {useValidSpeculationRulesHeaderValue: false, shouldPrefetch: false});
+  }, "It should reject the speculation rules set if it fails to parse the SpeculationRules header.");
+
+  subsetTestByKey('InnerListInSpeculationRulesHeader', promise_test, async t => {
+    return runSpeculationRulesFetchTest(t, {useInnerListInSpeculationRulesHeaderValue: true, shouldPrefetch: false});
+  }, "It should reject the speculation rules passed as inner list in the SpeculationRules header.");
+
+  subsetTestByKey('EmptyRuleSet', promise_test, async t => {
+    return runSpeculationRulesFetchTest(t, {useEmptySpeculationRulesSet: true, shouldPrefetch: false});
+  }, "It should reject an empty speculation rules set.");
+
+  subsetTestByKey('FailToParseRuleSet', promise_test, async t => {
+    return runSpeculationRulesFetchTest(t, {useValidJsonForSpeculationRulesSet: false, shouldPrefetch: false});
+  }, "It should reject the speculation rules set if it cannot parse it.");
+
+  subsetTestByKey('InvalidUrlForSpeculationRulesSet', promise_test, async t => {
+    return runSpeculationRulesFetchTest(t, {useValidUrlForSpeculationRulesSet: false, shouldPrefetch: false});
+  }, "It should reject the speculation rules set with invalid URL.");
+
+  subsetTestByKey('StatusCode199', promise_test, async t => {
+    return runSpeculationRulesFetchTest(t, {status: 199, shouldPrefetch: false});
+  }, "It should reject the speculation rules set with unsuccessful status code.");
+
+  subsetTestByKey('StatusCode404', promise_test, async t => {
+    return runSpeculationRulesFetchTest(t, {status: 404, shouldPrefetch: false});
+  }, "It should reject the speculation rules set with unsuccessful status code.");
+
+  subsetTestByKey('InvalidMimeType', promise_test, async t => {
+    return runSpeculationRulesFetchTest(t, {useValidMimeTypeForSpeculationRulesSet: false, shouldPrefetch: false});
+  }, "It should reject the speculation rules set with invalid MIME type.");
+
+  subsetTestByKey('CSPExemption', promise_test, async t => {
+    return runSpeculationRulesFetchTest(t, {shouldPrefetch: true, strictCSP: true});
+  }, "It should accept the speculation rules when the main page has strict CSP.");
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=BaseCase-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=BaseCase-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=CSPExemption-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=CSPExemption-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=EmptyRuleSet-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=EmptyRuleSet-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=FailCORS-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=FailCORS-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=FailToParseRuleSet-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=FailToParseRuleSet-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=FailToParseSpeculationRulesHeader-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=FailToParseSpeculationRulesHeader-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=FollowRedirect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=FollowRedirect-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=InnerListInSpeculationRulesHeader-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=InnerListInSpeculationRulesHeader-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=InvalidMimeType-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=InvalidMimeType-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=InvalidUrlForSpeculationRulesSet-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=InvalidUrlForSpeculationRulesSet-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=RelativeUrlForCandidate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=RelativeUrlForCandidate-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=RelativeUrlForSpeculationRulesSet-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=RelativeUrlForSpeculationRulesSet-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=StatusCode199-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=StatusCode199-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=StatusCode404-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=StatusCode404-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=UseNonUTF8EncodingForSpeculationRulesSet-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=UseNonUTF8EncodingForSpeculationRulesSet-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/utils.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+
+<meta name="variant" content="?from_protocol=http&to_protocol=http">
+<meta name="variant" content="?from_protocol=http&to_protocol=https">
+<meta name="variant" content="?from_protocol=https&to_protocol=http">
+<meta name="variant" content="?from_protocol=https&to_protocol=https">
+
+<script>
+  setup(() => assertSpeculationRulesIsSupported());
+
+  // This is split across four test variants due to the test timeouts.
+  let { from_protocol, to_protocol } = Object.fromEntries(new URLSearchParams(location.search));
+  promise_test(async t => {
+    let agent = await spawnWindow(t, { protocol: from_protocol });
+    let nextUrl = agent.getExecutorURL({ protocol: to_protocol, page: 2 });
+    await agent.forceSinglePrefetch(nextUrl);
+    await agent.navigate(nextUrl);
+
+    if (to_protocol == "https") {
+      assert_prefetched(await agent.getRequestHeaders(), "Prefetch should work for HTTPS urls.");
+    } else {
+      assert_not_prefetched(await agent.getRequestHeaders(), "Prefetch should not work for HTTP urls.");
+    }
+  }, `test single ${to_protocol} url prefetch from a ${from_protocol} url`);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=http&to_protocol=http-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=http&to_protocol=http-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=http&to_protocol=https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=http&to_protocol=https-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=https&to_protocol=http-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=https&to_protocol=http-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=https&to_protocol=https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=https&to_protocol=https-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/utils.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+
+<meta name="variant" content="?status=200&should_prefetch=true">
+<meta name="variant" content="?status=250&should_prefetch=true">
+<meta name="variant" content="?status=299&should_prefetch=true">
+<meta name="variant" content="?status=400&should_prefetch=false">
+<meta name="variant" content="?status=500&should_prefetch=false">
+
+<script>
+  setup(() => assertSpeculationRulesIsSupported());
+
+  // This is split across four test variants due to the test timeouts.
+  let { status, should_prefetch } = Object.fromEntries(new URLSearchParams(location.search));
+  promise_test(async t => {
+    let agent = await spawnWindow(t);
+    let nextUrl = agent.getExecutorURL({ page: 2, pipe: `status(${status})` });
+    await agent.forceSinglePrefetch(nextUrl);
+    await agent.navigate(nextUrl);
+
+    if (should_prefetch == 'true')
+      assert_prefetched(await agent.getRequestHeaders(), `Prefetch should work for request status:${status}.`);
+    else
+      assert_not_prefetched(await agent.getRequestHeaders(), `Prefetch should not work for request statue:${status}.`);
+  }, "Check that only prefetched requests with status in 200-299 range are used.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=200&should_prefetch=true-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=200&should_prefetch=true-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=250&should_prefetch=true-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=250&should_prefetch=true-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=299&should_prefetch=true-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=299&should_prefetch=true-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=400&should_prefetch=false-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=400&should_prefetch=false-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=500&should_prefetch=false-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=500&should_prefetch=false-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-traverse-reload.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-traverse-reload.sub-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-traverse-reload.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-traverse-reload.sub.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/utils.js"></script>
+<script src="/websockets/constants.sub.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+<script>
+setup(() => assertSpeculationRulesIsSupported());
+
+promise_test(async t => {
+  let agent = await spawnWindow(t, { protocol: 'https', pipe: 'header(Cache-Control, no-store)' });
+  let previousUrl = await agent.execute_script(() => location.href);
+  await agent.execute_script(async () => {
+    window.preventBfcache = new WebSocket('wss://{{ports[wss][0]}}/echo');
+  });
+
+  let nextUrl = agent.getExecutorURL({ protocol: 'https', page: 2 });
+  await agent.navigate(nextUrl);
+
+  await agent.forceSinglePrefetch(previousUrl);
+  await agent.execute_script(() => {
+    window.executor.suspend(() => history.go(-1));
+  });
+
+  assert_equals(previousUrl, await agent.execute_script(() => location.href));
+  assert_prefetched(await agent.getRequestHeaders(), "traversal should use prefetch");
+}, "prefetches can be used for traversal navigations");
+
+promise_test(async t => {
+  let agent = await spawnWindow(t, { protocol: 'https', pipe: 'header(Cache-Control, no-store)' });
+  let previousUrl = await agent.execute_script(() => location.href);
+  await agent.execute_script(async () => {
+    window.preventBfcache = new WebSocket('wss://{{ports[wss][0]}}/echo');
+  });
+
+  let nextUrl = agent.getExecutorURL({ protocol: 'https', page: 2 });
+  await agent.navigate(nextUrl);
+
+  await agent.forceSinglePrefetch(previousUrl);
+  // In https://html.spec.whatwg.org/multipage/nav-history-apis.html#delta-traverse,
+  // `sourceDocument` is `History`'s relevant global object's associated
+  // Document. In this case, it's `iframe.contentDocument`, and thus the
+  // prefetch from `win`'s Document (iframe's parent Document) isn't used.
+  await agent.execute_script(() => {
+    window.executor.suspend(() => {
+      const iframe = document.createElement('iframe');
+      document.body.appendChild(iframe);
+      iframe.contentWindow.history.go(-1);
+    });
+  });
+
+  assert_equals(previousUrl, await agent.execute_script(() => location.href));
+  assert_not_prefetched(await agent.getRequestHeaders(),
+      "prefetch from different Document should not be used");
+}, "History's Document is used for traversal navigations");
+
+promise_test(async t => {
+  let agent = await spawnWindow(t, { protocol: 'https', pipe: 'header(Cache-Control, no-store)' });
+  let previousUrl = await agent.execute_script(() => location.href);
+  await agent.forceSinglePrefetch(previousUrl);
+  await agent.execute_script(() => {
+    window.executor.suspend(() => location.reload());
+  });
+
+  assert_equals(previousUrl, await agent.execute_script(() => location.href));
+  assert_prefetched(await agent.getRequestHeaders(), "reload should use prefetch");
+}, "prefetches can be used for reload navigations");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-uses-cache.sub.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-uses-cache.sub.https.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+
+<meta name="variant" content="?same-site">
+<meta name="variant" content="?cross-site">
+
+<script>
+setup(() => assertSpeculationRulesIsSupported());
+
+promise_test(async t => {
+  const is_same_site = location.search === '?same-site';
+  const initiator = await spawnWindow(t);
+  const url1 = initiator.getExecutorURL({
+    hostname: is_same_site ? undefined : '{{hosts[alt][www]}}',
+    page: 1,
+    pipe: 'header(Cache-Control,private\\,max-age=604800)'
+  });
+  const url2 = initiator.getExecutorURL({
+    hostname: is_same_site ? undefined : '{{hosts[][]}}',
+    page: 2,
+    pipe: 'header(Cache-Control,private\\,max-age=604800)'
+  });
+
+  await initiator.forceSinglePrefetch(url1);
+  initiator.navigate(url2);
+  assert_equals(await initiator.getDeliveryType(), '');
+  assert_not_prefetched(await initiator.getRequestHeaders(),
+                        'Content should not have been prefetched.');
+
+  initiator.navigate(url1);
+  if (is_same_site) {
+    assert_equals(await initiator.getDeliveryType(), 'cache',
+      'Navigation should have retrieved the response from the HTTP Cache.');
+    // Note: Even though we didn't use a prefetch, the cached response for
+    // |url1| was obtained using a prefetch request, and the recorded headers
+    // at the time of the first request would have Sec-Purpose: 'prefetch'.
+    assert_prefetched(await initiator.getRequestHeaders(),
+      'The cached response should have been from the initial prefetch request.');
+  } else {
+    assert_equals(await initiator.getDeliveryType(), '',
+      'Navigation response should not have been from the HTTP Cache.');
+  }
+
+
+  await initiator.forceSinglePrefetch(url2);
+  initiator.navigate(url2);
+  assert_equals(await initiator.getDeliveryType(), 'navigational-prefetch',
+    'Navigation should have used the prefetch');
+  if (is_same_site) {
+    // Note: Even though we did use a prefetch, the recorded request headers in
+    // the response will not be prefetch headers. This is because the prefetch
+    // request retrieved its response from the HTTP cache, and the response in
+    // the cache was initially obtained from the first navigation to |url2|,
+    // which was not a prefetch.
+    assert_not_prefetched(await initiator.getRequestHeaders(),
+      'The prefetch request should have used a response from the HTTP cache.');
+  } else {
+    assert_prefetched(await initiator.getRequestHeaders(),
+      'The prefetch request should have used a fresh response');
+  }
+
+}, 'Test that prefetches use/store responses to/from the HTTP cache.');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-uses-cache.sub.https_cross-site-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-uses-cache.sub.https_cross-site-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-uses-cache.sub.https_same-site-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-uses-cache.sub.https_same-site-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-middle-of-prefetch.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-middle-of-prefetch.https.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<meta name="timeout" content="long">
+<meta name="variant" content="?origin=same-origin">
+<meta name="variant" content="?origin=cross-site-redirect">
+<meta name="variant" content="?origin=cross-site-initial">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/utils.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+<script src="resources/redirect-helper.sub.js"></script>
+
+<script>
+setup(() => assertSpeculationRulesIsSupported());
+// Attempt to use the prefetched result in the middle of its redirects during
+// prefetch.
+// i.e. prefetch `prefetchInitialUrl` that is redirected to `prefetchFinalUrl`,
+// then navigate (either directly or via redirect) to `prefetchFinalUrl.
+
+// Prefetches should be completed before navigation starts, because otherwise
+// the prefetch's redirected URL is not known at the time of navigation.
+const prefetchTiming = 'redirect-received-before-navigation-start';
+
+promise_test(async t => {
+  const {agent,
+         prefetchInitialUrl,
+         prefetchFinalUrl,
+         redirectToPrefetchInitialUrl,
+         redirectToPrefetchFinalUrl} = await prepare(t, prefetchTiming);
+
+  await agent.forceSinglePrefetch(prefetchInitialUrl);
+  await agent.navigate(prefetchFinalUrl,
+                       {expectedDestinationUrl: prefetchFinalUrl});
+
+  assert_not_prefetched(await agent.getRequestHeaders(),
+      'Prefetched response should not be used by navigation.');
+}, 'Navigate to the final URL of the prefetch');
+
+promise_test(async t => {
+  const {agent,
+         prefetchInitialUrl,
+         prefetchFinalUrl,
+         redirectToPrefetchInitialUrl,
+         redirectToPrefetchFinalUrl} = await prepare(t, prefetchTiming);
+
+  await agent.forceSinglePrefetch(prefetchInitialUrl);
+  await agent.navigate(redirectToPrefetchFinalUrl,
+                       {expectedDestinationUrl: prefetchFinalUrl});
+
+  assert_not_prefetched(await agent.getRequestHeaders(),
+      'Prefetched response should not be used by navigation.');
+}, 'Navigation is redirected to the final URL of the prefetch');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-middle-of-prefetch.https_origin=cross-site-initial-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-middle-of-prefetch.https_origin=cross-site-initial-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-middle-of-prefetch.https_origin=cross-site-redirect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-middle-of-prefetch.https_origin=cross-site-redirect-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-middle-of-prefetch.https_origin=same-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-middle-of-prefetch.https_origin=same-origin-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-to-prefetch-url.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-to-prefetch-url.https.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<meta name="timeout" content="long">
+<meta name="variant" content="?origin=same-origin">
+<meta name="variant" content="?origin=cross-site-redirect">
+<meta name="variant" content="?origin=cross-site-initial">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/utils.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+<script src="resources/redirect-helper.sub.js"></script>
+
+<script>
+setup(() => assertSpeculationRulesIsSupported());
+// Navigation is redirected to the prefetch URL, not directly navigating to
+// the prefetch URL.
+// The spec doesn't serve the prefetched result, but the Chromium does.
+// The tests here is based on the spec.
+// https://github.com/WICG/nav-speculation/issues/367
+for (const prefetchTiming of
+    ['redirect-received-before-navigation-start',
+     'redirect-received-after-navigation-start']) {
+  promise_test(async t => {
+    const {agent,
+           prefetchInitialUrl,
+           prefetchFinalUrl,
+           redirectToPrefetchInitialUrl,
+           redirectToPrefetchFinalUrl} = await prepare(t, prefetchTiming);
+
+    await agent.forceSinglePrefetch(prefetchInitialUrl);
+    await agent.navigate(redirectToPrefetchInitialUrl,
+                         {expectedDestinationUrl: prefetchFinalUrl});
+
+    assert_not_prefetched(await agent.getRequestHeaders(),
+        'Prefetched response should not be used by navigation.');
+  }, prefetchTiming);
+}
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-to-prefetch-url.https_origin=cross-site-initial-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-to-prefetch-url.https_origin=cross-site-initial-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-to-prefetch-url.https_origin=cross-site-redirect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-to-prefetch-url.https_origin=cross-site-redirect-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-to-prefetch-url.https_origin=same-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-to-prefetch-url.https_origin=same-origin-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<meta name="timeout" content="long">
+<meta name="variant" content="?origin=same-origin">
+<meta name="variant" content="?origin=cross-site-redirect">
+<meta name="variant" content="?origin=cross-site-initial">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/utils.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+<script src="resources/redirect-helper.sub.js"></script>
+
+<script>
+setup(() => assertSpeculationRulesIsSupported());
+// Navigate to the initial URL of the prefetch.
+for (const prefetchTiming of
+    ['redirect-received-before-navigation-start',
+     'redirect-received-after-navigation-start']) {
+  promise_test(async t => {
+    const {agent,
+           prefetchInitialUrl,
+           prefetchFinalUrl,
+           redirectToPrefetchInitialUrl,
+           redirectToPrefetchFinalUrl} = await prepare(t, prefetchTiming);
+
+    await agent.forceSinglePrefetch(prefetchInitialUrl);
+    await agent.navigate(prefetchInitialUrl,
+                         {expectedDestinationUrl: prefetchFinalUrl});
+
+    assert_prefetched(await agent.getRequestHeaders(),
+        'Prefetched response should be used by navigation.');
+  }, prefetchTiming);
+}
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https_origin=cross-site-initial-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https_origin=cross-site-initial-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https_origin=cross-site-redirect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https_origin=cross-site-redirect-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https_origin=same-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https_origin=same-origin-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<title>Prefetch with the referrer policy specified in speculation rules</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/subset-tests.js"></script>
+<script src="/common/utils.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+
+<!--Split test cases due to the use of timeouts in speculation rules test utilities.-->
+<meta name="variant" content="?1-1">
+<meta name="variant" content="?2-2">
+<meta name="variant" content="?3-3">
+<meta name="variant" content="?4-4">
+<meta name="variant" content="?5-5">
+<meta name="variant" content="?6-6">
+<meta name="variant" content="?7-7">
+<meta name="variant" content="?8-last">
+
+<script>
+"use strict";
+
+setup(() => assertSpeculationRulesIsSupported());
+
+subsetTest(promise_test, async t => {
+  const agent = await spawnWindow(t);
+  await agent.setReferrerPolicy("strict-origin-when-cross-origin");
+  const expectedReferrer = agent.getExecutorURL().origin + "/";
+
+  const nextURL = agent.getExecutorURL({ page: 2 });
+  await agent.forceSinglePrefetch(nextURL, { referrer_policy: "strict-origin" });
+  await agent.navigate(nextURL);
+
+  const headers = await agent.getRequestHeaders();
+  assert_prefetched(headers, "must be prefetched");
+  assert_equals(headers.referer, expectedReferrer, "must send the origin as the referrer");
+}, 'with "strict-origin" referrer policy in rule set overriding "strict-origin-when-cross-origin" of referring page');
+
+subsetTest(promise_test, async t => {
+  const agent = await spawnWindow(t);
+  const next_url = agent.getExecutorURL({ page: 2 });
+  await agent.execute_script((url) => {
+    const a = addLink(url);
+    a.referrerPolicy = 'no-referrer';
+    insertDocumentRule(undefined, { referrer_policy: 'strict-origin' });
+  }, [next_url]);
+  await new Promise(resolve => t.step_timeout(resolve, 2000));
+  await agent.navigate(next_url);
+
+  const headers = await agent.getRequestHeaders();
+  assert_prefetched(headers, 'must be prefetched');
+  const expected_referrer = next_url.origin + '/';
+  assert_equals(headers.referer, expected_referrer, 'must send the origin as the referrer');
+}, 'with "strict-origin" referrer policy in rule set override "no-referrer" of link');
+
+subsetTest(promise_test, async t => {
+  const agent = await spawnWindow(t);
+  await agent.setReferrerPolicy("unsafe-url");
+
+  const nextURL = agent.getExecutorURL({ hostname: get_host_info().NOTSAMESITE_HOST, page: 2 });
+  await agent.forceSinglePrefetch(nextURL, { referrer_policy: "no-referrer" });
+  await agent.navigate(nextURL);
+
+  // This referring page's referrer policy would not be eligible for
+  // cross-site prefetching, but setting a sufficiently strict policy in the
+  // rule allows for prefetching.
+  const headers = await agent.getRequestHeaders();
+  assert_prefetched(headers, "must be prefetched");
+  assert_equals(headers.referer, undefined, "must send no referrer");
+}, 'with "no-referrer" referrer policy in rule set overriding "unsafe-url" of cross-site referring page');
+
+subsetTest(promise_test, async t => {
+  const agent = await spawnWindow(t);
+  await agent.setReferrerPolicy("strict-origin-when-cross-origin");
+
+  const nextURL = agent.getExecutorURL({ page: 2 });
+  await agent.forceSinglePrefetch(nextURL, { referrer_policy: "no-referrrrrrrer" });
+  await agent.navigate(nextURL);
+
+  const headers = await agent.getRequestHeaders();
+  assert_not_prefetched(headers, "must not be prefetched");
+}, 'unrecognized policies invalidate the rule');
+
+subsetTest(promise_test, async t => {
+  const agent = await spawnWindow(t);
+  await agent.setReferrerPolicy("strict-origin");
+  const expectedReferrer = agent.getExecutorURL().origin + "/";
+
+  const nextURL = agent.getExecutorURL({ page: 2 });
+  await agent.execute_script((url) => {
+    const a = addLink(url);
+    a.referrerPolicy = 'no-referrrrrrrer';
+    insertDocumentRule();
+  }, [nextURL]);
+  await new Promise(resolve => t.step_timeout(resolve, 2000));
+  await agent.navigate(nextURL);
+
+  const headers = await agent.getRequestHeaders();
+  assert_prefetched(headers, "must be prefetched");
+  assert_equals(headers.referer, expectedReferrer, "must send the origin as the referrer");
+}, 'unrecognized policies in link referrerpolicy attribute are ignored');
+
+subsetTest(promise_test, async t => {
+  const agent = await spawnWindow(t);
+  await agent.setReferrerPolicy("strict-origin-when-cross-origin");
+
+  const nextURL = agent.getExecutorURL({ page: 2 });
+  await agent.forceSinglePrefetch(nextURL, { referrer_policy: "never" });
+  await agent.navigate(nextURL);
+
+  const headers = await agent.getRequestHeaders();
+  assert_not_prefetched(headers, "must not be prefetched");
+}, 'treat legacy referrer policy values as invalid');
+
+subsetTest(promise_test, async t => {
+  const agent = await spawnWindow(t);
+  await agent.setReferrerPolicy("strict-origin");
+  const expectedReferrer = agent.getExecutorURL().origin + "/";
+
+  const nextURL = agent.getExecutorURL({ hostname: get_host_info().NOTSAMESITE_HOST, page: 2 });
+  await agent.forceSinglePrefetch(nextURL, { referrer_policy: "unsafe-url" });
+  await agent.navigate(nextURL);
+
+  // This referring page's referrer policy would normally make it eligible for
+  // cross-site prefetching, but setting an unacceptable policy in the rule
+  // makes it ineligible.
+  const headers = await agent.getRequestHeaders();
+  assert_not_prefetched(headers, "must not be prefetched");
+  assert_equals(headers.referer, expectedReferrer, "must send the origin as the referrer");
+}, 'with "unsafe-url" referrer policy in rule set overriding "strict-origin" of cross-site referring page');
+
+subsetTest(promise_test, async t => {
+  const agent = await spawnWindow(t);
+  await agent.setReferrerPolicy("strict-origin");
+  const expectedReferrer = agent.getExecutorURL().origin + "/";
+
+  const nextURL = agent.getExecutorURL({ page: 2 });
+  // The empty string is a valid value for "referrer_policy" and will be
+  // treated as if the key were omitted.
+  await agent.forceSinglePrefetch(nextURL, { referrer_policy: "" });
+  await agent.navigate(nextURL);
+
+  const headers = await agent.getRequestHeaders();
+  assert_prefetched(headers, "must be prefetched");
+  assert_equals(headers.referer, expectedReferrer, "must send the origin as the referrer");
+}, 'with empty string referrer policy in rule set defaulting to "strict-origin" of referring page');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_1-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_1-1-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_2-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_2-2-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_3-3-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_3-3-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_4-4-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_4-4-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_5-5-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_5-5-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_6-6-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_6-6-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_7-7-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_7-7-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_8-last-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_8-last-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-not-accepted.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-not-accepted.https.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<title>Prefetch attempts with an unacceptable referrer policy</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/subset-tests.js"></script>
+<script src="/common/utils.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+
+<!--Split test cases due to the use of timeouts in speculation rules test utilities.-->
+<meta name="variant" content="?1-1">
+<meta name="variant" content="?2-2">
+<meta name="variant" content="?3-last">
+
+<script>
+"use strict";
+
+setup(() => assertSpeculationRulesIsSupported());
+
+subsetTest(promise_test, async t => {
+  const agent = await spawnWindow(t);
+  await agent.setReferrerPolicy("unsafe-url");
+  const expectedReferrer = agent.getExecutorURL().href;
+
+  const nextURL = agent.getExecutorURL({ page: 2 });
+  await agent.forceSinglePrefetch(nextURL);
+  await agent.navigate(nextURL);
+
+  const headers = await agent.getRequestHeaders();
+  // The referrer policy restriction does not apply to same-site prefetch.
+  assert_prefetched(headers, "must be prefetched");
+  assert_equals(headers.referer, expectedReferrer, "must send the full URL as the referrer");
+}, 'with "unsafe-url" referrer policy on same-site referring page');
+
+subsetTest(promise_test, async t => {
+  const agent = await spawnWindow(t);
+  await agent.setReferrerPolicy("unsafe-url");
+  const expectedReferrer = agent.getExecutorURL().href;
+
+  const nextURL = agent.getExecutorURL({ hostname: get_host_info().NOTSAMESITE_HOST, page: 2 });
+  // This prefetch attempt should be ignored.
+  await agent.forceSinglePrefetch(nextURL);
+  await agent.navigate(nextURL);
+
+  const headers = await agent.getRequestHeaders();
+  assert_not_prefetched(headers, "must not be prefetched");
+  assert_equals(headers.referer, expectedReferrer, "must send the full URL as the referrer");
+}, 'with "unsafe-url" referrer policy on cross-site referring page');
+
+subsetTest(promise_test, async t => {
+  const agent = await spawnWindow(t);
+  await agent.setReferrerPolicy("unsafe-url");
+  const expectedReferrer = agent.getExecutorURL().href;
+
+  const nextURL = agent.getExecutorURL({ hostname: get_host_info().NOTSAMESITE_HOST, page: 2 });
+  // This prefetch attempt should be ignored.
+  await agent.execute_script((url) => {
+    addLink(url);
+    insertDocumentRule();
+  }, [nextURL]);
+  await new Promise(resolve => t.step_timeout(resolve, 2000));
+  await agent.navigate(nextURL);
+
+  const headers = await agent.getRequestHeaders();
+  assert_not_prefetched(headers, "must not be prefetched");
+  assert_equals(headers.referer, expectedReferrer, "must send the full URL as the referrer");
+}, 'with "unsafe-url" referrer policy on cross-site referring page with document rule');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-not-accepted.https_1-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-not-accepted.https_1-1-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-not-accepted.https_2-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-not-accepted.https_2-2-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-not-accepted.https_3-last-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-not-accepted.https_3-last-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy.https.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<title>Prefetch is done with the referring page's referrer policy</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/subset-tests.js"></script>
+<script src="/common/utils.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+
+<!--Split test cases due to the use of timeouts in speculation rules test utilities.-->
+<meta name="variant" content="?1-1">
+<meta name="variant" content="?2-2">
+<meta name="variant" content="?3-3">
+<meta name="variant" content="?4-last">
+
+<script>
+"use strict";
+
+setup(() => assertSpeculationRulesIsSupported());
+
+subsetTest(promise_test, async t => {
+  const agent = await spawnWindow(t);
+  await agent.setReferrerPolicy("strict-origin-when-cross-origin");
+  const expectedReferrer = agent.getExecutorURL().href;
+
+  const nextURL = agent.getExecutorURL({ page: 2 });
+  await agent.forceSinglePrefetch(nextURL);
+  await agent.navigate(nextURL);
+
+  const headers = await agent.getRequestHeaders();
+  assert_prefetched(headers, "must be prefetched");
+  assert_equals(headers.referer, expectedReferrer, "must send the full URL as the referrer");
+}, 'with "strict-origin-when-cross-origin" referrer policy');
+
+subsetTest(promise_test, async t => {
+  const agent = await spawnWindow(t);
+  await agent.setReferrerPolicy("strict-origin");
+  const expectedReferrer = agent.getExecutorURL().origin + "/";
+
+  const nextURL = agent.getExecutorURL({ page: 2 });
+  await agent.forceSinglePrefetch(nextURL);
+  await agent.navigate(nextURL);
+
+  const headers = await agent.getRequestHeaders();
+  assert_prefetched(headers, "must be prefetched");
+  assert_equals(headers.referer, expectedReferrer, "must send the origin as the referrer");
+}, 'with "strict-origin" referrer policy');
+
+subsetTest(promise_test, async t => {
+  const agent = await spawnWindow(t);
+  await agent.setReferrerPolicy("no-referrer");
+
+  const nextURL = agent.getExecutorURL({ page: 2 });
+  await agent.forceSinglePrefetch(nextURL);
+  await agent.navigate(nextURL);
+
+  const headers = await agent.getRequestHeaders();
+  assert_prefetched(headers, "must be prefetched");
+  assert_equals(headers.referer, undefined, "must send no referrer");
+}, 'with "no-referrer" referrer policy');
+
+subsetTest(promise_test, async t => {
+  const agent = await spawnWindow(t);
+  await agent.setReferrerPolicy("no-referrer");
+
+  const next_url = agent.getExecutorURL({ page: 2 });
+  await agent.execute_script((url) => {
+    const a = addLink(url);
+    a.referrerPolicy = 'strict-origin';
+    insertDocumentRule();
+  }, [next_url]);
+  await new Promise(resolve => t.step_timeout(resolve, 2000));
+  await agent.navigate(next_url);
+
+  const headers = await agent.getRequestHeaders();
+  const expected_referrer = next_url.origin + '/';
+  assert_prefetched(headers, 'must be prefetched');
+  assert_equals(headers.referer, expected_referrer);
+}, 'with "strict-origin" link referrer policy overriding "no-referrer" of referring page');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy.https_1-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy.https_1-1-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy.https_2-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy.https_2-2-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy.https_3-3-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy.https_3-3-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy.https_4-last-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy.https_4-last-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/authenticate.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/authenticate.py
@@ -1,0 +1,27 @@
+# TODO(https://crbug.com/406819294): Simplify relative import for util.
+import importlib
+util = importlib.import_module("speculation-rules.prefetch.resources.util")
+
+def main(request, response):
+  def fmt(x):
+    return f'"{x.decode("utf-8")}"' if x is not None else "undefined"
+
+  sec_purpose = request.headers.get("Sec-Purpose", b"").decode("utf-8")
+
+  headers = [
+    (b"Content-Type", b"text/html"),
+    (b'WWW-Authenticate', b'Basic'),
+    (b'Cache-Control', b'no-store')
+  ]
+  status = 200 if request.auth.username is not None or sec_purpose.startswith(
+      "prefetch") else 401
+
+  content = util.get_executor_html(
+    request,
+    f'''window.requestCredentials = {{
+        username: {fmt(request.auth.username)},
+        password: {fmt(request.auth.password)}
+      }};
+    ''')
+
+  return status, headers, content

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/basic-service-worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/basic-service-worker.js
@@ -1,0 +1,102 @@
+const originalSwOption = new URL(location.href).searchParams.get('sw');
+let swOption = originalSwOption;
+
+if (swOption === 'fetch-handler-navigation-preload') {
+  self.addEventListener('activate', event => {
+    if (self.registration.navigationPreload) {
+      event.waitUntil(self.registration.navigationPreload.enable());
+    }
+  });
+}
+
+if (swOption === 'race-fetch-handler' ||
+  swOption === 'race-fetch-handler-to-fallback' ||
+  swOption === 'race-fetch-handler-modify-url') {
+  swOption = swOption.substring('race-'.length);
+  self.addEventListener('install', event => {
+    event.addRoutes([{
+      condition: { urlPattern: { pathname: '/**/counting-executor.py' } },
+      source: 'race-network-and-fetch-handler'
+    }]);
+  });
+}
+
+const interceptedRequests = [];
+
+self.addEventListener('message', event => {
+  if (event.data === 'getInterceptedRequests') {
+    event.source.postMessage(interceptedRequests);
+  }
+});
+
+if (swOption !== 'no-fetch-handler') {
+  self.addEventListener('fetch', event => {
+
+    // Intercept the prefetched and navigated URLs only (e.g. do not intercept
+    // subresource requests related to `/common/dispatcher/dispatcher.js`).
+    if (!event.request.url.includes('counting-executor.py')) {
+      return;
+    }
+
+    const headers = {};
+    event.request.headers.forEach((value, key) => {
+      headers[key] = value;
+    });
+    const interceptedRequest = {
+      request: {
+        url: event.request.url,
+        headers: headers,
+      },
+      clientId: event.clientId,
+      resultingClientId: event.resultingClientId
+    };
+    interceptedRequests.push(interceptedRequest);
+
+    if (swOption === 'fetch-handler') {
+      event.respondWith(fetch(event.request));
+    } else if (swOption === 'fetch-handler-synthetic') {
+      const finalUrl = new URL(event.request.url).searchParams.get('location');
+      if (finalUrl) {
+        event.respondWith(Response.redirect(finalUrl));
+      } else {
+        // Fallback to the network.
+      }
+    } else if (swOption === 'fetch-handler-modify-url') {
+      // The "Sec-Purpose: prefetch" header is dropped in fetch-handler-modify-*
+      // cases in Step 33 of // https://fetch.spec.whatwg.org/#dom-request
+      // because it's a https://fetch.spec.whatwg.org/#forbidden-request-header
+      const url = new URL(event.request.url);
+      url.searchParams.set('intercepted', 'true');
+      if (originalSwOption === 'race-fetch-handler-modify-url') {
+        // See the comment in `basic.sub.https.html` for delay value.
+        url.searchParams.set('delay', '500');
+      }
+      event.respondWith(fetch(url, {headers: event.request.headers}));
+    } else if (swOption === 'fetch-handler-modify-referrer') {
+      event.respondWith(fetch(event.request,
+          {referrer: new URL('/intercepted', location.href).href}));
+    } else if (swOption === 'fetch-handler-navigation-preload') {
+      event.respondWith((async () => {
+        try {
+          if (event.preloadResponse === 'undefined') {
+            interceptedRequest.preloadResponse = 'undefined';
+            return fetch(event.request);
+          }
+          const response = await event.preloadResponse;
+          if (response) {
+            interceptedRequest.preloadResponse = 'resolved';
+            return response;
+          } else {
+            interceptedRequest.preloadResponse = 'resolved to undefined';
+            return fetch(event.request);
+          }
+        } catch(e) {
+          interceptedRequest.preloadResponse = 'rejected';
+          throw e;
+        }
+      })());
+    } else {
+      // Do nothing to fallback to the network.
+    }
+  });
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/conditional-status.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/conditional-status.py
@@ -1,0 +1,19 @@
+import json
+import os.path
+from wptserve.pipes import template
+
+def main(request, response):
+  response.headers.set(b"Content-Type", b"text/html")
+
+  prefetch = request.headers.get("Sec-Purpose", b"").decode("utf-8").startswith("prefetch")
+
+  response.content = template(
+    request,
+    open(os.path.join(os.path.dirname(__file__), "executor.sub.html"), "rb").read())
+
+  if prefetch:
+    response.status = 503
+    response.content += b"<body>503"
+  else:
+    response.status = 200
+    response.content += b"<body>200"

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/cookies.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/cookies.py
@@ -1,0 +1,31 @@
+import json
+
+# TODO(https://crbug.com/406819294): Simplify relative import for util.
+import importlib
+util = importlib.import_module("speculation-rules.prefetch.resources.util")
+
+def main(request, response):
+  cookies = json.dumps({
+      key.decode("utf-8"): request.cookies[key].value.decode("utf-8")
+      for key in request.cookies
+  })
+
+  sec_purpose = request.headers.get("Sec-Purpose", b"").decode("utf-8")
+
+  cookie_count = int(
+      request.cookies[b"count"].value) if b"count" in request.cookies else 0
+  response.set_cookie("count", f"{cookie_count+1}",
+                      secure=True, samesite="None")
+  response.set_cookie(
+      "type", "prefetch" if sec_purpose.startswith("prefetch") else "navigate")
+
+  headers = [(b"Content-Type", b"text/html"), (b"Cache-Control", b"no-store")]
+
+  if b"cookieindices" in request.GET:
+    headers.extend([(b"Vary", b"Cookie"), (b"Cookie-Indices", b"\"vary1\", \"vary2\"")])
+
+  content = util.get_executor_html(
+    request,
+    f'window.requestCookies = {cookies};')
+
+  return headers, content

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/counting-executor.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/counting-executor.py
@@ -1,0 +1,41 @@
+import json
+import os.path
+import time
+from wptserve.pipes import template
+
+def main(request, response):
+  response.headers.set(b"Content-Type", b"text/html")
+  response.headers.set(b"Cache-Control", b"no-store")
+
+  uuid = request.GET[b"uuid"]
+
+  # The lock is needed because the server receives concurrent requests to the
+  # same `uuid` e.g. due to `race-network-and-fetch-handler`.
+  with request.server.stash.lock:
+    request_count = request.server.stash.take(uuid)
+    if request_count is None:
+      request_count = {"prefetch": 0, "nonPrefetch": 0}
+
+    if b"check" in request.GET:
+      response.content = json.dumps(request_count)
+      return
+
+    prefetch = request.headers.get(
+      "Sec-Purpose", b"").decode("utf-8").startswith("prefetch")
+
+    request_count["prefetch" if prefetch else "nonPrefetch"] += 1
+    request.server.stash.put(uuid, request_count)
+
+  # This delay is after the `stash.put` above so that the request is counted
+  # upon received (i.e. we don't have to wait for the delay completion).
+  if b"delay" in request.GET:
+    time.sleep(float(request.GET[b"delay"]) / 1E3)
+
+  if b"location" in request.GET:
+    response.status = 302
+    response.headers.set(b"Location", request.GET[b"location"])
+    return
+
+  response.content = template(
+    request,
+    open(os.path.join(os.path.dirname(__file__), "executor.sub.html"), "rb").read())

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/executor.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/executor.sub.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<script src="/common/dispatcher/dispatcher.js" nonce="abc"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="utils.sub.js" nonce="abc"></script>
+<script nonce="abc">
+// For a given string `str` that is escaped by WPT's `.sub.html` or
+// `pipe=sub(html)` functionality, return the original unescaped string.
+//
+// Concretely, for `str` as the result of `html.escape(x, quote=True)`,
+// return the original unescaped string `x`.
+// See `/tools/wptserve/wptserve/pipes.py` and
+// https://docs.python.org/3/library/html.html#html.escape.
+//
+// See https://crbug.com/404573971 for fixing the escaping issue.
+function reverse_html_escape(str) {
+  str = str.replaceAll('&lt;', '<');
+  str = str.replaceAll('&gt;', '>');
+  str = str.replaceAll('&quot;', '"');
+  str = str.replaceAll('&#x27;', "'");
+  str = str.replaceAll('&amp;', '&');
+  return str;
+}
+
+// To be consistent with https://fetch.spec.whatwg.org/#headers-class
+// (accessed via iterable),
+// - The keys are lower-cased header names, and
+// - The entries are removed when the corresponding headers are non-existent.
+window.requestHeaders = {
+  "purpose": "{{header_or_default(Purpose, NONEXISTENT)}}",
+  "sec-purpose": "{{header_or_default(Sec-Purpose, NONEXISTENT)}}",
+  "referer": "{{header_or_default(Referer, NONEXISTENT)}}",
+  "sec-fetch-dest": "{{header_or_default(Sec-Fetch-Dest, NONEXISTENT)}}",
+  "sec-fetch-mode": "{{header_or_default(Sec-Fetch-Mode, NONEXISTENT)}}",
+  "service-worker-navigation-preload":
+      "{{header_or_default(Service-Worker-Navigation-Preload, NONEXISTENT)}}",
+  // Convert to the raw string to avoid backslashes from being processed as
+  // escape sequences.
+  // TODO(crbug.com/404573971): Remove `header_or_default` to reflect
+  // `__no_tags__` properly.
+  sec_speculation_tags:
+      String.raw`{{header_or_default(Sec-Speculation-Tags, __no_tags__)}}`,
+};
+Object.keys(requestHeaders).forEach(key => {
+  if (requestHeaders[key] === "NONEXISTENT") {
+    delete requestHeaders[key];
+  } else {
+    requestHeaders[key] = reverse_html_escape(requestHeaders[key]);
+  }
+});
+
+// Add a link to the page in order to use during the test
+function add_link(id, url) {
+  const link_element = document.createElement("a");
+  const link_text = document.createTextNode(url);
+  link_element.setAttribute("href", url);
+  link_element.setAttribute("id", id);
+  link_element.appendChild(link_text);
+  document.body.appendChild(link_element);
+}
+
+// "id" is the id of the link that we need to hover on in order
+// to start the prefetch
+async function start_non_immediate_prefetch_on_hover(id) {
+  let target = document.getElementById(id);
+
+  test_driver.set_test_context(window.opener);
+  // Inject the inputs to run this test.
+  await new test_driver.Actions().addPointer("mouse").pointerMove(0, 0, {origin: target}).send();
+}
+
+// "id" is the id of the link that we need to press on in order
+// to start the prefetch
+async function start_non_immediate_prefetch_on_pointerdown(id) {
+  let target = document.getElementById(id);
+
+  test_driver.set_test_context(window.opener);
+  // Inject the inputs to run this test.
+  // Move mouse pointer outside of the anchor so that we don't start the
+  // navigation before making sure the prefetch request started server-side.
+  await new test_driver.Actions().addPointer("mouse").pointerMove(0, 0, {origin: target}).pointerDown().pointerMove(0, 0).pointerUp().send();
+}
+
+async function navigate_by_form_generated_post(url) {
+  let form = document.createElement('form');
+  form.method = 'POST';
+  form.action = url;
+  document.body.appendChild(form);
+  form.submit();
+}
+
+// The fetch request's URL sent to the server.
+window.requestUrl = reverse_html_escape(
+    "{{location[server]}}{{location[path]}}{{location[query]}}");
+
+const uuid = new URLSearchParams(location.search).get('uuid');
+window.executor = new Executor(uuid);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/executor.sub.html.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/executor.sub.html.headers
@@ -1,0 +1,1 @@
+Cache-Control: no-store

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/post-navigation-handler.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/post-navigation-handler.py
@@ -1,0 +1,10 @@
+import os
+from wptserve.pipes import template
+
+# This is used only to accept POST navigations.
+def main(request, response):
+    response.headers.set(b"Content-Type", b"text/html")
+    response.headers.set(b"Cache-Control", b"no-store")
+    response.content = template(
+    request,
+    open(os.path.join(os.path.dirname(__file__), "executor.sub.html"), "rb").read())

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/prefetch.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/prefetch.py
@@ -1,0 +1,17 @@
+from wptserve.handlers import json_handler
+
+@json_handler
+def main(request, response):
+  uuid = request.GET[b"uuid"]
+  prefetch = request.headers.get(
+      "Sec-Purpose", b"").decode("utf-8").startswith("prefetch")
+  response.headers.set("Cache-Control", "no-store")
+
+  n = request.server.stash.take(uuid)
+  if n is None:
+    n = 0
+  if prefetch:
+    n += 1
+    request.server.stash.put(uuid, n)
+
+  return n

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/prefetch_nvs_hint.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/prefetch_nvs_hint.py
@@ -1,0 +1,40 @@
+import time
+
+# TODO(https://crbug.com/406819294): Simplify relative import for util.
+import importlib
+util = importlib.import_module("speculation-rules.prefetch.resources.util")
+
+def main(request, response):
+  response.headers.set("Cache-Control", "no-store")
+  uuid = request.GET[b"uuid"]
+  wait_for_prefetch_start_uuid = None
+  if b"wait_for_prefetch_uuid" in request.GET:
+    wait_for_prefetch_start_uuid = request.GET[b"wait_for_prefetch_uuid"]
+  prefetch = request.headers.get(
+      "Sec-Purpose", b"").decode("utf-8").startswith("prefetch")
+  if b"unblock" in request.GET:
+    request.server.stash.put(uuid, 0)
+    return ''
+
+  if b"wait_for_prefetch" in request.GET:
+    if wait_for_prefetch_start_uuid is None:
+      return ''
+    wait_for_prefetch = None
+    while wait_for_prefetch is None:
+      time.sleep(0.1)
+      wait_for_prefetch = request.server.stash.take(wait_for_prefetch_start_uuid)
+    return ''
+
+  if b"nvs_header" in request.GET:
+    nvs_header = request.GET[b"nvs_header"]
+    response.headers.set("No-Vary-Search", nvs_header)
+
+  if prefetch:
+    if wait_for_prefetch_start_uuid is not None:
+      request.server.stash.put(wait_for_prefetch_start_uuid, 0)
+    nvswait = None
+    while nvswait is None:
+      time.sleep(0.1)
+      nvswait = request.server.stash.take(uuid)
+
+  return util.get_executor_html(request, '')

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/random_redirect.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/random_redirect.py
@@ -1,0 +1,12 @@
+import secrets
+from urllib.parse import urlparse
+
+def main(request, response):
+    response.status = 302
+    location = request.GET.first(b"location")
+
+    # Add a query param. This is hacky but sufficient.
+    location += (b'&' if urlparse(location).query else b'?') + b'random=' + \
+        secrets.token_urlsafe(32).encode('utf-8')
+
+    response.headers.set(b"Location", location)

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/redirect-helper.sub.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/redirect-helper.sub.js
@@ -1,0 +1,73 @@
+// Prefetched redirect chain (as test variant parameters):
+// origin=same-origin:
+// initiator-(same-origin)->prefetchInitialUrl-(same-origin)->prefetchFinalUrl
+// origin=cross-site-initial:
+// initiator-(cross-site)-->prefetchInitialUrl-(same-origin)->prefetchFinalUrl
+// origin=cross-site-redirect:
+// initiator-(same-origin)->prefetchInitialUrl-(cross-site)-->prefetchFinalUrl
+const { origin } = Object.fromEntries(new URLSearchParams(location.search));
+
+// `prefetchTiming`:
+// - 'redirect-received-after-navigation-start':
+//   prefetch is started before navigation starts but the redirect response
+//   is received after navigation starts.
+// - Otherwise:
+//   prefetch (including its redirects) is completed before navigation starts.
+async function prepare(t, prefetchTiming) {
+  const agent = await spawnWindow(t);
+
+  let prefetchFinalUrl;
+  let prefetchInitialOrigin;
+  if (origin === 'same-origin') {
+    prefetchFinalUrl = agent.getExecutorURL({ page: 2 });
+    prefetchInitialOrigin = location.origin;
+  } else if (origin === 'cross-site-initial') {
+    prefetchFinalUrl = agent.getExecutorURL(
+        { page: 2, hostname: '{{hosts[alt][www]}}' });
+    prefetchInitialOrigin = prefetchFinalUrl.origin;
+  } else if (origin === 'cross-site-redirect') {
+    prefetchFinalUrl = agent.getExecutorURL(
+        { page: 2, hostname: '{{hosts[alt][www]}}' });
+    prefetchInitialOrigin = location.origin;
+  } else {
+    t.assert_unreached('Invalid origin option: ' + origin);
+  }
+
+  let prefetchInitialUrl;
+  if (prefetchTiming === 'redirect-received-after-navigation-start') {
+    // Because `forceSinglePrefetch()` waits for 2 seconds, we put 2.5-second
+    // delay here to make the redirect response is received after `navigate()`
+    // below. (In Chromium, the delay cannot go above 3 seconds, since more than
+    // 1 second with no response causes a timeout that falls back to
+    // non-prefetch.)
+    prefetchInitialUrl = new URL('/common/slow-redirect.py?delay=2.5',
+                                 prefetchInitialOrigin);
+    prefetchInitialUrl.searchParams.set('location', prefetchFinalUrl);
+  } else {
+    // Because `forceSinglePrefetch()` waits for 2 seconds, the redirect and
+    // final responses are expected to be received before `navigate()` below.
+    prefetchInitialUrl = new URL('/common/redirect.py', prefetchInitialOrigin);
+    prefetchInitialUrl.searchParams.set('location', prefetchFinalUrl);
+  }
+
+  const redirectToPrefetchInitialUrl = new URL('/common/redirect.py',
+                                               location.href);
+  redirectToPrefetchInitialUrl.searchParams.set(
+      'location', prefetchInitialUrl);
+
+  const redirectToPrefetchFinalUrl = new URL('/common/redirect.py',
+                                             location.href);
+  redirectToPrefetchFinalUrl.searchParams.set(
+      'location', prefetchFinalUrl);
+
+  // `type` is set just to make `redirectToPrefetchFinalUrl` different
+  // from `prefetchInitialUrl`.
+  redirectToPrefetchFinalUrl.searchParams.set(
+      'type', 'navigation');
+
+  return {agent,
+          prefetchInitialUrl,
+          prefetchFinalUrl,
+          redirectToPrefetchInitialUrl,
+          redirectToPrefetchFinalUrl};
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/ruleset.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/ruleset.py
@@ -1,0 +1,50 @@
+def main(request, response):
+    url = request.GET[b"url"].decode("utf-8")
+    uuid = request.GET[b"uuid"].decode("utf-8")
+    page = request.GET[b"page"].decode("utf-8")
+    valid_json = request.GET[b"valid_json"].decode("utf-8")
+    empty_json = request.GET[b"empty_json"].decode("utf-8")
+    fail_cors = request.GET[b"fail_cors"].decode("utf-8")
+    valid_encoding = request.GET[b"valid_encoding"].decode("utf-8")
+    redirect = request.GET[b"redirect"].decode("utf-8")
+    sec_fetch_dest = request.headers[b"Sec-Fetch-Dest"].decode(
+        "utf-8").lower() if b"Sec-Fetch-Dest" in request.headers else None
+    content_type = b"application/speculationrules+json" if request.GET[
+        b"valid_mime"].decode("utf-8") == "true" else b"application/json"
+    status = int(request.GET[b"status"])
+
+    if redirect == "true":
+        new_url = request.url.replace("redirect=true",
+                                      "redirect=false").encode("utf-8")
+        return 301, [(b"Location", new_url),
+                     (b'Access-Control-Allow-Origin', b'*')], b""
+
+    encoding = "utf-8" if valid_encoding == "true" else "windows-1250"
+    content_type += f'; charset={encoding}'.encode('utf-8')
+    strparam = b'\xc3\xb7'.decode('utf-8')
+
+    content = f'''
+      {{
+        "prefetch": [
+          {{
+            "source":"list",
+            "urls":["{url}?uuid={uuid}&page={page}&str={strparam}"]
+          }}
+        ]
+      }}
+  '''
+    if empty_json == "true":
+        content = ""
+    elif valid_json != "true":
+        content = "invalid json"
+    elif sec_fetch_dest is None:
+        content = "Missing Sec-Fetch-Dest"
+    elif sec_fetch_dest != "speculationrules":
+        content = "Unexpected Sec-Fetch-Dest " + sec_fetch_dest
+
+    headers = [(b"Content-Type", content_type)]
+    if fail_cors != "true":
+        origin = request.headers[
+            b"Origin"] if b"Origin" in request.headers else b'*'
+        headers.append((b'Access-Control-Allow-Origin', origin))
+    return status, headers, content.encode(encoding)

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/slow-executor.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/slow-executor.py
@@ -1,0 +1,13 @@
+import os.path
+import time
+
+from wptserve.pipes import template
+
+def main(request, response):
+    time.sleep(float(request.GET.first(b"delay")))
+    response.headers.set(b"Content-Type", b"text/html")
+    response.headers.set(b"Cache-Control", b"no-store")
+    response.content = template(
+        request,
+        open(os.path.join(os.path.dirname(__file__), "executor.sub.html"), "rb").read())
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/sw.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/sw.js
@@ -1,0 +1,1 @@
+self.addEventListener('fetch', event => event.respondWith(fetch(event.request)));

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/util.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/util.py
@@ -1,0 +1,16 @@
+import os
+from wptserve.pipes import template
+
+# Returns the executor HTML (as bytes).
+# `additional_script` (str) is inserted to the JavaScript before the executor.
+def get_executor_html(request, additional_script):
+  content = template(
+    request,
+    open(os.path.join(os.path.dirname(__file__), "executor.sub.html"), "rb").read())
+
+  # Insert an additional script at the head of script before Executor.
+  content = content.replace(
+      b'<script nonce="abc">',
+      b'<script nonce="abc">' + additional_script.encode('utf-8'))
+
+  return content

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/utils.sub.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/utils.sub.js
@@ -1,0 +1,283 @@
+/**
+ * Utilities for initiating prefetch via speculation rules.
+ */
+
+// Resolved URL to find this script.
+const SR_PREFETCH_UTILS_URL = new URL(document.currentScript.src, document.baseURI);
+
+// If (and only if) you are writing a test that depends on
+// `requires: ["anonymous-client-ip-when-cross-origin"]`, then you must use this
+// host as the cross-origin host. (If you need a generic cross-origin host, use
+// `get_host_info().NOTSAMESITE_HOST` or similar instead.)
+//
+// TODO(domenic): document in the web platform tests server infrastructure that
+// such a host must exist, and possibly separate it from `{{hosts[alt][]}}`.
+const CROSS_ORIGIN_HOST_THAT_WORKS_WITH_ACIWCO = "{{hosts[alt][]}}";
+
+class PrefetchAgent extends RemoteContext {
+  constructor(uuid, t) {
+    super(uuid);
+    this.t = t;
+  }
+
+  getExecutorURL(options = {}) {
+    let {hostname, username, password, protocol, executor, ...extra} = options;
+    let params = new URLSearchParams({uuid: this.context_id, ...extra});
+    if(executor === undefined) {
+      executor = "executor.sub.html";
+    }
+    let url = new URL(`${executor}?${params}`, SR_PREFETCH_UTILS_URL);
+    if(hostname !== undefined) {
+      url.hostname = hostname;
+    }
+    if(username !== undefined) {
+      url.username = username;
+    }
+    if(password !== undefined) {
+      url.password = password;
+    }
+    if(protocol !== undefined) {
+      url.protocol = protocol;
+      url.port = protocol === "https" ? "{{ports[https][0]}}" : "{{ports[http][0]}}";
+    }
+    return url;
+  }
+
+  // Requests prefetch via speculation rules.
+  //
+  // In the future, this should also use browser hooks to force the prefetch to
+  // occur despite heuristic matching, etc., and await the completion of the
+  // prefetch.
+  async forceSinglePrefetch(url, extra = {}, wait_for_completion = true) {
+    return this.forceSpeculationRules(
+      {
+        prefetch: [{source: 'list', urls: [url], ...extra}]
+      }, wait_for_completion);
+  }
+
+  async forceSpeculationRules(rules, wait_for_completion = true) {
+    await this.execute_script((rules) => {
+      insertSpeculationRules(rules);
+    }, [rules]);
+    if (!wait_for_completion) {
+      return Promise.resolve();
+    }
+    return new Promise(resolve => this.t.step_timeout(resolve, 2000));
+  }
+
+  // `url` is the URL to navigate.
+  //
+  // `expectedDestinationUrl` is the expected URL after navigation.
+  // When omitted, `url` is used. When explicitly null, the destination URL is
+  // not validated.
+  async navigate(url, {expectedDestinationUrl} = {}) {
+    await this.execute_script((url) => {
+      window.executor.suspend(() => {
+        location.href = url;
+      });
+    }, [url]);
+    if (expectedDestinationUrl === undefined) {
+      expectedDestinationUrl = url;
+    }
+    if (expectedDestinationUrl) {
+      expectedDestinationUrl.username = '';
+      expectedDestinationUrl.password = '';
+      assert_equals(
+          await this.execute_script(() => location.href),
+          expectedDestinationUrl.toString(),
+          "expected navigation to reach destination URL");
+    }
+    await this.execute_script(() => {});
+  }
+
+  async getRequestHeaders() {
+    return this.execute_script(() => requestHeaders);
+  }
+
+  async getResponseCookies() {
+    return this.execute_script(() => {
+      let cookie = {};
+      document.cookie.split(/\s*;\s*/).forEach((kv)=>{
+        let [key, value] = kv.split(/\s*=\s*/);
+        cookie[key] = value;
+      });
+      return cookie;
+    });
+  }
+
+  async getRequestCookies() {
+    return this.execute_script(() => window.requestCookies);
+  }
+
+  async getRequestCredentials() {
+    return this.execute_script(() => window.requestCredentials);
+  }
+
+  async setReferrerPolicy(referrerPolicy) {
+    return this.execute_script(referrerPolicy => {
+      const meta = document.createElement("meta");
+      meta.name = "referrer";
+      meta.content = referrerPolicy;
+      document.head.append(meta);
+    }, [referrerPolicy]);
+  }
+
+  async getDeliveryType(){
+    return this.execute_script(() => {
+      return performance.getEntriesByType("navigation")[0].deliveryType;
+    });
+  }
+}
+
+// Produces a URL with a UUID which will record when it's prefetched.
+// |extra_params| can be specified to add extra search params to the generated
+// URL.
+function getPrefetchUrl(extra_params={}) {
+  let params = new URLSearchParams({ uuid: token(), ...extra_params });
+  return new URL(`prefetch.py?${params}`, SR_PREFETCH_UTILS_URL);
+}
+
+// Produces n URLs with unique UUIDs which will record when they are prefetched.
+function getPrefetchUrlList(n) {
+  return Array.from({ length: n }, () => getPrefetchUrl());
+}
+
+async function isUrlPrefetched(url) {
+  let response = await fetch(url, {redirect: 'follow'});
+  assert_true(response.ok);
+  return response.json();
+}
+
+// Must also include /common/utils.js and /common/dispatcher/dispatcher.js to use this.
+async function spawnWindowWithReference(t, options = {}, uuid = token()) {
+  let agent = new PrefetchAgent(uuid, t);
+  let w = window.open(agent.getExecutorURL(options), '_blank', options);
+  t.add_cleanup(() => w.close());
+  return {"agent":agent, "window":w};
+}
+
+// Must also include /common/utils.js and /common/dispatcher/dispatcher.js to use this.
+async function spawnWindow(t, options = {}, uuid = token()) {
+  let agent_window_pair = await spawnWindowWithReference(t, options, uuid);
+  return agent_window_pair.agent;
+}
+
+function insertSpeculationRules(body) {
+  let script = document.createElement('script');
+  script.type = 'speculationrules';
+  script.textContent = JSON.stringify(body);
+  document.head.appendChild(script);
+}
+
+// Creates and appends <a href=|href|> to |insertion point|. If
+// |insertion_point| is not specified, document.body is used.
+function addLink(href, insertion_point=document.body) {
+  const a = document.createElement('a');
+  a.href = href;
+  insertion_point.appendChild(a);
+  return a;
+}
+
+// Inserts a prefetch document rule with |predicate|. |predicate| can be
+// undefined, in which case the default predicate will be used (i.e. all links
+// in document will match).
+function insertDocumentRule(predicate, extra_options={}) {
+  insertSpeculationRules({
+    prefetch: [{
+      source: 'document',
+      eagerness: 'immediate',
+      where: predicate,
+      ...extra_options
+    }]
+  });
+}
+
+function assert_prefetched (requestHeaders, description) {
+  assert_in_array(requestHeaders.purpose, [undefined, "prefetch"], "The vendor-specific header Purpose, if present, must be 'prefetch'.");
+  assert_in_array(requestHeaders['sec-purpose'],
+                  ["prefetch", "prefetch;anonymous-client-ip"], description);
+}
+
+function assert_prefetched_anonymous_client_ip(requestHeaders, description) {
+  assert_in_array(requestHeaders.purpose, [undefined, "prefetch"], "The vendor-specific header Purpose, if present, must be 'prefetch'.");
+  assert_equals(requestHeaders['sec-purpose'],
+                "prefetch;anonymous-client-ip",
+                description);
+}
+
+function assert_not_prefetched (requestHeaders, description){
+  assert_equals(requestHeaders.purpose, undefined, description);
+  assert_equals(requestHeaders['sec-purpose'], undefined, description);
+}
+
+// If the prefetch request is intercepted and modified by ServiceWorker,
+// - "Sec-Purpose: prefetch" header is dropped in Step 33 of
+//   https://fetch.spec.whatwg.org/#dom-request
+//   because it's a https://fetch.spec.whatwg.org/#forbidden-request-header.
+// - "Purpose: prefetch" can still be sent.
+// Note that this check passes also for non-prefetch requests, so additional
+// checks are needed to distinguish from non-prefetch requests.
+function assert_prefetched_without_sec_purpose(requestHeaders, description) {
+  assert_in_array(requestHeaders.purpose, [undefined, "prefetch"],
+      "The vendor-specific header Purpose, if present, must be 'prefetch'.");
+  assert_equals(requestHeaders['sec-purpose'], undefined, description);
+}
+
+// For ServiceWorker tests.
+// `interceptedRequest` is an element of `interceptedRequests` in
+// `resources/basic-service-worker.js`.
+
+// The ServiceWorker fetch handler intercepted a prefetching request.
+function assert_intercept_prefetch(interceptedRequest, expectedUrl) {
+  assert_equals(interceptedRequest.request.url, expectedUrl.toString(),
+      "intercepted request URL.");
+
+  assert_prefetched(interceptedRequest.request.headers,
+      "Prefetch request should be intercepted.");
+
+  if (new URL(location.href).searchParams.has('clientId')) {
+    // https://github.com/WICG/nav-speculation/issues/346
+    // https://crbug.com/404294123
+    assert_equals(interceptedRequest.resultingClientId, "",
+        "resultingClientId shouldn't be exposed.");
+
+    // https://crbug.com/404286918
+    // `assert_not_equals()` isn't used for now to create stable failure diffs.
+    assert_false(interceptedRequest.clientId === "",
+        "clientId should be initiator.");
+  }
+}
+
+// The ServiceWorker fetch handler intercepted a non-prefetching request.
+function assert_intercept_non_prefetch(interceptedRequest, expectedUrl) {
+  assert_equals(interceptedRequest.request.url, expectedUrl.toString(),
+      "intercepted request URL.");
+
+  assert_not_prefetched(interceptedRequest.request.headers,
+      "Non-prefetch request should be intercepted.");
+
+  if (new URL(location.href).searchParams.has('clientId')) {
+    // Because this is an ordinal non-prefetch request, `resultingClientId`
+    // can be set as normal.
+    assert_not_equals(interceptedRequest.resultingClientId, "",
+        "resultingClientId can be exposed.");
+
+    assert_not_equals(interceptedRequest.clientId, "",
+        "clientId should be initiator.");
+  }
+}
+
+function assert_served_by_navigation_preload(requestHeaders) {
+  assert_equals(
+    requestHeaders['service-worker-navigation-preload'],
+    'true',
+    'Service-Worker-Navigation-Preload');
+}
+
+// Use nvs_header query parameter to ask the wpt server
+// to populate No-Vary-Search response header.
+function addNoVarySearchHeaderUsingQueryParam(url, value){
+  if(value){
+    url.searchParams.append("nvs_header", value);
+  }
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/w3c-import.log
@@ -1,0 +1,33 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/authenticate.py
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/basic-service-worker.js
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/conditional-status.py
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/cookies.py
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/counting-executor.py
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/executor.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/executor.sub.html.headers
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/post-navigation-handler.py
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/prefetch.py
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/prefetch_nvs_hint.py
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/random_redirect.py
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/redirect-helper.sub.js
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/ruleset.py
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/slow-executor.py
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/sw.js
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/util.py
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/utils.sub.js

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/same-origin-cookies.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/same-origin-cookies.https.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src='/resources/testdriver-vendor.js'></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/subset-tests.js"></script>
+<script src="/common/utils.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+
+<!--Split test cases due to the use of timeouts in speculation rules test utilities.-->
+<meta name="variant" content="?1-1">
+<meta name="variant" content="?2-last">
+
+<script>
+  setup(() => assertSpeculationRulesIsSupported());
+
+  subsetTest(promise_test, async t => {
+    await test_driver.delete_all_cookies();
+
+    let executor = 'cookies.py';
+    let agent = await spawnWindow(t, { executor });
+    let response_cookies = await agent.getResponseCookies();
+    let request_cookies = await agent.getRequestCookies();
+    assert_equals(request_cookies["count"], undefined);
+    assert_equals(request_cookies["type"], undefined);
+    assert_equals(response_cookies["count"], "1");
+    assert_equals(response_cookies["type"], "navigate");
+
+    let nextUrl = agent.getExecutorURL({ executor, page: 2 });
+    await agent.forceSinglePrefetch(nextUrl);
+    await agent.navigate(nextUrl);
+
+    response_cookies = await agent.getResponseCookies();
+    request_cookies = await agent.getRequestCookies();
+    assert_equals(request_cookies["count"], "1");
+    assert_equals(request_cookies["type"], "navigate");
+    assert_equals(response_cookies["count"], "2");
+    assert_equals(response_cookies["type"], "prefetch");
+
+    assert_prefetched(await agent.getRequestHeaders());
+  }, "speculation rules based prefetch should use cookies for same origin urls.");
+
+  // Regression test for https://crbug.com/1524338
+  subsetTest(promise_test, async t => {
+    await test_driver.delete_all_cookies();
+
+    let executor = 'cookies.py';
+    let agent = await spawnWindow(t, { executor });
+    let response_cookies = await agent.getResponseCookies();
+    let request_cookies = await agent.getRequestCookies();
+    assert_equals(request_cookies["count"], undefined);
+    assert_equals(request_cookies["type"], undefined);
+    assert_equals(response_cookies["count"], "1");
+    assert_equals(response_cookies["type"], "navigate");
+
+    await agent.setReferrerPolicy("no-referrer");
+
+    let nextUrl = agent.getExecutorURL({ executor, page: 2 });
+    await agent.forceSinglePrefetch(nextUrl);
+    await agent.navigate(nextUrl);
+
+    response_cookies = await agent.getResponseCookies();
+    request_cookies = await agent.getRequestCookies();
+    assert_equals(request_cookies["count"], "1");
+    assert_equals(request_cookies["type"], "navigate");
+    assert_equals(response_cookies["count"], "2");
+    assert_equals(response_cookies["type"], "prefetch");
+
+    assert_prefetched(await agent.getRequestHeaders());
+  }, "same origin prefetch with no referrer works when cookies are present.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/same-origin-cookies.https_1-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/same-origin-cookies.https_1-1-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/same-origin-cookies.https_2-last-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/same-origin-cookies.https_2-last-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/sec-fetch-headers.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/sec-fetch-headers.https-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/sec-fetch-headers.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/sec-fetch-headers.https.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<title>Prefetch request's Sec-Fetch-* request headers</title>
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/utils.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+
+<script>
+"use strict";
+
+setup(() => assertSpeculationRulesIsSupported());
+
+// https://wicg.github.io/nav-speculation/prefetch.html#create-a-navigation-request
+
+promise_test(async t => {
+  const agent = await spawnWindow(t);
+  const nextUrl = agent.getExecutorURL({ page: 2 });
+  await agent.forceSinglePrefetch(nextUrl);
+  await agent.navigate(nextUrl);
+
+  const headers = await agent.getRequestHeaders();
+  assert_prefetched(headers, "must be prefetched");
+  assert_equals(headers['sec-fetch-dest'], "document", "Sec-Fetch-Dest");
+}, 'Sec-Fetch-Dest');
+
+promise_test(async t => {
+  const agent = await spawnWindow(t);
+  const nextUrl = agent.getExecutorURL({ page: 2 });
+  await agent.forceSinglePrefetch(nextUrl);
+  await agent.navigate(nextUrl);
+
+  const headers = await agent.getRequestHeaders();
+  assert_prefetched(headers, "must be prefetched");
+  assert_equals(headers['sec-fetch-mode'], "navigate", "Sec-Fetch-Mode");
+}, 'Sec-Fetch-Mode');
+
+promise_test(async t => {
+  const agent = await spawnWindow(t);
+  const nextUrl = new URL('/common/redirect.py', location.href);
+  const finalUrl = agent.getExecutorURL({ page: 2 });
+  nextUrl.searchParams.set('location', finalUrl);
+  await agent.forceSinglePrefetch(nextUrl);
+  await agent.navigate(nextUrl, {expectedDestinationUrl: finalUrl});
+
+  const headers = await agent.getRequestHeaders();
+  assert_prefetched(headers, "must be prefetched");
+  assert_equals(headers['sec-fetch-dest'], "document", "Sec-Fetch-Dest");
+}, 'Sec-Fetch-Dest with redirects');
+
+promise_test(async t => {
+  const agent = await spawnWindow(t);
+  const nextUrl = new URL('/common/redirect.py', location.href);
+  const finalUrl = agent.getExecutorURL({ page: 2 });
+  nextUrl.searchParams.set('location', finalUrl);
+  await agent.forceSinglePrefetch(nextUrl);
+  await agent.navigate(nextUrl, {expectedDestinationUrl: finalUrl});
+
+  const headers = await agent.getRequestHeaders();
+  assert_prefetched(headers, "must be prefetched");
+  assert_equals(headers['sec-fetch-mode'], "navigate", "Sec-Fetch-Mode");
+}, 'Sec-Fetch-Mode with redirects');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/user-pass.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/user-pass.https.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/utils.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+
+<meta name="variant" content="?cross-origin=true">
+<meta name="variant" content="?cross-origin=false">
+
+<script>
+  setup(() => assertSpeculationRulesIsSupported());
+
+  let cross_origin = Object.fromEntries(new URLSearchParams(location.search))["cross-origin"] === "true";
+  promise_test(async t => {
+    let executor = "authenticate.py";
+    let credentials = { username: "user", password: "pass" };
+    let agent = await spawnWindow(t, { executor, ...credentials });
+    let request_credentials = await agent.getRequestCredentials();
+    assert_equals(request_credentials.username, credentials.username);
+    assert_equals(request_credentials.password, credentials.password);
+
+    let host = cross_origin ? { hostname: get_host_info().NOTSAMESITE_HOST } : {};
+    let nextUrl = agent.getExecutorURL({ page: 2, executor, ...host });
+    await agent.forceSinglePrefetch(nextUrl);
+    await agent.navigate(nextUrl);
+
+    let requestHeaders = await agent.getRequestHeaders();
+    request_credentials = await agent.getRequestCredentials();
+    if (cross_origin) {
+      assert_equals(request_credentials.username, undefined);
+      assert_equals(request_credentials.password, undefined);
+    }
+    else {
+      assert_equals(request_credentials.username, credentials.username);
+      assert_equals(request_credentials.password, credentials.password);
+    }
+    assert_prefetched(requestHeaders);
+  }, "test www-authenticate basic does not forward credentials to cross-origin pages.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/user-pass.https_cross-origin=false-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/user-pass.https_cross-origin=false-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/user-pass.https_cross-origin=true-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/user-pass.https_cross-origin=true-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/w3c-import.log
@@ -1,0 +1,50 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/anonymous-client.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/clear-prefetch-cache-after-clear-site-data-cache.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cross-origin-cookies-anonymous-client-ip-duplicate.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cross-origin-cookies.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators-2.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators.sub.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/duplicate-urls.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/fragment.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/implicit-source.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-a-element.sub.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-iframe-location-href.sub.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-window-open.sub.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/multiple-url.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-http-cache-interference.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-prefetch-for-post.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-traverse-reload.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-uses-cache.sub.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-middle-of-prefetch.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-to-prefetch-url.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-not-accepted.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/same-origin-cookies.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/sec-fetch-headers.https.html
+/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/user-pass.https.html

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/resources/utils.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/resources/utils.js
@@ -1,0 +1,54 @@
+globalThis.assertSpeculationRulesIsSupported = () => {
+  assert_implements(
+      'supports' in HTMLScriptElement,
+      'HTMLScriptElement.supports must be supported');
+  assert_implements(
+      HTMLScriptElement.supports('speculationrules'),
+      '<script type="speculationrules"> must be supported');
+};
+
+// If you want access to these, be sure to include
+// /html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js.
+// So as to avoid requiring everyone to do that, we only conditionally define this infrastructure.
+if (globalThis.RemoteContextHelper) {
+  class PreloadingRemoteContextWrapper extends RemoteContextHelper.RemoteContextWrapper {
+    /**
+    * Starts preloading a page with this `PreloadingRemoteContextWrapper` as the
+    * referrer, using `<script type="speculationrules">`.
+    *
+    * @param {"prefetch"|"prerender"} preloadType - The preload type to use.
+    * @param {object} [extrasInSpeculationRule] - Additional properties to add
+    *     to the speculation rule JSON.
+    * @param {RemoteContextConfig|object} [extraConfig] - Additional remote
+    *     context configuration for the preloaded context.
+    * @returns {Promise<PreloadingRemoteContextWrapper>}
+    */
+    addPreload(preloadType, { extrasInSpeculationRule = {}, ...extraConfig } = {}) {
+      const referrerRemoteContext = this;
+
+      return this.helper.createContext({
+        executorCreator(url) {
+          return referrerRemoteContext.executeScript((url, preloadType, extrasInSpeculationRule) => {
+            const script = document.createElement("script");
+            script.type = "speculationrules";
+            script.textContent = JSON.stringify({
+              [preloadType]: [
+                {
+                  source: "list",
+                  urls: [url],
+                  ...extrasInSpeculationRule
+                }
+              ]
+            });
+            document.head.append(script);
+          }, [url, preloadType, extrasInSpeculationRule]);
+        },
+        extraConfig
+      });
+    }
+  }
+
+  globalThis.PreloadingRemoteContextHelper = class extends RemoteContextHelper {
+    static RemoteContextWrapper = PreloadingRemoteContextWrapper;
+  };
+}

--- a/LayoutTests/tests-options.json
+++ b/LayoutTests/tests-options.json
@@ -5552,6 +5552,63 @@
     "imported/w3c/web-platform-tests/shadow-dom/declarative/gethtml.html": [
         "slow"
     ],
+    "imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/speculation-rules/prefetch/cross-origin-cookies-anonymous-client-ip-duplicate.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/speculation-rules/prefetch/cross-origin-cookies.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators-2.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators.sub.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-a-element.sub.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-iframe-location-href.sub.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-window-open.sub.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/speculation-rules/prefetch/no-prefetch-for-post.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-traverse-reload.sub.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-uses-cache.sub.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-middle-of-prefetch.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-to-prefetch-url.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/speculation-rules/prefetch/same-origin-cookies.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/speculation-rules/prefetch/sec-fetch-headers.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/speculation-rules/prefetch/tentative/service-worker/basic.sub.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/speculation-rules/prefetch/tentative/service-worker/redirect.sub.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/speculation-rules/prefetch/user-pass.https.html": [
+        "slow"
+    ],
     "imported/w3c/web-platform-tests/subresource-integrity/integrity-policy/parsing.html": [
         "slow"
     ],


### PR DESCRIPTION
#### aa36ac49c44c37ad04a65ab5f5ab7dff4472246b
<pre>
Implement speculation rules - same origin conservative prefetch
<a href="https://bugs.webkit.org/show_bug.cgi?id=295193">https://bugs.webkit.org/show_bug.cgi?id=295193</a>

Reviewed by NOBODY (OOPS!).

This implements an initial version of same-origin conservative prefetch
speculation rules.

* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=and-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=baseURLChangedByBaseElement-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=baseURLChangedBySameDocumentNavigation-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=defaultPredicate-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=hrefMatches-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=immediateMutation-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=invalidPredicate-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=linkHrefChanged-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=linkInShadowTree-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=linkToSelfFragment-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=newRuleSetAdded-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=not-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=or-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatches-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatchesDisplayLocked-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatchesDisplayNone-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatchesScopingRoot-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=unslottedLink-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=http&amp;to_protocol=http-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=http&amp;to_protocol=https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=https&amp;to_protocol=http-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=https&amp;to_protocol=https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/executor.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/executor.sub.html.headers: Added.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/prefetch.py: Added.
(main):
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/utils.sub.js: Added.
(PrefetchAgent):
(PrefetchAgent.prototype.getExecutorURL):
(PrefetchAgent.prototype.async forceSinglePrefetch):
(PrefetchAgent.prototype.async forceSpeculationRules):
(PrefetchAgent.prototype.async navigate):
(PrefetchAgent.prototype.async getRequestHeaders):
(PrefetchAgent.prototype.async getResponseCookies):
(PrefetchAgent.prototype.async getRequestCookies):
(PrefetchAgent.prototype.async getRequestCredentials):
(PrefetchAgent.prototype.async setReferrerPolicy):
(PrefetchAgent.prototype.async getDeliveryType):
(getPrefetchUrl):
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/resources/utils.js: Added.
(globalThis.assertSpeculationRulesIsSupported):
(globalThis.RemoteContextHelper.PreloadingRemoteContextWrapper.prototype.addPreload):
(globalThis.RemoteContextHelper.PreloadingRemoteContextWrapper):
* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::JSGlobalObject):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::speculationRules const):
(JSC::JSGlobalObject::speculationRules):
* Source/JavaScriptCore/runtime/SpeculationRules.cpp: Added.
(JSC::parseStringOrStringList):
(JSC::parseDocumentPredicate):
(JSC::parseSingleRule):
(JSC::parseRules):
(JSC::SpeculationRules::parseSpeculationRules):
* Source/JavaScriptCore/runtime/SpeculationRules.h: Added.
(JSC::SpeculationRules::DocumentPredicate::DocumentPredicate):
(JSC::SpeculationRules::DocumentPredicate::value const):
(JSC::SpeculationRules::create):
(JSC::SpeculationRules::prefetchRules const):
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::registerSpeculationRules):
* Source/WebCore/bindings/js/ScriptController.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::resolveStyle):
(WebCore::Document::updateBaseURL):
(WebCore::Document::considerSpeculationRules):
(WebCore::Document::prefetch):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::determineScriptType):
(WebCore::ScriptElement::prepareScript):
(WebCore::ScriptElement::registerSpeculationRules):
* Source/WebCore/dom/ScriptElement.h:
* Source/WebCore/dom/ScriptElementCachedScriptFetcher.h:
(WebCore::ScriptElementCachedScriptFetcher::isSpeculationRules const):
* Source/WebCore/dom/ScriptType.h:
* Source/WebCore/dom/SpeculationRulesMatcher.cpp: Copied from Source/WebCore/dom/ScriptElementCachedScriptFetcher.h.
(WebCore::matches):
(WebCore::SpeculationRulesMatcher::hasMatchingRule):
* Source/WebCore/dom/SpeculationRulesMatcher.h: Copied from Source/WebCore/dom/ScriptElementCachedScriptFetcher.h.
* Source/WebCore/dom/TextDecoderStreamDecoder.cpp:
* Source/WebCore/dom/TrustedTypePolicy.cpp:
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::defaultEventHandler):
(WebCore::HTMLAnchorElement::attributeChanged):
(WebCore::HTMLAnchorElement::insertedIntoAncestor):
(WebCore::HTMLAnchorElement::setFullURL):
(WebCore::HTMLAnchorElement::setShouldBePrefetched):
(WebCore::HTMLAnchorElement::checkForSpeculationRules):
* Source/WebCore/html/HTMLAnchorElement.h:
* Source/WebCore/html/HTMLScriptElement.h:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::becomeMainResourceClient):
(WebCore::DocumentLoader::setPrefetchedMainResource):
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/loader/DocumentPrefetcher.cpp: Copied from Source/WebCore/dom/ScriptType.h.
(WebCore::DocumentPrefetcher::DocumentPrefetcher):
(WebCore::DocumentPrefetcher::~DocumentPrefetcher):
(WebCore::DocumentPrefetcher::prefetch):
(WebCore::DocumentPrefetcher::matchPrefetchedDocument):
(WebCore::DocumentPrefetcher::clear):
* Source/WebCore/loader/DocumentPrefetcher.h: Copied from Source/WebCore/dom/ScriptType.h.
(WebCore::DocumentPrefetcher::create):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::FrameLoader):
(WebCore::FrameLoader::commitProvisionalLoad):
(WebCore::FrameLoader::continueLoadAfterNavigationPolicy):
(WebCore::FrameLoader::dispatchDidCommitLoad):
(WebCore::FrameLoader::prefetch):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/LinkLoader.cpp:
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::allowedByContentSecurityPolicy const):
* Source/WebCore/platform/ReferrerPolicy.cpp:
(WebCore::parseReferrerPolicy):
* Source/WebCore/platform/ReferrerPolicy.h:
* Source/WebCore/platform/network/HTTPHeaderNames.in:
* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(_check_parameter_name_against_text):
</pre>