### PR TITLE
[WebDriver] Provide better error messages in generic errors like UnknownError and InvalidArgument

### DIFF
--- a/Source/WebDriver/Session.cpp
+++ b/Source/WebDriver/Session.cpp
@@ -251,7 +251,7 @@ void Session::createTopLevelBrowsingContext(Function<void(CommandResult&&)>&& co
 
         auto handle = response.responseObject->getString("handle"_s);
         if (!handle) {
-            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve handle for the new browsing context"_s));
             return;
         }
 
@@ -272,7 +272,7 @@ void Session::handleUserPrompts(Function<void(CommandResult&&)>&& completionHand
 
         auto isShowingJavaScriptDialog = response.responseObject->getBoolean("result"_s);
         if (!isShowingJavaScriptDialog) {
-            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not determine if a JavaScript dialog is showing"_s));
             return;
         }
 
@@ -403,13 +403,13 @@ void Session::getCurrentURL(Function<void(CommandResult&&)>&& completionHandler)
 
             auto browsingContext = response.responseObject->getObject("context"_s);
             if (!browsingContext) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve browsing context information"_s));
                 return;
             }
 
             auto url = browsingContext->getString("url"_s);
             if (!url) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve URL from browsing context"_s));
                 return;
             }
 
@@ -523,13 +523,13 @@ void Session::getTitle(Function<void(CommandResult&&)>&& completionHandler)
 
             auto valueString = response.responseObject->getString("result"_s);
             if (!valueString) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve title from browsing context"_s));
                 return;
             }
 
             auto resultValue = JSON::Value::parseJSON(valueString);
             if (!resultValue) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not parse title from browsing context"_s));
                 return;
             }
 
@@ -555,13 +555,13 @@ void Session::getWindowHandle(Function<void(CommandResult&&)>&& completionHandle
 
         auto browsingContext = response.responseObject->getObject("context"_s);
         if (!browsingContext) {
-            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve browsing context information"_s));
             return;
         }
 
         auto handle = browsingContext->getString("handle"_s);
         if (!handle) {
-            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve browsing context handle"_s));
             return;
         }
 
@@ -650,7 +650,7 @@ void Session::getWindowHandles(Function<void(CommandResult&&)>&& completionHandl
 
         auto browsingContextArray = response.responseObject->getArray("contexts"_s);
         if (!browsingContextArray) {
-            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve browsing contexts"_s));
             return;
         }
 
@@ -658,13 +658,13 @@ void Session::getWindowHandles(Function<void(CommandResult&&)>&& completionHandl
         for (unsigned i = 0; i < browsingContextArray->length(); ++i) {
             auto browsingContext = browsingContextArray->get(i)->asObject();
             if (!browsingContext) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Invalid browsing context information returned"_s));
                 return;
             }
 
             auto handle = browsingContext->getString("handle"_s);
             if (!handle) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "No handle returned for browsing context"_s));
                 return;
             }
 
@@ -700,13 +700,13 @@ void Session::newWindow(std::optional<String> typeHint, Function<void(CommandRes
 
             auto handle = response.responseObject->getString("handle"_s);
             if (!handle) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "No handle returned for the new browsing context"_s));
                 return;
             }
 
             auto presentation = response.responseObject->getString("presentation"_s);
             if (!presentation) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "No presentation returned for the new browsing context"_s));
                 return;
             }
 
@@ -764,7 +764,7 @@ void Session::switchToFrame(RefPtr<JSON::Value>&& frameID, Function<void(Command
 
             auto frameHandle = response.responseObject->getString("result"_s);
             if (!frameHandle) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not resolve child frame handle"_s));
                 return;
             }
 
@@ -818,43 +818,43 @@ void Session::getToplevelBrowsingContextRect(Function<void(CommandResult&&)>&& c
 
         auto browsingContext = response.responseObject->getObject("context"_s);
         if (!browsingContext) {
-            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve browsing context information"_s));
             return;
         }
 
         auto windowOrigin = browsingContext->getObject("windowOrigin"_s);
         if (!windowOrigin) {
-            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve window origin from browsing context"_s));
             return;
         }
 
         auto x = windowOrigin->getDouble("x"_s);
         if (!x) {
-            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve x coordinate from window origin"_s));
             return;
         }
 
         auto y = windowOrigin->getDouble("y"_s);
         if (!y) {
-            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve y coordinate from window origin"_s));
             return;
         }
 
         auto windowSize = browsingContext->getObject("windowSize"_s);
         if (!windowSize) {
-            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve window size from browsing context"_s));
             return;
         }
 
         auto width = windowSize->getDouble("width"_s);
         if (!width) {
-            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve width from window size"_s));
             return;
         }
 
         auto height = windowSize->getDouble("height"_s);
         if (!height) {
-            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve height from window size"_s));
             return;
         }
 
@@ -996,13 +996,13 @@ void Session::fullscreenWindow(Function<void(CommandResult&&)>&& completionHandl
 
             auto valueString = response.responseObject->getString("result"_s);
             if (!valueString) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve fullscreen information from browsing context"_s));
                 return;
             }
 
             auto resultValue = JSON::Value::parseJSON(valueString);
             if (!resultValue) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not parse fullscreen information"_s));
                 return;
             }
 
@@ -1191,13 +1191,13 @@ void Session::findElements(const String& strategy, const String& selector, FindE
 
             auto valueString = response.responseObject->getString("result"_s);
             if (!valueString) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve element info from browsing context"_s));
                 return;
             }
 
             auto resultValue = JSON::Value::parseJSON(valueString);
             if (!resultValue) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not parse element info"_s));
                 return;
             }
 
