### PR TITLE
REGRESSION ( 296795@main): [ Sequoia Release WK2 arm64  ] 8X http/tests/webgpu/webgpu/shader are consistent  failures

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/shader/execution/expression/binary/bitwise_shift-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/execution/expression/binary/bitwise_shift-expected.txt
@@ -2,94 +2,32 @@
 FAIL :shift_left_abstract:inputSource="const";vectorize="_undef_" assert_unreached:
   - EXPECTATION FAILED: Pipeline Creation Error, validation:
       at (elided: below max severity)
-  - EXCEPTION: Error: Unexpected validation error occurred: 12 errors generated while compiling the shader:
+  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     48:49: shift left value must be less than the bit width of the shifted value, which is 64
-    49:26: shift left value must be less than the bit width of the shifted value, which is 64
-    50:45: shift left value must be less than the bit width of the shifted value, which is 64
-    53:49: shift left value must be less than the bit width of the shifted value, which is 64
-    54:26: shift left value must be less than the bit width of the shifted value, which is 64
-    55:45: shift left value must be less than the bit width of the shifted value, which is 64
-    58:49: shift left value must be less than the bit width of the shifted value, which is 64
-    59:26: shift left value must be less than the bit width of the shifted value, which is 64
-    60:45: shift left value must be less than the bit width of the shifted value, which is 64
-    63:49: shift left value must be less than the bit width of the shifted value, which is 64
-    64:26: shift left value must be less than the bit width of the shifted value, which is 64
-    65:45: shift left value must be less than the bit width of the shifted value, which is 64
     TestFailedButDeviceReusable@
     @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :shift_left_abstract:inputSource="const";vectorize=2 assert_unreached:
   - EXPECTATION FAILED: Pipeline Creation Error, validation:
       at (elided: below max severity)
-  - EXCEPTION: Error: Unexpected validation error occurred: 12 errors generated while compiling the shader:
+  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     48:61: shift left value must be less than the bit width of the shifted value, which is 64
-    49:35: shift left value must be less than the bit width of the shifted value, which is 64
-    50:57: shift left value must be less than the bit width of the shifted value, which is 64
-    53:61: shift left value must be less than the bit width of the shifted value, which is 64
-    54:35: shift left value must be less than the bit width of the shifted value, which is 64
-    55:57: shift left value must be less than the bit width of the shifted value, which is 64
-    58:61: shift left value must be less than the bit width of the shifted value, which is 64
-    59:35: shift left value must be less than the bit width of the shifted value, which is 64
-    60:57: shift left value must be less than the bit width of the shifted value, which is 64
-    63:61: shift left value must be less than the bit width of the shifted value, which is 64
-    64:35: shift left value must be less than the bit width of the shifted value, which is 64
-    65:57: shift left value must be less than the bit width of the shifted value, which is 64
     TestFailedButDeviceReusable@
     @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :shift_left_abstract:inputSource="const";vectorize=3 assert_unreached:
   - EXPECTATION FAILED: Pipeline Creation Error, validation:
       at (elided: below max severity)
-  - EXCEPTION: Error: Unexpected validation error occurred: 18 errors generated while compiling the shader:
+  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     48:64: shift left value must be less than the bit width of the shifted value, which is 64
-    49:38: shift left value must be less than the bit width of the shifted value, which is 64
-    50:60: shift left value must be less than the bit width of the shifted value, which is 64
-    53:64: shift left value must be less than the bit width of the shifted value, which is 64
-    54:38: shift left value must be less than the bit width of the shifted value, which is 64
-    55:60: shift left value must be less than the bit width of the shifted value, which is 64
-    58:64: shift left value must be less than the bit width of the shifted value, which is 64
-    59:38: shift left value must be less than the bit width of the shifted value, which is 64
-    60:60: shift left value must be less than the bit width of the shifted value, which is 64
-    63:64: shift left value must be less than the bit width of the shifted value, which is 64
-    64:38: shift left value must be less than the bit width of the shifted value, which is 64
-    65:60: shift left value must be less than the bit width of the shifted value, which is 64
-    68:64: shift left value must be less than the bit width of the shifted value, which is 64
-    69:38: shift left value must be less than the bit width of the shifted value, which is 64
-    70:60: shift left value must be less than the bit width of the shifted value, which is 64
-    73:64: shift left value must be less than the bit width of the shifted value, which is 64
-    74:38: shift left value must be less than the bit width of the shifted value, which is 64
-    75:60: shift left value must be less than the bit width of the shifted value, which is 64
     TestFailedButDeviceReusable@
     @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :shift_left_abstract:inputSource="const";vectorize=4 assert_unreached:
   - EXPECTATION FAILED: Pipeline Creation Error, validation:
       at (elided: below max severity)
