### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore::RegisterAllocator

### DIFF
--- a/Source/WebCore/cssjit/RegisterAllocator.h
+++ b/Source/WebCore/cssjit/RegisterAllocator.h
@@ -31,12 +31,10 @@
 #include <wtf/Deque.h>
 #include <wtf/Vector.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 #if CPU(ARM64)
-static const JSC::MacroAssembler::RegisterID callerSavedRegisters[] = {
+static constexpr std::array<JSC::MacroAssembler::RegisterID, 15> callerSavedRegisters {
     JSC::ARM64Registers::x0,
     JSC::ARM64Registers::x1,
     JSC::ARM64Registers::x2,
@@ -53,12 +51,12 @@ static const JSC::MacroAssembler::RegisterID callerSavedRegisters[] = {
     JSC::ARM64Registers::x13,
     JSC::ARM64Registers::x14,
 };
-static const JSC::MacroAssembler::RegisterID calleeSavedRegisters[] = {
+static constexpr std::array<JSC::MacroAssembler::RegisterID, 1> calleeSavedRegisters = {
     JSC::ARM64Registers::x19
 };
 static const JSC::MacroAssembler::RegisterID tempRegister = JSC::ARM64Registers::x15;
 #elif CPU(X86_64)
-static const JSC::MacroAssembler::RegisterID callerSavedRegisters[] = {
+static constexpr std::array<JSC::MacroAssembler::RegisterID, 8> callerSavedRegisters {
     JSC::X86Registers::eax,
     JSC::X86Registers::ecx,
     JSC::X86Registers::edx,
@@ -68,7 +66,7 @@ static const JSC::MacroAssembler::RegisterID callerSavedRegisters[] = {
     JSC::X86Registers::r9,
     JSC::X86Registers::r10,
 };
-static const JSC::MacroAssembler::RegisterID calleeSavedRegisters[] = {
+static constexpr std::array<JSC::MacroAssembler::RegisterID, 4> calleeSavedRegisters {
     JSC::X86Registers::r12,
     JSC::X86Registers::r13,
     JSC::X86Registers::r14,
@@ -77,10 +75,11 @@ static const JSC::MacroAssembler::RegisterID calleeSavedRegisters[] = {
 #else
 #error RegisterAllocator has no defined registers for the architecture.
 #endif
-static const unsigned calleeSavedRegisterCount = std::size(calleeSavedRegisters);
-static const unsigned maximumRegisterCount = calleeSavedRegisterCount + std::size(callerSavedRegisters);
 
-typedef Vector<JSC::MacroAssembler::RegisterID, maximumRegisterCount> RegisterVector;
+static constexpr unsigned calleeSavedRegisterCount = std::size(calleeSavedRegisters);
+static constexpr unsigned maximumRegisterCount = calleeSavedRegisterCount + std::size(callerSavedRegisters);
+
+using RegisterVector = Vector<JSC::MacroAssembler::RegisterID, maximumRegisterCount>;
 
 class RegisterAllocator {
 public:
@@ -151,10 +150,8 @@ public:
 
     const Vector<JSC::MacroAssembler::RegisterID, calleeSavedRegisterCount>& reserveCalleeSavedRegisters(unsigned count)
     {
-        RELEASE_ASSERT(count <= std::size(calleeSavedRegisters));
         RELEASE_ASSERT(!m_reservedCalleeSavedRegisters.size());
-        for (unsigned i = 0; i < count; ++i) {
-            JSC::MacroAssembler::RegisterID registerId = calleeSavedRegisters[i];
+        for (auto registerId : std::span { calleeSavedRegisters }.first(count)) {
             m_reservedCalleeSavedRegisters.append(registerId);
             m_registers.append(registerId);
         }
@@ -245,7 +242,5 @@ inline RegisterAllocator::~RegisterAllocator()
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(CSS_SELECTOR_JIT)


### PR DESCRIPTION
#### 4a28a644f796982179de3d7f4c6320b642502266
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore::RegisterAllocator
<a href="https://bugs.webkit.org/show_bug.cgi?id=295297">https://bugs.webkit.org/show_bug.cgi?id=295297</a>

Reviewed by Darin Adler.

This tested as performance neutral on Speedometer.

* Source/WebCore/cssjit/RegisterAllocator.h:
(WebCore::RegisterAllocator::reserveCalleeSavedRegisters):

Canonical link: <a href="https://commits.webkit.org/297033@main">https://commits.webkit.org/297033@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04401c0f31be33c9c1e66fca94739c4c3d279fc8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109871 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29529 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19959 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115892 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60108 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111834 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30207 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38117 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83525 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112819 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24083 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98945 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63967 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23457 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17093 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59687 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93454 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17135 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118684 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36910 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27355 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92503 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37283 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95211 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92326 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37301 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15042 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32756 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17800 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36805 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42275 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36465 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39807 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38174 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->