### PR TITLE
Bifurcate megapage caches into compact and non-compact variants

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_basic_heap_page_caches.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_basic_heap_page_caches.h
@@ -48,6 +48,9 @@ struct pas_basic_heap_page_caches {
                                                  would create unnecessary fragmentation in the large
                                                  heap. */
     pas_shared_page_directory_by_size medium_shared_page_directories;
+    pas_megapage_cache small_compact_exclusive_segregated_megapage_cache;
+    pas_megapage_cache small_compact_other_megapage_cache;
+    pas_megapage_cache medium_compact_megapage_cache;
 };
 
 #define PAS_BASIC_HEAP_PAGE_CACHES_INITIALIZER(small_log_shift, medium_log_shift) \
@@ -60,7 +63,10 @@ struct pas_basic_heap_page_caches {
         .small_other_megapage_cache = PAS_MEGAPAGE_CACHE_INITIALIZER(pas_megapage_cache_size_small), \
         .medium_megapage_cache = PAS_MEGAPAGE_CACHE_INITIALIZER(pas_megapage_cache_size_medium), \
         .medium_shared_page_directories = PAS_SHARED_PAGE_DIRECTORY_BY_SIZE_INITIALIZER( \
-            (medium_log_shift), pas_share_pages) \
+            (medium_log_shift), pas_share_pages), \
+        .small_compact_exclusive_segregated_megapage_cache = PAS_MEGAPAGE_CACHE_INITIALIZER(pas_megapage_cache_size_small_compact), \
+        .small_compact_other_megapage_cache = PAS_MEGAPAGE_CACHE_INITIALIZER(pas_megapage_cache_size_small_compact), \
+        .medium_compact_megapage_cache = PAS_MEGAPAGE_CACHE_INITIALIZER(pas_megapage_cache_size_medium_compact) \
     })
 
 static inline pas_shared_page_directory_by_size*

--- a/Source/bmalloc/libpas/src/libpas/pas_create_basic_heap_page_caches_with_reserved_memory.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_create_basic_heap_page_caches_with_reserved_memory.c
@@ -37,6 +37,29 @@
 #include "pas_reserved_memory_provider.h"
 #include "pas_segregated_shared_page_directory.h"
 
+static pas_allocation_result allocate_from_compact_megapages(
+    size_t size,
+    pas_alignment alignment,
+    const char* name,
+    pas_heap* heap,
+    pas_physical_memory_transaction* transaction,
+    void* arg)
+{
+    const pas_heap_config* heap_config;
+
+    PAS_UNUSED_PARAM(name);
+    PAS_UNUSED_PARAM(arg);
+    PAS_ASSERT(heap);
+    PAS_ASSERT(transaction);
+    PAS_ASSERT(!alignment.alignment_begin);
+
+    heap_config = pas_heap_config_kind_get_config(heap->config_kind);
+
+    return pas_large_heap_try_allocate_and_forget(
+        &heap->large_heap, size, alignment.alignment, pas_non_compact_allocation_mode,
+        heap_config, transaction);
+}
+
 static pas_allocation_result allocate_from_megapages(
     size_t size,
     pas_alignment alignment,
@@ -58,7 +81,7 @@ static pas_allocation_result allocate_from_megapages(
     PAS_PROFILE(MEGAPAGES_ALLOCATION, heap, size, alignment.alignment, heap_config, cache_size);
 
     return pas_large_heap_try_allocate_and_forget(
-        &heap->large_heap, size, alignment.alignment, pas_non_compact_allocation_mode,
+        &heap->megapage_large_heap, size, alignment.alignment, pas_non_compact_allocation_mode,
         heap_config, transaction);
 }
 
@@ -110,6 +133,21 @@ pas_basic_heap_page_caches* pas_create_basic_heap_page_caches_with_reserved_memo
         &caches->medium_megapage_cache,
         allocate_from_megapages,
         pas_megapage_cache_size_medium);
