### PR TITLE
AX: [iOS] empty headings should not be accessibility elements

### DIFF
--- a/LayoutTests/accessibility/ios-simulator/heading-is-ax-element-expected.txt
+++ b/LayoutTests/accessibility/ios-simulator/heading-is-ax-element-expected.txt
@@ -1,0 +1,13 @@
+This tests that empty headings aren't exposed when appropriate.
+
+PASS: heading1.isIgnored === true
+PASS: heading1Text.isIgnored === false
+PASS: heading2.isIgnored === true
+PASS: heading3.isIgnored === false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello world
+
+

--- a/LayoutTests/accessibility/ios-simulator/heading-is-ax-element.html
+++ b/LayoutTests/accessibility/ios-simulator/heading-is-ax-element.html
@@ -1,0 +1,33 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+
+<h1 id="heading1">Hello world</h1>
+<h1 id="heading2"></h1>
+<h1 id="heading3" aria-label="Good morning"></h1>
+
+<script>
+var output = "This tests that empty headings aren't exposed when appropriate.\n\n";
+
+var heading1, heading1Text, heading2, heading3;
+if (window.accessibilityController) {
+    heading1 = accessibilityController.accessibleElementById("heading1");
+    heading1Text = heading1.childAtIndex(0);
+    heading2 = accessibilityController.accessibleElementById("heading2");
+    heading3 = accessibilityController.accessibleElementById("heading3");
+    
+    output += expect("heading1.isIgnored", "true");
+    output += expect("heading1Text.isIgnored", "false");
+    output += expect("heading2.isIgnored", "true");
+    output += expect("heading3.isIgnored", "false");
+    
+    debug(output);
+}
+</script>
+
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -926,9 +926,10 @@ static AccessibilityObjectWrapper *ancestorWithRole(const AXCoreObject& descenda
         return true;
     }
 
-    // Don't expose headers as elements; instead expose their children as elements, with the header trait (unless they have no children)
+    // Don't expose headers as elements; instead expose their children as elements, with the header trait (unless they have no children).
+    // Only expose a heading with no children if it has an accessibility label, indicating that it is using aria-label or aria-labelledby.
     case AccessibilityRole::Heading:
-        return ![self accessibilityElementCount];
+        return ![self accessibilityElementCount] && [self accessibilityLabel] != nil;
     case AccessibilityRole::Video:
         return [self accessibilityIsWebInteractiveVideo];
 


### PR DESCRIPTION
#### d6e8371fac8e55a12433147d430367d399906d9a
<pre>
AX: [iOS] empty headings should not be accessibility elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=295319">https://bugs.webkit.org/show_bug.cgi?id=295319</a>
<a href="https://rdar.apple.com/153276276">rdar://153276276</a>

Reviewed by Tyler Wilcock.

We were exposing heading elements with no children as accessibility elements
on iOS, causing confusion in search, and providing no useful information to
ATs. Only do this when the heading actually has a label, either using
aria-label or aria-labelledby.

* LayoutTests/accessibility/ios-simulator/heading-is-ax-element-expected.txt: Added.
* LayoutTests/accessibility/ios-simulator/heading-is-ax-element.html: Added.
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper determineIsAccessibilityElement]):

Canonical link: <a href="https://commits.webkit.org/296937@main">https://commits.webkit.org/296937@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f969029f2b958f861a5d24d6ab4440a33cbc2c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109978 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29636 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20068 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116000 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60226 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111941 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30314 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38224 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83610 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112926 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24172 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99041 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64052 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23544 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17190 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59795 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93545 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17232 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118791 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37017 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27440 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92583 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37390 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95308 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92407 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23559 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37393 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15129 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32895 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36912 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42383 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36574 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39914 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38281 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->