### PR TITLE
[WPE] Click count leaking through successive layout test within the same WPEView

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
@@ -153,6 +153,10 @@ void PageClientImpl::toolTipChanged(const String&, const String&)
 
 void PageClientImpl::didCommitLoadForMainFrame(const String&, bool)
 {
+#if ENABLE(WPE_PLATFORM)
+    if (GRefPtr<WPEView> view = m_view.wpeView())
+        wpe_view_clear_press_count(view.get());
+#endif
 }
 
 void PageClientImpl::didChangeContentSize(const WebCore::IntSize&)

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
@@ -997,6 +997,20 @@ guint wpe_view_compute_press_count(WPEView* view, gdouble x, gdouble y, guint bu
 }
 
 /**
+ * wpe_view_clear_press_count
+ * @view: a #WPEView
+ *
+ * Clear any button press being tracked.
+ */
+void wpe_view_clear_press_count(WPEView* view)
+{
+    g_return_if_fail(WPE_IS_VIEW(view));
+
+    auto* priv = view->priv;
+    priv->lastButtonPress = { };
+}
+
+/**
  * wpe_view_focus_in:
  * @view: a #WPEView
  *

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.h
@@ -138,6 +138,7 @@ WPE_API guint                   wpe_view_compute_press_count           (WPEView 
                                                                         gdouble             y,
                                                                         guint               button,
                                                                         guint32             time);
+WPE_API void                    wpe_view_clear_press_count             (WPEView            *view);
 WPE_API void                    wpe_view_focus_in                      (WPEView            *view);
 WPE_API void                    wpe_view_focus_out                     (WPEView            *view);
 WPE_API gboolean                wpe_view_get_has_focus                 (WPEView            *view);

--- a/Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp
+++ b/Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp
@@ -34,6 +34,11 @@
 #include <wtf/text/Base64.h>
 #include <wtf/text/MakeString.h>
 
+#if ENABLE(WPE_PLATFORM)
+#include <WebKit/WKView.h>
+#include <wpe/wpe-platform.h>
+#endif
+
 #if USE(CAIRO)
 #include <cairo.h>
 #elif USE(SKIA)


### PR DESCRIPTION
#### 73636813c28fde71e3b86b395acabaa71e2328a1
<pre>
[WPE] Click count leaking through successive layout test within the same WPEView
<a href="https://bugs.webkit.org/show_bug.cgi?id=295252">https://bugs.webkit.org/show_bug.cgi?id=295252</a>

Reviewed by NOBODY (OOPS!).

Add a new function to reset click count tracking between page loads, avoiding
accidental double and triple clicks.

Found this issue while rebaselining the fast/html/details-* tests after
296203@main. Some rebaselines were flaky as the tests were affected by
this when running together.

This helps WPE mirror the GTK4 WebView behavior of resetting the click
count between page loads.

* Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp:
(WebKit::PageClientImpl::didCommitLoadForMainFrame): Reset click count
between page loads.
* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:
(wpe_view_clear_press_count): Added.
* Source/WebKit/WPEPlatform/wpe/WPEView.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73636813c28fde71e3b86b395acabaa71e2328a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110761 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20856 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116790 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61029 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112724 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31104 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39010 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84219 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113709 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24846 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99737 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64660 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24214 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17870 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60583 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94239 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17929 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119580 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37806 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28100 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93181 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38182 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96000 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93005 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38038 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15787 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33780 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37699 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43169 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37360 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40698 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39067 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->