### PR TITLE
StabilityTracer: com.apple.WebKit.GPU at WebCore:  void std::__1::map<std::__1::pair<WTF::MediaTime, WTF::MediaTime>, WTF::Ref<WebCore::MediaSample, WTF::RawPtrTraits<WebCore::MediaSample>

### DIFF
--- a/LayoutTests/media/media-source/media-source-append-overlapping-dts-expected.txt
+++ b/LayoutTests/media/media-source/media-source-append-overlapping-dts-expected.txt
@@ -9,15 +9,12 @@ RUN(sourceBuffer.appendBuffer(samples))
 EVENT(updateend)
 RUN(sourceBuffer.appendBuffer(samples))
 EVENT(updateend)
-EXPECTED (bufferedSamples.length == '9') OK
+EXPECTED (bufferedSamples.length == '6') OK
 {PTS({0/1 = 0.000000}), DTS({0/1 = 0.000000}), duration({1/1 = 1.000000}), flags(1), generation(0)}
 {PTS({1/1 = 1.000000}), DTS({1/1 = 1.000000}), duration({1/1 = 1.000000}), flags(0), generation(0)}
 {PTS({2/1 = 2.000000}), DTS({2/1 = 2.000000}), duration({1/1 = 1.000000}), flags(0), generation(0)}
 {PTS({3/1 = 3.000000}), DTS({3/1 = 3.000000}), duration({1/1 = 1.000000}), flags(0), generation(0)}
 {PTS({4/1 = 4.000000}), DTS({4/1 = 4.000000}), duration({1/1 = 1.000000}), flags(1), generation(0)}
 {PTS({6/1 = 6.000000}), DTS({4/1 = 4.000000}), duration({1/1 = 1.000000}), flags(1), generation(1)}
-{PTS({7/1 = 7.000000}), DTS({5/1 = 5.000000}), duration({1/1 = 1.000000}), flags(0), generation(1)}
-{PTS({4/1 = 4.000000}), DTS({6/1 = 6.000000}), duration({1/1 = 1.000000}), flags(0), generation(1)}
-{PTS({5/1 = 5.000000}), DTS({7/1 = 7.000000}), duration({1/1 = 1.000000}), flags(0), generation(1)}
 END OF TEST
 

--- a/LayoutTests/media/media-source/media-source-append-overlapping-dts.html
+++ b/LayoutTests/media/media-source/media-source-append-overlapping-dts.html
@@ -41,15 +41,12 @@
 
         samples = concatenateSamples([
             makeASample(6, 4, 1, 1, 1, SAMPLE_FLAG.SYNC, 1),
-            makeASample(7, 5, 1, 1, 1, SAMPLE_FLAG.NONE, 1),
-            makeASample(4, 6, 1, 1, 1, SAMPLE_FLAG.NONE, 1),
-            makeASample(5, 7, 1, 1, 1, SAMPLE_FLAG.NONE, 1),
         ]);
         run('sourceBuffer.appendBuffer(samples)');
         await waitFor(sourceBuffer, 'updateend');
 
         bufferedSamples = await internals.bufferedSamplesForTrackId(sourceBuffer, 1);
-        testExpected("bufferedSamples.length", 9);
+        testExpected("bufferedSamples.length", 6);
         bufferedSamples.forEach(consoleWrite);
         endTest();
 

--- a/Source/WebCore/Modules/mediasource/SampleMap.cpp
+++ b/Source/WebCore/Modules/mediasource/SampleMap.cpp
@@ -139,17 +139,18 @@ PresentationOrderSampleMap::iterator PresentationOrderSampleMap::findSampleWithP
 
 PresentationOrderSampleMap::iterator PresentationOrderSampleMap::findSampleContainingPresentationTime(const MediaTime& time)
 {
+    if (m_samples.empty())
+        return end();
+
     // upper_bound will return the first sample whose presentation start time is greater than the search time.
     // If this is the first sample, that means no sample in the map contains the requested time.
     auto iter = m_samples.upper_bound(time);
     if (iter == begin())
         return end();
-
     // Look at the previous sample; does it contain the requested time?
-    --iter;
-    const auto& sample = iter->second;
+    Ref sample = std::prev(iter)->second;
     if (sample->presentationTime() + sample->duration() > time)
-        return iter;
+        return std::prev(iter);
     return end();
 }
 
@@ -165,11 +166,10 @@ PresentationOrderSampleMap::iterator PresentationOrderSampleMap::findSampleConta
         return iter;
 
     // Look at the previous sample; does it contain the requested time?