@@ -1256,13 +1256,13 @@ void Session::getActiveElement(Function<void(CommandResult&&)>&& completionHandl
 
             auto valueString = response.responseObject->getString("result"_s);
             if (!valueString) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve active element information from browsing context"_s));
                 return;
             }
 
             auto resultValue = JSON::Value::parseJSON(valueString);
             if (!resultValue) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not parse active element information"_s));
                 return;
             }
 
@@ -1306,13 +1306,13 @@ void Session::getElementShadowRoot(const String& elementID, Function<void(Comman
 
             auto valueString = response.responseObject->getString("result"_s);
             if (!valueString) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve shadow root information from browsing context"_s));
                 return;
             }
 
             auto resultValue = JSON::Value::parseJSON(valueString);
             if (!resultValue) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not parse shadow root information"_s));
                 return;
             }
 
@@ -1356,13 +1356,13 @@ void Session::isElementSelected(const String& elementID, Function<void(CommandRe
 
             auto valueString = response.responseObject->getString("result"_s);
             if (!valueString) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve element selection state from browsing context"_s));
                 return;
             }
 
             auto resultValue = JSON::Value::parseJSON(valueString);
             if (!resultValue) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not parse element selection state"_s));
                 return;
             }
 
@@ -1373,7 +1373,7 @@ void Session::isElementSelected(const String& elementID, Function<void(CommandRe
 
             auto booleanResult = resultValue->asString();
             if (!booleanResult || booleanResult != "true"_s) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Element selection state is not a boolean"_s));
                 return;
             }
 
@@ -1412,13 +1412,13 @@ void Session::getElementText(const String& elementID, Function<void(CommandResul
 
             auto valueString = response.responseObject->getString("result"_s);
             if (!valueString) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve element text from browsing context"_s));
                 return;
             }
 
             auto resultValue = JSON::Value::parseJSON(valueString);
             if (!resultValue) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not parse element text"_s));
                 return;
             }
 
@@ -1456,13 +1456,13 @@ void Session::getElementTagName(const String& elementID, Function<void(CommandRe
 
             auto valueString = response.responseObject->getString("result"_s);
             if (!valueString) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve element tag name from browsing context"_s));
                 return;
             }
 
             auto resultValue = JSON::Value::parseJSON(valueString);
             if (!resultValue) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not parse element tag name"_s));
                 return;
             }
 
@@ -1527,13 +1527,13 @@ void Session::isElementEnabled(const String& elementID, Function<void(CommandRes
 
             auto valueString = response.responseObject->getString("result"_s);
             if (!valueString) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve element enabled state from browsing context"_s));
                 return;
             }
 
             auto resultValue = JSON::Value::parseJSON(valueString);
             if (!resultValue) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not parse element enabled state"_s));
                 return;
             }
 
@@ -1566,7 +1566,7 @@ void Session::getComputedRole(const String& elementID, Function<void(CommandResu
 
             auto valueString = response.responseObject->getString("role"_s);
             if (!valueString) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve computed role from browsing context"_s));
                 return;
             }
 
@@ -1600,7 +1600,7 @@ void Session::getComputedLabel(const String& elementID, Function<void(CommandRes
 
             auto valueString = response.responseObject->getString("label"_s);
             if (!valueString) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve computed label from browsing context"_s));
                 return;
             }
 
@@ -1639,13 +1639,13 @@ void Session::isElementDisplayed(const String& elementID, Function<void(CommandR
 
             auto valueString = response.responseObject->getString("result"_s);
             if (!valueString) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve element display state from browsing context"_s));
                 return;
             }
 
             auto resultValue = JSON::Value::parseJSON(valueString);
             if (!resultValue) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not parse element display state"_s));
                 return;
             }
 
@@ -1684,13 +1684,13 @@ void Session::getElementAttribute(const String& elementID, const String& attribu
 
             auto valueString = response.responseObject->getString("result"_s);
             if (!valueString) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve element attribute from browsing context"_s));
                 return;
             }
 
             auto resultValue = JSON::Value::parseJSON(valueString);
             if (!resultValue) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not parse element attribute"_s));
                 return;
             }
 
@@ -1728,13 +1728,13 @@ void Session::getElementProperty(const String& elementID, const String& property
 
             auto valueString = response.responseObject->getString("result"_s);
             if (!valueString) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve element property from browsing context"_s));
                 return;
             }
 
             auto resultValue = JSON::Value::parseJSON(valueString);
             if (!resultValue) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not parse element property"_s));
                 return;
             }
 
@@ -1772,13 +1772,13 @@ void Session::getElementCSSValue(const String& elementID, const String& cssPrope
 
             auto valueString = response.responseObject->getString("result"_s);
             if (!valueString) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve element CSS value from browsing context"_s));
                 return;
             }
 
             auto resultValue = JSON::Value::parseJSON(valueString);
             if (!resultValue) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not parse element CSS value"_s));
                 return;
             }
 
