### PR TITLE
[WTF] Provide a type hint to debuggers for opaque bitfield values where supported

### DIFF
--- a/Source/WebCore/rendering/style/StyleBoxData.h
+++ b/Source/WebCore/rendering/style/StyleBoxData.h
@@ -91,11 +91,11 @@ private:
 
     int m_specifiedZIndex;
     int m_usedZIndex;
-    unsigned m_hasAutoSpecifiedZIndex : 1;
-    unsigned m_hasAutoUsedZIndex : 1;
-    unsigned m_boxSizing : 1; // BoxSizing
-    unsigned m_boxDecorationBreak : 1; // BoxDecorationBreak
-    unsigned m_verticalAlign : 4; // VerticalAlign
+    PREFERRED_TYPE(bool) unsigned m_hasAutoSpecifiedZIndex : 1;
+    PREFERRED_TYPE(bool) unsigned m_hasAutoUsedZIndex : 1;
+    PREFERRED_TYPE(BoxSizing) unsigned m_boxSizing : 1;
+    PREFERRED_TYPE(BoxDecorationBreak) unsigned m_boxDecorationBreak : 1;
+    PREFERRED_TYPE(VerticalAlign) unsigned m_verticalAlign : 4;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleMiscNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleMiscNonInheritedData.h
@@ -100,21 +100,21 @@ public:
     LengthPoint objectPosition;
     int order;
 
-    unsigned hasAttrContent : 1 { false };
-    unsigned hasDisplayAffectedByAnimations : 1 { false };
+    PREFERRED_TYPE(bool) unsigned hasAttrContent : 1 { false };
+    PREFERRED_TYPE(bool) unsigned hasDisplayAffectedByAnimations : 1 { false };
 #if ENABLE(DARK_MODE_CSS)
-    unsigned hasExplicitlySetColorScheme : 1 { false };
+    PREFERRED_TYPE(bool) unsigned hasExplicitlySetColorScheme : 1 { false };
 #endif
-    unsigned hasExplicitlySetDirection : 1 { false };
-    unsigned hasExplicitlySetWritingMode : 1 { false };
-    unsigned tableLayout : 1; // TableLayoutType
-    unsigned aspectRatioType : 2; // AspectRatioType
-    unsigned appearance : appearanceBitWidth; // StyleAppearance
-    unsigned usedAppearance : appearanceBitWidth; // StyleAppearance
-    unsigned textOverflow : 1; // Whether or not lines that spill out should be truncated with "..."
-    unsigned userDrag : 2; // UserDrag
-    unsigned objectFit : 3; // ObjectFit
-    unsigned resize : 3; // Resize
+    PREFERRED_TYPE(bool) unsigned hasExplicitlySetDirection : 1 { false };
+    PREFERRED_TYPE(bool) unsigned hasExplicitlySetWritingMode : 1 { false };
+    PREFERRED_TYPE(TableLayoutType) unsigned tableLayout : 1;
+    PREFERRED_TYPE(AspectRatioType) unsigned aspectRatioType : 2;
+    PREFERRED_TYPE(StyleAppearance) unsigned appearance : appearanceBitWidth;
+    PREFERRED_TYPE(StyleAppearance) unsigned usedAppearance : appearanceBitWidth;
+    PREFERRED_TYPE(bool) unsigned textOverflow : 1; // Whether or not lines that spill out should be truncated with "..."
+    PREFERRED_TYPE(UserDrag) unsigned userDrag : 2;
+    PREFERRED_TYPE(ObjectFit) unsigned objectFit : 3;
+    PREFERRED_TYPE(Resize) unsigned resize : 3;
 
 private:
     StyleMiscNonInheritedData();

--- a/Source/WebCore/rendering/style/StyleMultiColData.h
+++ b/Source/WebCore/rendering/style/StyleMultiColData.h
@@ -63,10 +63,10 @@ public:
 
     bool autoWidth : 1;
     bool autoCount : 1;
