### PR TITLE
ANGLE: PoolAllocator push/pop feature is not useful

### DIFF
--- a/Source/ThirdParty/ANGLE/src/common/PoolAlloc.cpp
+++ b/Source/ThirdParty/ANGLE/src/common/PoolAlloc.cpp
@@ -128,14 +128,10 @@ class Allocation
 class PageHeader
 {
   public:
-    PageHeader(PageHeader *nextPage, size_t pageCount)
-        : nextPage(nextPage),
-          pageCount(pageCount)
-#    if defined(ANGLE_POOL_ALLOC_GUARD_BLOCKS)
-          ,
-          lastAllocation(nullptr)
-#    endif
-    {}
+    PageHeader(PageHeader *nextPage)
+        : nextPage(nextPage)
+    {
+    }
 
     ~PageHeader()
     {
@@ -148,9 +144,8 @@ class PageHeader
     }
 
     PageHeader *nextPage;
-    size_t pageCount;
 #    if defined(ANGLE_POOL_ALLOC_GUARD_BLOCKS)
-    Allocation *lastAllocation;
+    Allocation *lastAllocation { nullptr };
 #    endif
 };
 #endif
@@ -163,7 +158,6 @@ PoolAllocator::PoolAllocator(int growthIncrement, int allocationAlignment)
     : mAlignment(allocationAlignment),
 #if !defined(ANGLE_DISABLE_POOL_ALLOC)
       mPageSize(growthIncrement),
-      mFreeList(nullptr),
       mInUseList(nullptr),
       mNumCalls(0),
       mTotalBytes(0),
@@ -209,9 +203,6 @@ void PoolAllocator::initialize(int pageSize, int alignment)
     // be obtained to allocate memory.
     //
     mCurrentPageOffset = mPageSize;
-
-#else  // !defined(ANGLE_DISABLE_POOL_ALLOC)
-    mStack.push_back({});
 #endif
 }
 
@@ -225,23 +216,10 @@ PoolAllocator::~PoolAllocator()
         delete[] reinterpret_cast<char *>(mInUseList);
         mInUseList = next;
     }
-    // We should not check the guard blocks
-    // here, because we did it already when the block was
-    // placed into the free list.
-    //
-    while (mFreeList)
-    {
-        PageHeader *next = mFreeList->nextPage;
-        delete[] reinterpret_cast<char *>(mFreeList);
-        mFreeList = next;
-    }
 #else  // !defined(ANGLE_DISABLE_POOL_ALLOC)
-    for (auto &allocs : mStack)
+    for (auto &alloc : mStack)
     {
-        for (auto alloc : allocs)
-        {
-            free(alloc);
-        }
+        free(alloc);
     }
     mStack.clear();
 #endif
@@ -267,84 +245,6 @@ void Allocation::checkGuardBlock(unsigned char *blockMem,
         }
     }
 #endif
-}
-
-void PoolAllocator::push()
-{
-#if !defined(ANGLE_DISABLE_POOL_ALLOC)
-    AllocState state = {mCurrentPageOffset, mInUseList};
-
-    mStack.push_back(state);
-
-    //
-    // Indicate there is no current page to allocate from.
-    //
-    mCurrentPageOffset = mPageSize;
-#else  // !defined(ANGLE_DISABLE_POOL_ALLOC)
-    mStack.push_back({});
-#endif
-}
-
-// Do a mass-deallocation of all the individual allocations that have occurred since the last
-// push(), or since the last pop(), or since the object's creation.
-//
-// Single-page allocations are saved for future use unless the release strategy is All.
-void PoolAllocator::pop(ReleaseStrategy releaseStrategy)
-{
-    if (mStack.size() < 1)
-    {
-        return;
-    }
-
-#if !defined(ANGLE_DISABLE_POOL_ALLOC)
-    PageHeader *page   = mStack.back().page;
-    mCurrentPageOffset = mStack.back().offset;
-
-    while (mInUseList != page)
-    {
-        // Grab the pageCount before calling the destructor.  While the destructor doesn't actually
-        // touch this variable, it's confusing MSAN.
-        const size_t pageCount = mInUseList->pageCount;
-        PageHeader *nextInUse  = mInUseList->nextPage;
-
-        // invoke destructor to free allocation list
-        mInUseList->~PageHeader();
-
-        if (pageCount > 1 || releaseStrategy == ReleaseStrategy::All)
-        {
-            delete[] reinterpret_cast<char *>(mInUseList);
-        }
-        else
-        {
-#    if defined(ANGLE_WITH_ASAN)
-            // Clear any container annotations left over from when the memory
-            // was last used. (crbug.com/1419798)
-            __asan_unpoison_memory_region(mInUseList, mPageSize);
-#    endif
-            mInUseList->nextPage = mFreeList;
-            mFreeList            = mInUseList;
-        }
-        mInUseList = nextInUse;
-    }
-
-    mStack.pop_back();
-#else  // !defined(ANGLE_DISABLE_POOL_ALLOC)
-    for (auto &alloc : mStack.back())
-    {
-        free(alloc);
-    }
-    mStack.pop_back();
-#endif
-}
-
-//
-// Do a mass-deallocation of all the individual allocations
-// that have occurred.
-//
-void PoolAllocator::popAll()
-{
-    while (mStack.size() > 0)
-        pop();
 }
 
 void *PoolAllocator::allocate(size_t numBytes)
