### PR TITLE
[JSC] Optimize 16-bit string comparison in DFG and FTL

### DIFF
--- a/JSTests/microbenchmarks/string-equality-16bit-16bit.js
+++ b/JSTests/microbenchmarks/string-equality-16bit-16bit.js
@@ -1,0 +1,21 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const str16 = "こん" + "にちは";
+
+let count1 = 0;
+let count2 = 0;
+
+for (let i = 0; i < 1e6; i++) {
+    const s = i % 2 === 0 ? "こん" + "ばんは" : "こん" + "にちは";
+    if (str16 === s) {
+        count1++;
+    } else {
+        count2++;
+    }
+}
+
+shouldBe(count1, 1e6 / 2);
+shouldBe(count2, 1e6 / 2);

--- a/JSTests/microbenchmarks/string-equality-8bit-8bit.js
+++ b/JSTests/microbenchmarks/string-equality-8bit-8bit.js
@@ -1,0 +1,21 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const str8 = "hello" + " world";
+
+let count1 = 0;
+let count2 = 0;
+
+for (let i = 0; i < 1e6; i++) {
+    const s = i % 2 === 0 ? "hello" + " earth" : "hello" + " world";
+    if (str8 === s) {
+        count1++;
+    } else {
+        count2++;
+    }
+}
+
+shouldBe(count1, 1e6 / 2);
+shouldBe(count2, 1e6 / 2);

--- a/JSTests/microbenchmarks/string-equality-long-16bit.js
+++ b/JSTests/microbenchmarks/string-equality-long-16bit.js
@@ -1,0 +1,24 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const longStr16 = "あ".repeat(100) + "い".repeat(100) + "う".repeat(100);
+
+let count1 = 0;
+let count2 = 0;
+
+for (let i = 0; i < 1e4; i++) {
+    const s = i % 2 === 0 
+        ? "あ".repeat(100) + "い".repeat(100) + "え".repeat(100)
+        : "あ".repeat(100) + "い".repeat(100) + "う".repeat(100);
+    
+    if (longStr16 === s) {
+        count1++;
+    } else {
+        count2++;
+    }
+}
+
+shouldBe(count1, 1e4 / 2);
+shouldBe(count2, 1e4 / 2);

--- a/JSTests/microbenchmarks/string-equality-mixed-encoding.js
+++ b/JSTests/microbenchmarks/string-equality-mixed-encoding.js
@@ -1,0 +1,26 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const str8 = "hello" + " world";
+const str16 = "こん" + "にちは";
+
+let count1 = 0;
+let count2 = 0;
+
+for (let i = 0; i < 1e6; i++) {
+    const useStr8 = i % 4 === 0;
+    const useStr16 = i % 4 === 1;
+    const s1 = useStr8 ? str8 : str16;
+    const s2 = useStr16 ? str16 : str8;
+    
+    if (s1 === s2) {
+        count1++;
+    } else {
+        count2++;
+    }
+}
+
+shouldBe(count1, 1e6 / 2);
+shouldBe(count2, 1e6 / 2);

--- a/JSTests/stress/string-equality-16bit-16bit.js
+++ b/JSTests/stress/string-equality-16bit-16bit.js
@@ -1,0 +1,40 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+const testLoopCount = 10000;
+
+for (let i = 0; i < testLoopCount; i++) {
+    const str1 = "こん" + "にちは" + "世界";
+    const str2 = "こん" + "にちは" + "世界";
+    const str3 = "こん" + "にちは";
+    const str4 = "こん" + "にちは" + "世界!";
+    
+    shouldBe(str1 === str2, true);
+    shouldBe(str1 == str2, true);
+    
+    shouldBe(str1 === str3, false);
+    shouldBe(str1 == str3, false);
+    
+    shouldBe(str1 === str4, false);
+    shouldBe(str1 == str4, false);
+    
+    shouldBe(str1 === str1, true);
+    
+    const newStr1 = "テスト" + i.toString();
+    const newStr2 = "テスト" + i.toString();
+    shouldBe(newStr1 === newStr2, true);
+    
+    const large1 = "あ".repeat(1000);
+    const large2 = "あ".repeat(1000);
+    const large3 = "あ".repeat(999) + "い";
+    shouldBe(large1 === large2, true);
+    shouldBe(large1 === large3, false);
+    
+    const mixed1 = "ひらがな" + "カタカナ" + "漢字";
+    const mixed2 = "ひらがな" + "カタカナ" + "漢字";
+    const mixed3 = "ひらがな" + "カタカナ" + "感じ";
+    shouldBe(mixed1 === mixed2, true);
+    shouldBe(mixed1 === mixed3, false);
+}

