### PR TITLE
Pasteboard history should not include items copied from ephemeral sessions.

### DIFF
--- a/Source/WebCore/PAL/pal/spi/mac/NSPasteboardSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSPasteboardSPI.h
@@ -34,4 +34,5 @@ extern NSString *_NXSmartPaste;
 
 @interface NSPasteboard ()
 - (NSData *)_dataWithoutConversionForType:(NSString *)type securityScoped:(BOOL)securityScoped;
+- (BOOL)_setExpirationDate:(NSDate *)date;
 @end

--- a/Source/WebCore/platform/Pasteboard.h
+++ b/Source/WebCore/platform/Pasteboard.h
@@ -72,6 +72,8 @@ class FragmentedSharedBuffer;
 
 struct SimpleRange;
 
+static constexpr auto pasteboardExpirationDelay = 8_min;
+
 enum class PlainTextURLReadingPolicy : bool { IgnoreURL, AllowURL };
 enum class WebContentReadingPolicy : bool { AnyType, OnlyRichTextTypes };
 enum ShouldSerializeSelectedTextForDataTransfer { DefaultSelectedTextType, IncludeImageAltTextForDataTransfer };

--- a/Source/WebCore/platform/PlatformPasteboard.h
+++ b/Source/WebCore/platform/PlatformPasteboard.h
@@ -58,6 +58,8 @@ struct PasteboardURL;
 struct PasteboardWebContent;
 class FragmentedSharedBuffer;
 
+enum class PasteboardDataLifetime : bool { Persistent, Ephemeral };
+
 class PlatformPasteboard {
 public:
     WEBCORE_EXPORT explicit PlatformPasteboard(const String& pasteboardName);
@@ -84,7 +86,7 @@ public:
 
     // Take ownership of the pasteboard, and return new change count.
     WEBCORE_EXPORT int64_t addTypes(const Vector<String>& pasteboardTypes);
-    WEBCORE_EXPORT int64_t setTypes(const Vector<String>& pasteboardTypes);
+    WEBCORE_EXPORT int64_t setTypes(const Vector<String>& pasteboardTypes, PasteboardDataLifetime = PasteboardDataLifetime::Persistent);
 
     // These methods will return 0 if pasteboard ownership has been taken from us.
     WEBCORE_EXPORT int64_t copy(const String& fromPasteboard);
@@ -101,8 +103,8 @@ public:
     WEBCORE_EXPORT URL readURL(size_t index, String& title) const;
     WEBCORE_EXPORT int count() const;
     WEBCORE_EXPORT int numberOfFiles() const;
-    WEBCORE_EXPORT int64_t write(const Vector<PasteboardCustomData>&);
-    WEBCORE_EXPORT int64_t write(const PasteboardCustomData&);
+    WEBCORE_EXPORT int64_t write(const Vector<PasteboardCustomData>&, PasteboardDataLifetime = PasteboardDataLifetime::Persistent);
+    WEBCORE_EXPORT int64_t write(const PasteboardCustomData&, PasteboardDataLifetime = PasteboardDataLifetime::Persistent);
     WEBCORE_EXPORT Vector<String> typesSafeForDOMToReadAndWrite(const String& origin) const;
     WEBCORE_EXPORT bool containsStringSafeForDOMToReadForType(const String&) const;
 
@@ -118,9 +120,6 @@ private:
 
 #if PLATFORM(MAC)
     NSPasteboardItem *itemAtIndex(size_t index) const;
-#endif
-
-#if PLATFORM(MAC)
     RetainPtr<NSPasteboard> m_pasteboard;
 #endif
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
@@ -340,7 +340,7 @@ int64_t PlatformPasteboard::addTypes(const Vector<String>&)
     return 0;
 }
 
-int64_t PlatformPasteboard::setTypes(const Vector<String>&)
+int64_t PlatformPasteboard::setTypes(const Vector<String>&, PasteboardDataLifetime)
 {
     return 0;
 }
@@ -682,7 +682,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return representationsToRegister;
 }
 
