### PR TITLE
Align Scoped Custom Element Registries with latest specification

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/CustomElementRegistry-upgrade-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/CustomElementRegistry-upgrade-expected.txt
@@ -2,5 +2,5 @@
 PASS upgrade is a function on both global and scoped CustomElementRegistry
 PASS upgrade is a no-op when called on a shadow root with no association
 PASS upgrade should upgrade a candidate element when called on a shadow root with an association
-FAIL upgrade should not upgrade a candidate element not associated with a registry assert_equals: expected "GlobalABElement" but got "HTMLElement"
+PASS upgrade should not upgrade a candidate element not associated with a registry
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Document-importNode-cross-document.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Document-importNode-cross-document.window-expected.txt
@@ -1,14 +1,14 @@
 
 PASS Cloning with global registry
 PASS Cloning with explicit global registry
-FAIL Cloning with scoped registry assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
-FAIL Cloning including shadow tree with global registry assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
-FAIL Cloning including shadow tree with explicit global registry assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
+PASS Cloning with scoped registry
+PASS Cloning including shadow tree with global registry
+PASS Cloning including shadow tree with explicit global registry
 PASS Cloning including shadow tree with scoped registry
 PASS Cloning with global registry (null registry target)
 PASS Cloning with explicit global registry (null registry target)
-FAIL Cloning with scoped registry (null registry target) assert_equals: expected object "[object CustomElementRegistry]" but got null
+PASS Cloning with scoped registry (null registry target)
 PASS Cloning including shadow tree with global registry (null registry target)
 PASS Cloning including shadow tree with explicit global registry (null registry target)
-FAIL Cloning including shadow tree with scoped registry (null registry target) assert_equals: expected object "[object CustomElementRegistry]" but got null
+PASS Cloning including shadow tree with scoped registry (null registry target)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Document-importNode-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Document-importNode-expected.txt
@@ -1,11 +1,11 @@
 
 PASS importNode should clone using the global regsitry by default
-FAIL importNode should clone using target's registry if non-null assert_true: expected true got false
+PASS importNode should clone using target's registry if non-null
 PASS importNode should clone using the specified registry if target's registry is null
 PASS importNode should preserve null-ness of custom element registry
 PASS importNode should clone a shadow host with a declarative shadow DOM using the global registry by default
 PASS importNode should clone a shadow host with a declarative shadow DOM using a specified scoped registry
-FAIL importNode should clone using target's registry if non-null, including when it's not the global registry assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
+PASS importNode should clone using target's registry if non-null, including when it's not the global registry
 PASS importNode should clone a template content using the global registry by default
 PASS importNode should clone a template content using a specified scoped registry
 PASS importNode should clone a template content with a nested template element using a scoped registry

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/adoption.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/adoption.window-expected.txt
@@ -5,11 +5,11 @@ PASS Adoption with scoped registry
 PASS Adoption with global registry into a scoped registry
 PASS Adoption with explicit global registry into a scoped registry
 PASS Adoption with scoped registry into a scoped registry
-FAIL Adoption including shadow root with global registry assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
-FAIL Adoption including shadow root with explicit global registry assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
+PASS Adoption including shadow root with global registry
+PASS Adoption including shadow root with explicit global registry
 PASS Adoption including shadow root with scoped registry
-FAIL Adoption including shadow root with global registry into a scoped registry assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
-FAIL Adoption including shadow root with explicit global registry into a scoped registry assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
+PASS Adoption including shadow root with global registry into a scoped registry
+PASS Adoption including shadow root with explicit global registry into a scoped registry
 PASS Adoption including shadow root with scoped registry into a scoped registry
 PASS Adoption with global registry (null registry target)
 PASS Adoption with explicit global registry (null registry target)
@@ -17,11 +17,11 @@ PASS Adoption with scoped registry (null registry target)
 PASS Adoption with global registry into a scoped registry (null registry target)
 PASS Adoption with explicit global registry into a scoped registry (null registry target)
 PASS Adoption with scoped registry into a scoped registry (null registry target)
