### PR TITLE
[macOS] [Liquid Glass] Add a UI delegate method to let clients override top inset color based on a proposed default color

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
@@ -353,6 +353,8 @@ struct UIEdgeInsets;
  */
 - (void)_webView:(WKWebView *)webView willCloseLocalInspector:(_WKInspector *)inspector WK_API_AVAILABLE(macos(12.0));
 
+- (NSColor *)_webView:(WKWebView *)webView adjustedColorForTopContentInsetColor:(NSColor *)proposedColor WK_API_AVAILABLE(macos(26.0));
+
 #endif // !TARGET_OS_IPHONE
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -278,6 +278,7 @@ struct PerWebProcessState {
     BOOL _shouldSuppressTopColorExtensionView;
 #if PLATFORM(MAC)
     BOOL _alwaysPrefersSolidColorHardPocket;
+    BOOL _isGettingAdjustedColorForTopContentInsetColorFromDelegate;
     RetainPtr<NSColor> _overrideTopScrollEdgeEffectColor;
 #endif
 
@@ -541,6 +542,13 @@ struct PerWebProcessState {
 - (void)_addReasonToHideTopScrollPocket:(WebKit::HideScrollPocketReason)reason;
 - (void)_removeReasonToHideTopScrollPocket:(WebKit::HideScrollPocketReason)reason;
 - (void)_updateTopScrollPocketCaptureColor;
+- (void)_updateHiddenScrollPocketEdges;
+- (void)_doAfterAdjustingColorForTopContentInsetFromUIDelegate:(Function<void()>&&)callback;
+#endif
+
+#if PLATFORM(MAC) && ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+- (NSColor *)_adjustedColorForTopContentInsetColorFromUIDelegate:(NSColor *)proposedColor;
+@property (nonatomic, setter=_setAlwaysPrefersSolidColorHardPocket:) BOOL _alwaysPrefersSolidColorHardPocket;
 #endif
 
 #if ENABLE(GAMEPAD)
@@ -578,14 +586,6 @@ struct PerWebProcessState {
 - (void)_updatePDFPageNumberIndicatorIfNeeded;
 - (void)_removeAnyPDFPageNumberIndicator;
 
-#endif
-
-#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
-- (void)_updateHiddenScrollPocketEdges;
-#endif
-
-#if PLATFORM(MAC) && ENABLE(CONTENT_INSET_BACKGROUND_FILL)
-@property (nonatomic, setter=_setAlwaysPrefersSolidColorHardPocket:) BOOL _alwaysPrefersSolidColorHardPocket;
 #endif
 
 @property (nonatomic, setter=_setHasActiveNowPlayingSession:) BOOL _hasActiveNowPlayingSession;

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1601,7 +1601,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _overrideTopScrollEdgeEffectColor = adoptNS(color.copy);
 
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
-    [self _updateTopScrollPocketCaptureColor];
+    [self _doAfterAdjustingColorForTopContentInsetFromUIDelegate:[strongSelf = RetainPtr { self }] {
+        [strongSelf _updateTopScrollPocketCaptureColor];
+    }];
 #endif
 }
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2385,7 +2385,7 @@ void WebViewImpl::updateTopScrollPocketCaptureColor()
         return;
 
     RetainPtr captureColor = [view _overrideTopScrollEdgeEffectColor];
-    if (!captureColor && ![view _shouldSuppressTopColorExtensionView])
+    if (!captureColor)
         captureColor = [view _sampledTopFixedPositionContentColor];
 
     if (!captureColor) {
@@ -2394,6 +2394,8 @@ void WebViewImpl::updateTopScrollPocketCaptureColor()
         else
             captureColor = NSColor.controlBackgroundColor;
     }
+
+    captureColor = [view _adjustedColorForTopContentInsetColorFromUIDelegate:captureColor.get()];
     [m_topScrollPocket setCaptureColor:captureColor.get()];
 
     if (RetainPtr attachedInspectorWebView = [view _horizontallyAttachedInspectorWebView])
@@ -6109,6 +6111,10 @@ bool WebViewImpl::completeBackSwipeForTesting()
 void WebViewImpl::effectiveAppearanceDidChange()
 {
     m_page->effectiveAppearanceDidChange();
+
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+    updateTopScrollPocketCaptureColor();
+#endif
 }
 
 bool WebViewImpl::effectiveAppearanceIsDark()

--- a/Tools/TestWebKitAPI/cocoa/TestUIDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestUIDelegate.h
@@ -34,7 +34,10 @@
 #if PLATFORM(MAC)
 @property (nonatomic, copy) void (^getContextMenuFromProposedMenu)(NSMenu *, _WKContextMenuElementInfo *, id <NSSecureCoding>, void (^)(NSMenu *));
 @property (nonatomic, copy) void (^getWindowFrameWithCompletionHandler)(WKWebView *, void(^)(CGRect));
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+@property (nonatomic, copy) NSColor *(^adjustedColorForTopContentInsetColor)(WKWebView *webView, NSColor *proposedColor);
 #endif
+#endif // PLATFORM(MAC)
 @property (nonatomic, copy) void (^requestStorageAccessPanelForDomain)(WKWebView *, NSString *, NSString *, void  (^completionHandler)(BOOL));
 @property (nonatomic, copy) void (^requestStorageAccessPanelForQuirksForDomain)(WKWebView *, NSString *, NSString *, NSDictionary<NSString *, NSArray<NSString *> *> *, void  (^completionHandler)(BOOL));
 @property (nonatomic, copy) void (^saveDataToFile)(WKWebView *, NSData *, NSString *, NSString *, NSURL *);

--- a/Tools/TestWebKitAPI/cocoa/TestUIDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestUIDelegate.mm
@@ -106,6 +106,18 @@
         _runOpenPanelWithParameters(webView, parameters, frame, completionHandler);
 }
 
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+
+- (NSColor *)_webView:(WKWebView *)webView adjustedColorForTopContentInsetColor:(NSColor *)proposedColor
+{
+    if (_adjustedColorForTopContentInsetColor)
+        return _adjustedColorForTopContentInsetColor(webView, proposedColor);
+
+    return proposedColor;
+}
+
+#endif // ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+
 #endif // PLATFORM(MAC)
 
 - (void)webViewDidClose:(WKWebView *)webView


### PR DESCRIPTION
#### 0c720ad19cf2d37dbd38cb71bfcbebf10f53e78c
<pre>
[macOS] [Liquid Glass] Add a UI delegate method to let clients override top inset color based on a proposed default color
<a href="https://bugs.webkit.org/show_bug.cgi?id=295447">https://bugs.webkit.org/show_bug.cgi?id=295447</a>
<a href="https://rdar.apple.com/154998521">rdar://154998521</a>

Reviewed by Abrar Rahman Protyasha.

Add support for `-[WKUIDelegate _webView:adjustedColorForTopContentInsetColor:]`. This new UI
delegate method has some important nuances that make it well-suited for a client (like Safari) to
only *sometimes* extend colors into the top inset area, and otherwise fall back to a hard scroll
pocket tinted with the system background:

1.  It&apos;s called for both the top scroll pocket capture color, as well as the top fixed color
    extension (i.e. the &quot;top inset color&quot; here refers to both pieces of UI).

2.  It&apos;s safe to change a couple of properties of the scroll pocket underneath this delegate method
    without triggering reentrancy (or worse, infinite recursion):
    a. `-[WKWebView _setShouldSuppressTopColorExtensionView:]`
    b. `-[WKWebView _setOverrideTopScrollEdgeEffectColor:]`

3.  It&apos;s automatically called when the system appearance changes, as the web view internally updates
    the scroll pocket capture color.

See below for more details.

* Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _updateFixedColorExtensionViews]):