-int64_t PlatformPasteboard::write(const Vector<PasteboardCustomData>& itemData)
+int64_t PlatformPasteboard::write(const Vector<PasteboardCustomData>& itemData, PasteboardDataLifetime)
 {
     auto registrationLists = createNSArray(itemData, [] (auto& data) {
         return createItemProviderRegistrationList(data);
@@ -724,7 +724,7 @@ Vector<String> PlatformPasteboard::typesSafeForDOMToReadAndWrite(const String&) 
     return { };
 }
 
-int64_t PlatformPasteboard::write(const Vector<PasteboardCustomData>&)
+int64_t PlatformPasteboard::write(const Vector<PasteboardCustomData>&, PasteboardDataLifetime)
 {
     return 0;
 }
@@ -851,7 +851,7 @@ void PlatformPasteboard::updateSupportedTypeIdentifiers(const Vector<String>& ty
     [m_pasteboard updateSupportedTypeIdentifiers:createNSArray(types).get()];
 }
 
-int64_t PlatformPasteboard::write(const PasteboardCustomData& data)
+int64_t PlatformPasteboard::write(const PasteboardCustomData& data, PasteboardDataLifetime)
 {
     return write(Vector<PasteboardCustomData> { data });
 }

--- a/Source/WebCore/platform/libwpe/PlatformPasteboardLibWPE.cpp
+++ b/Source/WebCore/platform/libwpe/PlatformPasteboardLibWPE.cpp
@@ -134,7 +134,7 @@ Vector<String> PlatformPasteboard::typesSafeForDOMToReadAndWrite(const String&) 
     return { };
 }
 
-int64_t PlatformPasteboard::write(const PasteboardCustomData& customData)
+int64_t PlatformPasteboard::write(const PasteboardCustomData& customData, PasteboardDataLifetime)
 {
     PasteboardWebContent contents;
     customData.forEachPlatformStringOrBuffer([&contents] (auto& type, auto& stringOrBuffer) {
@@ -152,7 +152,7 @@ int64_t PlatformPasteboard::write(const PasteboardCustomData& customData)
     return m_changeCount;
 }
 
-int64_t PlatformPasteboard::write(const Vector<PasteboardCustomData>& data)
+int64_t PlatformPasteboard::write(const Vector<PasteboardCustomData>& data, PasteboardDataLifetime)
 {
     if (data.isEmpty() || data.size() > 1)
         return m_changeCount;


### PR DESCRIPTION
#### 978bbafb7a3ab151703ba7e9694b78e2d63c3fe1
<pre>
Pasteboard history should not include items copied from ephemeral sessions.
<a href="https://bugs.webkit.org/show_bug.cgi?id=295442">https://bugs.webkit.org/show_bug.cgi?id=295442</a>
<a href="https://rdar.apple.com/153315024">rdar://153315024</a>

Reviewed by Abrar Rahman Protyasha.

In order to keep items copied in an ephemeral
session from showing up in pasteboard history,
we need to set a value before writing to the pasteboard.
We also have decided that we should be expiring the content
pasted to the pasteboard after the same amount of time as
we lock private browsing.

* Source/WebCore/PAL/pal/spi/mac/NSPasteboardSPI.h:
* Source/WebCore/platform/Pasteboard.h:
* Source/WebCore/platform/PlatformPasteboard.h:
* Source/WebCore/platform/ios/PlatformPasteboardIOS.mm:
(WebCore::PlatformPasteboard::setTypes):
(WebCore::PlatformPasteboard::write):
* Source/WebCore/platform/mac/PlatformPasteboardMac.mm:
(WebCore::PlatformPasteboard::write):
(WebCore::PlatformPasteboard::setTypes):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::searchTheWeb):
(WebKit::WebPageProxy::handleContextMenuCopySubject):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::writeSelectionToPasteboard):
(WebKit::WebViewImpl::setPromisedDataForImage):

Canonical link: <a href="https://commits.webkit.org/297124@main">https://commits.webkit.org/297124@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6598b911b37d09e392d60d2878199ca63f1874cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110507 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30166 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20599 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116533 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60774 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112470 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30845 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38754 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84032 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113455 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24618 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99503 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64473 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23980 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17642 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60328 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93999 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17702 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119323 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37547 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27864 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93004 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37921 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95774 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92827 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23670 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37824 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15565 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33520 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37442 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42913 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37104 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40444 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38813 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->