-    --iter;
-    const auto& sample = iter->second;
+    Ref sample = std::prev(iter)->second;
     if (sample->presentationTime() + sample->duration() > time)
-        return iter;
-    return ++iter;
+        return std::prev(iter);
+    return iter;
 }
 
 PresentationOrderSampleMap::iterator PresentationOrderSampleMap::findSampleStartingOnOrAfterPresentationTime(const MediaTime& time)
@@ -217,7 +217,7 @@ PresentationOrderSampleMap::reverse_iterator PresentationOrderSampleMap::reverse
         return rend();
 
     // Otherwise, return the sample immediately previous to the one found.
-    return --reverse_iterator(--found);
+    return std::prev(reverse_iterator(std::prev(found)));
 }
 
 DecodeOrderSampleMap::reverse_iterator DecodeOrderSampleMap::reverseFindSampleWithDecodeKey(const KeyType& key)
@@ -225,7 +225,7 @@ DecodeOrderSampleMap::reverse_iterator DecodeOrderSampleMap::reverseFindSampleWi
     DecodeOrderSampleMap::iterator found = findSampleWithDecodeKey(key);
     if (found == end())
         return rend();
-    return --reverse_iterator(found);
+    return std::prev(reverse_iterator(found));
 }
 
 DecodeOrderSampleMap::reverse_iterator DecodeOrderSampleMap::findSyncSamplePriorToPresentationTime(const MediaTime& time, const MediaTime& threshold)
@@ -234,7 +234,7 @@ DecodeOrderSampleMap::reverse_iterator DecodeOrderSampleMap::findSyncSamplePrior
     if (reverseCurrentSamplePTS == m_presentationOrder.rend())
         return rend();
 
-    const auto& sample = reverseCurrentSamplePTS->second;
+    Ref sample = reverseCurrentSamplePTS->second;
     reverse_iterator reverseCurrentSampleDTS = reverseFindSampleWithDecodeKey(KeyType(sample->decodeTime(), sample->presentationTime()));
 
     reverse_iterator foundSample = findSyncSamplePriorToDecodeIterator(reverseCurrentSampleDTS);
@@ -256,7 +256,7 @@ DecodeOrderSampleMap::iterator DecodeOrderSampleMap::findSyncSampleAfterPresenta
     if (currentSamplePTS == m_presentationOrder.end())
         return end();
 
-    const auto& sample = currentSamplePTS->second;
+    Ref sample = currentSamplePTS->second;
     iterator currentSampleDTS = findSampleWithDecodeKey(KeyType(sample->decodeTime(), sample->presentationTime()));
     
     MediaTime upperBound = time + threshold;
