### PR TITLE
[GTK] Rename GTK4 TestExpectations to GTK3 TestExpectations

### DIFF
--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1163,6 +1163,32 @@ editing/selection/select-bidi-run.html [ Skip ]
 # Fails on 32-bit release and 64-bit debug builders
 webkit.org/b/83560 fast/events/drop-with-file-paths.html [ Failure ]
 
+# Tests passing in GTK3 (begin).
+# These two tests print console messages in GTK4.
+http/tests/xmlhttprequest/response-access-on-error.html [ DumpJSConsoleLogInStdErr ]
+imported/w3c/web-platform-tests/css/css-masking/inheritance.sub.html [ DumpJSConsoleLogInStdErr ]
+
+webkit.org/b/277166 fast/dom/Window/window-focus-self.html [ Failure ]
+webkit.org/b/277166 fast/dom/Window/window-resize-and-move-arguments.html [ Failure ]
+webkit.org/b/277166 fast/dom/Window/window-resize.html [ Failure ]
+webkit.org/b/277166 imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-non-integer-left.html [ Failure ]
+webkit.org/b/277166 imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-non-integer-screenx.html [ Failure ]
+webkit.org/b/277166 imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-non-integer-top.html [ Failure ]
+webkit.org/b/277166 imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-screenx-screeny.html [ Failure ]
+webkit.org/b/277166 imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-top-left.html [ Failure ]
+
+webkit.org/b/277401 editing/pasteboard/data-transfer-set-data-sanitize-url-when-copying-in-null-origin.html [ Failure ]
+webkit.org/b/277402 fast/events/context-activated-by-key-event.html [ Failure ]
+webkit.org/b/277414 imported/w3c/web-platform-tests/html/interaction/focus/document-level-focus-apis/document-has-system-focus.html [ Failure ]
+
+webkit.org/b/277426 editing/async-clipboard/clipboard-read-text-same-origin.html [ Skip ] # Timeout
+
+webkit.org/b/277427 fast/events/drag-and-drop-link-fast-multiple-times-does-not-crash.html [ Skip ] # Timeout
+
+webkit.org/b/279016 gamepad/ [ Skip ] # Timing out, see bug for details.
+
+# Tests passing in GTK3 (end).
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of tests with architecture-specific results
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/gtk/fast/text/hyphenate-locale-expected.txt
+++ b/LayoutTests/platform/gtk/fast/text/hyphenate-locale-expected.txt
@@ -27,9 +27,9 @@ layer at (0,0) size 785x688
           RenderText {#text} at (0,1) size 156x40
             text run at (0,1) width 156: "reciprocity"
         RenderBlock {DIV} at (0,42) size 135x84
-          RenderText {#text} at (0,1) size 130x82
-            text run at (0,1) width 130: "reciproc" + hyphen string "-"
-            text run at (0,43) width 38: "ity"
+          RenderText {#text} at (0,1) size 114x82
+            text run at (0,1) width 114: "recipro" + hyphen string "-"
+            text run at (0,43) width 54: "city"
         RenderBlock {DIV} at (0,126) size 135x84
           RenderText {#text} at (0,1) size 130x82
             text run at (0,1) width 130: "reciproc" + hyphen string "-"

--- a/LayoutTests/platform/gtk3/TestExpectations
+++ b/LayoutTests/platform/gtk3/TestExpectations
@@ -1,4 +1,4 @@
-# These are the layout test expectations for the GTK port of WebKit when running with GTK4
+# These are the layout test expectations for the GTK port of WebKit when running with GTK3
 #
 # See http://trac.webkit.org/wiki/TestExpectations for more information on this file.
 #
@@ -7,7 +7,7 @@
 #////////////////////////////////////////////////////////////////////////////////////////
 # TESTS PASSING
 #
-# These tests are passing on GTK4 but they do not in other ports or GTK3
+# These tests are passing on GTK3 but they do not in other ports or GTK4
 # Note: Passing tests should be on the top of the file to ensure that
 #       expected failures below are not overriden by a folder that is
 #       set to Pass to unskip it from the main expectations file and
@@ -16,9 +16,22 @@
 #       it picks as the valid rule the last one matching.
 #////////////////////////////////////////////////////////////////////////////////////////
 
-# These two tests print console messages in GTK4.
-http/tests/xmlhttprequest/response-access-on-error.html [ DumpJSConsoleLogInStdErr ]
-imported/w3c/web-platform-tests/css/css-masking/inheritance.sub.html [ DumpJSConsoleLogInStdErr ]
+webkit.org/b/277166 fast/dom/Window/window-focus-self.html [ Pass ]
+webkit.org/b/277166 fast/dom/Window/window-resize-and-move-arguments.html [ Pass ]
+webkit.org/b/277166 fast/dom/Window/window-resize.html [ Pass ]
+webkit.org/b/277166 imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-non-integer-left.html [ Pass ]
+webkit.org/b/277166 imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-non-integer-screenx.html [ Pass ]
+webkit.org/b/277166 imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-non-integer-top.html [ Pass ]
+webkit.org/b/277166 imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-screenx-screeny.html [ Pass ]
+webkit.org/b/277166 imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-top-left.html [ Pass ]
+
+webkit.org/b/277401 editing/pasteboard/data-transfer-set-data-sanitize-url-when-copying-in-null-origin.html [ Pass ]
+webkit.org/b/277402 fast/events/context-activated-by-key-event.html [ Pass ]
+webkit.org/b/277414 imported/w3c/web-platform-tests/html/interaction/focus/document-level-focus-apis/document-has-system-focus.html [ Pass ]
+
+webkit.org/b/277426 editing/async-clipboard/clipboard-read-text-same-origin.html [ Pass ]
+
+webkit.org/b/277427 fast/events/drag-and-drop-link-fast-multiple-times-does-not-crash.html [ Pass ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of PASSING tests. See below where to put expected failures.
@@ -43,6 +56,8 @@ webkit.org/b/277414 imported/w3c/web-platform-tests/html/interaction/focus/docum
 webkit.org/b/277426 editing/async-clipboard/clipboard-read-text-same-origin.html [ Skip ] # Timeout
 
 webkit.org/b/277427 fast/events/drag-and-drop-link-fast-multiple-times-does-not-crash.html [ Skip ] # Timeout
+
+gamepad/gamepad-user-activation.html [ Failure ]
 
 #//////////////////////////////////////////////////////////////////////////////////////////
 # Triaged Expectations

--- a/Tools/Scripts/webkitpy/port/gtk.py
+++ b/Tools/Scripts/webkitpy/port/gtk.py
@@ -122,8 +122,8 @@ class GtkPort(GLibPort):
     def _search_paths(self):
         search_paths = []
 
-        if self._is_gtk4_build():
-            search_paths.append(self.port_name + "4")
+        if self._is_gtk3_build():
+            search_paths.append(self.port_name + "3")
 
         if self._driver_class() in [WaylandDriver, WestonDriver]:
             search_paths.append(self.port_name + "-wayland")
@@ -197,16 +197,16 @@ class GtkPort(GLibPort):
         return self._executive.run_command(command + args, cwd=self.webkit_base(), stdout=None, return_stderr=False, decode_output=False, env=env, pass_fds=pass_fds)
 
     @memoized
-    def _is_gtk4_build(self):
+    def _is_gtk3_build(self):
         try:
             libdir = self._build_path('lib')
             candidates = self._filesystem.glob(os.path.join(libdir, 'libwebkit*gtk-*.so'))
             if not candidates:
                 return False
             if len(candidates) > 1:
-                _log.warning("Multiple WebKit2GTK libraries found. Skipping GTK4 detection.")
+                _log.warning("Multiple WebKit2GTK libraries found. Skipping GTK3 detection.")
                 return False
-            return os.path.basename(candidates[0]) == 'libwebkitgtk-6.0.so'
+            return os.path.basename(candidates[0]) == 'libwebkit2gtk-4.0.so'
 
         except (webkitpy.common.system.executive.ScriptError, IOError, OSError):
             return False

--- a/Tools/Scripts/webkitpy/port/gtk_unittest.py
+++ b/Tools/Scripts/webkitpy/port/gtk_unittest.py
@@ -107,8 +107,7 @@ class GtkPortTest(port_testcase.PortTestCase):
                               ['/mock-checkout/LayoutTests/TestExpectations',
                                '/mock-checkout/LayoutTests/platform/wk2/TestExpectations',
                                '/mock-checkout/LayoutTests/platform/glib/TestExpectations',
-                               '/mock-checkout/LayoutTests/platform/gtk/TestExpectations',
-                               '/mock-checkout/LayoutTests/platform/gtk4/TestExpectations'])
+                               '/mock-checkout/LayoutTests/platform/gtk/TestExpectations'])
 
     def test_gtk3_expectations_binary_only(self):
         port = self.make_port()
@@ -121,7 +120,8 @@ class GtkPortTest(port_testcase.PortTestCase):
                               ['/mock-checkout/LayoutTests/TestExpectations',
                                '/mock-checkout/LayoutTests/platform/wk2/TestExpectations',
                                '/mock-checkout/LayoutTests/platform/glib/TestExpectations',
-                               '/mock-checkout/LayoutTests/platform/gtk/TestExpectations'])
+                               '/mock-checkout/LayoutTests/platform/gtk/TestExpectations',
+                               '/mock-checkout/LayoutTests/platform/gtk3/TestExpectations'])
 
     def test_gtk_expectations_both_binaries(self):
         port = self.make_port()