-  - EXCEPTION: Error: Unexpected validation error occurred: 24 errors generated while compiling the shader:
+  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     38:67: shift left value must be less than the bit width of the shifted value, which is 64
-    39:41: shift left value must be less than the bit width of the shifted value, which is 64
-    40:63: shift left value must be less than the bit width of the shifted value, which is 64
-    43:67: shift left value must be less than the bit width of the shifted value, which is 64
-    44:41: shift left value must be less than the bit width of the shifted value, which is 64
-    45:63: shift left value must be less than the bit width of the shifted value, which is 64
-    48:67: shift left value must be less than the bit width of the shifted value, which is 64
-    49:41: shift left value must be less than the bit width of the shifted value, which is 64
-    50:63: shift left value must be less than the bit width of the shifted value, which is 64
-    53:67: shift left value must be less than the bit width of the shifted value, which is 64
-    54:41: shift left value must be less than the bit width of the shifted value, which is 64
-    55:63: shift left value must be less than the bit width of the shifted value, which is 64
-    58:67: shift left value must be less than the bit width of the shifted value, which is 64
-    59:41: shift left value must be less than the bit width of the shifted value, which is 64
-    60:63: shift left value must be less than the bit width of the shifted value, which is 64
-    63:67: shift left value must be less than the bit width of the shifted value, which is 64
-    64:41: shift left value must be less than the bit width of the shifted value, which is 64
-    65:63: shift left value must be less than the bit width of the shifted value, which is 64
-    68:67: shift left value must be less than the bit width of the shifted value, which is 64
-    69:41: shift left value must be less than the bit width of the shifted value, which is 64
-    70:63: shift left value must be less than the bit width of the shifted value, which is 64
-    73:67: shift left value must be less than the bit width of the shifted value, which is 64
-    74:41: shift left value must be less than the bit width of the shifted value, which is 64
-    75:63: shift left value must be less than the bit width of the shifted value, which is 64
     TestFailedButDeviceReusable@
     @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
@@ -178,22 +116,8 @@ FAIL :shift_right_abstract:inputSource="const";vectorize="_undef_" assert_unreac
       at (elided: only 2 shown)
   - EXPECTATION FAILED: Pipeline Creation Error, validation:
       at (elided: only 2 shown)
-  - EXCEPTION: Error: Unexpected validation error occurred: 15 errors generated while compiling the shader:
+  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     48:49: shift right value must be less than the bit width of the shifted value, which is 64
-    49:26: shift right value must be less than the bit width of the shifted value, which is 64
-    50:45: shift right value must be less than the bit width of the shifted value, which is 64
-    53:49: shift right value must be less than the bit width of the shifted value, which is 64
-    54:26: shift right value must be less than the bit width of the shifted value, which is 64
-    55:45: shift right value must be less than the bit width of the shifted value, which is 64
-    58:49: shift right value must be less than the bit width of the shifted value, which is 64
-    59:26: shift right value must be less than the bit width of the shifted value, which is 64
-    60:45: shift right value must be less than the bit width of the shifted value, which is 64
-    63:49: shift right value must be less than the bit width of the shifted value, which is 64
-    64:26: shift right value must be less than the bit width of the shifted value, which is 64
-    65:45: shift right value must be less than the bit width of the shifted value, which is 64
-    68:50: shift right value must be less than the bit width of the shifted value, which is 64
-    69:26: shift right value must be less than the bit width of the shifted value, which is 64
-    70:46: shift right value must be less than the bit width of the shifted value, which is 64
     TestFailedButDeviceReusable@
     @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
