### PR TITLE
[css-anchor-position-1] Scroll compensation should be determined per-axis

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-006-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL #target1 is scroll-adjusted in x axis only assert_equals: expected 150 but got 100
-FAIL #target2 is scroll-adjusted in y axis only assert_equals: expected 150 but got 100
+PASS #target1 is scroll-adjusted in x axis only
+PASS #target2 is scroll-adjusted in y axis only
 PASS #target3 is scroll-adjusted in neither axis
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-007-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-007-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL #target3 is scroll-adjusted in both axises assert_equals: expected 50 but got 100
+PASS #target3 is scroll-adjusted in both axises
 

--- a/Source/WebCore/platform/BoxSides.h
+++ b/Source/WebCore/platform/BoxSides.h
@@ -47,6 +47,24 @@ enum class BoxAxis : uint8_t {
     Vertical
 };
 
+// FIXME: BoxAxis etc. should just be OptionSet friendly types themselves.
+enum class BoxAxisFlag : uint8_t {
+    Horizontal = 1 << 0,
+    Vertical = 1 << 1
+};
+
+constexpr BoxAxisFlag boxAxisToFlag(BoxAxis axis)
+{
+    switch (axis) {
+    case BoxAxis::Horizontal:
+        return BoxAxisFlag::Horizontal;
+    case BoxAxis::Vertical:
+        return BoxAxisFlag::Vertical;
+    }
+    ASSERT_NOT_REACHED();
+    return BoxAxisFlag::Horizontal;
+}
+
 constexpr BoxAxis mapAxisLogicalToPhysical(const WritingMode, const LogicalBoxAxis);
 constexpr LogicalBoxAxis mapAxisPhysicalToLogical(const WritingMode, const BoxAxis);
 constexpr LogicalBoxAxis oppositeAxis(LogicalBoxAxis axis) { return axis == LogicalBoxAxis::Inline ? LogicalBoxAxis::Block : LogicalBoxAxis::Inline; }
