### PR TITLE
REGRESSION (GitHub): automatically export WPT changes when running `git webkit pr`

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/land.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/land.py
@@ -117,6 +117,7 @@ class Land(Command):
             callback=callback,
             unblock=True if merge_type == 'unsafe' else False,
             update_issue=False,  # If we're immediately landing, no reason to track the code change as a WIP
+            export_wpt=args.export_wpt
         )
 
     @classmethod

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/clean_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/clean_unittest.py
@@ -76,7 +76,7 @@ class TestClean(testing.PathTestCase):
         ) as repo, mocks.local.Svn():
             repo.staged['added.txt'] = 'added'
             self.assertEqual(0, program.main(
-                args=('pull-request', '-i', 'pr-branch'),
+                args=('pull-request', '-i', 'pr-branch', '--no-wpt-export'),
                 path=self.path,
             ))
 
@@ -95,7 +95,7 @@ class TestClean(testing.PathTestCase):
         ) as repo, mocks.local.Svn():
             repo.staged['added.txt'] = 'added'
             self.assertEqual(0, program.main(
-                args=('pull-request', '-i', 'pr-branch'),
+                args=('pull-request', '-i', 'pr-branch', '--no-wpt-export'),
                 path=self.path,
             ))
             remote.pull_requests[-1]['state'] = 'closed'

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/land_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/land_unittest.py
@@ -72,7 +72,7 @@ class TestLand(testing.PathTestCase):
     def test_none(self):
         with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(), mocks.local.Svn():
             self.assertEqual(1, program.main(
-                args=('land', '-v'),
+                args=('land', '-v', '--no-wpt-export'),
                 path=self.path,
             ))
         self.assertEqual(captured.stderr.getvalue(), 'No repository provided\n')
@@ -80,7 +80,7 @@ class TestLand(testing.PathTestCase):
     def test_non_editable(self):
         with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path), mocks.local.Svn():
             self.assertEqual(1, program.main(
-                args=('land', '-v'),
+                args=('land', '-v', '--no-wpt-export'),
                 path=self.path,
             ))
             self.assertEqual(str(local.Git(self.path).commit()), '5@main')
@@ -96,7 +96,7 @@ class TestLand(testing.PathTestCase):
     def test_with_oops(self):
         with OutputCapture(level=logging.INFO) as captured, repository(self.path), mocks.local.Svn():
             self.assertEqual(1, program.main(
-                args=('land', '-v'),
+                args=('land', '-v', '--no-wpt-export'),
                 path=self.path,
             ))
             self.assertEqual(str(local.Git(self.path).commit()), '3.1@eng/example')
@@ -117,7 +117,7 @@ class TestLand(testing.PathTestCase):
     def test_default(self):
         with OutputCapture(level=logging.INFO) as captured, repository(self.path, has_oops=False), mocks.local.Svn(), MockTerminal.input('n'):
             self.assertEqual(0, program.main(
-                args=('land', '-v'),
+                args=('land', '-v', '--no-wpt-export'),
                 path=self.path,
             ))
             self.assertEqual(str(local.Git(self.path).commit()), '6@main')
@@ -144,7 +144,7 @@ class TestLand(testing.PathTestCase):
     def test_canonicalize(self):
         with OutputCapture(level=logging.INFO) as captured, repository(self.path, has_oops=False), mocks.local.Svn(), MockTerminal.input('n'):
             self.assertEqual(0, program.main(
-                args=('land', '-v'),
+                args=('land', '-v', '--no-wpt-export'),
                 path=self.path,
                 identifier_template='Canonical link: https://commits.webkit.org/{}',
             ))
@@ -186,7 +186,7 @@ class TestLand(testing.PathTestCase):
     def test_no_svn_canonical_svn(self):
         with OutputCapture(level=logging.INFO) as captured, repository(self.path, has_oops=False), mocks.local.Svn():
             self.assertEqual(1, program.main(
-                args=('land', '-v'),
+                args=('land', '-v', '--no-wpt-export'),
                 path=self.path, canonical_svn=True,
             ))
             self.assertEqual(str(local.Git(self.path).commit()), '3.1@eng/example')