@@ -399,7 +299,7 @@ void *PoolAllocator::allocate(size_t numBytes)
         }
 
         // Use placement-new to initialize header
-        new (memory) PageHeader(mInUseList, (numBytesToAlloc + mPageSize - 1) / mPageSize);
+        new (memory) PageHeader(mInUseList);
         mInUseList = memory;
 
         // Make next allocation come from a new page
@@ -418,7 +318,7 @@ void *PoolAllocator::allocate(size_t numBytes)
 #else  // !defined(ANGLE_DISABLE_POOL_ALLOC)
 
     void *alloc = malloc(numBytes + mAlignment - 1);
-    mStack.back().push_back(alloc);
+    mStack.push_back(alloc);
 
     intptr_t intAlloc = reinterpret_cast<intptr_t>(alloc);
     intAlloc          = rx::roundUpPow2<intptr_t>(intAlloc, mAlignment);
@@ -431,22 +331,13 @@ uint8_t *PoolAllocator::allocateNewPage(size_t numBytes)
 {
     // Need a simple page to allocate from.  Pick a page from the free list, if any.  Otherwise need
     // to make the allocation.
-    PageHeader *memory;
-    if (mFreeList)
+    PageHeader *memory = reinterpret_cast<PageHeader *>(::new char[mPageSize]);
+    if (memory == nullptr)
     {
-        memory    = mFreeList;
-        mFreeList = mFreeList->nextPage;
-    }
-    else
-    {
-        memory = reinterpret_cast<PageHeader *>(::new char[mPageSize]);
-        if (memory == nullptr)
-        {
-            return nullptr;
-        }
+        return nullptr;
     }
     // Use placement-new to initialize header
-    new (memory) PageHeader(mInUseList, 1);
+    new (memory) PageHeader(mInUseList);
     mInUseList = memory;
 
     // Leave room for the page header.

--- a/Source/ThirdParty/ANGLE/src/common/PoolAlloc.h
+++ b/Source/ThirdParty/ANGLE/src/common/PoolAlloc.h
@@ -39,16 +39,9 @@ namespace angle
 class Allocation;
 class PageHeader;
 
-//
-// There are several stacks.  One is to track the pushing and popping
-// of the user, and not yet implemented.  The others are simply a
-// repositories of free pages or used pages.
-//
-// Page stacks are linked together with a simple header at the beginning
-// of each allocation obtained from the underlying OS.  Multi-page allocations
-// are returned to the OS.  Individual page allocations are kept for future
-// re-use.
-//
+
+// Pages are linked together with a simple header at the beginning
+// of each allocation obtained from the underlying OS.
 // The "page size" used is not, nor must it match, the underlying OS
 // page size.  But, having it be about that size or equal to a set of
 // pages is likely most optimal.
@@ -56,11 +49,6 @@ class PageHeader;
 class PoolAllocator : angle::NonCopyable
 {
   public:
-    enum class ReleaseStrategy : uint8_t
-    {
-        OnlyMultiPage,
-        All,
-    };
 
     static const int kDefaultAlignment = sizeof(void *);
     //
@@ -78,23 +66,6 @@ class PoolAllocator : angle::NonCopyable
     // Initialize page size and alignment after construction
     //
     void initialize(int pageSize, int alignment);
-
-    //
-    // Call push() to establish a new place to pop memory to.  Does not
-    // have to be called to get things started.
-    //
-    void push();
-
-    //
-    // Call pop() to free all memory allocated since the last call to push(),
-    // or if no last call to push, frees all memory since first allocation.
-    //
-    void pop(ReleaseStrategy releaseStrategy = ReleaseStrategy::OnlyMultiPage);
-
-    //
-    // Call popAll() to free all memory allocated.
-    //
-    void popAll();
 
     //
     // Call allocate() to actually acquire memory.  Returns 0 if no memory
@@ -130,8 +101,8 @@ class PoolAllocator : angle::NonCopyable
     }
 
     // There is no deallocate.  The point of this class is that deallocation can be skipped by the
-    // user of it, as the model of use is to simultaneously deallocate everything at once by calling
-    // pop(), and to not have to solve memory leak problems.
+    // user of it, as the model of use is to simultaneously deallocate everything at once by destroying
+    // the instance.
 
     // Catch unwanted allocations.
     // TODO(jmadill): Remove this when we remove the global allocator.
@@ -142,13 +113,6 @@ class PoolAllocator : angle::NonCopyable
     size_t mAlignment;  // all returned allocations will be aligned at
                         // this granularity, which will be a power of 2
 #if !defined(ANGLE_DISABLE_POOL_ALLOC)
-    struct AllocState
-    {
-        size_t offset;
-        PageHeader *page;
-    };
-    using AllocStack = std::vector<AllocState>;
-
     // Slow path of allocation when we have to get a new page.
     uint8_t *allocateNewPage(size_t numBytes);
     // Track allocations if and only if we're using guard blocks
@@ -164,19 +128,15 @@ class PoolAllocator : angle::NonCopyable
     // any) will align to pointer size by extension (since mAlignment is made aligned to at least
     // pointer size).
     size_t mCurrentPageOffset;
-    // List of popped memory
-    PageHeader *mFreeList;
     // List of all memory currently being used.  The head of this list is where allocations are
     // currently being made from.
     PageHeader *mInUseList;
-    // Stack of where to allocate from, to partition pool
-    AllocStack mStack;
 
     int mNumCalls;       // just an interesting statistic
     size_t mTotalBytes;  // just an interesting statistic
 
 #else  // !defined(ANGLE_DISABLE_POOL_ALLOC)
-    std::vector<std::vector<void *>> mStack;
+    std::vector<void *> mStack;
 #endif
 
     bool mLocked;

--- a/Source/ThirdParty/ANGLE/src/common/PoolAlloc_unittest.cpp
+++ b/Source/ThirdParty/ANGLE/src/common/PoolAlloc_unittest.cpp
@@ -26,14 +26,15 @@ TEST(PoolAllocatorTest, Interface)
     // Write to allocation to check later
     uint32_t *writePtr = static_cast<uint32_t *>(allocation);
     *writePtr          = kTestValue;
-    // Test push and creating a new allocation
-    poolAllocator.push();
-    allocation = poolAllocator.allocate(numBytes);
-    EXPECT_NE(nullptr, allocation);
-    // Make an allocation that spans multiple pages
-    allocation = poolAllocator.allocate(10 * 1024);
-    // pop previous two allocations
-    poolAllocator.pop();
+    // Test other allocator creating a new allocation
+    {
+        PoolAllocator poolAllocator2;
+        allocation = poolAllocator2.allocate(numBytes);
+        EXPECT_NE(nullptr, allocation);
+        // Make an allocation that spans multiple pages
+        allocation = poolAllocator2.allocate(10 * 1024);
+        // Free previous two allocations.
+    }
     // Verify first allocation still has data
     EXPECT_EQ(kTestValue, *writePtr);
     // Make a bunch of allocations
@@ -46,8 +47,6 @@ TEST(PoolAllocatorTest, Interface)
         //  overwrite any other allocation we get error.
         memset(allocation, 0xb8, numBytes);
     }
