### PR TITLE
attachShadow throws type error with document-fragment ShadowRoot

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-customElementRegistry-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-customElementRegistry-expected.txt
@@ -3,5 +3,5 @@ PASS A newly attached disconnected ShadowRoot should use the global registry by 
 PASS A newly attached connected ShadowRoot should use the global registry by default
 PASS A newly attached disconnected ShadowRoot should use the scoped registry if explicitly specified in attachShadow
 PASS A newly attached connected ShadowRoot should use the scoped registry if explicitly specified in attachShadow
-PASS attachShadow() should throw for a null customElementRegistry value
+PASS attachShadow() should use the global registry when customElementRegistry is null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-customElementRegistry.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-customElementRegistry.html
@@ -35,8 +35,9 @@ test(() => {
 
 test(() => {
     const host = document.body.appendChild(document.createElement('div'));
-    assert_throws_js(TypeError, () => host.attachShadow({mode: 'closed', customElementRegistry: null}))
-}, 'attachShadow() should throw for a null customElementRegistry value');
+    const shadowRoot = host.attachShadow({mode: 'closed', customElementRegistry: null});
+    assert_equals(shadowRoot.customElementRegistry, window.customElements);
+}, 'attachShadow() should use the global registry when customElementRegistry is null');
 
 </script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/attachShadow-with-ShadowRoot-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/attachShadow-with-ShadowRoot-expected.txt
@@ -1,0 +1,4 @@
+
+PASS can use ShadowRoot as options for attachShadow
+PASS can use ShadowRoot in document fragment as options for attachShadow
+

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/attachShadow-with-ShadowRoot.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/attachShadow-with-ShadowRoot.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<head>
+    <title>Shadow DOM: Element.attachShadow with ShadowRoot</title>
+    <meta name="author" title="Jesse Jurman" href="mailto:j.r.jurman@gmail.com">
+    <meta name="assert" content="It should be possible to use an existing ShadowRoot as input for Element.attachShadow">
+    <link rel=help href="https://bugs.webkit.org/show_bug.cgi?id=295174">
+
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/testdriver.js"></script>
+    <script src="/resources/testdriver-actions.js"></script>
+    <script src="/resources/testdriver-vendor.js"></script>
+</head>
+
+
+<body>
+    <div id="elementSource">
+        <span>
+            <template shadowrootmode="open"></template>
+        </span>
+    </div>
+
+    <div id="elementTarget"></div>
+
+    <template id="templateSource">
+        <span>
+            <template shadowrootmode="open"></template>
+        </span>
+    </template>
+
+    <div id="templateTarget"></div>
+</body>
+
+<script>
+'use strict';
+
+// test that we can use a ShadowRoot as an input for attachShadow
+promise_test(async () => {
+    const shadowRoot = elementSource.children[0].shadowRoot;
+
+    // validate that the ShadowRoot is an object, and has properties we expect (like "mode")
+    assert_equals(typeof shadowRoot, 'object');
+    assert_equals(shadowRoot.mode, 'open');
+
+    // attach the shadowRoot to our target element
+    elementTarget.attachShadow(shadowRoot);
+
+    // validate that our target element has a shadowRoot with the same options
+    assert_equals(typeof elementTarget.shadowRoot, 'object');
+    assert_equals(elementTarget.shadowRoot.mode, 'open');
+}, 'can use ShadowRoot as options for attachShadow');
+
+// test that we can use a ShadowRoot in a template element as an input for attachShadow
+promise_test(async () => {
+    const shadowRoot = templateSource.content.children[0].shadowRoot;
+
+    // validate that the ShadowRoot is an object, and has properties we expect (like "mode")
+    assert_equals(typeof shadowRoot, 'object');
+    assert_equals(shadowRoot.mode, 'open');
+
+    // attach the shadowRoot to our target element
+    templateTarget.attachShadow(shadowRoot);
+
+    // validate that our target element has a shadowRoot with the same options
+    assert_equals(typeof templateTarget.shadowRoot, 'object');
+    assert_equals(templateTarget.shadowRoot.mode, 'open');
+}, 'can use ShadowRoot in document fragment as options for attachShadow');
+
+</script>

--- a/Source/WebCore/dom/ShadowRootInit.idl
+++ b/Source/WebCore/dom/ShadowRootInit.idl
@@ -31,6 +31,6 @@ dictionary ShadowRootInit {
     boolean clonable = false;
     boolean serializable = false;
     SlotAssignmentMode slotAssignment = "named";
-    [EnabledBySetting=ScopedCustomElementRegistryEnabled] CustomElementRegistry customElementRegistry;
+    [EnabledBySetting=ScopedCustomElementRegistryEnabled] CustomElementRegistry? customElementRegistry = null;
     [EnabledBySetting=ShadowRootReferenceTargetEnabled] DOMString referenceTarget;
 };


### PR DESCRIPTION
#### ec8e119886a47d33257396dbc2a98cdf52785745
<pre>
attachShadow throws type error with document-fragment ShadowRoot
<a href="https://bugs.webkit.org/show_bug.cgi?id=295174">https://bugs.webkit.org/show_bug.cgi?id=295174</a>
<a href="https://rdar.apple.com/154658449">rdar://154658449</a>

Reviewed by Chris Dumez and Anne van Kesteren.

Allow customElementRegistry in ShadowRootInit to be null, in which case, we use the global registry.

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-customElementRegistry-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-customElementRegistry.html:
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/attachShadow-with-ShadowRoot-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/attachShadow-with-ShadowRoot.html: Added.
* Source/WebCore/dom/ShadowRootInit.idl:

Canonical link: <a href="https://commits.webkit.org/296853@main">https://commits.webkit.org/296853@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8af91e37fe1b652b0d90cea0fea3cc1fc5e775d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109724 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29382 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19811 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115745 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59958 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111687 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30060 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37970 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83381 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112672 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23955 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98819 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63842 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23334 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16964 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59539 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93330 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17002 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118537 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36763 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27232 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92389 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37136 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95079 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92210 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37180 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14918 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32591 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17716 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36657 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42128 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36318 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39660 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38027 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->