-    unsigned fill : 1; // ColumnFill
-    unsigned columnSpan : 1; // ColumnSpan
-    unsigned axis : 2; // ColumnAxis
-    unsigned progression : 2; // ColumnProgression
+    PREFERRED_TYPE(ColumnFill) unsigned fill : 1;
+    PREFERRED_TYPE(ColumnSpan) unsigned columnSpan : 1;
+    PREFERRED_TYPE(ColumnAxis) unsigned axis : 2;
+    PREFERRED_TYPE(ColumnProgression) unsigned progression : 2;
 
 private:
     StyleMultiColData();

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.h
@@ -31,6 +31,7 @@
 #include "ScrollbarColor.h"
 #include "StyleColor.h"
 #include "StyleCustomPropertyData.h"
+#include "StyleLineBoxContain.h"
 #include "StyleDynamicRangeLimit.h"
 #include "StyleTextEdge.h"
 #include "StyleTextShadow.h"
@@ -42,6 +43,10 @@
 #include <wtf/OptionSet.h>
 #include <wtf/RefCounted.h>
 #include <wtf/text/AtomString.h>
+
+#if HAVE(CORE_MATERIAL)
+#include "AppleVisualEffect.h"
+#endif
 
 #if ENABLE(TEXT_AUTOSIZING)
 #include "TextSizeAdjustment.h"
@@ -116,80 +121,65 @@ public:
 
     DataRef<Style::CustomPropertyData> customProperties;
 
-    // Paged media properties.
     unsigned short widows;
     unsigned short orphans;
-    unsigned hasAutoWidows : 1;
-    unsigned hasAutoOrphans : 1;
-    
-    unsigned textSecurity : 2; // TextSecurity
-    unsigned userModify : 2; // UserModify (editing)
-    unsigned wordBreak : 3; // WordBreak
-    unsigned overflowWrap : 2; // OverflowWrap
-    unsigned nbspMode : 1; // NBSPMode
-    unsigned lineBreak : 3; // LineBreak
-    unsigned userSelect : 2; // UserSelect
-    unsigned colorSpace : 1; // ColorSpace
-    unsigned speakAs : 4 { 0 }; // OptionSet<SpeakAs>
-    unsigned hyphens : 2; // Hyphens
-    unsigned textCombine : 1; // TextCombine
-    unsigned textEmphasisFill : 1; // TextEmphasisFill
-    unsigned textEmphasisMark : 3; // TextEmphasisMark
-    unsigned textEmphasisPosition : 4; // TextEmphasisPosition
-    unsigned textIndentLine : 1; // TextIndentLine
-    unsigned textIndentType : 1; // TextIndentType
-    unsigned textUnderlinePosition : 4; // TextUnderlinePosition
-    unsigned lineBoxContain: 7; // OptionSet<Style::LineBoxContain>
-    // CSS Image Values Level 3
-    unsigned imageOrientation : 1; // ImageOrientation
-    unsigned imageRendering : 3; // ImageRendering
-    unsigned lineSnap : 2; // LineSnap
-    unsigned lineAlign : 1; // LineAlign
+    PREFERRED_TYPE(bool) unsigned hasAutoWidows : 1;
+    PREFERRED_TYPE(bool) unsigned hasAutoOrphans : 1;
+
+    PREFERRED_TYPE(TextSecurity) unsigned textSecurity : 2;
+    PREFERRED_TYPE(UserModify) unsigned userModify : 2;
+    PREFERRED_TYPE(WordBreak) unsigned wordBreak : 3;
+    PREFERRED_TYPE(OverflowWrap) unsigned overflowWrap : 2;
+    PREFERRED_TYPE(NBSPMode) unsigned nbspMode : 1;
+    PREFERRED_TYPE(LineBreak) unsigned lineBreak : 3;
+    PREFERRED_TYPE(UserSelect) unsigned userSelect : 2;
+    PREFERRED_TYPE(ColorSpace) unsigned colorSpace : 1;
+    PREFERRED_TYPE(OptionSet<SpeakAs>) unsigned speakAs : 4 { 0 };
+    PREFERRED_TYPE(Hyphens) unsigned hyphens : 2;
+    PREFERRED_TYPE(TextCombine) unsigned textCombine : 1;
+    PREFERRED_TYPE(TextEmphasisFill) unsigned textEmphasisFill : 1;
+    PREFERRED_TYPE(TextEmphasisMark) unsigned textEmphasisMark : 3;
+    PREFERRED_TYPE(TextEmphasisPosition) unsigned textEmphasisPosition : 4;
+    PREFERRED_TYPE(TextIndentLine) unsigned textIndentLine : 1;
+    PREFERRED_TYPE(TextIndentType) unsigned textIndentType : 1;
+    PREFERRED_TYPE(TextUnderlinePosition) unsigned textUnderlinePosition : 4;
+    PREFERRED_TYPE(OptionSet<Style::LineBoxContain>) unsigned lineBoxContain: 7;
+    PREFERRED_TYPE(ImageOrientation) unsigned imageOrientation : 1;
+    PREFERRED_TYPE(ImageRendering) unsigned imageRendering : 3;
+    PREFERRED_TYPE(LineSnap) unsigned lineSnap : 2;
+    PREFERRED_TYPE(LineAlign) unsigned lineAlign : 1;
 #if ENABLE(OVERFLOW_SCROLLING_TOUCH)
