### PR TITLE
Occasional crash in WKMouseDeviceObserver.connectedDeviceCount.setter due to precondition violation

### DIFF
--- a/Source/WebKit/UIProcess/WKMouseDeviceObserver.swift
+++ b/Source/WebKit/UIProcess/WKMouseDeviceObserver.swift
@@ -74,14 +74,14 @@ internal import WebKit_Internal
         connectionObservationTask = Task {
             let connectSequence = NotificationCenter.default.notifications(named: .GCMouseDidConnect).map { $0.object is GCMouse }
             for await _ in connectSequence {
-                connectedDeviceCount += 1
+                connectedDeviceCount = GCMouse.mice().count
             }
         }
 
         disconnectionObservationTask = Task {
             let disconnectSequence = NotificationCenter.default.notifications(named: .GCMouseDidDisconnect).map { $0.object is GCMouse }
             for await _ in disconnectSequence {
-                connectedDeviceCount -= 1
+                connectedDeviceCount = GCMouse.mice().count
             }
         }
     }


### PR DESCRIPTION
#### fcb9f8f5a37d34b5251b17371ff76c749b45802a
<pre>
Occasional crash in WKMouseDeviceObserver.connectedDeviceCount.setter due to precondition violation
<a href="https://bugs.webkit.org/show_bug.cgi?id=295342">https://bugs.webkit.org/show_bug.cgi?id=295342</a>
<a href="https://rdar.apple.com/154860259">rdar://154860259</a>

Reviewed by Aditya Keerthi.

This crash happens due to a violation of the precondition asserting that the number of connected devices
is &gt;= 0. This is a perfectly valid precondition, since it doesn&apos;t make sense that there could be a _negative_
amount of connected devices.

This implies that there is some underlying issue in how the notifications are published. To workaround this
and be more resliant, access the array of connected devices directly and use its count, instead of manually
incrementing and decrementing.

* Source/WebKit/UIProcess/WKMouseDeviceObserver.swift:
(WKMouseDeviceObserver.start):

Canonical link: <a href="https://commits.webkit.org/296926@main">https://commits.webkit.org/296926@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/215e5ec58f8511cf2dd114bc376b92f91c6f3dcf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109983 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29641 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20073 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116005 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60231 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30319 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38229 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83616 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112931 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24175 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99046 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64058 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23547 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59800 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93548 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17236 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118796 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37022 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27446 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92590 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37395 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95312 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92414 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23551 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37398 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15133 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32901 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36917 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42388 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36579 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39919 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38286 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->