### PR TITLE
Web Extensions: Get getTree() to display tree structure with mock nodes

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIBookmarks.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIBookmarks.h
@@ -49,7 +49,16 @@ public:
         String url;
     };
 
-    struct MockBookmarkNode {
+    struct MockBookmarkNode: public CanMakeWeakPtr<MockBookmarkNode>, public RefCounted<MockBookmarkNode> {
+        WTF_MAKE_FAST_ALLOCATED;
+
+    public:
+        template<typename... Args>
+        static Ref<MockBookmarkNode> create(Args&&... args)
+        {
+            return adoptRef(*new MockBookmarkNode(std::forward<Args>(args)...));
+        }
+
         String id;
         String parentId;
         String title;
@@ -57,9 +66,42 @@ public:
         size_t index;
         WallTime dateAdded;
         BookmarkTreeNodeType type;
+        Vector<Ref<MockBookmarkNode>> children;
+
+        MockBookmarkNode(const MockBookmarkNode& other)
+            : id(other.id)
+            , parentId(other.parentId)
+            , title(other.title)
+            , url(other.url)
+            , index(other.index)
+            , dateAdded(other.dateAdded)
+            , type(other.type)
+            , children(other.children)
+        {
+
+        }
+
+        MockBookmarkNode& operator=(const MockBookmarkNode& other)
+        {
+            if (this == &other)
+                return *this;
+
+            id = other.id;
+            parentId = other.parentId;
+            title = other.title;
+            url = other.url;
+            index = other.index;
+            dateAdded = other.dateAdded;
+            type = other.type;
+            children = other.children;
+            return *this;
+        }
+
+        MockBookmarkNode() = default;
     };
 
-    Vector<MockBookmarkNode> m_mockBookmarks;
+    HashMap<String, Ref<MockBookmarkNode>> m_mockBookmarks;
+    void initializeMockBookmarksInternal();
 
 #if PLATFORM(COCOA)
     void createBookmark(NSDictionary *bookmark, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);


### PR DESCRIPTION
#### 883a1e2a1a7a8d1d9a89e141e5d678f00fa54981
<pre>
Web Extensions: Get getTree() to display tree structure with mock nodes
<a href="https://rdar.apple.com/154437204">rdar://154437204</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=295067">https://bugs.webkit.org/show_bug.cgi?id=295067</a>

Reviewed by Brian Weinstein.

Created root node and appended nodes to the parent&apos;s children array or root&apos;s
children array. Then returned the root. Created tests for these.

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIBookmarksCocoa.mm:
(WebKit::toWebAPI):
(WebKit::WebExtensionAPIBookmarks::initializeMockBookmarksInternal):
(WebKit::WebExtensionAPIBookmarks::createBookmark):
(WebKit::WebExtensionAPIBookmarks::getRecent):
(WebKit::WebExtensionAPIBookmarks::getTree):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIBookmarks.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIBookmarks.mm:
(TestWebKitAPI::TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPICreateParse)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPIGetTree)):

Canonical link: <a href="https://commits.webkit.org/297188@main">https://commits.webkit.org/297188@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c1aa009124d965abf25eaf506458b08dc7a0de0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110649 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30308 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20741 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116675 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60916 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112612 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30987 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38897 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84137 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113597 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24746 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99633 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64578 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24108 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17772 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60470 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94135 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17831 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119465 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37689 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27994 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93099 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/110146 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38063 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95903 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92923 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37947 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15690 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/33666 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17875 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37585 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43057 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37247 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40586 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38955 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->