-    unsigned useTouchOverflowScrolling: 1;
+    PREFERRED_TYPE(bool) unsigned useTouchOverflowScrolling: 1;
 #endif
-    unsigned textAlignLast : 3; // TextAlignLast
-    unsigned textJustify : 2; // TextJustify
-    unsigned textDecorationSkipInk : 2; // TextDecorationSkipInk
-    unsigned mathStyle : 1; // MathStyle
-    unsigned rubyPosition : 2; // RubyPosition
-    unsigned rubyAlign : 2; // RubyAlign
-    unsigned rubyOverhang : 1; // RubyOverhang
-    unsigned textZoom: 1; // TextZoom
-
+    PREFERRED_TYPE(TextAlignLast) unsigned textAlignLast : 3;
+    PREFERRED_TYPE(TextJustify) unsigned textJustify : 2;
+    PREFERRED_TYPE(TextDecorationSkipInk) unsigned textDecorationSkipInk : 2;
+    PREFERRED_TYPE(MathStyle) unsigned mathStyle : 1;
+    PREFERRED_TYPE(RubyPosition) unsigned rubyPosition : 2;
+    PREFERRED_TYPE(RubyAlign) unsigned rubyAlign : 2;
+    PREFERRED_TYPE(RubyOverhang) unsigned rubyOverhang : 1;
+    PREFERRED_TYPE(TextZoom) unsigned textZoom: 1;
 #if PLATFORM(IOS_FAMILY)
-    unsigned touchCalloutEnabled : 1;
+    PREFERRED_TYPE(bool) unsigned touchCalloutEnabled : 1;
 #endif
