### PR TITLE
[iOS] msn.com videos exit from fullscreen immediately

### DIFF
--- a/LayoutTests/media/fullscreen-content-offset-expected.txt
+++ b/LayoutTests/media/fullscreen-content-offset-expected.txt
@@ -1,0 +1,29 @@
+
+* Testing element 'first'
+EVENT(fullscreenchange)
+EVENT(fullscreenchange)
+
+* Testing element 'second'
+EVENT(fullscreenchange)
+EVENT(fullscreenchange)
+
+* Testing element 'third'
+EVENT(fullscreenchange)
+EVENT(fullscreenchange)
+
+* Testing element 'fourth'
+EVENT(fullscreenchange)
+EVENT(fullscreenchange)
+
+END OF TEST
+
+
+
+
+
+
+
+
+
+
+

--- a/LayoutTests/media/fullscreen-content-offset.html
+++ b/LayoutTests/media/fullscreen-content-offset.html
@@ -1,0 +1,205 @@
+<html>
+<head>
+    <meta name="fullscreen-content-offset" content="width=device-width, initial-scale=1">
+    <title>Test that element is visible on screen when scroll events are fired while entering fullscreen</title>
+    <style>        
+        .video-grandparent {
+            display: inline-block;
+        }
+        .video-container {
+            background-color: yellow;
+            color: white;
+            width: 400px;
+            height: 400px;
+            margin: 1em;
+        }
+    </style>
+
+    <script src="video-test.js"></script>
+    <script>
+        let observer;
+        let fullscreenElement;
+    
+        function logElementFailure(element, msg)
+        {
+            const bounds = element.getBoundingClientRect();
+            const location = `[${bounds.left}, ${bounds.top}, ${bounds.right}, ${bounds.bottom}]`;
+            const viewportLocation = `[${window.visualViewport.offsetLeft}, ${window.visualViewport.offsetTop}]`;
+            const size = `${bounds.right - bounds.left}x${bounds.bottom - bounds.top}`;
+
+            consoleWrite(`<span style='color:red'>FAIL: ${msg} when element is occluded, viewport scroll = ${viewportLocation}, element location = ${location}, element size = ${size}</span>`);
+        }
+    
+        function calculateVisibilityPercentage(bounds)
+        {
+            const boundsArea = (bounds.right - bounds.left) * (bounds.bottom - bounds.top);
+            if (!boundsArea)
+                return Number.NaN;
+
+            const viewportBounds = new DOMRect(window.visualViewport.offsetLeft, window.visualViewport.offsetTop, window.visualViewport.width, window.visualViewport.height);
+            const maxLeft = Math.max(bounds.left, viewportBounds.left);
+            const minRight = Math.min(bounds.right, viewportBounds.right);
+            const maxTop = Math.max(bounds.top, viewportBounds.top);
+            const minBottom = Math.min(bounds.bottom, viewportBounds.bottom);
+            const intersectionArea = (minRight - maxLeft) * (minBottom - maxTop);
+            return intersectionArea > 0 ? (100 * intersectionArea / boundsArea) : 0;
+        }
+
+        function checkFullscreenElement(event)
+        {
+            if (!fullscreenElement) 
+                return;
+
+            const visibility = calculateVisibilityPercentage(fullscreenElement.getBoundingClientRect());
+            if (!visibility)
+                logElementFailure(fullscreenElement, `'${event.type}' fired`);
+        };
+
+        function requestFullscreen(target)
+        {
+            fullscreenElement = target;
+    
+            observer = new IntersectionObserver(entries => {
+                entries.forEach(entry => {
+                    if (!entry.isIntersecting)
+                        logElementFailure(entry.target, `IntersectionObserver called`);
+                })
+            });
+            observer.observe(fullscreenElement);
+
+            const fullscreenHandler = (event) => {
+                if (document.fullscreenElement == fullscreenElement) {
+                    setTimeout(() => { document.exitFullscreen() }, 100);
+                    return;
+                }
+            
+                fullscreenElement = null;
+                setTimeout(() => {
+                    event.target.removeEventListener('fullscreenchange', fullscreenHandler);
+                    observer.disconnect();
+                    observer = null;
+
+                    testNextElement();
+                });
+            };
+
+            waitForEvent('fullscreenchange', fullscreenHandler, false, false, target);
+
+            target.requestFullscreen();
+        }
+            
+        async function testElementById(id)
+        {
+            consoleWrite(`* Testing element '${id}'`);
+            setTimeout(() => { 
+                const element = document.getElementById(id);
+                window.scrollTo(0, element.offsetTop);
+    
+                if (!internals)
+                    return;
+    
+                setTimeout(() => {
+                    internals.withUserGesture(() => { requestFullscreen(element.parentElement.parentElement) });
+                }, 100);            
+            }, 100);
+        }
+        
+        const elementsToTest = ['first', 'second', 'third', 'fourth'];
+        function testNextElement()
+        {
+            consoleWrite(``);
+
+            const nextElementID = elementsToTest.splice(0, 1)[0];
+            if (!nextElementID) {
+                endTest();
+                return;
+            }
+
+            setTimeout(() => { testElementById(nextElementID) }, 100);
+        }
+    
+        window.addEventListener('load', () => {
+            consoleElement = document.querySelector('#console');
+
+            window.addEventListener('scroll', (event) => {
+                if (fullscreenElement)
+                    checkFullscreenElement(event);
+            });
+
+            testNextElement();
+            
+        });
+    
+    </script>
+    
+    </head>
+    <body>
+        <div id='console'></div>
+
+        <div class='video-grandparent'>
+            <div class='video-parent'>
+                <div id='first' class='video-container'></div>
+            </div>
+        </div>
+        <br>
+        <div class='video-grandparent'>
+            <div class='video-parent'>
+                <div id='second' class='video-container'></div>
+            </div>
+        </div>
+        <br>
+        <div class='video-grandparent'>
+            <div class='video-parent'>
+                <div class='video-container'></div>
+            </div>
+        </div>
+        <br>
+        <div class='video-grandparent'>
+            <div class='video-parent'>
+                <div class='video-container'></div>
+            </div>
+        </div>
+        <br>
+        <div class='video-grandparent'>
+            <div class='video-parent'>
+                <div class='video-container'></div>
+            </div>
+        </div>
+        <br>
+        <div class='video-grandparent'>
+            <div class='video-parent'>
+                <div id='third' class='video-container'></div>
+            </div>
+        </div>
+        <br>
+        <div class='video-grandparent'>
+            <div class='video-parent'>
+                <div class='video-container'></div>
+            </div>
+        </div>
+        <br>
+        <div class='video-grandparent'>
+            <div class='video-parent'>
+                <div class='video-container'></div>
+            </div>
+        </div>
+        <br>
+        <div class='video-grandparent'>
+            <div class='video-parent'>
+                <div class='video-container'></div>
+            </div>
+        </div>
+        <br>
+        <div class='video-grandparent'>
+            <div class='video-parent'>
+                <div class='video-container'></div>
+            </div>
+        </div>
+        <br>
+        <div class='video-grandparent'>
+            <div class='video-parent'>
+                <div id='fourth' class='video-container'></div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -1169,12 +1169,12 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             return completionHandler(false);
         }
 
