### PR TITLE
Adopt UniqueRef and const in UIProcess/Automation

### DIFF
--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -352,23 +352,17 @@ private:
     std::optional<unichar> charCodeIgnoringModifiersForVirtualKey(Inspector::Protocol::Automation::VirtualKey) const;
 #endif
 
-    Ref<Inspector::FrontendRouter> protectedFrontendRouter() const;
-    Ref<Inspector::BackendDispatcher> protectedBackendDispatcher() const;
-#if ENABLE(REMOTE_INSPECTOR)
-    Ref<Debuggable> protectedDebuggable() const;
-#endif
-
     WeakPtr<WebProcessPool> m_processPool;
 
     std::unique_ptr<API::AutomationSessionClient> m_client;
     String m_sessionIdentifier { "Untitled Session"_s };
-    Ref<Inspector::FrontendRouter> m_frontendRouter;
-    Ref<Inspector::BackendDispatcher> m_backendDispatcher;
-    Ref<Inspector::AutomationBackendDispatcher> m_domainDispatcher;
-    std::unique_ptr<Inspector::AutomationFrontendDispatcher> m_domainNotifier;
+    const Ref<Inspector::FrontendRouter> m_frontendRouter;
+    const Ref<Inspector::BackendDispatcher> m_backendDispatcher;
+    const Ref<Inspector::AutomationBackendDispatcher> m_domainDispatcher;
+    const UniqueRef<Inspector::AutomationFrontendDispatcher> m_domainNotifier;
 
 #if ENABLE(WEBDRIVER_BIDI)
-    std::unique_ptr<WebDriverBidiProcessor> m_bidiProcessor;
+    const UniqueRef<WebDriverBidiProcessor> m_bidiProcessor;
 #endif
 
     HashMap<WebPageProxyIdentifier, String> m_webPageHandleMap;
@@ -430,7 +424,7 @@ private:
 
 #if ENABLE(REMOTE_INSPECTOR)
     Inspector::FrontendChannel* m_remoteChannel { nullptr };
-    Ref<Debuggable> m_debuggable;
+    const Ref<Debuggable> m_debuggable;
 #endif
 
 };

--- a/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp
@@ -52,29 +52,19 @@ WebDriverBidiProcessor::WebDriverBidiProcessor(WebAutomationSession& session)
     : m_session(session)
     , m_frontendRouter(FrontendRouter::create())
     , m_backendDispatcher(BackendDispatcher::create(m_frontendRouter.copyRef()))
-    , m_browserAgent(makeUnique<BidiBrowserAgent>(session, m_backendDispatcher))
-    , m_browsingContextAgent(makeUnique<BidiBrowsingContextAgent>(session, m_backendDispatcher))
-    , m_scriptAgent(makeUnique<BidiScriptAgent>(session, m_backendDispatcher))
-    , m_storageAgent(makeUnique<BidiStorageAgent>(session, m_backendDispatcher))
-    , m_browsingContextDomainNotifier(makeUnique<BidiBrowsingContextFrontendDispatcher>(m_frontendRouter))
-    , m_logDomainNotifier(makeUnique<BidiLogFrontendDispatcher>(m_frontendRouter))
+    , m_browserAgent(makeUniqueRef<BidiBrowserAgent>(session, m_backendDispatcher))
+    , m_browsingContextAgent(makeUniqueRef<BidiBrowsingContextAgent>(session, m_backendDispatcher))
+    , m_scriptAgent(makeUniqueRef<BidiScriptAgent>(session, m_backendDispatcher))
+    , m_storageAgent(makeUniqueRef<BidiStorageAgent>(session, m_backendDispatcher))
+    , m_browsingContextDomainNotifier(makeUniqueRef<BidiBrowsingContextFrontendDispatcher>(m_frontendRouter))
+    , m_logDomainNotifier(makeUniqueRef<BidiLogFrontendDispatcher>(m_frontendRouter))
 {
-    protectedFrontendRouter()->connectFrontend(*this);
+    m_frontendRouter->connectFrontend(*this);
 }
 
 WebDriverBidiProcessor::~WebDriverBidiProcessor()
 {
-    protectedFrontendRouter()->disconnectFrontend(*this);
-}
-
-Ref<Inspector::FrontendRouter> WebDriverBidiProcessor::protectedFrontendRouter() const
-{
-    return m_frontendRouter;
-}
-
-Ref<Inspector::BackendDispatcher> WebDriverBidiProcessor::protectedBackendDispatcher() const
-{
-    return m_backendDispatcher;
+    m_frontendRouter->disconnectFrontend(*this);
 }
 
 void WebDriverBidiProcessor::processBidiMessage(const String& message)