@@ -312,7 +312,7 @@ DecodeOrderSampleMap::reverse_iterator_range DecodeOrderSampleMap::findDependent
 
 DecodeOrderSampleMap::iterator_range DecodeOrderSampleMap::findSamplesBetweenDecodeKeys(const KeyType& beginKey, const KeyType& endKey)
 {
-    if (beginKey > endKey)
+    if (beginKey >= endKey)
         return { end(), end() };
 
     // beginKey is inclusive, so use lower_bound to include samples wich start exactly at beginKey.

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -1144,7 +1144,7 @@ bool SourceBufferPrivate::processMediaSample(SourceBufferPrivateClient& client, 
             // a decode error if left in place, so remove these samples as well.
             DecodeOrderSampleMap::KeyType decodeKey(sample->decodeTime(), sample->presentationTime());
             auto samplesWithHigherDecodeTimes = trackBuffer.samples().decodeOrder().findSamplesBetweenDecodeKeys(decodeKey, erasedSamples.decodeOrder().begin()->first);
-            if (samplesWithHigherDecodeTimes.first != samplesWithHigherDecodeTimes.second)
+            if (samplesWithHigherDecodeTimes.first != trackBuffer.samples().decodeOrder().end() && samplesWithHigherDecodeTimes.first != samplesWithHigherDecodeTimes.second)
                 dependentSamples.insert(samplesWithHigherDecodeTimes.first, samplesWithHigherDecodeTimes.second);
 
             PlatformTimeRanges erasedRanges = removeSamplesFromTrackBuffer(dependentSamples, trackBuffer, "didReceiveSample"_s);

--- a/Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp
@@ -52,7 +52,7 @@ public:
     {
         return adoptRef(*new TestSample(presentationTime, decodeTime, duration, flags));
     }
-    
+
     MediaTime presentationTime() const final { return m_presentationTime; }
     MediaTime decodeTime() const final { return m_decodeTime; }
     MediaTime duration() const final { return m_duration; }
@@ -95,25 +95,35 @@ class SampleMapTest : public testing::Test {
 public:
     void SetUp() final {
         map.addSample(TestSample::create(MediaTime(0, 1), MediaTime(0, 1), MediaTime(1, 1), MediaSample::IsSync));
-        map.addSample(TestSample::create(MediaTime(1, 1), MediaTime(0, 1), MediaTime(1, 1), MediaSample::None));
-        map.addSample(TestSample::create(MediaTime(2, 1), MediaTime(0, 1), MediaTime(1, 1), MediaSample::None));
-        map.addSample(TestSample::create(MediaTime(3, 1), MediaTime(0, 1), MediaTime(1, 1), MediaSample::None));
-        map.addSample(TestSample::create(MediaTime(4, 1), MediaTime(0, 1), MediaTime(1, 1), MediaSample::None));
-        map.addSample(TestSample::create(MediaTime(5, 1), MediaTime(0, 1), MediaTime(1, 1), MediaSample::IsSync));
-        map.addSample(TestSample::create(MediaTime(6, 1), MediaTime(0, 1), MediaTime(1, 1), MediaSample::None));
-        map.addSample(TestSample::create(MediaTime(7, 1), MediaTime(0, 1), MediaTime(1, 1), MediaSample::None));
-        map.addSample(TestSample::create(MediaTime(8, 1), MediaTime(0, 1), MediaTime(1, 1), MediaSample::None));
-        map.addSample(TestSample::create(MediaTime(9, 1), MediaTime(0, 1), MediaTime(1, 1), MediaSample::None));
+        map.addSample(TestSample::create(MediaTime(1, 1), MediaTime(1, 1), MediaTime(1, 1), MediaSample::None));
+        map.addSample(TestSample::create(MediaTime(2, 1), MediaTime(2, 1), MediaTime(1, 1), MediaSample::None));
+        map.addSample(TestSample::create(MediaTime(3, 1), MediaTime(3, 1), MediaTime(1, 1), MediaSample::None));
+        map.addSample(TestSample::create(MediaTime(4, 1), MediaTime(4, 1), MediaTime(1, 1), MediaSample::None));
+        map.addSample(TestSample::create(MediaTime(5, 1), MediaTime(5, 1), MediaTime(1, 1), MediaSample::IsSync));
+        map.addSample(TestSample::create(MediaTime(6, 1), MediaTime(6, 1), MediaTime(1, 1), MediaSample::None));
+        map.addSample(TestSample::create(MediaTime(7, 1), MediaTime(7, 1), MediaTime(1, 1), MediaSample::None));
+        map.addSample(TestSample::create(MediaTime(8, 1), MediaTime(8, 1), MediaTime(1, 1), MediaSample::None));
+        map.addSample(TestSample::create(MediaTime(9, 1), MediaTime(9, 1), MediaTime(1, 1), MediaSample::None));
         // Gap at MediaTime(10, 1) -> MediaTime(11, 1);
-        map.addSample(TestSample::create(MediaTime(11, 1), MediaTime(0, 1), MediaTime(1, 1), MediaSample::IsSync));
-        map.addSample(TestSample::create(MediaTime(12, 1), MediaTime(0, 1), MediaTime(1, 1), MediaSample::None));
-        map.addSample(TestSample::create(MediaTime(13, 1), MediaTime(0, 1), MediaTime(1, 1), MediaSample::None));
-        map.addSample(TestSample::create(MediaTime(14, 1), MediaTime(0, 1), MediaTime(1, 1), MediaSample::None));
-        map.addSample(TestSample::create(MediaTime(15, 1), MediaTime(0, 1), MediaTime(1, 1), MediaSample::IsSync));
-        map.addSample(TestSample::create(MediaTime(16, 1), MediaTime(0, 1), MediaTime(1, 1), MediaSample::None));
-        map.addSample(TestSample::create(MediaTime(17, 1), MediaTime(0, 1), MediaTime(1, 1), MediaSample::None));
-        map.addSample(TestSample::create(MediaTime(18, 1), MediaTime(0, 1), MediaTime(1, 1), MediaSample::None));
-        map.addSample(TestSample::create(MediaTime(19, 1), MediaTime(0, 1), MediaTime(1, 1), MediaSample::None));
+        map.addSample(TestSample::create(MediaTime(11, 1), MediaTime(11, 1), MediaTime(1, 1), MediaSample::IsSync));
+        map.addSample(TestSample::create(MediaTime(12, 1), MediaTime(12, 1), MediaTime(1, 1), MediaSample::None));
+        map.addSample(TestSample::create(MediaTime(13, 1), MediaTime(13, 1), MediaTime(1, 1), MediaSample::None));
+        map.addSample(TestSample::create(MediaTime(14, 1), MediaTime(14, 1), MediaTime(1, 1), MediaSample::None));
+        map.addSample(TestSample::create(MediaTime(15, 1), MediaTime(15, 1), MediaTime(1, 1), MediaSample::IsSync));
+        map.addSample(TestSample::create(MediaTime(16, 1), MediaTime(16, 1), MediaTime(1, 1), MediaSample::None));
+        map.addSample(TestSample::create(MediaTime(17, 1), MediaTime(17, 1), MediaTime(1, 1), MediaSample::None));
+        map.addSample(TestSample::create(MediaTime(18, 1), MediaTime(18, 1), MediaTime(1, 1), MediaSample::None));
+        map.addSample(TestSample::create(MediaTime(19, 1), MediaTime(19, 1), MediaTime(1, 1), MediaSample::None));
+        // Some B-frames
+        map.addSample(TestSample::create(MediaTime(20, 1), MediaTime(20, 1), MediaTime(1, 1), MediaSample::IsSync));
+        map.addSample(TestSample::create(MediaTime(23, 1), MediaTime(21, 1), MediaTime(1, 1), MediaSample::None));
+        map.addSample(TestSample::create(MediaTime(22, 1), MediaTime(22, 1), MediaTime(1, 1), MediaSample::None));
+        map.addSample(TestSample::create(MediaTime(21, 1), MediaTime(23, 1), MediaTime(1, 1), MediaSample::None));
+        map.addSample(TestSample::create(MediaTime(24, 1), MediaTime(24, 1), MediaTime(1, 1), MediaSample::IsSync));
+        map.addSample(TestSample::create(MediaTime(28, 1), MediaTime(25, 1), MediaTime(1, 1), MediaSample::None));
+        map.addSample(TestSample::create(MediaTime(27, 1), MediaTime(26, 1), MediaTime(1, 1), MediaSample::None));
+        map.addSample(TestSample::create(MediaTime(26, 1), MediaTime(27, 1), MediaTime(1, 1), MediaSample::None));
+        map.addSample(TestSample::create(MediaTime(25, 1), MediaTime(28, 1), MediaTime(1, 1), MediaSample::None));
     }
 
     SampleMap map;
@@ -124,9 +134,10 @@ TEST_F(SampleMapTest, findSampleWithPresentationTime)
     auto& presentationMap = map.presentationOrder();
     EXPECT_EQ(MediaTime(0, 1), presentationMap.findSampleWithPresentationTime(MediaTime(0, 1))->second->presentationTime());
     EXPECT_EQ(MediaTime(19, 1), presentationMap.findSampleWithPresentationTime(MediaTime(19, 1))->second->presentationTime());
+    EXPECT_EQ(MediaTime(26, 1), presentationMap.findSampleWithPresentationTime(MediaTime(26, 1))->second->presentationTime());
     EXPECT_TRUE(presentationMap.end() == presentationMap.findSampleWithPresentationTime(MediaTime(-1, 1)));
     EXPECT_TRUE(presentationMap.end() == presentationMap.findSampleWithPresentationTime(MediaTime(10, 1)));
-    EXPECT_TRUE(presentationMap.end() == presentationMap.findSampleWithPresentationTime(MediaTime(20, 1)));
+    EXPECT_TRUE(presentationMap.end() == presentationMap.findSampleWithPresentationTime(MediaTime(29, 1)));
     EXPECT_TRUE(presentationMap.end() == presentationMap.findSampleWithPresentationTime(MediaTime(1, 2)));
 }
 
@@ -136,9 +147,10 @@ TEST_F(SampleMapTest, findSampleContainingPresentationTime)
     EXPECT_EQ(MediaTime(0, 1), presentationMap.findSampleContainingPresentationTime(MediaTime(0, 1))->second->presentationTime());
     EXPECT_EQ(MediaTime(19, 1), presentationMap.findSampleContainingPresentationTime(MediaTime(19, 1))->second->presentationTime());
     EXPECT_EQ(MediaTime(0, 1), presentationMap.findSampleContainingPresentationTime(MediaTime(1, 2))->second->presentationTime());
+    EXPECT_EQ(MediaTime(26, 1), presentationMap.findSampleContainingPresentationTime(MediaTime(26, 1) + MediaTime(1, 2))->second->presentationTime());
     EXPECT_TRUE(presentationMap.end() == presentationMap.findSampleContainingPresentationTime(MediaTime(-1, 1)));
-    EXPECT_TRUE(presentationMap.end() == presentationMap.findSampleContainingPresentationTime(MediaTime(10, 1)));
-    EXPECT_TRUE(presentationMap.end() == presentationMap.findSampleContainingPresentationTime(MediaTime(20, 1)));
+    EXPECT_TRUE(presentationMap.end() == presentationMap.findSampleContainingPresentationTime(MediaTime(29, 1)));
+    EXPECT_TRUE(presentationMap.end() == presentationMap.findSampleContainingPresentationTime(MediaTime(30, 1)));
 }
 
 TEST_F(SampleMapTest, findSampleStartingOnOrAfterPresentationTime)
@@ -149,7 +161,9 @@ TEST_F(SampleMapTest, findSampleStartingOnOrAfterPresentationTime)
     EXPECT_EQ(MediaTime(1, 1), presentationMap.findSampleStartingOnOrAfterPresentationTime(MediaTime(1, 2))->second->presentationTime());
     EXPECT_EQ(MediaTime(0, 1), presentationMap.findSampleStartingOnOrAfterPresentationTime(MediaTime(-1, 1))->second->presentationTime());
     EXPECT_EQ(MediaTime(11, 1), presentationMap.findSampleStartingOnOrAfterPresentationTime(MediaTime(10, 1))->second->presentationTime());
-    EXPECT_TRUE(presentationMap.end() == presentationMap.findSampleContainingPresentationTime(MediaTime(20, 1)));
+    EXPECT_EQ(MediaTime(25, 1), presentationMap.findSampleStartingOnOrAfterPresentationTime(MediaTime(25, 1))->second->presentationTime());
+    EXPECT_EQ(MediaTime(26, 1), presentationMap.findSampleStartingOnOrAfterPresentationTime(MediaTime(25, 1) + MediaTime(1, 2))->second->presentationTime());
+    EXPECT_TRUE(presentationMap.end() == presentationMap.findSampleStartingOnOrAfterPresentationTime(MediaTime(30, 1)));
 }
 
 TEST_F(SampleMapTest, findSampleContainingOrAfterPresentationTime)
