### PR TITLE
[WPE] Add new TestExpectations file for WPE legacy API

### DIFF
--- a/LayoutTests/platform/wpe-legacy-api/TestExpectations
+++ b/LayoutTests/platform/wpe-legacy-api/TestExpectations
@@ -1,0 +1,44 @@
+# These are the layout test expectations for the WPE port of WebKit using the legacy api.
+#
+# See http://trac.webkit.org/wiki/TestExpectations for more information on this file.
+#
+# Never add any tests to this file without opening a bug on bugzilla.webkit.org.
+
+#////////////////////////////////////////////////////////////////////////////////////////
+# TESTS PASSING
+#
+# These tests are passing on WPE using the legacy API but they do not in the WPE port
+# Note: Passing tests should be on the top of the file to ensure that
+#       expected failures below are not overriden by a folder that is
+#       set to Pass to unskip it from the main expectations file and
+#       declared after the expected failure.
+#       The layout test runner evaluates the rules from top to bottom and
+#       it picks as the valid rule the last one matching.
+#////////////////////////////////////////////////////////////////////////////////////////
+
+fast/events/touch/touch-inside-iframe-scrolled.html [ Pass ]
+fast/events/touch/send-oncancel-event.html [ Pass ]
+
+#////////////////////////////////////////////////////////////////////////////////////////
+# End of PASSING tests. See below where to put expected failures.
+#////////////////////////////////////////////////////////////////////////////////////////
+
+#//////////////////////////////////////////////////////////////////////////////////////////
+# Triaged Expectations
+# * KEEP THE SECTIONS SORTED ALPHABETICALLY.
+# * ALWAYS WITH BUG ENTRIES for things like Timeout, Failure and Crash.
+#
+# For more info, check the glib/TestExpectations file
+# If unsure of where to put the expectations, add the test to the end of the file and
+# ask for triaging.
+#//////////////////////////////////////////////////////////////////////////////////////////
+
+fast/events/touch/touch-event-pageXY.html [ Skip ] # Timeout.
+fast/events/touch/zoomed-touch-event-pageXY.html [ Skip ] # Timeout.
+fast/events/touch/touch-target-limited.html [ Skip ] # Timeout.
+fast/events/touch/multi-touch-inside-nested-iframes.html [ Skip ] # Timeout.
+fast/events/touch/multi-touch-grouped-targets.html [ Skip ] # Timeout.
+
+#//////////////////////////////////////////////////////////////////////////////////////////
+# End of Triaged Expectations
+#//////////////////////////////////////////////////////////////////////////////////////////

--- a/Tools/Scripts/webkitpy/port/wpe.py
+++ b/Tools/Scripts/webkitpy/port/wpe.py
@@ -52,9 +52,13 @@ class WPEPort(GLibPort):
         if self._display_server == 'xvfb':
             # While not supported by WPE, xvfb is used as the default value in the main scripts
             self._display_server = 'headless'
+        self._wpe_legacy_api = self.get_option("wpe_legacy_api")
 
     def _port_flag_for_scripts(self):
-        return "--wpe"
+        port = "--wpe"
+        if self._wpe_legacy_api:
+            port += " --wpe-legacy-api"
+        return port
 
     @memoized
     def _driver_class(self):
@@ -95,7 +99,16 @@ class WPEPort(GLibPort):
         return self._path_to_image_diff()
 
     def _search_paths(self):
-        return [self.port_name, 'glib', 'wk2'] + self.get_option("additional_platform_directory", [])
+        search_paths = []
+
+        if self._wpe_legacy_api:
+            search_paths.append('wpe-legacy-api')
+
+        search_paths.append(self.port_name)
+        search_paths.append('glib')
+        search_paths.append('wk2')
+        search_paths.extend(self.get_option("additional_platform_directory", []))
+        return search_paths
 
     def default_baseline_search_path(self, **kwargs):
         return list(map(self._webkit_baseline_path, self._search_paths()))

--- a/Tools/Scripts/webkitpy/port/wpe_unittest.py
+++ b/Tools/Scripts/webkitpy/port/wpe_unittest.py
@@ -64,6 +64,15 @@ class WPEPortTest(port_testcase.PortTestCase):
                           '/mock-checkout/LayoutTests/platform/glib/TestExpectations',
                           '/mock-checkout/LayoutTests/platform/wpe/TestExpectations'])
 
+    def test_port_legacy_api_specific_expectations_files(self):
+        port = self.make_port(options=MockOptions(configuration='Release', wpe_legacy_api=True))
+        self.assertEqual(port.expectations_files(),
+                         ['/mock-checkout/LayoutTests/TestExpectations',
+                          '/mock-checkout/LayoutTests/platform/wk2/TestExpectations',
+                          '/mock-checkout/LayoutTests/platform/glib/TestExpectations',
+                          '/mock-checkout/LayoutTests/platform/wpe/TestExpectations',
+                          '/mock-checkout/LayoutTests/platform/wpe-legacy-api/TestExpectations'])
+
     def test_default_timeout_ms(self):
         self.assertEqual(self.make_port(options=MockOptions(configuration='Release')).default_timeout_ms(), 15000)
         self.assertEqual(self.make_port(options=MockOptions(configuration='Debug')).default_timeout_ms(), 30000)


### PR DESCRIPTION
#### 27c4f6093910ecd97909c3f93573aa4b8edad64a
<pre>
[WPE] Add new TestExpectations file for WPE legacy API
<a href="https://bugs.webkit.org/show_bug.cgi?id=295321">https://bugs.webkit.org/show_bug.cgi?id=295321</a>

Reviewed by Carlos Garcia Campos.

Since 295733@main, there&apos;s a new post-commit bot that runs layout and
api tests using WPE legacy API. Add a new test expectations file for WPE
legacy API, so it&apos;s possible to keep track which tests behave
differently.

* LayoutTests/platform/wpe-legacy-api/TestExpectations: Added.
* Tools/Scripts/webkitpy/port/wpe.py:
(WPEPort.__init__):
(WPEPort._port_flag_for_scripts):
(WPEPort._search_paths):
* Tools/Scripts/webkitpy/port/wpe_unittest.py:
(WPEPortTest.test_port_specific_expectations_files):
(WPEPortTest):
(WPEPortTest.test_port_legacy_api_specific_expectations_files):

Canonical link: <a href="https://commits.webkit.org/297329@main">https://commits.webkit.org/297329@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e79ba1054fec60c8aef03a3350fb0b2c4fe1a3ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29602 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20033 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115966 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60192 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111907 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30280 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38190 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83580 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112892 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24140 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99004 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64022 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/109376 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23512 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17153 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59760 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93511 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17194 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118757 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36983 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27412 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92558 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37356 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95270 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92382 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37360 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15096 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32854 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17951 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36878 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36538 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39880 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38247 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->