### PR TITLE
Implement convertVideoPixelFormatToString for VideoPixelFormat logging purposes

### DIFF
--- a/Source/WebCore/platform/VideoPixelFormat.cpp
+++ b/Source/WebCore/platform/VideoPixelFormat.cpp
@@ -26,6 +26,9 @@
 #include "config.h"
 #include "VideoPixelFormat.h"
 
+#include <wtf/NeverDestroyed.h>
+#include <wtf/text/WTFString.h>
+
 #if USE(GSTREAMER)
 #include <gst/video/video-format.h>
 #endif
@@ -76,6 +79,32 @@ std::optional<VideoPixelFormat> convertVideoFramePixelFormat(uint32_t format, bo
     UNUSED_PARAM(shouldDiscardAlpha);
 #endif
     return { };
+}
+
+String convertVideoPixelFormatToString(VideoPixelFormat format)
+{
+    static const std::array<NeverDestroyed<String>, 9> values {
+        MAKE_STATIC_STRING_IMPL("I420"),
+        MAKE_STATIC_STRING_IMPL("I420A"),
+        MAKE_STATIC_STRING_IMPL("I422"),
+        MAKE_STATIC_STRING_IMPL("I444"),
+        MAKE_STATIC_STRING_IMPL("NV12"),
+        MAKE_STATIC_STRING_IMPL("RGBA"),
+        MAKE_STATIC_STRING_IMPL("RGBX"),
+        MAKE_STATIC_STRING_IMPL("BGRA"),
+        MAKE_STATIC_STRING_IMPL("BGRX"),
+    };
+    static_assert(!static_cast<size_t>(VideoPixelFormat::I420), "VideoPixelFormat::I420 is not 0 as expected");
+    static_assert(static_cast<size_t>(VideoPixelFormat::I420A) == 1, "VideoPixelFormat::I420A is not 1 as expected");
+    static_assert(static_cast<size_t>(VideoPixelFormat::I422) == 2, "VideoPixelFormat::I422 is not 2 as expected");
+    static_assert(static_cast<size_t>(VideoPixelFormat::I444) == 3, "VideoPixelFormat::I444 is not 3 as expected");
+    static_assert(static_cast<size_t>(VideoPixelFormat::NV12) == 4, "VideoPixelFormat::NV12 is not 4 as expected");
+    static_assert(static_cast<size_t>(VideoPixelFormat::RGBA) == 5, "VideoPixelFormat::RGBA is not 5 as expected");
+    static_assert(static_cast<size_t>(VideoPixelFormat::RGBX) == 6, "VideoPixelFormat::RGBX is not 6 as expected");
+    static_assert(static_cast<size_t>(VideoPixelFormat::BGRA) == 7, "VideoPixelFormat::BGRA is not 7 as expected");
+    static_assert(static_cast<size_t>(VideoPixelFormat::BGRX) == 8, "VideoPixelFormat::BGRX is not 8 as expected");
+    ASSERT(static_cast<size_t>(format) < std::size(values));
+    return values[static_cast<size_t>(format)];
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/VideoPixelFormat.h
+++ b/Source/WebCore/platform/VideoPixelFormat.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <optional>
+#include <wtf/Forward.h>
 
 namespace WebCore {
 
@@ -48,4 +49,6 @@ inline bool isRGBVideoPixelFormat(VideoPixelFormat format)
     return format == VideoPixelFormat::RGBA || format == VideoPixelFormat::RGBX || format == VideoPixelFormat::BGRA || format == VideoPixelFormat::BGRX;
 }
 
-}
+WEBCORE_EXPORT String convertVideoPixelFormatToString(VideoPixelFormat);
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -538,7 +538,9 @@ void VideoFrame::copyTo(std::span<uint8_t> destination, VideoPixelFormat pixelFo
         return;
     }
 
-    GST_TRACE("Copying frame data to pixel format %d", static_cast<int>(pixelFormat));
+#ifndef GST_DISABLE_GST_DEBUG
+    GST_TRACE("Copying frame data to %s pixel format", convertVideoPixelFormatToString(pixelFormat).ascii().data());
+#endif
     if (pixelFormat == VideoPixelFormat::NV12) {
         auto spanPlaneLayoutY = computedPlaneLayout[GST_VIDEO_COMP_Y];
         auto widthY = inputFrame.componentWidth(GST_VIDEO_COMP_Y);


### PR DESCRIPTION
#### fd2ce7f4123a27eae55445a2d49a3d24eca50aac
<pre>
Implement convertVideoPixelFormatToString for VideoPixelFormat logging purposes
<a href="https://bugs.webkit.org/show_bug.cgi?id=295267">https://bugs.webkit.org/show_bug.cgi?id=295267</a>

Reviewed by Xabier Rodriguez-Calvar.

* Source/WebCore/platform/VideoPixelFormat.cpp:
(WebCore::convertVideoPixelFormatToString):
* Source/WebCore/platform/VideoPixelFormat.h:
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::VideoFrame::copyTo):

Canonical link: <a href="https://commits.webkit.org/296957@main">https://commits.webkit.org/296957@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e4f3a7f782219b368ea253edfa0ff06146df440

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109827 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29485 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115848 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60064 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111790 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30163 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38073 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83462 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112775 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24041 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98900 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63925 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23420 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17049 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59643 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93411 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17092 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118640 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36866 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27316 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92464 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37239 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95168 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92287 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23574 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37260 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15003 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32712 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36761 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42231 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36421 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39763 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38130 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->