### PR TITLE
REGRESSION(296179@main): [iOS] imported/w3c/web-platform-tests/css/css-fonts/generic-family-keywords-002.html is a constant failure

### DIFF
--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-fonts/generic-family-keywords-002-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-fonts/generic-family-keywords-002-expected.txt
@@ -7,9 +7,11 @@ FAIL font-family: -webkit-cursive treated as <font-family>, not <generic-name> a
 FAIL font-family: -webkit-fantasy treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
 FAIL font-family: -webkit-monospace treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 30
 FAIL font-family: -webkit-system-ui treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 30
-PASS font-family: -webkit-emoji treated as <font-family>, not <generic-name>
 PASS font-family: -webkit-math treated as <font-family>, not <generic-name>
-PASS font-family: -webkit-fangsong treated as <font-family>, not <generic-name>
+FAIL font-family: -webkit-generic(fangsong) treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
+FAIL font-family: -webkit-generic(kai) treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
+FAIL font-family: -webkit-generic(khmer-mul) treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
+FAIL font-family: -webkit-generic(nastaliq) treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
 PASS font-family: -webkit-ui-serif treated as <font-family>, not <generic-name>
 PASS font-family: -webkit-ui-sans-serif treated as <font-family>, not <generic-name>
 PASS font-family: -webkit-ui-monospace treated as <font-family>, not <generic-name>
@@ -18,5 +20,7 @@ PASS font-family: NonGenericFontFamilyName treated as <font-family>, not <generi
 FAIL font-family: -webkit-body treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
 FAIL font-family: -webkit-standard treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
 PASS font-family: -webkit-pictograph treated as <font-family>, not <generic-name>
+PASS font-family: emoji treated as <font-family>, not <generic-name>
+PASS font-family: fangsong treated as <font-family>, not <generic-name>
 PASS font-family: BlinkMacSystemFont treated as <font-family>, not <generic-name>
 

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1639,8 +1639,6 @@ webkit.org/b/273396 imported/w3c/web-platform-tests/css/motion/offset-path-shape
 webkit.org/b/273396 imported/w3c/web-platform-tests/css/motion/offset-path-shape-polygon-002.html [ ImageOnlyFailure ]
 webkit.org/b/273396 platform/gtk/fonts/webkit-font-smoothing.html [ ImageOnlyFailure ]
 
-imported/w3c/web-platform-tests/css/css-fonts/generic-family-keywords-002.html [ Failure ]
-
 # Bidi content-aware paste not yet supported
 editing/pasteboard/paste-rtl-paragraph-with-leading-ltr-text.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7927,6 +7927,4 @@ imported/w3c/web-platform-tests/focus/focus-contenteditable-element-in-iframe-sc
 fast/snapshot/nested-stacking-context.html [ Skip ]
 fast/snapshot/positioned-abs-relative-body.html [ Skip ]
 
-webkit.org/b/295422 imported/w3c/web-platform-tests/css/css-fonts/generic-family-keywords-002.html [ Failure ]
-
 webkit.org/b/295432 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-clip-rect-zoom.html [ Pass ImageOnlyFailure ]

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-fonts/generic-family-keywords-002-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-fonts/generic-family-keywords-002-expected.txt
@@ -7,9 +7,11 @@ PASS font-family: -webkit-cursive treated as <font-family>, not <generic-name>
 FAIL font-family: -webkit-fantasy treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 34
 FAIL font-family: -webkit-monospace treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 31
 PASS font-family: -webkit-system-ui treated as <font-family>, not <generic-name>
-PASS font-family: -webkit-emoji treated as <font-family>, not <generic-name>
 PASS font-family: -webkit-math treated as <font-family>, not <generic-name>
-PASS font-family: -webkit-fangsong treated as <font-family>, not <generic-name>
+FAIL font-family: -webkit-generic(fangsong) treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
+FAIL font-family: -webkit-generic(kai) treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
+FAIL font-family: -webkit-generic(khmer-mul) treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
+FAIL font-family: -webkit-generic(nastaliq) treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
 PASS font-family: -webkit-ui-serif treated as <font-family>, not <generic-name>
 PASS font-family: -webkit-ui-sans-serif treated as <font-family>, not <generic-name>
 PASS font-family: -webkit-ui-monospace treated as <font-family>, not <generic-name>
@@ -18,5 +20,7 @@ PASS font-family: NonGenericFontFamilyName treated as <font-family>, not <generi
 FAIL font-family: -webkit-body treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
 FAIL font-family: -webkit-standard treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
 FAIL font-family: -webkit-pictograph treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 65
+PASS font-family: emoji treated as <font-family>, not <generic-name>
+PASS font-family: fangsong treated as <font-family>, not <generic-name>
 PASS font-family: BlinkMacSystemFont treated as <font-family>, not <generic-name>
 

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -414,8 +414,6 @@ webkit.org/b/214290 imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens
 
 webkit.org/b/212351 fast/events/mouse-cursor-udpate-during-raf.html [ Failure ]
 
-imported/w3c/web-platform-tests/css/css-fonts/generic-family-keywords-002.html [ Failure ]
-
 webkit.org/b/217370 fast/events/setDragImage-element-non-nullable.html [ Failure ]
 Bug(WPE) fast/events/selectstart-by-drag.html [ Failure ]
 


### PR DESCRIPTION
#### b28a8934994ac0c3bec669558ca32c29b1ef58ca
<pre>
REGRESSION(296179@main): [iOS] imported/w3c/web-platform-tests/css/css-fonts/generic-family-keywords-002.html is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=295422">https://bugs.webkit.org/show_bug.cgi?id=295422</a>
<a href="https://rdar.apple.com/154973303">rdar://154973303</a>

Reviewed by Tim Nguyen.

This needs to be rebaselined. On the last WPT import sync font-family-keywords.js was updated.
This files defines the list of generic font family keywords that are tested in this test.

We still passes the same tests as before but now that are more keywords being tested.

* LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-fonts/generic-family-keywords-002-expected.txt:
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-fonts/generic-family-keywords-002-expected.txt:
* LayoutTests/platform/wpe/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/297000@main">https://commits.webkit.org/297000@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ec636e9a0906483cf24ca3701ae25fa93339b90

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110209 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29868 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20300 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116233 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/60457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30546 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38455 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/83794 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/60457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113157 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24366 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99248 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64240 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/23731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17382 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60027 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/93743 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17442 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119022 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37249 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/27618 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37621 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92589 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23598 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37582 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15320 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/33138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37143 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36805 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40145 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38514 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->