@@ -160,19 +174,23 @@ TEST_F(SampleMapTest, findSampleContainingOrAfterPresentationTime)
     EXPECT_EQ(MediaTime(0, 1), presentationMap.findSampleContainingOrAfterPresentationTime(MediaTime(1, 2))->second->presentationTime());
     EXPECT_EQ(MediaTime(0, 1), presentationMap.findSampleContainingOrAfterPresentationTime(MediaTime(-1, 1))->second->presentationTime());
     EXPECT_EQ(MediaTime(11, 1), presentationMap.findSampleContainingOrAfterPresentationTime(MediaTime(10, 1))->second->presentationTime());
-    EXPECT_TRUE(presentationMap.end() == presentationMap.findSampleContainingOrAfterPresentationTime(MediaTime(20, 1)));
+    EXPECT_EQ(MediaTime(26, 1), presentationMap.findSampleContainingOrAfterPresentationTime(MediaTime(26, 1))->second->presentationTime());
+    EXPECT_EQ(MediaTime(25, 1), presentationMap.findSampleContainingOrAfterPresentationTime(MediaTime(25, 1) + MediaTime(1, 2))->second->presentationTime());
+    EXPECT_TRUE(presentationMap.end() == presentationMap.findSampleContainingOrAfterPresentationTime(MediaTime(30, 1)));
 }
 
 TEST_F(SampleMapTest, findSampleStartingAfterPresentationTime)
 {
     auto& presentationMap = map.presentationOrder();
     EXPECT_EQ(MediaTime(1, 1), presentationMap.findSampleStartingAfterPresentationTime(MediaTime(0, 1))->second->presentationTime());
-    EXPECT_TRUE(presentationMap.end() == presentationMap.findSampleStartingAfterPresentationTime(MediaTime(19, 1)));
     EXPECT_EQ(MediaTime(1, 1), presentationMap.findSampleStartingAfterPresentationTime(MediaTime(1, 2))->second->presentationTime());
     EXPECT_EQ(MediaTime(0, 1), presentationMap.findSampleStartingAfterPresentationTime(MediaTime(-1, 1))->second->presentationTime());
     EXPECT_EQ(MediaTime(11, 1), presentationMap.findSampleStartingAfterPresentationTime(MediaTime(10, 1))->second->presentationTime());
-    EXPECT_TRUE(presentationMap.end() == presentationMap.findSampleStartingAfterPresentationTime(MediaTime(20, 1)));
+    EXPECT_EQ(MediaTime(23, 1), presentationMap.findSampleStartingAfterPresentationTime(MediaTime(22, 1))->second->presentationTime());
+    EXPECT_EQ(MediaTime(26, 1), presentationMap.findSampleStartingAfterPresentationTime(MediaTime(25, 1))->second->presentationTime());
+    EXPECT_TRUE(presentationMap.end() == presentationMap.findSampleStartingAfterPresentationTime(MediaTime(30, 1)));
 }
