### PR TITLE
ANGLE: PoolAllocator is more complex than necessary

### DIFF
--- a/Source/ThirdParty/ANGLE/src/common/PoolAlloc.cpp
+++ b/Source/ThirdParty/ANGLE/src/common/PoolAlloc.cpp
@@ -4,393 +4,32 @@
 // found in the LICENSE file.
 //
 // PoolAlloc.cpp:
-//    Implements the class methods for PoolAllocator and Allocation classes.
+//    Implements the PoolAllocator.
 //
 
 #include "common/PoolAlloc.h"
 
-#include <assert.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <utility>
 
-#include "common/mathutil.h"
 #include "common/platform.h"
-#include "common/tls.h"
 
 #if defined(ANGLE_WITH_ASAN)
 #    include <sanitizer/asan_interface.h>
 #endif
+#if !defined(ANGLE_DISABLE_POOL_ALLOC)
+#    include "common/aligned_memory.h"
+#endif
 
 namespace angle
 {
-// If we are using guard blocks, we must track each individual allocation.  If we aren't using guard
-// blocks, these never get instantiated, so won't have any impact.
 
-class Allocation
+constexpr size_t kPoolAllocatorPageSize = 16 * 1024;
+
+PoolAllocator::PoolAllocator(size_t alignment) : mAlignment(alignment)
 {
-  public:
-    Allocation(size_t size, unsigned char *mem, Allocation *prev = 0)
-        : mSize(size), mMem(mem), mPrevAlloc(prev)
-    {
-        // Allocations are bracketed:
-        //
-        //    [allocationHeader][initialGuardBlock][userData][finalGuardBlock]
-        //
-        // This would be cleaner with if (kGuardBlockSize)..., but that makes the compiler print
-        // warnings about 0 length memsets, even with the if() protecting them.
-#if defined(ANGLE_POOL_ALLOC_GUARD_BLOCKS)
-        memset(preGuard(), kGuardBlockBeginVal, kGuardBlockSize);
-        memset(data(), kUserDataFill, mSize);
-        memset(postGuard(), kGuardBlockEndVal, kGuardBlockSize);
-#endif
-    }
-
-    void checkAllocList() const;
-
-    static size_t AlignedHeaderSize(uint8_t *allocationBasePtr, size_t alignment)
-    {
-        // Make sure that the data offset after the header is aligned to the given alignment.
-        size_t base = reinterpret_cast<size_t>(allocationBasePtr);
-        return rx::roundUpPow2(base + kGuardBlockSize + HeaderSize(), alignment) - base;
-    }
-
-    // Return total size needed to accommodate user buffer of 'size',
-    // plus our tracking data and any necessary alignments.
-    static size_t AllocationSize(uint8_t *allocationBasePtr,
-                                 size_t size,
-                                 size_t alignment,
-                                 size_t *preAllocationPaddingOut)
-    {
-        // The allocation will be laid out as such:
-        //
-        //                      Aligned to |alignment|
-        //                               ^
-        //   preAllocationPaddingOut     |
-        //        ___^___                |
-        //       /       \               |
-        //       <padding>[header][guard][data][guard]
-        //       \___________ __________/
-        //                   V
-        //              dataOffset
-        //
-        // Note that alignment is at least as much as a pointer alignment, so the pointers in the
-        // header are also necessarily aligned appropriately.
-        //
-        size_t dataOffset        = AlignedHeaderSize(allocationBasePtr, alignment);
-        *preAllocationPaddingOut = dataOffset - HeaderSize() - kGuardBlockSize;
-
-        return dataOffset + size + kGuardBlockSize;
-    }
-
-    // Given memory pointing to |header|, returns |data|.
-    static uint8_t *GetDataPointer(uint8_t *memory, size_t alignment)
-    {
-        uint8_t *alignedPtr = memory + kGuardBlockSize + HeaderSize();
-
-        // |memory| must be aligned already such that user data is aligned to |alignment|.
-        ASSERT((reinterpret_cast<uintptr_t>(alignedPtr) & (alignment - 1)) == 0);
-
-        return alignedPtr;
-    }
-
-  private:
-    void checkGuardBlock(unsigned char *blockMem, unsigned char val, const char *locText) const;
-
-    void checkAlloc() const
-    {
-        checkGuardBlock(preGuard(), kGuardBlockBeginVal, "before");
-        checkGuardBlock(postGuard(), kGuardBlockEndVal, "after");
-    }
-
-    // Find offsets to pre and post guard blocks, and user data buffer
-    unsigned char *preGuard() const { return mMem + HeaderSize(); }
-    unsigned char *data() const { return preGuard() + kGuardBlockSize; }
-    unsigned char *postGuard() const { return data() + mSize; }
-    size_t mSize;            // size of the user data area
-    unsigned char *mMem;     // beginning of our allocation (points to header)
-    Allocation *mPrevAlloc;  // prior allocation in the chain
-
-    static constexpr unsigned char kGuardBlockBeginVal = 0xfb;
-    static constexpr unsigned char kGuardBlockEndVal   = 0xfe;
-    static constexpr unsigned char kUserDataFill       = 0xcd;
-#if defined(ANGLE_POOL_ALLOC_GUARD_BLOCKS)
-    static constexpr size_t kGuardBlockSize = 16;
-    static constexpr size_t HeaderSize() { return sizeof(Allocation); }
-#else
-    static constexpr size_t kGuardBlockSize = 0;
-    static constexpr size_t HeaderSize() { return 0; }
-#endif
-};
-
-#if !defined(ANGLE_DISABLE_POOL_ALLOC)
-class PageHeader
-{
-  public:
-    PageHeader(PageHeader *nextPage, size_t pageCount)
-        : nextPage(nextPage),
-          pageCount(pageCount)
-    {
-    }
-
-    PageHeader *nextPage;
-    size_t pageCount;
-#    if defined(ANGLE_POOL_ALLOC_GUARD_BLOCKS)
-    Allocation *lastAllocation = nullptr;
-#    endif
-};
-#endif
-
-//
-// Implement the functionality of the PoolAllocator class, which
-// is documented in PoolAlloc.h.
-//
-PoolAllocator::PoolAllocator(int growthIncrement, int allocationAlignment)
-    : mAlignment(allocationAlignment),
-#if !defined(ANGLE_DISABLE_POOL_ALLOC)
-      mPageSize(growthIncrement),
-      mFreeList(nullptr),
-      mInUseList(nullptr),
-      mNumCalls(0),
-      mTotalBytes(0),
-#endif
-      mLocked(false)
-{
-#if !defined(ANGLE_DISABLE_POOL_ALLOC)
-    mPageHeaderSkip = sizeof(PageHeader);
-
-    // Alignment == 1 is a special fast-path where fastAllocate() is enabled
-    if (mAlignment != 1)
-    {
-#endif
-        // Adjust mAlignment to be at least pointer aligned and
-        // power of 2.
-        //
-        size_t minAlign = sizeof(void *);
-        if (mAlignment < minAlign)
-        {
-            mAlignment = minAlign;
-        }
-        mAlignment = gl::ceilPow2(static_cast<unsigned int>(mAlignment));
-#if !defined(ANGLE_DISABLE_POOL_ALLOC)
-    }
-    //
-    // Don't allow page sizes we know are smaller than all common
-    // OS page sizes.
-    //
-    if (mPageSize < 4 * 1024)
-    {
-        mPageSize = 4 * 1024;
-    }
-
-    //
-    // A large mCurrentPageOffset indicates a new page needs to
-    // be obtained to allocate memory.
-    //
-    mCurrentPageOffset = mPageSize;
-#endif
+    ASSERT(gl::isPow2(mAlignment) && mAlignment < kPoolAllocatorPageSize);
 }
-
-PoolAllocator::~PoolAllocator()
-{
-    reset();
-#if !defined(ANGLE_DISABLE_POOL_ALLOC)
-    while (mFreeList)
-    {
-        PageHeader *next = mFreeList->nextPage;
-        delete[] reinterpret_cast<char *>(mFreeList);
-        mFreeList = next;
-    }
-#endif
-}
-
-//
-// Check a single guard block for damage
-//
-void Allocation::checkGuardBlock(unsigned char *blockMem,
-                                 unsigned char val,
-                                 const char *locText) const
-{
-#if defined(ANGLE_POOL_ALLOC_GUARD_BLOCKS)
-    for (size_t x = 0; x < kGuardBlockSize; x++)
-    {
-        if (blockMem[x] != val)
-        {
-            char assertMsg[80];
-            // We don't print the assert message.  It's here just to be helpful.
-            snprintf(assertMsg, sizeof(assertMsg),
-                     "PoolAlloc: Damage %s %zu byte allocation at 0x%p\n", locText, mSize, data());
-            assert(0 && "PoolAlloc: Damage in guard block");
-        }
-    }
-#endif
-}
-
-void PoolAllocator::reset()
-{
-#if !defined(ANGLE_DISABLE_POOL_ALLOC)
-    mNumCalls   = 0;
-    mTotalBytes = 0;
-
-    mCurrentPageOffset = mPageSize;
-    PageHeader *page   = std::exchange(mInUseList, nullptr);
-    while (page)
-    {
-        const size_t pageCount = page->pageCount;
-        PageHeader *nextInUse  = page->nextPage;
-
-#    if defined(ANGLE_POOL_ALLOC_GUARD_BLOCKS)
-        if (page->lastAllocation)
-        {
-            Allocation *allocations = std::exchange(page->lastAllocation, nullptr);
-            allocations->checkAllocList();
-        }
-#    endif
-
-        if (pageCount > 1)
-        {
-            delete[] reinterpret_cast<uint8_t *>(page);
-        }
-        else
-        {
-#    if defined(ANGLE_WITH_ASAN)
-            // Clear any container annotations left over from when the memory
-            // was last used. (crbug.com/1419798)
-            __asan_unpoison_memory_region(page, mPageSize);
-#    endif
-            page->nextPage = mFreeList;
-            mFreeList      = page;
-        }
-        page = nextInUse;
-    }
-#else  // !defined(ANGLE_DISABLE_POOL_ALLOC)
-    mStack.clear();
-#endif
-}
-
-void *PoolAllocator::allocate(size_t numBytes)
-{
-    ASSERT(!mLocked);
-
-#if !defined(ANGLE_DISABLE_POOL_ALLOC)
-    //
-    // Just keep some interesting statistics.
-    //
-    ++mNumCalls;
-    mTotalBytes += numBytes;
-
-    uint8_t *currentPagePtr = reinterpret_cast<uint8_t *>(mInUseList) + mCurrentPageOffset;
-
-    size_t preAllocationPadding = 0;
-    size_t allocationSize =
-        Allocation::AllocationSize(currentPagePtr, numBytes, mAlignment, &preAllocationPadding);
-
-    // Integer overflow is unexpected.
-    ASSERT(allocationSize >= numBytes);
-
-    // Do the allocation, most likely case first, for efficiency.
-    if (allocationSize <= mPageSize - mCurrentPageOffset)
-    {
-        // There is enough room to allocate from the current page at mCurrentPageOffset.
-        uint8_t *memory = currentPagePtr + preAllocationPadding;
-        mCurrentPageOffset += allocationSize;
-
-        return initializeAllocation(memory, numBytes);
-    }
-
-    if (allocationSize > mPageSize - mPageHeaderSkip)
-    {
-        // If the allocation is larger than a whole page, do a multi-page allocation.  These are not
-        // mixed with the others.  The OS is efficient in allocating and freeing multiple pages.
-
-        // We don't know what the alignment of the new allocated memory will be, so conservatively
-        // allocate enough memory for up to alignment extra bytes being needed.
-        allocationSize = Allocation::AllocationSize(reinterpret_cast<uint8_t *>(mPageHeaderSkip),
-                                                    numBytes, mAlignment, &preAllocationPadding);
-
-        size_t numBytesToAlloc = allocationSize + mPageHeaderSkip + mAlignment;
-
-        // Integer overflow is unexpected.
-        ASSERT(numBytesToAlloc >= allocationSize);
-
-        uint8_t *memory = new (std::nothrow) uint8_t[numBytesToAlloc];
-        if (memory == nullptr)
-        {
-            return nullptr;
-        }
-        mInUseList =
-            new (memory) PageHeader(mInUseList, (numBytesToAlloc + mPageSize - 1) / mPageSize);
-
-        // Make next allocation come from a new page
-        mCurrentPageOffset = mPageSize;
-
-        // Now that we actually have the pointer, make sure the data pointer will be aligned.
-        currentPagePtr = reinterpret_cast<uint8_t *>(mInUseList) + mPageHeaderSkip;
-        Allocation::AllocationSize(currentPagePtr, numBytes, mAlignment, &preAllocationPadding);
-
-        return initializeAllocation(currentPagePtr + preAllocationPadding, numBytes);
-    }
-
-    uint8_t *newPageAddr = allocateNewPage(numBytes);
-    return initializeAllocation(newPageAddr, numBytes);
-
-#else  // !defined(ANGLE_DISABLE_POOL_ALLOC)
-
-    uint8_t *alloc = new (std::nothrow) uint8_t[numBytes + mAlignment - 1];
-    mStack.emplace_back(std::unique_ptr<uint8_t[]>(alloc));
-
-    intptr_t intAlloc = reinterpret_cast<intptr_t>(alloc);
-    intAlloc          = rx::roundUpPow2<intptr_t>(intAlloc, mAlignment);
-    return reinterpret_cast<void *>(intAlloc);
-#endif
-}
-
-#if !defined(ANGLE_DISABLE_POOL_ALLOC)
-uint8_t *PoolAllocator::allocateNewPage(size_t numBytes)
-{
-    // Need a simple page to allocate from.  Pick a page from the free list, if any.  Otherwise need
-    // to make the allocation.
-    if (mFreeList)
-    {
-        PageHeader *page = mFreeList;
-        mFreeList = mFreeList->nextPage;
-        page->nextPage   = mInUseList;
-        mInUseList       = page;
-    }
-    else
-    {
-        uint8_t *memory = new (std::nothrow) uint8_t[mPageSize];
-        if (memory == nullptr)
-        {
-            return nullptr;
-        }
-        mInUseList = new (memory) PageHeader(mInUseList, 1);
-    }
-
-    // Leave room for the page header.
-    mCurrentPageOffset      = mPageHeaderSkip;
-    uint8_t *currentPagePtr = reinterpret_cast<uint8_t *>(mInUseList) + mCurrentPageOffset;
-
-    size_t preAllocationPadding = 0;
-    size_t allocationSize =
-        Allocation::AllocationSize(currentPagePtr, numBytes, mAlignment, &preAllocationPadding);
-
-    mCurrentPageOffset += allocationSize;
-
-    // The new allocation is made after the page header and any alignment required before it.
-    return reinterpret_cast<uint8_t *>(mInUseList) + mPageHeaderSkip + preAllocationPadding;
-}
-
-void *PoolAllocator::initializeAllocation(uint8_t *memory, size_t numBytes)
-{
-#    if defined(ANGLE_POOL_ALLOC_GUARD_BLOCKS)
-    mInUseList->lastAllocation =
-        new (memory) Allocation(numBytes, memory, mInUseList->lastAllocation);
-#    endif
-
-    return Allocation::GetDataPointer(memory, mAlignment);
-}
-#endif
 
 void PoolAllocator::lock()
 {
@@ -404,15 +43,176 @@ void PoolAllocator::unlock()
     mLocked = false;
 }
 
-//
-// Check all allocations in a list for damage by calling check on each.
-//
-void Allocation::checkAllocList() const
+#if !defined(ANGLE_DISABLE_POOL_ALLOC)
+
+namespace
 {
-    for (const Allocation *alloc = this; alloc != nullptr; alloc = alloc->mPrevAlloc)
+
+inline Span<uint8_t> AllocatePageMemory(size_t size, size_t alignment)
+{
+    uint8_t *result = reinterpret_cast<uint8_t *>(AlignedAlloc(size, alignment));
+    if (ANGLE_UNLIKELY(result == nullptr))
     {
-        alloc->checkAlloc();
+        return {};
+    }
+    return {result, size};
+}
+
+inline void DeallocatePageMemory(uint8_t *memory)
+{
+    AlignedFree(memory);
+}
+
+#    if defined(ANGLE_POOL_ALLOC_GUARD_BLOCKS)
+
+constexpr uint8_t kGuardFillValue = 0xfe;
+constexpr uint8_t kDataFillValue  = 0xcd;
+
+#    endif
+
+}  // anonymous namespace.
+
+class PoolAllocator::PageHeader
+{
+  public:
+    PageHeader(PageHeader *next, size_t size) : next(next), size(size) {}
+
+    PageHeader *next;
+    size_t size;
+};
+
+#    if defined(ANGLE_POOL_ALLOC_GUARD_BLOCKS)
+
+size_t PoolAllocator::adjustAllocationExtent(size_t alignedSize) const
+{
+    size_t adjustedSize = alignedSize;
+    if (mAlignment != 1)
+    {
+        adjustedSize += 2 * mAlignment;
+    }
+    return adjustedSize;
+}
+
+void PoolAllocator::addGuard(Span<uint8_t> alignedData, size_t size)
+{
+    if (!alignedData.empty())
+    {
+        memset(alignedData.data(), kDataFillValue, alignedData.size());
+        Span<uint8_t> alignmentGuard = alignedData.subspan(size);
+        if (!alignmentGuard.empty())
+        {
+            mGuards.push_back(alignmentGuard);
+        }
+    }
+
+    if (mAlignment != 1)
+    {
+        Span guard = bump(mAlignment);
+        memset(guard.data(), kGuardFillValue, guard.size());
+        mGuards.push_back(guard);
     }
 }
+
+#    endif
+
+PoolAllocator::~PoolAllocator()
+{
+    reset();
+    PageHeader *page = mUnusedPages;
+    while (page)
+    {
+        PageHeader *next = page->next;
+        DeallocatePageMemory(reinterpret_cast<uint8_t *>(page));
+        page = next;
+    }
+}
+
+void PoolAllocator::reset()
+{
+#    if defined(ANGLE_POOL_ALLOC_GUARD_BLOCKS)
+    for (Span<uint8_t> guard : mGuards)
+    {
+        uint8_t expectedValue = reinterpret_cast<uintptr_t>(guard.data()) % mAlignment != 0
+                                    ? kDataFillValue
+                                    : kGuardFillValue;
+        for (uint8_t value : guard)
+        {
+            ASSERT(value == expectedValue);
+        }
+    }
+    mGuards.clear();
+#    endif
+    mMemory          = {};
+    PageHeader *page = std::exchange(mPages, nullptr);
+    while (page)
+    {
+        PageHeader *next = page->next;
+        if (page->size > kPoolAllocatorPageSize)
+        {
+            DeallocatePageMemory(reinterpret_cast<uint8_t *>(page));
+        }
+        else
+        {
+#    if defined(ANGLE_WITH_ASAN)
+            // Clear any container annotations left over from when the memory
+            // was last used. (crbug.com/1419798)
+            __asan_unpoison_memory_region(page, page->size);
+#    endif
+            page->next   = mUnusedPages;
+            mUnusedPages = page;
+        }
+        page = next;
+    }
+}
+
+bool PoolAllocator::allocateNewPage(size_t numBytes)
+{
+    size_t headerSize = rx::roundUpPow2(sizeof(PageHeader), mAlignment);
+    size_t pageExtent = rx::roundUpPow2(numBytes + headerSize, kPoolAllocatorPageSize);
+    if (mUnusedPages != nullptr && mUnusedPages->size >= pageExtent)
+    {
+        PageHeader *page = mUnusedPages;
+        mUnusedPages     = page->next;
+        mMemory    = {reinterpret_cast<uint8_t *>(page) + headerSize, page->size - headerSize};
+        page->next = mPages;
+        mPages     = page;
+        return true;
+    }
+
+    Span<uint8_t> memory =
+        AllocatePageMemory(pageExtent, std::max(mAlignment, alignof(PageHeader)));
+    if (ANGLE_UNLIKELY(memory.empty()))
+    {
+        return false;
+    }
+    mMemory = memory;
+    mPages  = new (bump(headerSize).data()) PageHeader(mPages, pageExtent);
+    return true;
+}
+
+#else  // !defined(ANGLE_DISABLE_POOL_ALLOC)
+
+PoolAllocator::~PoolAllocator() = default;
+
+void PoolAllocator::reset()
+{
+    mAllocations.clear();
+}
+
+void *PoolAllocator::allocate(size_t numBytes)
+{
+    ASSERT(!mLocked);
+    uint8_t *alloc = new (std::nothrow) uint8_t[numBytes + mAlignment - 1];
+    if (ANGLE_UNLIKELY(!alloc))
+    {
+        return nullptr;
+    }
+    mAllocations.push_back(std::unique_ptr<uint8_t[]>(alloc));
+    uintptr_t intAlloc = reinterpret_cast<uintptr_t>(alloc);
+    intAlloc           = rx::roundUpPow2<uintptr_t>(intAlloc, mAlignment);
+    return reinterpret_cast<void *>(intAlloc);
+}
+
+#endif
 
 }  // namespace angle

