### PR TITLE
[WEBXR][GTK][WPE] Implement startSession/endSession in the PlatformXRCoordinator

### DIFF
--- a/Source/WebKit/UIProcess/API/APIUIClient.h
+++ b/Source/WebKit/UIProcess/API/APIUIClient.h
@@ -51,7 +51,7 @@ OBJC_CLASS UIViewController;
 #include "WebAuthenticationFlags.h"
 #endif
 
-#if ENABLE(WEBXR) && PLATFORM(COCOA)
+#if ENABLE(WEBXR)
 #include "PlatformXRSessionEnums.h"
 #include <WebCore/PlatformXR.h>
 #endif
@@ -230,7 +230,7 @@ public:
 
     virtual void queryPermission(const WTF::String& permissionName, SecurityOrigin& origin, CompletionHandler<void(std::optional<WebCore::PermissionState>)>&& completionHandler) { completionHandler({ }); }
 
-#if ENABLE(WEBXR) && PLATFORM(COCOA)
+#if ENABLE(WEBXR)
     virtual void requestPermissionOnXRSessionFeatures(WebKit::WebPageProxy&, const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList& granted, const PlatformXR::Device::FeatureList& /* consentRequired */, const PlatformXR::Device::FeatureList& /* consentOptional */, const PlatformXR::Device::FeatureList& /* requiredFeaturesRequested */, const PlatformXR::Device::FeatureList& /* optionalFeaturesRequested */, CompletionHandler<void(std::optional<PlatformXR::Device::FeatureList>&&)>&& completionHandler) { completionHandler(granted); }
     virtual void supportedXRSessionFeatures(PlatformXR::Device::FeatureList& vrFeatures, PlatformXR::Device::FeatureList& arFeatures) { }
 

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
@@ -153,7 +153,7 @@ void PlatformXRSystem::requestPermissionOnSessionFeatures(IPC::Connection& conne
     }
 
     if (PlatformXR::isImmersive(mode)) {
-        MESSAGE_CHECK_COMPLETION(m_immersiveSessionState == ImmersiveSessionState::Idle, connection, completionHandler({ }));
+        MESSAGE_CHECK_COMPLETION(m_immersiveSessionState == ImmersiveSessionState::Idle || m_immersiveSessionState == ImmersiveSessionState::SessionEndingFromWebContent, connection, completionHandler({ }));
         setImmersiveSessionState(ImmersiveSessionState::RequestingPermissions, [](bool) mutable { });
         m_immersiveSessionGrantedFeatures = std::nullopt;
     }
@@ -316,11 +316,8 @@ void PlatformXRSystem::setImmersiveSessionState(ImmersiveSessionState state, Com
     case ImmersiveSessionState::SessionEndingFromSystem:
         break;
     }
-
-    completion(true);
-#else
-    completion(true);
 #endif
+    completion(true);
 }
 
 void PlatformXRSystem::invalidateImmersiveSessionState(ImmersiveSessionState nextSessionState)

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.h
@@ -23,11 +23,30 @@
 
 #include "OpenXRUtils.h"
 
+typedef void* EGLDisplay;
+typedef void* EGLContext;
+typedef void* EGLConfig;
+typedef unsigned EGLenum;
+#if defined(XR_USE_PLATFORM_EGL)
+typedef void (*(*PFNEGLGETPROCADDRESSPROC)(const char *))(void);
+#endif
+#include <openxr/openxr_platform.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace WebKit {
+
+struct OpenXRExtensionMethods {
+    WTF_MAKE_FAST_ALLOCATED(OpenXRExtensionMethods);
+public:
+#if defined(XR_USE_PLATFORM_EGL)
+    PFNEGLGETPROCADDRESSPROC getProcAddressFunc { nullptr };
+#endif
+#if defined(XR_USE_GRAPHICS_API_OPENGL_ES)
+    PFN_xrGetOpenGLESGraphicsRequirementsKHR xrGetOpenGLESGraphicsRequirementsKHR { nullptr };
+#endif
+};
 
 class OpenXRExtensions final {
     WTF_MAKE_TZONE_ALLOCATED(OpenXRExtensions);
@@ -37,9 +56,8 @@ public:
     OpenXRExtensions(Vector<XrExtensionProperties>&&);
     ~OpenXRExtensions();
 
-    void loadMethods(XrInstance);
+    bool loadMethods(XrInstance);
     bool isExtensionSupported(std::span<const char>) const;
-    struct OpenXRExtensionMethods;
     const OpenXRExtensionMethods& methods() const { return *m_methods; }
 
 private:


### PR DESCRIPTION
#### 12938589f723f90a88f566ff6ba314aa4782cd79
<pre>
[WEBXR][GTK][WPE] Implement startSession/endSession in the PlatformXRCoordinator
<a href="https://bugs.webkit.org/show_bug.cgi?id=295281">https://bugs.webkit.org/show_bug.cgi?id=295281</a>

Reviewed by Adrian Perez de Castro.

Provides an OpenXR implementation for starting/ending XR sessions. This involves
creating a XrSession using a surfaceless display with an offscreen context.
This commit provides an early version of an OpenXR render loop that is able
to poll OpenXR events related to the session lifetime and handle them
accordingly (like terminating the session). This render loop runs in a
different thread and will be eventually used to submit frames to the OpenXR
runtime.

There are still several missing blocks, like swapchains, reference spaces,
input sources, or actions that will be added in follow-up patches.

* Source/WebKit/UIProcess/API/APIUIClient.h: enable permission request
calls in !COCOA.
* Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp:
(WebKit::PlatformXRSystem::requestPermissionOnSessionFeatures): fixed a message
check assertion. Sessions ended from web contents do not transition to idle state.
(WebKit::PlatformXRSystem::setImmersiveSessionState): simplified code.
* Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.cpp:
(WebKit::OpenXRExtensions::loadMethods): get proc addrs for OpenGLES.
(): Deleted.
* Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.h:
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp:
(WebKit::OpenXRCoordinator::~OpenXRCoordinator): destroy session.
(WebKit::OpenXRCoordinator::requestPermissionOnSessionFeatures): added.
(WebKit::OpenXRCoordinator::startSession): ditto.
(WebKit::OpenXRCoordinator::endSessionIfExists): ditto.
(WebKit::OpenXRCoordinator::createInstance): check EGL extension
availability before using it.
(WebKit::OpenXRCoordinator::initializeDevice): call loadMethods()
(WebKit::OpenXRCoordinator::initializeGraphicsBinding): added.
(WebKit::OpenXRCoordinator::createSessionIfNeeded): ditto.
(WebKit::OpenXRCoordinator::handleSessionStateChange): ditto.
(WebKit::OpenXRCoordinator::pollEvents): ditto.
(WebKit::OpenXRCoordinator::renderLoop): ditto.
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h:

Canonical link: <a href="https://commits.webkit.org/296971@main">https://commits.webkit.org/296971@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b48f2c2301c321805156ede9f635e6cde8a3c255

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110120 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29779 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20211 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116142 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60368 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30457 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38366 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83724 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113068 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed webkitperl tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24291 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99169 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64168 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23658 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59938 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93667 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17361 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118933 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37160 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27546 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92697 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37532 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95437 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92520 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23581 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37511 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15247 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33043 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37054 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42525 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36716 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40056 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38425 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->