### PR TITLE
[JSC] Fix GetButterfly handling in DFG array allocation sinking

### DIFF
--- a/JSTests/stress/array-allocation-sink-escape-materialize-1.js
+++ b/JSTests/stress/array-allocation-sink-escape-materialize-1.js
@@ -1,0 +1,25 @@
+
+function foo() {
+    for (var e = arguments.length, t = new Array(e), n = 0; n < e; n++)
+        t[n] = arguments[n];
+    for (var o = 0; o < t.length; o += 1)
+        if (t.length == t[o])
+            return t[o]
+}
+
+function bar(i, e) {
+    var t = foo(
+        i + 1,
+        i + 2,
+        i + 3,
+    );
+    e.canRsize = t;
+    return e;
+}
+noInline(bar);
+
+for (let i = 0; i < testLoopCount; i++) {
+    bar(i, {
+        canRsize: false,
+    });
+}

--- a/JSTests/stress/array-allocation-sink-escape-materialize-10.js
+++ b/JSTests/stress/array-allocation-sink-escape-materialize-10.js
@@ -1,0 +1,68 @@
+function testExceptionPath(shouldThrow) {
+    let a = new Array(3);
+    a[0] = 10;
+    a[1] = 20;
+    a[2] = 30;
+    
+    let len = a.length;
+    
+    try {
+        if (shouldThrow) {
+            throw new Error("Test exception");
+        }
+        return len + a[0];
+    } catch (e) {
+        return a.length + 100;
+    }
+}
+
+function testNestedTryFinally(idx) {
+    let a = new Array(2);
+    a[0] = idx;
+    a[1] = idx * 2;
+    
+    let len = a.length;
+    
+    try {
+        try {
+            if (idx % 7 === 0) {
+                throw new Error("Inner");
+            }
+            return len;
+        } finally {
+            if (idx % 3 === 0) {
+                len += a.length;
+            }
+        }
+    } catch (e) {
+        return a[0] + a[1];
+    }
+}
+
+function testArrayEscapeInCatch(idx) {
+    let a = new Array(4);
+    for (let i = 0; i < 4; i++) {
+        a[i] = i * idx;
+    }
+    
+    let len = a.length; 
+    
+    try {
+        if (idx % 5 === 0) {
+            throw a;
+        }
+        return len;
+    } catch (escaped) {
+        return escaped.length + escaped[0];
+    }
+}
+
+noInline(testExceptionPath);
+noInline(testNestedTryFinally);
+noInline(testArrayEscapeInCatch);
+
+for (let i = 0; i < testLoopCount; i++) {
+    testExceptionPath(i % 10 === 0);
+    testNestedTryFinally(i);
+    testArrayEscapeInCatch(i);
+}

--- a/JSTests/stress/array-allocation-sink-escape-materialize-11.js
+++ b/JSTests/stress/array-allocation-sink-escape-materialize-11.js
@@ -1,0 +1,11 @@
+function test(b) {
+    let arr = new Array(8);
+    arr[1] = b;
+    arr[3] = arr.length; 
+    arr[5] = arr.length; 
+    return arr[1] + arr[3] + arr[5];
+}
+noInline(test);
+
+for (let i = 0; i < testLoopCount; i++)
+    test(i);

--- a/JSTests/stress/array-allocation-sink-escape-materialize-12.js
+++ b/JSTests/stress/array-allocation-sink-escape-materialize-12.js
@@ -1,0 +1,12 @@
+function test(b) {
+    let arr = new Array(2);
+    arr[0] = b;
+    let obj = {};
+    if (b % 2)
+        obj.arr = arr;
+    return arr.length + arr[0];
+}
+noInline(test);
+
+for (let i = 0; i < testLoopCount; i++)
+    test(i);

