### PR TITLE
Remove _UIFindInteraction staging.

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -127,8 +127,8 @@ DECLARE_SYSTEM_HEADER
 #endif
 
 #if HAVE(UIFINDINTERACTION)
+#import <UIKit/UIFindInteraction.h>
 #import <UIKit/UIFindSession_Private.h>
-#import <UIKit/_UIFindInteraction.h>
 #import <UIKit/_UITextSearching.h>
 #endif
 
@@ -313,10 +313,6 @@ typedef id<NSCoding, NSCopying> _UITextSearchDocumentIdentifier;
 
 - (BOOL)supportsTextReplacement;
 
-@end
-
-@interface _UIFindInteraction : NSObject <UIInteraction>
-@property (nonatomic, strong) id<_UITextSearching> searchableObject;
 @end
 
 @interface UIFindInteraction ()
@@ -1213,19 +1209,6 @@ typedef NS_ENUM(NSUInteger, _UIScrollDeviceCategory) {
 @interface UIColorPickerViewController ()
 @property (nonatomic, copy, setter=_setSuggestedColors:) NSArray<UIColor *> *_suggestedColors;
 @end
-
-#if HAVE(UIFINDINTERACTION)
-
-@interface _UIFindInteraction (Staging_84486967)
-
-- (void)presentFindNavigatorShowingReplace:(BOOL)replaceVisible;
-
-- (void)findNext;
-- (void)findPrevious;
-
-@end
-
-#endif // HAVE(UIFINDINTERACTION)
 
 #if HAVE(AUTOCORRECTION_ENHANCEMENTS)
 @interface UIWKDocumentContext (Staging_112795757)

--- a/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
+++ b/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
@@ -39,6 +39,7 @@
 #import <UIKit/UIContextMenuInteraction_ForWebKitOnly.h>
 #import <UIKit/UIDevice_Private.h>
 #import <UIKit/UIEvent_Private.h>
+#import <UIKit/UIFindInteraction.h>
 #import <UIKit/UIKeyboardImpl.h>
 #import <UIKit/UIKeyboardInputModeController.h>
 #import <UIKit/UIKeyboardPreferencesController.h>
@@ -99,22 +100,6 @@ extern NSString * const UIWindowDidRotateNotification;
 extern NSNotificationName const _UIWindowSceneEnhancedWindowingModeChanged;
 
 WTF_EXTERN_C_END
-
-#if HAVE(UIFINDINTERACTION)
-
-@interface _UIFindInteraction : NSObject <UIInteraction>
-@end
-
-@interface _UIFindInteraction (Staging_84486967)
-
-- (void)presentFindNavigatorShowingReplace:(BOOL)replaceVisible;
-
-- (void)findNext;
-- (void)findPrevious;
-
-@end
-
-#endif // HAVE(UIFINDINTERACTION)
 
 @interface UIApplication ()
 - (void)_enqueueHIDEvent:(IOHIDEventRef)event;
@@ -604,6 +589,7 @@ typedef NS_ENUM(NSInteger, NSTextBlockLayer) {
 @property (nonatomic, readwrite) UITextSearchMatchMethod wordMatchMethod;
 @property (nonatomic, readwrite) NSStringCompareOptions stringCompareOptions;
 @end
+
 #endif
 
 #if HAVE(AUTOCORRECTION_ENHANCEMENTS)


### PR DESCRIPTION
#### f8d126a11419687c3d856c67b8b5dd0579c6fecf
<pre>
Remove _UIFindInteraction staging.
<a href="https://bugs.webkit.org/show_bug.cgi?id=295245">https://bugs.webkit.org/show_bug.cgi?id=295245</a>
<a href="https://rdar.apple.com/154711569">rdar://154711569</a>

Reviewed by Abrar Rahman Protyasha.

Removing old staging code.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Tools/TestRunnerShared/spi/UIKitSPIForTesting.h:

Canonical link: <a href="https://commits.webkit.org/296851@main">https://commits.webkit.org/296851@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bf8639f8660b37ba16902694f9d7501e64fa32f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109773 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29431 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115794 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60007 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111736 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30109 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38019 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83415 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112721 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23991 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98854 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63878 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23369 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17003 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59588 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93362 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17045 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118586 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36812 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27269 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92418 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37185 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95121 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92240 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23505 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37213 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14957 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32641 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36707 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42177 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36367 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39709 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38076 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->