### PR TITLE
www.ricoh-imaging.co.jp: REGRESSION (293848@main): Images does not come into view while scrolling on product page

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-inline-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-inline-style-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Animation starts when the name is mutated via inline style
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-inline-style.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-inline-style.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<link rel="help" href="https://drafts.csswg.org/css-animations-1/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+#target { color: red }
+@keyframes green {
+    from, to { color: green }
+}
+</style>
+<div id=target style="animation-duration: 1s"></div>
+<script>
+test(t => {
+    target.style.animationName = "none";
+    assert_equals(getComputedStyle(target).color, "rgb(255, 0, 0)");
+    target.style.animationName = "green";
+    assert_equals(getComputedStyle(target).color, "rgb(0, 128, 0)");
+}, "Animation starts when the name is mutated via inline style");
+</script>

--- a/Source/WebCore/css/CSSToStyleMap.cpp
+++ b/Source/WebCore/css/CSSToStyleMap.cpp
@@ -385,7 +385,7 @@ void CSSToStyleMap::mapAnimationName(Animation& layer, const CSSValue& value)
         return;
 
     if (primitiveValue->valueID() == CSSValueNone)
-        layer.setIsNoneAnimation(true);
+        layer.setName(Animation::initialName());
     else
         layer.setName({ AtomString { primitiveValue->stringValue() }, m_builderState.styleScopeOrdinal(), primitiveValue->isCustomIdent() });
 }

--- a/Source/WebCore/platform/animation/Animation.cpp
+++ b/Source/WebCore/platform/animation/Animation.cpp
@@ -56,7 +56,6 @@ Animation::Animation()
     , m_allowsDiscreteTransitionsSet(false)
     , m_rangeStartSet(false)
     , m_rangeEndSet(false)
-    , m_isNone(false)
     , m_delayFilled(false)
     , m_directionFilled(false)
     , m_durationFilled(false)
@@ -102,7 +101,6 @@ Animation::Animation(const Animation& o)
     , m_allowsDiscreteTransitionsSet(o.m_allowsDiscreteTransitionsSet)
     , m_rangeStartSet(o.m_rangeStartSet)
     , m_rangeEndSet(o.m_rangeEndSet)
-    , m_isNone(o.m_isNone)
     , m_delayFilled(o.m_delayFilled)
     , m_directionFilled(o.m_directionFilled)
     , m_durationFilled(o.m_durationFilled)
@@ -147,8 +145,7 @@ bool Animation::animationsMatch(const Animation& other, bool matchProperties) co
         && m_compositeOperationSet == other.m_compositeOperationSet
         && m_allowsDiscreteTransitionsSet == other.m_allowsDiscreteTransitionsSet
         && m_rangeStartSet == other.m_rangeStartSet
-        && m_rangeEndSet == other.m_rangeEndSet
-        && m_isNone == other.m_isNone;
+        && m_rangeEndSet == other.m_rangeEndSet;
 
     if (!result)
         return false;

--- a/Source/WebCore/platform/animation/Animation.h
+++ b/Source/WebCore/platform/animation/Animation.h
@@ -57,17 +57,9 @@ public:
     bool isRangeStartSet() const { return m_rangeStartSet; }
     bool isRangeEndSet() const { return m_rangeEndSet; }
 
-    // Flags this to be the special "none" animation (animation-name: none)
-    bool isNoneAnimation() const { return m_isNone; }
-
-    // We can make placeholder Animation objects to keep the comma-separated lists
-    // of properties in sync. isValidAnimation means this is not a placeholder.
-    bool isValidAnimation() const { return !m_isNone && !m_name.name.isEmpty(); }
-
     bool isEmpty() const
     {
         return !m_nameSet
-            && !m_isNone
             && (!m_directionSet || m_directionFilled)
             && (!m_durationSet || m_durationFilled)
             && (!m_fillModeSet || m_fillModeFilled)
@@ -201,8 +193,6 @@ public:
     void setRangeEnd(SingleTimelineRange range) { m_range.end = range; m_rangeEndSet = true; }
     void setRange(TimelineRange range) { setRangeStart(range.start); setRangeEnd(range.end); }
 
-    void setIsNoneAnimation(bool n) { m_isNone = n; }
-
     void fillDelay(double delay) { setDelay(delay); m_delayFilled = true; }
     void fillDirection(Direction direction) { setDirection(direction); m_directionFilled = true; }
     void fillDuration(MarkableDouble duration) { setDuration(duration); m_durationFilled = true; }
@@ -285,8 +275,6 @@ private:
     bool m_allowsDiscreteTransitionsSet : 1;
     bool m_rangeStartSet : 1;
     bool m_rangeEndSet : 1;
-
-    bool m_isNone : 1;
 
     bool m_delayFilled : 1;
     bool m_directionFilled : 1;

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -402,9 +402,6 @@ void Styleable::updateCSSAnimations(const RenderStyle* currentStyle, const Rende
     // first item in the list.
     if (currentAnimationList) {
         for (auto& currentAnimation : makeReversedRange(*currentAnimationList)) {
-            if (!currentAnimation->isValidAnimation())
-                continue;
-
             auto& animationName = currentAnimation->name().name;
             if (animationName == noneAtom() || animationName.isEmpty())
                 continue;


### PR DESCRIPTION
#### ff8c5f9cb0abd8fc9729beb3c33ee26f6bcce09c
<pre>
www.ricoh-imaging.co.jp: REGRESSION (293848@main): Images does not come into view while scrolling on product page
<a href="https://bugs.webkit.org/show_bug.cgi?id=295401">https://bugs.webkit.org/show_bug.cgi?id=295401</a>
<a href="https://rdar.apple.com/154838379">rdar://154838379</a>

Reviewed by Simon Fraser.

The inline style mutation optimization relies on the style builder overwriting a property in RenderStyle fully
without having to start from the initial value. In case of animation-name mutation we failed to clear m_isNone state
if it had been previously set and the animation wouldn&apos;t run.

* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-inline-style-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-inline-style.html: Added.
* Source/WebCore/css/CSSToStyleMap.cpp:
(WebCore::CSSToStyleMap::mapAnimationName):
* Source/WebCore/platform/animation/Animation.cpp:
(WebCore::Animation::Animation):
(WebCore::Animation::animationsMatch const):
* Source/WebCore/platform/animation/Animation.h:
(WebCore::Animation::isEmpty const):
(WebCore::Animation::isNoneAnimation const): Deleted.

Get rid of the separate isNone state and instead just set the name to the initial value (which is &quot;none&quot;).

(WebCore::Animation::isValidAnimation const): Deleted.

The only call site for this already tested for &quot;none&quot; and empty name explicitly.

(WebCore::Animation::setIsNoneAnimation): Deleted.
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::updateCSSAnimations const):

Canonical link: <a href="https://commits.webkit.org/296973@main">https://commits.webkit.org/296973@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abfcf77e7cb1a20a5bca400c922db6e25d4a1c1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116157 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/60383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112098 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30472 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38381 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83737 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/60383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113083 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24305 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99183 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64181 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23672 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17317 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59953 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93681 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17374 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118948 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37175 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27559 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92709 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37547 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95450 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92532 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23582 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37524 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15260 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33062 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37069 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42540 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36731 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40071 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38440 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->