--- a/JSTests/stress/array-allocation-sink-escape-materialize-13.js
+++ b/JSTests/stress/array-allocation-sink-escape-materialize-13.js
@@ -1,0 +1,16 @@
+
+function leak(x) {
+    return x;
+}
+
+function test(b) {
+    let arr = new Array(4);
+    arr[1] = 10;
+    if (b % 4 === 0)
+        leak(arr);
+    return arr.length + arr[1];
+}
+noInline(test);
+
+for (let i = 0; i < testLoopCount; i++)
+    test(i);

--- a/JSTests/stress/array-allocation-sink-escape-materialize-14.js
+++ b/JSTests/stress/array-allocation-sink-escape-materialize-14.js
@@ -1,0 +1,14 @@
+function test(b) {
+    let arr = new Array(4);
+    if (b % 3 === 0)
+        arr[0] = b;
+    if (b % 5 === 0)
+        return arr.length;
+    if (b % 7 === 0)
+        return arr[1];
+    return arr.length + arr[2];
+}
+noInline(test);
+
+for (let i = 0; i < testLoopCount; i++)
+    test(i);

--- a/JSTests/stress/array-allocation-sink-escape-materialize-2.js
+++ b/JSTests/stress/array-allocation-sink-escape-materialize-2.js
@@ -1,0 +1,11 @@
+
+function test(b) {
+    let a = new Array(4);
+    a[0] = 43;
+    a.length;
+}
+noInline(test);
+
+for (let i = 0; i < testLoopCount; i++) {
+    test(i);
+}

--- a/JSTests/stress/array-allocation-sink-escape-materialize-3.js
+++ b/JSTests/stress/array-allocation-sink-escape-materialize-3.js
@@ -1,0 +1,20 @@
+
+function test(b) {
+    let a = new Array(4);
+    if (b % 2 == 0) {
+        return a.length;
+    } else {
+        if (b % 13 == 0) {
+            a[0] = 15 + a.length;
+        } else {
+            a[1] = 15 + a.length;
+        }
+        a[2] += a.length;
+        return a;
+    }
+}
+noInline(test);
+
+for (let i = 0; i < testLoopCount; i++) {
+    test(i);
+}

--- a/JSTests/stress/array-allocation-sink-escape-materialize-4.js
+++ b/JSTests/stress/array-allocation-sink-escape-materialize-4.js
@@ -1,0 +1,18 @@
+function conditionalGetButterfly(shouldEscape) {
+    let a = new Array(5);
+    a[0] = 42;
+    a[1] = 43;
+
+    let len = a.length;
+
+    if (shouldEscape) {
+        return len;
+    }
+
+    return a[0] + a[1];
+}
+noInline(conditionalGetButterfly);
+
+for (let i = 0; i < testLoopCount; i++) {
+    conditionalGetButterfly(i % 10 === 0);
+}

--- a/JSTests/stress/array-allocation-sink-escape-materialize-5.js
+++ b/JSTests/stress/array-allocation-sink-escape-materialize-5.js
@@ -1,0 +1,19 @@
+function forceArrayMaterialization(idx) {
+    let a = new Array(3);
+    a[0] = idx;
+    a[1] = idx + 1;
+    a[2] = idx + 2;
+
+    let butterfly = a.length;
+
+    if (idx % 7 === 0) {
+        return a;
+    }
+
+    return butterfly * 2;
+}
+noInline(forceArrayMaterialization);
+
+for (let i = 0; i < testLoopCount; i++) {
+    forceArrayMaterialization(i);
+}

--- a/JSTests/stress/array-allocation-sink-escape-materialize-6.js
+++ b/JSTests/stress/array-allocation-sink-escape-materialize-6.js
@@ -1,0 +1,32 @@
+
+function multipleGetButterfly(mode) {
+    let a = new Array(4);
+    a[0] = 10;
+    a[1] = 20;
+    a[2] = 30;
+    a[3] = 40;
+
+    let len1 = a.length;
+    let len2 = a.length;
+    let len3 = a.length;
+
+    switch (mode % 4) {
+        case 0:
+            return a[0] + len1;
+        case 1:
+            return len1 + len2 + len3;
+        case 2:
+            let result = a;
+            return [result, len1, len2, len3];
+        case 3:
+            if (len1 > 3) {
+                return a;
+            }
+            return len2 + len3;
+    }
+}
+noInline(multipleGetButterfly);
+
+for (let i = 0; i < testLoopCount; i++) {
+    multipleGetButterfly(i);
+}