@@ -200,7 +200,7 @@ class TestLand(testing.PathTestCase):
     def test_svn(self):
         with MockTime, OutputCapture(level=logging.INFO) as captured, repository(self.path, has_oops=False, git_svn=True), mocks.local.Svn(), MockTerminal.input('n'):
             self.assertEqual(0, program.main(
-                args=('land', '-v'),
+                args=('land', '-v', '--no-wpt-export'),
                 path=self.path, canonical_svn=True,
             ))
             self.assertEqual(str(local.Git(self.path).commit()), '6@main')
@@ -230,7 +230,7 @@ class TestLand(testing.PathTestCase):
                 patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]):
 
             self.assertEqual(0, program.main(
-                args=('land', '-v'),
+                args=('land', '-v', '--no-wpt-export'),
                 path=self.path,
             ))
             self.assertEqual(str(local.Git(self.path).commit()), '6@main')
@@ -270,7 +270,7 @@ class TestLand(testing.PathTestCase):
                 )), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
 
             self.assertEqual(0, program.main(
-                args=('land', '-v'),
+                args=('land', '-v', '--no-wpt-export'),
                 path=self.path,
                 identifier_template='Canonical link: https://commits.webkit.org/{}',
             ))
@@ -327,7 +327,7 @@ class TestLand(testing.PathTestCase):
                 )), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
 
             self.assertEqual(0, program.main(
-                args=('land', '-v'),
+                args=('land', '-v', '--no-wpt-export'),
                 path=self.path, canonical_svn=True,
             ))
             self.assertEqual(str(local.Git(self.path).commit()), '6@main')
@@ -413,7 +413,7 @@ class TestLandGitHub(testing.PathTestCase):
                 repository(self.path, remote='https://{}'.format(remote.remote)), mocks.local.Svn():
 
             self.assertEqual(1, program.main(
-                args=('land', '-v'),
+                args=('land', '-v', '--no-wpt-export'),
                 path=self.path,
             ))
             self.assertEqual(str(local.Git(self.path).commit()), '3.1@eng/example')
@@ -435,7 +435,7 @@ class TestLandGitHub(testing.PathTestCase):
                 repository(self.path, has_oops=False, remote='https://{}'.format(remote.remote)), mocks.local.Svn():
 
             self.assertEqual(1, program.main(
-                args=('land', '-v'),
+                args=('land', '-v', '--no-wpt-export'),
                 path=self.path,
             ))
             self.assertEqual(str(local.Git(self.path).commit()), '3.1@eng/example')
@@ -457,7 +457,7 @@ class TestLandGitHub(testing.PathTestCase):
                 approved=True) as remote, \
                 repository(self.path, has_oops=True, remote='https://{}'.format(remote.remote)), mocks.local.Svn():
             self.assertEqual(0, program.main(
-                args=('land', '-v'),
+                args=('land', '-v', '--no-wpt-export'),
                 path=self.path,
             ))
 
@@ -500,7 +500,7 @@ class TestLandGitHub(testing.PathTestCase):
             remotes=dict(fork='https://{}/Contributor/WebKit'.format(remote.hosts[0])),
         ):
             self.assertEqual(0, program.main(
-                args=('land', '-v'),
+                args=('land', '-v', '--no-wpt-export'),
                 path=self.path,
             ))
 
@@ -551,7 +551,7 @@ class TestLandGitHub(testing.PathTestCase):
             BUGS_EXAMPLE_COM_PASSWORD='password',
         )), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
             self.assertEqual(0, program.main(
-                args=('land', '-v'),
+                args=('land', '-v', '--no-wpt-export'),
                 path=self.path,
             ))
             self.assertEqual(len(Tracker.instance().issue(1).comments), 2)
@@ -638,7 +638,7 @@ class TestLandBitBucket(testing.PathTestCase):
                 )), mocks.local.Svn():
 
             self.assertEqual(1, program.main(
-                args=('land', '-v'),
+                args=('land', '-v', '--no-wpt-export'),
                 path=self.path,
             ))
             self.assertEqual(str(local.Git(self.path).commit()), '3.1@eng/example')
@@ -662,7 +662,7 @@ class TestLandBitBucket(testing.PathTestCase):
                 )), mocks.local.Svn():
 
             self.assertEqual(1, program.main(
-                args=('land', '-v'),
+                args=('land', '-v', '--no-wpt-export'),
                 path=self.path,
             ))
             self.assertEqual(str(local.Git(self.path).commit()), '3.1@eng/example')