-    // Free everything
-    poolAllocator.popAll();
 }
 
 #if !defined(ANGLE_POOL_ALLOC_GUARD_BLOCKS)

--- a/Source/ThirdParty/ANGLE/src/compiler/translator/Compiler.cpp
+++ b/Source/ThirdParty/ANGLE/src/compiler/translator/Compiler.cpp
@@ -266,19 +266,17 @@ namespace
 class [[nodiscard]] TScopedPoolAllocator
 {
   public:
-    TScopedPoolAllocator(angle::PoolAllocator *allocator) : mAllocator(allocator)
+    TScopedPoolAllocator()
     {
-        mAllocator->push();
-        SetGlobalPoolAllocator(mAllocator);
+        SetGlobalPoolAllocator(&mAllocator);
     }
     ~TScopedPoolAllocator()
     {
         SetGlobalPoolAllocator(nullptr);
-        mAllocator->pop(angle::PoolAllocator::ReleaseStrategy::All);
     }
 
   private:
-    angle::PoolAllocator *mAllocator;
+    angle::PoolAllocator mAllocator;
 };
 
 class [[nodiscard]] TScopedSymbolTableLevel
@@ -369,14 +367,12 @@ bool ValidateFragColorAndFragData(GLenum shaderType,
 
 TShHandleBase::TShHandleBase()
 {
-    allocator.push();
     SetGlobalPoolAllocator(&allocator);
 }
 
 TShHandleBase::~TShHandleBase()
 {
     SetGlobalPoolAllocator(nullptr);
-    allocator.popAll();
 }
 
 TCompiler::TCompiler(sh::GLenum type, ShShaderSpec spec, ShShaderOutput output)
@@ -1397,7 +1393,7 @@ bool TCompiler::compile(const char *const shaderStrings[],
         compileOptions.flattenPragmaSTDGLInvariantAll = true;
     }
 
-    TScopedPoolAllocator scopedAlloc(&allocator);
+    TScopedPoolAllocator scopedAlloc;
     TIntermBlock *root = compileTreeImpl(shaderStrings, numStrings, compileOptions);
 
     if (root)

--- a/Source/ThirdParty/ANGLE/src/tests/compiler_tests/ImmutableString_test.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/compiler_tests/ImmutableString_test.cpp
@@ -10,6 +10,8 @@
 #include "compiler/translator/PoolAlloc.h"
 #include "gtest/gtest.h"
 
+#include <optional>
+
 using namespace sh;
 
 class ImmutableStringBuilderTest : public testing::Test
@@ -20,17 +22,17 @@ class ImmutableStringBuilderTest : public testing::Test
   protected:
     void SetUp() override
     {
-        allocator.push();
-        SetGlobalPoolAllocator(&allocator);
+        allocator.emplace();
+        SetGlobalPoolAllocator(&*allocator);
     }
 
     void TearDown() override
     {
         SetGlobalPoolAllocator(nullptr);
-        allocator.pop();
+        allocator = std::nullopt;
     }
 
-    angle::PoolAllocator allocator;
+    std::optional<angle::PoolAllocator> allocator;
 };
 
 // Test writing a 32-bit signed int as hexadecimal using ImmutableStringBuilder.