--- a/JSTests/stress/array-allocation-sink-escape-materialize-7.js
+++ b/JSTests/stress/array-allocation-sink-escape-materialize-7.js
@@ -1,0 +1,28 @@
+function innerFunction(arr) {
+    let len = arr.length;
+    if (len > 2) {
+        return arr;
+    }
+    return len * 2;
+}
+
+function outerFunction(mode) {
+    let a = new Array(3);
+    a[0] = mode;
+    a[1] = mode + 1;
+
+    let initialLen = a.length;
+
+    if (mode % 5 === 0) {
+        let result = innerFunction(a);
+        return [result, initialLen];
+    } else {
+        return a[0] + a[1] + initialLen;
+    }
+}
+noInline(innerFunction);
+noInline(outerFunction);
+
+for (let i = 0; i < testLoopCount; i++) {
+    outerFunction(i);
+}

--- a/JSTests/stress/array-allocation-sink-escape-materialize-8.js
+++ b/JSTests/stress/array-allocation-sink-escape-materialize-8.js
@@ -1,0 +1,27 @@
+function controlFlowTest(cond1, cond2) {
+    let a, b;
+
+    if (cond1) {
+        a = new Array(3);
+        a[0] = 100;
+        a[1] = 200;
+    } else {
+        a = new Array(4);
+        a[0] = 300;
+        a[1] = 400;
+        a[2] = 500;
+    }
+
+    let len = a.length;
+
+    if (cond2) {
+        return a;
+    } else {
+        return len + a[0];
+    }
+}
+noInline(controlFlowTest);
+
+for (let i = 0; i < testLoopCount; i++) {
+    controlFlowTest(i % 2 === 0, i % 3 === 0);
+}

--- a/JSTests/stress/array-allocation-sink-escape-materialize-9.js
+++ b/JSTests/stress/array-allocation-sink-escape-materialize-9.js
@@ -1,0 +1,54 @@
+function testInt32Array(idx) {
+    let a = new Array(4);
+    a[0] = 1;
+    a[1] = 2;
+    a[2] = 3;
+    a[3] = 4;
+
+    let len = a.length;
+
+    if (idx % 11 === 0) {
+        return a;
+    }
+    return len + a[idx % 4];
+}
+
+function testDoubleArray(idx) {
+    let a = new Array(4);
+    a[0] = 1.5;
+    a[1] = 2.7;
+    a[2] = 3.9;
+    a[3] = 4.1;
+
+    let len = a.length;
+
+    if (idx % 13 === 0) {
+        return a;
+    }
+    return len + a[idx % 4];
+}
+
+function testContiguousArray(idx) {
+    let a = new Array(4);
+    a[0] = "hello";
+    a[1] = 42;
+    a[2] = 3.14;
+    a[3] = null;
+
+    let len = a.length;
+
+    if (idx % 17 === 0) {
+        return a;
+    }
+    return len;
+}
+
+noInline(testInt32Array);
+noInline(testDoubleArray);
+noInline(testContiguousArray);
+
+for (let i = 0; i < testLoopCount; i++) {
+    testInt32Array(i);
+    testDoubleArray(i);
+    testContiguousArray(i);
+}

--- a/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
@@ -141,7 +141,7 @@ public:
     // once it is escaped if it still has pointers to it in order to
     // replace any use of those pointers by the corresponding
     // materialization
