### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in WTF::BitVector

### DIFF
--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -940,7 +940,7 @@ public:
             return;
         size_t sizeInBytes = BitVector::byteCount(m_numBits);
         uint8_t* buffer = this->allocate(encoder, sizeInBytes);
-        memcpy(buffer, bitVector.bits(), sizeInBytes);
+        memcpy(buffer, bitVector.words().data(), sizeInBytes);
     }
 
     void decode(Decoder&, BitVector& bitVector) const
@@ -949,7 +949,7 @@ public:
             return;
         bitVector.ensureSize(m_numBits);
         size_t sizeInBytes = BitVector::byteCount(m_numBits);
-        memcpy(bitVector.bits(), this->buffer(), sizeInBytes);
+        memcpy(bitVector.words().data(), this->buffer(), sizeInBytes);
     }
 
 private:

--- a/Source/WTF/wtf/FixedBitVector.h
+++ b/Source/WTF/wtf/FixedBitVector.h
@@ -98,7 +98,7 @@ ALWAYS_INLINE bool FixedBitVector::concurrentTestAndSet(size_t bitIndex, Depende
 
     WordType mask = one << (bitIndex % wordSize);
     size_t wordIndex = bitIndex / wordSize;
-    WordType* data = dependency.consume(m_bitVector.bits()) + wordIndex;
+    WordType* data = dependency.consume(m_bitVector.words().data()) + wordIndex;
     return !std::bit_cast<Atomic<WordType>*>(data)->transactionRelaxed(
         [&](WordType& value) -> bool {
             if (value & mask)
@@ -116,7 +116,7 @@ ALWAYS_INLINE bool FixedBitVector::concurrentTestAndClear(size_t bitIndex, Depen
 
     WordType mask = one << (bitIndex % wordSize);
     size_t wordIndex = bitIndex / wordSize;
-    WordType* data = dependency.consume(m_bitVector.bits()) + wordIndex;
+    WordType* data = dependency.consume(m_bitVector.words().data()) + wordIndex;
     return std::bit_cast<Atomic<WordType>*>(data)->transactionRelaxed(
         [&](WordType& value) -> bool {
             if (!(value & mask))
@@ -134,7 +134,7 @@ ALWAYS_INLINE bool FixedBitVector::testAndSet(size_t bitIndex)
 
     WordType mask = one << (bitIndex % wordSize);
     size_t wordIndex = bitIndex / wordSize;
-    WordType* bits = m_bitVector.bits();
+    WordType* bits = m_bitVector.words().data();
     bool previousValue = bits[wordIndex] & mask;
     bits[wordIndex] |= mask;
     return previousValue;
@@ -147,7 +147,7 @@ ALWAYS_INLINE bool FixedBitVector::testAndClear(size_t bitIndex)
 
     WordType mask = one << (bitIndex % wordSize);
     size_t wordIndex = bitIndex / wordSize;
-    WordType* bits = m_bitVector.bits();
+    WordType* bits = m_bitVector.words().data();
     bool previousValue = bits[wordIndex] & mask;
     bits[wordIndex] &= ~mask;
     return previousValue;
@@ -160,7 +160,7 @@ ALWAYS_INLINE bool FixedBitVector::test(size_t bitIndex)
 
     WordType mask = one << (bitIndex % wordSize);
     size_t wordIndex = bitIndex / wordSize;
-    return m_bitVector.bits()[wordIndex] & mask;
+    return m_bitVector.words().data()[wordIndex] & mask;
 }
 
 ALWAYS_INLINE size_t FixedBitVector::findBit(size_t startIndex, bool value) const


### PR DESCRIPTION
#### b5118559131b23f55e18d8d599329d40fae3d644
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in WTF::BitVector
<a href="https://bugs.webkit.org/show_bug.cgi?id=295316">https://bugs.webkit.org/show_bug.cgi?id=295316</a>

Reviewed by Darin Adler.

This tested as performance neutral on Speedometer and JetStream.

* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::CachedBitVector::encode):
(JSC::CachedBitVector::decode const):
* Source/WTF/wtf/BitVector.h:
* Source/WTF/wtf/FixedBitVector.h:
(WTF::FixedBitVector::concurrentTestAndSet):
(WTF::FixedBitVector::concurrentTestAndClear):
(WTF::FixedBitVector::testAndSet):
(WTF::FixedBitVector::testAndClear):
(WTF::FixedBitVector::test):

Canonical link: <a href="https://commits.webkit.org/296949@main">https://commits.webkit.org/296949@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33f97fa83b622b2624817f23266175de1fa4c6a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109921 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20009 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115943 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60163 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30257 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38167 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83565 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112869 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24120 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98986 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64007 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23492 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17134 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59737 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/102412 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93491 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17176 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118734 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/108473 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36960 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27389 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92543 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37333 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95252 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92367 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23568 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37338 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15078 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32818 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36855 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42325 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/132749 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36515 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35924 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39857 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38224 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->