-FAIL Adoption including shadow root with global registry (null registry target) assert_equals: expected null but got object "[object CustomElementRegistry]"
-FAIL Adoption including shadow root with explicit global registry (null registry target) assert_equals: expected null but got object "[object CustomElementRegistry]"
+PASS Adoption including shadow root with global registry (null registry target)
+PASS Adoption including shadow root with explicit global registry (null registry target)
 PASS Adoption including shadow root with scoped registry (null registry target)
-FAIL Adoption including shadow root with global registry into a scoped registry (null registry target) assert_equals: expected null but got object "[object CustomElementRegistry]"
-FAIL Adoption including shadow root with explicit global registry into a scoped registry (null registry target) assert_equals: expected null but got object "[object CustomElementRegistry]"
+PASS Adoption including shadow root with global registry into a scoped registry (null registry target)
+PASS Adoption including shadow root with explicit global registry into a scoped registry (null registry target)
 PASS Adoption including shadow root with scoped registry into a scoped registry (null registry target)
 FAIL Adoption with global registry (scoped registry target) assert_equals: expected null but got object "[object CustomElementRegistry]"
 FAIL Adoption with explicit global registry (scoped registry target) assert_equals: expected null but got object "[object CustomElementRegistry]"
@@ -29,10 +29,10 @@ PASS Adoption with scoped registry (scoped registry target)
 FAIL Adoption with global registry into a scoped registry (scoped registry target) assert_equals: expected null but got object "[object CustomElementRegistry]"
 FAIL Adoption with explicit global registry into a scoped registry (scoped registry target) assert_equals: expected null but got object "[object CustomElementRegistry]"
 PASS Adoption with scoped registry into a scoped registry (scoped registry target)
-FAIL Adoption including shadow root with global registry (scoped registry target) assert_equals: expected null but got object "[object CustomElementRegistry]"
-FAIL Adoption including shadow root with explicit global registry (scoped registry target) assert_equals: expected null but got object "[object CustomElementRegistry]"
+PASS Adoption including shadow root with global registry (scoped registry target)
+PASS Adoption including shadow root with explicit global registry (scoped registry target)
 PASS Adoption including shadow root with scoped registry (scoped registry target)
-FAIL Adoption including shadow root with global registry into a scoped registry (scoped registry target) assert_equals: expected null but got object "[object CustomElementRegistry]"
-FAIL Adoption including shadow root with explicit global registry into a scoped registry (scoped registry target) assert_equals: expected null but got object "[object CustomElementRegistry]"
+PASS Adoption including shadow root with global registry into a scoped registry (scoped registry target)
+PASS Adoption including shadow root with explicit global registry into a scoped registry (scoped registry target)
 PASS Adoption including shadow root with scoped registry into a scoped registry (scoped registry target)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/global.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/global.window-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL initialize() of global registry should throw for nodes from another document assert_throws_dom: function "() => customElements.initialize(contentDocument)" did not throw
-FAIL createElement() should throw with global registry from another document assert_throws_dom: function "() => contentDocument.createElement("div", { customElementRegistry: customElements })" did not throw
-FAIL createElementNS() should throw with global registry from another document assert_throws_dom: function "() => contentDocument.createElementNS("x", "div", { customElementRegistry: customElements })" did not throw
-FAIL attachShadow() should throw with global registry from another document assert_throws_dom: function "() => element.attachShadow({ mode: "closed", customElementRegistry: customElements })" did not throw
-FAIL importNode() should throw with global registry from another document assert_throws_dom: function "() => contentDocument.importNode(element, { customElementRegistry: customElements })" did not throw
+PASS initialize() of global registry should throw for nodes from another document
+PASS createElement() should throw with global registry from another document
+PASS createElementNS() should throw with global registry from another document
+PASS attachShadow() should throw with global registry from another document
+PASS importNode() should throw with global registry from another document
 

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -1031,7 +1031,7 @@ void ContainerNode::childrenChanged(const ChildChange& change)
         cache->childrenChanged(*this);
 }
 
