### PR TITLE
[macOS] imported/w3c/web-platform-tests/mimesniff/media/media-sniff.window.html is a constant failure

### DIFF
--- a/LayoutTests/platform/mac-sonoma-wk1/imported/w3c/web-platform-tests/mimesniff/media/media-sniff.window-expected.txt
+++ b/LayoutTests/platform/mac-sonoma-wk1/imported/w3c/web-platform-tests/mimesniff/media/media-sniff.window-expected.txt
@@ -17,12 +17,12 @@ PASS flac.flac loads when served with Content-Type application/octet-stream
 PASS flac.flac loads when served with Content-Type text/html
 PASS flac.flac loads when served with Content-Type audio/ogg; codec=vorbis
 PASS flac.flac loads when served with Content-Type application/pdf
-PASS ogg.ogg loads when served with Content-Type
-PASS ogg.ogg loads when served with Content-Type bogus/mime
-PASS ogg.ogg loads when served with Content-Type application/octet-stream
-PASS ogg.ogg loads when served with Content-Type text/html
-PASS ogg.ogg loads when served with Content-Type audio/ogg; codec=vorbis
-PASS ogg.ogg loads when served with Content-Type application/pdf
+FAIL ogg.ogg loads when served with Content-Type  assert_unreached: No error expected frorm the HTMLMediaElement Reached unreachable code
+FAIL ogg.ogg loads when served with Content-Type bogus/mime assert_unreached: No error expected frorm the HTMLMediaElement Reached unreachable code
+FAIL ogg.ogg loads when served with Content-Type application/octet-stream assert_unreached: No error expected frorm the HTMLMediaElement Reached unreachable code
+FAIL ogg.ogg loads when served with Content-Type text/html assert_unreached: No error expected frorm the HTMLMediaElement Reached unreachable code
+FAIL ogg.ogg loads when served with Content-Type audio/ogg; codec=vorbis assert_unreached: No error expected frorm the HTMLMediaElement Reached unreachable code
+FAIL ogg.ogg loads when served with Content-Type application/pdf assert_unreached: No error expected frorm the HTMLMediaElement Reached unreachable code
 PASS mp4.mp4 loads when served with Content-Type
 PASS mp4.mp4 loads when served with Content-Type bogus/mime
 PASS mp4.mp4 loads when served with Content-Type application/octet-stream


### PR DESCRIPTION
#### 1c7453b7ba3c494ac505c0f2eb8d4175ca26bb20
<pre>
[macOS] imported/w3c/web-platform-tests/mimesniff/media/media-sniff.window.html is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=293981">https://bugs.webkit.org/show_bug.cgi?id=293981</a>
<a href="https://rdar.apple.com/152524059">rdar://152524059</a>

Reviewed by Jonathan Bedard.

Adding rebaseline in wk1.

* LayoutTests/platform/mac-sonoma-wk1/imported/w3c/web-platform-tests/mimesniff/media/media-sniff.window-expected.txt: Copied from LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/mimesniff/media/media-sniff.window-expected.txt.
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/mimesniff/media/media-sniff.window-expected.txt:

Canonical link: <a href="https://commits.webkit.org/296838@main">https://commits.webkit.org/296838@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1c7d1dc7a633a6d1346413059c518e15b45af5c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109728 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29386 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19815 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115749 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59962 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30064 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37974 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83385 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112676 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23964 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/98823 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63846 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23344 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16968 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59543 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/93339 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17008 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118541 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36767 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27229 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92391 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37140 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95084 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92212 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23496 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37176 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14922 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32595 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36661 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36322 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39664 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38031 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->