@@ -216,25 +140,8 @@ FAIL :shift_right_abstract:inputSource="const";vectorize=2 assert_unreached:
       at (elided: only 2 shown)
   - EXPECTATION FAILED: Pipeline Creation Error, validation:
       at (elided: only 2 shown)
-  - EXCEPTION: Error: Unexpected validation error occurred: 18 errors generated while compiling the shader:
+  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     48:61: shift right value must be less than the bit width of the shifted value, which is 64
-    49:35: shift right value must be less than the bit width of the shifted value, which is 64
-    50:57: shift right value must be less than the bit width of the shifted value, which is 64
-    53:61: shift right value must be less than the bit width of the shifted value, which is 64
-    54:35: shift right value must be less than the bit width of the shifted value, which is 64
-    55:57: shift right value must be less than the bit width of the shifted value, which is 64
-    58:61: shift right value must be less than the bit width of the shifted value, which is 64
-    59:35: shift right value must be less than the bit width of the shifted value, which is 64
-    60:57: shift right value must be less than the bit width of the shifted value, which is 64
-    63:61: shift right value must be less than the bit width of the shifted value, which is 64
-    64:35: shift right value must be less than the bit width of the shifted value, which is 64
-    65:57: shift right value must be less than the bit width of the shifted value, which is 64
-    68:61: shift right value must be less than the bit width of the shifted value, which is 64
-    69:35: shift right value must be less than the bit width of the shifted value, which is 64
-    70:57: shift right value must be less than the bit width of the shifted value, which is 64
-    73:61: shift right value must be less than the bit width of the shifted value, which is 64
-    74:35: shift right value must be less than the bit width of the shifted value, which is 64
-    75:57: shift right value must be less than the bit width of the shifted value, which is 64
     TestFailedButDeviceReusable@
     @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
@@ -253,25 +160,8 @@ FAIL :shift_right_abstract:inputSource="const";vectorize=3 assert_unreached:
       at (elided: only 2 shown)
   - EXPECTATION FAILED: Pipeline Creation Error, validation:
       at (elided: only 2 shown)
-  - EXCEPTION: Error: Unexpected validation error occurred: 18 errors generated while compiling the shader:
+  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     363:65: shift right value must be less than the bit width of the shifted value, which is 64
-    364:38: shift right value must be less than the bit width of the shifted value, which is 64
-    365:61: shift right value must be less than the bit width of the shifted value, which is 64
-    368:65: shift right value must be less than the bit width of the shifted value, which is 64
-    369:38: shift right value must be less than the bit width of the shifted value, which is 64
-    370:61: shift right value must be less than the bit width of the shifted value, which is 64
-    373:65: shift right value must be less than the bit width of the shifted value, which is 64
-    374:38: shift right value must be less than the bit width of the shifted value, which is 64
-    375:61: shift right value must be less than the bit width of the shifted value, which is 64
-    378:65: shift right value must be less than the bit width of the shifted value, which is 64
-    379:38: shift right value must be less than the bit width of the shifted value, which is 64
-    380:61: shift right value must be less than the bit width of the shifted value, which is 64
-    383:65: shift right value must be less than the bit width of the shifted value, which is 64
-    384:38: shift right value must be less than the bit width of the shifted value, which is 64
-    385:61: shift right value must be less than the bit width of the shifted value, which is 64
-    388:65: shift right value must be less than the bit width of the shifted value, which is 64
-    389:38: shift right value must be less than the bit width of the shifted value, which is 64
-    390:61: shift right value must be less than the bit width of the shifted value, which is 64
     TestFailedButDeviceReusable@
     @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
