### PR TITLE
[ macOS wk2 Release ] imported/w3c/web-platform-tests/css/css-pseudo/highlight-custom-properties-dynamic-001.html is a flaky image failure (295076)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-custom-properties-dynamic-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-custom-properties-dynamic-001.html
@@ -21,7 +21,22 @@
   requestAnimationFrame(() => {
     requestAnimationFrame(() => {
       originating.style.setProperty("--background-color", "green");
-      requestAnimationFrame(() => takeScreenshot());
+      let attempts = 0;
+      const maxAttempts = 30;
+      function waitForStyleUpdate() {
+        const computedStyle = getComputedStyle(originating, "::selection");
+        const backgroundColor = computedStyle.backgroundColor;
+        // Check if the background color has been updated to green
+        if (backgroundColor === "rgb(0, 128, 0)" || backgroundColor === "green") {
+          takeScreenshot();
+        } else if (attempts < maxAttempts) {
+          attempts++;
+          requestAnimationFrame(waitForStyleUpdate);
+        } else {
+          takeScreenshot();
+        }
+      }
+      waitForStyleUpdate();
     });
   });
 </script>


### PR DESCRIPTION
#### 18b5186dc92837595991ee040e437ba94e4b244a
<pre>
[ macOS wk2 Release ] imported/w3c/web-platform-tests/css/css-pseudo/highlight-custom-properties-dynamic-001.html is a flaky image failure (295076)
<a href="https://rdar.apple.com/154442195">rdar://154442195</a>

Reviewed by Jonathan Bedard.

Test was racy, added a loop to check if it turns green instead of a single requestAnimationFrame.

* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-custom-properties-dynamic-001.html:

Canonical link: <a href="https://commits.webkit.org/296952@main">https://commits.webkit.org/296952@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a140d0f4dd19289368917bb910f9a297f667eafd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110031 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29690 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20122 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116053 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60279 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30368 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38277 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83649 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112979 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24210 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99087 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64091 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23580 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17232 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59849 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93583 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17278 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118844 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37071 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27478 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92623 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37443 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95355 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92447 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23570 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37431 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15171 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32953 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36965 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36627 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39967 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38336 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->