-void ContainerNode::cloneChildNodes(Document& document, CustomElementRegistry* registry, ContainerNode& clone, size_t currentDepth) const
+void ContainerNode::cloneChildNodes(Document& document, CustomElementRegistry* fallbackRegistry, ContainerNode& clone, size_t currentDepth) const
 {
     if (currentDepth == 1024)
         return;
@@ -1039,7 +1039,7 @@ void ContainerNode::cloneChildNodes(Document& document, CustomElementRegistry* r
     NodeVector postInsertionNotificationTargets;
     bool hadElement = false;
     for (RefPtr child = firstChild(); child; child = child->nextSibling()) {
-        Ref clonedChild = child->cloneNodeInternal(document, CloningOperation::SelfWithTemplateContent, registry);
+        Ref clonedChild = child->cloneNodeInternal(document, CloningOperation::SelfWithTemplateContent, fallbackRegistry);
         {
             WidgetHierarchyUpdatesSuspensionScope suspendWidgetHierarchyUpdates;
             ScriptDisallowedScope::InMainThread scriptDisallowedScope;
@@ -1052,7 +1052,7 @@ void ContainerNode::cloneChildNodes(Document& document, CustomElementRegistry* r
             hadElement = hadElement || is<Element>(clonedChild);
         }
         if (RefPtr childAsContainerNode = dynamicDowncast<ContainerNode>(*child))
-            childAsContainerNode->cloneChildNodes(document, registry, downcast<ContainerNode>(clonedChild), currentDepth + 1);
+            childAsContainerNode->cloneChildNodes(document, fallbackRegistry, downcast<ContainerNode>(clonedChild), currentDepth + 1);
     }
     clone.childrenChanged(makeChildChangeForCloneInsertion(hadElement ? ClonedChildIncludesElements::Yes : ClonedChildIncludesElements::No));
 

--- a/Source/WebCore/dom/CustomElementRegistry.h
+++ b/Source/WebCore/dom/CustomElementRegistry.h
@@ -105,7 +105,7 @@ public:
     JSC::JSValue get(const AtomString&);
     String getName(JSC::JSValue);
     void upgrade(Node& root);
-    void initialize(Node& root);
+    ExceptionOr<void> initialize(Node& root);
 
     MemoryCompactRobinHoodHashMap<AtomString, Ref<DeferredPromise>>& promiseMap() { return m_promiseMap; }
     bool isShadowDisabled(const AtomString& name) const { return m_disabledShadowSet.contains(name); }

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -532,6 +532,7 @@ public:
     WEBCORE_EXPORT Ref<Element> createElement(const QualifiedName&, bool createdByParser, CustomElementRegistry* = nullptr);
 
     RefPtr<CustomElementRegistry> customElementRegistryForBindings();
+    CustomElementRegistry* effectiveGlobalCustomElementRegistry();
     static CustomElementNameValidationStatus validateCustomElementName(const AtomString&);
     void setActiveCustomElementRegistry(CustomElementRegistry*);
     CustomElementRegistry* activeCustomElementRegistry() { return m_activeCustomElementRegistry.get(); }

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -620,20 +620,20 @@ bool Element::dispatchSimulatedClick(Event* underlyingEvent, SimulatedClickMouse
     return simulateClick(*this, underlyingEvent, eventOptions, visualOptions, SimulatedClickSource::UserAgent);
 }
 
-Ref<Node> Element::cloneNodeInternal(Document& document, CloningOperation type, CustomElementRegistry* registry) const
+Ref<Node> Element::cloneNodeInternal(Document& document, CloningOperation type, CustomElementRegistry* fallbackRegistry) const
 {
     switch (type) {
     case CloningOperation::SelfOnly:
     case CloningOperation::SelfWithTemplateContent: {
-        Ref clone = cloneElementWithoutChildren(document, registry);
+        Ref clone = cloneElementWithoutChildren(document, fallbackRegistry);
         ScriptDisallowedScope::EventAllowedScope eventAllowedScope { clone };
-        cloneShadowTreeIfPossible(clone, registry);
+        cloneShadowTreeIfPossible(clone);
         return clone;
     }
     case CloningOperation::Everything:
         break;
     }
-    return cloneElementWithChildren(document, registry);
+    return cloneElementWithChildren(document, fallbackRegistry);
 }
 
 SerializedNode Element::serializeNode(CloningOperation) const
@@ -642,36 +642,48 @@ SerializedNode Element::serializeNode(CloningOperation) const
     return { SerializedNode::Element { } };
 }
 
-void Element::cloneShadowTreeIfPossible(Element& newHost, CustomElementRegistry* registry) const
+void Element::cloneShadowTreeIfPossible(Element& newHost) const
 {
     RefPtr oldShadowRoot = this->shadowRoot();
     if (!oldShadowRoot || !oldShadowRoot->isClonable())
         return;
 
     Ref clonedShadowRoot = [&] {
-        Ref clone = oldShadowRoot->cloneNodeInternal(newHost.document(), Node::CloningOperation::SelfWithTemplateContent, registry);
+        Ref clone = oldShadowRoot->cloneNodeInternal(newHost.document(), Node::CloningOperation::SelfWithTemplateContent, nullptr);
         return downcast<ShadowRoot>(WTFMove(clone));
     }();
     if (oldShadowRoot->usesNullCustomElementRegistry())
         clonedShadowRoot->setUsesNullCustomElementRegistry(); // Set this flag for Element::insertedIntoAncestor.
-    else if (RefPtr registry = oldShadowRoot->customElementRegistry())
-        clonedShadowRoot->setCustomElementRegistry(registry.releaseNonNull());
+    else {
+        clonedShadowRoot->clearUsesNullCustomElementRegistry(); // Unset flag potentially set by DocumentFragment constructor
+        if (RefPtr registry = oldShadowRoot->customElementRegistry()) {
+            if (!registry->isScoped())
+                registry = newHost.document().effectiveGlobalCustomElementRegistry();
+            clonedShadowRoot->setCustomElementRegistry(WTFMove(registry));
+        }
+    }
     newHost.addShadowRoot(clonedShadowRoot.copyRef());
-    oldShadowRoot->cloneChildNodes(newHost.document(), clonedShadowRoot->usesNullCustomElementRegistry() ? nullptr : registry, clonedShadowRoot);
+    oldShadowRoot->cloneChildNodes(newHost.document(), nullptr, clonedShadowRoot);
 }
 
-Ref<Element> Element::cloneElementWithChildren(Document& document, CustomElementRegistry* registry) const
+Ref<Element> Element::cloneElementWithChildren(Document& document, CustomElementRegistry* fallbackRegistry) const
 {
-    Ref clone = cloneElementWithoutChildren(document, registry);
+    Ref clone = cloneElementWithoutChildren(document, fallbackRegistry);
     ScriptDisallowedScope::EventAllowedScope eventAllowedScope { clone };
-    cloneShadowTreeIfPossible(clone, registry);
-    cloneChildNodes(document, registry, clone);
+    cloneShadowTreeIfPossible(clone);
+    cloneChildNodes(document, fallbackRegistry, clone);
     return clone;
 }
 
-Ref<Element> Element::cloneElementWithoutChildren(Document& document, CustomElementRegistry* registry) const
+Ref<Element> Element::cloneElementWithoutChildren(Document& document, CustomElementRegistry* fallbackRegistry) const
 {
-    Ref clone = cloneElementWithoutAttributesAndChildren(document, registry);
+    RefPtr registry = CustomElementRegistry::registryForElement(*this);
+    if (!registry)
+        registry = fallbackRegistry;
+    if (registry && !registry->isScoped())
+        registry = document.effectiveGlobalCustomElementRegistry();
+
+    Ref clone = cloneElementWithoutAttributesAndChildren(document, registry.get());
 
     // This will catch HTML elements in the wrong namespace that are not correctly copied.
     // This is a sanity check as HTML overloads some of the DOM methods.
@@ -3329,6 +3341,8 @@ ExceptionOr<ShadowRoot&> Element::attachShadow(const ShadowRootInit& init, std::
         return Exception { ExceptionCode::NotSupportedError };
     }
     RefPtr registry = init.customElementRegistry;
+    if (registry && !registry->isScoped() && registry != document().customElementRegistry())
+        return Exception { ExceptionCode::NotSupportedError };
     auto scopedRegistry = ShadowRoot::ScopedCustomElementRegistry::No;
     if (!registryKind)
         registryKind = !registry && usesNullCustomElementRegistry() ? CustomElementRegistryKind::Null : CustomElementRegistryKind::Window;

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -965,7 +965,7 @@ private:
     // The cloneNode function is private so that non-virtual cloneElementWith/WithoutChildren are used instead.
     Ref<Node> cloneNodeInternal(Document&, CloningOperation, CustomElementRegistry*) const override;
     SerializedNode serializeNode(CloningOperation) const override;
-    void cloneShadowTreeIfPossible(Element& newHost, CustomElementRegistry*) const;
+    void cloneShadowTreeIfPossible(Element& newHost) const;
     virtual Ref<Element> cloneElementWithoutAttributesAndChildren(Document&, CustomElementRegistry*) const;
 
     inline void removeShadowRoot(); // Defined in ElementRareData.h.

--- a/Source/WebCore/dom/TreeScope.cpp
+++ b/Source/WebCore/dom/TreeScope.cpp
@@ -145,7 +145,7 @@ void TreeScope::setParentTreeScope(TreeScope& newParentScope)
     setDocumentScope(newParentScope.documentScope());
 }
 
-void TreeScope::setCustomElementRegistry(Ref<CustomElementRegistry>&& registry)
+void TreeScope::setCustomElementRegistry(RefPtr<CustomElementRegistry>&& registry)
 {
     m_customElementRegistry = WTFMove(registry);
 }

--- a/Source/WebCore/dom/TreeScope.h
+++ b/Source/WebCore/dom/TreeScope.h
@@ -80,7 +80,7 @@ public:
     Element* focusedElementInScope();
     Element* pointerLockElement() const;
 
-    void setCustomElementRegistry(Ref<CustomElementRegistry>&&);
+    void setCustomElementRegistry(RefPtr<CustomElementRegistry>&&);
     CustomElementRegistry* customElementRegistry() const { return m_customElementRegistry.get(); }
 
     WEBCORE_EXPORT RefPtr<Element> getElementById(const AtomString&) const;

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -627,6 +627,7 @@ CustomElementRegistry& LocalDOMWindow::ensureCustomElementRegistry()
         }
         document()->setCustomElementRegistry(*m_customElementRegistry);
     }