-    enum class Kind { Escaped, Array, Object, Activation, Function, GeneratorFunction, AsyncFunction, AsyncGeneratorFunction, InternalFieldObject, RegExpObject };
+    enum class Kind { Escaped, Array, ArrayButterfly, Object, Activation, Function, GeneratorFunction, AsyncFunction, AsyncGeneratorFunction, InternalFieldObject, RegExpObject };
 
     using Fields = UncheckedKeyHashMap<PromotedLocationDescriptor, Node*>;
 
@@ -257,6 +257,11 @@ public:
         return m_kind == Kind::Array;
     }
 
+    bool isArrayButterfly() const
+    {
+        return m_kind == Kind::ArrayButterfly;
+    }
+
     bool isObjectAllocation() const
     {
         return m_kind == Kind::Object;
@@ -294,6 +299,10 @@ public:
         switch (m_kind) {
         case Kind::Array:
             out.print("Array"_s);
+            break;
+
+        case Kind::ArrayButterfly:
+            out.print("ArrayButterfly"_s);
             break;
 
         case Kind::Escaped:
@@ -343,12 +352,15 @@ public:
         out.print(")"_s);
     }
 
+    unsigned arrayButterflyId() { return m_arrayButterflyId++; }
+
 private:
     Node* m_identifier; // This is the actual node that created the allocation
     Kind m_kind;
     Fields m_fields;
     IndexingType m_indexingType { NoIndexingShape };
     unsigned m_length { 0 };
+    unsigned m_arrayButterflyId { 0 };
 
     // This set of structures is the intersection of structures seen at control flow edges. It's used
     // for checks and speculation since it can't be widened.
@@ -1021,20 +1033,62 @@ private:
                 goto escapeChildren;
             break;
 
-        case GetButterfly:
+        case GetButterfly: {
+            // D@2 (GetButterfly) is subtle because PutByVal/GetByVal can cause the associated Array to escape and be materialized.
+            // In such cases, GetButterfly must also be materialized at the same site as the Array, since it depends on the materialized Array.
+            // That is, when PutByVal/GetByVal triggers materialization, GetButterfly must be lowered at the same location and maintain
+            // a dependency on the materialized Array to ensure correctness.
+            //
+            // Below, we enumerate all possible interaction cases between GetButterfly and Array:
+            //
+            //         GetButterfly state (rows) vs Array state (columns)
+            //
+            //                   |     S     |    SEM    |     E     |
+            //           ---------------------------------------------
+            //            S      |    OK     |    OK     |    OK     |
+            //           SEM     |   Error   |    OK     |    OK     |
+            //            E      |    n/a    |   Error   |    OK     |
+            //
+            // Allocation Kinds:
+            //   Sink-only (S): Allocation is purely local and can be eliminated during optimization.
+            //   Escape-only (E): Allocation escapes the local context; cannot be sunk.
+            //   Sink + Escape + Materialize (SEM):
+            //      Allocation starts as sinkable but later escapes; it must be materialized at a specific point
+            //      while preserving dependency ordering.
+            //
+            // Cases:
+            //  (1)     S\S S\SEM: Fine. Let it sink. (e.g. [2])
+            //  (2) S\E SEM\E E/E: Fine. But not profitable to sink GetButterfly.
+            //  (3)       SEM\SEM: Fine iff they materialize at the same site due to PutByVal/GetByVal. (e.g. [1])
+            //
+            //  (4)         SEM\S: Not fine since GetButterfly(Array). (e.g. [4])
+            //  (5)         E\SEM: Not fine similar to (4). (e.g. [3])
+            //  (6)           E\S: Not possible since PutByVal/GetByVal can escape-only GetButterfly.
+            //
+            //
+            // [1] array-allocation-sink-escape-materialize-1.js
+            // [2] array-allocation-sink-escape-materialize-2.js
+            // [3] array-allocation-sink-escape-materialize-3.js
+            // [4] array-allocation-profile-should-not-update-itself-in-concurrent-compiler.js
+            Node* base = node->child1().node();
+            Allocation* array = m_heap.onlyLocalAllocation(base);
+            if (array && array->isArrayAllocation()) {
+                // Treat GetButterfly as a separate allocation to track its dependency on the Array.
+                // 1. If PutByVal/GetByVal cause escape, materialize both at the same site.
+                // 2. If the Array escapes, also escape the ArrayButterfly since sinking it isn't beneficial.
+                m_heap.newAllocation(node, Allocation::Kind::ArrayButterfly);
+                array->set(PromotedLocationDescriptor(ArrayButterflyPropertyPLoc, array->arrayButterflyId()), node);
+            } else
+                goto escapeChildren;
+            break;
+        }
+
         case GetArrayLength: {
             Node* base = node->child1().node();
             target = m_heap.onlyLocalAllocation(base);
-            if (target && target->isArrayAllocation()) {
-                // No special handling is required for GetButterfly because:
-                // 1. If the array is a sink candidate, then all referrers of GetButterfly (i.e., GetArrayLength,
-                //    PutByVal, and GetByVal) will be eliminated. Consequently, GetButterfly itself
-                //    will have zero references and will be removed in a later phase.
-                // 2. If the array is not a sink candidate, then at least one node (GetByVal or PutByVal)
-                //    must have caused the array to escape.
-                if (node->op() == GetArrayLength)
-                    exactRead = PromotedLocationDescriptor(ArrayLengthPropertyPLoc);
-            } else
+            if (target && target->isArrayAllocation())
+                exactRead = PromotedLocationDescriptor(ArrayLengthPropertyPLoc);
+            else
                 goto escapeChildren;
             break;
         }
@@ -1518,6 +1572,31 @@ escapeChildren:
             }
         }
 