Call out to the delegate through `-_adjustedColorForTopContentInsetColorFromUIDelegate:` when we&apos;re
about to reveal the top fixed color extension view. We intentionally check the state of
`_shouldSuppressTopColorExtensionView` after calling into the delegate, such that changes to the
property during the delegate call take effect immediately.

(-[WKWebView _doAfterAdjustingColorForTopContentInsetFromUIDelegate:]):

Add a helper to invoke the given callback on the next runloop if we&apos;re in the middle of a call to
`-_adjustedColorForTopContentInsetColorFromUIDelegate:`, if needed.

(-[WKWebView _adjustedColorForTopContentInsetColorFromUIDelegate:]):

Add a helper method to invoke the new UI delegate method (or simply return the default proposed
color, if the method is not implemented).

(-[WKWebView _setShouldSuppressTopColorExtensionView:]):

Defer calls to update the scroll pocket until the next runloop; see below for more details.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _setOverrideTopScrollEdgeEffectColor:]):

Defer calls to update the scroll pocket until the next runloop to avoid recursing infinitely if the
client implements the new delegate method. Note that this doesn&apos;t completely *prevent* an
incorrectly-implemented WebKit client from triggering fixed color updates indefinitely. See (2)
above for more details.

* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::updateTopScrollPocketCaptureColor):

Call out to the delegate through `-_adjustedColorForTopContentInsetColorFromUIDelegate:` when
computing and setting the top capture color.

(WebKit::WebViewImpl::effectiveAppearanceDidChange):

Update the scroll pocket capture color here, which depends on `+controlBackgroundColor` as well as
the UI delegate.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/ObscuredContentInsets.mm:
(TestWebKitAPI::TEST(ObscuredContentInsets, AdjustedColorForTopContentInsetColor)):

Add an API test that adopts this new UI delegate method in a way that&apos;s similar to how Safari would
use it, by (only sometimes) overriding the proposed color. This also forces an appearance change
on the web view, and checks that as a result, the delegate has the opportunity to override the
capture color.

* Tools/TestWebKitAPI/cocoa/TestUIDelegate.h:
* Tools/TestWebKitAPI/cocoa/TestUIDelegate.mm:
(-[TestUIDelegate _webView:adjustedColorForTopContentInsetColor:]):

Canonical link: <a href="https://commits.webkit.org/297028@main">https://commits.webkit.org/297028@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/107e9859f06f44cc3805bdcaa83dcce79a4937f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110258 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29917 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20349 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116282 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60506 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112221 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30596 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38504 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83828 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113206 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24406 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99288 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64276 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23765 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17424 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60076 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/102749 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93780 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17482 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119072 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37298 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27653 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92802 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37670 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95558 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92628 "Found 2 new API test failures: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23612 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37622 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15354 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33187 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37192 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42663 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36854 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40194 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38563 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->