-
-    unsigned hangingPunctuation : 4; // OptionSet<HangingPunctuation>
-
-    unsigned paintOrder : 3; // PaintOrder
-    unsigned capStyle : 2; // LineCap
-    unsigned joinStyle : 2; // LineJoin
-    unsigned hasSetStrokeWidth : 1;
-    unsigned hasSetStrokeColor : 1;
-
-    unsigned hasAutoCaretColor : 1;
-    unsigned hasVisitedLinkAutoCaretColor : 1;
-
-    unsigned hasAutoAccentColor : 1;
-
-    unsigned effectiveInert : 1;
-
-    unsigned isInSubtreeWithBlendMode : 1;
-
-    unsigned isForceHidden : 1;
-
-    unsigned usedContentVisibility : 2; // ContentVisibility
-
-    unsigned autoRevealsWhenFound : 1;
-
-    unsigned insideDefaultButton : 1;
-
-    unsigned insideDisabledSubmitButton : 1;
-
+    PREFERRED_TYPE(OptionSet<HangingPunctuation>) unsigned hangingPunctuation : 4;
+    PREFERRED_TYPE(PaintOrder) unsigned paintOrder : 3;
+    PREFERRED_TYPE(LineCap) unsigned capStyle : 2;
+    PREFERRED_TYPE(LineJoin) unsigned joinStyle : 2;
+    PREFERRED_TYPE(bool) unsigned hasSetStrokeWidth : 1;
+    PREFERRED_TYPE(bool) unsigned hasSetStrokeColor : 1;
+    PREFERRED_TYPE(bool) unsigned hasAutoCaretColor : 1;
+    PREFERRED_TYPE(bool) unsigned hasVisitedLinkAutoCaretColor : 1;
+    PREFERRED_TYPE(bool) unsigned hasAutoAccentColor : 1;
+    PREFERRED_TYPE(bool) unsigned effectiveInert : 1;
+    PREFERRED_TYPE(bool) unsigned isInSubtreeWithBlendMode : 1;
+    PREFERRED_TYPE(bool) unsigned isForceHidden : 1;
+    PREFERRED_TYPE(ContentVisibility) unsigned usedContentVisibility : 2;
+    PREFERRED_TYPE(bool) unsigned autoRevealsWhenFound : 1;
+    PREFERRED_TYPE(bool) unsigned insideDefaultButton : 1;
+    PREFERRED_TYPE(bool) unsigned insideDisabledSubmitButton : 1;
 #if HAVE(CORE_MATERIAL)
-    unsigned usedAppleVisualEffectForSubtree : 4; // AppleVisualEffect
+    PREFERRED_TYPE(AppleVisualEffect) unsigned usedAppleVisualEffectForSubtree : 4;
 #endif
 
     OptionSet<TouchAction> usedTouchActions;

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -243,70 +243,50 @@ public:
     FixedVector<Style::PositionTryFallback> positionTryFallbacks;
 
     std::optional<Length> blockStepSize;
-    unsigned blockStepAlign : 2; // BlockStepAlign
-    unsigned blockStepInsert : 2; // BlockStepInsert
-    unsigned blockStepRound : 2; // BlockStepRound
+    PREFERRED_TYPE(BlockStepAlign) unsigned blockStepAlign : 2;
+    PREFERRED_TYPE(BlockStepInsert) unsigned blockStepInsert : 2;
+    PREFERRED_TYPE(BlockStepRound) unsigned blockStepRound : 2;
 
-    unsigned overscrollBehaviorX : 2; // OverscrollBehavior
-    unsigned overscrollBehaviorY : 2; // OverscrollBehavior
+    PREFERRED_TYPE(OverscrollBehavior) unsigned overscrollBehaviorX : 2;
+    PREFERRED_TYPE(OverscrollBehavior) unsigned overscrollBehaviorY : 2;
 
-    unsigned pageSizeType : 2; // PageSizeType
-    unsigned transformStyle3D : 2; // TransformStyle3D
-    unsigned transformStyleForcedToFlat : 1; // The used value for transform-style is forced to flat by a grouping property.
-    unsigned backfaceVisibility : 1; // BackfaceVisibility
+    PREFERRED_TYPE(PageSizeType) unsigned pageSizeType : 2;
+    PREFERRED_TYPE(TransformStyle3D) unsigned transformStyle3D : 2;
+    PREFERRED_TYPE(bool) unsigned transformStyleForcedToFlat : 1; // The used value for transform-style is forced to flat by a grouping property.
+    PREFERRED_TYPE(BackfaceVisibility) unsigned backfaceVisibility : 1;
 
