### PR TITLE
[Style] Remove exposure of the underlying LengthType in Style::LengthWrappers

### DIFF
--- a/LayoutTests/fast/css/absolute-positioned-max-content-width-expected.html
+++ b/LayoutTests/fast/css/absolute-positioned-max-content-width-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  #test {
+    padding: 16px;
+    position: absolute;
+    word-wrap: break-word;
+    box-sizing: border-box;
+  }
+</style>
+</head>
+<body>
+<p>The text below should not wrap.</p>
+<div id="test">Test</div>
+</body>

--- a/LayoutTests/fast/css/absolute-positioned-max-content-width.html
+++ b/LayoutTests/fast/css/absolute-positioned-max-content-width.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  #test {
+    padding: 16px;
+    position: absolute;
+    width: max-content;
+    word-wrap: break-word;
+    box-sizing: border-box;
+  }
+</style>
+</head>
+<body>
+<p>The text below should not wrap.</p>
+<div id="test">Test</div>
+</body>

--- a/LayoutTests/fast/css/absolute-positioned-min-content-width-expected.html
+++ b/LayoutTests/fast/css/absolute-positioned-min-content-width-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  #test {
+    padding: 16px;
+    position: absolute;
+    word-wrap: break-word;
+    box-sizing: border-box;
+  }
+</style>
+</head>
+<body>
+<p>The text below should not wrap.</p>
+<div id="test">Test</div>
+</body>

--- a/LayoutTests/fast/css/absolute-positioned-min-content-width.html
+++ b/LayoutTests/fast/css/absolute-positioned-min-content-width.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  #test {
+    padding: 16px;
+    position: absolute;
+    width: min-content;
+    word-wrap: break-word;
+    box-sizing: border-box;
+  }
+</style>
+</head>
+<body>
+<p>The text below should not wrap.</p>
+<div id="test">Test</div>
+</body>

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -93,6 +93,7 @@ rendering/BackgroundPainter.cpp
 rendering/BorderPainter.cpp
 rendering/RenderBox.cpp
 rendering/RenderElement.cpp
+rendering/RenderFlexibleBox.cpp
 rendering/RenderGrid.cpp
 rendering/RenderLayer.cpp
 rendering/RenderLayerCompositor.cpp

--- a/Source/WebCore/rendering/AutoTableLayout.h
+++ b/Source/WebCore/rendering/AutoTableLayout.h
@@ -45,7 +45,7 @@ private:
     void recalcColumn(unsigned effCol);
 
     float calcEffectiveLogicalWidth();
-    float shrinkCellWidth(const LengthType&, float available);
+    template<typename> float shrinkCellWidthForType(float available);
 
     void insertSpanCell(RenderTableCell*);
 

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -4218,7 +4218,7 @@ static bool isNonBlocksOrNonFixedHeightListItems(const RenderObject& renderer)
     if (!renderer.isRenderBlock())
         return true;
     if (CheckedPtr renderListItem = dynamicDowncast<RenderListItem>(renderer))
-        return renderListItem->style().height().type() != LengthType::Fixed;
+        return !renderListItem->style().height().isFixed();
     return false;
 }
 

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -310,13 +310,9 @@ public:
     LayoutSize offsetFromContainer(const RenderElement&, const LayoutPoint&, bool* offsetDependsOnPoint = nullptr) const override;
     
     LayoutUnit adjustBorderBoxLogicalWidthForBoxSizing(const Style::Length<CSS::Nonnegative, float>& logicalWidth) const;
+    LayoutUnit adjustBorderBoxLogicalWidthForBoxSizing(LayoutUnit computedLogicalWidth) const;
     LayoutUnit adjustContentBoxLogicalWidthForBoxSizing(const Style::Length<CSS::Nonnegative, float>& logicalWidth) const;