@@ -686,7 +686,7 @@ class TestLandBitBucket(testing.PathTestCase):
                 )), mocks.local.Svn():
 
             self.assertEqual(0, program.main(
-                args=('land', '-v'),
+                args=('land', '-v', '--no-wpt-export'),
                 path=self.path,
             ))
             repo = local.Git(self.path)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -358,7 +358,7 @@ class TestDoPullRequest(testing.PathTestCase):
     def test_no_modified(self):
         with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path), mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', []):
             self.assertEqual(1, program.main(
-                args=('pull-request', '-i', 'pr-branch', '-v'),
+                args=('pull-request', '-i', 'pr-branch', '-v', '--no-wpt-export'),
                 path=self.path,
             ))
         self.assertEqual(
@@ -371,7 +371,7 @@ class TestDoPullRequest(testing.PathTestCase):
         with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', []):
             repo.staged['added.txt'] = 'added'
             self.assertEqual(1, program.main(
-                args=('pull-request', '-i', 'pr-branch', '-v'),
+                args=('pull-request', '-i', 'pr-branch', '-v', '--no-wpt-export'),
                 path=self.path,
             ))
             self.assertDictEqual(repo.staged, {})
@@ -392,7 +392,7 @@ No pre-PR checks to run""")
         with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', []):
             repo.modified['modified.txt'] = 'diff'
             self.assertEqual(1, program.main(
-                args=('pull-request', '-i', 'pr-branch', '-v'),
+                args=('pull-request', '-i', 'pr-branch', '-v', '--no-wpt-export'),
                 path=self.path,
             ))
             self.assertDictEqual(repo.modified, dict())
@@ -418,7 +418,7 @@ No pre-PR checks to run""")
 
             repo.staged['added.txt'] = 'added'
             self.assertEqual(0, program.main(
-                args=('pull-request', '-i', 'pr-branch', '-v', '--no-history'),
+                args=('pull-request', '-i', 'pr-branch', '-v', '--no-wpt-export', '--no-history'),
                 path=self.path,
             ))
             self.assertEqual(local.Git(self.path).remote().pull_requests.get(1).draft, False)
@@ -455,7 +455,7 @@ No pre-PR checks to run""")
 
             repo.staged['added.txt'] = 'added'
             self.assertEqual(0, program.main(
-                args=('pull-request', '-i', 'pr-branch', '-v', '--no-history', '--draft'),
+                args=('pull-request', '-i', 'pr-branch', '-v', '--no-wpt-export', '--no-history', '--draft'),
                 path=self.path,
             ))
             self.assertEqual(local.Git(self.path).remote().pull_requests.get(1).draft, True)
@@ -494,7 +494,7 @@ No pre-PR checks to run""")
             with OutputCapture():
                 repo.staged['added.txt'] = 'added'
                 self.assertEqual(0, program.main(
-                    args=('pull-request', '-i', 'pr-branch'),
+                    args=('pull-request', '-i', 'pr-branch', '--no-wpt-export'),
                     path=self.path,
                 ))
 
@@ -505,7 +505,7 @@ No pre-PR checks to run""")
             with OutputCapture(level=logging.INFO) as captured:
                 repo.staged['added.txt'] = 'diff'
                 self.assertEqual(0, program.main(
-                    args=('pull-request', '-v', '--no-history'),
+                    args=('pull-request', '-v', '--no-wpt-export', '--no-history'),
                     path=self.path,
                 ))
 
@@ -547,14 +547,14 @@ No pre-PR checks to run""")
             with OutputCapture():
                 repo.staged['added.txt'] = 'added'
                 self.assertEqual(0, program.main(
-                    args=('pull-request', '-i', 'pr-branch', '--remote', 'security'),
+                    args=('pull-request', '-i', 'pr-branch', '--remote', 'security', '--no-wpt-export'),
                     path=self.path,
                 ))
 
             with OutputCapture(level=logging.INFO) as captured:
                 repo.staged['added.txt'] = 'diff'
                 self.assertEqual(1, program.main(
-                    args=('pull-request', '-v', '--no-history', '--defaults'),
+                    args=('pull-request', '-v', '--no-wpt-export', '--no-history', '--defaults'),
                     path=self.path,
                 ))
 