--- a/JSTests/stress/string-equality-16bit-8bit.js
+++ b/JSTests/stress/string-equality-16bit-8bit.js
@@ -1,0 +1,40 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+const testLoopCount = 10000;
+
+for (let i = 0; i < testLoopCount; i++) {
+    const str16bit = "こん" + "にちは";
+    const str8bit = "hel" + "lo";
+    
+    shouldBe(str16bit === str8bit, false);
+    shouldBe(str16bit == str8bit, false);
+    
+    const japanese = "１" + "２３";
+    const ascii = "1" + "23";
+    shouldBe(japanese === ascii, false);
+    shouldBe(japanese == ascii, false);
+    
+    const fullwidthA = "Ａ";
+    const asciiA = "A";
+    shouldBe(fullwidthA === asciiA, false);
+    shouldBe(fullwidthA == asciiA, false);
+    
+    const dynamic16bit = "テ" + "スト" + i.toString();
+    const dynamic8bit = "te" + "st" + i.toString();
+    shouldBe(dynamic16bit === dynamic8bit, false);
+    
+    const nonEmpty16bit = "あ";
+    const empty8bit = "";
+    shouldBe(nonEmpty16bit === empty8bit, false);
+    
+    const large16bit = "あ".repeat(1000);
+    const large8bit = "a".repeat(1000);
+    shouldBe(large16bit === large8bit, false);
+    
+    const symbols = "🌸" + "🗾🍣";
+    const asciiSymbols = "a" + "bc";
+    shouldBe(symbols === asciiSymbols, false);
+}

--- a/JSTests/stress/string-equality-8bit-16bit.js
+++ b/JSTests/stress/string-equality-8bit-16bit.js
@@ -1,0 +1,36 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+const testLoopCount = 10000;
+
+for (let i = 0; i < testLoopCount; i++) {
+    const str8bit = "hel" + "lo";
+    const str16bit = "こん" + "にちは";
+    
+    shouldBe(str8bit === str16bit, false);
+    shouldBe(str8bit == str16bit, false);
+    
+    const ascii = "1" + "23";
+    const japanese = "１" + "２３";
+    shouldBe(ascii === japanese, false);
+    shouldBe(ascii == japanese, false);
+    
+    const asciiA = "A";
+    const fullwidthA = "Ａ";
+    shouldBe(asciiA === fullwidthA, false);
+    shouldBe(asciiA == fullwidthA, false);
+    
+    const dynamic8bit = "te" + "st" + i.toString();
+    const dynamic16bit = "テ" + "スト" + i.toString();
+    shouldBe(dynamic8bit === dynamic16bit, false);
+    
+    const empty8bit = "";
+    const nonEmpty16bit = "あ";
+    shouldBe(empty8bit === nonEmpty16bit, false);
+    
+    const large8bit = "a".repeat(1000);
+    const large16bit = "あ".repeat(1000);
+    shouldBe(large8bit === large16bit, false);
+}

--- a/JSTests/stress/string-equality-8bit-8bit.js
+++ b/JSTests/stress/string-equality-8bit-8bit.js
@@ -1,0 +1,34 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+const testLoopCount = 10000;
+
+for (let i = 0; i < testLoopCount; i++) {
+    const str1 = "hello" + " world";
+    const str2 = "hello" + " world";
+    const str3 = "hel" + "lo";
+    const str4 = "hello" + " world!";
+    
+    shouldBe(str1 === str2, true);
+    shouldBe(str1 == str2, true);
+    
+    shouldBe(str1 === str3, false);
+    shouldBe(str1 == str3, false);
+    
+    shouldBe(str1 === str4, false);
+    shouldBe(str1 == str4, false);
+    
+    shouldBe(str1 === str1, true);
+    
+    const newStr1 = "test" + i.toString();
+    const newStr2 = "test" + i.toString();
+    shouldBe(newStr1 === newStr2, true);
+    
+    const large1 = "a".repeat(1000);
+    const large2 = "a".repeat(1000);
+    const large3 = "a".repeat(999) + "b";
+    shouldBe(large1 === large2, true);
+    shouldBe(large1 === large3, false);
+}

