### PR TITLE
[iOS] [SelectionHonorsOverflowScrolling] No selection UI after selecting text on paused video

### DIFF
--- a/LayoutTests/editing/selection/ios/live-text-selection-in-video-expected.txt
+++ b/LayoutTests/editing/selection/ios/live-text-selection-in-video-expected.txt
@@ -1,0 +1,13 @@
+
+Select text in the video above. This test requires WebKitTestRunner.
+
+Verifies that the highlight and handles show up in the correct place when selecting Live Text inside a video
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS viewBeforeSelecting is not viewAfterSelecting
+PASS viewAfterSelecting is not viewAfterClearingSelection
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/live-text-selection-in-video.html
+++ b/LayoutTests/editing/selection/ios/live-text-selection-in-video.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true SelectionHonorsOverflowScrolling=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+body, html {
+    font-family: system-ui;
+    font-size: 16px;
+    line-height: 1.5;
+}
+
+video {
+    width: 100%;
+}
+</style>
+</head>
+<body>
+    <video></video>
+    <p>Select text in the video above. This test requires WebKitTestRunner.</p>
+    <div id="description"></div>
+    <div id="console"></div>
+    <script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        description("Verifies that the highlight and handles show up in the correct place when selecting Live Text inside a video");
+
+        const video = document.querySelector("video");
+        video.controls = false;
+        video.addEventListener("canplaythrough", completeTest);
+        video.src = "../../../media/content/audio-describes-video.mp4";
+
+        async function completeTest() {
+            // Rect centered in the video, rotated by 5 degrees clockwise.
+            const liveTextQuad = {
+                topLeft : new DOMPointReadOnly(0.1837, 0.3269),
+                topRight : new DOMPointReadOnly(0.7814, 0.2746),
+                bottomRight : new DOMPointReadOnly(0.8163, 0.6731),
+                bottomLeft : new DOMPointReadOnly(0.2186, 0.7254),
+            };
+
+            window.internals?.installImageOverlay(video, [
+                {
+                    topLeft : liveTextQuad.topLeft,
+                    topRight : liveTextQuad.topRight,
+                    bottomRight : liveTextQuad.bottomRight,
+                    bottomLeft : liveTextQuad.bottomLeft,
+                    children: [
+                        {
+                            text : "Bip",
+                            topLeft : liveTextQuad.topLeft,
+                            topRight : liveTextQuad.topRight,
+                            bottomRight : liveTextQuad.bottomRight,
+                            bottomLeft : liveTextQuad.bottomLeft
+                        }
+                    ]
+                }
+            ]);
+
+            const {x, y} = UIHelper.midPointOfRect(video.getBoundingClientRect());
+            viewBeforeSelecting = await UIHelper.frontmostViewAtPoint(x, y);
+
+            await UIHelper.longPressElement(video);
+            await UIHelper.waitForSelectionToAppear();
+
+            viewAfterSelecting = await UIHelper.frontmostViewAtPoint(x, y);
+
+            getSelection().removeAllRanges();
+            await UIHelper.waitForSelectionToDisappear();
+
+            viewAfterClearingSelection = await UIHelper.frontmostViewAtPoint(x, y);
+
+            shouldNotBe("viewBeforeSelecting", "viewAfterSelecting");
+            shouldNotBe("viewAfterSelecting", "viewAfterClearingSelection");
+
+            finishJSTest();
+        };
+    });
+    </script>
+</body>
+</html>

--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -34,6 +34,7 @@
 #include "Editor.h"
 #include "ElementChildIteratorInlines.h"
 #include "ElementInlines.h"
+#include "GraphicsLayer.h"
 #include "HTMLBodyElement.h"
 #include "HTMLDListElement.h"
 #include "HTMLDivElement.h"
@@ -1574,7 +1575,7 @@ EnclosingLayerInfomation computeEnclosingLayer(const SimpleRange& range)
         if (!identifier)
             continue;
 
-        return { startLayer, endLayer, layer, identifier };
+        return { WTFMove(startLayer), WTFMove(endLayer), WTFMove(layer), WTFMove(graphicsLayer), WTFMove(identifier) };
     }
     return { };
 }

--- a/Source/WebCore/editing/Editing.h
+++ b/Source/WebCore/editing/Editing.h
@@ -35,6 +35,7 @@
 namespace WebCore {
 
 class Document;
+class GraphicsLayer;
 class HTMLElement;
 class HTMLImageElement;
 class HTMLSpanElement;
@@ -121,6 +122,7 @@ struct EnclosingLayerInfomation {
     CheckedPtr<RenderLayer> startLayer;
     CheckedPtr<RenderLayer> endLayer;
     CheckedPtr<RenderLayer> enclosingLayer;
+    RefPtr<GraphicsLayer> enclosingGraphicsLayer;
     std::optional<PlatformLayerIdentifier> enclosingGraphicsLayerID;
 };
 

--- a/Source/WebCore/page/TextIndicator.cpp
+++ b/Source/WebCore/page/TextIndicator.cpp
@@ -386,8 +386,7 @@ static bool initializeIndicator(TextIndicatorData& data, LocalFrame& frame, cons
         return rect;
     });
 
