### PR TITLE
[EWS] Add 8 Windows bots

### DIFF
--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -87,6 +87,9 @@
                   { "name": "wincairo-release-tests-01", "platform": "win" },
                   { "name": "wincairo-release-tests-02", "platform": "win" },
 
+                  { "name": "win-build-bot-001", "platform": "win" },
+                  { "name": "win-build-bot-002", "platform": "win" },
+
                   { "name": "playstation-release-build-01", "platform": "playstation" },
                   { "name": "playstation-debug-build-01", "platform": "playstation" },
 
@@ -535,7 +538,7 @@
                     "name": "Windows-64-bit-Release-Build", "factory": "BuildFactory",
                     "platform": "win", "configuration": "release", "architectures": ["x86_64"],
                     "triggers": ["win-release-tests"],
-                    "workernames": ["wincairo-release-build-01"]
+                    "workernames": ["wincairo-release-build-01", "win-build-bot-002"]
                   },
                   {
                     "name": "Windows-64-bit-Release-Tests", "factory": "TestAllButJSCFactory",
@@ -546,7 +549,7 @@
                     "name": "Windows-64-bit-Debug-Build", "factory": "BuildFactory",
                     "platform": "win", "configuration": "debug", "architectures": ["x86_64"],
                     "triggers": ["win-debug-tests"],
-                    "workernames": ["wincairo-debug-build-01"]
+                    "workernames": ["wincairo-debug-build-01", "win-build-bot-001"]
                   },
                   {
                     "name": "Windows-64-bit-Debug-Tests", "factory": "TestAllButJSCFactory",

--- a/Tools/CISupport/ews-build/config.json
+++ b/Tools/CISupport/ews-build/config.json
@@ -45,14 +45,12 @@
     { "name": "playstation-ews-002", "platform": "playstation" },
     { "name": "playstation-ews-003", "platform": "playstation" },
     { "name": "playstation-ews-004", "platform": "playstation" },
-    { "name": "win-tests-ews-001", "platform": "win" },
-    { "name": "win-tests-ews-002", "platform": "win" },
-    { "name": "win-tests-ews-003", "platform": "win" },
-    { "name": "win-tests-ews-004", "platform": "win" },
-    { "name": "win-tests-ews-005", "platform": "win" },
-    { "name": "win-tests-ews-006", "platform": "win" },
-    { "name": "win-tests-ews-007", "platform": "win" },
-    { "name": "win-tests-ews-008", "platform": "win" },
+    { "name": "win-bot-001", "platform": "win" },
+    { "name": "win-bot-002", "platform": "win" },
+    { "name": "win-bot-003", "platform": "win" },
+    { "name": "win-bot-004", "platform": "win" },
+    { "name": "win-bot-005", "platform": "win" },
+    { "name": "win-bot-006", "platform": "win" },
     { "name": "wincairo-ews-001", "platform": "win" },
     { "name": "wincairo-ews-002", "platform": "win" },
     { "name": "wincairo-ews-003", "platform": "win" },
@@ -375,14 +373,14 @@
       "factory": "WinBuildFactory", "configuration": "release",
       "architectures": ["x86_64"], "platform": "win",
       "triggers": ["win-tests-ews"],
-      "workernames": ["wincairo-ews-001", "wincairo-ews-002", "wincairo-ews-003", "wincairo-ews-004"]
+      "workernames": ["wincairo-ews-001", "wincairo-ews-002", "wincairo-ews-003", "wincairo-ews-004", "win-bot-001", "win-bot-002"]
     },
     {
       "name": "Win-Tests-EWS", "shortname": "win-tests", "icon": "testOnly",
       "factory": "WinTestsFactory", "configuration": "release",
       "architectures": ["x86_64"], "platform": "win",
       "triggered_by": ["win-build-ews"],
-      "workernames": ["win-tests-ews-001", "win-tests-ews-002", "win-tests-ews-003", "win-tests-ews-004", "win-tests-ews-005", "win-tests-ews-006", "win-tests-ews-007", "win-tests-ews-008"]
+      "workernames": ["win-bot-003", "win-bot-004", "win-bot-005", "win-bot-006"]
     },
     {
       "name": "WPE-Build-EWS", "shortname": "wpe", "icon": "buildOnly",


### PR DESCRIPTION
#### dec30c7d704cf1de8a25cd655b36d01aa73a5c98
<pre>
[EWS] Add 8 Windows bots
<a href="https://bugs.webkit.org/show_bug.cgi?id=294231">https://bugs.webkit.org/show_bug.cgi?id=294231</a>

Reviewed by Ryan Haddad.

Sponsored by Playwright, this is the Azure budget previously used by the
win-tests-ews-* bots. We&apos;re planning ahead for Sony to stop running their
Windows EWS bots, so these aren&apos;t getting directly applied to just the
win-tests queue.

Currently allocated as follows:

* Win-Build-EWS 2 workers
* Win-Tests-EWS 4 workers
* Windows-64-bit-Debug-Build 1 worker
* Windows-64-bit-Release-Build 1 worker

Canonical link: <a href="https://commits.webkit.org/297233@main">https://commits.webkit.org/297233@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a4f1da0397c94d076a5c7a3424956246b3a8a96

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109876 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29534 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19964 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115897 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60113 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111839 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30212 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38122 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83530 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112824 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24085 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98949 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63971 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23459 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17097 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59692 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93456 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17139 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118689 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36915 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27359 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92508 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/109372 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37288 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95215 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92331 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23736 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37304 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15046 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32762 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36810 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36470 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39812 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38179 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->