### PR TITLE
Disable 'SVG 1.1' deprecated properties behind feature flag

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2635,6 +2635,20 @@ EnableInheritURIQueryComponent:
     WebCore:
       default: false
 
+EnableSVGDeprecatedProperties:
+  type: bool
+  status: preview
+  category: dom
+  humanReadableName: "Enable SVG 1.1 Deprecated Properties"
+  humanReadableDescription: "Enable SVG 1.1 Deprecated Properties"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 EncryptedMediaAPIEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/svg/SVGGraphicsElement.idl
+++ b/Source/WebCore/svg/SVGGraphicsElement.idl
@@ -28,8 +28,8 @@
 ] interface SVGGraphicsElement : SVGElement {
     readonly attribute SVGAnimatedTransformList transform;
 
-    readonly attribute SVGElement nearestViewportElement;
-    readonly attribute SVGElement farthestViewportElement;
+    [EnabledBySetting=EnableSVGDeprecatedProperties] readonly attribute SVGElement nearestViewportElement;
+    [EnabledBySetting=EnableSVGDeprecatedProperties] readonly attribute SVGElement farthestViewportElement;
 
     [ImplementedAs=getBBoxForBindings, NewObject] SVGRect getBBox();
     [ImplementedAs=getCTMForBindings, NewObject] SVGMatrix getCTM();

--- a/Source/WebCore/svg/SVGSVGElement.idl
+++ b/Source/WebCore/svg/SVGSVGElement.idl
@@ -35,8 +35,8 @@
     attribute float currentScale;
     [SameObject] readonly attribute SVGPoint currentTranslate;
     
-    readonly attribute boolean useCurrentView;
-    readonly attribute SVGViewSpec currentView;
+    [EnabledBySetting=EnableSVGDeprecatedProperties] readonly attribute boolean useCurrentView;
+    [EnabledBySetting=EnableSVGDeprecatedProperties] readonly attribute SVGViewSpec currentView;
 
     NodeList getIntersectionList(SVGRect rect, SVGElement? referenceElement);
     NodeList getEnclosureList(SVGRect rect, SVGElement? referenceElement);


### PR DESCRIPTION
#### a229ccbd2e800bfbaee55c28c40aa3f3b7cb22c3
<pre>
Disable &apos;SVG 1.1&apos; deprecated properties behind feature flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=295261">https://bugs.webkit.org/show_bug.cgi?id=295261</a>
<a href="https://rdar.apple.com/154733488">rdar://154733488</a>

Reviewed by NOBODY (OOPS!).

This patch adds new flag called &apos;EnableSVGDeprecatedProperties&apos;, which
gives access to deprecated SVG properties listed below, which are removed
from SVG 2 specification and also removed from Gecko / Firefox and
Blink / Chrome.

- nearestViewportElement [Removed from Gecko / Firefox]
- farthestViewportElement [Removed from Gecko / Firefox]
- useCurrentView [Removed from Gecko / Firefox &amp; Blink / Chromium ]
- currentView [Removed from Gecko / Firefox &amp; Blink / Chromium ]

This flag will be enabled in Safari Technology Preview to obtain data
whether the following can be removed from WebKit without any web
compatibility issues.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/svg/SVGGraphicsElement.idl:
* Source/WebCore/svg/SVGSVGElement.idl:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a229ccbd2e800bfbaee55c28c40aa3f3b7cb22c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109829 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29487 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115850 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60066 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111792 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30165 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38075 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83463 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112777 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24046 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98904 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63926 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23425 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17053 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59645 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/102320 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93416 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17096 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118642 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/108381 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36868 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27320 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92474 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37241 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95172 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92297 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37263 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15007 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32714 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36763 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42233 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/132657 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36423 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35907 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39765 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38132 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->