-    auto [startLayer, endLayer, enclosingLayer, enclosingGraphicsLayerID] = computeEnclosingLayer(range);
-    data.enclosingGraphicsLayerID = enclosingGraphicsLayerID;
+    data.enclosingGraphicsLayerID = computeEnclosingLayer(range).enclosingGraphicsLayerID;
 
     // Store the selection rect in window coordinates, to be used subsequently
     // to determine if the indicator and selection still precisely overlap.

--- a/Source/WebKit/Shared/EditorState.h
+++ b/Source/WebKit/Shared/EditorState.h
@@ -163,6 +163,7 @@ struct EditorState {
         std::optional<WebCore::ScrollingNodeID> scrollingNodeIDAtStart;
         std::optional<WebCore::ScrollingNodeID> scrollingNodeIDAtEnd;
         WebCore::ScrollOffset enclosingScrollOffset;
+        bool enclosingLayerUsesContentsLayer { false };
 #endif // PLATFORM(IOS_FAMILY)
     };
 

--- a/Source/WebKit/Shared/EditorState.serialization.in
+++ b/Source/WebKit/Shared/EditorState.serialization.in
@@ -133,5 +133,6 @@ using WebCore::ScrollOffset = WebCore::IntPoint;
     std::optional<WebCore::ScrollingNodeID> scrollingNodeIDAtStart;
     std::optional<WebCore::ScrollingNodeID> scrollingNodeIDAtEnd;
     WebCore::ScrollOffset enclosingScrollOffset;
+    bool enclosingLayerUsesContentsLayer;
 #endif
 };

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -6148,7 +6148,7 @@ void WebPage::computeEnclosingLayerID(EditorState& state, const VisibleSelection
     if (!selectionRange)
         return;
 
-    auto [startLayer, endLayer, enclosingLayer, enclosingGraphicsLayerID] = computeEnclosingLayer(*selectionRange);
+    auto [startLayer, endLayer, enclosingLayer, graphicsLayer, enclosingGraphicsLayerID] = computeEnclosingLayer(*selectionRange);
 
     state.visualData->enclosingLayerID = WTFMove(enclosingGraphicsLayerID);
 
@@ -6187,6 +6187,9 @@ void WebPage::computeEnclosingLayerID(EditorState& state, const VisibleSelection
             break;
         }
     }
+
+    ASSERT_IMPLIES(state.visualData->enclosingLayerID, graphicsLayer);
+    state.visualData->enclosingLayerUsesContentsLayer = graphicsLayer && graphicsLayer->usesContentsLayer();
 
     if (selection.isCaret()) {
         state.visualData->scrollingNodeIDAtStart = state.visualData->enclosingScrollingNodeID;


### PR DESCRIPTION
#### b4a7920b91df67da0e06ab3382c84f38b7bea9e8
<pre>
[iOS] [SelectionHonorsOverflowScrolling] No selection UI after selecting text on paused video
<a href="https://bugs.webkit.org/show_bug.cgi?id=295380">https://bugs.webkit.org/show_bug.cgi?id=295380</a>
<a href="https://rdar.apple.com/154794749">rdar://154794749</a>

Reviewed by Abrar Rahman Protyasha.

When selecting Live Text in a video, the selection UI is currently obscured by the `WKVideoView`
above it. This happens because our logic currently prefers keeping selection UI below child content
layers rather than above, so that composited layers can correctly overlap or occlude the selection
on iOS. However, in the case of videos, the composited layer representing the video element is
backed by an `m_contentsLayer` representing the video player layer which is opaque, thereby covering
the selection. There&apos;s currently no mechanism to detect this and ensure that the selection UI is
inserted above the video layer.

To fix this, we detect the case where the composited `GraphicsLayer` containing the selection uses a
contents layer (in this case, a video player layer) and err on the side of inserting the selection
UI above all the other composited children under the layer (which aligns with shipping behavior on
iOS).

* LayoutTests/editing/selection/ios/live-text-selection-in-video-expected.txt: Added.
* LayoutTests/editing/selection/ios/live-text-selection-in-video.html: Added.

Add a layout test to exercise the change by injecting Live Text into a video element and selecting.

* Source/WebCore/editing/Editing.cpp:
(WebCore::computeEnclosingLayer):

Make this return the enclosing `GraphicsLayer` as well, so that we can use it in the call site.

* Source/WebCore/editing/Editing.h:
* Source/WebCore/page/TextIndicator.cpp:
(WebCore::initializeIndicator):
* Source/WebKit/Shared/EditorState.h:
* Source/WebKit/Shared/EditorState.serialization.in:
* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm:
(-[WKTextInteractionWrapper prepareToMoveSelectionContainer:]):

Adjust this logic to insert all the selection views as the last of the parent view&apos;s subviews, only
if the enclosing graphics layer `usesContentsLayer`; see above for more details.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::computeEnclosingLayerID const):

Set `enclosingLayerUsesContentsLayer` if and only if the enclosing layer `usesContentsLayer`.

Canonical link: <a href="https://commits.webkit.org/296954@main">https://commits.webkit.org/296954@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae9ded8fe1d83286943c1607d93202ad928d5d2a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110074 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29733 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20165 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116096 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60322 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112037 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38320 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83688 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113022 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24254 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99131 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64132 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23620 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17266 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59892 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93628 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17322 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118887 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37114 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27513 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/92659 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37486 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92485 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23572 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37473 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15213 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32996 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37008 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42479 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36670 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40010 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38379 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->