--- a/JSTests/stress/string-equality-ascii-16bit.js
+++ b/JSTests/stress/string-equality-ascii-16bit.js
@@ -1,0 +1,36 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+const testLoopCount = 10000;
+
+for (let i = 0; i < testLoopCount; i++) {
+    const mixed1 = "Hel" + "lo世界";
+    const mixed2 = "Hel" + "lo世界";
+    const mixed3 = "Hel" + "lo世";
+    shouldBe(mixed1 === mixed2, true);
+    shouldBe(mixed1 === mixed3, false);
+    
+    const num1 = "12" + "3あ";
+    const num2 = "12" + "3あ";
+    const num3 = "12" + "3い";
+    shouldBe(num1 === num2, true);
+    shouldBe(num1 === num3, false);
+    
+    const punct1 = "Hel" + "lo, 世界!";
+    const punct2 = "Hel" + "lo, 世界!";
+    const punct3 = "Hel" + "lo, 世界?";
+    shouldBe(punct1 === punct2, true);
+    shouldBe(punct1 === punct3, false);
+    
+    const space1 = "あ " + "い う";
+    const space2 = "あ " + "い う";
+    const space3 = "あ　" + "い　う";
+    shouldBe(space1 === space2, true);
+    shouldBe(space1 === space3, false);
+    
+    const dynamic1 = "te" + "st" + "テ" + "スト" + i;
+    const dynamic2 = "te" + "st" + "テ" + "スト" + i;
+    shouldBe(dynamic1 === dynamic2, true);
+}

--- a/JSTests/stress/string-equality-emoji.js
+++ b/JSTests/stress/string-equality-emoji.js
@@ -1,0 +1,53 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+const testLoopCount = 10000;
+
+for (let i = 0; i < testLoopCount; i++) {
+    const emoji1 = "🌸" + "🗾🍣";
+    const emoji2 = "🌸" + "🗾🍣";
+    const emoji3 = "🌸" + "🗾🍤";
+    shouldBe(emoji1 === emoji2, true);
+    shouldBe(emoji1 === emoji3, false);
+    
+    const face1 = "😀" + "😃😄";
+    const face2 = "😀" + "😃😄";
+    const face3 = "😀" + "😃😅";
+    shouldBe(face1 === face2, true);
+    shouldBe(face1 === face3, false);
+    
+    const mixed1 = "Hel" + "lo🌍World";
+    const mixed2 = "Hel" + "lo🌍World";
+    const mixed3 = "Hel" + "lo🌎World";
+    shouldBe(mixed1 === mixed2, true);
+    shouldBe(mixed1 === mixed3, false);
+    
+    const numEmoji1 = "1️⃣" + "2️⃣3️⃣";
+    const numEmoji2 = "1️⃣" + "2️⃣3️⃣";
+    const numEmoji3 = "1️⃣" + "2️⃣4️⃣";
+    shouldBe(numEmoji1 === numEmoji2, true);
+    shouldBe(numEmoji1 === numEmoji3, false);
+    
+    const flag1 = "🇯🇵" + "🇺🇸";
+    const flag2 = "🇯🇵" + "🇺🇸";
+    const flag3 = "🇯🇵" + "🇬🇧";
+    shouldBe(flag1 === flag2, true);
+    shouldBe(flag1 === flag3, false);
+    
+    const heart1 = "❤️" + "💙💚";
+    const heart2 = "❤️" + "💙💚";
+    const heart3 = "❤️" + "💙💛";
+    shouldBe(heart1 === heart2, true);
+    shouldBe(heart1 === heart3, false);
+    
+    const complex1 = "👨‍👩" + "‍👧‍👦";
+    const complex2 = "👨‍👩" + "‍👧‍👦";
+    shouldBe(complex1 === complex2, true);
+    
+    const emojiBase = "🎉";
+    const dynamic1 = emojiBase + i.toString();
+    const dynamic2 = emojiBase + i.toString();
+    shouldBe(dynamic1 === dynamic2, true);
+}

