### PR TITLE
Web Inspector: Quick Open dialog doesn't show any results when an Inspector Bootstrap script exists

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Controllers/ResourceQueryController.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/ResourceQueryController.js
@@ -74,7 +74,7 @@ WI.ResourceQueryController = class ResourceQueryController extends WI.QueryContr
                     specialCharacterIndices: this._findSpecialCharacterIndicesInDisplayName(displayName),
                 };
 
-                let url = resource.url;
+                let url = resource.url || resource.sourceURL;
                 cachedData.url = {
                     searchString: url.toLowerCase(),
                     specialCharacterIndices: this._findSpecialCharacterIndicesInURL(url),


### PR DESCRIPTION
#### 78f0f936588edd39cc017fd0db14f84cf37698b9
<pre>
Web Inspector: Quick Open dialog doesn&apos;t show any results when an Inspector Bootstrap script exists
<a href="https://bugs.webkit.org/show_bug.cgi?id=295402">https://bugs.webkit.org/show_bug.cgi?id=295402</a>
<a href="https://rdar.apple.com/154947309">rdar://154947309</a>

Reviewed by Devin Rousso.

An Inspector Bootstrap Script does not have a `url`, but it does have a fixed `sourceURL`
string defined in `WI.NetworkManager.bootstrapScriptURL`.

Checking for either `url` or `sourceURL` should avoid causing the exception in
`WI.ResourceQueryController.prototype.executeQuery()` for any type of resource
that might have a `null` url value.

* Source/WebInspectorUI/UserInterface/Controllers/ResourceQueryController.js:
(WI.ResourceQueryController.prototype.executeQuery):

Canonical link: <a href="https://commits.webkit.org/296982@main">https://commits.webkit.org/296982@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51bd3b65c517517d5620ae79303a4f9b82257289

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110131 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29790 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116153 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60379 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30468 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38377 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83732 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113079 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24302 "Found 2 new test failures: fast/filter-image/clipped-filter.html media/video-unmuted-after-play-holds-sleep-assertion.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99181 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64176 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23669 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17315 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59949 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93678 "Found 1 new API test failure: TestWebKitAPI.WKWebsiteDataStoreConfiguration.TotalQuotaRatioWithPersistedDomain (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17372 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118944 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37171 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27557 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92703 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37543 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95448 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92526 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23586 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37520 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15258 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33057 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37065 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42536 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36727 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40067 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38436 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->