### PR TITLE
[Liquid Glass] Color extensions sometimes fail to update when scrolling to sticky elements

### DIFF
--- a/LayoutTests/fast/page-color-sampling/color-sampling-for-sticky-element-after-scrolling-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-for-sticky-element-after-scrolling-expected.txt
@@ -1,0 +1,14 @@
+Scroll down
+
+PASS colorsBeforeScrolling.top is null
+PASS colorsBeforeScrolling.left is null
+PASS colorsBeforeScrolling.right is null
+PASS colorsBeforeScrolling.bottom is null
+PASS colorsAfterScrolling.top is "rgb(28, 28, 30)"
+PASS colorsAfterScrolling.left is null
+PASS colorsAfterScrolling.right is null
+PASS colorsAfterScrolling.bottom is null
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/page-color-sampling/color-sampling-for-sticky-element-after-scrolling.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-for-sticky-element-after-scrolling.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
+<html>
+<head>
+<script src="../../resources/ui-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+html {
+    height: 100%;
+    color: white;
+    font-family: system-ui;
+    text-align: center;
+    font-size: 20px;
+}
+
+body {
+    background-color: #1C1C1E;
+    margin: 0;
+    padding: 0;
+    height: 100%;
+}
+
+.outer-wrapper {
+    margin: 100px 16px;
+    padding: 0 0 30px 0;
+}
+
+.wrapper {
+    margin: 24px 0 16px 0;
+}
+
+.sticky-container {
+    position: relative;
+    border-radius: 10px;
+    margin: 10px 0;
+    margin-top: -10px;
+    z-index: 0;
+    background-color: #2C2C2E;
+}
+
+.sticky {
+    height: 24px;
+    background: #1C1C1E;
+    position: sticky;
+    top: 0;
+    width: 100%;
+}
+
+.tall {
+    height: 4000px;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    await UIHelper.setObscuredInsets(100, 0, 0, 0);
+    await UIHelper.ensurePresentationUpdate();
+
+    colorsBeforeScrolling = await UIHelper.fixedContainerEdgeColors();
+    await UIHelper.scrollDown();
+    await UIHelper.ensurePresentationUpdate();
+    colorsAfterScrolling = await UIHelper.fixedContainerEdgeColors();
+
+    shouldBeNull("colorsBeforeScrolling.top");
+    shouldBeNull("colorsBeforeScrolling.left");
+    shouldBeNull("colorsBeforeScrolling.right");
+    shouldBeNull("colorsBeforeScrolling.bottom");
+
+    shouldBeEqualToString("colorsAfterScrolling.top", "rgb(28, 28, 30)");
+    shouldBeNull("colorsAfterScrolling.left");
+    shouldBeNull("colorsAfterScrolling.right");
+    shouldBeNull("colorsAfterScrolling.bottom");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div class="outer-wrapper">
+        <h1 class="alerts-title">Scroll down</h1>
+        <div class="wrapper">
+            <div class="sticky-container">
+                <div class="sticky"></div>
+                <div class="tall">
+                    <pre id="description"></pre>
+                    <pre id="console"></pre>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -165,6 +165,20 @@ window.UIHelper = class UIHelper {
         });
     }
 