@@ -286,31 +176,8 @@ FAIL :shift_right_abstract:inputSource="const";vectorize=4 assert_unreached:
       at (elided: only 2 shown)
   - EXPECTATION FAILED: Pipeline Creation Error, validation:
       at (elided: only 2 shown)
-  - EXCEPTION: Error: Unexpected validation error occurred: 24 errors generated while compiling the shader:
+  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     358:68: shift right value must be less than the bit width of the shifted value, which is 64
-    359:41: shift right value must be less than the bit width of the shifted value, which is 64
-    360:64: shift right value must be less than the bit width of the shifted value, which is 64
-    363:68: shift right value must be less than the bit width of the shifted value, which is 64
-    364:41: shift right value must be less than the bit width of the shifted value, which is 64
-    365:64: shift right value must be less than the bit width of the shifted value, which is 64
-    368:68: shift right value must be less than the bit width of the shifted value, which is 64
-    369:41: shift right value must be less than the bit width of the shifted value, which is 64
-    370:64: shift right value must be less than the bit width of the shifted value, which is 64
-    373:68: shift right value must be less than the bit width of the shifted value, which is 64
-    374:41: shift right value must be less than the bit width of the shifted value, which is 64
-    375:64: shift right value must be less than the bit width of the shifted value, which is 64
-    378:68: shift right value must be less than the bit width of the shifted value, which is 64
-    379:41: shift right value must be less than the bit width of the shifted value, which is 64
-    380:64: shift right value must be less than the bit width of the shifted value, which is 64
-    383:68: shift right value must be less than the bit width of the shifted value, which is 64
-    384:41: shift right value must be less than the bit width of the shifted value, which is 64
-    385:64: shift right value must be less than the bit width of the shifted value, which is 64
-    388:68: shift right value must be less than the bit width of the shifted value, which is 64
-    389:41: shift right value must be less than the bit width of the shifted value, which is 64
-    390:64: shift right value must be less than the bit width of the shifted value, which is 64
-    393:68: shift right value must be less than the bit width of the shifted value, which is 64
-    394:41: shift right value must be less than the bit width of the shifted value, which is 64
-    395:64: shift right value must be less than the bit width of the shifted value, which is 64
     TestFailedButDeviceReusable@
     @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/value_constructor-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/value_constructor-expected.txt
@@ -356,7 +356,6 @@ PASS :array_zero_value:case="u32"
 FAIL :array_zero_value:case="valid_array" assert_unreached:
   - VALIDATION FAILED: Unexpected compilationInfo 'error' message.
     8:58: error: cannot use override value in constant expression
-    8:46: error: 'array<u32, 2>' cannot be used as an element type of an array
 
     ---- shader ----
     override o : i32 = 1;
@@ -368,9 +367,8 @@ FAIL :array_zero_value:case="valid_array" assert_unreached:
         }
         const x : array<array<u32, 2>, 2> = array<array<u32, 2>, 2>();
       at (elided: below max severity)
-  - EXCEPTION: Error: Unexpected validation error occurred: 2 errors generated while compiling the shader:
+  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     8:57: cannot use override value in constant expression
-    8:45: 'array<u32, 2>' cannot be used as an element type of an array
     TestFailedButDeviceReusable@
     @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
@@ -385,7 +383,6 @@ PASS :array_value:case="u32"
 FAIL :array_value:case="valid_array" assert_unreached:
   - VALIDATION FAILED: Unexpected compilationInfo 'error' message.
     8:58: error: cannot use override value in constant expression
-    8:46: error: 'array<u32, 2>' cannot be used as an element type of an array
 
     ---- shader ----
     override o : i32 = 1;
