### PR TITLE
AX: consider z-index when computing ignored when a modal is present

### DIFF
--- a/LayoutTests/accessibility/element-outside-modal-with-zindex-expected.txt
+++ b/LayoutTests/accessibility/element-outside-modal-with-zindex-expected.txt
@@ -1,0 +1,15 @@
+This tests that content with a higher zindex than the active modal is exposed to accessibility.
+
+PASS: accessibilityController.accessibleElementById('modalButton').isIgnored === false
+PASS: accessibilityController.accessibleElementById('text1').childAtIndex(0).isIgnored === false
+PASS: accessibilityController.accessibleElementById('text2') == null === true
+PASS: accessibilityController.accessibleElementById('floatingButton').isIgnored === false
+PASS: accessibilityController.accessibleElementById('displayContentsButton').isIgnored === false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+This is content floating above the modal.This is content floating beneath the modal.
+My Button
+Display Contents Button

--- a/LayoutTests/accessibility/element-outside-modal-with-zindex.html
+++ b/LayoutTests/accessibility/element-outside-modal-with-zindex.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="../resources/js-test.js"></script>
+    <script src="../resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<div role="dialog" aria-modal="true" style="z-index: 10">
+    <button id="modalButton" aria-label="Button"></button>
+</div>
+
+<div id="text1" style="z-index: 50; width: 200px; position: absolute;">This is content floating above the modal.</div>
+
+<div id="text2" style="position: absolute; width: 200px;">This is content floating beneath the modal.</div>
+
+<div style="position: absolute; width: 200px; z-index: 100;">
+    <div role="group">
+        <button id="floatingButton">My Button</button>
+    </div>
+</div>
+
+<div role="group" aria-label="content" style="position: absolute; width: 200px; z-index: 100">
+    <button style="display:contents" id="displayContentsButton">Display Contents Button</button>
+</div>
+
+<script>
+var output = "This tests that content with a higher zindex than the active modal is exposed to accessibility.\n\n"
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    document.getElementById("modalButton").focus();
+    setTimeout(async function() {
+        await waitFor(() => accessibilityController.accessibleElementById('text2') == null);
+        output += expect("accessibilityController.accessibleElementById('modalButton').isIgnored", "false");
+        output += expect("accessibilityController.accessibleElementById('text1').childAtIndex(0).isIgnored", "false");
+        output += expect("accessibilityController.accessibleElementById('text2') == null", "true");
+        output += expect("accessibilityController.accessibleElementById('floatingButton').isIgnored", "false");
+        output += expect("accessibilityController.accessibleElementById('displayContentsButton').isIgnored", "false");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -902,6 +902,9 @@ http/wpt/service-workers/mac [ Skip ]
 # TextMarkerRangeForElement is only implemented on Cocoa platforms.
 accessibility/full-size-kana-untransformed.html [ Skip ]
 
+# Static text are not exposed as accessibility elements on glib appointments.
+accessibility/element-outside-modal-with-zindex.html [ Skip ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of Accessibility-related bugs
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -243,6 +243,7 @@ public:
     Element* element() const final;
     Node* node() const override { return nullptr; }
     RenderObject* renderer() const override { return nullptr; }
+    RenderObject* rendererOrNearestAncestor() const;
     // Resolves the computed style if necessary (and safe to do so).
     const RenderStyle* style() const;
 


### PR DESCRIPTION
#### a2ad036263e755b05cf39684ac4d2b76c6877639
<pre>
AX: consider z-index when computing ignored when a modal is present
<a href="https://bugs.webkit.org/show_bug.cgi?id=295404">https://bugs.webkit.org/show_bug.cgi?id=295404</a>
<a href="https://rdar.apple.com/154886931">rdar://154886931</a>

Reviewed by Tyler Wilcock.

There can be authoring errors when using aria-modal, and frequently, absolutely positioned
content that should be floating above the modal is excluded from accessibility because of
our modal heuristics. We can be more forgiving by also checking if content has a higher
z-index than the modal, indicating that it should be accessible.

* LayoutTests/accessibility/element-outside-modal-with-zindex-expected.txt: Added.
* LayoutTests/accessibility/element-outside-modal-with-zindex.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::nearestRendererFromNode):
(WebCore::zIndexFromRenderer):
(WebCore::AccessibilityObject::ignoredFromModalPresence const):
(WebCore::AccessibilityObject::rendererOrNearestAncestor const):
* Source/WebCore/accessibility/AccessibilityObject.h:

Canonical link: <a href="https://commits.webkit.org/297016@main">https://commits.webkit.org/297016@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b79078d38f0d9ca8e7f2e9d728a32087b051a581

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29914 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20346 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116279 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60503 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112218 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38501 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83825 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113203 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24404 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99285 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64273 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23763 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17421 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60073 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93778 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17479 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119069 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37295 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27651 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92799 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37667 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95555 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92625 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23610 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37620 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15351 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33184 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37189 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42660 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36851 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40191 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38560 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->