+    ASSERT(!m_customElementRegistry->isScoped());
     ASSERT(m_customElementRegistry->scriptExecutionContext() == document());
     return *m_customElementRegistry;
 }


### PR DESCRIPTION
#### d49fe62f68615a250dc40a95a5a0aad8f6625bab
<pre>
Align Scoped Custom Element Registries with latest specification
<a href="https://bugs.webkit.org/show_bug.cgi?id=295337">https://bugs.webkit.org/show_bug.cgi?id=295337</a>
<a href="https://rdar.apple.com/155438084">rdar://155438084</a>

Reviewed by Ryosuke Niwa.

WebKit&apos;s current implementation is not aligned with the DOM and HTML
standards in these ways:

1. When cloning, children of ShadowRoot nodes can have their registry
   impacted. This is not supposed to happen as that violates
   encapsulation.
2. When cloning, the supplied registry is not treated as a fallback. A
   clone of a node with a non-null registry can end up with a different
   registry. This is not supposed to happen.
3. The global registry is only sometimes confined to its original
   document. As we want consistent behavior, we make it always belong
   to a single document and nodes that use that registry will use a new
   global registry (or null) when moving into another document going
   forward.
4. To ensure that confinement and allow for flexibility, we&apos;re also
   adding exceptions.

One edge case that is not tackled by this PR is that a global registry
element does not become a null registry element when inserted into a
scoped registry document. (Instead it starts using the scoped registry,
which is wrong.)

Canonical link: <a href="https://commits.webkit.org/297779@main">https://commits.webkit.org/297779@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38727bd818518c37348d64f4a21a39a6a71d0546

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112831 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32566 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23044 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119034 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63348 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114793 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33218 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41129 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85869 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36515 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115778 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26512 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101501 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66175 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25800 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19632 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62793 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95906 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19707 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122256 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39909 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29755 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94732 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40292 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97721 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94471 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24115 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39597 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17410 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36012 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39795 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45293 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39434 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42768 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41173 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->