### PR TITLE
REGRESSION(296481@main): chatgpt.com: box-shadow does not have rounded corners on a div with border-radius set

### DIFF
--- a/LayoutTests/fast/box-shadow/negative-spread-with-huge-radii-expected.html
+++ b/LayoutTests/fast/box-shadow/negative-spread-with-huge-radii-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .box {
+            margin: 20px;
+            width: 300px;
+            height: 100px;
+            border: 1px solid black;
+            box-sizing: border-box;
+            border-radius: 50px;
+        }
+    </style>
+</head>
+<body>
+    <div class="box"></div>
+</body>
+</html>

--- a/LayoutTests/fast/box-shadow/negative-spread-with-huge-radii.html
+++ b/LayoutTests/fast/box-shadow/negative-spread-with-huge-radii.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .box {
+            margin: 20px;
+            width: 300px;
+            height: 100px;
+            border: 1px solid black;
+            border-radius: 340282001837565597733306976381245063168px;
+            box-sizing: border-box;
+            box-shadow: red 0px 0px 0px -1px;
+        }
+    </style>
+</head>
+<body>
+    <div class="box"></div>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/LayoutRoundedRect.cpp
+++ b/Source/WebCore/platform/graphics/LayoutRoundedRect.cpp
@@ -146,6 +146,14 @@ void LayoutRoundedRect::Radii::makeRenderableInRect(const LayoutRect& rect)
     float heightRatio = static_cast<float>(rect.height()) / maxRadiusHeight;
     scale(widthRatio < heightRatio ? widthRatio : heightRatio);
 
+    if (!areRenderableInRect(rect)) {
+        maxRadiusWidth = std::max(topLeft().width() + topRight().width(), bottomLeft().width() + bottomRight().width());
+        maxRadiusHeight = std::max(topLeft().height() + bottomLeft().height(), topRight().height() + bottomRight().height());
+
+        widthRatio = static_cast<float>(rect.width()) / maxRadiusWidth;
+        heightRatio = static_cast<float>(rect.height()) / maxRadiusHeight;
+        scale(widthRatio < heightRatio ? widthRatio : heightRatio);
+    }
 }
 
 LayoutRoundedRect::LayoutRoundedRect(LayoutUnit x, LayoutUnit y, LayoutUnit width, LayoutUnit height)


### PR DESCRIPTION
#### 15f34ffae5a84c22353884cc6f9683adb8dfc2d6
<pre>
REGRESSION(296481@main): chatgpt.com: box-shadow does not have rounded corners on a div with border-radius set
<a href="https://bugs.webkit.org/show_bug.cgi?id=295213">https://bugs.webkit.org/show_bug.cgi?id=295213</a>
<a href="https://rdar.apple.com/154591934">rdar://154591934</a>

Reviewed by Alan Baradlay.

ChatGPT&apos;s CSS has:

    .rounded-full {
        border-radius:3.40282e + 38px
    }

so I guess they want a border-radius that&apos;s 9x10^31km big. That triggers rounding issues
in `Radii::makeRenderableInRect()` which result in the radii still being unrenderable after
one pass of shrinking, so if necessary, shrink the radii again.

* LayoutTests/fast/box-shadow/negative-spread-with-huge-radii-expected.html: Added.
* LayoutTests/fast/box-shadow/negative-spread-with-huge-radii.html: Added.
* Source/WebCore/platform/graphics/LayoutRoundedRect.cpp:
(WebCore::LayoutRoundedRect::Radii::makeRenderableInRect):

Canonical link: <a href="https://commits.webkit.org/296839@main">https://commits.webkit.org/296839@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3bfd7afc9a848077d8dba9764402c3bcf5fd420

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109700 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29358 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19787 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115721 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59934 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111663 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30036 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37946 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83363 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112648 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23935 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98795 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63823 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23318 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16941 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59515 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93310 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16977 "Found 1 new test failure: fast/mediastream/getUserMedia-webaudio.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118513 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36739 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27211 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92369 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37112 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95054 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92190 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23495 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37153 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14900 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32567 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36633 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42104 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36294 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39636 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38003 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->