### PR TITLE
REGRESSION (296287@main):  Regressed `variable-css-wide-keywords.html` (two subtests)

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6380,7 +6380,6 @@ imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/standards-decor-n
 # New failures after import of css/css-variables
 imported/w3c/web-platform-tests/css/css-variables/variable-reference-visited.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-variables/wide-keyword-fallback-002.html [ ImageOnlyFailure ]
-webkit.org/b/294587 [ Debug ] imported/w3c/web-platform-tests/css/css-variables/variable-css-wide-keywords.html [ Skip ]
 
 # WPT tests that are timing out.
 imported/w3c/web-platform-tests/FileAPI/url/unicode-origin.sub.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-css-wide-keywords-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-css-wide-keywords-expected.txt
@@ -33,7 +33,7 @@ PASS `initial` as a value for an unregistered custom property
 PASS `inherit` as a value for an unregistered custom property
 PASS `unset` as a value for an unregistered custom property
 PASS `revert` as a value for an unregistered custom property
-FAIL `revert-layer` as a value for an unregistered custom property assert_equals: expected "rgb(144, 238, 144)" but got "rgb(255, 99, 71)"
+PASS `revert-layer` as a value for an unregistered custom property
 PASS `initial` as a value for a non-inheriting registered custom property
 PASS `initial` as a value for an inheriting registered custom property
 PASS `inherit` as a value for a non-inheriting registered custom property
@@ -42,8 +42,8 @@ PASS `unset` as a value for a non-inheriting registered custom property
 PASS `unset` as a value for an inheriting registered custom property
 PASS `revert` as a value for a non-inheriting registered custom property
 PASS `revert` as a value for an inheriting registered custom property
-FAIL `revert-layer` as a value for a non-inheriting registered custom property assert_equals: expected "rgb(144, 238, 144)" but got "rgb(255, 165, 0)"
-FAIL `revert-layer` as a value for an inheriting registered custom property assert_equals: expected "rgb(144, 238, 144)" but got "rgb(255, 99, 71)"
+PASS `revert-layer` as a value for a non-inheriting registered custom property
+PASS `revert-layer` as a value for an inheriting registered custom property
 FAIL `initial` as a `var()` fallback for an unregistered custom property assert_equals: expected "rgb(144, 238, 144)" but got "rgba(0, 0, 0, 0)"
 FAIL `inherit` as a `var()` fallback for an unregistered custom property assert_equals: expected "rgb(144, 238, 144)" but got "rgba(0, 0, 0, 0)"
 FAIL `unset` as a `var()` fallback for an unregistered custom property assert_equals: expected "rgb(144, 238, 144)" but got "rgba(0, 0, 0, 0)"
@@ -57,6 +57,6 @@ PASS `unset` as a `var()` fallback for a non-inheriting registered custom proper
 PASS `unset` as a `var()` fallback for an inheriting registered custom property
 PASS `revert` as a `var()` fallback for a non-inheriting registered custom property
 PASS `revert` as a `var()` fallback for an inheriting registered custom property
-FAIL `revert-layer` as a `var()` fallback for a non-inheriting registered custom property assert_equals: expected "rgb(144, 238, 144)" but got "rgb(255, 165, 0)"
-FAIL `revert-layer` as a `var()` fallback for an inheriting registered custom property assert_equals: expected "rgb(144, 238, 144)" but got "rgb(255, 99, 71)"
+PASS `revert-layer` as a `var()` fallback for a non-inheriting registered custom property
+PASS `revert-layer` as a `var()` fallback for an inheriting registered custom property
 

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -70,9 +70,10 @@ private:
     template<CustomPropertyCycleTracking trackCycles>
     void applyPropertiesImpl(int firstProperty, int lastProperty);
     void applyCascadeProperty(const PropertyCascade::Property&);
-    void applyRollbackCascadeProperty(const PropertyCascade::Property&, SelectorChecker::LinkMatchMask);
+    bool applyRollbackCascadeProperty(const PropertyCascade&, CSSPropertyID, SelectorChecker::LinkMatchMask);
+    bool applyRollbackCascadeCustomProperty(const PropertyCascade&, const AtomString&);
     void applyProperty(CSSPropertyID, CSSValue&, SelectorChecker::LinkMatchMask, CascadeLevel);
-    void applyCustomProperty(const AtomString& name, Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>&&, SelectorChecker::LinkMatchMask, CascadeLevel);
+    void applyCustomProperty(const AtomString& name, Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>&&);
 
     Ref<CSSValue> resolveVariableReferences(CSSPropertyID, CSSValue&);
     std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> resolveCustomPropertyValue(CSSCustomPropertyValue&);


### PR DESCRIPTION
#### 6b0e4aabca67b8376679927d96c7df93c408c047
<pre>
REGRESSION (296287@main):  Regressed `variable-css-wide-keywords.html` (two subtests)
<a href="https://bugs.webkit.org/show_bug.cgi?id=294585">https://bugs.webkit.org/show_bug.cgi?id=294585</a>
<a href="https://rdar.apple.com/154133529">rdar://154133529</a>

Reviewed by Alan Baradlay.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-css-wide-keywords-expected.txt:
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyCustomPropertyImpl):
(WebCore::Style::Builder::applyRollbackCascadeProperty):

Refactor to move more code here.

(WebCore::Style::Builder::applyRollbackCascadeCustomProperty):

Add a separate rollback applying function for custom properties.

(WebCore::Style::Builder::applyProperty):
(WebCore::Style::Builder::applyCustomProperty):

The code was calling applyRollbackCascadeProperty for custom property reverts but that function only supports regular properties.

* Source/WebCore/style/StyleBuilder.h:

Canonical link: <a href="https://commits.webkit.org/296909@main">https://commits.webkit.org/296909@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df4169c6c244b2422f48fd66cab700b1d65235e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109964 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29622 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20054 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115986 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60212 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111927 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30300 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38210 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83597 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112912 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24157 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99026 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64039 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23529 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17175 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59781 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93529 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17217 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118777 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37003 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27425 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92572 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37376 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95293 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92396 "Found 2 new API test failures: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23535 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37379 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15113 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32877 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36898 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42369 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36559 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39900 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38267 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->