### PR TITLE
[Form Control Refresh] Author-specified padding on a <button> is being ignored

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/button-author-level-padding-applies-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/button-author-level-padding-applies-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Author-level CSS padding should apply to buttons with native appearance
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/button-author-level-padding-applies.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/button-author-level-padding-applies.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<title>Author-level CSS padding should apply to buttons with native appearance</title>
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<button id="btn"></button>
+<script>
+test(() => {
+    let value = "10px";
+    btn.style.paddingLeft = value;
+    assert_equals(window.getComputedStyle(btn).paddingLeft, value);
+    btn.style.paddingTop = value;
+    assert_equals(window.getComputedStyle(btn).paddingTop, value);
+    btn.style.paddingRight = value;
+    assert_equals(window.getComputedStyle(btn).paddingRight, value);
+    btn.style.paddingBottom = value;
+    assert_equals(window.getComputedStyle(btn).paddingBottom, value);
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/select-author-level-padding-applies-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/select-author-level-padding-applies-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Author-level CSS padding should apply to select controls with native appearance
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/select-author-level-padding-applies.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/select-author-level-padding-applies.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<title>Author-level CSS padding should apply to select controls with native appearance</title>
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<select id="select"></select>
+<script>
+test(() => {
+    let value = "10px";
+    select.style.paddingLeft = value;
+    assert_equals(window.getComputedStyle(select).paddingLeft, value);
+    select.style.paddingTop = value;
+    assert_equals(window.getComputedStyle(select).paddingTop, value);
+    select.style.paddingRight = value;
+    assert_equals(window.getComputedStyle(select).paddingRight, value);
+    select.style.paddingBottom = value;
+    assert_equals(window.getComputedStyle(select).paddingBottom, value);
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7928,3 +7928,7 @@ fast/snapshot/nested-stacking-context.html [ Skip ]
 fast/snapshot/positioned-abs-relative-body.html [ Skip ]
 
 webkit.org/b/295432 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-clip-rect-zoom.html [ Pass ImageOnlyFailure ]
+
+# The padding for native buttons and select controls is overridden on iOS 18 and earlier.
+imported/w3c/web-platform-tests/css/css-ui/button-author-level-padding-applies.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-ui/select-author-level-padding-applies.html [ Skip ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2456,3 +2456,6 @@ webkit.org/b/295308 fullscreen/full-screen-enter-while-exiting-multiple-elements
 webkit.org/b/295408 imported/w3c/web-platform-tests/xhr/send-redirect.htm [ Pass Failure ]
 
 webkit.org/b/295435 compositing/layer-creation/overlap-animation-container.html [ Pass Failure ]
+
+# The padding for native select controls is overridden on macOS Sequoia and earlier.
+imported/w3c/web-platform-tests/css/css-ui/select-author-level-padding-applies.html [ Skip ]


### PR DESCRIPTION
#### 5a4508b65f711bf324f1a2868ed258d60112b4eb
<pre>
[Form Control Refresh] Author-specified padding on a &lt;button&gt; is being ignored
<a href="https://bugs.webkit.org/show_bug.cgi?id=295355">https://bugs.webkit.org/show_bug.cgi?id=295355</a>
<a href="https://rdar.apple.com/154889296">rdar://154889296</a>

Reviewed by Aditya Keerthi.

Check if the author has explicitly set padding for native controls before applying
padding in RenderThemeCocoa.

Tested by button-author-level-padding-applies.html and
select-author-level-padding-applies.html.

* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/button-author-level-padding-applies-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/button-author-level-padding-applies.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/select-author-level-padding-applies-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/select-author-level-padding-applies.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::applyPaddingIfNotExplicitlySet):
(WebCore::RenderThemeCocoa::adjustColorWellSwatchWrapperStyleForVectorBasedControls const):
(WebCore::applyEmPadding):
(WebCore::applyEmPaddingForNumberField):
(WebCore::RenderThemeCocoa::adjustTextFieldStyleForVectorBasedControls const):
(WebCore::applyCommonButtonPaddingToStyleForVectorBasedControls):
(WebCore::adjustSelectListButtonStyleForVectorBasedControls):
(WebCore::adjustInputElementButtonStyleForVectorBasedControls):
(WebCore::RenderThemeCocoa::adjustButtonStyleForVectorBasedControls const):

Canonical link: <a href="https://commits.webkit.org/297013@main">https://commits.webkit.org/297013@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/232f7ad39bb36dd1a3235eb6e136449d1c3ad8c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110267 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29926 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20358 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116291 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/60515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112230 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30605 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38513 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/83834 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/60515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113215 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/24417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/99297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/64282 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/23776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/17433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/60085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/93792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/17491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119081 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37307 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/27661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/92808 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37679 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/95567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/92634 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/37633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/15363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/33196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17787 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37201 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42672 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/36863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40203 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/38572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->