### PR TITLE
bmalloc header prerequisites for modularization

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_darwin_spi.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_darwin_spi.h
@@ -85,6 +85,18 @@ VM_FLAGS_ALIAS_MASK);
 #define pas_stack_logging_flag_zone        8    /* NSZoneMalloc, etc... */
 #define pas_stack_logging_flag_cleared    64    /* for NewEmptyHandle */
 
+PAS_END_EXTERN_C;
+
+// In a build using clang modules, we must never redeclare items
+// from other headers, but instead include those headers.
+#if defined(__has_include) && __has_include(<stack_logging.h>)
+#include <stack_logging.h>
+#else
+// But, we want to ensure these symbols are available even
+// in the case that we don't have such headers available.
+
+PAS_BEGIN_EXTERN_C;
+
 typedef void(malloc_logger_t)(uint32_t type,
                               uintptr_t arg1,
                               uintptr_t arg2,
@@ -97,6 +109,8 @@ extern malloc_logger_t* malloc_logger;
 #endif
 
 PAS_END_EXTERN_C;
+
+#endif /* defined(__has_include) && __has_include(<stack_logging.h>) */
 
 #endif /* PAS_OS(DARWIN) */
 

--- a/Source/bmalloc/libpas/src/libpas/pas_scavenger.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_scavenger.h
@@ -31,9 +31,9 @@
 #include <sys/qos.h>
 #endif
 
-PAS_BEGIN_EXTERN_C;
-
 #include "pas_allocation_mode.h"
+
+PAS_BEGIN_EXTERN_C;
 
 enum pas_scavenger_state {
     pas_scavenger_state_no_thread,

--- a/Source/bmalloc/libpas/src/libpas/pas_system_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_system_heap.h
@@ -32,6 +32,12 @@
 #include "pas_log.h"
 #include "pas_utils.h"
 
+#if PAS_BMALLOC
+// FIXME: Find a way to declare bmalloc's symbol visibility without having to
+// import a bmalloc header.
+#include "BExport.h"
+#endif
+
 PAS_BEGIN_EXTERN_C;
 
 /* Bmalloc has a SystemHeap singleton that can be used to divert bmalloc calls to system malloc.
@@ -39,9 +45,6 @@ PAS_BEGIN_EXTERN_C;
 
 #if PAS_BMALLOC
 
-// FIXME: Find a way to declare bmalloc's symbol visibility without having to
-// import a bmalloc header.
-#include "BExport.h"
 
 /* The implementations are provided by bmalloc. */
 BEXPORT extern bool pas_system_heap_is_enabled(pas_heap_config_kind);


### PR DESCRIPTION
#### 6164db046c71ea7b60a19f3834165a27f1bf96df
<pre>
bmalloc header prerequisites for modularization
<a href="https://bugs.webkit.org/show_bug.cgi?id=295400">https://bugs.webkit.org/show_bug.cgi?id=295400</a>
<a href="https://rdar.apple.com/154946113">rdar://154946113</a>

Reviewed by Elliott Williams.

These are the changes required to allow bmalloc (later) to be built as a clang
module. Such clang modules are built in independent compilation contexts, so
we need to be a little stricter about include rules. Details below.

* Source/bmalloc/libpas/src/libpas/pas_darwin_spi.h: This header
  redeclares some items from the stack_logging module, which isn&apos;t
  permitted if that module is available.
* Source/bmalloc/libpas/src/libpas/pas_scavenger.h: see below
* Source/bmalloc/libpas/src/libpas/pas_system_heap.h: these two
  headers include other headers within an extern &quot;C&quot; block,
  which requires special handling with clang modules. It does not
  appear to be possible to get this exactly right since it means
  some files could then *only* be included within such an
  extern &quot;C&quot; block, and that does not appear to be the intention
  here. Instead, move these includes to be outside the extern &quot;C&quot;.

Canonical link: <a href="https://commits.webkit.org/297081@main">https://commits.webkit.org/297081@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/627afe327a3b8e775197223ff788cedef3f264c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110126 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29785 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116148 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60374 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30463 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38372 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83728 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113074 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24296 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99176 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64172 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23663 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17310 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59944 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/102617 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93672 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17367 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118939 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/108680 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37166 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27551 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92707 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37538 "Failed to checkout and rebase branch from PR 47548") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95443 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92530 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23647 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15253 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/33051 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37060 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/132955 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36722 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35957 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40062 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38431 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->