### PR TITLE
ANGLE: Avoid computing shader cache key if cacheCompiledShader is not used

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/Shader.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/Shader.cpp
@@ -699,12 +699,12 @@ void Shader::compile(const Context *context, angle::JobResultExpectancy resultEx
 
     // Find a shader in Blob Cache
     Compiler *compiler = context->getCompiler();
-    setShaderKey(context, options, compiler->getShaderOutputType(),
-                 compiler->getBuiltInResources());
-    ASSERT(!mShaderHash.empty());
     MemoryShaderCache *shaderCache = context->getMemoryShaderCache();
     if (shaderCache != nullptr)
     {
+        setShaderKey(context, options, compiler->getShaderOutputType(),
+                 compiler->getBuiltInResources());
+        ASSERT(!mShaderHash.empty());
         egl::CacheGetResult result =
             shaderCache->getShader(context, this, mShaderHash, resultExpectancy);
         switch (result)
@@ -784,6 +784,7 @@ void Shader::resolveCompile(const Context *context)
             MemoryShaderCache *shaderCache = context->getMemoryShaderCache();
             if (shaderCache != nullptr)
             {
+                ASSERT(!mShaderHash.empty());
                 // Save to the shader cache.
                 if (shaderCache->putShader(context, mShaderHash, this) != angle::Result::Continue)
                 {


### PR DESCRIPTION
#### 9bb2b0c8e75b881aeb1775a24eebbf3ee65754a0
<pre>
ANGLE: Avoid computing shader cache key if cacheCompiledShader is not used
<a href="https://bugs.webkit.org/show_bug.cgi?id=295324">https://bugs.webkit.org/show_bug.cgi?id=295324</a>

Reviewed by NOBODY (OOPS!).

The shader is saved to frontend cache only if the cacheCompiledShader
feature is used. It&apos;s not used for Metal at the moment.

Speeds up the PerformanceTests/Canvas/WebGL-compileShader by ~5%

* Source/ThirdParty/ANGLE/src/libANGLE/Shader.cpp:
(gl::Shader::compile):
(gl::Shader::resolveCompile):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bb2b0c8e75b881aeb1775a24eebbf3ee65754a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109953 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29611 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20043 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115975 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60201 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38199 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83586 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112901 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24145 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99011 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64028 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23516 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17160 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59769 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93517 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17202 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118766 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36992 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27415 "Found 60 new test failures: css3/filters/blur-clipped-by-ancestor.html fast/canvas/webgl/attrib-location-length-limits.html fast/canvas/webgl/debug-messages-to-console.html fast/canvas/webgl/gl-object-get-calls.html fast/canvas/webgl/gl-uniform-arrays.html fast/canvas/webgl/glsl-sampler-array-unused-element.html fast/canvas/webgl/program-test.html fast/canvas/webgl/texture-npot.html fast/canvas/webgl/uniform-location-length-limits.html fast/canvas/webgl/uniform-location.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92562 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37365 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95278 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92386 "Found 2 new API test failures: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37367 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15102 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32864 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36887 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36548 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39889 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38256 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->