### PR TITLE
Digital Credentials API: add default toJSON() to DigitalCredential interface

### DIFF
--- a/LayoutTests/http/wpt/identity/idl.https-expected.txt
+++ b/LayoutTests/http/wpt/identity/idl.https-expected.txt
@@ -83,4 +83,5 @@ PASS DigitalCredential interface: existence and properties of interface prototyp
 PASS DigitalCredential interface: attribute protocol
 PASS DigitalCredential interface: attribute data
 PASS DigitalCredential interface: operation userAgentAllowsProtocol(DOMString)
+PASS DigitalCredential interface: operation toJSON()
 

--- a/LayoutTests/http/wpt/identity/idl.https.html
+++ b/LayoutTests/http/wpt/identity/idl.https.html
@@ -22,6 +22,7 @@ interface DigitalCredential : Credential {
     readonly attribute DOMString protocol;
     readonly attribute Uint8Array data;
     static boolean userAgentAllowsProtocol(DOMString protocol);
+    [Default] object toJSON();
 };
 </script>
 <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get.tentative.https-expected.txt
@@ -11,4 +11,5 @@ PASS navigator.credentials.get() promise is rejected if called with an aborted s
 FAIL navigator.credentials.get() promise is rejected if abort controller is aborted after call to get(). promise_rejects_dom: function "function() { throw e }" threw object "NotSupportedError: Digital credentials are not supported." that is not a DOMException AbortError: property "code" is equal to 9, expected 20
 FAIL navigator.credentials.get() promise is rejected if abort controller is aborted after call to get() in cross-origin iframe. assert_equals: expected "AbortError" but got "NotAllowedError"
 PASS Mediation is required to get a DigitalCredential.
+PASS Throws TypeError when request data is not JSON stringifiable.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get.tentative.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get.tentative.https.html
@@ -231,4 +231,24 @@
       );
     }
   }, "Mediation is required to get a DigitalCredential.");
+
+promise_test(async t => {
+  const throwingValues = [
+    BigInt(123),
+    (() => { const o = {}; o.self = o; return o; })(),
+    Symbol("foo")
+  ];
+
+  for (const badValue of throwingValues) {
+    const options = makeGetOptions("openid4vp");
+    options.digital.requests[0].data = badValue;
+
+    await promise_rejects_js(
+      t,
+      TypeError,
+      navigator.credentials.get(options),
+      `Should throw for: ${String(badValue)}`
+    );
+  }
+}, "Throws TypeError when request data is not JSON stringifiable.");
 </script>

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/digital-credentials/get.tentative.https-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/digital-credentials/get.tentative.https-expected.txt
@@ -13,4 +13,5 @@ PASS navigator.credentials.get() promise is rejected if called with an aborted s
 FAIL navigator.credentials.get() promise is rejected if abort controller is aborted after call to get(). promise_rejects_dom: function "function() { throw e }" threw object "NotSupportedError: Digital credentials are not supported." that is not a DOMException AbortError: property "code" is equal to 9, expected 20
 FAIL navigator.credentials.get() promise is rejected if abort controller is aborted after call to get() in cross-origin iframe. assert_equals: expected "AbortError" but got "NotAllowedError"
 PASS Mediation is required to get a DigitalCredential.
+PASS Throws TypeError when request data is not JSON stringifiable.
 

--- a/LayoutTests/platform/mac-sonoma/imported/w3c/web-platform-tests/digital-credentials/get.tentative.https-expected.txt
+++ b/LayoutTests/platform/mac-sonoma/imported/w3c/web-platform-tests/digital-credentials/get.tentative.https-expected.txt
@@ -11,4 +11,5 @@ PASS navigator.credentials.get() promise is rejected if called with an aborted s
 FAIL navigator.credentials.get() promise is rejected if abort controller is aborted after call to get(). promise_rejects_dom: function "function() { throw e }" threw object "NotSupportedError: Digital credentials are not supported." that is not a DOMException AbortError: property "code" is equal to 9, expected 20
 FAIL navigator.credentials.get() promise is rejected if abort controller is aborted after call to get() in cross-origin iframe. assert_equals: expected "AbortError" but got "NotAllowedError"
 PASS Mediation is required to get a DigitalCredential.
+PASS Throws TypeError when request data is not JSON stringifiable.
 

--- a/Source/WebCore/Modules/identity/DigitalCredential.cpp
+++ b/Source/WebCore/Modules/identity/DigitalCredential.cpp
@@ -68,6 +68,11 @@ static ExceptionOr<UnvalidatedDigitalCredentialRequest> jsToCredentialRequest(co
     auto scope = DECLARE_THROW_SCOPE(document.globalObject()->vm());
     auto* globalObject = document.globalObject();
 
+    // Check that the object is JSON stringifiable.
+    JSC::JSONStringify(globalObject, request.data.get(), 0);
+    if (scope.exception()) [[unlikely]]
+        return Exception { ExceptionCode::ExistingExceptionError };
+
     switch (request.protocol) {
     case IdentityCredentialProtocol::OrgIsoMdoc: {
         auto result = convertDictionary<MobileDocumentRequest>(*globalObject, request.data.get());

--- a/Source/WebCore/Modules/identity/DigitalCredential.idl
+++ b/Source/WebCore/Modules/identity/DigitalCredential.idl
@@ -32,4 +32,5 @@
     [SameObject] readonly attribute object data;
     readonly attribute IdentityCredentialProtocol protocol;
     static boolean userAgentAllowsProtocol(DOMString protocol);
+    [Default] object toJSON();
 };


### PR DESCRIPTION
#### 251eeb10a290a5a87d6aae85c355d40ae32bd130
<pre>
Digital Credentials API: add default toJSON() to DigitalCredential interface
<a href="https://bugs.webkit.org/show_bug.cgi?id=295018">https://bugs.webkit.org/show_bug.cgi?id=295018</a>
<a href="https://rdar.apple.com/problem/154733737">rdar://problem/154733737</a>

Reviewed by Abrar Rahman Protyasha.

Spec change:
<a href="https://github.com/w3c-fedid/digital-credentials/pull/179">https://github.com/w3c-fedid/digital-credentials/pull/179</a>

* Adds a default `toJSON()` method to the `DigitalCredential` interface.
* Adds JSON strinfication check for incoming request, as required by the spec.

Canonical link: <a href="https://commits.webkit.org/296963@main">https://commits.webkit.org/296963@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3d8dc21686ea72fe3de674a5bfd5f958a43aa2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110087 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29746 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20178 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116109 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60335 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112050 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30424 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38333 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83698 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113035 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24262 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99143 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64142 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23629 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17278 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59905 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93636 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17337 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118900 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37127 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27523 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92666 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37499 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95411 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92492 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23579 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37482 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15225 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33009 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37021 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42492 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36683 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40023 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38392 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->