### PR TITLE
[Form Control Refresh] Focus ring clipped for native <select> buttons

### DIFF
--- a/LayoutTests/fast/forms/select/select-focus-ring-is-not-clipped-expected-mismatch.html
+++ b/LayoutTests/fast/forms/select/select-focus-ring-is-not-clipped-expected-mismatch.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<style>
+    body {
+        margin: 0;
+        padding: 0;
+        padding-top: 5px;
+    }
+    #d1, #d2 {
+        top: 0;
+        left: 0;
+        width: 20px;
+        height: 30px;
+        background-color: black;
+        position: absolute;
+    }
+</style>
+</head>
+<body>
+<select id="select"><option>Option</option></select>
+<div id="d1"></div>
+<div id="d2"></div>
+</body>
+<script defer>
+    var selectRect = select.getBoundingClientRect();
+    d2.style.left = selectRect.x + selectRect.width - 10 + "px";
+</script>
+</html>

--- a/LayoutTests/fast/forms/select/select-focus-ring-is-not-clipped.html
+++ b/LayoutTests/fast/forms/select/select-focus-ring-is-not-clipped.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+</head>
+<style>
+    body {
+        margin: 0;
+        padding: 0;
+        padding-top: 5px;
+    }
+    #d1, #d2 {
+        top: 0;
+        left: 0;
+        width: 20px;
+        height: 30px;
+        background-color: black;
+        position: absolute;
+    }
+</style>
+<body onload="runTest()">
+<select id="select"><option>Option</option></select>
+<div id="d1"></div>
+<div id="d2"></div>
+</body>
+<script>
+    select.focus();
+</script>
+</html>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1630,6 +1630,9 @@ BleedAvoidance RenderBox::determineBleedAvoidance(GraphicsContext& context) cons
     if (!style.hasBackground() || !style.hasBorder() || !style.hasBorderRadius() || borderImageIsLoadedAndCanBeRendered())
         return BleedAvoidance::None;
 
+    if (!theme().mayNeedBleedAvoidance(style))
+        return BleedAvoidance::None;
+
     AffineTransform ctm = context.getCTM();
     FloatSize contextScaling(static_cast<float>(ctm.xScale()), static_cast<float>(ctm.yScale()));
 

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -263,6 +263,8 @@ public:
 
     virtual Color disabledSubmitButtonTextColor() const { return Color::black; }
 
+    virtual bool mayNeedBleedAvoidance(const RenderStyle&) const { return true; }
+
 protected:
     ControlStyle extractControlStyleForRenderer(const RenderObject&) const;
 

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
@@ -236,6 +236,8 @@ protected:
 
     Color buttonTextColor(OptionSet<StyleColorOptions>, bool) const;
     Color disabledSubmitButtonTextColor() const final;
+
+    bool mayNeedBleedAvoidance(const RenderStyle&) const final;
 #endif
 
 private:

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -3553,6 +3553,53 @@ Color RenderThemeCocoa::disabledSubmitButtonTextColor() const
     return textColor;
 }
 
+bool RenderThemeCocoa::mayNeedBleedAvoidance(const RenderStyle& style) const
+{
+    if (style.nativeAppearanceDisabled())
+        return true;
+
+    switch (style.usedAppearance()) {
+    case StyleAppearance::BorderlessAttachment:
+    case StyleAppearance::Button:
+    case StyleAppearance::Checkbox:
+#if PLATFORM(MAC)
+    case StyleAppearance::ColorWell:
+    case StyleAppearance::ColorWellSwatch:
+#endif
+    case StyleAppearance::DefaultButton:
+    case StyleAppearance::InnerSpinButton:
+    case StyleAppearance::ListButton:
+#if PLATFORM(MAC)
+    case StyleAppearance::Menulist:
+#else
+    case StyleAppearance::MenulistButton:
+#endif
+    case StyleAppearance::Meter:
+    case StyleAppearance::ProgressBar:
+    case StyleAppearance::PushButton:
+    case StyleAppearance::Radio:
+    case StyleAppearance::SearchField:
+#if PLATFORM(MAC)
+    case StyleAppearance::SearchFieldCancelButton:
+#endif
+    case StyleAppearance::SearchFieldDecoration:
+    case StyleAppearance::SearchFieldResultsButton:
+    case StyleAppearance::SearchFieldResultsDecoration:
+    case StyleAppearance::SquareButton:
+    case StyleAppearance::SliderHorizontal:
+    case StyleAppearance::SliderThumbHorizontal:
+    case StyleAppearance::SliderThumbVertical:
+    case StyleAppearance::SliderVertical:
+    case StyleAppearance::TextArea:
+    case StyleAppearance::TextField:
+    case StyleAppearance::SwitchThumb:
+    case StyleAppearance::SwitchTrack:
+        return false;
+    default:
+        return true;
+    }
+}
+
 #endif
 
 void RenderThemeCocoa::adjustCheckboxStyle(RenderStyle& style, const Element* element) const


### PR DESCRIPTION
#### 77ba7337d7cdd989edca5358355aeaf95a2d5f06
<pre>
[Form Control Refresh] Focus ring clipped for native &lt;select&gt; buttons
<a href="https://bugs.webkit.org/show_bug.cgi?id=295256">https://bugs.webkit.org/show_bug.cgi?id=295256</a>
<a href="https://rdar.apple.com/154729412">rdar://154729412</a>

Reviewed by Aditya Keerthi.

After 296129@main, native select buttons no longer had their border
radius reset, causing bleed avoidance to apply which resulted in the
focus ring getting clipped.

With these changes, bleed avoidance (except when handled directly by
the theme) no longer applies to any painted control.

* LayoutTests/fast/forms/select/select-focus-ring-is-not-clipped-expected-mismatch.html: Added.
* LayoutTests/fast/forms/select/select-focus-ring-is-not-clipped.html: Added.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::determineBleedAvoidance const):
* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::mayNeedBleedAvoidance const):
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.h:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::RenderThemeCocoa::mayNeedBleedAvoidance const):

Canonical link: <a href="https://commits.webkit.org/296951@main">https://commits.webkit.org/296951@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8f600e9be6df79df4e339675ec5de72806eae74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110053 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29712 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20144 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116075 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60301 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112016 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30390 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38299 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83671 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113001 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24236 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99110 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64115 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23604 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17250 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59871 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93616 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17301 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118866 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37093 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27497 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92640 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37465 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95378 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92466 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23571 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37454 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15192 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32975 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36987 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42458 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36649 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39989 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38358 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->