@@ -397,9 +394,8 @@ FAIL :array_value:case="valid_array" assert_unreached:
         }
         const x : array<array<u32, 2>, 2> = array<array<u32, 2>, 2>(array(0,1), array(2,3));
       at (elided: below max severity)
-  - EXCEPTION: Error: Unexpected validation error occurred: 2 errors generated while compiling the shader:
+  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     8:57: cannot use override value in constant expression
-    8:45: 'array<u32, 2>' cannot be used as an element type of an array
     TestFailedButDeviceReusable@
     @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2196,14 +2196,4 @@ webkit.org/b/295217 [ Sequoia x86_64 ] svg/gradients/spreadMethodAlpha.svg [ Ima
 
 webkit.org/b/295226 http/wpt/mediarecorder/MediaRecorder-audio-samplingrate-change.html [ Pass Failure ]
 
-# webkit.org/b/295253 REGRESSION ( 296795@main): [ Sequoia Release WK2 arm64 ] 8X http/tests/webgpu/webgpu/shader are consistent failures 
-[ Sequoia Release arm64 ] http/tests/webgpu/webgpu/shader/execution/expression/binary/bitwise_shift.html [ Failure ]
-[ Sequoia Release arm64 ] http/tests/webgpu/webgpu/shader/validation/expression/access/array.html [ Failure ]
-[ Sequoia Release arm64 ] http/tests/webgpu/webgpu/shader/validation/expression/access/matrix.html [ Failure ]
-[ Sequoia Release arm64 ] http/tests/webgpu/webgpu/shader/validation/expression/access/vector.html [ Failure ]
-[ Sequoia Release arm64 ] http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/value_constructor.html [ Failure ]
-[ Sequoia Release arm64 ] http/tests/webgpu/webgpu/shader/validation/parse/identifiers.html [ Failure ]
-[ Sequoia Release arm64 ] http/tests/webgpu/webgpu/shader/validation/shader_io/workgroup_size.html [ Failure ]
-[ Sequoia Release arm64 ] http/tests/webgpu/webgpu/shader/validation/types/matrix.html [ Failure ]
-
 webkit.org/b/295304 [ Sonoma Debug x86_64 ] webgl/1.0.x/conformance/rendering/many-draw-calls.html [ Timeout ]


### PR DESCRIPTION
#### bdb3bdda85a2f7225c081be03cfd20b1eb2a4781
<pre>
REGRESSION ( 296795@main): [ Sequoia Release WK2 arm64  ] 8X http/tests/webgpu/webgpu/shader are consistent  failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=295253">https://bugs.webkit.org/show_bug.cgi?id=295253</a>
<a href="https://rdar.apple.com/154721362">rdar://154721362</a>

Reviewed by Mike Wyrzykowski and Dan Glastonbury.

There were 3 issues that for some reason weren&apos;t caught by EWS:
- a few tests just needed updated expectations, since they included multiple errors
  in the output and now the type checker only returns a single error
- lambda functions didn&apos;t mark the result as WARN_UNUSED_RETURN, so one function
  was missing the CHECK on the lambda result. All lambdas have now been updated.
- in one place the Result was being checked as a boolean, so there was no unused
  warning, but the error wasn&apos;t propagated

* LayoutTests/http/tests/webgpu/webgpu/shader/execution/expression/binary/bitwise_shift-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/value_constructor-expected.txt:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::declareBuiltins):
(WGSL::TypeChecker::check):
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::allocateSimpleConstructor):
(WGSL::TypeChecker::allocateTextureStorageConstructor):

Canonical link: <a href="https://commits.webkit.org/296911@main">https://commits.webkit.org/296911@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a55b3cf4334c25604c4332a62a7524e05c56598

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109942 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20031 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115964 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60190 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38188 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83576 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112890 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99008 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64018 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23510 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17157 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59758 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93509 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17198 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118755 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36981 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27408 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92554 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37354 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95274 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92378 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23537 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37354 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15100 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32851 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36876 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42347 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36536 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39878 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38245 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->