-        auto page = [self._webView _page];
-        auto* manager = self._manager;
-
+        RefPtr page = [self._webView _page].get();
+        RefPtr manager = { self._manager };
         if (page && manager) {
             OBJC_ALWAYS_LOG(logIdentifier, "presentation completed");
 
+            [self._webView _wkScrollView].contentOffset = _viewState._savedContentOffset;
             [self._webView becomeFirstResponder];
             completionHandler(true);
             manager->setAnimatingFullScreen(false);


### PR DESCRIPTION
#### 497185e84d36649dfa0fff3651c0bcd37aeddb4b
<pre>
[iOS] msn.com videos exit from fullscreen immediately
<a href="https://bugs.webkit.org/show_bug.cgi?id=295220">https://bugs.webkit.org/show_bug.cgi?id=295220</a>
<a href="https://rdar.apple.com/143989393">rdar://143989393</a>

Reviewed by Jer Noble.

msn.com creates and deletes &lt;video&gt; elements automatically based on the position of the
video containing element relative to the visual viewport. WebKit on iOS resets the scrollview
before entering element fullscreen, resulting in some &lt;video&gt; elements being offscreen after
entering fullscreen, which causes msn.com to delete the video element, which causes WebKit
to exit from fullscreen. Fix this by restoring the position of the scrollview before allowing
deferred `scroll` events to fire.

* LayoutTests/media/fullscreen-content-offset-expected.txt: Added.
* LayoutTests/media/fullscreen-content-offset.html: Added.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController beganEnterFullScreenWithInitialFrame:finalFrame:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/296897@main">https://commits.webkit.org/296897@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d2dc4e5beb05ced61e862b220fe08c208877be3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109842 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29500 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19930 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115863 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60079 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30178 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38088 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83488 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112790 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24057 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98915 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63940 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23437 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17064 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59658 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93427 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17107 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118655 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36881 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27333 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92477 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37254 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95183 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92300 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23528 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37274 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15018 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32727 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36776 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42246 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36436 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39778 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38145 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->