@@ -588,14 +588,14 @@ No pre-PR checks to run""")
             with OutputCapture():
                 repo.staged['added.txt'] = 'added'
                 self.assertEqual(0, program.main(
-                    args=('pull-request', '-i', 'pr-branch', '--remote', 'security'),
+                    args=('pull-request', '-i', 'pr-branch', '--remote', 'security', '--no-wpt-export'),
                     path=self.path,
                 ))
 
             with OutputCapture(level=logging.INFO) as captured, MockTerminal.input('2'):
                 repo.staged['added.txt'] = 'diff'
                 self.assertEqual(0, program.main(
-                    args=('pull-request', '-v', '--no-history'),
+                    args=('pull-request', '-v', '--no-wpt-export', '--no-history'),
                     path=self.path,
                 ))
 
@@ -637,14 +637,14 @@ No pre-PR checks to run""")
             with OutputCapture():
                 repo.staged['added.txt'] = 'added'
                 self.assertEqual(0, program.main(
-                    args=('pull-request', '-i', 'pr-branch'),
+                    args=('pull-request', '-i', 'pr-branch', '--no-wpt-export'),
                     path=self.path,
                 ))
 
             with OutputCapture(level=logging.INFO) as captured:
                 repo.staged['modified.txt'] = 'diff'
                 self.assertEqual(0, program.main(
-                    args=('pull-request', '-v', '--no-history', '--append'),
+                    args=('pull-request', '-v', '--no-wpt-export', '--no-history', '--append'),
                     path=self.path,
                 ))
 
@@ -679,7 +679,7 @@ No pre-PR checks to run""")
             with OutputCapture():
                 repo.staged['added.txt'] = 'added'
                 self.assertEqual(0, program.main(
-                    args=('pull-request', '-i', 'pr-branch'),
+                    args=('pull-request', '-i', 'pr-branch', '--no-wpt-export'),
                     path=self.path,
                 ))
 
@@ -689,7 +689,7 @@ No pre-PR checks to run""")
             with OutputCapture(level=logging.INFO) as captured, MockTerminal.input('n'):
                 repo.staged['added.txt'] = 'diff'
                 self.assertEqual(0, program.main(
-                    args=('pull-request', '-v', '--no-history'),
+                    args=('pull-request', '-v', '--no-wpt-export', '--no-history'),
                     path=self.path,
                 ))
 
@@ -747,7 +747,7 @@ No pre-PR checks to run""")
             ]
             repo.head = repo.commits['eng/pr-branch'][-1]
             self.assertEqual(0, program.main(
-                args=('pull-request', '-v', '--no-history'),
+                args=('pull-request', '-v', '--no-wpt-export', '--no-history'),
                 path=self.path,
             ))
 
@@ -802,7 +802,7 @@ No pre-PR checks to run""")
         ) as repo, mocks.local.Svn():
             repo.staged['added.txt'] = 'added'
             self.assertEqual(0, program.main(
-                args=('pull-request', '-i', 'https://bugs.example.com/show_bug.cgi?id=1', '-v', '--no-history'),
+                args=('pull-request', '-i', 'https://bugs.example.com/show_bug.cgi?id=1', '-v', '--no-wpt-export', '--no-history'),
                 path=self.path,
             ))
 
@@ -859,7 +859,7 @@ No pre-PR checks to run""")
         ) as repo, mocks.local.Svn():
             repo.staged['added.txt'] = 'added'
             self.assertEqual(0, program.main(
-                args=('pull-request', '-i', '1', '-v', '--no-history'),
+                args=('pull-request', '-i', '1', '-v', '--no-wpt-export', '--no-history'),
                 path=self.path,
             ))
 
@@ -929,7 +929,7 @@ No pre-PR checks to run""")
 
             repo.staged['added.txt'] = 'added'
             self.assertEqual(0, program.main(
-                args=('pull-request', '-i', '1', '-v', '--no-history'),
+                args=('pull-request', '-i', '1', '-v', '--no-wpt-export', '--no-history'),
                 path=self.path,
             ))
 