+        auto fixGetButterflyEscapees = [&](auto& escapees) {
+            // Case (4): Remove GetButterfly if its base Array didn’t escape.
+            escapees.removeIf([&] (const auto& entry) {
+                return entry.key->op() == GetButterfly && !escapees.contains(entry.key->child1().node());
+            });
+
+            // Case (5): Ensure ArrayButterfly SEM when its parent Array does.
+            Vector<std::pair<Node*, Allocation*>> toAdd;
+            for (const auto& entry : escapees) {
+                if (entry.value.kind() != Allocation::Kind::Array)
+                    continue;
+                for (const auto& field : entry.value.fields()) {
+                    if (field.key.kind() != ArrayButterflyPropertyPLoc)
+                        continue;
+                    if (Allocation* allocation = m_heap.onlyLocalAllocation(field.value))
+                        toAdd.append({ field.value, allocation });
+                }
+            }
+
+            for (const auto& pair : toAdd) {
+                m_sinkCandidates.add(pair.first);
+                escapees.add(pair.first, *pair.second);
+            }
+        };
+
         auto forEachEscapee = [&] (auto callback) {
             for (BasicBlock* block : m_graph.blocksInNaturalOrder()) {
                 m_heap = m_heapAtHead[block];
@@ -1532,6 +1611,7 @@ escapeChildren:
                         });
                     auto escapees = m_heap.takeEscapees();
                     escapees.removeIf([&] (const auto& entry) { return !m_sinkCandidates.contains(entry.key); });
+                    fixGetButterflyEscapees(escapees);
                     callback(escapees, node);
                 }
 
@@ -1553,6 +1633,7 @@ escapeChildren:
                         if (mustEscape && m_sinkCandidates.contains(entry.key))
                             escapingOnEdge.add(entry.key, entry.value);
                     }
+                    fixGetButterflyEscapees(escapingOnEdge);
                     callback(escapingOnEdge, block->terminal());
                 }
             }
@@ -1678,16 +1759,29 @@ escapeChildren:
         UncheckedKeyHashMap<Node*, NodeSet> dependencies;
         UncheckedKeyHashMap<Node*, NodeSet> reverseDependencies;
         UncheckedKeyHashMap<Node*, NodeSet> forMaterialization;