+
 TEST_F(SampleMapTest, findSamplesBetweenPresentationTimes)
 {
     auto& presentationMap = map.presentationOrder();
@@ -184,7 +202,16 @@ TEST_F(SampleMapTest, findSamplesBetweenPresentationTimes)
     EXPECT_EQ(MediaTime(1, 1), iterator_range.first->second->presentationTime());
     EXPECT_EQ(MediaTime(2, 1), iterator_range.second->second->presentationTime());
 
-    iterator_range = presentationMap.findSamplesBetweenPresentationTimes(MediaTime(9, 1), MediaTime(21, 1));
+    iterator_range = presentationMap.findSamplesBetweenPresentationTimes(MediaTime(19, 1), MediaTime(25, 1));
+    EXPECT_EQ(MediaTime(19, 1), iterator_range.first->second->presentationTime());
+    EXPECT_EQ(MediaTime(25, 1), iterator_range.second->second->presentationTime());
+    MediaTime currentTime = iterator_range.first->second->presentationTime();
+    for (auto it = iterator_range.first; it != iterator_range.second; ++it) {
+        EXPECT_EQ(it->second->presentationTime(), currentTime);
+        currentTime += MediaTime { 1, 1 };
+    }
+
+    iterator_range = presentationMap.findSamplesBetweenPresentationTimes(MediaTime(9, 1), MediaTime(31, 1));
     EXPECT_EQ(MediaTime(9, 1), iterator_range.first->second->presentationTime());
     EXPECT_TRUE(presentationMap.end() == iterator_range.second);
 
@@ -196,7 +223,7 @@ TEST_F(SampleMapTest, findSamplesBetweenPresentationTimes)
     EXPECT_TRUE(presentationMap.end() == iterator_range.first);
     EXPECT_TRUE(presentationMap.end() == iterator_range.second);
 
-    iterator_range = presentationMap.findSamplesBetweenPresentationTimes(MediaTime(20, 1), MediaTime(21, 1));
+    iterator_range = presentationMap.findSamplesBetweenPresentationTimes(MediaTime(30, 1), MediaTime(31, 1));
     EXPECT_TRUE(presentationMap.end() == iterator_range.first);
     EXPECT_TRUE(presentationMap.end() == iterator_range.second);
 }
