### PR TITLE
[Model Element] Limit the number of models that can load in parallel to lower peak memory footprint

### DIFF
--- a/LayoutTests/model-element/model-element-multiple-loads-expected.txt
+++ b/LayoutTests/model-element/model-element-multiple-loads-expected.txt
@@ -1,0 +1,3 @@
+
+PASS <model> resolves the ready promises of all models created at the same time.
+

--- a/LayoutTests/model-element/model-element-multiple-loads.html
+++ b/LayoutTests/model-element/model-element-multiple-loads.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ModelElementEnabled=true ModelProcessEnabled=true ] -->
+<meta charset="utf-8">
+<title>Loading multiple &lt;model></title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="resources/model-element-test-utils.js"></script>
+<body>
+<script>
+'use strict';
+
+promise_test(async t => {
+    const [model1, source1] = createModelAndSource(t, "resources/heart.usdz");
+    const [model2, source2] = createModelAndSource(t, "resources/cube.usdz");
+    const [model3, source3] = createModelAndSource(t, "resources/stopwatch-30s.usdz");
+    const [model4, source4] = createModelAndSource(t, "resources/stopwatch-60s.usdz");
+    const [model5, source5] = createModelAndSource(t, "resources/heart.usdz");
+    const [model6, source6] = createModelAndSource(t, "resources/cube.usdz");
+    const [model7, source7] = createModelAndSource(t, "resources/stopwatch-30s.usdz");
+    const [model8, source8] = createModelAndSource(t, "resources/stopwatch-60s.usdz");
+    const [model9, source9] = createModelAndSource(t, "resources/heart.usdz");
+    const [model10, source10] = createModelAndSource(t, "resources/cube.usdz");
+
+    await model1.ready;
+    await model2.ready;
+    await model3.ready;
+    await model4.ready;
+    await model5.ready;
+    await model6.ready;
+    await model7.ready;
+    await model8.ready;
+    await model9.ready;
+    await model10.ready;
+}, `<model> resolves the ready promises of all models created at the same time.`);
+
+</script>
+</body>


### PR DESCRIPTION
#### e2bb25947e8b195a461879373d31304ace24c087
<pre>
[Model Element] Limit the number of models that can load in parallel to lower peak memory footprint
<a href="https://rdar.apple.com/153908401">rdar://153908401</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=295257">https://bugs.webkit.org/show_bug.cgi?id=295257</a>

Reviewed by Mike Wyrzykowski.

Limit the number of models that can load in parallel to 3 by default to lower
the peak footprint. When a model load is scheduled, it&apos;s appended to a Deque
and RKUSDModelLoadScheduler::loadNextModel() is called to take a loader
off that Deque to load if the number of in-progress loaders is within the limit.
RKUSDModelLoadScheduler::loadNextModel() is called whenever a loader has
finished to see if another loader can start loading.

* LayoutTests/model-element/model-element-multiple-loads-expected.txt: Added.
* LayoutTests/model-element/model-element-multiple-loads.html: Added.
Test to make sure many models created at the same time can all finish
loading in the end.
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::RKModelLoaderUSD::load):
(WebKit::RKUSDModelLoadScheduler::singleton):
(WebKit::RKUSDModelLoadScheduler::scheduleModelLoad):
(WebKit::RKUSDModelLoadScheduler::loadNextModel):
(WebKit::ModelProcessModelPlayerProxy::load):
(WebKit::loadREModelUsingRKUSDLoader): Deleted.

Canonical link: <a href="https://commits.webkit.org/296887@main">https://commits.webkit.org/296887@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc10a1a71d3dbd3a9308a7129f29b5f10d950f47

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109857 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29515 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19945 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115878 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60094 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38103 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83526 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112805 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24067 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98935 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63955 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23444 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17082 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59673 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93437 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17125 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118670 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36896 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27343 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92491 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37269 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95201 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92314 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23521 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37289 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15033 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32742 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36791 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42261 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36451 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39793 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38160 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->