+
+    pas_megapage_cache_construct(
+        &caches->small_compact_exclusive_segregated_megapage_cache,
+        allocate_from_compact_megapages,
+        pas_megapage_cache_size_small_compact);
+
+    pas_megapage_cache_construct(
+        &caches->small_compact_other_megapage_cache,
+        allocate_from_compact_megapages,
+        pas_megapage_cache_size_small_compact);
+
+    pas_megapage_cache_construct(
+        &caches->medium_compact_megapage_cache,
+        allocate_from_compact_megapages,
+        pas_megapage_cache_size_medium_compact);
 
     for (PAS_EACH_SEGREGATED_PAGE_CONFIG_VARIANT_ASCENDING(segregated_variant)) {
         pas_shared_page_directory_by_size* directories;

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils_inlines.h
@@ -163,10 +163,12 @@ typedef struct {
         case pas_segregated_page_shared_role: \
             megapage_cache = &page_caches->small_other_megapage_cache; \
             megapage_kind = pas_small_other_fast_megapage_kind; \
+            PAS_PROFILE(SMALL_SHARED_SEGREGATED_PAGE_ALLOCATION, heap, megapage_cache); \
             break; \
         case pas_segregated_page_exclusive_role: \
             megapage_cache = &page_caches->small_exclusive_segregated_megapage_cache; \
             megapage_kind = pas_small_exclusive_segregated_fast_megapage_kind; \
+            PAS_PROFILE(SMALL_EXCLUSIVE_SEGREGATED_PAGE_ALLOCATION, heap, megapage_cache); \
             break; \
         } \
         \
@@ -189,6 +191,7 @@ typedef struct {
         \
         pas_bitfit_page_config page_config; \
         pas_basic_heap_page_caches* page_caches; \
+        pas_megapage_cache* megapage_cache; \
         void* allocation; \
         \
         page_config = upcase_name ## _HEAP_CONFIG.small_bitfit_config; \
@@ -196,9 +199,11 @@ typedef struct {
         PAS_ASSERT(page_config.base.is_enabled); \
         \
         page_caches = ((pas_basic_heap_runtime_config*)heap->runtime_config)->page_caches; \
+        megapage_cache = &page_caches->small_other_megapage_cache; \
         \
+        PAS_PROFILE(SMALL_BITFIT_PAGE_ALLOCATION, heap, megapage_cache); \
         allocation = pas_fast_megapage_cache_try_allocate( \
-            &page_caches->small_other_megapage_cache, \
+            megapage_cache, \
             &name ## _megapage_table, \
             page_config.base.page_config_ptr, \
             pas_small_other_fast_megapage_kind, \
@@ -217,6 +222,7 @@ typedef struct {
         \
         pas_segregated_page_config page_config; \
         pas_basic_heap_page_caches* page_caches; \
+        pas_megapage_cache* megapage_cache; \
         void* allocation; \
         \
         PAS_UNUSED_PARAM(role); \
@@ -226,9 +232,11 @@ typedef struct {
         PAS_ASSERT(page_config.base.is_enabled); \
         \
         page_caches = ((pas_basic_heap_runtime_config*)heap->runtime_config)->page_caches; \
+        megapage_cache = &page_caches->medium_megapage_cache; \
         \
+        PAS_PROFILE(MEDIUM_SEGREGATED_PAGE_ALLOCATION, heap, megapage_cache); \
         allocation = pas_medium_megapage_cache_try_allocate( \
-            &page_caches->medium_megapage_cache, \
+            megapage_cache, \
             page_config.base.page_config_ptr, \
             arguments.allocate_page_should_zero, \
             pas_heap_for_segregated_heap(heap), \
@@ -244,6 +252,7 @@ typedef struct {
         \
         pas_bitfit_page_config page_config; \
         pas_basic_heap_page_caches* page_caches; \
+        pas_megapage_cache* megapage_cache; \
         void* allocation; \
         \
         page_config = upcase_name ## _HEAP_CONFIG.medium_bitfit_config; \
@@ -251,9 +260,11 @@ typedef struct {
         PAS_ASSERT(page_config.base.is_enabled); \
         \
         page_caches = ((pas_basic_heap_runtime_config*)heap->runtime_config)->page_caches; \
+        megapage_cache = &page_caches->medium_megapage_cache; \
         \
+        PAS_PROFILE(MEDIUM_BITFIT_PAGE_ALLOCATION, heap, megapage_cache); \
         allocation = pas_medium_megapage_cache_try_allocate( \
-            &page_caches->medium_megapage_cache, \
+            megapage_cache, \
             page_config.base.page_config_ptr, \
             arguments.allocate_page_should_zero, \
             pas_heap_for_segregated_heap(heap), \
@@ -269,6 +280,7 @@ typedef struct {
         \
         pas_bitfit_page_config page_config; \
         pas_basic_heap_page_caches* page_caches; \
+        pas_megapage_cache* megapage_cache; \
         void* allocation; \
         \
         page_config = upcase_name ## _HEAP_CONFIG.marge_bitfit_config; \
@@ -276,9 +288,11 @@ typedef struct {
         PAS_ASSERT(page_config.base.is_enabled); \
         \
         page_caches = ((pas_basic_heap_runtime_config*)heap->runtime_config)->page_caches; \
+        megapage_cache = &page_caches->medium_megapage_cache; \
         \
+        PAS_PROFILE(MARGE_BITFIT_PAGE_ALLOCATION, heap, megapage_cache); \
         allocation = pas_medium_megapage_cache_try_allocate( \
-            &page_caches->medium_megapage_cache, \
+            megapage_cache, \
             page_config.base.page_config_ptr, \
             arguments.allocate_page_should_zero, \
             pas_heap_for_segregated_heap(heap), \

--- a/Source/bmalloc/libpas/src/libpas/pas_megapage_cache.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_megapage_cache.h
@@ -60,12 +60,17 @@ struct pas_megapage_cache_config {
 
 typedef enum {
     pas_megapage_cache_size_small,
-    pas_megapage_cache_size_medium
+    pas_megapage_cache_size_medium,
+    pas_megapage_cache_size_small_compact,
+    pas_megapage_cache_size_medium_compact,
 } pas_megapage_cache_size;
+
+#define PAS_MEGAPAGE_CACHE_SIZE_IS_COMPACT(cache_size) \
+    ((cache_size) == pas_megapage_cache_size_small_compact || (cache_size) == pas_megapage_cache_size_medium_compact)
 
 #define PAS_MEGAPAGE_CACHE_INITIALIZER(cache_size) { \
         .free_heap = PAS_SIMPLE_LARGE_FREE_HEAP_INITIALIZER, \
-        .provider = pas_small_medium_bootstrap_heap_page_provider, \
+        .provider = PAS_MEGAPAGE_CACHE_SIZE_IS_COMPACT(cache_size) ? pas_bootstrap_heap_page_provider : pas_small_medium_bootstrap_heap_page_provider, \
         .provider_arg = (void*)(uintptr_t)(cache_size) \
     }
 


### PR DESCRIPTION
#### 813ff18c41b82a29182334254008326e089c2963
<pre>
Bifurcate megapage caches into compact and non-compact variants
<a href="https://bugs.webkit.org/show_bug.cgi?id=295062">https://bugs.webkit.org/show_bug.cgi?id=295062</a>
<a href="https://rdar.apple.com/154434088">rdar://154434088</a>

Reviewed by Mark Lam.

Adds new compact megapage caches to basic libpas heaps to support
separate heap management for compact pointers.

* Source/bmalloc/libpas/src/libpas/pas_basic_heap_page_caches.h:
* Source/bmalloc/libpas/src/libpas/pas_create_basic_heap_page_caches_with_reserved_memory.c:
(allocate_from_large):
(allocate_from_megapages):
(pas_create_basic_heap_page_caches_with_reserved_memory):
* Source/bmalloc/libpas/src/libpas/pas_heap_config_utils_inlines.h:
* Source/bmalloc/libpas/src/libpas/pas_megapage_cache.h:

Canonical link: <a href="https://commits.webkit.org/296942@main">https://commits.webkit.org/296942@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc962cba37e36f5acd02c363bda45a1984d97031

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29678 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20110 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116041 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60267 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30356 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38265 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/83659 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112967 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24214 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99078 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64102 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23585 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17225 "Found 1 new test failure: fast/css/css-typed-om/css-builder-converter-clip-viewport-dimension-without-renderview-crash.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59837 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/102510 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93587 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17269 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118832 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/108573 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37059 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/27477 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/92626 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37431 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95344 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92450 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23563 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37433 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15164 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32941 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36953 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/132847 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36615 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35940 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39955 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38324 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->