### PR TITLE
REGRESSION (274503@main): ynet.co.il: Video in element fullscreen is cropped

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -193,12 +193,6 @@ struct OverriddenLayoutParameters {
     CGSize maximumUnobscuredSize { CGSizeZero };
 };
 
-struct OverriddenZoomScaleParameters {
-    CGFloat minimumZoomScale { 1 };
-    CGFloat maximumZoomScale { 1 };
-    BOOL allowUserScaling { YES };
-};
-
 // This holds state that should be reset when the web process exits.
 struct PerWebProcessState {
     CGFloat viewportMetaTagWidth { WebCore::ViewportArguments::ValueAuto };
@@ -348,7 +342,9 @@ struct PerWebProcessState {
     PerWebProcessState _perProcessState;
 
     std::optional<OverriddenLayoutParameters> _overriddenLayoutParameters;
-    std::optional<OverriddenZoomScaleParameters> _overriddenZoomScaleParameters;
+#if PLATFORM(IOS_FAMILY)
+    BOOL _forcesInitialScaleFactor;
+#endif
     CGRect _inputViewBoundsInWindow;
 
     BOOL _fastClickingIsDisabled;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -224,8 +224,7 @@ enum class TapHandlingResult : uint8_t;
 - (void)_resetUnobscuredSafeAreaInsets;
 - (void)_resetObscuredInsets;
 
-- (void)_overrideZoomScaleParametersWithMinimumZoomScale:(CGFloat)minimumZoomScale maximumZoomScale:(CGFloat)maximumZoomScale allowUserScaling:(BOOL)allowUserScaling;
-- (void)_clearOverrideZoomScaleParameters;
+@property (nonatomic, setter=_setForcesInitialScaleFactor:) BOOL _forcesInitialScaleFactor;
 
 - (void)_setPointerTouchCompatibilitySimulatorEnabled:(BOOL)enabled;
 

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -218,7 +218,6 @@ struct WKWebViewState {
             page->setForceAlwaysUserScalable(_savedForceAlwaysUserScalable);
         }
         [webView _setViewScale:_savedViewScale];
-        scrollView.zoomScale = _savedZoomScale;
         scrollView.bouncesZoom = _savedBouncesZoom;
         webView._minimumEffectiveDeviceWidth = _savedMinimumEffectiveDeviceWidth;
     }
@@ -1066,7 +1065,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         // apply the default web view state (which sets both parameters anyways)?
         [webView _setMinimumEffectiveDeviceWidth:0];
         [webView _setViewScale:1.f];
-        [webView _overrideZoomScaleParametersWithMinimumZoomScale:WebKit::baseScale maximumZoomScale:WebKit::baseScale allowUserScaling:NO];
+        [webView _setForcesInitialScaleFactor:YES];
         [webView _resetContentOffset];
         [_window insertSubview:webView.get() atIndex:0];
         WebKit::WKWebViewState().applyTo(webView.get());
@@ -1372,7 +1371,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     [webView becomeFirstResponder];
 
-    [webView _clearOverrideZoomScaleParameters];
+    [webView _setForcesInitialScaleFactor:NO];
     _viewState.applyTo(webView.get());
     if (auto page = [webView _page])
         page->setOverrideViewportArguments(std::nullopt);

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -402,4 +402,5 @@ Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
 Tests/WebKitCocoa/iOSMouseSupport.mm
 Tests/WebKitCocoa/iOSStylusSupport.mm
 
+Tests/WebKitCocoa/UI/ElementFullscreen.mm
 Tests/WebKitCocoa/UI/VideoPresentationMode.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -655,9 +655,9 @@
 		A14FC58B1B89927100D107EB /* ContentFilteringPlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = A14FC5891B89927100D107EB /* ContentFilteringPlugIn.mm */; };
 		A170E3AA2ABA7857009EA799 /* VectorCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = A170E3A22ABA7857009EA799 /* VectorCocoa.mm */; };
 		A17191AD2CD2DB090088944E /* WKWebViewLogging.mm in Sources */ = {isa = PBXBuildFile; fileRef = A17191AC2CD2DB090088944E /* WKWebViewLogging.mm */; };