--- a/JSTests/stress/string-equality-japanese-characters.js
+++ b/JSTests/stress/string-equality-japanese-characters.js
@@ -1,0 +1,49 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+const testLoopCount = 10000;
+
+for (let i = 0; i < testLoopCount; i++) {
+    const hiragana1 = "あい" + "うえお";
+    const hiragana2 = "あい" + "うえお";
+    const hiragana3 = "あい" + "うえか";
+    shouldBe(hiragana1 === hiragana2, true);
+    shouldBe(hiragana1 === hiragana3, false);
+    
+    const katakana1 = "アイ" + "ウエオ";
+    const katakana2 = "アイ" + "ウエオ";
+    const katakana3 = "アイ" + "ウエカ";
+    shouldBe(katakana1 === katakana2, true);
+    shouldBe(katakana1 === katakana3, false);
+    
+    const kanji1 = "日本" + "語文字";
+    const kanji2 = "日本" + "語文字";
+    const kanji3 = "日本" + "語文章";
+    shouldBe(kanji1 === kanji2, true);
+    shouldBe(kanji1 === kanji3, false);
+    
+    const mixed1 = "ひらがな" + "カタカナ" + "漢字";
+    const mixed2 = "ひらがな" + "カタカナ" + "漢字";
+    const mixed3 = "ひらがな" + "カタカナ" + "感じ";
+    shouldBe(mixed1 === mixed2, true);
+    shouldBe(mixed1 === mixed3, false);
+    
+    const sentence1 = "今日は" + "とても良い" + "天気ですね。";
+    const sentence2 = "今日は" + "とても良い" + "天気ですね。";
+    const sentence3 = "今日は" + "とても悪い" + "天気ですね。";
+    shouldBe(sentence1 === sentence2, true);
+    shouldBe(sentence1 === sentence3, false);
+    
+    const jpNum1 = "一二" + "三四五";
+    const jpNum2 = "一二" + "三四五";
+    const jpNum3 = "一二" + "三四六";
+    shouldBe(jpNum1 === jpNum2, true);
+    shouldBe(jpNum1 === jpNum3, false);
+    
+    const counter = String.fromCharCode(12354 + (i % 83));
+    const dynamic1 = "テ" + "スト" + counter;
+    const dynamic2 = "テ" + "スト" + counter;
+    shouldBe(dynamic1 === dynamic2, true);
+}

--- a/JSTests/stress/string-equality-null-characters.js
+++ b/JSTests/stress/string-equality-null-characters.js
@@ -1,0 +1,56 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+const testLoopCount = 10000;
+
+for (let i = 0; i < testLoopCount; i++) {
+    const null8bit1 = "a" + "\u0000" + "b";
+    const null8bit2 = "a" + "\u0000" + "b";
+    const null8bit3 = "a" + "\u0000" + "c";
+    shouldBe(null8bit1 === null8bit2, true);
+    shouldBe(null8bit1 === null8bit3, false);
+    
+    const null16bit1 = "あ" + "\u0000" + "い";
+    const null16bit2 = "あ" + "\u0000" + "い";
+    const null16bit3 = "あ" + "\u0000" + "う";
+    shouldBe(null16bit1 === null16bit2, true);
+    shouldBe(null16bit1 === null16bit3, false);
+    
+    const multiNull1 = "\u0000" + "\u0000" + "\u0000";
+    const multiNull2 = "\u0000" + "\u0000" + "\u0000";
+    const multiNull3 = "\u0000" + "\u0000";
+    shouldBe(multiNull1 === multiNull2, true);
+    shouldBe(multiNull1 === multiNull3, false);
+    
+    const control1 = "a" + "\u0001\u0002\u0003" + "b";
+    const control2 = "a" + "\u0001\u0002\u0003" + "b";
+    const control3 = "a" + "\u0001\u0002\u0004" + "b";
+    shouldBe(control1 === control2, true);
+    shouldBe(control1 === control3, false);
+    
+    const whitespace1 = "a" + "\t\n\r" + "b";
+    const whitespace2 = "a" + "\t\n\r" + "b";
+    const whitespace3 = "a" + "\t\n " + "b";
+    shouldBe(whitespace1 === whitespace2, true);
+    shouldBe(whitespace1 === whitespace3, false);
+    
+    const mixedNull1 = "テスト" + "\u0000" + "test";
+    const mixedNull2 = "テスト" + "\u0000" + "test";
+    const mixedNull3 = "テスト" + "\u0001" + "test";
+    shouldBe(mixedNull1 === mixedNull2, true);
+    shouldBe(mixedNull1 === mixedNull3, false);
+    
+    const startNull1 = "\u0000" + "hello";
+    const startNull2 = "\u0000" + "hello";
+    const endNull1 = "hello" + "\u0000";
+    const endNull2 = "hello" + "\u0000";
+    shouldBe(startNull1 === startNull2, true);
+    shouldBe(endNull1 === endNull2, true);
+    shouldBe(startNull1 === endNull1, false);
+    
+    const dynamic1 = "test\u0000" + i.toString();
+    const dynamic2 = "test\u0000" + i.toString();
+    shouldBe(dynamic1 === dynamic2, true);
+}

