### PR TITLE
[HDR] Opening a web page with HDR images on SDR screen then moving it to HDR screen does not show HDR contents.

### DIFF
--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -1146,17 +1146,6 @@ void LocalFrame::deviceOrPageScaleFactorChanged()
         root->compositor().deviceOrPageScaleFactorChanged();
 }
 
-void LocalFrame::screenSupportedContentsFormatsChanged()
-{
-    for (RefPtr child = tree().firstChild(); child; child = child->tree().nextSibling()) {
-        if (RefPtr localFrame = dynamicDowncast<LocalFrame>(child.get()))
-            localFrame->screenSupportedContentsFormatsChanged();
-    }
-
-    if (CheckedPtr root = contentRenderer())
-        root->compositor().screenSupportedContentsFormatsChanged();
-}
-
 void LocalFrame::dropChildren()
 {
     ASSERT(isMainFrame());

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -223,7 +223,6 @@ public:
     WEBCORE_EXPORT float frameScaleFactor() const;
 
     void deviceOrPageScaleFactorChanged();
-    void screenSupportedContentsFormatsChanged();
 
 #if ENABLE(DATA_DETECTION)
     DataDetectionResultsStorage* dataDetectionResultsIfExists() const { return m_dataDetectionResults.get(); }

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1744,8 +1744,14 @@ void Page::updateScreenSupportedContentsFormats()
     if (m_screenSupportsHDR == supportsHighDynamicRange)
         return;
     m_screenSupportsHDR = supportsHighDynamicRange;
-    for (auto& rootFrame : m_rootFrames)
-        rootFrame->screenSupportedContentsFormatsChanged();
+
+    forEachDocument([&] (Document& document) {
+        if (!document.hasHDRContent())
+            return;
+
+        if (RefPtr view = document.view())
+            view->setDescendantsNeedUpdateBackingAndHierarchyTraversal();
+    });
 #endif
 }
 

--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -598,20 +598,6 @@ void GraphicsLayer::noteDeviceOrPageScaleFactorChangedIncludingDescendants()
         layer->noteDeviceOrPageScaleFactorChangedIncludingDescendants();
 }
 
-void GraphicsLayer::noteScreenSupportedContentsFormatsChangedIncludingDescendants()
-{
-    screenSupportedContentsFormatsChanged();
-
-    if (m_maskLayer)
-        m_maskLayer->screenSupportedContentsFormatsChanged();
-
-    if (m_replicaLayer)
-        m_replicaLayer->noteScreenSupportedContentsFormatsChangedIncludingDescendants();
-
-    for (auto& layer : children())
-        layer->noteScreenSupportedContentsFormatsChangedIncludingDescendants();
-}
-
 void GraphicsLayer::setIsInWindow(bool inWindow)
 {
     if (auto* tiledBacking = this->tiledBacking())

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -661,11 +661,9 @@ public:
     virtual bool allowsTiling() const { return m_allowsTiling; }
 
     virtual void deviceOrPageScaleFactorChanged() { }
-    virtual void screenSupportedContentsFormatsChanged() { }
     virtual void setShouldUpdateRootRelativeScaleFactor(bool) { }
 
     WEBCORE_EXPORT void noteDeviceOrPageScaleFactorChangedIncludingDescendants();
-    void noteScreenSupportedContentsFormatsChangedIncludingDescendants();
 
     WEBCORE_EXPORT void setIsInWindow(bool);
 

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -5145,13 +5145,6 @@ void GraphicsLayerCA::deviceOrPageScaleFactorChanged()
     noteChangesForScaleSensitiveProperties();
 }
 
-void GraphicsLayerCA::screenSupportedContentsFormatsChanged()
-{
-#if HAVE(SUPPORT_HDR_DISPLAY)
-    noteLayerPropertyChanged(DrawsHDRContentChanged | DebugIndicatorsChanged);
-#endif
-}
-
 void GraphicsLayerCA::noteChangesForScaleSensitiveProperties()
 {
     noteLayerPropertyChanged(GeometryChanged | ContentsScaleChanged | ContentsOpaqueChanged);

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -198,7 +198,6 @@ public:
     WEBCORE_EXPORT void setCustomAppearance(CustomAppearance) override;
 
     WEBCORE_EXPORT void deviceOrPageScaleFactorChanged() override;
-    WEBCORE_EXPORT void screenSupportedContentsFormatsChanged() override;
     void setShouldUpdateRootRelativeScaleFactor(bool value) override { m_shouldUpdateRootRelativeScaleFactor = value; }
 
     float rootRelativeScaleFactor() { return m_rootRelativeScaleFactor; }

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -5353,12 +5353,6 @@ void RenderLayerCompositor::deviceOrPageScaleFactorChanged()
         rootLayer->noteDeviceOrPageScaleFactorChangedIncludingDescendants();
 }
 