-
-    LayoutUnit adjustBorderBoxLogicalWidthForBoxSizing(LayoutUnit computedLogicalWidth, LengthType originalType) const;
-    LayoutUnit adjustContentBoxLogicalWidthForBoxSizing(LayoutUnit computedLogicalWidth, LengthType originalType) const;
-
-    template<typename T> LayoutUnit adjustBorderBoxLogicalWidthForBoxSizing(T computedLogicalWidth, LengthType originalType) const { return adjustBorderBoxLogicalWidthForBoxSizing(LayoutUnit(computedLogicalWidth), originalType); }
-    template<typename T> LayoutUnit adjustContentBoxLogicalWidthForBoxSizing(T computedLogicalWidth, LengthType originalType) const { return adjustContentBoxLogicalWidthForBoxSizing(LayoutUnit(computedLogicalWidth), originalType); }
+    LayoutUnit adjustContentBoxLogicalWidthForBoxSizing(LayoutUnit computedLogicalWidth) const;
 
     // Overridden by fieldsets to subtract out the intrinsic border.
     virtual LayoutUnit adjustBorderBoxLogicalHeightForBoxSizing(LayoutUnit height) const;
@@ -433,6 +429,7 @@ public:
     std::optional<LayoutUnit> computePercentageLogicalHeight(const Style::MaximumSize& logicalHeight, UpdatePercentageHeightDescendants = UpdatePercentageHeightDescendants::Yes) const;
     std::optional<LayoutUnit> computePercentageLogicalHeight(const Style::FlexBasis& logicalHeight, UpdatePercentageHeightDescendants = UpdatePercentageHeightDescendants::Yes) const;
     std::optional<LayoutUnit> computePercentageLogicalHeight(const Style::Percentage<CSS::Nonnegative, float>& logicalHeight, UpdatePercentageHeightDescendants = UpdatePercentageHeightDescendants::Yes) const;
+    std::optional<LayoutUnit> computePercentageLogicalHeight(const Style::UnevaluatedCalculation<CSS::LengthPercentage<CSS::Nonnegative, float>>& logicalHeight, UpdatePercentageHeightDescendants = UpdatePercentageHeightDescendants::Yes) const;
     bool hasAutoHeightOrContainingBlockWithAutoHeight(UpdatePercentageHeightDescendants = UpdatePercentageHeightDescendants::Yes) const;
 
     virtual LayoutUnit availableLogicalHeight(AvailableLogicalHeightType) const;
@@ -740,9 +737,7 @@ private:
 
     void computePositionedLogicalHeight(LogicalExtentComputedValues&) const;
 
-    LayoutUnit computePositionedLogicalWidthUsing(const Style::PreferredSize& logicalWidth, const PositionedLayoutConstraints& inlineConstraints) const;
-    LayoutUnit computePositionedLogicalWidthUsing(const Style::MinimumSize& logicalWidth, const PositionedLayoutConstraints& inlineConstraints) const;
-    LayoutUnit computePositionedLogicalWidthUsing(const Style::MaximumSize& logicalWidth, const PositionedLayoutConstraints& inlineConstraints) const;
+    template<typename SizeType> LayoutUnit computePositionedLogicalWidthUsing(const SizeType&, const PositionedLayoutConstraints&) const;
 
     LayoutUnit computePositionedLogicalHeightUsing(const Style::PreferredSize& logicalHeight, LayoutUnit computedHeight, const PositionedLayoutConstraints& blockConstraints) const;
     LayoutUnit computePositionedLogicalHeightUsing(const Style::MinimumSize& logicalHeight, LayoutUnit computedHeight, const PositionedLayoutConstraints& blockConstraints) const;