@@ -136,7 +136,7 @@ class GtkPortTest(port_testcase.PortTestCase):
                                '/mock-checkout/LayoutTests/platform/wk2/TestExpectations',
                                '/mock-checkout/LayoutTests/platform/glib/TestExpectations',
                                '/mock-checkout/LayoutTests/platform/gtk/TestExpectations'])
-            self.assertEqual(captured.root.log.getvalue(), 'Multiple WebKit2GTK libraries found. Skipping GTK4 detection.\n')
+            self.assertEqual(captured.root.log.getvalue(), 'Multiple WebKit2GTK libraries found. Skipping GTK3 detection.\n')
 
     def test_setup_environ_for_test_gstreamer_prefix(self):
         environment_user = {}


### PR DESCRIPTION
#### 316dc6ddbcf76143aeb73d48bde1ba1213a3084f
<pre>
[GTK] Rename GTK4 TestExpectations to GTK3 TestExpectations
<a href="https://bugs.webkit.org/show_bug.cgi?id=295288">https://bugs.webkit.org/show_bug.cgi?id=295288</a>

Reviewed by Carlos Alberto Lopez Perez.

Rename file &apos;platform/gtk4/TestExpectations&apos; to
&apos;platform/gtk3/TestExpectations&apos;, since now GTK4 is the default. Merge
test failures into &apos;platform/gtk/TestExpectations&apos; and update
&apos;platform/gtk3/TestExpectations&apos; accordingly.

Also, now when emitting a new baseline for GTK the baseline is store at
&apos;platform/gtk&apos;, instead of &apos;platform/gtk4&apos;.

* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/gtk/fast/text/hyphenate-locale-expected.txt:
* LayoutTests/platform/gtk3/TestExpectations: Renamed from LayoutTests/platform/gtk4/TestExpectations.
* Tools/Scripts/webkitpy/port/gtk.py:
(GtkPort._search_paths):
(GtkPort._is_gtk4_build):
(GtkPort):
(GtkPort._is_gtk3_build):

Canonical link: <a href="https://commits.webkit.org/299551@main">https://commits.webkit.org/299551@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96c16d691cda54aa17ee8822b2975d0e1ceb2925

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111420 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117452 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61688 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113382 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31767 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39668 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84681 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114367 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25367 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100300 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65128 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/110853 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24713 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18436 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61272 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94754 "Found 1 new API test failure: TestWebKitAPI.WKWebsiteDataStoreConfiguration.TotalQuotaRatioWithPersistedDomain (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18502 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120668 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38469 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28588 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93604 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38845 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96569 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93428 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38535 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16309 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34503 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18991 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38358 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38023 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41356 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39725 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->