### PR TITLE
[Model Element] Model with autoplay sometimes does not play after page reload

### DIFF
--- a/LayoutTests/model-element/model-element-suspend-before-ready-expected.txt
+++ b/LayoutTests/model-element/model-element-suspend-before-ready-expected.txt
@@ -1,0 +1,1 @@
+PASSED: model's animation is running properly after it's suspended (before model is ready) and then resumed

--- a/LayoutTests/model-element/model-element-suspend-before-ready.html
+++ b/LayoutTests/model-element/model-element-suspend-before-ready.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ UsesBackForwardCache=true ModelElementEnabled=true ModelProcessEnabled=true ] -->
+<html>
+<head>
+<title>Suspended &lt;model> with autoplay should play again after it is resumed</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="resources/model-utils.js"></script>
+<script>
+    if (window.testRunner)
+        testRunner.waitUntilDone();
+
+    internals.disableModelLoadDelaysForTesting();
+
+    window.addEventListener("pageshow", async () => {
+        assert_equals(document.visibilityState, "visible");
+
+        if (!event.persisted)
+            return;
+
+        // Wait a little bit since the reload of suspended model
+        // is not synchronous.
+        await sleepForSeconds(0.5);
+
+        const model = document.getElementById("test-model");
+        await model.ready;
+        // This page was restored from the page cache. Make sure
+        // the animation is still running and progressing.
+        assert_false(model.paused, "Model's animation should be running after resume; model.paused ");
+
+        document.getElementById("result").innerText = "PASSED: model's animation is running properly after it's suspended (before model is ready) and then resumed";
+        testRunner.dumpAsText();
+        testRunner.notifyDone();
+    }, false);
+
+    window.addEventListener("pagehide", function(event) {
+        assert_true(event.persisted, "Page should have entered the page cache");
+    }, false);
+
+    window.addEventListener('load', async () => {
+        const model = document.getElementById("test-model");
+        assert_true(!!model, "Model element should exist");
+        model.addEventListener("load", async () => {
+            // We want to test suspending the model before it has finished loading
+            window.location.href = "resources/go-back-on-load.html";
+        }, false);
+    }, false);
+</script>
+<body>
+    <model id='test-model' autoplay loop>
+        <source src='resources/stopwatch-60s.usdz'/>
+    </model>
+    <div id="result"></div>
+</body>
+</html>

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
@@ -144,11 +144,19 @@ void ModelProcessModelPlayer::didFinishEnvironmentMapLoading(bool succeeded)
 
 std::optional<WebCore::ModelPlayerAnimationState> ModelProcessModelPlayer::currentAnimationState() const
 {
+    // Has no current state to return if the model load hasn't returned with its extents.
+    if (!m_boundingBoxExtents)
+        return std::nullopt;
+
     return m_animationState;
 }
 
 std::optional<std::unique_ptr<WebCore::ModelPlayerTransformState>> ModelProcessModelPlayer::currentTransformState() const
 {
+    // Has no current state to return if the model load hasn't returned with its extents.
+    if (!m_boundingBoxExtents)
+        return std::nullopt;
+
     return ModelProcessModelPlayerTransformState::create(m_entityTransform, m_boundingBoxCenter, m_boundingBoxExtents, m_hasPortal, m_stageModeOperation);
 }
 


### PR DESCRIPTION
#### 1b9846552a066ee555d4d65dccde02418f17a885
<pre>
[Model Element] Model with autoplay sometimes does not play after page reload
<a href="https://bugs.webkit.org/show_bug.cgi?id=295221">https://bugs.webkit.org/show_bug.cgi?id=295221</a>
<a href="https://rdar.apple.com/154646578">rdar://154646578</a>

Reviewed by Mike Wyrzykowski.

This issue happens under a timing condition where the model got suspended
before the model process has finished loading it. That can happen if the model
process crashes during model load, or if page navigation happens before the
model finishes loading.

In HTMLModelElement::unloadModelPlayer(), we try to save off the current state
of the model player before the deleting the model player, so we can restore to
that state when the element is resumed and a new model player is created.
However, if the model player hasn&apos;t even finished loading when unloadModelPlayer()
is called, its animation/transform states won&apos;t be valid. Before this fix, the
invalid animation state returned has paused=true, so after the model element is
resumed and the model player is created with that animation state, it then
incorrectly pauses the animation.

To fix this, return null for ModelProcessModelPlayer::currentAnimationState()
and ModelProcessModelPlayer::currentTransformState() if the model load has not
completed successfully. We can tell whether the model load has finished loading
by checking for the presence of a non-null m_boundingBoxExtents.

* LayoutTests/model-element/model-element-suspend-before-ready-expected.txt: Added.
* LayoutTests/model-element/model-element-suspend-before-ready.html: Added.
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp:
(WebKit::ModelProcessModelPlayer::currentAnimationState const):
(WebKit::ModelProcessModelPlayer::currentTransformState const):

Canonical link: <a href="https://commits.webkit.org/296870@main">https://commits.webkit.org/296870@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/637da4d906a13ad93c67dc60620c34ad1669b978

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109774 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29432 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19862 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115795 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60008 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38020 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83417 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112722 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23995 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98857 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63880 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23373 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17005 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 18 flakes 2 failures; Uploaded test results; 13 flakes") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59589 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93366 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17047 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118587 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36813 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27270 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92424 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37186 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95123 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92246 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23514 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37216 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14959 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32642 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36708 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42178 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36368 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39710 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38077 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->