### PR TITLE
Drop deprecated WKSpeechRecognitionPermissionCallbackComplete code in the UI Process C API

### DIFF
--- a/Source/WebKit/UIProcess/API/C/WKSpeechRecognitionPermissionCallback.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKSpeechRecognitionPermissionCallback.cpp
@@ -35,9 +35,3 @@ WKTypeID WKSpeechRecognitionPermissionCallbackGetTypeID()
 {
     return toAPI(SpeechRecognitionPermissionCallback::APIType);
 }
-
-void WKSpeechRecognitionPermissionCallbackComplete(WKSpeechRecognitionPermissionCallbackRef speechRecognitionPermissionCallback, bool granted)
-{
-    // FIXME: Deprecate and remove this.
-    return toProtectedImpl(speechRecognitionPermissionCallback)->complete(granted);
-}

--- a/Source/WebKit/UIProcess/API/C/WKSpeechRecognitionPermissionCallback.h
+++ b/Source/WebKit/UIProcess/API/C/WKSpeechRecognitionPermissionCallback.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,8 +32,6 @@ extern "C" {
 #endif
 
 WK_EXPORT WKTypeID WKSpeechRecognitionPermissionCallbackGetTypeID(void);
-
-WK_EXPORT void WKSpeechRecognitionPermissionCallbackComplete(WKSpeechRecognitionPermissionCallbackRef speechRecognitionPermissionCallback, bool granted);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
#### fcdc68b838499e522f7f8414d67ffbef056d29c8
<pre>
Drop deprecated WKSpeechRecognitionPermissionCallbackComplete code in the UI Process C API
<a href="https://bugs.webkit.org/show_bug.cgi?id=295232">https://bugs.webkit.org/show_bug.cgi?id=295232</a>
<a href="https://rdar.apple.com/154704585">rdar://154704585</a>

Reviewed by Chris Dumez.

`WKSpeechRecognitionPermissionCallbackComplete` is no longer needed. This drops code marked with
a `// FIXME: Deprecate and remove this.` two years ago in 260291@main.

* Source/WebKit/UIProcess/API/C/WKSpeechRecognitionPermissionCallback.cpp:
(WKSpeechRecognitionPermissionCallbackGetTypeID):
(WKSpeechRecognitionPermissionCallbackComplete): Deleted.
* Source/WebKit/UIProcess/API/C/WKSpeechRecognitionPermissionCallback.h:

Canonical link: <a href="https://commits.webkit.org/297219@main">https://commits.webkit.org/297219@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cba59e90904d685573c86fa83fa74e5ac4bbb13c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109742 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115763 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59976 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30078 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37988 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83396 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112690 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23966 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98832 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63859 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23346 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59557 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93340 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17018 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118555 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36781 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27243 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92403 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37154 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95094 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92225 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23729 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37188 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14931 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32609 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36676 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42146 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36336 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39678 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38045 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->