@@ -993,7 +993,7 @@ No pre-PR checks to run""")
             ))
             repo.head = repo.commits['main'][-1]
             self.assertEqual(1, program.main(
-                args=('pull-request', '-v', '--no-history'),
+                args=('pull-request', '-v', '--no-wpt-export', '--no-history'),
                 path=self.path,
             ))
 
@@ -1025,7 +1025,7 @@ No pre-PR checks to run""")
 
             repo.staged['added.txt'] = 'added'
             self.assertEqual(0, program.main(
-                args=('pull-request', '-i', 'https://bugs.example.com/show_bug.cgi?id=1', '-v', '--no-history', '--remote',  'origin'),
+                args=('pull-request', '-i', 'https://bugs.example.com/show_bug.cgi?id=1', '-v', '--no-wpt-export', '--no-history', '--remote',  'origin'),
                 path=self.path,
             ))
 
@@ -1082,7 +1082,7 @@ No pre-PR checks to run""")
 
             repo.staged['added.txt'] = 'added'
             self.assertEqual(1, program.main(
-                args=('pull-request', '-i', 'https://bugs.example.com/show_bug.cgi?id=1', '-v', '--no-history'),
+                args=('pull-request', '-i', 'https://bugs.example.com/show_bug.cgi?id=1', '-v', '--no-wpt-export', '--no-history'),
                 path=self.path,
             ))
 
@@ -1139,7 +1139,7 @@ No pre-PR checks to run""")
             repo.head = repo.commits['eng/pr-branch'][-1]
 
             self.assertEqual(1, program.main(
-                args=('pull-request', '-v', '--no-history'),
+                args=('pull-request', '-v', '--no-wpt-export', '--no-history'),
                 path=self.path,
             ))
 
@@ -1198,7 +1198,7 @@ No pre-PR checks to run""")
             repo.head = repo.commits['eng/pr-branch'][-1]
 
             self.assertEqual(0, program.main(
-                args=('pull-request', '-v', '--no-history'),
+                args=('pull-request', '-v', '--no-wpt-export', '--no-history'),
                 path=self.path,
             ))
 
@@ -1271,7 +1271,7 @@ No pre-PR checks to run""")
             ]
             repo.head = repo.commits['eng/pr-branch'][-1]
             self.assertEqual(0, program.main(
-                args=('pull-request', '-v', '--no-history'),
+                args=('pull-request', '-v', '--no-wpt-export', '--no-history'),
                 path=self.path,
             ))
 
@@ -1338,7 +1338,7 @@ No pre-PR checks to run""")
             ]
             repo.head = repo.commits['eng/pr-branch'][-1]
             self.assertEqual(0, program.main(
-                args=('pull-request', '-v', '--no-history'),
+                args=('pull-request', '-v', '--no-wpt-export', '--no-history'),
                 path=self.path,
             ))
 
@@ -1418,7 +1418,7 @@ No pre-PR checks to run""")
             ]
             repo.head = repo.commits['eng/pr-branch'][-1]
             self.assertEqual(0, program.main(
-                args=('pull-request', '-v', '--no-history'),
+                args=('pull-request', '-v', '--no-wpt-export', '--no-history'),
                 path=self.path,
             ))
 
@@ -1493,7 +1493,7 @@ No pre-PR checks to run""")
             ]
             repo.head = repo.commits['eng/pr-branch'][-1]
             self.assertEqual(0, program.main(
-                args=('pull-request', '-v', '--no-history', '--cc-radar'),
+                args=('pull-request', '-v', '--no-wpt-export', '--no-history', '--cc-radar'),
                 path=self.path,
             ))
 
@@ -1567,7 +1567,7 @@ No pre-PR checks to run""")
             ]
             repo.head = repo.commits['eng/pr-branch'][-1]
             self.assertEqual(0, program.main(
-                args=('pull-request', '-v', '--no-history', '--no-cc-radar'),
+                args=('pull-request', '-v', '--no-wpt-export', '--no-history', '--no-cc-radar'),
                 path=self.path,
             ))
 
@@ -1636,7 +1636,7 @@ No pre-PR checks to run""")
             ]
             repo.head = repo.commits['eng/pr-branch'][-1]
             self.assertEqual(0, program.main(
-                args=('pull-request', '-v', '--no-history', '--no-issue'),
+                args=('pull-request', '-v', '--no-wpt-export', '--no-history', '--no-issue'),
                 path=self.path,
             ))
 
@@ -1679,7 +1679,7 @@ No pre-PR checks to run""")
 
             repo.staged['added.txt'] = 'added'
             self.assertEqual(0, program.main(
-                args=('pull-request', '-i', 'pr-branch', '-v'),
+                args=('pull-request', '-i', 'pr-branch', '-v', '--no-wpt-export'),
                 path=self.path,
             ))
             self.assertEqual(local.Git(self.path).remote().pull_requests.get(1).draft, False)
