### PR TITLE
[EWS] Swapping bots in EWS queues

### DIFF
--- a/Tools/CISupport/ews-build/config.json
+++ b/Tools/CISupport/ews-build/config.json
@@ -67,11 +67,11 @@
     { "name": "ews107", "platform": "mac-sonoma" },
     { "name": "ews108", "platform": "*" },
     { "name": "ews109", "platform": "ios-18" },
-    { "name": "ews110", "platform": "ios-simulator-18" },
-    { "name": "ews111", "platform": "ios-simulator-18" },
+    { "name": "ews110", "platform": "mac-sequoia" },
+    { "name": "ews111", "platform": "mac-sequoia" },
     { "name": "ews112", "platform": "mac-sonoma" },
     { "name": "ews113", "platform": "mac-sonoma" },
-    { "name": "ews114", "platform": "*" },
+    { "name": "ews114", "platform": "mac-sequoia" },
     { "name": "ews115", "platform": "mac-sonoma" },
     { "name": "ews116", "platform": "mac-sonoma" },
     { "name": "ews117", "platform": "mac-sonoma" },
@@ -194,9 +194,9 @@
     { "name": "ews254", "platform": "ios-simulator-18" },
     { "name": "ews255", "platform": "ios-simulator-18" },
     { "name": "ews256", "platform": "ios-simulator-18" },
-    { "name": "ews257", "platform": "mac-sequoia" },
-    { "name": "ews258", "platform": "mac-sequoia" },
-    { "name": "ews259", "platform": "mac-sequoia" },
+    { "name": "ews257", "platform": "ios-simulator-18" },
+    { "name": "ews258", "platform": "ios-simulator-18" },
+    { "name": "ews259", "platform": "ios-simulator-18" },
     { "name": "ews260", "platform": "mac-sequoia" },
     { "name": "ews261", "platform": "mac-sequoia" },
     { "name": "ews262", "platform": "mac-sequoia" },
@@ -276,7 +276,7 @@
       "factory": "macOSWK2Factory", "platform": "mac-sequoia",
       "configuration": "debug",
       "triggered_by": ["macos-sequoia-debug-build-ews"],
-      "workernames": ["ews138", "ews139", "ews140", "ews175", "ews176", "ews177", "ews178", "ews179", "ews180", "ews257", "ews258", "ews259"]
+      "workernames": ["ews110", "ews111", "ews114", "ews138", "ews139", "ews140", "ews175", "ews176", "ews177", "ews178", "ews179", "ews180"]
     },
     {
       "name": "macOS-Sonoma-Release-Build-EWS", "shortname": "mac", "icon": "buildOnly",
@@ -449,7 +449,7 @@
       "name": "API-Tests-iOS-Simulator-EWS", "shortname": "api-ios", "icon": "testOnly",
       "factory": "APITestsFactory", "platform": "*",
       "triggered_by": ["ios-18-sim-build-ews"],
-      "workernames": ["ews110", "ews111", "ews114", "ews156", "ews157", "ews158", "ews159", "ews160", "ews183", "ews254", "ews255", "ews256"]
+      "workernames": ["ews156", "ews157", "ews158", "ews159", "ews160", "ews183", "ews254", "ews255", "ews256", "ews257", "ews258", "ews259"]
     },
     {
       "name": "API-Tests-macOS-EWS", "shortname": "api-mac", "icon": "testOnly",


### PR DESCRIPTION
#### b6652793a6ca763d35bc8a157df0198fb033b399
<pre>
[EWS] Swapping bots in EWS queues
<a href="https://bugs.webkit.org/show_bug.cgi?id=295246">https://bugs.webkit.org/show_bug.cgi?id=295246</a>
<a href="https://rdar.apple.com/153655586">rdar://153655586</a>

Reviewed by Brianna Fan.

Swapping three bots with the bots that have 32GB RAM.

* Tools/CISupport/ews-build/config.json:

Canonical link: <a href="https://commits.webkit.org/296876@main">https://commits.webkit.org/296876@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afc138fc1e560d4468aecddb9706bc4f6bdf91b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109765 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115786 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59999 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111728 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30101 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38011 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83410 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112713 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23982 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98847 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63873 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23362 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16992 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59580 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93355 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17037 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118578 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36804 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27262 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92413 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/109261 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37177 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95113 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92235 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37203 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14949 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32633 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17727 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36699 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36359 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39701 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38068 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->