+    static async scrollDown()
+    {
+        const midX = innerWidth / 2;
+        const midY = innerHeight / 2;
+        if (!this.isIOSFamily())
+            return await this.mouseWheelScrollAt(midX, midY, 0, -1, 0, -100);
+
+        await this.sendEventStream(new this.EventStreamBuilder()
+            .begin(midX, midY + 180)
+            .move(midX, midY - 180, 0.3)
+            .end()
+            .takeResult());
+    }
+
     static async animationFrame()
     {
         return new Promise(requestAnimationFrame);

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -152,6 +152,8 @@ public:
     virtual void scrollingTreeNodeDidBeginScrollSnapping(ScrollingNodeID) { }
     virtual void scrollingTreeNodeDidEndScrollSnapping(ScrollingNodeID) { }
 
+    virtual void stickyScrollingTreeNodeBeganSticking(ScrollingNodeID) { }
+
     WEBCORE_EXPORT TrackingType eventTrackingTypeForPoint(EventTrackingRegions::EventType, IntPoint);
 
     virtual void receivedWheelEventWithPhases(PlatformWheelEventPhase /* phase */, PlatformWheelEventPhase /* momentumPhase */) { }

--- a/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.h
@@ -45,6 +45,7 @@ public:
     virtual ~ScrollingTreeStickyNode();
 
     FloatSize scrollDeltaSinceLastCommit() const;
+    WEBCORE_EXPORT bool isCurrentlySticking() const;
 
 protected:
     ScrollingTreeStickyNode(ScrollingTree&, ScrollingNodeID);
@@ -60,6 +61,12 @@ protected:
     virtual bool hasViewportClippingLayer() const { return false; }
     const ViewportConstraints& constraints() const final { return m_constraints; }
 
+private:
+    void updateIsSticking();
+
+    bool m_isSticking { false };
+
+protected:
     StickyPositionViewportConstraints m_constraints;
 };
 

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h
@@ -39,7 +39,6 @@ class ScrollingTreeStickyNodeCocoa : public ScrollingTreeStickyNode {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(ScrollingTreeStickyNodeCocoa, WEBCORE_EXPORT);
 public:
     WEBCORE_EXPORT static Ref<ScrollingTreeStickyNodeCocoa> create(ScrollingTree&, ScrollingNodeID);
-    WEBCORE_EXPORT bool isCurrentlySticking() const;
 
     virtual ~ScrollingTreeStickyNodeCocoa() = default;
 

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.mm
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.mm
@@ -93,20 +93,6 @@ bool ScrollingTreeStickyNodeCocoa::hasViewportClippingLayer() const
     return m_viewportAnchorLayer && m_layer != m_viewportAnchorLayer;
 }
 
-bool ScrollingTreeStickyNodeCocoa::isCurrentlySticking() const
-{
-    if (auto constrainingRect = findConstrainingRect()) {
-        auto stickyOffset = m_constraints.computeStickyOffset(*constrainingRect);
-        auto stickyRect = m_constraints.stickyBoxRect();
-        auto containingRect = m_constraints.containingBlockRect();
-
-        return stickyOffset.height() > 0
-            && stickyOffset.height() < containingRect.height() - stickyRect.height();
-    }
-
-    return false;
-}
-
 FloatPoint ScrollingTreeStickyNodeCocoa::layerTopLeft() const
 {
     FloatRect layerBounds = [m_layer bounds];

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -111,6 +111,8 @@ public:
     WebPageProxy& webPageProxy() const;
     Ref<WebPageProxy> protectedWebPageProxy() const;
 
+    void stickyScrollingTreeNodeBeganSticking(WebCore::ScrollingNodeID);
+
     std::optional<WebCore::RequestedScrollData> commitScrollingTreeState(IPC::Connection&, const RemoteScrollingCoordinatorTransaction&, std::optional<WebCore::LayerHostingContextIdentifier> = std::nullopt);
 
     bool hasFixedOrSticky() const;
@@ -202,6 +204,7 @@ protected:
     std::optional<unsigned> m_currentHorizontalSnapPointIndex;
     std::optional<unsigned> m_currentVerticalSnapPointIndex;
     bool m_waitingForDidScrollReply { false };
+    bool m_stickyScrollingTreeNodesBeganSticking { false };
     HashSet<WebCore::PlatformLayerIdentifier> m_layersWithScrollingRelations;
 };
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
@@ -152,6 +152,12 @@ void RemoteScrollingTree::scrollingTreeNodeDidEndScrollSnapping(ScrollingNodeID 
         scrollingCoordinatorProxy->scrollingTreeNodeDidEndScrollSnapping(nodeID);
 }
 
