### PR TITLE
Safari blocking extension redirect as "known tracker".

### DIFF
--- a/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp
+++ b/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp
@@ -76,21 +76,25 @@ std::optional<ThreadableWebSocketChannel::ValidatedURL> ThreadableWebSocketChann
     if (RefPtr page = document.page()) {
         if (!page->allowsLoadFromURL(requestedURL, MainFrameMainResource::No))
             return { };
+
 #if ENABLE(CONTENT_EXTENSIONS)
         if (RefPtr documentLoader = document.loader()) {
             auto results = page->protectedUserContentProvider()->processContentRuleListsForLoad(*page, validatedURL.url, ContentExtensions::ResourceType::WebSocket, *documentLoader);
-            if (results.summary.blockedLoad)
+            if (results.shouldBlock())
                 return { };
+
             if (results.summary.madeHTTPS) {
                 ASSERT(validatedURL.url.protocolIs("ws"_s));
                 validatedURL.url.setProtocol("wss"_s);
             }
+
             validatedURL.areCookiesAllowed = !results.summary.blockedCookies;
         }
 #else
         UNUSED_PARAM(document);
 #endif
     }
+
     return validatedURL;
 }
 

--- a/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -355,7 +355,8 @@ ContentRuleListResults ContentExtensionsBackend::processContentRuleListsForLoad(
             String newProtocol = url.protocolIs("http"_s) ? "https"_s : "wss"_s;
             currentDocument->addConsoleMessage(MessageSource::ContentBlocker, MessageLevel::Info, makeString("Promoted URL from "_s, url.string(), " to "_s, newProtocol));
         }
