### PR TITLE
Many tests failing on WebKitLegacy due to small pixel diff

### DIFF
--- a/Source/WebCore/page/mac/WebCoreFrameView.h
+++ b/Source/WebCore/page/mac/WebCoreFrameView.h
@@ -42,6 +42,9 @@ class LocalFrame;
 - (void)setScrollBarsSuppressed:(BOOL)suppressed repaintOnUnsuppress:(BOOL)repaint;
 - (void)setScrollOrigin:(NSPoint)origin updatePositionAtAll:(BOOL)updatePositionAtAll immediately:(BOOL)updatePositionImmediately;
 - (NSPoint)scrollOrigin;
+- (int)verticalScrollbarWidth;
+- (int)horizontalScrollbarHeight;
+
 @end
 
 @protocol WebCoreFrameView

--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -647,6 +647,8 @@ void GraphicsLayer::setSize(const FloatSize& size)
     if (size == m_size)
         return;
     
+    ALWAYS_LOG_WITH_STREAM(stream << " GL::setSize: " << size);
+    
     m_size = size;
 
     if (shouldRepaintOnSizeChange())
@@ -951,6 +953,7 @@ static void dumpChildren(TextStream& ts, const Vector<Ref<GraphicsLayer>>& child
 
 void GraphicsLayer::dumpProperties(TextStream& ts, OptionSet<LayerTreeAsTextOptions> options) const
 {
+    ALWAYS_LOG_WITH_STREAM(stream << " dumpProperties: ");
     TextStream::IndentScope indentScope(ts);
     if (!m_offsetFromRenderer.isZero())
         ts << indent << "(offsetFromRenderer "_s << m_offsetFromRenderer << ")\n"_s;

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -2619,6 +2619,7 @@ void RenderBox::repaintDuringLayoutIfMoved(const LayoutRect& oldRect)
         m_frameRect = newRect;
         repaint();
         repaintOverhangingFloats(true);
+        ALWAYS_LOG_WITH_STREAM(stream<< "RB:setSize: " << m_frameRect);
     }
 }
 

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -70,7 +70,7 @@ public:
 
     template<typename T> void setX(T x) { m_frameRect.setX(x); }
     template<typename T> void setY(T y) { m_frameRect.setY(y); }
-    template<typename T> void setWidth(T width) { m_frameRect.setWidth(width); }
+    template<typename T> void setWidth(T width) { ALWAYS_LOG_WITH_STREAM(stream<< "RB:sewidth: " << width); m_frameRect.setWidth(width); }
     template<typename T> void setHeight(T height) { m_frameRect.setHeight(height); }
 
     inline LayoutUnit logicalLeft() const;
@@ -99,7 +99,7 @@ public:
 
     void setLocation(const LayoutPoint& location) { m_frameRect.setLocation(location); }
     
-    void setSize(const LayoutSize& size) { m_frameRect.setSize(size); }
+    void setSize(const LayoutSize& size) { ALWAYS_LOG_WITH_STREAM(stream<< "RB:setSize: " << size); m_frameRect.setSize(size); }
     void move(LayoutUnit dx, LayoutUnit dy) { m_frameRect.move(dx, dy); }
 
     LayoutRect frameRect() const { return m_frameRect; }

--- a/Source/WebKitLegacy/mac/WebView/WebDynamicScrollBarsView.h
+++ b/Source/WebKitLegacy/mac/WebView/WebDynamicScrollBarsView.h
@@ -62,6 +62,7 @@ struct WebDynamicScrollBarsViewPrivate;
 // visible is that they have been suppressed by setAlwaysHideHorizontal/VerticalScroller:.
 - (BOOL)horizontalScrollingAllowed;
 - (BOOL)verticalScrollingAllowed;
+- (NSRect)documentVisibleRect;
 @end
 
 #endif // !TARGET_OS_IPHONE

--- a/Source/WebKitLegacy/mac/WebView/WebDynamicScrollBarsViewInternal.h
+++ b/Source/WebKitLegacy/mac/WebView/WebDynamicScrollBarsViewInternal.h
@@ -63,6 +63,10 @@
 // NOTE: As opposed to other places in the code, programmatically moving the
 // scrollers from inside this class should not fire JS events.
 - (BOOL)inProgrammaticScroll;
+
+- (float)verticalScrollbarWidth;
+- (float)horizontalScrollbarHeight;
+
 @end
 
 #endif // !PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 4e1eac62349af97196c2fae4fdd948602deb4b99
