### PR TITLE
AVVideoCaptureSource first frames check is not always correct on restart

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
@@ -200,7 +200,7 @@ private:
     std::unique_ptr<Timer> m_startupTimer;
 #endif
     std::unique_ptr<Timer> m_verifyCapturingTimer;
-    uint64_t m_framesCount { 0 };
+    std::atomic<uint64_t> m_framesCount { 0 };
     uint64_t m_lastFramesCount { 0 };
     int64_t m_defaultTorchMode { 0 };
     OptionSet<RealtimeMediaSourceSettings::Flag> m_pendingSettingsChanges;

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -278,8 +278,10 @@ AVVideoCaptureSource::~AVVideoCaptureSource()
 void AVVideoCaptureSource::verifyIsCapturing()
 {
     ASSERT(m_isRunning);
-    if (m_lastFramesCount != m_framesCount) {
-        m_lastFramesCount = m_framesCount;
+
+    uint64_t framesCount = m_framesCount;
+    if (m_lastFramesCount != framesCount) {
+        m_lastFramesCount = framesCount;
         return;
     }
 
@@ -292,6 +294,8 @@ void AVVideoCaptureSource::updateVerifyCapturingTimer()
     if (!m_isRunning || m_interrupted) {
         if (m_verifyCapturingTimer)
             m_verifyCapturingTimer->stop();
+        m_framesCount = 0;
+        m_lastFramesCount = 0;
         return;
     }
 


### PR DESCRIPTION
#### 23fe8add2e30694e12662b64c44b3110a70e040b
<pre>
AVVideoCaptureSource first frames check is not always correct on restart
<a href="https://rdar.apple.com/122102805">rdar://122102805</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=295333">https://bugs.webkit.org/show_bug.cgi?id=295333</a>

Reviewed by Eric Carlson.

When capture restarts, we would reset m_frameCount to 0 when getting the signal that session is now running.
There could be video frames already in flight on the output queue.
Sometimes, the video frames will be processed before we would reset m_frameCount to 0, defeating the skipping of the first video frames which may be darker.
This could create a potential flickering.

To prevent this, we now reset m_frameCount to 0 when stopping the capture.
We also make it a std::atomic given it is used in two threads.

Manually tested.

* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::verifyIsCapturing):
(WebCore::AVVideoCaptureSource::updateVerifyCapturingTimer):

Canonical link: <a href="https://commits.webkit.org/296960@main">https://commits.webkit.org/296960@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26aa061c061c410b42bffb6d5221024b05ff3a14

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109966 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29624 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20056 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115988 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60214 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111929 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38212 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83598 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112914 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24161 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99029 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64040 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23533 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17178 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59783 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93536 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17220 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118779 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37005 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27428 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92574 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37378 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95296 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92398 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23577 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37381 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15117 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32882 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36900 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42371 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36561 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39902 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38269 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->