-		A176D24B2D6D2A4E00C63915 /* GPUExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2472D6D295400C63915 /* GPUExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		A176D24C2D6D2A4E00C63915 /* NetworkingExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2482D6D295400C63915 /* NetworkingExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		A176D24D2D6D2A4E00C63915 /* WebContentExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2492D6D295400C63915 /* WebContentExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A176D24B2D6D2A4E00C63915 /* GPUExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2472D6D295400C63915 /* GPUExtension.appex */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A176D24C2D6D2A4E00C63915 /* NetworkingExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2482D6D295400C63915 /* NetworkingExtension.appex */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A176D24D2D6D2A4E00C63915 /* WebContentExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2492D6D295400C63915 /* WebContentExtension.appex */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A1798B7F22431D2B000764BD /* libWebCoreTestSupport.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = A1798B7E22431D2B000764BD /* libWebCoreTestSupport.dylib */; };
 		A1798B8522433647000764BD /* WebProcessPlugInWithInternals.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1798B8422433647000764BD /* WebProcessPlugInWithInternals.mm */; };
 		A17991881E1C994E00A505ED /* SharedBuffer.mm in Sources */ = {isa = PBXBuildFile; fileRef = A17991861E1C994E00A505ED /* SharedBuffer.mm */; };