@@ -212,7 +239,16 @@ TEST_F(SampleMapTest, findSamplesBetweenPresentationTimesFromEnd)
     EXPECT_EQ(MediaTime(1, 1), iterator_range.first->second->presentationTime());
     EXPECT_EQ(MediaTime(2, 1), iterator_range.second->second->presentationTime());
 
-    iterator_range = presentationMap.findSamplesBetweenPresentationTimesFromEnd(MediaTime(9, 1), MediaTime(21, 1));
+    iterator_range = presentationMap.findSamplesBetweenPresentationTimesFromEnd(MediaTime(19, 1), MediaTime(25, 1));
+    EXPECT_EQ(MediaTime(19, 1), iterator_range.first->second->presentationTime());
+    EXPECT_EQ(MediaTime(25, 1), iterator_range.second->second->presentationTime());
+    MediaTime currentTime = iterator_range.first->second->presentationTime();
+    for (auto it = iterator_range.first; it != iterator_range.second; ++it) {
+        EXPECT_EQ(it->second->presentationTime(), currentTime);
+        currentTime += MediaTime { 1, 1 };
+    }
+
+    iterator_range = presentationMap.findSamplesBetweenPresentationTimesFromEnd(MediaTime(9, 1), MediaTime(31, 1));
     EXPECT_EQ(MediaTime(9, 1), iterator_range.first->second->presentationTime());
     EXPECT_TRUE(presentationMap.end() == iterator_range.second);
 