-        for (const auto& entry : escapees) {
-            auto& myDependencies = dependencies.add(entry.key, NodeSet()).iterator->value;
-            auto& myDependenciesForMaterialization = forMaterialization.add(entry.key, NodeSet()).iterator->value;
-            reverseDependencies.add(entry.key, NodeSet());
-            for (const auto& field : entry.value.fields()) {
-                if (escapees.contains(field.value) && field.value != entry.key) {
-                    myDependencies.addVoid(field.value);
-                    reverseDependencies.add(field.value, NodeSet()).iterator->value.addVoid(entry.key);
-                    if (field.key.neededForMaterialization())
-                        myDependenciesForMaterialization.addVoid(field.value);
+        auto addDependency = [&](Node* a, Node* b, bool neededForMaterialization) {
+            dependencies.add(a, NodeSet()).iterator->value.addVoid(b);
+            reverseDependencies.add(b, NodeSet()).iterator->value.addVoid(a);
+            if (neededForMaterialization)
+                forMaterialization.add(a, NodeSet()).iterator->value.addVoid(b);
+        };
+
+        auto requiresReverseDependency = [&] (Allocation::Kind allocationKind, PromotedLocationKind fieldKind) {
+            return allocationKind == Allocation::Kind::Array && fieldKind == ArrayButterflyPropertyPLoc;
+        };
+
+        for (auto& [escape, escapeAllocation] : escapees) {
+            dependencies.add(escape, NodeSet());
+            forMaterialization.add(escape, NodeSet());
+            reverseDependencies.add(escape, NodeSet());
+            for (auto& [fieldLocation, field] : escapeAllocation.fields()) {
+                if (escapees.contains(field) && field != escape) {
+                    Node* from = escape;
+                    Node* to = field;
+                    // Swap to ensure that Array is materialized before ArrayButterfly.
+                    if (requiresReverseDependency(escapeAllocation.kind(), fieldLocation.kind()))
+                        std::swap(from, to);
+                    addDependency(from, to, fieldLocation.neededForMaterialization());
                 }
             }
         }
@@ -1797,8 +1891,13 @@ escapeChildren:
             escaped.addVoid(allocation.identifier());
         for (const Allocation& allocation : toMaterialize) {
             for (const auto& field : allocation.fields()) {
-                if (escaped.contains(field.value) && !materialized.contains(field.value))
+                if (escaped.contains(field.value) && !materialized.contains(field.value)) {
+                    // Skip recovery for ArrayButterfly fields since they have reverse dependencies
+                    // and will be handled by their parent Array's materialization
+                    if (requiresReverseDependency(allocation.kind(), field.key.kind()))
+                        continue;
                     toRecover.append(PromotedHeapLocation(allocation.identifier(), field.key));
+                }
             }
             materialized.addVoid(allocation.identifier());
         }
@@ -1838,6 +1937,12 @@ escapeChildren:
                 node->prediction(), Node::VarArg, MaterializeNewArrayWithConstantSize,
                 where->origin.withSemantic(node->origin.semantic),
                 OpInfo(node->indexingType()), OpInfo(data), 0, 0);
+        }
+
+        case Allocation::Kind::ArrayButterfly: {
+            Node* node = allocation.identifier();
+            return m_graph.addNode(node->prediction(), GetButterfly,
+                where->origin.withSemantic(node->origin.semantic), node->child1());
         }
 
         case Allocation::Kind::Object: {
@@ -2498,6 +2603,13 @@ escapeChildren:
             node->children = AdjacencyList(
                 AdjacencyList::Variable,
                 firstChild, m_graph.m_varArgChildren.size() - firstChild);
+            break;
+        }
+
+        case GetButterfly: {
+            Edge& base = node->child1();
+            base.setNode(resolve(block, base.node()));
+            ASSERT(base->op() == MaterializeNewArrayWithConstantSize);
             break;
         }
 

--- a/Source/JavaScriptCore/dfg/DFGPromotedHeapLocation.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPromotedHeapLocation.cpp
@@ -99,6 +99,10 @@ void printInternal(PrintStream& out, PromotedLocationKind kind)
         out.print("ArrayLengthPropertyPLoc");
         return;
 
+    case ArrayButterflyPropertyPLoc:
+        out.print("ArrayButterflyPropertyPLoc");
+        return;
+
     case ArrayIndexedPropertyPLoc:
         out.print("ArrayIndexedPropertyPLoc");
         return;

--- a/Source/JavaScriptCore/dfg/DFGPromotedHeapLocation.h
+++ b/Source/JavaScriptCore/dfg/DFGPromotedHeapLocation.h
@@ -55,6 +55,7 @@ enum PromotedLocationKind {
     ArgumentsCalleePLoc,
     ArrayPLoc,
     ArrayLengthPropertyPLoc,
+    ArrayButterflyPropertyPLoc,
     ArrayIndexedPropertyPLoc,
     ClosureVarPLoc,
     InternalFieldObjectPLoc,

--- a/Source/JavaScriptCore/dfg/DFGValidate.cpp
+++ b/Source/JavaScriptCore/dfg/DFGValidate.cpp
@@ -980,7 +980,7 @@ private:
                     break;
 
                 case GetButterfly:
-                    VALIDATE((node), !node->child1()->isPhantomAllocation() || node->child1()->op() == PhantomNewArrayWithConstantSize);
+                    VALIDATE((node), !node->child1()->isPhantomAllocation());
                     break;
 
                 default:

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -595,7 +595,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, dumpBaselineJITSizeStatistics, false, Normal, nullptr) \
     v(Bool, dumpDFGJITSizeStatistics, false, Normal, nullptr) \
     v(Bool, useLoopUnrolling, true, Normal, nullptr) \
-    v(Bool, usePartialLoopUnrolling, false, Normal, nullptr) \
+    v(Bool, usePartialLoopUnrolling, true, Normal, nullptr) \
     v(Bool, verboseLoopUnrolling, false, Normal, nullptr) \
     v(Bool, disallowLoopUnrollingForNonInnermost, true, Normal, nullptr) \
     v(Unsigned, maxLoopUnrollingCount, 5, Normal, nullptr) \


### PR DESCRIPTION
#### e900fb17651543852a1e0924f5856924beaee745
<pre>
[JSC] Fix GetButterfly handling in DFG array allocation sinking
<a href="https://bugs.webkit.org/show_bug.cgi?id=295191">https://bugs.webkit.org/show_bug.cgi?id=295191</a>
<a href="https://rdar.apple.com/154419571">rdar://154419571</a>

Reviewed by NOBODY (OOPS!).

DFG&apos;s object allocation sinking previously mishandled GetButterfly nodes
when their base arrays were sunk and later materialized. Specifically, when
PutByVal or GetByVal triggered array escape, the corresponding GetButterfly
nodes were not correctly updated to depend on the materialized array, leading
to incorrect butterfly references and potential crashes.

This patch fixes the issue by:

1. Introducing a new Allocation::Kind::ArrayButterfly to model GetButterfly as
   a dependent allocation.
2. Adding ArrayButterflyPropertyPLoc to track butterfly-to-array relationships.
3. Implementing fixGetButterflyEscapees() to synchronize escape status between
   arrays and their butterflies.
4. Enforcing materialization ordering to ensure arrays materialize before their
   GetButterfly uses.
5. Updating GetButterfly lowering to depend on the correct materialized array.

This fix ensures that GetButterfly correctly accesses the butterfly of
materialized arrays.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/738d0090546f5bcf92ce6894fa0310c4e8abec76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110272 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29931 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20363 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116296 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/60520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30610 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38518 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83841 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/60520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113220 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/24421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/99303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64289 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/23780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/17439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60090 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/102763 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/93797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/17497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119086 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/108826 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37312 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27666 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92815 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37684 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/95573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92641 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/37636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/15369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/33202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37206 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42677 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/133101 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36868 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35976 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40208 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38577 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->