@@ -3469,6 +3469,7 @@
 		A1AD38272C3D9FAF003499BE /* FullscreenLifecycle.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FullscreenLifecycle.mm; sourceTree = "<group>"; };
 		A1AE4A092D5DBFCC00320629 /* HostWindowManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = HostWindowManager.h; path = cocoa/HostWindowManager.h; sourceTree = "<group>"; };
 		A1AE4A0A2D5DBFCC00320629 /* HostWindowManager.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = HostWindowManager.mm; path = cocoa/HostWindowManager.mm; sourceTree = "<group>"; };
+		A1C0982F2E12FB5800FAC83A /* ElementFullscreen.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ElementFullscreen.mm; sourceTree = "<group>"; };
 		A1C142C124AA7B2E00444207 /* ContextMenuMouseEvents.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ContextMenuMouseEvents.mm; sourceTree = "<group>"; };
 		A1C1F5E72C9C96C00042E924 /* TestWebKitAPI.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestWebKitAPI.xctestplan; sourceTree = "<group>"; };
 		A1C4FB6C1BACCE50003742D0 /* QuickLook.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = QuickLook.mm; sourceTree = "<group>"; };
@@ -5688,6 +5689,7 @@
 		A1D8C7952DBFFFB500A6878F /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				A1C0982F2E12FB5800FAC83A /* ElementFullscreen.mm */,
 				A1D8C7942DBFFFB500A6878F /* VideoPresentationMode.mm */,
 			);
 			path = UI;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UI/ElementFullscreen.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UI/ElementFullscreen.mm
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if PLATFORM(IOS)
+
+#import "PlatformUtilities.h"
+#import "TestWKWebView.h"
+#import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/WebKit.h>
+#import <WebKit/_WKFullscreenDelegate.h>
+
+@interface UIScrollView ()
+@property (nonatomic, getter=isZoomEnabled) BOOL zoomEnabled;
+@end
+
+@interface TestElementFullscreenDelegate : NSObject <_WKFullscreenDelegate>
+- (void)waitForDidEnterElementFullscreen;
+@end
+
+@implementation TestElementFullscreenDelegate {
+    bool _didEnterElementFullscreen;
+}
+
+- (void)waitForDidEnterElementFullscreen
+{
+    _didEnterElementFullscreen = false;
+    TestWebKitAPI::Util::run(&_didEnterElementFullscreen);
+}
+
+#pragma mark WKUIDelegate
+
+- (void)_webViewDidEnterElementFullscreen:(WKWebView *)webView
+{
+    _didEnterElementFullscreen = true;
+}
+
+@end
+
+TEST(ElementFullscreen, ScrollViewSetToInitialScale)
+{
+    // This test must run in TestWebKitAPI.app
+    if (![NSBundle.mainBundle.bundleIdentifier isEqualToString:@"org.webkit.TestWebKitAPI"])
+        return;
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setAllowsInlineMediaPlayback:YES];
+    [configuration preferences].elementFullscreenEnabled = YES;
+    RetainPtr fullscreenDelegate = adoptNS([[TestElementFullscreenDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView _setFullscreenDelegate:fullscreenDelegate.get()];
+
+    RetainPtr preferences = adoptNS([[WKWebpagePreferences alloc] init]);
+    [preferences setPreferredContentMode:WKContentModeDesktop];
+    [webView synchronouslyLoadHTMLString:@"<meta name=viewport content='width=1000'>" preferences:preferences.get()];
+
+    [webView evaluateJavaScript:@"document.querySelector('body').requestFullscreen()" completionHandler:nil];
+    [fullscreenDelegate waitForDidEnterElementFullscreen];
+    [webView waitForNextPresentationUpdate];
+
+    CGFloat expectedScale = std::min<CGFloat>(UIScreen.mainScreen.bounds.size.width / 1000, 1);
+
+    EXPECT_EQ([webView scrollView].zoomScale, expectedScale);
+    EXPECT_EQ([webView scrollView].minimumZoomScale, expectedScale);
+    EXPECT_EQ([webView scrollView].maximumZoomScale, expectedScale);
+    EXPECT_EQ([webView scrollView].isZoomEnabled, NO);
+}
+
+#endif // PLATFORM(IOS)


### PR DESCRIPTION
#### 82a00cb3625eebcfc66e15c0355cf565a8de158f
<pre>
REGRESSION (274503@main): ynet.co.il: Video in element fullscreen is cropped
<a href="https://bugs.webkit.org/show_bug.cgi?id=295219">https://bugs.webkit.org/show_bug.cgi?id=295219</a>
<a href="https://rdar.apple.com/150685881">rdar://150685881</a>

Reviewed by Wenson Hsieh.

In 274503@main we enforced a min/max/current zoom scale value of 1 on WKScrollView when in element
fullscreen. This ensures that if the user had pinched to zoom in on a page, that scale factor was
undone when entering fullscreen. However, 1 is not the correct scale value to apply for a page that
is wider than the screen&apos;s dimensions, and on such pages web content would appear cropped in element
fullscreen.

Addressed this by setting the min/max/current zoom scale to the initial zoom scale in element
fullscreen. This ensures that a wide page is scaled to fit the screen.

Added an API test.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _updateScrollViewForTransaction:]):
(-[WKWebView _forcesInitialScaleFactor]):
(-[WKWebView _setForcesInitialScaleFactor:]):
(-[WKWebView _overrideZoomScaleParametersWithMinimumZoomScale:maximumZoomScale:allowUserScaling:]): Deleted.
(-[WKWebView _clearOverrideZoomScaleParameters]): Deleted.
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(WebKit::WKWebViewState::applyTo):
(-[WKFullScreenWindowController _enterFullScreen:windowScene:completionHandler:]):
(-[WKFullScreenWindowController _reinsertWebViewUnderPlaceholder]):
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UI/ElementFullscreen.mm: Added.
(-[TestElementFullscreenDelegate waitForDidEnterElementFullscreen]):
(-[TestElementFullscreenDelegate _webViewDidEnterElementFullscreen:]):
(TEST(ElementFullscreen, ScrollViewSetToInitialScale)):

Canonical link: <a href="https://commits.webkit.org/296848@main">https://commits.webkit.org/296848@main</a>
</pre>