--- a/Source/ThirdParty/ANGLE/src/tests/compiler_tests/IntermNode_test.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/compiler_tests/IntermNode_test.cpp
@@ -15,6 +15,8 @@
 #include "compiler/translator/SymbolTable.h"
 #include "gtest/gtest.h"
 
+#include <optional>
+
 using namespace sh;
 
 class IntermNodeTest : public testing::Test
@@ -25,14 +27,14 @@ class IntermNodeTest : public testing::Test
   protected:
     void SetUp() override
     {
-        allocator.push();
-        SetGlobalPoolAllocator(&allocator);
+        allocator.emplace();
+        SetGlobalPoolAllocator(&*allocator);
     }
 
     void TearDown() override
     {
         SetGlobalPoolAllocator(nullptr);
-        allocator.pop();
+        allocator = std::nullopt;
     }
 
     TIntermSymbol *createTestSymbol(const TType &type)
@@ -131,7 +133,7 @@ class IntermNodeTest : public testing::Test
     }
 
   private:
-    angle::PoolAllocator allocator;
+    std::optional<angle::PoolAllocator> allocator;
     int mUniqueIndex;
 };
 

--- a/Source/ThirdParty/ANGLE/src/tests/compiler_tests/Type_test.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/compiler_tests/Type_test.cpp
@@ -20,7 +20,6 @@ namespace sh
 TEST(Type, VectorAndMatrixMangledNameConsistent)
 {
     angle::PoolAllocator allocator;
-    allocator.push();
     SetGlobalPoolAllocator(&allocator);
 
     const TType *staticTypeScalar = StaticType::Get<EbtFloat, EbpMedium, EvqGlobal, 1, 1>();
@@ -37,7 +36,6 @@ TEST(Type, VectorAndMatrixMangledNameConsistent)
               std::string(typeMat2x4->getMangledName()));
 
     SetGlobalPoolAllocator(nullptr);
-    allocator.pop();
 }
 
 // Verify that basic type mangled names are unique.