--- a/JSTests/stress/string-equality-surrogate-pairs.js
+++ b/JSTests/stress/string-equality-surrogate-pairs.js
@@ -1,0 +1,52 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+const testLoopCount = 10000;
+
+for (let i = 0; i < testLoopCount; i++) {
+    const math1 = "𝔸" + "𝔹ℂ𝔻";
+    const math2 = "𝔸" + "𝔹ℂ𝔻";
+    const math3 = "𝔸" + "𝔹ℂ𝔼";
+    shouldBe(math1 === math2, true);
+    shouldBe(math1 === math3, false);
+    
+    const ancient1 = "𐊀" + "𐊁𐊂";
+    const ancient2 = "𐊀" + "𐊁𐊂";
+    const ancient3 = "𐊀" + "𐊁𐊃";
+    shouldBe(ancient1 === ancient2, true);
+    shouldBe(ancient1 === ancient3, false);
+    
+    const music1 = "𝄞" + "𝄢𝄫";
+    const music2 = "𝄞" + "𝄢𝄫";
+    const music3 = "𝄞" + "𝄢𝄪";
+    shouldBe(music1 === music2, true);
+    shouldBe(music1 === music3, false);
+    
+    const high1 = String.fromCharCode(0xD800);
+    const low1 = String.fromCharCode(0xDC00);
+    const surrogate1 = high1 + low1;
+    const surrogate2 = high1 + low1;
+    const low2 = String.fromCharCode(0xDC01);
+    const surrogate3 = high1 + low2;
+    shouldBe(surrogate1 === surrogate2, true);
+    shouldBe(surrogate1 === surrogate3, false);
+    
+    const mixed1 = "A" + "𝔸B";
+    const mixed2 = "A" + "𝔸B";
+    const mixed3 = "A" + "𝔹B";
+    shouldBe(mixed1 === mixed2, true);
+    shouldBe(mixed1 === mixed3, false);
+    
+    const large1 = "𝔸".repeat(100);
+    const large2 = "𝔸".repeat(100);
+    const large3 = "𝔸".repeat(99) + "𝔹";
+    shouldBe(large1 === large2, true);
+    shouldBe(large1 === large3, false);
+    
+    const baseChar = "𝕏";
+    const dynamic1 = baseChar + i.toString();
+    const dynamic2 = baseChar + i.toString();
+    shouldBe(dynamic1 === dynamic2, true);
+}

--- a/JSTests/stress/string-equality-unicode-scripts.js
+++ b/JSTests/stress/string-equality-unicode-scripts.js
@@ -1,0 +1,62 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+const testLoopCount = 10000;
+
+for (let i = 0; i < testLoopCount; i++) {
+    const arabic1 = "السلام" + " عليكم";
+    const arabic2 = "السلام" + " عليكم";
+    const arabic3 = "السلام" + " عليكن";
+    shouldBe(arabic1 === arabic2, true);
+    shouldBe(arabic1 === arabic3, false);
+    
+    const cyrillic1 = "Привет" + " мир";
+    const cyrillic2 = "Привет" + " мир";
+    const cyrillic3 = "Привет" + " вам";
+    shouldBe(cyrillic1 === cyrillic2, true);
+    shouldBe(cyrillic1 === cyrillic3, false);
+    
+    const greek1 = "Γεια σας" + " κόσμος";
+    const greek2 = "Γεια σας" + " κόσμος";
+    const greek3 = "Γεια σου" + " κόσμος";
+    shouldBe(greek1 === greek2, true);
+    shouldBe(greek1 === greek3, false);
+    
+    const hebrew1 = "שלום" + " עולם";
+    const hebrew2 = "שלום" + " עולם";
+    const hebrew3 = "שלום" + " לכם";
+    shouldBe(hebrew1 === hebrew2, true);
+    shouldBe(hebrew1 === hebrew3, false);
+    
+    const chinese1 = "你好" + "世界";
+    const chinese2 = "你好" + "世界";
+    const chinese3 = "你好" + "朋友";
+    shouldBe(chinese1 === chinese2, true);
+    shouldBe(chinese1 === chinese3, false);
+    
+    const korean1 = "안녕" + "하세요";
+    const korean2 = "안녕" + "하세요";
+    const korean3 = "안녕히" + "가세요";
+    shouldBe(korean1 === korean2, true);
+    shouldBe(korean1 === korean3, false);
+    
+    const thai1 = "สวัสดี" + "ครับ";
+    const thai2 = "สวัสดี" + "ครับ";
+    const thai3 = "สวัสดี" + "ค่ะ";
+    shouldBe(thai1 === thai2, true);
+    shouldBe(thai1 === thai3, false);
+    
+    const mixed1 = "Hello" + "世界" + "Мир";
+    const mixed2 = "Hello" + "世界" + "Мир";
+    const mixed3 = "Hello" + "世界" + "Мира";
+    shouldBe(mixed1 === mixed2, true);
+    shouldBe(mixed1 === mixed3, false);
+    
+    const scripts = ["α", "β", "γ", "δ", "ε"];
+    const script = scripts[i % scripts.length];
+    const dynamic1 = "test" + script;
+    const dynamic2 = "test" + script;
+    shouldBe(dynamic1 === dynamic2, true);
+}


