### PR TITLE
[WebGPU] synchronizeResource is not needed for UMA systems

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-295370-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-295370-expected.txt
@@ -1,0 +1,3 @@
+CONSOLE MESSAGE: promises created
+CONSOLE MESSAGE: Pass
+

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-295370.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-295370.html
@@ -1,0 +1,245 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let adapter1 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter1.requestDevice({
+  defaultQueue: {},
+  requiredFeatures: [
+    'core-features-and-limits',
+    'shader-f16',
+  ],
+});
+// START
+a = await adapter0.requestDevice()
+veryExplicitBindGroupLayout1 = a.createBindGroupLayout({
+  entries : [ {
+    binding : 3,
+    visibility :
+        GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+    externalTexture : {}
+  } ]
+})
+c = new VideoFrame(
+    new ArrayBuffer(16),
+    {codedWidth : 2, codedHeight : 2, format : 'NV12', timestamp : 0})
+veryExplicitBindGroupLayout3 = a.createBindGroupLayout({
+  entries : [ {
+    binding : 3,
+    visibility :
+        GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+    externalTexture : {}
+  } ]
+})
+pipelineLayout5 = a.createPipelineLayout({
+  bindGroupLayouts : [
+    veryExplicitBindGroupLayout3, veryExplicitBindGroupLayout1,
+    veryExplicitBindGroupLayout3, veryExplicitBindGroupLayout3
+  ]
+})
+d = a.createShaderModule({
+  code : ` enable f16;
+              @group(1) @binding(3) var e: texture_external;
+              
+              var<private> h = modf(0.06523);
+              struct i {
+              @location(0) j: vec4u,   @location(5) k: vec4i}
+              struct l {
+              @builtin(local_invocation_index) local_invocation_index: u32}
+              fn m(v: f16) -> f16 {
+            return v;
+            }
+              struct VertexOutput1 {
+              @location(2) n: vec4h,   @builtin(position) position: vec4f,   @location(15) @interpolate(flat) o: i32}
+              fn p(a0: texture_external) -> array<mat3x4h, 1> {
+              var aa: array<mat3x4h, 1>;
+              h = modf(bitcast<f32>(clamp(vec2i(q(120517399), q(140421516)), bitcast<vec2i>(aa[r(918813200)][q(1)]), vec2i(q(194565119), q(213139276))).y));
+              aa[u32(sqrt(vec4h(m(23740.1), m(31744.3), m(10788.2), m(13512.0)))[0])] += mat3x4h(vec4h(textureLoad(e, vec2u(r(74411865), r(744372268)))), vec4h(textureLoad(e, vec2u(r(74411865), r(744372268)))), vec4h(textureLoad(e, vec2u(r(74411865), r(744372268))).arab.zyxy));
+              return aa;
+            }
+              fn q(v: i32) -> i32 {
+            return v;
+            }
+              fn s() -> array<array<vec2i, 1>, 2> {
+              var aa: array<array<vec2i, 1>, 2>;
+              return aa;
+            }
+              struct FragmentInput5 {
+              @location(2) n: vec4h}
+              fn t() {
+              p(e);
+            }
+              struct ab {
+              @builtin(num_workgroups) num_workgroups: vec3u}
+              fn r(v: u32) -> u32 {
+            return v;
+            }
+              @vertex fn ac() -> VertexOutput1 {
+              var aa: VertexOutput1;
+              t();
+              return aa;
+            }
+              @fragment fn u(a0: FragmentInput5) -> i {
+              var aa: i;
+              return aa;
+            }
+              `
+})
+ad = a.createRenderPipeline({
+  layout : pipelineLayout5,
+  fragment : {module : d, targets : [ {format : 'rgba16uint'} ]},
+  vertex : {module : d}
+})
+externalTexture0 = a.importExternalTexture({source : c});
+w = a.createTexture({
+  size : {width : 1, depthOrArrayLayers : 13},
+  dimension : '3d',
+  format : 'rgba16uint',
+  usage : GPUTextureUsage.RENDER_ATTACHMENT
+})
+x = new VideoFrame(
+    new ArrayBuffer(16),
+    {codedWidth : 2, codedHeight : 2, format : 'BGRX', timestamp : 0})
+ae = await a.createRenderPipelineAsync({
+  layout : pipelineLayout5,
+  vertex : {
+    module : d}
+})
+bindGroup1 = a.createBindGroup({
+  layout : veryExplicitBindGroupLayout3,
+  entries : [ {binding : 3, resource : externalTexture0} ]
+})
+af = a.createBindGroup({
+  layout : veryExplicitBindGroupLayout3,
+  entries : [ {binding : 3, resource : externalTexture0} ]
+})
+recycledExplicitBindGroupLayout0 = ae.getBindGroupLayout(0)
+ag = w.createView()
+ah = a.importExternalTexture({source : c})
+videoFrame2 = new VideoFrame(
+    new ArrayBuffer(16),
+    {codedWidth : 2, codedHeight : 2, format : 'RGBX', timestamp : 0})
+ai = a.importExternalTexture({source : videoFrame2})
+aj = a.createBindGroup({
+  layout : veryExplicitBindGroupLayout1,
+  entries : [ {binding : 3, resource : ai} ]
+})
+pipeline7 = await a.createRenderPipelineAsync({
+  layout : pipelineLayout5,
+  fragment : {module : d, targets : [ {format : 'rgba16uint'} ]},
+  vertex : {module : d}
+});
+ak = a.createCommandEncoder();
+al = pipeline7.getBindGroupLayout(2);
+am = ak.beginRenderPass({
+  colorAttachments :
+      [ {view : ag, depthSlice : 5, loadOp : 'load', storeOp : 'store'} ]
+})
+try {
+  am.setBindGroup(2, aj)
+} catch {
+}
+try {
+  am.setPipeline(ad)
+am.setBindGroup(3, af)
+am.setBindGroup(0, bindGroup1)
+} catch {
+}
+externalTexture8 = a.importExternalTexture({source : x})
+let an = a.createBindGroup(
+    {layout : al, entries : [ {binding : 3, resource : externalTexture8} ]})
+try {
+  am.setBindGroup(1, an)
+} catch {
+}
+try {
+  am.draw(801)
+} catch {
+}
+a.createBindGroup({
+  layout : recycledExplicitBindGroupLayout0,
+  entries : [ {binding : 3, resource : ah} ]
+})
+try {
+  am.end()
+} catch {
+}
+commandBuffer8 = ak.finish()
+gc()
+try {
+  a.queue.submit([ commandBuffer8 ])
+} catch {
+}
+// END
+await device0.queue.onSubmittedWorkDone();
+log('Pass');
+globalThis.testRunner?.dumpAsText();
+globalThis.testRunner?.notifyDone();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+};
+</script>

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -180,7 +180,7 @@ private PUBLIC_IN_WEBGPU_SWIFT:
     NSString* m_lastErrorString { nil };
     uint64_t m_debugGroupStackSize { 0 };
     ThreadSafeWeakPtr<CommandBuffer> m_cachedCommandBuffer;
