### PR TITLE
REGRESSION (290813@main): Some videos on Amazon Prime have no audio

### DIFF
--- a/LayoutTests/http/tests/media/hls/hls-audio-tracks-language-expected.txt
+++ b/LayoutTests/http/tests/media/hls/hls-audio-tracks-language-expected.txt
@@ -4,5 +4,8 @@ EXPECTED (video.audioTracks.length == '3') OK
 EXPECTED (video.audioTracks[0].language == 'en-US') OK
 EXPECTED (video.audioTracks[1].language == 'fr-FR') OK
 EXPECTED (video.audioTracks[2].language == 'es-US') OK
+EXPECTED (video.audioTracks[0].label == 'English Sound') OK
+EXPECTED (video.audioTracks[1].label == 'French Sound') OK
+EXPECTED (video.audioTracks[2].label == 'Spanish Sound') OK
 END OF TEST
 

--- a/LayoutTests/http/tests/media/hls/hls-audio-tracks-language.html
+++ b/LayoutTests/http/tests/media/hls/hls-audio-tracks-language.html
@@ -19,6 +19,9 @@
                 testExpected("video.audioTracks[0].language", "en-US");
                 testExpected("video.audioTracks[1].language", "fr-FR");
                 testExpected("video.audioTracks[2].language", "es-US");
+                testExpected("video.audioTracks[0].label", "English Sound");
+                testExpected("video.audioTracks[1].label", "French Sound");
+                testExpected("video.audioTracks[2].label", "Spanish Sound");
                 endTest();
             }
         </script>

--- a/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
@@ -281,13 +281,13 @@ TrackID AVTrackPrivateAVFObjCImpl::id() const
 
 AtomString AVTrackPrivateAVFObjCImpl::label() const
 {
+    ASSERT(m_assetTrack || m_mediaSelectionOption);
+
     NSArray *commonMetadata = nil;
     if (m_assetTrack)
         commonMetadata = [m_assetTrack commonMetadata];
-    else if (m_mediaSelectionOption)
+    if (![commonMetadata count] && m_mediaSelectionOption)
         commonMetadata = [m_mediaSelectionOption->avMediaSelectionOption() commonMetadata];
-    else
-        ASSERT_NOT_REACHED();
 
     NSArray *titles = [PAL::getAVMetadataItemClass() metadataItemsFromArray:commonMetadata withKey:AVMetadataCommonKeyTitle keySpace:AVMetadataKeySpaceCommon];
     if (![titles count])


### PR DESCRIPTION
#### 301e595d41541677e2d5ab037126e1edd11ada5b
<pre>
REGRESSION (290813@main): Some videos on Amazon Prime have no audio
<a href="https://bugs.webkit.org/show_bug.cgi?id=295385">https://bugs.webkit.org/show_bug.cgi?id=295385</a>
<a href="https://rdar.apple.com/154418594">rdar://154418594</a>

Reviewed by Jean-Yves Avenard.

In 290813@main, an AVAssetTrack was always added to AVTrackPrivateAVFObjCImpl when that object was
created with an AVMediaSelectionOption. But because a number of the functions in
AVTrackPrivateAVFObjCImpl check first for the presence of an AVAssetTrack, this caused a change in
behavior where those AudioTracks created with an AVMediaSelectionOption no longer had a label.

Amazon Prime expected its AudioTracks to have labels that matched the names in its HLS
manifest, and would disable tracks not matching the label that corresponds to the audio language
selected by the user.

Resolved this in AVTrackPrivateAVFObjCImpl::label() by falling back to the AVMediaSelectionOption
when an AVAssetTrack does not have commonMetadata necessary for determining a label.

Modified http/tests/media/hls/hls-audio-tracks-language.html to assert each track&apos;s label as well
as its language.

* LayoutTests/http/tests/media/hls/hls-audio-tracks-language-expected.txt:
* LayoutTests/http/tests/media/hls/hls-audio-tracks-language.html:
* Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm:
(WebCore::AVTrackPrivateAVFObjCImpl::label const):

Canonical link: <a href="https://commits.webkit.org/296981@main">https://commits.webkit.org/296981@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebb4142dbee17bea88486ab45c490e355d466f7c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110149 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29808 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20240 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116171 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60397 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112112 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30486 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38395 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83746 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113097 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24324 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99197 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64190 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23690 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17332 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59967 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93701 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17388 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118962 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37189 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27571 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/92730 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37561 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95464 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92553 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23588 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37534 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15274 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33078 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37083 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42554 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36745 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40085 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38454 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->