<pre>
Many tests failing on WebKitLegacy due to small pixel diff
<a href="https://bugs.webkit.org/show_bug.cgi?id=295231">https://bugs.webkit.org/show_bug.cgi?id=295231</a>
<a href="https://rdar.apple.com/154299299">rdar://154299299</a>

Reviewed by NOBODY (OOPS!).

Hard code scrollbar size for mock scrollbars on wk1.

* Source/WebCore/page/mac/WebCoreFrameView.h:
* Source/WebCore/platform/graphics/GraphicsLayer.cpp:
(WebCore::GraphicsLayer::setSize):
(WebCore::GraphicsLayer::dumpProperties const):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::repaintDuringLayoutIfMoved):
* Source/WebCore/rendering/RenderBox.h:
(WebCore::RenderBox::setWidth):
(WebCore::RenderBox::setSize):
* Source/WebKitLegacy/mac/WebView/WebDynamicScrollBarsView.h:
* Source/WebKitLegacy/mac/WebView/WebDynamicScrollBarsView.mm:
(-[WebDynamicScrollBarsView initWithFrame:]):
(-[WebDynamicScrollBarsView initWithCoder:]):
(-[WebDynamicScrollBarsView setAlwaysHideHorizontalScroller:]):
(-[WebDynamicScrollBarsView setAlwaysHideVerticalScroller:]):
(-[WebDynamicScrollBarsView documentVisibleRect]):
(-[WebDynamicScrollBarsView updateScrollers]):
(-[WebDynamicScrollBarsView verticalScrollbarWidth]):
(-[WebDynamicScrollBarsView horizontalScrollbarHeight]):
* Source/WebKitLegacy/mac/WebView/WebDynamicScrollBarsViewInternal.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e1eac62349af97196c2fae4fdd948602deb4b99

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109908 "15 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29566 "Hash 4e1eac62 for PR 47400 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115930 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60147 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111871 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30244 "Hash 4e1eac62 for PR 47400 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38154 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83550 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112856 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/30244 "Hash 4e1eac62 for PR 47400 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98975 "Found 93 new API test failures: TestWebKitAPI.WKInspectorDelegate.InspectorConfiguration, TestWebKitAPI.WebKit2.CrashGPUProcessWhileCapturingAndCalling, TestWebKitAPI.WebKitLegacy.DidRemoveFrameFromHierarchy, TestWebKitAPI.VideoControlsManager.VideoControlsManagerSingleSmallAutoplayingVideo, TestWebKitAPI.WebKitLegacy.WillSendSubmitEvent, TestWebKitAPI.WKInspectorExtension.CanEvaluateScriptInExtensionTab, TestWebKitAPI.WKWebExtensionAPIDevTools.Basics, TestWebKitAPI.WebKit2.DoNotUnmuteWhenTakingAThumbnail, TestWebKitAPI.WebKit.InvalidDeviceIdHashSalts, TestWebKitAPI.WebKit.InterruptionBetweenSameProcessPages ... (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63992 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/30244 "Hash 4e1eac62 for PR 47400 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17123 "Found 60 new test failures: accessibility/mac/scrollbars.html accessibility/mac/webkit-scrollarea-position.html accessibility/mac/webkit-scrollarea.html compositing/direct-image-compositing.html compositing/geometry/horizontal-scroll-composited.html compositing/transforms/transformed-replaced-with-shadow-children.html css3/scroll-snap/resnap-after-layout.html css3/scroll-snap/scroll-snap-wheel-event.html editing/selection/caret-at-bidi-boundary.html fast/canvas/webgl/texImage2D-mse-flipY-false.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59724 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/30244 "Hash 4e1eac62 for PR 47400 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17165 "Found 1 new test failure: inspector/sampling-profiler/call-frame-with-dom-functions.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118721 "Built successfully") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36947 "Hash 4e1eac62 for PR 47400 does not build (failure)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27380 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92530 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37320 "Hash 4e1eac62 for PR 47400 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95241 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92353 "Found 2 new API test failures: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15069 "Found 2 new test failures: imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/span-limits.html inspector/sampling-profiler/call-frame-with-dom-functions.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32799 "Built successfully") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36842 "Hash 4e1eac62 for PR 47400 does not build (failure)") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42312 "Built successfully") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36502 "Hash 4e1eac62 for PR 47400 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39844 "Hash 4e1eac62 for PR 47400 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38211 "Hash 4e1eac62 for PR 47400 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->