### PR TITLE
[JSC] JITWorklist: consider size when determining a JITPlan's expected load

### DIFF
--- a/Source/JavaScriptCore/jit/JITWorklist.h
+++ b/Source/JavaScriptCore/jit/JITWorklist.h
@@ -89,8 +89,10 @@ private:
     JITWorklist();
 
     void wakeThreads(const AbstractLocker&, unsigned enqueuedTier);
+    unsigned planLoad(JITPlan&);
 
     size_t queueLength(const AbstractLocker&) const;
+    size_t totalOngoingCompilations(const AbstractLocker&) const;
 
     void waitUntilAllPlansForVMAreReady(VM&);
 
@@ -102,6 +104,7 @@ private:
     void dump(const AbstractLocker&, PrintStream&) const;
 
     unsigned m_numberOfActiveThreads { 0 };
+    unsigned m_totalLoad { 0 }; // Total load of the queues and ongoing compilations
     std::array<unsigned, static_cast<size_t>(JITPlan::Tier::Count)> m_ongoingCompilationsPerTier { 0, 0, 0 };
     std::array<unsigned, static_cast<size_t>(JITPlan::Tier::Count)> m_maximumNumberOfConcurrentCompilationsPerTier;
     std::array<unsigned, static_cast<size_t>(JITPlan::Tier::Count)> m_loadWeightsPerTier;

--- a/Source/JavaScriptCore/jit/JITWorklistThread.h
+++ b/Source/JavaScriptCore/jit/JITWorklistThread.h
@@ -60,6 +60,7 @@ private:
     Lock m_rightToRun;
     JITWorklist& m_worklist;
     RefPtr<JITPlan> m_plan { nullptr };
+    unsigned m_planLoad { 0 };
     Safepoint* m_safepoint { nullptr };
 };
 


### PR DESCRIPTION
#### 1656e50c527a22441a66716538de00c1deb66dc0
<pre>
[JSC] JITWorklist: consider size when determining a JITPlan&apos;s expected load
<a href="https://bugs.webkit.org/show_bug.cgi?id=295209">https://bugs.webkit.org/show_bug.cgi?id=295209</a>
<a href="https://rdar.apple.com/154678309">rdar://154678309</a>

Reviewed by Yusuke Suzuki.

Currently, a JITPlan&apos;s load is determined solely by the tier. But
for really large codeBlocks, the compilation time can be on the same
order as higher tiers. Let&apos;s avoid mispredicting the load for these
these outliers by bumping the load for large codeBlocks.

This requires more bookkeeping since each plan in a particular queue
can have a different load, and so total load can no longer be
inferred by queue length. To handle this, maintain a running
total load which is incremented when JITPlans are enqueued and
decremented when they complete compilation or are canceled.

The cancellation case complicates the bookkeeping in a couple of ways:

1. Need to coordinate which thread decrements in the case of cancellation.
 a. If the cancellation occurs while the JITPlan is still waiting
    in a queue, then the thread driving the cancellation needs to
    handle the bookkeeping.
 b. Otherwise, cancellation occurred after a compile thread dequeued
    the plan and is about to or is compiling the plan. In this case,
    the compile thread decrements the load once the cancellation is
    processed.

2. Once a JITPlan is canceled, the codeBlock can be dead so cannot
   be accessed after that point. But since case 1b occurs asynchronously
   some time later, the load cannot be computed at this point. To handle
   this, the compiler thread remembers the JITPlan before dropping
   the worklist lock during poll, which is the handoff point described
   in 1a-b.

The size threshold for outliers is chosen as follows:

Median compilation time and size for each tier:
Baseline: ~15 usec / 90 bytecode instructions
DFG: ~100 usec / 90 bytecode instructions
FTL: ~800-1000 usec / 114 bytecode instructions

At 2000 bytecode instructions, baseline compiles take around
100-200 usec, which is similar to DFG median. At 12000 bytecode
instructions, baseline compiles take 500+ usec which is similar to FTL.

At 2000 bytecode instructions, DFG compiles are around 1000 usec, which
is similar to FTL.

FTL load is always set to 1 thread unit and since a compile of a JITPlan
is single threaded, there&apos;s no benefit to adjusting them.

* Source/JavaScriptCore/jit/JITWorklist.cpp:
(JSC::JITWorklist::planLoad):
(JSC::JITWorklist::wakeThreads):
(JSC::JITWorklist::enqueue):
(JSC::JITWorklist::totalOngoingCompilations const):
(JSC::JITWorklist::removeMatchingPlansForVM):
* Source/JavaScriptCore/jit/JITWorklist.h:
* Source/JavaScriptCore/jit/JITWorklistThread.cpp:
(JSC::JITWorklistThread::poll):
* Source/JavaScriptCore/jit/JITWorklistThread.h:

Canonical link: <a href="https://commits.webkit.org/296834@main">https://commits.webkit.org/296834@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de351c55f883d0b4defccd29bc113ecd0f3d6a8b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109689 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29347 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19776 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115710 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59923 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37935 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83352 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112637 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23928 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98787 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63811 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23310 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16932 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59504 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/102180 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93303 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16969 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118502 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/108241 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36728 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27205 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92360 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37101 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95046 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92181 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23492 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37146 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14893 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32556 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36622 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42093 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/132517 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36283 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35877 "Found 2 jsc stress test failures: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js.default, wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention.js.default") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39625 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37992 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->