@@ -1714,7 +1714,7 @@ No pre-PR checks to run""")
 
             repo.staged['added.txt'] = 'added'
             self.assertEqual(1, program.main(
-                args=('pull-request', '-i', 'pr-branch', '-v', '--draft'),
+                args=('pull-request', '-i', 'pr-branch', '-v', '--no-wpt-export', '--draft'),
                 path=self.path,
             ))
 
@@ -1751,14 +1751,14 @@ No pre-PR checks to run""")
             with OutputCapture():
                 repo.staged['added.txt'] = 'added'
                 self.assertEqual(0, program.main(
-                    args=('pull-request', '-i', 'pr-branch'),
+                    args=('pull-request', '-i', 'pr-branch', '--no-wpt-export'),
                     path=self.path,
                 ))
 
             with OutputCapture(level=logging.INFO) as captured:
                 repo.staged['added.txt'] = 'diff'
                 self.assertEqual(0, program.main(
-                    args=('pull-request', '-v'),
+                    args=('pull-request', '-v', '--no-wpt-export'),
                     path=self.path,
                 ))
 
@@ -1793,14 +1793,14 @@ No pre-PR checks to run""")
             with OutputCapture():
                 repo.staged['added.txt'] = 'added'
                 self.assertEqual(0, program.main(
-                    args=('pull-request', '-i', 'pr-branch'),
+                    args=('pull-request', '-i', 'pr-branch', '--no-wpt-export'),
                     path=self.path,
                 ))
 
             with OutputCapture(level=logging.INFO) as captured:
                 repo.staged['modified.txt'] = 'diff'
                 self.assertEqual(0, program.main(
-                    args=('pull-request', '-v', '--append'),
+                    args=('pull-request', '-v', '--no-wpt-export', '--append'),
                     path=self.path,
                 ))
 
@@ -1835,7 +1835,7 @@ No pre-PR checks to run""")
             with OutputCapture():
                 repo.staged['added.txt'] = 'added'
                 self.assertEqual(0, program.main(
-                    args=('pull-request', '-i', 'pr-branch'),
+                    args=('pull-request', '-i', 'pr-branch', '--no-wpt-export'),
                     path=self.path,
                 ))
 
@@ -1845,7 +1845,7 @@ No pre-PR checks to run""")
             with OutputCapture(level=logging.INFO) as captured, MockTerminal.input('n'):
                 repo.staged['added.txt'] = 'diff'
                 self.assertEqual(0, program.main(
-                    args=('pull-request', '-v'),
+                    args=('pull-request', '-v', '--no-wpt-export'),
                     path=self.path,
                 ))
 
@@ -1892,7 +1892,7 @@ No pre-PR checks to run""")
             ]
             repo.head = repo.commits['eng/pr-branch'][-1]
             self.assertEqual(0, program.main(
-                args=('pull-request', '-v', '--no-history'),
+                args=('pull-request', '-v', '--no-wpt-export', '--no-history'),
                 path=self.path,
             ))
 