@@ -1850,13 +1850,13 @@ void Session::elementIsFileUpload(const String& elementID, Function<void(Command
 
         auto valueString = response.responseObject->getString("result"_s);
         if (!valueString) {
-            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve element file upload information from browsing context"_s));
             return;
         }
 
         auto resultValue = JSON::Value::parseJSON(valueString);
         if (!resultValue) {
-            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not parse element file upload information"_s));
             return;
         }
 
@@ -1998,13 +1998,13 @@ void Session::elementIsEditable(const String& elementID, Function<void(CommandRe
 
         auto valueString = response.responseObject->getString("result"_s);
         if (!valueString) {
-            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve element editable state from browsing context"_s));
             return;
         }
 
         auto resultValue = JSON::Value::parseJSON(valueString);
         if (!resultValue) {
-            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not parse element editable state"_s));
             return;
         }
 
@@ -2388,13 +2388,13 @@ void Session::getPageSource(Function<void(CommandResult&&)>&& completionHandler)
 
             auto valueString = response.responseObject->getString("result"_s);
             if (!valueString) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve page source from browsing context"_s));
                 return;
             }
 
             auto resultValue = JSON::Value::parseJSON(valueString);
             if (!resultValue) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not parse page source information"_s));
                 return;
             }
 
@@ -2471,13 +2471,13 @@ void Session::executeScript(const String& script, RefPtr<JSON::Array>&& argument
 
             auto valueString = response.responseObject->getString("result"_s);
             if (!valueString) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve script result from browsing context"_s));
                 return;
             }
 
             auto resultValue = JSON::Value::parseJSON(valueString);
             if (!resultValue) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not parse script result"_s));
                 return;
             }
 
@@ -2671,7 +2671,7 @@ void Session::getAllCookies(Function<void(CommandResult&&)>&& completionHandler)
 
             auto cookiesArray = response.responseObject->getArray("cookies"_s);
             if (!cookiesArray) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve cookies from browsing context"_s));
                 return;
             }
 
@@ -2679,13 +2679,13 @@ void Session::getAllCookies(Function<void(CommandResult&&)>&& completionHandler)
             for (unsigned i = 0; i < cookiesArray->length(); ++i) {
                 auto cookieObject = cookiesArray->get(i)->asObject();
                 if (!cookieObject) {
-                    completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                    completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Invalid cookie object in browsing context"_s));
                     return;
                 }
 
                 auto cookie = parseAutomationCookie(*cookieObject);
                 if (!cookie) {
-                    completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                    completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Invalid cookie data in browsing context"_s));
                     return;
                 }
                 cookies->pushObject(serializeCookie(cookie.value()));
@@ -3095,7 +3095,7 @@ void Session::getAlertText(Function<void(CommandResult&&)>&& completionHandler)
 
         auto valueString = response.responseObject->getString("message"_s);
         if (!valueString) {
-            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+            completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve alert text from browsing context"_s));
             return;
         }
 
@@ -3151,7 +3151,7 @@ void Session::takeScreenshot(std::optional<String> elementID, std::optional<bool
 
             auto data = response.responseObject->getString("data"_s);
             if (!data) {
-                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError));
+                completionHandler(CommandResult::fail(CommandResult::ErrorCode::UnknownError, "Could not retrieve screenshot data from browsing context"_s));
                 return;
             }
 


### PR DESCRIPTION
#### b3e4aefa1583db42af63b5022ef4e5f4fd1ed4db
<pre>
[WebDriver] Provide better error messages in generic errors like UnknownError and InvalidArgument
<a href="https://bugs.webkit.org/show_bug.cgi?id=295338">https://bugs.webkit.org/show_bug.cgi?id=295338</a>

Reviewed by Carlos Garcia Campos.

- Tell which parameters are invalid in a request.
- Tell what check failed when processing a response from the browser.

* Source/WebDriver/Session.cpp:
* Source/WebDriver/WebDriverService.cpp:

Canonical link: <a href="https://commits.webkit.org/297044@main">https://commits.webkit.org/297044@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/670322666507899ece8735e060977f0dc84ca5bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109980 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29638 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116002 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60228 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30316 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38226 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83613 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24174 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99042 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64055 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23546 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17191 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59797 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93547 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17233 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118793 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27442 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92587 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37392 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95309 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92411 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23624 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37395 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15130 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32897 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36914 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42385 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36576 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39916 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38283 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->