### PR TITLE
codeweavers.com: REGRESSION (294860@main): STTF highlight flickers when opening link. (293912)

### DIFF
--- a/LayoutTests/http/tests/scroll-to-text-fragment/no-scroll-loop-with-scroll-style-change-expected.txt
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/no-scroll-loop-with-scroll-style-change-expected.txt
@@ -1,0 +1,2 @@
+PASS: Page scrolls to correct Text Fragment.
+PASS: No Scroll loop detected.

--- a/LayoutTests/http/tests/scroll-to-text-fragment/no-scroll-loop-with-scroll-style-change.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/no-scroll-loop-with-scroll-style-change.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Scroll to text fragment - ensure that we don't get into a cycle when scrolling changes a pages style</title>
+<meta name="assert" content="This test checks that loading a stylesheet doesn't cause the page to re-scroll.">
+
+<head>
+<script src="/js-test-resources/ui-helper.js"></script>
+<style>
+    .banner {
+        position: relative;
+        width: 400px;
+        height: 100px;
+        top: 0;
+        left: 100px;
+        background-color: lightblue;
+    }
+    .banner.stuck {
+        position: fixed;
+    }
+</style>
+
+<script>
+
+    var savedScrollPosition = 0;
+    var haveTopElement = false;
+    const yOffsets = [];
+    document.addEventListener('scroll', () => {
+        adjustStyle();
+        yOffsets.push(window.pageYOffset);
+    });
+
+    function adjustStyle() {
+        const banner = document.querySelector('.banner');
+        if (window.pageYOffset > 0 && window.pageYOffset > savedScrollPosition) {
+           
+           banner.classList.add('stuck');
+
+        } else if (window.pageYOffset < savedScrollPosition) {
+            
+            banner.classList.remove('stuck');
+
+        }
+        savedScrollPosition = window.pageYOffset;
+    }
+
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+
+  
+ async function runTest()
+ {
+    if (!testRunner.runUIScript)
+        return;
+
+    location.href = "#:~:text=Scroll%20Point";
+    var output = "";
+
+    for (i = 0; i < 3; i++) {
+        await UIHelper.ensurePresentationUpdate();
+    }
+
+    if (window.pageYOffset > 0)
+        output += "PASS: Page scrolls to correct Text Fragment.";
+    else 
+        output += "FAIL: Page does not scroll to correct Text Fragment.";
+    output += '<br>';
+
+    // make sure we're always scrolling down
+    if (yOffsets.every((offset, i) => i === yOffsets.length - 1 || offset <= yOffsets[i + 1]))
+        output += "PASS: No Scroll loop detected.";
+    else
+        output += "FAIL: Scrolled backwards.";
+
+    var target = document.getElementById('target');
+    target.innerHTML = output;
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+  }
+
+  window.addEventListener('load', () => {
+    runTest();
+  }, false);
+</script>
+</head>
+
+<body style="height: 10000px; margin-top: 1000px;">
+    <div class="banner"></div>
+    <div id="target">
+
+        <p>Scroll Point</p>
+
+    </div>
+</body>
+</html>
+
+
+

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -309,6 +309,8 @@ void TemporarySelectionChange::setSelection(const VisibleSelection& selection, I
             options.add(FrameSelection::SetSelectionOption::RevealSelectionBounds);
         if (m_options & TemporarySelectionOption::ForceCenterScroll)
             options.add(FrameSelection::SetSelectionOption::ForceCenterScroll);
+        if (m_options & TemporarySelectionOption::OnlyAllowForwardScrolling)
+            options.add(FrameSelection::SetSelectionOption::OnlyAllowForwardScrolling);
     }
 
     m_document->selection().setSelection(selection, options);

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -140,6 +140,8 @@ enum class TemporarySelectionOption : uint16_t {
     UserTriggered = 1 << 7,
     
     ForceCenterScroll = 1 << 8,
+
+    OnlyAllowForwardScrolling = 1 << 9
 };
 
 class TemporarySelectionChange {

--- a/Source/WebCore/editing/FrameSelection.h
+++ b/Source/WebCore/editing/FrameSelection.h
@@ -127,7 +127,7 @@ public:
     enum class ShouldUpdateAppearance : bool { No, Yes };
     enum class Alteration : bool { Move, Extend };
     enum class CursorAlignOnScroll : bool { IfNeeded, Always };
-    enum class SetSelectionOption : uint16_t {
+    enum class SetSelectionOption : uint32_t {
         FireSelectEvent = 1 << 0,
         CloseTyping = 1 << 1,
         ClearTypingStyle = 1 << 2,
@@ -144,6 +144,7 @@ public:
         ForBindings = 1 << 13,
         DoNotNotifyEditorClients = 1 << 14,
         MaintainLiveRange = 1 << 15,
+        OnlyAllowForwardScrolling = 1 << 16
     };
     static constexpr OptionSet<SetSelectionOption> defaultSetSelectionOptions(UserTriggered = UserTriggered::No);
 
@@ -274,7 +275,7 @@ public:
 
     WEBCORE_EXPORT RefPtr<HTMLFormElement> currentForm() const;
 
-    WEBCORE_EXPORT void revealSelection(SelectionRevealMode = SelectionRevealMode::Reveal, const ScrollAlignment& = ScrollAlignment::alignCenterIfNeeded, RevealExtentOption = RevealExtentOption::DoNotRevealExtent, ScrollBehavior = ScrollBehavior::Instant);
+    WEBCORE_EXPORT void revealSelection(SelectionRevealMode = SelectionRevealMode::Reveal, const ScrollAlignment& = ScrollAlignment::alignCenterIfNeeded, RevealExtentOption = RevealExtentOption::DoNotRevealExtent, ScrollBehavior = ScrollBehavior::Instant, OnlyAllowForwardScrolling =  OnlyAllowForwardScrolling::No);
     WEBCORE_EXPORT void setSelectionFromNone();
 
     bool shouldShowBlockCursor() const { return m_shouldShowBlockCursor; }
@@ -297,7 +298,7 @@ public:
 #endif
 private:
     void updateSelectionAppearanceNow();
-    void updateAndRevealSelection(const AXTextStateChangeIntent&, ScrollBehavior = ScrollBehavior::Instant, RevealExtentOption = RevealExtentOption::RevealExtent, ForceCenterScroll = ForceCenterScroll::No);
+    void updateAndRevealSelection(const AXTextStateChangeIntent&, ScrollBehavior = ScrollBehavior::Instant, RevealExtentOption = RevealExtentOption::RevealExtent, ForceCenterScroll = ForceCenterScroll::No, OnlyAllowForwardScrolling = OnlyAllowForwardScrolling::No);
     void updateDataDetectorsForSelection();
 
     bool setSelectionWithoutUpdatingAppearance(const VisibleSelection&, OptionSet<SetSelectionOption>, CursorAlignOnScroll, TextGranularity);

--- a/Source/WebCore/page/ScrollBehavior.h
+++ b/Source/WebCore/page/ScrollBehavior.h
@@ -35,6 +35,8 @@ enum class ScrollBehavior : uint8_t {
     Smooth
 };
 
+enum class OnlyAllowForwardScrolling : bool { No, Yes };
+
 bool useSmoothScrolling(ScrollBehavior, Element* associatedElement);
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -147,6 +147,7 @@ struct ScrollRectToVisibleOptions {
     const ScrollAlignment& alignY { ScrollAlignment::alignCenterIfNeeded };
     ShouldAllowCrossOriginScrolling shouldAllowCrossOriginScrolling { ShouldAllowCrossOriginScrolling::No };
     ScrollBehavior behavior { ScrollBehavior::Auto };
+    OnlyAllowForwardScrolling onlyAllowForwardScrolling { OnlyAllowForwardScrolling::No };
     std::optional<LayoutRect> visibilityCheckRect { std::nullopt };
 };
 


### PR DESCRIPTION
#### 841a09adfc066cbb41e6ada9896b82f52c875844
<pre>
codeweavers.com: REGRESSION (294860@main): STTF highlight flickers when opening link. (293912)
<a href="https://bugs.webkit.org/show_bug.cgi?id=295320">https://bugs.webkit.org/show_bug.cgi?id=295320</a>
<a href="https://rdar.apple.com/151939787">rdar://151939787</a>

Reviewed by Simon Fraser.

If a page changes style based on scroll position, it&apos;s possible
for a Scroll To Text Fragment fragment to get into a situation
where the code to center the fragment gets into a cycle where
centering the fragment will cause a layout change that will force
the fragment to not be center, causing the fragment to be re-center
and then that layout will also un-center the fragment and so forth.
In order to combat this cycle, only allow Scroll To Text Fragment centering
to increase the value of Y. This should account for content loading in from
the top, and make it impossible to cycle in this manner.

* Source/WebCore/editing/Editor.cpp:
(WebCore::TemporarySelectionChange::setSelection):
* Source/WebCore/editing/Editor.h:
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::setSelection):
(WebCore::FrameSelection::updateAndRevealSelection):
(WebCore::FrameSelection::revealSelection):
* Source/WebCore/editing/FrameSelection.h:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::maintainScrollPositionAtScrollToTextFragmentRange):
(WebCore::LocalFrameView::scrollToFocusedElementInternal):
(WebCore::LocalFrameView::scrollRectToVisibleInTopLevelView):
(WebCore::LocalFrameView::scrollToTextFragmentRange):
* Source/WebCore/page/ScrollBehavior.h:
* Source/WebCore/rendering/RenderLayer.h:

Canonical link: <a href="https://commits.webkit.org/297071@main">https://commits.webkit.org/297071@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0207022314f90ce8a727f6b7aae22327b82466c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29824 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116187 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60413 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112128 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30502 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38411 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83762 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113113 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24334 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99209 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64207 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23699 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17344 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59983 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93711 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17400 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118978 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37205 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27587 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92738 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37577 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95476 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92561 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23640 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37548 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15286 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33094 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37099 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42570 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36761 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40101 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38470 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->