### PR TITLE
[commits.webkit.org] "Copy Link" button feels slow due to its commit validation behavior

### DIFF
--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/static/js/search.js
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/static/js/search.js
@@ -67,7 +67,7 @@ function ValidateCommitFormat() {
     }
 }
 
-async function GenerateCompareLink() {
+async function GenerateCompareLink(validateCommits=false) {
     const commitOne = document.getElementById('commit1').value;
     const commitTwo = document.getElementById('commit2').value;
     const message = document.getElementById('compareMessage');
@@ -76,7 +76,7 @@ async function GenerateCompareLink() {
         message.innerHTML = ErrorMessage(`${commitOne} is not a valid commit format<br>`);
     } else if (!VALID_REF_RE.test(commitTwo)) {
         message.innerHTML = ErrorMessage(`${commitTwo} is not a valid commit format<br>`);
-    } else {
+    } else if (validateCommits == true) {
         try {
             const commitOneData = await GetCommit(commitOne);
             const commitTwoData = await GetCommit(commitTwo);
@@ -85,6 +85,8 @@ async function GenerateCompareLink() {
             console.error(error);
             message.innerHTML = ErrorMessage(`${error.message}<br>`);
         }
+    } else {
+        return COMMIT_URL + 'compare/' + commitOne + '...' + commitTwo;
     }
     return;
 }
@@ -97,16 +99,22 @@ async function CopyCompareLink() {
                 const compareLink = await GenerateCompareLink();
                 if (compareLink) {
                     const message = document.getElementById('compareMessage');
-                    message.innerHTML = `<a href="${compareLink}"> ${compareLink} </a> copied to clipboard!`;
+                    message.innerHTML = `Copied to clipboard!`;
                     resolve(compareLink);
                 }
             })
         })
     ]);
+
+    const formattedLink = await GenerateCompareLink(true);
+    if (formattedLink) {
+        const message = document.getElementById('compareMessage');
+        message.innerHTML = message.innerHTML + `<br><a href="${formattedLink}"> ${formattedLink} </a>`;
+    }
 }
 
 async function CompareRedirect() {
-    let compareLink = await GenerateCompareLink();
+    let compareLink = await GenerateCompareLink(true);
     if (compareLink) {
         window.location.href = compareLink;
     }


### PR DESCRIPTION
#### 7c39e3fe235609f279e8cbfda01e754873e491b2
<pre>
[commits.webkit.org] &quot;Copy Link&quot; button feels slow due to its commit validation behavior
<a href="https://rdar.apple.com/144348929">rdar://144348929</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=287205">https://bugs.webkit.org/show_bug.cgi?id=287205</a>

Reviewed by Ryan Haddad.

Add an option to generate a comparision link without validation.
Then, when &apos;Copy Link&apos; is pressed, we can return a naive link generated from user input
and output a well-formatted link when the validation is complete.

* Tools/Scripts/libraries/reporelaypy/reporelaypy/static/js/search.js:
(GenerateCompareLink):
(CopyCompareLink):
(CompareRedirect):

Canonical link: <a href="https://commits.webkit.org/296983@main">https://commits.webkit.org/296983@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a081c9b31984f8c5d30358a4be6ecb7595bdcbd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109757 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29415 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19845 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115778 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59991 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111720 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30093 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38003 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83406 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112705 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23977 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98839 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63869 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/109189 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23357 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16984 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59572 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93350 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17027 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118570 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36796 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27258 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92408 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37169 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95103 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92230 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23589 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37198 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14940 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32625 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36691 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36351 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39693 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38060 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->