--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
@@ -1159,7 +1159,7 @@ LayoutUnit RenderDeprecatedFlexibleBox::allowedChildFlex(RenderBox* child, bool 
             LayoutUnit width = contentWidthForChild(child);
             if (auto fixedMaxWidth = child->style().maxWidth().tryFixed())
                 maxWidth = fixedMaxWidth->value;
-            else if (child->style().maxWidth().type() == LengthType::Intrinsic)
+            else if (child->style().maxWidth().isIntrinsicKeyword())
                 maxWidth = child->maxPreferredLogicalWidth();
             else if (child->style().maxWidth().isMinIntrinsic())
                 maxWidth = child->minPreferredLogicalWidth();
@@ -1184,7 +1184,7 @@ LayoutUnit RenderDeprecatedFlexibleBox::allowedChildFlex(RenderBox* child, bool 
         LayoutUnit width = contentWidthForChild(child);
         if (auto fixedMinWidth = child->style().minWidth().tryFixed())
             minWidth = fixedMinWidth->value;
-        else if (child->style().minWidth().type() == LengthType::Intrinsic)
+        else if (child->style().minWidth().isIntrinsicKeyword())
             minWidth = child->maxPreferredLogicalWidth();
         else if (child->style().minWidth().isMinIntrinsic())
             minWidth = child->minPreferredLogicalWidth();

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
@@ -105,7 +105,7 @@ template<typename Numeric, CSS::PrimitiveKeyword... Ks> struct LengthWrapperBase
         requires (SupportsIsIntrinsic)
     {
         return (SupportsMinContent && m_value.type() == WebCore::LengthType::MinContent)
-            || (SupportsMinContent && m_value.type() == WebCore::LengthType::MaxContent)
+            || (SupportsMaxContent && m_value.type() == WebCore::LengthType::MaxContent)
             || (SupportsWebkitFillAvailable && m_value.type() == WebCore::LengthType::FillAvailable)
             || (SupportsFitContent && m_value.type() == WebCore::LengthType::FitContent);
     }
@@ -130,9 +130,6 @@ template<typename Numeric, CSS::PrimitiveKeyword... Ks> struct LengthWrapperBase
     ALWAYS_INLINE bool isZero() const { return m_value.isZero(); }
     ALWAYS_INLINE bool isPositive() const { return m_value.isPositive(); }
     ALWAYS_INLINE bool isNegative() const { return m_value.isNegative(); }
-
-    // FIXME: Remove this when RenderBox's adjust*Box functions no longer need it.
-    ALWAYS_INLINE WebCore::LengthType type() const { return m_value.type(); }
 
     std::optional<Fixed> tryFixed() const { return isFixed() ? std::make_optional(Fixed { m_value.value() }) : std::nullopt; }
     std::optional<Percentage> tryPercentage() const { return isPercent() ? std::make_optional(Percentage { m_value.value() }) : std::nullopt; }


### PR DESCRIPTION
#### 69d2b44d2c118bb83c0a6db3754f31551fb481f4
<pre>
[Style] Remove exposure of the underlying LengthType in Style::LengthWrappers
<a href="https://bugs.webkit.org/show_bug.cgi?id=294923">https://bugs.webkit.org/show_bug.cgi?id=294923</a>

Reviewed by Darin Adler.

Remove the need for Style::LengthWrapperBase to expose the underlying Length&apos;s
LengthType property by removing all callers.

* LayoutTests/fast/css/absolute-positioned-max-content-width-expected.html: Added.
* LayoutTests/fast/css/absolute-positioned-max-content-width.html: Added.
* LayoutTests/fast/css/absolute-positioned-min-content-width-expected.html: Added.
* LayoutTests/fast/css/absolute-positioned-min-content-width.html: Added.
    - Add tests for regression reported in <a href="https://bugs.webkit.org/show_bug.cgi?id=295287.">https://bugs.webkit.org/show_bug.cgi?id=295287.</a>
* Source/WebCore/rendering/AutoTableLayout.cpp:
* Source/WebCore/rendering/AutoTableLayout.h:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
* Source/WebCore/rendering/RenderBox.cpp:
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp:
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
* Source/WebCore/rendering/RenderGrid.cpp:
* Source/WebCore/style/values/primitives/StyleLengthWrapper.h:

Canonical link: <a href="https://commits.webkit.org/296946@main">https://commits.webkit.org/296946@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b80b64b987ab97bfcf46d794ef02a49535ad8b10

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109990 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29649 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20081 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116012 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60238 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111953 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30327 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38236 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83627 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112938 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24182 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99053 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64069 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23554 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17201 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59807 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93555 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17244 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118803 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37030 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27450 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92599 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37402 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95319 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92456 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23564 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37406 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15140 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32911 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36924 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42395 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36586 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39926 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38295 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->