### PR TITLE
REGRESSION (296407@main): White line through audio player on sfgate.com article

### DIFF
--- a/LayoutTests/compositing/iframes/hidpi-iframe-on-subpixel-boundary-tiling-expected.html
+++ b/LayoutTests/compositing/iframes/hidpi-iframe-on-subpixel-boundary-tiling-expected.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        :root {
+            overflow: hidden;
+        }
+        .tiled {
+            width: 4097px;
+        }
+
+        iframe {
+            margin-left: 12.5px;
+            margin-top: 451.65625px;
+            width: 550px;
+            height: 130px;
+            border: none;
+        }
+    </style>
+</head>
+<body>
+    <div class="tiled">
+        <iframe srcdoc="
+        <style>
+            body {
+                background-color: silver;
+            }
+            </style>
+            <body>
+            </body>
+        "></iframe>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/iframes/hidpi-iframe-on-subpixel-boundary-tiling.html
+++ b/LayoutTests/compositing/iframes/hidpi-iframe-on-subpixel-boundary-tiling.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        :root {
+            overflow: hidden;
+        }
+        .tiled {
+            width: 4097px;
+            will-change: transform;
+        }
+
+        iframe {
+            margin-left: 12.5px;
+            margin-top: 451.65625px;
+            width: 550px;
+            height: 130px;
+            border: none;
+        }
+    </style>
+</head>
+<body>
+    <div class="tiled">
+        <iframe srcdoc="
+        <style>
+            body {
+                background-color: silver;
+            }
+            </style>
+            <body>
+            </body>
+        "></iframe>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderWidget.cpp
+++ b/Source/WebCore/rendering/RenderWidget.cpp
@@ -283,7 +283,7 @@ void RenderWidget::paintContents(PaintInfo& paintInfo, const LayoutPoint& paintO
     }
 
     // FIXME: Remove repaintrect enclosing/integral snapping when RenderWidget becomes device pixel snapped.
-    m_widget->paint(paintInfo.context(), snappedIntRect(paintRect), paintInfo.requireSecurityOriginAccessForWidgets ? Widget::SecurityOriginPaintPolicy::AccessibleOriginOnly : Widget::SecurityOriginPaintPolicy::AnyOrigin, paintInfo.regionContext);
+    m_widget->paint(paintInfo.context(), enclosingIntRect(paintRect), paintInfo.requireSecurityOriginAccessForWidgets ? Widget::SecurityOriginPaintPolicy::AccessibleOriginOnly : Widget::SecurityOriginPaintPolicy::AnyOrigin, paintInfo.regionContext);
 
     if (paintInfo.regionContext)
         paintInfo.regionContext->popTransform();


### PR DESCRIPTION
#### 144b7ec6d94604dcac3b4d09e33f4efa621ae319
<pre>
REGRESSION (296407@main): White line through audio player on sfgate.com article
<a href="https://bugs.webkit.org/show_bug.cgi?id=295315">https://bugs.webkit.org/show_bug.cgi?id=295315</a>
<a href="https://rdar.apple.com/154779362">rdar://154779362</a>

Reviewed by Alan Baradlay.

The snappIntRect() passed to `m_widget-&gt;paint()` causes clipping when painting the widget contents,
so use `enclosingIntRect()` to ensure it&apos;s not clipped for subpixel-positioned iframes.

* LayoutTests/compositing/iframes/hidpi-iframe-on-subpixel-boundary-tiling-expected.html: Added.
* LayoutTests/compositing/iframes/hidpi-iframe-on-subpixel-boundary-tiling.html: Added.
* Source/WebCore/rendering/RenderWidget.cpp:
(WebCore::RenderWidget::paintContents):

Canonical link: <a href="https://commits.webkit.org/296910@main">https://commits.webkit.org/296910@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52da042a3134d366258a8f3d5741326b76c671bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109920 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29578 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20008 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115942 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60162 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111883 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30256 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38166 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83562 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112868 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24119 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98984 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64004 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23491 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17132 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59736 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93490 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17174 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118733 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36959 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27387 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92540 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37332 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95250 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92364 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23536 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37336 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15076 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32817 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36854 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42324 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36514 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39856 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38223 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->