@@ -88,7 +78,7 @@ void WebDriverBidiProcessor::processBidiMessage(const String& message)
     LOG(Automation, "[s:%s] processBidiMessage of length %d", session->sessionIdentifier().utf8().data(), message.length());
     LOG(Automation, "%s", message.utf8().data());
 
-    protectedBackendDispatcher()->dispatch(message);
+    m_backendDispatcher->dispatch(message);
 }
 
 // Translate internal error messages that come from the inspector protocol payload.

--- a/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h
+++ b/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h
@@ -52,7 +52,7 @@ public:
     void processBidiMessage(const String&);
     void sendBidiMessage(const String&);
 
-    BidiBrowserAgent& browserAgent() const { return *m_browserAgent; }
+    BidiBrowserAgent& browserAgent() const { return m_browserAgent; }
 
     // Inspector::FrontendChannel methods. Domain events sent via WebDriverBidi domain notifiers are packaged up
     // by FrontendRouter and are then sent back out-of-process via WebAutomationSession::sendBidiMessage().
@@ -60,24 +60,21 @@ public:
     void sendMessageToFrontend(const String&) override;
 
     // Event entry points called from the owning WebAutomationSession.
-    Inspector::BidiBrowsingContextFrontendDispatcher& browsingContextDomainNotifier() const { return *m_browsingContextDomainNotifier; }
-    Inspector::BidiLogFrontendDispatcher& logDomainNotifier() const { return *m_logDomainNotifier; }
+    Inspector::BidiBrowsingContextFrontendDispatcher& browsingContextDomainNotifier() const { return m_browsingContextDomainNotifier; }
+    Inspector::BidiLogFrontendDispatcher& logDomainNotifier() const { return m_logDomainNotifier; }
 
 private:
-    Ref<Inspector::FrontendRouter> protectedFrontendRouter() const;
-    Ref<Inspector::BackendDispatcher> protectedBackendDispatcher() const;
-
     WeakPtr<WebAutomationSession> m_session;
 
-    Ref<Inspector::FrontendRouter> m_frontendRouter;
-    Ref<Inspector::BackendDispatcher> m_backendDispatcher;
+    const Ref<Inspector::FrontendRouter> m_frontendRouter;
+    const Ref<Inspector::BackendDispatcher> m_backendDispatcher;
 
-    std::unique_ptr<BidiBrowserAgent> m_browserAgent;
-    std::unique_ptr<BidiBrowsingContextAgent> m_browsingContextAgent;
-    std::unique_ptr<BidiScriptAgent> m_scriptAgent;
-    std::unique_ptr<BidiStorageAgent> m_storageAgent;
-    std::unique_ptr<Inspector::BidiBrowsingContextFrontendDispatcher> m_browsingContextDomainNotifier;
-    std::unique_ptr<Inspector::BidiLogFrontendDispatcher> m_logDomainNotifier;
+    const UniqueRef<BidiBrowserAgent> m_browserAgent;
+    const UniqueRef<BidiBrowsingContextAgent> m_browsingContextAgent;
+    const UniqueRef<BidiScriptAgent> m_scriptAgent;
+    const UniqueRef<BidiStorageAgent> m_storageAgent;
+    const UniqueRef<Inspector::BidiBrowsingContextFrontendDispatcher> m_browsingContextDomainNotifier;
+    const UniqueRef<Inspector::BidiLogFrontendDispatcher> m_logDomainNotifier;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### d91c64eda48a34556bb287f5be135cf271a85b88
<pre>
Adopt UniqueRef and const in UIProcess/Automation
<a href="https://bugs.webkit.org/show_bug.cgi?id=295396">https://bugs.webkit.org/show_bug.cgi?id=295396</a>

Reviewed by Youenn Fablet.

Helps with <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/296968@main">https://commits.webkit.org/296968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5cfb56fed7c2f16e6bb842f7dc8565d08b899d66

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110117 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29776 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20208 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116139 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/60365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30454 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38363 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83720 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/60365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113065 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24287 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99166 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64164 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23654 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59935 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93663 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17358 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118930 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37157 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27543 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92694 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37529 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95434 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92517 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37507 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15244 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33040 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17767 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37051 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42522 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36713 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40053 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38422 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->