@@ -1944,7 +1944,7 @@ No pre-PR checks to run""")
             ]
             repo.head = repo.commits['eng/pr-branch'][-1]
             self.assertEqual(0, program.main(
-                args=('pull-request', '-v', '--no-history'),
+                args=('pull-request', '-v', '--no-wpt-export', '--no-history'),
                 path=self.path,
             ))
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py
@@ -100,7 +100,7 @@ class TestRevert(testing.PathTestCase):
             ),
         ), mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
             result = program.main(
-                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '-v', '--no-history', '--pr'),
+                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '-v', '--no-history', '--pr', '--no-wpt-export'),
                 path=self.path,
             )
             self.assertEqual(0, result)
@@ -149,7 +149,7 @@ class TestRevert(testing.PathTestCase):
             ),
         ), mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
             result = program.main(
-                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '--no-pr', '-v'),
+                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '--no-pr', '-v', '--no-wpt-export'),
                 path=self.path,
             )
             self.assertEqual(0, result)
@@ -157,7 +157,7 @@ class TestRevert(testing.PathTestCase):
             self.assertDictEqual(repo.staged, dict())
             self.assertEqual(True, 'Unreviewed, reverting 5@main (d8bce26fa65c)' in repo.head.message)
             with MockTerminal.input('{}/show_bug.cgi?id=2'.format(self.BUGZILLA)):
-                result = program.main(args=('pull-request', '-v', '--no-history'), path=self.path)
+                result = program.main(args=('pull-request', '-v', '--no-history', '--no-wpt-export'), path=self.path)
             self.assertEqual(0, result)
             self.assertEqual(local.Git(self.path).remote().pull_requests.get(1).draft, False)
 
@@ -202,7 +202,7 @@ class TestRevert(testing.PathTestCase):
             ),
         ), mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
             result = program.main(
-                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '--issue', '{}/show_bug.cgi?id=2'.format(self.BUGZILLA), '-v', '--no-pr'),
+                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '--issue', '{}/show_bug.cgi?id=2'.format(self.BUGZILLA), '-v', '--no-pr', '--no-wpt-export'),
                 path=self.path,
             )
             self.assertEqual(0, result)
@@ -210,7 +210,7 @@ class TestRevert(testing.PathTestCase):
             self.assertDictEqual(repo.staged, dict())
             self.assertEqual(True, 'Unreviewed, reverting 5@main (d8bce26fa65c)' in repo.head.message)
             with MockTerminal.input('{}/show_bug.cgi?id=2'.format(self.BUGZILLA)):
-                result = program.main(args=('pull-request', '-v', '--no-history'), path=self.path)
+                result = program.main(args=('pull-request', '-v', '--no-history', '--no-wpt-export'), path=self.path)
             self.assertEqual(0, result)
             self.assertEqual(local.Git(self.path).remote().pull_requests.get(1).draft, False)
 
@@ -253,7 +253,7 @@ class TestRevert(testing.PathTestCase):
             ),
         ), mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
             result = program.main(
-                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '--no-issue', '-v', '--no-pr'),
+                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '--no-issue', '-v', '--no-pr', '--no-wpt-export'),
                 path=self.path,
             )
             self.assertEqual(0, result)
@@ -286,7 +286,7 @@ index 05e8751..0bf3c85 100644
 """
             }
             result = program.main(
-                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '-i', 'pr-branch', '-v', '--pr'),
+                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '-i', 'pr-branch', '-v', '--pr', '--no-wpt-export'),
                 path=self.path,
             )
             self.assertEqual(1, result)
@@ -306,13 +306,13 @@ index 05e8751..0bf3c85 100644
             ),
         ), mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
             result = program.main(
-                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '-v', '--pr'),
+                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '-v', '--pr', '--no-wpt-export'),
                 path=self.path,
             )
             self.assertEqual(0, result)
             with MockTerminal.input('{}/show_bug.cgi?id=2'.format(self.BUGZILLA)):
                 result = program.main(
-                    args=('pull-request', '-v', '--no-history'),
+                    args=('pull-request', '-v', '--no-history', '--no-wpt-export'),
                     path=self.path,
                 )
             self.assertEqual(0, result)
@@ -371,7 +371,7 @@ index 05e8751..0bf3c85 100644
             ),
         ), mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
             result = program.main(
-                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '--issue', '{}/show_bug.cgi?id=2'.format(self.BUGZILLA), '-v', '--pr'),
+                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '--issue', '{}/show_bug.cgi?id=2'.format(self.BUGZILLA), '-v', '--pr', '--no-wpt-export'),
                 path=self.path,
             )
             self.assertEqual(0, result)
@@ -405,7 +405,7 @@ index 05e8751..0bf3c85 100644
         ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
 
             result = program.main(
-                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '--issue', '{}/show_bug.cgi?id=1'.format(self.BUGZILLA), '-v', '--safe'),
+                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '--issue', '{}/show_bug.cgi?id=1'.format(self.BUGZILLA), '-v', '--safe', '--no-wpt-export'),
                 path=self.path,
             )
             self.assertEqual(0, result)