--- a/Source/ThirdParty/ANGLE/src/common/span.h
+++ b/Source/ThirdParty/ANGLE/src/common/span.h
@@ -102,6 +102,12 @@ class Span
         return count == 0 ? Span() : Span(mData + offset, count);
     }
 
+    constexpr Span subspan(size_type offset) const
+    {
+        ASSERT(offset <= mSize);
+        return offset == mSize ? Span() : Span(mData + offset, mSize - offset);
+    }
+
   private:
     T *mData     = nullptr;
     size_t mSize = 0;

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/vulkan/AllocatorHelperPool.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/vulkan/AllocatorHelperPool.cpp
@@ -49,7 +49,7 @@ bool DedicatedCommandBlockPool::empty() const
 void DedicatedCommandBlockPool::allocateNewBlock(size_t blockSize)
 {
     ASSERT(mAllocator);
-    mCurrentWritePointer   = mAllocator->fastAllocate(blockSize);
+    mCurrentWritePointer   = reinterpret_cast<uint8_t *>(mAllocator->allocate(blockSize));
     mCurrentBytesRemaining = blockSize;
     mCommandBuffer->pushToCommands(mCurrentWritePointer);
 }

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/vulkan/AllocatorHelperPool.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/vulkan/AllocatorHelperPool.h
@@ -36,10 +36,9 @@ class DedicatedCommandBlockAllocator
     DedicatedCommandMemoryAllocator *getAllocator() { return &mAllocator; }
 
   private:
-    static constexpr size_t kDefaultPoolAllocatorPageSize = 16 * 1024;
     // Using a pool allocator per CBH to avoid threading issues that occur w/ shared allocator
     // between multiple CBHs.
-    DedicatedCommandMemoryAllocator mAllocator{kDefaultPoolAllocatorPageSize, 1};
+    DedicatedCommandMemoryAllocator mAllocator{1};
 };
 
 // Used in SecondaryCommandBuffer


### PR DESCRIPTION
#### 0ebb7ad84892cd1df014a5c33ff363b39a8250d2
<pre>
ANGLE: PoolAllocator is more complex than necessary
<a href="https://bugs.webkit.org/show_bug.cgi?id=295398">https://bugs.webkit.org/show_bug.cgi?id=295398</a>
<a href="https://rdar.apple.com/154944202">rdar://154944202</a>

Reviewed by Dan Glastonbury and Mike Wyrzykowski.

Simplify PoolAllocator implementation by removing verbose debug code

Hard-code the page size for the page allocations to the de-facto size
that is used.

Changes the alignment algorithm:

Before, the current pointer would be at an arbitrary address. Allocation
would first align the current pointer and then current pointer
would be bumped the exact size amount.

After, current pointer is always aligned at mAlignment. The page is
allocated aligned to mAlignment. Each allocation size is rounded up to
alignment and current pointer is bumped by that amount. This means that
the initial allocation is now made with AlignedAlloc instead of new[].

