### PR TITLE
[GTK4] Gamepad tests are timing out when run with run-webkit-tests

### DIFF
--- a/LayoutTests/platform/gtk4/TestExpectations
+++ b/LayoutTests/platform/gtk4/TestExpectations
@@ -44,8 +44,6 @@ webkit.org/b/277426 editing/async-clipboard/clipboard-read-text-same-origin.html
 
 webkit.org/b/277427 fast/events/drag-and-drop-link-fast-multiple-times-does-not-crash.html [ Skip ] # Timeout
 
-webkit.org/b/279016 gamepad/ [ Skip ] # Timing out, seemingly due to lack of sandbox permissions, see bug for details.
-
 #//////////////////////////////////////////////////////////////////////////////////////////
 # Triaged Expectations
 # * KEEP THE SECTIONS SORTED ALPHABETICALLY.

--- a/Source/WebKit/UIProcess/Gamepad/gtk/UIGamepadProviderGtk.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/gtk/UIGamepadProviderGtk.cpp
@@ -71,6 +71,14 @@ static WebPageProxy* getWebPageProxy(GtkWidget* widget)
 WebPageProxy* UIGamepadProvider::platformWebPageProxyForGamepadInput()
 {
     GUniquePtr<GList> toplevels(gtk_window_list_toplevels());
+
+    // Work around for WebKitTestRunner.
+    // If there's only one toplevel window available, try to get WebPageProxy from that window.
+    if (g_list_length(toplevels.get()) == 1) {
+        WebPageProxy* proxy = getWebPageProxy(GTK_WIDGET(toplevels.get()->data));
+        return proxy ? proxy : nullptr;
+    }
+
     for (GList* iter = toplevels.get(); iter; iter = g_list_next(iter)) {
         if (!WebCore::widgetIsOnscreenToplevelWindow(GTK_WIDGET(iter->data)))
             continue;


### PR DESCRIPTION
#### fa9069a83eb0d230c8cb3e671a1061aef44e0b03
<pre>
[GTK4] Gamepad tests are timing out when run with run-webkit-tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=279016">https://bugs.webkit.org/show_bug.cgi?id=279016</a>

Reviewed by NOBODY (OOPS!).

When running gamepad tests on WebKitTestRunner, the tests timeout
because during a loop throughout toplevel windows to retrieve the
WebPageProxy associated to a window, no active window is found.

However, when running tests, there&apos;s actually only one toplevel
window available so there&apos;s no need to iterate through a loop,
just simply try to retrieve the WebPageProxy from that window.

* LayoutTests/platform/gtk4/TestExpectations:
* Source/WebKit/UIProcess/Gamepad/gtk/UIGamepadProviderGtk.cpp:
(WebKit::UIGamepadProvider::platformWebPageProxyForGamepadInput):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa9069a83eb0d230c8cb3e671a1061aef44e0b03

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109959 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20049 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115981 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60207 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38205 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83593 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112907 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24153 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99023 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64035 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23524 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17171 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59775 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93525 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17213 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118772 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36998 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27421 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92568 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37371 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95289 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92392 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37374 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15109 "Found 1 new test failure: fast/animation/css-animation-resuming-when-visible-with-style-change2.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32870 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36893 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42364 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36554 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39895 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38262 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->