-        if (results.summary.blockedLoad) {
+
+        if (results.shouldBlock()) {
             String consoleMessage;
             if (auto message = customTrackerBlockingMessageForConsole(results, url, mainDocumentURL))
                 consoleMessage = WTFMove(*message);

--- a/Source/WebCore/contentextensions/ContentRuleListResults.h
+++ b/Source/WebCore/contentextensions/ContentRuleListResults.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,7 +33,7 @@
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
-    
+
 struct ContentRuleListResults {
     struct Result {
         bool blockedLoad { false };
@@ -53,6 +53,7 @@ struct ContentRuleListResults {
                 || !notifications.isEmpty();
         }
     };
+
     struct Summary {
         bool blockedLoad { false };
         bool madeHTTPS { false };
@@ -63,14 +64,17 @@ struct ContentRuleListResults {
         Vector<ContentExtensions::ModifyHeadersAction> modifyHeadersActions { };
         Vector<std::pair<ContentExtensions::RedirectAction, URL>> redirectActions { };
     };
+
     using ContentRuleListIdentifier = String;
 
     Summary summary;
     Vector<std::pair<ContentRuleListIdentifier, Result>> results;
-    
+
+    bool shouldBlock() const { return summary.blockedLoad && !summary.redirectedPriorToBlock; }
+
     bool shouldNotifyApplication() const
     {
-        return summary.blockedLoad
+        return shouldBlock()
             || summary.madeHTTPS
             || summary.blockedCookies
             || !summary.modifyHeadersActions.isEmpty()

--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -608,7 +608,7 @@ bool StyleSheetContents::subresourcesAllowReuse(CachePolicy cachePolicy, FrameLo
         if (page && documentLoader) {
             const auto& request = resource.resourceRequest();
             auto results = page->protectedUserContentProvider()->processContentRuleListsForLoad(*page, request.url(), ContentExtensions::toResourceType(resource.type(), resource.resourceRequest().requester(), loader.frame().isMainFrame()), *documentLoader);
-            if (results.summary.blockedLoad || results.summary.madeHTTPS)
+            if (results.shouldBlock() || results.summary.madeHTTPS)
                 return true;
         }
 #else

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1856,7 +1856,7 @@ void HTMLMediaElement::loadResource(const URL& initialURL, const ContentType& in
 
 #if ENABLE(CONTENT_EXTENSIONS)
     if (RefPtr documentLoader = frame->loader().documentLoader()) {
-        if (page->protectedUserContentProvider()->processContentRuleListsForLoad(*page, url, ContentExtensions::ResourceType::Media, *documentLoader).summary.blockedLoad) {
+        if (page->protectedUserContentProvider()->processContentRuleListsForLoad(*page, url, ContentExtensions::ResourceType::Media, *documentLoader).shouldBlock()) {
             mediaLoadingFailed(MediaPlayer::NetworkState::FormatError);
             return;
         }

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3635,9 +3635,8 @@ ResourceLoaderIdentifier FrameLoader::loadResourceSynchronously(const ResourceRe
         if (RefPtr page = m_frame->page()) {
             if (RefPtr documentLoader = m_documentLoader) {
                 auto results = page->protectedUserContentProvider()->processContentRuleListsForLoad(*page, newRequest.url(), ContentExtensions::ResourceType::Fetch, *documentLoader);
-                bool blockedLoad = results.summary.blockedLoad;
                 ContentExtensions::applyResultsToRequest(WTFMove(results), page.get(), newRequest);
-                if (blockedLoad && !results.summary.redirectedPriorToBlock) {
+                if (results.shouldBlock()) {
                     newRequest = { };
                     error = ResourceError(errorDomainWebKitInternal, 0, WTFMove(initialRequestURL), emptyString());
                     response = { };
@@ -4860,7 +4859,7 @@ void FrameLoader::prefetchDNSIfNeeded(const URL& url)
         return;
 
     auto results = page->protectedUserContentProvider()->processContentRuleListsForLoad(*page, url, ContentExtensions::ResourceType::Ping, *documentLoader);
-    if (results.summary.blockedLoad)
+    if (results.shouldBlock())
         return;
 #endif
 

--- a/Source/WebCore/loader/LinkLoader.cpp
+++ b/Source/WebCore/loader/LinkLoader.cpp
@@ -292,7 +292,7 @@ void LinkLoader::preconnectIfNeeded(const LinkLoadParameters& params, Document& 
         return;
 
     auto results = page->protectedUserContentProvider()->processContentRuleListsForLoad(*page, params.href, ContentExtensions::ResourceType::Ping, *documentLoader);
-    if (results.summary.blockedLoad && !results.summary.redirectedPriorToBlock)
+    if (results.shouldBlock())
         return;
 
     ContentExtensions::applyResultsToRequest(WTFMove(results), page.get(), request);

--- a/Source/WebCore/loader/PingLoader.cpp
+++ b/Source/WebCore/loader/PingLoader.cpp
@@ -71,13 +71,14 @@ static bool processContentRuleListsForLoad(const LocalFrame& frame, ResourceRequ
     RefPtr documentLoader = frame.loader().documentLoader();
     if (!documentLoader)
         return false;
+
     RefPtr page = frame.page();
     if (!page)
         return false;
+
     auto results = page->protectedUserContentProvider()->processContentRuleListsForLoad(*page, request.url(), resourceType, *documentLoader);
-    bool result = results.summary.blockedLoad;
     ContentExtensions::applyResultsToRequest(WTFMove(results), page.get(), request);
-    return result;
+    return results.shouldBlock();
 }
 
 #endif

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
  *           (C) 2007 Graham Dennis (graham.dennis@gmail.com)
  *
  * Redistribution and use in source and binary forms, with or without
@@ -441,9 +441,8 @@ void ResourceLoader::willSendRequestInternal(ResourceRequest&& request, const Re
         RefPtr documentLoader = m_documentLoader;
         if (page && documentLoader) {
             auto results = page->protectedUserContentProvider()->processContentRuleListsForLoad(*page, request.url(), m_resourceType, *documentLoader, redirectResponse.url());
-            bool blockedLoad = results.summary.blockedLoad;
             ContentExtensions::applyResultsToRequest(WTFMove(results), page.get(), request);
-            if (blockedLoad && !results.summary.redirectedPriorToBlock) {
+            if (results.shouldBlock()) {
                 RESOURCELOADER_RELEASE_LOG("willSendRequestInternal: resource load canceled because of content blocker");
                 didFail(blockedByContentBlockerError());
                 completionHandler({ });

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1190,10 +1190,9 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
         if (request.options().shouldEnableContentExtensionsCheck == ShouldEnableContentExtensionsCheck::Yes) {
             RegistrableDomain originalDomain { resourceRequest.url() };
             auto results = page->protectedUserContentProvider()->processContentRuleListsForLoad(page, resourceRequest.url(), ContentExtensions::toResourceType(type, request.resourceRequest().requester(), frame->isMainFrame()), *documentLoader);
-            bool blockedLoad = results.summary.blockedLoad;
             madeHTTPS = results.summary.madeHTTPS;
             request.applyResults(WTFMove(results), page.ptr());
-            if (blockedLoad && !results.summary.redirectedPriorToBlock) {
+            if (results.shouldBlock()) {
                 CACHEDRESOURCELOADER_RELEASE_LOG_WITH_FRAME("requestResource: Resource blocked by content blocker", frame.get());
                 if (type == CachedResource::Type::MainResource) {
                     auto resource = createResource(type, WTFMove(request), page->sessionID(), page->protectedCookieJar().ptr(), page->settings(), document.get());

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2687,7 +2687,7 @@ ExceptionOr<RefPtr<WindowProxy>> LocalDOMWindow::open(LocalDOMWindow& activeWind
     RefPtr mainFrameDocumentLoader = mainFrameDocument ? mainFrameDocument->loader() : nullptr;
     if (firstFrameDocument && page && mainFrameDocumentLoader) {
         auto results = page->protectedUserContentProvider()->processContentRuleListsForLoad(*page, firstFrameDocument->completeURL(urlString), ContentExtensions::ResourceType::Popup, *mainFrameDocumentLoader);
-        if (results.summary.blockedLoad)
+        if (results.shouldBlock())
             return RefPtr<WindowProxy> { nullptr };
     }
 #endif

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -311,6 +311,7 @@ void NetworkLoadChecker::checkRequest(ResourceRequest&& request, ContentSecurity
             auto type = m_options.mode == FetchOptions::Mode::Navigate ? ContentSecurityPolicy::InsecureRequestType::Navigation : ContentSecurityPolicy::InsecureRequestType::Load;
             contentSecurityPolicy->upgradeInsecureRequestIfNeeded(request, type);
         }
+
         if (!this->isAllowedByContentSecurityPolicy(request, client)) {
             contentSecurityPolicy = nullptr;
             handler(this->accessControlErrorForValidationHandler("Blocked by Content Security Policy."_s));
@@ -325,12 +326,15 @@ void NetworkLoadChecker::checkRequest(ResourceRequest&& request, ContentSecurity
             handler(WTFMove(result.error()));
             return;
         }
+
         if (!weakThis)
             return handler({ ResourceError { ResourceError::Type::Cancellation }});
-        if (result.value().results.summary.blockedLoad) {
+
+        if (result.value().results.shouldBlock()) {
             handler(weakThis->accessControlErrorForValidationHandler("Blocked by content extension"_s));
             return;
         }
+
         weakThis->continueCheckingRequestOrDoSyntheticRedirect(WTFMove(originalRequest), WTFMove(result.value().request), WTFMove(handler));
     });
 #else


### PR DESCRIPTION
#### 649580f44cf4a17068fdfca3a79c8ae42624020f
<pre>
Safari blocking extension redirect as &quot;known tracker&quot;.
<a href="https://webkit.org/b/293881">https://webkit.org/b/293881</a>
<a href="https://rdar.apple.com/problem/152403968">rdar://problem/152403968</a>

Reviewed by Jeff Miller.

This was mostly fixed by 296000@main (19746da205f1), however there were a couple of places
that didn&apos;t check `redirectedPriorToBlock`. Mainly the console log message saying a known
tracker resource was blocked was being logged to the console erroneously.

Fix this by adding a `shouldBlock()` helper function and using it everywhere `blockedLoad`
was being checked. This ensures consistency in the blocking and console reporting.

Unable to write automated tests due to the nature of known tracker blocking in Safari.

* Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp:
(WebCore::ThreadableWebSocketChannel::validateURL):
* Source/WebCore/contentextensions/ContentExtensionsBackend.cpp:
(WebCore::ContentExtensions::ContentExtensionsBackend::processContentRuleListsForLoad):
* Source/WebCore/contentextensions/ContentRuleListResults.h:
(WebCore::ContentRuleListResults::shouldBlock const):
(WebCore::ContentRuleListResults::shouldNotifyApplication const):
* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::StyleSheetContents::subresourcesAllowReuse const):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::loadResource):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadResourceSynchronously):
(WebCore::FrameLoader::prefetchDNSIfNeeded):
* Source/WebCore/loader/LinkLoader.cpp:
(WebCore::LinkLoader::preconnectIfNeeded):
* Source/WebCore/loader/PingLoader.cpp:
(WebCore::processContentRuleListsForLoad):
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::willSendRequestInternal):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestResource):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::open):
* Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp:
(WebKit::NetworkLoadChecker::checkRequest):

Canonical link: <a href="https://commits.webkit.org/296880@main">https://commits.webkit.org/296880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adcedac2be096ec8da11644395a90f955431c132

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19827 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115760 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59973 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111702 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30075 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37985 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83394 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112687 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23961 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98828 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63857 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23341 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16973 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59554 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93336 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17014 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118552 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36778 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27247 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92399 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37151 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95090 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92221 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37185 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14927 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32606 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17729 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36673 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42143 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36333 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39675 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38042 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->