-    unsigned useSmoothScrolling : 1; // ScrollBehavior
-
-    unsigned textDecorationStyle : 3; // TextDecorationStyle
-
-    unsigned textGroupAlign : 3; // TextGroupAlign
-
-    unsigned contentVisibility : 2; // ContentVisibility
-
-    unsigned effectiveBlendMode: 5; // BlendMode
-    unsigned isolation : 1; // Isolation
-
-    unsigned inputSecurity : 1; // InputSecurity
-
+    PREFERRED_TYPE(ScrollBehavior) unsigned useSmoothScrolling : 1;
+    PREFERRED_TYPE(TextDecorationStyle) unsigned textDecorationStyle : 3;
+    PREFERRED_TYPE(TextGroupAlign) unsigned textGroupAlign : 3;
+    PREFERRED_TYPE(ContentVisibility) unsigned contentVisibility : 2;
+    PREFERRED_TYPE(BlendMode) unsigned effectiveBlendMode: 5;
+    PREFERRED_TYPE(Isolation) unsigned isolation : 1;
+    PREFERRED_TYPE(InputSecurity) unsigned inputSecurity : 1;
 #if ENABLE(APPLE_PAY)
-    unsigned applePayButtonStyle : 2; // ApplePayButtonStyle
-    unsigned applePayButtonType : 4; // ApplePayButtonType
+    PREFERRED_TYPE(ApplePayButtonStyle) unsigned applePayButtonStyle : 2;
+    PREFERRED_TYPE(ApplePayButtonType) unsigned applePayButtonType : 4;
 #endif
-
-    unsigned breakBefore : 4; // BreakBetween
-    unsigned breakAfter : 4; // BreakBetween
-    unsigned breakInside : 3; // BreakInside
-
-    unsigned containIntrinsicWidthType : 2; // ContainIntrinsicSizeType
-    unsigned containIntrinsicHeightType : 2; // ContainIntrinsicSizeType
-
-    unsigned containerType : 2; // ContainerType
-
-    unsigned textBoxTrim : 2; // TextBoxTrim
-
-    unsigned overflowAnchor : 1; // Scroll Anchoring - OverflowAnchor
-
-    bool hasClip : 1;
-
-    unsigned positionTryOrder : 3; // Style::PositionTryOrder; 5 values so 3 bits.
-    unsigned positionVisibility : 3; // OptionSet<PositionVisibilty>
-
-    unsigned fieldSizing : 1; // FieldSizing
-
-    unsigned nativeAppearanceDisabled : 1;
-
+    PREFERRED_TYPE(BreakBetween) unsigned breakBefore : 4;
+    PREFERRED_TYPE(BreakBetween) unsigned breakAfter : 4;
+    PREFERRED_TYPE(BreakInside) unsigned breakInside : 3;
+    PREFERRED_TYPE(ContainIntrinsicSizeType) unsigned containIntrinsicWidthType : 2;
+    PREFERRED_TYPE(ContainIntrinsicSizeType) unsigned containIntrinsicHeightType : 2;
+    PREFERRED_TYPE(ContainerType) unsigned containerType : 2;
+    PREFERRED_TYPE(TextBoxTrim) unsigned textBoxTrim : 2;
+    PREFERRED_TYPE(OverflowAnchor) unsigned overflowAnchor : 1;
+    PREFERRED_TYPE(bool) unsigned hasClip : 1;
+    PREFERRED_TYPE(Style::PositionTryOrder) unsigned positionTryOrder : 3;
+    PREFERRED_TYPE(OptionSet<PositionVisibility>) unsigned positionVisibility : 3;
+    PREFERRED_TYPE(FieldSizing) unsigned fieldSizing : 1;
+    PREFERRED_TYPE(bool) unsigned nativeAppearanceDisabled : 1;
 #if HAVE(CORE_MATERIAL)
-    unsigned appleVisualEffect : 5; // AppleVisualEffect
+    PREFERRED_TYPE(AppleVisualEffect) unsigned appleVisualEffect : 5;
 #endif