+void RemoteScrollingTree::stickyScrollingTreeNodeBeganSticking(ScrollingNodeID nodeID)
+{
+    if (CheckedPtr scrollingCoordinatorProxy = m_scrollingCoordinatorProxy.get())
+        scrollingCoordinatorProxy->stickyScrollingTreeNodeBeganSticking(nodeID);
+}
+
 Ref<ScrollingTreeNode> RemoteScrollingTree::createScrollingTreeNode(ScrollingNodeType nodeType, ScrollingNodeID nodeID)
 {
     switch (nodeType) {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -71,6 +71,8 @@ public:
     void scrollingTreeNodeDidBeginScrollSnapping(WebCore::ScrollingNodeID) override;
     void scrollingTreeNodeDidEndScrollSnapping(WebCore::ScrollingNodeID) override;
 
+    void stickyScrollingTreeNodeBeganSticking(WebCore::ScrollingNodeID) final;
+
     void currentSnapPointIndicesDidChange(WebCore::ScrollingNodeID, std::optional<unsigned> horizontal, std::optional<unsigned> vertical) override;
     void reportExposedUnfilledArea(MonotonicTime, unsigned unfilledArea) override;
     void reportSynchronousScrollingReasonsChanged(MonotonicTime, OptionSet<WebCore::SynchronousScrollingReason>) override;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -15914,6 +15914,14 @@ void WebPageProxy::playAllAnimations(CompletionHandler<void()>&& completionHandl
 }
 #endif // ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
 
+void WebPageProxy::stickyScrollingTreeNodeBeganSticking()
+{
+    if (!protectedPreferences()->contentInsetBackgroundFillEnabled())
+        return;
+
+    send(Messages::WebPage::SetNeedsFixedContainerEdgesUpdate());
+}
+
 void WebPageProxy::adjustLayersForLayoutViewport(const FloatPoint& scrollPosition, const WebCore::FloatRect& layoutViewport, double scale)
 {
 #if ENABLE(ASYNC_SCROLLING) && PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1064,6 +1064,8 @@ public:
         
     void adjustLayersForLayoutViewport(const WebCore::FloatPoint& scrollPosition, const WebCore::FloatRect& layoutViewport, double scale);
 
+    void stickyScrollingTreeNodeBeganSticking();
+
 #if PLATFORM(COCOA)
     void scrollingNodeScrollViewDidScroll(WebCore::ScrollingNodeID);
     WebCore::FloatRect selectionBoundingRectInRootViewCoordinates() const;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -50,6 +50,8 @@ messages -> WebPage WantsAsyncDispatchMessage {
     SetUnderlayColor(WebCore::Color color)
     SetUnderPageBackgroundColorOverride(WebCore::Color underPageBackgroundColorOverride)
 
+    SetNeedsFixedContainerEdgesUpdate()
+
     ViewWillStartLiveResize()
     ViewWillEndLiveResize()
 


### PR DESCRIPTION
#### 2c0658bf3b5d5ba387a3e2e8dae776abf78f196a
<pre>
[Liquid Glass] Color extensions sometimes fail to update when scrolling to sticky elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=295296">https://bugs.webkit.org/show_bug.cgi?id=295296</a>
<a href="https://rdar.apple.com/152196131">rdar://152196131</a>

Reviewed by Abrar Rahman Protyasha.

Fixed and sticky color sampling/extensions currently update at most once per rendering update, and
only when the geometry of viewport-constrained layers update or we paint into a viewport-constrained
layer. This helps to minimize the performance overhead incurred by fixed/sticky element background
color extension, a key mitigation for overlay UI in Safari when Liquid Glass is enabled to prevent
visible web content from showing through gaps in the new UI, when there are fixed/sticky elements
near the edges of the viewport.

However, there&apos;s currently no mechanism to ensure that a sticky element will be detected and sampled
once it begins sticking to its enclosing constraining rect (for instance, when a sticky element
starts behaving like a fixed element, and becomes constrained to the viewport). As such, the
detection and sampling of sticky website content (often-times website headers) is generally flaky,
but tends to work well in practice on most of the web due to the fact that other unrelated viewport-
constrained elements are either repainted and/or moved around while scrolling, thereby triggering a
sampling update. In simpler web content (such as the Severe Weather alert seen in Safari view
controller in the Weather app), this doesn&apos;t happen since there&apos;s no other viewport-constrained
objects being inserted/removed/repainted, and so we can end up with a visible gap above sticky
elements.

To fix this, we add plumbing to make `ScrollingTreeStickyNode` observe when it first begins to stick
to its constraining rect when handling a scrolling tree commit, and tell its scrolling tree about
it. The remote scrolling tree then notifies its scrolling coordinator proxy in the UI process, which
then forwards the message to the `WebPageProxy`, and ultimately notifies the corresponding `WebPage`
to resample for color extension along edges with obscured insets. These notifications are batched
together for all sticky nodes that began sticking in a single commit, to avoid redundant IPC.

* LayoutTests/fast/page-color-sampling/color-sampling-for-sticky-element-after-scrolling-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/color-sampling-for-sticky-element-after-scrolling.html: Added.

Add a layout test to exercise this change by scrolling down, and verifying that the sticky element&apos;s
background color is sampled after scrolling.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.async scrollDown):

Add a helper method to scroll the page down on all platforms – on iOS, this simulates a swipe
gesture from the bottom of the screen to the top, and on other platforms it just simulates mouse
wheel scrolling. This allows us to avoid an `isIOSFamily()` check in the new layout test itself,
instead keeping the platform check in the testing helper.

* Source/WebCore/page/scrolling/ScrollingTree.h:
(WebCore::ScrollingTree::stickyScrollingTreeNodeBeganSticking):
* Source/WebCore/page/scrolling/ScrollingTreeStickyNode.cpp:
(WebCore::ScrollingTreeStickyNode::commitStateBeforeChildren):

(WebCore::ScrollingTreeStickyNode::updateIsSticking):
(WebCore::ScrollingTreeStickyNode::isSticking const):

Add a flag to `ScrollingTreeStickyNode`, which tracks whether or not the sticky node is sticking to
its constraining rect.

* Source/WebCore/page/scrolling/ScrollingTreeStickyNode.h:
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h:
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.mm:
(WebCore::ScrollingTreeStickyNodeCocoa::isCurrentlySticking const): Deleted.

Move this into the base class, in `ScrollingTreeStickyNode.cpp`. Also add a FIXME here to also check
horizontal scroll offset; it&apos;s not necessary to fix this particular bug, so I plan to address this
separately.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::commitScrollingTreeState):

Add a new flag, `m_scrollingTreeNodesBeganBehavingAsFixed`, that keeps track of when one or more
sticky scrolling tree nodes has begun sticking to the edges of its constraining rect, during a
scrolling tree commit. We set this flag and call `stickyScrollingTreeNodeBeganSticking` at the end
of the commit, if at least one node has begun sticking.

This flag prevents us from dispatching redundant IPC messages in the case where there are multiple
sticky scrolling nodes that begin sticking in the same commit.

(WebKit::RemoteScrollingCoordinatorProxy::stickyScrollingTreeNodeBeganSticking):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp:
(WebKit::RemoteScrollingTree::stickyScrollingTreeNodeBeganSticking):

Add some plumbing from `ScrollingTreeStickyNode` -&gt; `RemoteScrollingTree` -&gt;
`RemoteScrollingCoordinatorProxy` -&gt; `WebPageProxy` when any sticky scrolling tree node starts
sticking to the constraining rect (e.g. behaving as a fixed element).

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::stickyScrollingTreeNodeBeganSticking):

Whenever one or more sticky scrolling tree nodes begin sticking, tell the web page to resampling
for fixed container edges (fixed/sticky element color extensions).

* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Add a new IPC message to invalidate `m_needsFixedContainerEdgesUpdate` on `WebPage`.

Canonical link: <a href="https://commits.webkit.org/296901@main">https://commits.webkit.org/296901@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a91b5e6e83579edd4b68a944373b9549b6b0f711

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109872 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29530 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19960 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115893 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60109 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111835 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30208 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38118 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83527 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112820 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24081 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98946 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63968 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23455 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17094 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59688 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93452 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17136 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118685 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36911 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27354 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92504 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37284 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95212 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92327 "Found 2 new API test failures: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23530 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37303 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15043 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32757 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36806 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42276 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36466 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39808 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38175 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->