For now, stores the guard blocks out of line in a std::vector to
simplify the implementation.

Fixes UBs where objects of type PageHeader, Allocation pointed to
by internal implementation were not neccessarily aligned.

* Source/ThirdParty/ANGLE/src/common/PoolAlloc.cpp:
(angle::PoolAllocator::PoolAllocator):
(angle::PoolAllocator::lock):
(angle::PoolAllocator::unlock):
(angle::PoolAllocator::PageHeader::PageHeader):
(angle::PoolAllocator::adjustAllocationExtent const):
(angle::PoolAllocator::addGuard):
(angle::PoolAllocator::~PoolAllocator):
(angle::PoolAllocator::reset):
(angle::PoolAllocator::allocateNewPage):
(angle::PoolAllocator::allocate):
(angle::Allocation::Allocation): Deleted.
(angle::Allocation::AlignedHeaderSize): Deleted.
(angle::Allocation::AllocationSize): Deleted.
(angle::Allocation::GetDataPointer): Deleted.
(angle::Allocation::checkAlloc const): Deleted.
(angle::Allocation::preGuard const): Deleted.
(angle::Allocation::data const): Deleted.
(angle::Allocation::postGuard const): Deleted.
(angle::Allocation::HeaderSize): Deleted.
(angle::PageHeader::PageHeader): Deleted.
(angle::Allocation::checkGuardBlock const): Deleted.
(angle::PoolAllocator::initializeAllocation): Deleted.
(angle::Allocation::checkAllocList const): Deleted.
* Source/ThirdParty/ANGLE/src/common/PoolAlloc.h:
(angle::PoolAllocator::adjustAllocationExtent const):
(angle::PoolAllocator::addGuard):
(angle::PoolAllocator::bump):
(angle::PoolAllocator::allocate):
(angle::PoolAllocator::fastAllocate): Deleted.
* Source/ThirdParty/ANGLE/src/common/PoolAlloc_unittest.cpp:
(angle::PoolAllocatorTest::GetAlignment):
(angle::TEST_P):
(angle::TEST(PoolAllocatorTest, Interface)): Deleted.
* Source/ThirdParty/ANGLE/src/common/span.h:
(angle::Span::subspan const):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/vulkan/AllocatorHelperPool.cpp:
(rx::vk::DedicatedCommandBlockPool::allocateNewBlock):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/vulkan/AllocatorHelperPool.h:

Canonical link: <a href="https://commits.webkit.org/297465@main">https://commits.webkit.org/297465@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8024976eecadd80fa1c3878aa307d45c04f8bd6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22031 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117909 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62119 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40135 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/84999 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35687 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114838 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25742 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100690 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65438 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25063 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18826 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61753 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95121 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/18897 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121190 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38918 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/28941 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/93869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39299 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96948 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/93693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23903 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38878 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16663 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34934 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38816 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38453 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41778 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40168 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->