### PR TITLE
AX: aria-controls and aria-activedescendant targets outside an aria-modal shouldn't be ignored

### DIFF
--- a/LayoutTests/accessibility/linked-elements-outside-aria-modal-expected.txt
+++ b/LayoutTests/accessibility/linked-elements-outside-aria-modal-expected.txt
@@ -1,0 +1,19 @@
+This test verifies that when an input inside something that is aria-modal is linked to elements outside the modal, that those elements are still accessible.
+
+Checking aria-activedescendant relationship:
+PASS: accessibilityController.accessibleElementById('list1').isIgnored === false
+PASS: accessibilityController.accessibleElementById('list1-option1').isIgnored === false
+PASS: accessibilityController.accessibleElementById('list1-option2').isIgnored === false
+
+Checking aria-controls relationship:
+PASS: accessibilityController.accessibleElementById('list2-option1').isIgnored === false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+
+Apples
+Bananas
+Apples
+Bananas

--- a/LayoutTests/accessibility/linked-elements-outside-aria-modal.html
+++ b/LayoutTests/accessibility/linked-elements-outside-aria-modal.html
@@ -1,0 +1,64 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
+</head>
+
+<div id="modal1" role=dialog>
+    <input id="textfield1" role="combobox" aria-controls="list1">
+</div>
+
+<div id="modal2" role=dialog>
+    <input id="textfield2" role="combobox" aria-activedescendant="list2-option1">
+</div>
+
+<div id="list1" role="listbox">
+    <div role=option id="list1-option1">
+        Apples
+    </div>
+    <div role=option id="list1-option2">
+        Bananas
+    </div>
+</div>
+
+<div id="list2" role="listbox">
+    <div role=option id="list2-option1">
+        Apples
+    </div>
+    <div role=option id="list2-option2">
+        Bananas
+    </div>
+</div>
+
+<script>
+
+var output = "This test verifies that when an input inside something that is aria-modal is linked to elements outside the modal, that those elements are still accessible.\n\n";
+
+if (window.accessibilityController)
+{
+    window.jsTestIsAsync = true;
+
+    setTimeout(async function() {
+        document.getElementById("textfield1").focus();
+        output += "Checking aria-activedescendant relationship:\n";
+        output += await expectAsync("accessibilityController.accessibleElementById('list1').isIgnored", "false");
+        output += expect("accessibilityController.accessibleElementById('list1-option1').isIgnored", "false");
+        output += expect("accessibilityController.accessibleElementById('list1-option2').isIgnored", "false");
+        output += "\n";
+
+        document.getElementById("textfield2").focus();
+        document.getElementById("modal1").setAttribute("aria-modal", "false");
+        document.getElementById("modal2").setAttribute("aria-modal", "true");
+        output += "Checking aria-controls relationship:\n";
+        await waitFor(() => accessibilityController.accessibleElementById('list2-option1') != null);
+        output += expect("accessibilityController.accessibleElementById('list2-option1').isIgnored", "false");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -2452,6 +2452,19 @@ bool AccessibilityObject::ignoredFromModalPresence() const
     if (modalNode->document().frame() != this->frame())
         return false;
     
+    // Some objects might be outside of a modal, but are linked to elements inside of it. Don't ignore those.
+    for (RefPtr ancestor = this; ancestor; ancestor = ancestor->parentObject()) {
+        for (auto& controller : ancestor->controllers()) {
+            if (downcast<AccessibilityObject>(controller)->isModalDescendant(*modalNode))
+                return false;
+        }
+
+        for (auto& activeDescendant : ancestor->activeDescendantOfObjects()) {
+            if (downcast<AccessibilityObject>(activeDescendant)->isModalDescendant(*modalNode))
+                return false;
+        }
+    }
+
     return !isModalDescendant(*modalNode);
 }
 


### PR DESCRIPTION
#### 1003115317a556c8f140386d8e2b1409b1761605
<pre>
AX: aria-controls and aria-activedescendant targets outside an aria-modal shouldn&apos;t be ignored
<a href="https://bugs.webkit.org/show_bug.cgi?id=295292">https://bugs.webkit.org/show_bug.cgi?id=295292</a>
<a href="https://rdar.apple.com/153461447">rdar://153461447</a>

Reviewed by Tyler Wilcock.

We typically ignore all elements that are not in a modal, when a modal is active (see
`ignoredFromModalPresence`). However, there is a common pattern where controls inside
modals (e.g., comboboxes) have relationships to elements outside the modal (e.g.,
listboxes). We don&apos;t want those elements to be ignored, so if that relationship exists
don&apos;t ignore it.

* LayoutTests/accessibility/linked-elements-outside-aria-modal-expected.txt: Added.
* LayoutTests/accessibility/linked-elements-outside-aria-modal.html: Added.
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::ignoredFromModalPresence const):

Canonical link: <a href="https://commits.webkit.org/296917@main">https://commits.webkit.org/296917@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4659ef7b21a678bf83915fda416ece271ea25206

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29634 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20066 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115998 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60224 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111939 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30312 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38222 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83609 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112924 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24171 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99039 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64051 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23543 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17188 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59793 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93544 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17230 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118789 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37015 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27438 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92584 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37388 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95306 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92408 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23547 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37391 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15127 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32893 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36910 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42381 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36572 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39912 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38279 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->