-#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+#if CPU(X86_64)
     NSMutableSet<id<MTLTexture>> *m_managedTextures { nil };
     NSMutableSet<id<MTLBuffer>> *m_managedBuffers { nil };
 #endif

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -141,7 +141,7 @@ CommandEncoder::CommandEncoder(id<MTLCommandBuffer> commandBuffer, Device& devic
     , m_device(device)
     , m_uniqueId(uniqueId)
 {
-#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+#if CPU(X86_64)
     m_managedTextures = [NSMutableSet set];
     m_managedBuffers = [NSMutableSet set];
 #endif
@@ -1449,7 +1449,7 @@ void CommandEncoder::addBuffer(id<MTLBuffer> buffer)
     if (!buffer)
         return;
 
-#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+#if CPU(X86_64)
     if (buffer.storageMode == MTLStorageModeManaged)
         [m_managedBuffers addObject:buffer];
     else
@@ -1461,7 +1461,7 @@ void CommandEncoder::addTexture(id<MTLTexture> texture)
     if (!texture)
         return;
 
-#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+#if CPU(X86_64)
     if (texture.storageMode == MTLStorageModeManaged)
         [m_managedTextures addObject:texture];
     else
@@ -2095,7 +2095,7 @@ Ref<CommandBuffer> CommandEncoder::finish(const WGPUCommandBufferDescriptor& des
 
     commandBuffer.label = fromAPI(descriptor.label).createNSString().get();
 
-#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+#if CPU(X86_64)
     if (m_managedBuffers.count || m_managedTextures.count) {
         id<MTLBlitCommandEncoder> blitCommandEncoder = [commandBuffer blitCommandEncoder];
         for (id<MTLBuffer> buffer in m_managedBuffers)


### PR DESCRIPTION
#### 84d86c9e712c57a74dc460e7f46495728747e145
<pre>
[WebGPU] synchronizeResource is not needed for UMA systems
<a href="https://bugs.webkit.org/show_bug.cgi?id=295370">https://bugs.webkit.org/show_bug.cgi?id=295370</a>
<a href="https://rdar.apple.com/154828949">rdar://154828949</a>

Reviewed by Tadeu Zagallo.

SV exhibits a retain issue on some UMA devices with calls to
sychronizeResource: which is not neede on UMA, only Intel Macs.

* LayoutTests/fast/webgpu/nocrash/fuzz-295370-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-295370.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::CommandEncoder):
(WebGPU::CommandEncoder::finish):
Only compile the code on X86.

Canonical link: <a href="https://commits.webkit.org/296984@main">https://commits.webkit.org/296984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ff863af9a565c48ecb1583a4fc77c4e09520e51

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110141 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29800 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20232 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116163 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60389 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30478 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38387 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83743 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113089 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24312 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99190 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64187 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23679 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17324 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59959 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93688 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17381 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118954 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37181 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27566 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92715 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37553 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95457 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92538 "Found 2 new API test failures: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23592 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37530 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15267 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33070 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37075 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42546 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36737 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40077 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38446 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->