-
-    unsigned scrollbarWidth : 2; // ScrollbarWidth
-
-    unsigned usesAnchorFunctions : 1;
-    unsigned anchorFunctionScrollCompensatedAxes : 2;
-
-    unsigned usesTreeCountingFunctions : 1;
-
-    unsigned isPopoverInvoker : 1;
+    PREFERRED_TYPE(ScrollbarWidth) unsigned scrollbarWidth : 2;
+    PREFERRED_TYPE(bool) unsigned usesAnchorFunctions : 1;
+    PREFERRED_TYPE(OptionSet<BoxAxisFlag>) unsigned anchorFunctionScrollCompensatedAxes : 2;
+    PREFERRED_TYPE(bool) unsigned usesTreeCountingFunctions : 1;
+    PREFERRED_TYPE(bool) unsigned isPopoverInvoker : 1;
 
 private:
     StyleRareNonInheritedData();

--- a/Source/WebCore/rendering/style/StyleSelfAlignmentData.h
+++ b/Source/WebCore/rendering/style/StyleSelfAlignmentData.h
@@ -67,9 +67,9 @@ public:
     friend bool operator==(const StyleSelfAlignmentData&, const StyleSelfAlignmentData&) = default;
 
 private:
-    uint8_t m_position : 4 { 0 }; // ItemPosition
-    uint8_t m_positionType: 1 { 0 }; // ItemPositionType: Whether or not alignment uses the 'legacy' keyword.
-    uint8_t m_overflow : 2 { 0 }; // OverflowAlignment
+    PREFERRED_TYPE(ItemPosition) uint8_t m_position : 4 { 0 };
+    PREFERRED_TYPE(ItemPositionType) uint8_t m_positionType: 1 { 0 }; // Whether or not alignment uses the 'legacy' keyword.
+    PREFERRED_TYPE(OverflowAlignment) uint8_t m_overflow : 2 { 0 };
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, const StyleSelfAlignmentData&);


### PR DESCRIPTION
#### 99b626befab865c4f50048ef2c567c2a10d5d053
<pre>
[WTF] Provide a type hint to debuggers for opaque bitfield values where supported
<a href="https://bugs.webkit.org/show_bug.cgi?id=295294">https://bugs.webkit.org/show_bug.cgi?id=295294</a>

Reviewed by Darin Adler.

Newer versions of clang support an attribute, `preferred_type`, which provides
a hint to debuggers about what type is stored in opaqued bitfields:

    <a href="https://clang.llvm.org/docs/AttributeReference.html#preferred-type.">https://clang.llvm.org/docs/AttributeReference.html#preferred-type.</a>

This adds a new macro to wtf/Compiler.h called `PREFERRED_TYPE(...)` that
wraps the attribute when supported.

Some initial adoption of it was done in &apos;WebCore/rendering/style&apos; to
illustrate how it can be used.

* Source/WTF/wtf/Compiler.h:
    - Adds new PREFERRED_TYPE macro.
    - Cleans up Compiler.h a bit, fixing typos, reducing some duplication and
      making COMPILER_HAS_CPP_ATTRIBUTE a top level macro.

* Source/WebCore/rendering/style/StyleBoxData.h:
* Source/WebCore/rendering/style/StyleMiscNonInheritedData.h:
* Source/WebCore/rendering/style/StyleMultiColData.h:
* Source/WebCore/rendering/style/StyleRareInheritedData.h:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/rendering/style/StyleSelfAlignmentData.h:
    - Adopted PREFERRED_TYPE, replacing comments annotations.

Canonical link: <a href="https://commits.webkit.org/297027@main">https://commits.webkit.org/297027@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea23298394ebaf5d1152ea842c1cd3ac504e95c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110166 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29825 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20257 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116188 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60414 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112129 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30503 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38412 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83767 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113114 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24340 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99214 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64212 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23705 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17397 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59984 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/102657 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93717 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17407 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118979 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/108720 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37206 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27586 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92744 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37578 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95483 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92567 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23611 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37553 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15290 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33095 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37100 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42571 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/132995 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36762 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35963 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40102 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38471 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->