@@ -452,7 +452,7 @@ index 05e8751..0bf3c85 100644
         ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
 
             result = program.main(
-                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '--issue', '{}/show_bug.cgi?id=1'.format(self.BUGZILLA), '-v', '--unsafe'),
+                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '--issue', '{}/show_bug.cgi?id=1'.format(self.BUGZILLA), '-v', '--unsafe', '--no-wpt-export'),
                 path=self.path,
             )
             self.assertEqual(0, result)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/squash_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/squash_unittest.py
@@ -46,7 +46,7 @@ class TestSquash(testing.PathTestCase):
         ) as repo, mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', []):
             repo.checkout('eng/squash-branch')
             result = program.main(
-                args=('pull-request', '-v', '--squash', '--no-history'),
+                args=('pull-request', '-v', '--squash', '--no-history', '--no-wpt-export'),
                 path=self.path,
             )
             self.assertEqual(0, result)
@@ -91,7 +91,7 @@ class TestSquash(testing.PathTestCase):
         ) as repo, mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', []):
             repo.checkout('eng/squash-branch')
             result = program.main(
-                args=('pull-request', '-v', '--squash', '--no-history', '--new-message'),
+                args=('pull-request', '-v', '--squash', '--no-history', '--new-message', '--no-wpt-export'),
                 path=self.path,
             )
             self.assertEqual(0, result)
@@ -143,7 +143,7 @@ class TestSquash(testing.PathTestCase):
             self.assertDictEqual(repo.modified, dict())
             self.assertDictEqual(repo.staged, dict())
             self.assertEqual(True, '[Testing] Creating commits' in repo.head.message)
-            result = program.main(args=('pull-request', '-v', '--no-history'), path=self.path)
+            result = program.main(args=('pull-request', '-v', '--no-history', '--no-wpt-export'), path=self.path)
             self.assertEqual(0, result)
             self.assertEqual(local.Git(self.path).remote().pull_requests.get(1).draft, False)
 


### PR DESCRIPTION
#### a6bbe1800fab4a71116d310ff51a8bdcfbddf827
<pre>
REGRESSION (GitHub): automatically export WPT changes when running `git webkit pr`
<a href="https://bugs.webkit.org/show_bug.cgi?id=252049">https://bugs.webkit.org/show_bug.cgi?id=252049</a>
<a href="https://rdar.apple.com/105269959">rdar://105269959</a>

Reviewed by NOBODY (OOPS!).

Call into WebPlatformTestExporter after PR creation is finished.
This should look for any WPT changes in the PR and create a pull-request on web-platform-tests/wpt.

For reverts, the user is prompted before exporting.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/land.py:
(Land.merge_queue):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.parser):
(PullRequest.create_pull_request):
(PullRequest):
(PullRequest.import_test_exporter):
(PullRequest.export_to_wpt):
(PullRequest.main):

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py:
(Revert.main):

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/clean_unittest.py:
(TestClean.test_clean_pr):
(TestClean.test_delete_pr_branches):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/land_unittest.py:
(TestLand.test_none):
(TestLand.test_non_editable):
(TestLand.test_with_oops):
(TestLand.test_default):
(TestLand.test_canonicalize):
(TestLand.test_no_svn_canonical_svn):
(TestLand.test_svn):
(TestLand.test_default_with_radar):
(TestLand.test_canonicalize_with_bugzilla):
(TestLand.test_svn_with_bugzilla):
(TestLandGitHub):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py:
(TestRevert):
(test_update):
(test_pr):
(test_land_safe):
(test_land_unsafe):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/squash_unittest.py:
(TestSquash.test_github_with_previous_history):
(TestSquash.test_github_without_previous_history):
(TestSquash.test_github_two_step):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6bbe1800fab4a71116d310ff51a8bdcfbddf827

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114952 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34669 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25149 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121073 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65616 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7d57387a-7d3b-4c2f-9197-92cb9f560377) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116841 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35313 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43229 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87343 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42180 "Found 4 new test failures: js/arrowfunction-block-1.html js/dom/call-link-info-recursion.html resize-observer/element-leak.html streams/readable-stream-lock-after-worker-terminates-crash.html (failure)") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e61e7ba5-6901-49cf-a8d7-2697e8528f95) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117900 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28131 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103200 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67738 "Passed tests") | | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/114326 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27312 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21319 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64726 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97512 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21437 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124263 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41926 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31332 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96142 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/114385 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42297 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99391 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95927 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41123 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18964 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37962 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41800 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41349 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44665 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43092 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->