@@ -224,7 +260,7 @@ TEST_F(SampleMapTest, findSamplesBetweenPresentationTimesFromEnd)
     EXPECT_TRUE(presentationMap.end() == iterator_range.first);
     EXPECT_TRUE(presentationMap.end() == iterator_range.second);
 
-    iterator_range = presentationMap.findSamplesBetweenPresentationTimesFromEnd(MediaTime(20, 1), MediaTime(21, 1));
+    iterator_range = presentationMap.findSamplesBetweenPresentationTimesFromEnd(MediaTime(30, 1), MediaTime(31, 1));
     EXPECT_TRUE(presentationMap.end() == iterator_range.first);
     EXPECT_TRUE(presentationMap.end() == iterator_range.second);
 }
@@ -235,10 +271,41 @@ TEST_F(SampleMapTest, reverseFindSampleBeforePresentationTime)
     EXPECT_EQ(MediaTime(0, 1), presentationMap.reverseFindSampleBeforePresentationTime(MediaTime(0, 1))->second->presentationTime());
     EXPECT_EQ(MediaTime(9, 1), presentationMap.reverseFindSampleBeforePresentationTime(MediaTime(10, 1))->second->presentationTime());
     EXPECT_EQ(MediaTime(19, 1), presentationMap.reverseFindSampleBeforePresentationTime(MediaTime(19, 1))->second->presentationTime());
-    EXPECT_EQ(MediaTime(19, 1), presentationMap.reverseFindSampleBeforePresentationTime(MediaTime(21, 1))->second->presentationTime());
+    EXPECT_EQ(MediaTime(28, 1), presentationMap.reverseFindSampleBeforePresentationTime(MediaTime(31, 1))->second->presentationTime());
     EXPECT_TRUE(presentationMap.rend() == presentationMap.reverseFindSampleBeforePresentationTime(MediaTime(-1, 1)));
 }
 
+TEST_F(SampleMapTest, findSamplesBetweenDecodeKeys)
+{
+    auto& decodeMap = map.decodeOrder();
+    DecodeOrderSampleMap::MapType dependentSamples;
+    DecodeOrderSampleMap::KeyType decodeKeyStart(MediaTime(0, 1), MediaTime(0, 1));
+    DecodeOrderSampleMap::KeyType decodeKeyEnd(MediaTime(28, 1), MediaTime(25, 1));
+
+    auto samplesWithHigherDecodeTimes = decodeMap.findSamplesBetweenDecodeKeys(decodeKeyStart, decodeKeyEnd);
+    EXPECT_FALSE(samplesWithHigherDecodeTimes.first == samplesWithHigherDecodeTimes.second);
+    EXPECT_EQ(MediaTime(0, 1), samplesWithHigherDecodeTimes.first->second->presentationTime());
+    EXPECT_EQ(MediaTime(25, 1), samplesWithHigherDecodeTimes.second->second->presentationTime());
+
+    decodeKeyEnd = { MediaTime(25, 1), MediaTime(28, 1) };
+    samplesWithHigherDecodeTimes = decodeMap.findSamplesBetweenDecodeKeys(decodeKeyStart, decodeKeyEnd);
+    EXPECT_FALSE(samplesWithHigherDecodeTimes.first == samplesWithHigherDecodeTimes.second);
+    EXPECT_EQ(MediaTime(28, 1), samplesWithHigherDecodeTimes.second->second->presentationTime());
+
+    decodeKeyEnd = { MediaTime(28, 1), MediaTime(24, 1) };
+    samplesWithHigherDecodeTimes = decodeMap.findSamplesBetweenDecodeKeys(decodeKeyStart, decodeKeyEnd);
+    EXPECT_EQ(MediaTime(25, 1), samplesWithHigherDecodeTimes.second->second->presentationTime());
+
+    decodeKeyEnd = { MediaTime(28, 1), MediaTime(28, 1) };
+    samplesWithHigherDecodeTimes = decodeMap.findSamplesBetweenDecodeKeys(decodeKeyStart, decodeKeyEnd);
+    EXPECT_FALSE(samplesWithHigherDecodeTimes.first == samplesWithHigherDecodeTimes.second);
+    EXPECT_EQ(decodeMap.end(), samplesWithHigherDecodeTimes.second);
+
+    decodeKeyEnd = { MediaTime(29, 1), MediaTime(30, 1) };
+    samplesWithHigherDecodeTimes = decodeMap.findSamplesBetweenDecodeKeys(decodeKeyStart, decodeKeyEnd);
+    EXPECT_FALSE(samplesWithHigherDecodeTimes.first == samplesWithHigherDecodeTimes.second);
+    EXPECT_EQ(decodeMap.end(), samplesWithHigherDecodeTimes.second);
 }
 
