### PR TITLE
Use double instead of CoreIPCNumber for non-boolean number JavaScriptEvaluationResults

### DIFF
--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
@@ -32,10 +32,6 @@
 #include <WebCore/ExceptionDetails.h>
 #include <WebCore/SerializedScriptValue.h>
 
-#if PLATFORM(COCOA)
-#include "CoreIPCNumber.h"
-#endif
-
 namespace WebKit {
 
 #if !PLATFORM(COCOA)

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.h
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.h
@@ -62,7 +62,7 @@ class JavaScriptEvaluationResult {
 public:
 #if PLATFORM(COCOA)
     enum class NullType : bool { NullPointer, NSNull };
-    using Variant = Variant<NullType, bool, CoreIPCNumber, String, Seconds, Vector<JSObjectID>, HashMap<JSObjectID, JSObjectID>>;
+    using Variant = Variant<NullType, bool, double, String, Seconds, Vector<JSObjectID>, HashMap<JSObjectID, JSObjectID>>;
 
     JavaScriptEvaluationResult(JSObjectID, HashMap<JSObjectID, Variant>&&);
     static std::optional<JavaScriptEvaluationResult> extract(id);

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.serialization.in
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.serialization.in
@@ -23,7 +23,7 @@
 class WebKit::JavaScriptEvaluationResult {
 #if PLATFORM(COCOA)
     WebKit::JSObjectID root()
-    HashMap<WebKit::JSObjectID, Variant<WebKit::JavaScriptEvaluationResult::NullType, bool, WebKit::CoreIPCNumber, String, Seconds, Vector<WebKit::JSObjectID>, HashMap<WebKit::JSObjectID, WebKit::JSObjectID>>> map()
+    HashMap<WebKit::JSObjectID, Variant<WebKit::JavaScriptEvaluationResult::NullType, bool, double, String, Seconds, Vector<WebKit::JSObjectID>, HashMap<WebKit::JSObjectID, WebKit::JSObjectID>>> map()
 #else
     std::span<const uint8_t> wireBytes()
 #endif


### PR DESCRIPTION
#### 2de3690c0d2c282f1a609e01a783ff27629bab00
<pre>
Use double instead of CoreIPCNumber for non-boolean number JavaScriptEvaluationResults
<a href="https://bugs.webkit.org/show_bug.cgi?id=295360">https://bugs.webkit.org/show_bug.cgi?id=295360</a>
<a href="https://rdar.apple.com/154894423">rdar://154894423</a>

Reviewed by Richard Robinson.

The NSNumber comes from the result of JSValueToNumber which is a double.
This is not a change in behavior, just simplifying the IPC interface and
taking a step towards making the non-SerializedScriptValue version of
JavaScriptEvaluationResult work on non-ObjC platforms.

* Source/WebKit/Shared/JavaScriptEvaluationResult.cpp:
* Source/WebKit/Shared/JavaScriptEvaluationResult.h:
* Source/WebKit/Shared/JavaScriptEvaluationResult.mm:
(WebKit::JavaScriptEvaluationResult::toID):
(WebKit::JavaScriptEvaluationResult::toAPI):
(WebKit::JavaScriptEvaluationResult::toVariant):
(WebKit::JavaScriptEvaluationResult::jsValueToVariant):
* Source/WebKit/Shared/JavaScriptEvaluationResult.serialization.in:

Canonical link: <a href="https://commits.webkit.org/296934@main">https://commits.webkit.org/296934@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1163eb18140b6b2deecce4e1ffe6da7dc144f686

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110020 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29679 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20111 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116042 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/60268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30357 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38266 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/83644 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/60268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24208 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99080 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64086 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23578 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59838 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93581 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17271 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118833 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37060 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/27479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/92617 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37432 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95347 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92441 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37426 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15166 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/32942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17753 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36954 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42425 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36616 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39956 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/38325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->