### PR DESCRIPTION
#### e4b576d5067fea02f30320e1ad3541678db46725
<pre>
[JSC] Optimize 16-bit string comparison in DFG and FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=295374">https://bugs.webkit.org/show_bug.cgi?id=295374</a>

Previously, JSC&apos;s DFG and FTL JIT compilers only generated fast machine code for
string equality comparison when both operands were 8-bit strings. Other cases,
including 16-bit string comparison, fell back to the slow path (operationCompareStringEq).

This patch extends the optimization to handle 16-bit string comparisons as well.
When both operands are 16-bit strings, we now generate an inline comparison loop
similar to the 8-bit case, avoiding the expensive C++ call.  Mixed encoding comparisons
continue to use the slow path.

                                        TipOfTree                  Patched

string-equality-mixed-encoding        2.6945+-0.3466            2.5821+-0.0914          might be 1.0435x faster
string-equality-8bit-8bit             4.8215+-0.7379            4.8174+-0.9536
string-equality-long-16bit            2.5633+-0.4814            2.1642+-0.4516          might be 1.1844x faster
string-equality                       4.4529+-0.1344     ?      4.7678+-0.2863        ? might be 1.0707x slower
string-equality-16bit-16bit           6.8205+-0.3002     ^      3.9166+-0.4730        ^ definitely 1.7414x faster

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* JSTests/microbenchmarks/string-equality-16bit-16bit.js: Added.
(shouldBe):
* JSTests/microbenchmarks/string-equality-8bit-8bit.js: Added.
(shouldBe):
* JSTests/microbenchmarks/string-equality-long-16bit.js: Added.
(shouldBe):
* JSTests/microbenchmarks/string-equality-mixed-encoding.js: Added.
(shouldBe):
* JSTests/stress/string-equality-16bit-16bit.js: Added.
(shouldBe):
* JSTests/stress/string-equality-16bit-8bit.js: Added.
(shouldBe):
* JSTests/stress/string-equality-8bit-16bit.js: Added.
(shouldBe):
* JSTests/stress/string-equality-8bit-8bit.js: Added.
(shouldBe):
* JSTests/stress/string-equality-ascii-16bit.js: Added.
(shouldBe):
* JSTests/stress/string-equality-emoji.js: Added.
(shouldBe):
* JSTests/stress/string-equality-japanese-characters.js: Added.
(shouldBe):
* JSTests/stress/string-equality-null-characters.js: Added.
(shouldBe):
* JSTests/stress/string-equality-surrogate-pairs.js: Added.
(shouldBe):
* JSTests/stress/string-equality-unicode-scripts.js: Added.
(shouldBe):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4b576d5067fea02f30320e1ad3541678db46725

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116611 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60852 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30923 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38832 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84094 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113533 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24693 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99578 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64535 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24056 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17718 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60406 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/103076 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94078 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17777 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119401 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109139 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37625 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27940 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93060 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37999 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95849 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92882 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37894 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15638 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33599 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37520 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42991 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/133414 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37183 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36050 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40522 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38891 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->