### PR TITLE
object-fit: scale-down is ignored when srcset attribute and w descriptor is used

### DIFF
--- a/LayoutTests/fast/hidpi/image-srcset-fit-scale-down-expected.html
+++ b/LayoutTests/fast/hidpi/image-srcset-fit-scale-down-expected.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<style>
+img {
+  object-fit: scale-down;
+  object-position: 0 0;
+}
+div {
+    width: 1000px;
+    height: 1000px;
+    background-color: blue;
+}
+</style>
+<div>
+<img src="resources/green-400-px-square.png">
+</img>
+</div>

--- a/LayoutTests/fast/hidpi/image-srcset-fit-scale-down.html
+++ b/LayoutTests/fast/hidpi/image-srcset-fit-scale-down.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<style>
+img {
+  object-fit: scale-down;
+  object-position: 0 0;
+}
+div {
+    width: 1000px;
+    height: 1000px;
+    background-color: blue;
+}
+</style>
+<div>
+<img src="resources/blue-100-px-square.png"
+     srcset="resources/blue-100-px-square.png 100w,
+             resources/green-400-px-square.png 400w">
+</img>
+</div>


### PR DESCRIPTION
#### ec4f65f46d4515eb50ef2206085d8bb0a58ee5a9
<pre>
object-fit: scale-down is ignored when srcset attribute and w descriptor is used
<a href="https://bugs.webkit.org/show_bug.cgi?id=295203">https://bugs.webkit.org/show_bug.cgi?id=295203</a>
<a href="https://rdar.apple.com/154687132">rdar://154687132</a>

Reviewed by Simon Fraser.

This patch aligns WebKit with Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/80441f0a1eb089bf4e9d755a7af5c3bfd3b787ec">https://chromium.googlesource.com/chromium/src.git/+/80441f0a1eb089bf4e9d755a7af5c3bfd3b787ec</a>

The object-fit: scale-down property requires that the image be
sized to the smaller of &quot;none&quot; or &quot;contain&quot;. When a srcset is used,
the intrinsicSize of the image is scaled such that the srcset fills
the expected area. This causes scale-down to consider the intrinsic
size to be bigger than the actual image, and size things too large.

This change modifies the intrinsic size for content-fit: scale-down
in RenderReplaced::replacedContentRect to un-apply the
imageDevicePixelRatio, that is the scale that resized the src.

* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::computeAspectRatioInformationForRenderBox):
(WebCore::RenderReplaced::replacedContentRect):
* LayoutTests/fast/hidpi/image-srcset-fit-scale-down.html:
* LayoutTests/fast/hidpi/image-srcset-fit-scale-down-expected.html:

Canonical link: <a href="https://commits.webkit.org/296914@main">https://commits.webkit.org/296914@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a73ee5f63f1baa2c9fe33782513797c282ccb65

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20046 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115978 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60204 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111919 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30292 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38202 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83590 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112904 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24150 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99018 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64032 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23526 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17167 "Found 2 new test failures: fast/css/css-typed-om/css-builder-converter-clip-viewport-dimension-without-renderview-crash.html http/tests/media/media-element-frame-destroyed-crash.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59772 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93522 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17210 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118769 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36995 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27419 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92566 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37368 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95286 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92390 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23542 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37370 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15116 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32867 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36890 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42361 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36551 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39892 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38259 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->