+}
 #endif // ENABLE(MEDIA_SOURCE)


### PR DESCRIPTION
#### c9fa577e905045de03a1576fe10e49a44859cfe3
<pre>
StabilityTracer: com.apple.WebKit.GPU at WebCore:  void std::__1::map&lt;std::__1::pair&lt;WTF::MediaTime, WTF::MediaTime&gt;, WTF::Ref&lt;WebCore::MediaSample, WTF::RawPtrTraits&lt;WebCore::MediaSample&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=295328">https://bugs.webkit.org/show_bug.cgi?id=295328</a>
<a href="https://rdar.apple.com/152381158">rdar://152381158</a>

Reviewed by Youenn Fablet.

291838@main didn&apos;t fix the underlying issue.

Another tentative fix but further restricting the scope in which the crashing code occurs.
It is doubtful that this code is necessary in the first place. It was introduced by 205636@main
but the corresponding test wasn&apos;t impacted by the code change.
Additionally, by removing all frames until the next keyframe, any following frames
even satisfying the condition that timestamp &lt; presentationTime while timestamp &gt;= decodeTime
would have already been removed.

Adding API tests for further code test coverage.
Use std::prev/std::next in place of iterator increment/decrement.

* LayoutTests/media/media-source/media-source-append-overlapping-dts-expected.txt:
* LayoutTests/media/media-source/media-source-append-overlapping-dts.html:
* Source/WebCore/Modules/mediasource/SampleMap.cpp:
(WebCore::PresentationOrderSampleMap::findSampleContainingPresentationTime):
(WebCore::PresentationOrderSampleMap::findSampleContainingOrAfterPresentationTime):
(WebCore::PresentationOrderSampleMap::reverseFindSampleBeforePresentationTime):
(WebCore::DecodeOrderSampleMap::reverseFindSampleWithDecodeKey):
(WebCore::DecodeOrderSampleMap::findSyncSamplePriorToPresentationTime):
(WebCore::DecodeOrderSampleMap::findSyncSampleAfterPresentationTime):
(WebCore::DecodeOrderSampleMap::findSamplesBetweenDecodeKeys):
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::processMediaSample):
* Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp:
(TestWebKitAPI::TestSample::TestSample):
(TestWebKitAPI::TEST_F(SampleMapTest, findSampleWithPresentationTime)):
(TestWebKitAPI::TEST_F(SampleMapTest, findSampleContainingPresentationTime)):
(TestWebKitAPI::TEST_F(SampleMapTest, findSampleStartingOnOrAfterPresentationTime)):
(TestWebKitAPI::TEST_F(SampleMapTest, findSampleContainingOrAfterPresentationTime)):
(TestWebKitAPI::TEST_F(SampleMapTest, findSampleStartingAfterPresentationTime)):
(TestWebKitAPI::TEST_F(SampleMapTest, findSamplesBetweenPresentationTimes)):
(TestWebKitAPI::TEST_F(SampleMapTest, findSamplesBetweenPresentationTimesFromEnd)):
(TestWebKitAPI::TEST_F(SampleMapTest, reverseFindSampleBeforePresentationTime)):
(TestWebKitAPI::TEST_F(SampleMapTest, findSamplesBetweenDecodeKeys)):

Canonical link: <a href="https://commits.webkit.org/296933@main">https://commits.webkit.org/296933@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eeb68db167d35dbbea064fdefb262e5e125046a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109961 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29619 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20051 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115983 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60209 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111924 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30297 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38207 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83594 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112909 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24155 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99024 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64036 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23527 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17173 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59778 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93527 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17215 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118774 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37000 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27423 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92569 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37373 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95291 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92393 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23556 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37376 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15111 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32872 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36895 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42366 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36556 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39897 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38264 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->