-void RenderLayerCompositor::screenSupportedContentsFormatsChanged()
-{
-    if (RefPtr rootLayer = rootGraphicsLayer())
-        rootLayer->noteScreenSupportedContentsFormatsChangedIncludingDescendants();
-}
-
 void RenderLayerCompositor::removeFromScrollCoordinatedLayers(RenderLayer& layer)
 {
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -359,7 +359,6 @@ public:
     bool acceleratedDrawingEnabled() const { return m_acceleratedDrawingEnabled; }
 
     void deviceOrPageScaleFactorChanged();
-    void screenSupportedContentsFormatsChanged();
 
     GraphicsLayer* layerForHorizontalScrollbar() const { return m_layerForHorizontalScrollbar.get(); }
     GraphicsLayer* layerForVerticalScrollbar() const { return m_layerForVerticalScrollbar.get(); }

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -171,7 +171,7 @@ public:
 
     MonotonicTime lastDisplayTime() const { return m_lastDisplayTime; }
 
-    virtual void clearBackingStore() = 0;
+    virtual void clearBackingStore();
 
     virtual std::optional<ImageBufferBackendHandle> frontBufferHandle() const = 0;
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
@@ -136,6 +136,12 @@ RemoteLayerBackingStoreCollection* RemoteLayerBackingStore::backingStoreCollecti
     return nullptr;
 }
 
+void RemoteLayerBackingStore::clearBackingStore()
+{
+    m_contentsBufferHandle = std::nullopt;
+    setNeedsDisplay();
+}
+
 void RemoteLayerBackingStore::ensureBackingStore(const Parameters& parameters)
 {
     if (m_parameters == parameters)

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
@@ -68,7 +68,7 @@ bool RemoteLayerWithInProcessRenderingBackingStore::frontBufferMayBeVolatile() c
 void RemoteLayerWithInProcessRenderingBackingStore::clearBackingStore()
 {
     m_bufferSet.clearBuffers();
-    m_contentsBufferHandle = std::nullopt;
+    RemoteLayerBackingStore::clearBackingStore();
 }
 
 static std::optional<ImageBufferBackendHandle> handleFromBuffer(ImageBuffer& buffer)

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
@@ -83,7 +83,6 @@ void RemoteLayerWithRemoteRenderingBackingStore::prepareToDisplay()
 
 void RemoteLayerWithRemoteRenderingBackingStore::clearBackingStore()
 {
-    m_contentsBufferHandle = std::nullopt;
     m_cleared = true;
 }
 
@@ -115,7 +114,7 @@ void RemoteLayerWithRemoteRenderingBackingStore::ensureBackingStore(const Parame
         return;
 
     m_parameters = parameters;
-    m_cleared = true;
+    clearBackingStore();
     if (m_bufferSet) {
         RemoteImageBufferSetConfiguration configuration {
             .logicalSize = size(),


### PR DESCRIPTION
#### 8bc59df1bc504b8ee4eb1d1adb3c51f4ae4eaf8f
<pre>
[HDR] Opening a web page with HDR images on SDR screen then moving it to HDR screen does not show HDR contents.
<a href="https://bugs.webkit.org/show_bug.cgi?id=295443">https://bugs.webkit.org/show_bug.cgi?id=295443</a>
&lt;<a href="https://rdar.apple.com/154908419">rdar://154908419</a>&gt;

Reviewed by Mike Wyrzykowski.

If the screen changes to HDR, the value of Document::drawsHDRContent can change,
and we need to check compositing decisions again.

This should change the value passed to GraphicsLayer::setDrawsHDRContent, so we
no longer need to notify the GraphicsLayer tree of these changes.

Also fixes a bug where changing the pixel format of a RemoteLayerBackingStore
wasn&apos;t clearing the m_maxRequestedEDRHeadroom value, so this remained set on the
otherwise-SDR layer when moving to an SDR screen.

* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::screenSupportedContentsFormatsChanged): Deleted.
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateScreenSupportedContentsFormats):
* Source/WebCore/platform/graphics/GraphicsLayer.cpp:
(WebCore::GraphicsLayer::noteScreenSupportedContentsFormatsChangedIncludingDescendants): Deleted.
* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::deviceOrPageScaleFactorChanged):
(WebCore::GraphicsLayer::screenSupportedContentsFormatsChanged): Deleted.
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::ensureStructuralLayer):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::screenSupportedContentsFormatsChanged): Deleted.
* Source/WebCore/rendering/RenderLayerCompositor.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::clearBackingStore):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm:
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::clearBackingStore):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm:
(WebKit::RemoteLayerWithRemoteRenderingBackingStore::clearBackingStore):
(WebKit::RemoteLayerWithRemoteRenderingBackingStore::ensureBackingStore):

Canonical link: <a href="https://commits.webkit.org/297042@main">https://commits.webkit.org/297042@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb4821abe53dd553ef359d8116500354cfc695af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110394 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30053 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20486 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116419 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60648 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112357 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30732 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38640 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83948 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113342 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24521 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99400 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64390 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23882 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17540 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60215 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93902 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17596 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119210 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37434 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27772 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92915 "Found 9 new test failures: imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-descendant-text-mutated-001.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/basic-opacity.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/basic.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-vs-float-clearance-002.html imported/w3c/web-platform-tests/css/css-transforms/animation/transform-non-invertible-discrete-interpolation.html imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-left-of-viewport-offscreen-new.html imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-on-top-of-viewport-offscreen-new.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-exit.html imported/w3c/web-platform-tests/css/filter-effects/filters-drop-shadow-002.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37807 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95669 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92738 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23621 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37736 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15466 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33377 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37329 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42800 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36991 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40331 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38699 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->