### PR TITLE
attachShadow should use the shadow host's registry when customElementRegistry is null

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-customElementRegistry-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-customElementRegistry-expected.txt
@@ -4,4 +4,6 @@ PASS A newly attached connected ShadowRoot should use the global registry by def
 PASS A newly attached disconnected ShadowRoot should use the scoped registry if explicitly specified in attachShadow
 PASS A newly attached connected ShadowRoot should use the scoped registry if explicitly specified in attachShadow
 PASS attachShadow() should use the global registry when customElementRegistry is null
+PASS attachShadow() should use the shadow host's registry when customElementRegistry is null
+PASS attachShadow() should use the null registry when the shadow host uses null registry and customElementRegistry is null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-customElementRegistry.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-customElementRegistry.html
@@ -39,6 +39,29 @@ test(() => {
     assert_equals(shadowRoot.customElementRegistry, window.customElements);
 }, 'attachShadow() should use the global registry when customElementRegistry is null');
 
+test(() => {
+    const registry = new CustomElementRegistry;
+    const host = document.body.appendChild(document.createElement('div', {customElementRegistry: registry}));
+    const shadowRoot = host.attachShadow({mode: 'closed', customElementRegistry: null});
+    assert_equals(shadowRoot.customElementRegistry, registry);
+}, 'attachShadow() should use the shadow host\'s registry when customElementRegistry is null');
+
+test(() => {
+    const registry = new CustomElementRegistry;
+    const template = document.createElement('template');
+    template.innerHTML = '<div></div>';
+    const host = template.content.cloneNode(true).firstChild;
+    assert_equals(host.customElementRegistry, null);
+    const shadowRoot = host.attachShadow({mode: 'open', customElementRegistry: null, clonable: true});
+    assert_equals(shadowRoot.customElementRegistry, null);
+    shadowRoot.innerHTML = '<span></span>';
+    assert_equals(shadowRoot.querySelector('span').customElementRegistry, null);
+    const cloneHost = host.cloneNode(true);
+    assert_equals(cloneHost.customElementRegistry, null);
+    assert_equals(cloneHost.shadowRoot.customElementRegistry, null);
+    assert_equals(cloneHost.shadowRoot.querySelector('span').customElementRegistry, null);
+}, 'attachShadow() should use the null registry when the shadow host uses null registry and customElementRegistry is null');
+
 </script>
 </body>
 </html>

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -428,7 +428,7 @@ public:
 
     enum class CustomElementRegistryKind : bool { Window, Null };
 
-    WEBCORE_EXPORT ExceptionOr<ShadowRoot&> attachShadow(const ShadowRootInit&, CustomElementRegistryKind = CustomElementRegistryKind::Window);
+    WEBCORE_EXPORT ExceptionOr<ShadowRoot&> attachShadow(const ShadowRootInit&, std::optional<CustomElementRegistryKind> = std::nullopt);
     ExceptionOr<ShadowRoot&> attachDeclarativeShadow(ShadowRootMode, ShadowRootDelegatesFocus, ShadowRootClonable, ShadowRootSerializable, String referenceTarget, CustomElementRegistryKind);
 
     WEBCORE_EXPORT ShadowRoot* userAgentShadowRoot() const;


### PR DESCRIPTION
#### 937d03d33651ca2f95cfa708132589b9c132004b
<pre>
attachShadow should use the shadow host&apos;s registry when customElementRegistry is null
<a href="https://bugs.webkit.org/show_bug.cgi?id=295262">https://bugs.webkit.org/show_bug.cgi?id=295262</a>

Reviewed by Anne van Kesteren.

When attachShadow is called with null customElementRegistry, we should fallback to the shadow host&apos;s registry instead of the global registry.

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-customElementRegistry-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-customElementRegistry.html:
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/Element.cpp:

Canonical link: <a href="https://commits.webkit.org/296896@main">https://commits.webkit.org/296896@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a4c57ebe79f233d0c1211362972157e749850f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109854 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29512 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19942 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115875 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60091 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111817 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30190 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38100 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83515 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112802 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24072 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98931 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63956 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23449 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17079 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59670 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93442 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17122 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118667 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36893 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27344 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92494 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37266 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95198 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92317 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37291 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15030 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32739 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17737 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36788 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42258 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36448 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39790 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38157 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->