### PR TITLE
"inherit" as variable substitution fallback not working when setting custom property

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6379,7 +6379,6 @@ imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/standards-decor-n
 
 # New failures after import of css/css-variables
 imported/w3c/web-platform-tests/css/css-variables/variable-reference-visited.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-variables/wide-keyword-fallback-002.html [ ImageOnlyFailure ]
 
 # WPT tests that are timing out.
 imported/w3c/web-platform-tests/FileAPI/url/unicode-origin.sub.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/revert-in-fallback-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/revert-in-fallback-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL var(--unknown, revert) in custom property assert_equals: expected "" but got "revert"
+PASS var(--unknown, revert) in custom property
 PASS var(--unknown, revert) in shorthand
 PASS var(--unknown, revert) in shorthand observed via longhand
 PASS var(--unknown, revert) in longhand

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/revert-layer-in-fallback-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/revert-layer-in-fallback-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL var(--unknown, revert-layer) in custom property assert_equals: expected "PASS" but got "revert-layer"
+PASS var(--unknown, revert-layer) in custom property
 PASS var(--unknown, revert-layer) in shorthand
 PASS var(--unknown, revert-layer) in shorthand observed via longhand
 PASS var(--unknown, revert-layer) in longhand

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-css-wide-keywords-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-css-wide-keywords-expected.txt
@@ -44,11 +44,11 @@ PASS `revert` as a value for a non-inheriting registered custom property
 PASS `revert` as a value for an inheriting registered custom property
 PASS `revert-layer` as a value for a non-inheriting registered custom property
 PASS `revert-layer` as a value for an inheriting registered custom property
-FAIL `initial` as a `var()` fallback for an unregistered custom property assert_equals: expected "rgb(144, 238, 144)" but got "rgba(0, 0, 0, 0)"
-FAIL `inherit` as a `var()` fallback for an unregistered custom property assert_equals: expected "rgb(144, 238, 144)" but got "rgba(0, 0, 0, 0)"
-FAIL `unset` as a `var()` fallback for an unregistered custom property assert_equals: expected "rgb(144, 238, 144)" but got "rgba(0, 0, 0, 0)"
-FAIL `revert` as a `var()` fallback for an unregistered custom property assert_equals: expected "rgb(144, 238, 144)" but got "rgba(0, 0, 0, 0)"
-FAIL `revert-layer` as a `var()` fallback for an unregistered custom property assert_equals: expected "rgb(144, 238, 144)" but got "rgba(0, 0, 0, 0)"
+PASS `initial` as a `var()` fallback for an unregistered custom property
+PASS `inherit` as a `var()` fallback for an unregistered custom property
+PASS `unset` as a `var()` fallback for an unregistered custom property
+PASS `revert` as a `var()` fallback for an unregistered custom property
+PASS `revert-layer` as a `var()` fallback for an unregistered custom property
 PASS `initial` as a `var()` fallback for a non-inheriting registered custom property
 PASS `initial` as a `var()` fallback for an inheriting registered custom property
 PASS `inherit` as a `var()` fallback for a non-inheriting registered custom property

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -432,6 +432,11 @@ bool CSSPropertyParser::isValidCustomPropertyValueForSyntax(const CSSCustomPrope
     return !!consumeCustomPropertyValueWithSyntax(range, state, syntax).first;
 }
 
+std::optional<CSSWideKeyword> CSSPropertyParser::parseCSSWideKeyword(CSSParserTokenRange range)
+{
+    return consumeCSSWideKeyword(range);
+}
+
 std::pair<RefPtr<CSSValue>, CSSCustomPropertySyntax::Type> consumeCustomPropertyValueWithSyntax(CSSParserTokenRange& range, CSS::PropertyParserState& state, const CSSCustomPropertySyntax& syntax)
 {
     ASSERT(!syntax.isUniversal());

--- a/Source/WebCore/css/parser/CSSPropertyParser.h
+++ b/Source/WebCore/css/parser/CSSPropertyParser.h
@@ -65,6 +65,8 @@ public:
 
     static ComputedStyleDependencies collectParsedCustomPropertyValueDependencies(const CSSCustomPropertySyntax&, CSSParserTokenRange, const CSSParserContext&);
     static bool isValidCustomPropertyValueForSyntax(const CSSCustomPropertySyntax&, CSSParserTokenRange, const CSSParserContext&);
+
+    static std::optional<CSSWideKeyword> parseCSSWideKeyword(CSSParserTokenRange);
 };
 
 // MARK: - CSSPropertyID parsing

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -658,8 +658,13 @@ std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> Builder
     if (!resolvedData)
         return { };
 
-    if (!registered)
+    if (!registered) {
+        // CSS-wide keywords are allowed in var() fallbacks of unregistered properties.
+        if (auto keyword = CSSPropertyParser::parseCSSWideKeyword(resolvedData->tokens()))
+            return { { *keyword } };
+
         return { { CustomProperty::createForVariableData(name, *resolvedData) } };
+    }
 
     auto dependencies = CSSPropertyParser::collectParsedCustomPropertyValueDependencies(registered->syntax, resolvedData->tokens(), resolvedData->context());
 


### PR DESCRIPTION
#### ca01e51f31208ce0654b7e67b01e4d64241fcff0
<pre>
&quot;inherit&quot; as variable substitution fallback not working when setting custom property
<a href="https://bugs.webkit.org/show_bug.cgi?id=279740">https://bugs.webkit.org/show_bug.cgi?id=279740</a>
<a href="https://rdar.apple.com/136463977">rdar://136463977</a>

Reviewed by Alan Baradlay.

Support CSS-wide keywords in var() fallbacks.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/revert-in-fallback-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/revert-layer-in-fallback-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-css-wide-keywords-expected.txt:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::parseCSSWideKeyword):

Expose the parsing function.

* Source/WebCore/css/parser/CSSPropertyParser.h:
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::resolveCustomPropertyValue):

Try to parse unregistered custom property value as a keyword.

Canonical link: <a href="https://commits.webkit.org/296918@main">https://commits.webkit.org/296918@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8e99024588f79978e93f31efa2bcec9fc309a6c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109979 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29637 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20069 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116001 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60227 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111942 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30315 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38225 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83612 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112927 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24173 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99045 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64054 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23545 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17192 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59796 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93546 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17234 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118792 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37018 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27441 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92585 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37391 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95310 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92409 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23546 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37394 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15131 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32896 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36913 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42384 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36575 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39915 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38282 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->