--- a/Source/ThirdParty/ANGLE/src/tests/test_utils/ShaderCompileTreeTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/test_utils/ShaderCompileTreeTest.cpp
@@ -111,8 +111,8 @@ class OnlyContainsZeroConstantsTraverser final : public TIntermTraverser
 
 void ShaderCompileTreeTest::SetUp()
 {
-    mAllocator.push();
-    SetGlobalPoolAllocator(&mAllocator);
+    mAllocator.emplace();
+    SetGlobalPoolAllocator(&*mAllocator);
 
     ShBuiltInResources resources;
     sh::InitBuiltInResources(&resources);
@@ -128,7 +128,7 @@ void ShaderCompileTreeTest::TearDown()
     delete mTranslator;
 
     SetGlobalPoolAllocator(nullptr);
-    mAllocator.pop();
+    mAllocator = std::nullopt;
 }
 
 bool ShaderCompileTreeTest::compile(const std::string &shaderString)

--- a/Source/ThirdParty/ANGLE/src/tests/test_utils/ShaderCompileTreeTest.h
+++ b/Source/ThirdParty/ANGLE/src/tests/test_utils/ShaderCompileTreeTest.h
@@ -15,6 +15,8 @@
 #include "compiler/translator/PoolAlloc.h"
 #include "gtest/gtest.h"
 
+#include <optional>
+
 namespace sh
 {
 
@@ -53,7 +55,7 @@ class ShaderCompileTreeTest : public testing::Test
   private:
     TranslatorESSL *mTranslator;
 
-    angle::PoolAllocator mAllocator;
+    std::optional<angle::PoolAllocator> mAllocator;
 };
 
 // Returns true if the node is some kind of a zero node - either constructor or a constant union


### PR DESCRIPTION
#### ecc458aca176e62e9a2b2069f58fb9a9f3343c63
<pre>
ANGLE: PoolAllocator push/pop feature is not useful
<a href="https://bugs.webkit.org/show_bug.cgi?id=295392">https://bugs.webkit.org/show_bug.cgi?id=295392</a>
<a href="https://rdar.apple.com/154935331">rdar://154935331</a>

Reviewed by NOBODY (OOPS!).

PoolAllocator would manage a stack of pools (&quot;pages&quot;) upon client
calling push() and pop(). This made the code unneccessarily complicated.
The feature was only used with nesting of one, to mark the memory
unused after a shader compile.

Fix by removing the push/pop feauter. Instantiate PoolAllocator in
places the previous push() was and uninstantiating instead of previous
pop().

This removes the feature where the PoolAllocator would hold on to
the allocated memory in order to reuse it. This is seen as a
progression: the allocator is held by the compiler, the compiler is
held by the shader and each shader typically see only one compile.
Thus the free pages were just leaking unused until the shader was
destroyed. Instead, destructing the PoolAllocator instead of pop()
will donate the memory back to platform/OS, where it is likely
more useful.

* Source/ThirdParty/ANGLE/src/common/PoolAlloc.cpp:
(angle::PoolAllocator::PoolAllocator):
(angle::PoolAllocator::initialize):
(angle::PoolAllocator::~PoolAllocator):
(angle::PoolAllocator::allocate):
(angle::PoolAllocator::allocateNewPage):
(angle::PoolAllocator::push): Deleted.
(angle::PoolAllocator::pop): Deleted.
(angle::PoolAllocator::popAll): Deleted.
* Source/ThirdParty/ANGLE/src/common/PoolAlloc.h:
* Source/ThirdParty/ANGLE/src/common/PoolAlloc_unittest.cpp:
(angle::TEST(PoolAllocatorTest, Interface)):
* Source/ThirdParty/ANGLE/src/compiler/translator/Compiler.cpp:
(sh::TShHandleBase::TShHandleBase):
(sh::TShHandleBase::~TShHandleBase):
(sh::TCompiler::compile):
* Source/ThirdParty/ANGLE/src/tests/compiler_tests/ImmutableString_test.cpp:
* Source/ThirdParty/ANGLE/src/tests/compiler_tests/IntermNode_test.cpp:
* Source/ThirdParty/ANGLE/src/tests/compiler_tests/Type_test.cpp:
(sh::TEST(Type, VectorAndMatrixMangledNameConsistent)):
* Source/ThirdParty/ANGLE/src/tests/test_utils/ShaderCompileTreeTest.cpp:
(sh::ShaderCompileTreeTest::SetUp):
(sh::ShaderCompileTreeTest::TearDown):
* Source/ThirdParty/ANGLE/src/tests/test_utils/ShaderCompileTreeTest.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecc458aca176e62e9a2b2069f58fb9a9f3343c63

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110113 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20204 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116135 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60361 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30450 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38359 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83715 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113061 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24281 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99159 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64159 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23648 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17294 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59931 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93657 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17351 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118926 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37153 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27536 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92687 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37525 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95427 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92512 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37503 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15237 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33036 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37047 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36709 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40049 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38418 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->