### PR TITLE
[MSE][GStreamer] don't push samples while seeking

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -263,6 +263,7 @@ bool MediaPlayerPrivateGStreamerMSE::doSeek(const SeekTarget& target, float rate
     // This will also add support for fastSeek once done (see webkit.org/b/260607)
     if (!m_mediaSourcePrivate)
         return false;
+    m_mediaSourcePrivate->willSeek();
     m_mediaSourcePrivate->waitForTarget(target)->whenSettled(RunLoop::currentSingleton(), [this, weakThis = ThreadSafeWeakPtr { *this }](auto&& result) {
         RefPtr self = weakThis.get();
         if (!self || !result)

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
@@ -245,6 +245,12 @@ MediaSourcePrivateGStreamer::RegisteredTrack MediaSourcePrivateGStreamer::regist
     return info;
 }
 
+void MediaSourcePrivateGStreamer::willSeek()
+{
+    for (auto* sourceBuffer : m_activeSourceBuffers)
+        downcast<SourceBufferPrivateGStreamer>(sourceBuffer)->willSeek();
+}
+
 void MediaSourcePrivateGStreamer::unregisterTrack(TrackID trackId)
 {
     ASSERT(isMainThread());

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
@@ -105,6 +105,8 @@ public:
     RegisteredTrack registerTrack(TrackID, StreamType);
     void unregisterTrack(TrackID);
 
+    void willSeek();
+
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }
     ASCIILiteral logClassName() const override { return "MediaSourcePrivateGStreamer"_s; }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -451,6 +451,24 @@ void SourceBufferPrivateGStreamer::detach()
         downcast<MediaSourcePrivateGStreamer>(mediaSource)->detach();
 }
 
+void SourceBufferPrivateGStreamer::willSeek()
+{
+    ALWAYS_LOG(LOGIDENTIFIER);
+    m_seeking = true;
+}
+
+bool SourceBufferPrivateGStreamer::isSeeking() const
+{
+    return m_seeking;
+}
+
+void SourceBufferPrivateGStreamer::seekToTime(const MediaTime& time)
+{
+    m_seeking = false;
+    // WebKit now has the samples to complete the seek and is about to enqueue them.
+    SourceBufferPrivate::seekToTime(time);
+}
+
 #undef GST_CAT_DEFAULT
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
@@ -98,6 +98,10 @@ public:
     size_t platformMaximumBufferSize() const override;
     size_t platformEvictionThreshold() const final;
 
+    void willSeek();
+    bool isSeeking() const final;
+    void seekToTime(const MediaTime&) final;
+
 private:
     friend class AppendPipeline;
 
@@ -113,6 +117,10 @@ private:
     std::unique_ptr<AppendPipeline> m_appendPipeline;
     StdUnorderedMap<TrackID, RefPtr<MediaSourceTrackGStreamer>> m_tracks;
     std::optional<MediaPromise::Producer> m_appendPromise;
+
+    // Set while waiting for samples from the multiplatform layer after a seek has initiated.
+    // Unset once the samples are ready for the platform-specific layer.
+    bool m_seeking { false };
 
 #if !RELEASE_LOG_DISABLED
     const Ref<const Logger> m_logger;


### PR DESCRIPTION
#### 9a0ed144d41268b28ec6e7ee0f11837735ba1cf7
<pre>
[MSE][GStreamer] don&apos;t push samples while seeking
<a href="https://bugs.webkit.org/show_bug.cgi?id=295415">https://bugs.webkit.org/show_bug.cgi?id=295415</a>

Reviewed by Alicia Boya Garcia.

MediaSource::waitForTarget completes asynchronously. Even when the
target time is already buffered, it still enqueues a task to compute
seek time on next event loop cycle. This can lead to SourceBuffer
providing media data for incorrect time, after GStreamer seek already
flushed the source. For example this happens if
TrackQueue::LowLevelHandler callback was posted just before the seek.

The proposed change implements SourceBufferPrivate::isSeeking() that
returns true until MSE seek is completed, effectivly blocking
SourceBufferPrivate::provideMediaData during the seek.

See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1528">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1528</a>

Original author: Eugene Mutavchi &lt;Ievgen_Mutavchi@comcast.com&gt;

* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::doSeek): Signal the seek intent to the media source private.
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp:
(WebCore::MediaSourcePrivateGStreamer::willSeek): Forward the seek intent to all SourceBufferPrivates.
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h: Added willSeek().
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::willSeek): Set m_isSeeking to true.
(WebCore::SourceBufferPrivateGStreamer::isSeeking const): Return m_isSeeking value.
(WebCore::SourceBufferPrivateGStreamer::seekToTime): Unset m_isSeeking and call the default SourceBufferPrivate seekToTime() implementation.
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h: Added willSeek(), isSeeking(), seekToTime() and the m_isSeeking flag (to signal that we&apos;re waiting for samples from the multiplatform layer after a seek has been initiated; unset once the samples are ready for the platform-specific layer).

Canonical link: <a href="https://commits.webkit.org/298330@main">https://commits.webkit.org/298330@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce85e7eddec8320c0f16ff2e9ad74f2fc90b1e3a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115197 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34904 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25394 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121309 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65816 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117086 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35555 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43470 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/87531 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118145 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28344 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103415 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/67928 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27516 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21536 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64962 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97729 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21652 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124490 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42156 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/31542 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/96332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42527 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99605 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/96119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24449 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41325 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19171 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38120 "Failed to checkout and rebase branch from PR 47564") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42034 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47577 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41561 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44885 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43289 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->