@@ -329,6 +347,20 @@ constexpr LogicalBoxCorner mapCornerPhysicalToLogical(const WritingMode writingM
     if (isBlockStart)
         return isInlineStart ? LogicalBoxCorner::StartStart : LogicalBoxCorner::StartEnd;
     return isInlineStart ? LogicalBoxCorner::EndStart : LogicalBoxCorner::EndEnd;
+}
+
+constexpr BoxAxis boxAxisForSide(BoxSide side)
+{
+    switch (side) {
+    case BoxSide::Top:
+    case BoxSide::Bottom:
+        return BoxAxis::Vertical;
+    case BoxSide::Left:
+    case BoxSide::Right:
+        return BoxAxis::Horizontal;
+    }
+    ASSERT_NOT_REACHED();
+    return BoxAxis::Vertical;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -122,6 +122,7 @@ enum class BlockStepRound : uint8_t;
 enum class BorderCollapse : bool;
 enum class BorderStyle : uint8_t;
 enum class BoxAlignment : uint8_t;
+enum class BoxAxisFlag : uint8_t;
 enum class BoxDecorationBreak : bool;
 enum class BoxDirection : bool;
 enum class BoxLines : bool;
@@ -428,6 +429,8 @@ public:
     bool useTreeCountingFunctions() const { return m_nonInheritedFlags.useTreeCountingFunctions; }
     void setUsesAnchorFunctions();
     bool usesAnchorFunctions() const;
+    void setAnchorFunctionScrollCompensatedAxes(OptionSet<BoxAxisFlag>);
+    OptionSet<BoxAxisFlag> anchorFunctionScrollCompensatedAxes() const;
 
     void setIsPopoverInvoker();
     bool isPopoverInvoker() const;

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -861,6 +861,7 @@ inline bool RenderStyle::isInSubtreeWithBlendMode() const { return m_rareInherit
 inline bool RenderStyle::isForceHidden() const { return m_rareInheritedData->isForceHidden; }
 inline Isolation RenderStyle::isolation() const { return static_cast<Isolation>(m_nonInheritedData->rareData->isolation); }
 inline bool RenderStyle::usesAnchorFunctions() const { return m_nonInheritedData->rareData->usesAnchorFunctions; }
+inline OptionSet<BoxAxisFlag> RenderStyle::anchorFunctionScrollCompensatedAxes() const { return OptionSet<BoxAxisFlag>::fromRaw(m_nonInheritedData->rareData->anchorFunctionScrollCompensatedAxes); }
 
 inline bool RenderStyle::isPopoverInvoker() const { return m_nonInheritedData->rareData->isPopoverInvoker; }
 

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -350,6 +350,7 @@ inline void RenderStyle::setTransformStyle3D(TransformStyle3D b) { SET_NESTED(m_
 inline void RenderStyle::setTransformStyleForcedToFlat(bool b) { SET_NESTED(m_nonInheritedData, rareData, transformStyleForcedToFlat, static_cast<unsigned>(b)); }
 inline void RenderStyle::setTranslate(Style::Translate&& translate) { SET_NESTED(m_nonInheritedData, rareData, translate, WTFMove(translate)); }
 inline void RenderStyle::setUsesAnchorFunctions() { SET_NESTED(m_nonInheritedData, rareData, usesAnchorFunctions, true); }
+inline void RenderStyle::setAnchorFunctionScrollCompensatedAxes(OptionSet<BoxAxisFlag> axes) { SET_NESTED(m_nonInheritedData, rareData, anchorFunctionScrollCompensatedAxes, axes.toRaw()); }
 inline void RenderStyle::setIsPopoverInvoker() { SET_NESTED(m_nonInheritedData, rareData, isPopoverInvoker, true); }
 inline void RenderStyle::setUseSmoothScrolling(bool value) { SET_NESTED(m_nonInheritedData, rareData, useSmoothScrolling, value); }
 inline void RenderStyle::setUsedZIndex(int index) { SET_NESTED_PAIR(m_nonInheritedData, boxData, m_usedZIndex, index, m_hasAutoUsedZIndex, false); }

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -145,6 +145,7 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
 #endif
     , scrollbarWidth(static_cast<unsigned>(RenderStyle::initialScrollbarWidth()))
     , usesAnchorFunctions(false)
+    , anchorFunctionScrollCompensatedAxes(0)
     , isPopoverInvoker(false)
 {
 }
@@ -254,6 +255,7 @@ inline StyleRareNonInheritedData::StyleRareNonInheritedData(const StyleRareNonIn
 #endif
     , scrollbarWidth(o.scrollbarWidth)
     , usesAnchorFunctions(o.usesAnchorFunctions)
+    , anchorFunctionScrollCompensatedAxes(o.anchorFunctionScrollCompensatedAxes)
     , isPopoverInvoker(o.isPopoverInvoker)
 {
 }
@@ -370,6 +372,7 @@ bool StyleRareNonInheritedData::operator==(const StyleRareNonInheritedData& o) c
 #endif
         && scrollbarWidth == o.scrollbarWidth
         && usesAnchorFunctions == o.usesAnchorFunctions
+        && anchorFunctionScrollCompensatedAxes == o.anchorFunctionScrollCompensatedAxes
         && isPopoverInvoker == o.isPopoverInvoker;
 }
 
@@ -548,6 +551,7 @@ void StyleRareNonInheritedData::dumpDifferences(TextStream& ts, const StyleRareN
     LOG_IF_DIFFERENT(scrollbarWidth);
 
     LOG_IF_DIFFERENT_WITH_CAST(bool, usesAnchorFunctions);
+    LOG_IF_DIFFERENT_WITH_CAST(bool, anchorFunctionScrollCompensatedAxes);
     LOG_IF_DIFFERENT_WITH_CAST(bool, isPopoverInvoker);
 }
 #endif // !LOG_DISABLED

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -302,6 +302,8 @@ public:
     unsigned scrollbarWidth : 2; // ScrollbarWidth
 
     unsigned usesAnchorFunctions : 1;
+    unsigned anchorFunctionScrollCompensatedAxes : 2;
+
     unsigned usesTreeCountingFunctions : 1;
 
     unsigned isPopoverInvoker : 1;

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -43,6 +43,7 @@ namespace WebCore {
 class Document;
 class Element;
 class LayoutRect;
+class LayoutSize;
 class RenderBlock;
 class RenderBox;
 class RenderBoxModelObject;
@@ -97,10 +98,6 @@ using AnchorToAnchorPositionedMap = SingleThreadWeakHashMap<const RenderBoxModel
 
 class AnchorPositionEvaluator {
 public:
-    // Find the anchor element indicated by `elementName` and update the associated anchor resolution data.
-    // Returns nullptr if the anchor element can't be found.
-    static RefPtr<Element> findAnchorForAnchorFunctionAndAttemptResolution(BuilderState&, std::optional<ScopedName> elementName);
-
     using Side = Variant<CSSValueID, double>;
     static bool propertyAllowsAnchorFunction(CSSPropertyID);
     static std::optional<double> evaluate(BuilderState&, std::optional<ScopedName> elementName, Side);
@@ -111,7 +108,7 @@ public:
     static void updateAnchorPositioningStatesAfterInterleavedLayout(Document&, AnchorPositionedStates&);
     static void updateSnapshottedScrollOffsets(Document&);
     static void updatePositionsAfterScroll(Document&);
-    static void updateAnchorPositionedStateForLayoutTimePositioned(Element&, const RenderStyle&, AnchorPositionedStates&);
+    static void updateAnchorPositionedStateForDefaultAnchor(Element&, const RenderStyle&, AnchorPositionedStates&);
 
     static LayoutRect computeAnchorRectRelativeToContainingBlock(CheckedRef<const RenderBoxModelObject> anchorBox, const RenderBlock& containingBlock);
 
@@ -132,9 +129,12 @@ public:
     static CheckedPtr<RenderBoxModelObject> defaultAnchorForBox(const RenderBox&);
 
 private:
+    static CheckedPtr<RenderBoxModelObject> findAnchorForAnchorFunctionAndAttemptResolution(BuilderState&, std::optional<ScopedName> elementName);
     static AnchorElements findAnchorsForAnchorPositionedElement(const Element&, const HashSet<ResolvedScopedName>& anchorNames, const AnchorsForAnchorName&);
     static RefPtr<const Element> anchorPositionedElementOrPseudoElement(BuilderState&);
     static AnchorPositionedKey keyForElementOrPseudoElement(const Element&);
+    static void addAnchorFunctionScrollCompensatedAxis(RenderStyle&, const RenderBox& anchored, const RenderBoxModelObject& anchor, BoxAxis);
+    static LayoutSize scrollOffsetFromAnchor(const RenderBoxModelObject& anchor, const RenderBox& anchored);
 };
 
 } // namespace Style

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1407,7 +1407,7 @@ auto TreeResolver::updateAnchorPositioningState(Element& element, const RenderSt
     auto update = [&](const RenderStyle* style) {
         if (!style)
             return;
-        AnchorPositionEvaluator::updateAnchorPositionedStateForLayoutTimePositioned(element, *style, m_treeResolutionState.anchorPositionedStates);
+        AnchorPositionEvaluator::updateAnchorPositionedStateForDefaultAnchor(element, *style, m_treeResolutionState.anchorPositionedStates);
     };
 
     update(style);


### PR DESCRIPTION
#### 8347f2294551a54adb88315196f6908e97a1ba61
<pre>
[css-anchor-position-1] Scroll compensation should be determined per-axis
<a href="https://bugs.webkit.org/show_bug.cgi?id=295277">https://bugs.webkit.org/show_bug.cgi?id=295277</a>
<a href="https://rdar.apple.com/problem/154762565">rdar://problem/154762565</a>

Reviewed by Alan Baradlay.

&quot;An absolutely positioned box abspos compensates for scroll in the horizontal or vertical axis if both of the following conditions are true:
- abspos has a default anchor box.
- abspos has an anchor reference to its default anchor box or at least to something in the same scrolling context&quot;

<a href="https://drafts.csswg.org/css-anchor-position-1/#scroll">https://drafts.csswg.org/css-anchor-position-1/#scroll</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-006-expected.txt:
* Source/WebCore/platform/BoxSides.h:
(WebCore::boxAxisToFlag):
(WebCore::boxAxisForSide):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::anchorFunctionScrollCompensatedAxes const):
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setAnchorFunctionScrollCompensatedAxes):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
(WebCore::StyleRareNonInheritedData::StyleRareNonInheritedData):
(WebCore::StyleRareNonInheritedData::operator== const):
(WebCore::StyleRareNonInheritedData::dumpDifferences const):

Add style bits to record the scroll compensated axes.

* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::anchorSideMatchesInsetProperty):
(WebCore::Style::AnchorPositionEvaluator::addAnchorFunctionScrollCompensatedAxis):

Record the scroll compensated axes for anchor functions axes to the style.

(WebCore::Style::AnchorPositionEvaluator::scrollOffsetFromAnchor):

Only apply offset to the compensated axes.

(WebCore::Style::AnchorPositionEvaluator::findAnchorForAnchorFunctionAndAttemptResolution):

Anchors are boxes, return a renderer directly.

(WebCore::Style::AnchorPositionEvaluator::evaluate):
(WebCore::Style::AnchorPositionEvaluator::evaluateSize):
(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositionedStateForDefaultAnchor):

Always resolve the default anchor, scroll compensation computation needs it even if it not referenced.

(WebCore::Style::AnchorPositionEvaluator::updateSnapshottedScrollOffsets):
(WebCore::Style::scrollOffsetFromAnchor): Deleted.
(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositionedStateForLayoutTimePositioned): Deleted.
* Source/WebCore/style/AnchorPositionEvaluator.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::updateAnchorPositioningState):

Canonical link: <a href="https://commits.webkit.org/296908@main">https://commits.webkit.org/296908@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3646518a2e39582611f71262a571c0f13a37e5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109949 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29607 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20039 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115971 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60197 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111912 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30285 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38195 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83589 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112897 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99014 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64031 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17163 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59765 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93516 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17206 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118762 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36988 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92564 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37361 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95282 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92388 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23534 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37365 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15104 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32860 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36883 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42354 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36543 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39885 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38252 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->