### PR TITLE
Adopt UniqueRef in JavaScriptCore/inspector

### DIFF
--- a/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
@@ -66,7 +66,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(JSGlobalObjectInspectorController);
 
 JSGlobalObjectInspectorController::JSGlobalObjectInspectorController(JSGlobalObject& globalObject)
     : m_globalObject(globalObject)
-    , m_injectedScriptManager(makeUnique<InjectedScriptManager>(*this, InjectedScriptHost::create()))
+    , m_injectedScriptManager(makeUniqueRef<InjectedScriptManager>(*this, InjectedScriptHost::create()))
     , m_executionStopwatch(Stopwatch::create())
     , m_frontendRouter(FrontendRouter::create())
     , m_backendDispatcher(BackendDispatcher::create(m_frontendRouter.copyRef()))

--- a/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.h
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.h
@@ -113,7 +113,7 @@ private:
     void createLazyAgents();
 
     JSC::JSGlobalObject& m_globalObject;
-    std::unique_ptr<InjectedScriptManager> m_injectedScriptManager;
+    const UniqueRef<InjectedScriptManager> m_injectedScriptManager;
     std::unique_ptr<JSGlobalObjectConsoleClient> m_consoleClient;
     const Ref<WTF::Stopwatch> m_executionStopwatch;
     std::unique_ptr<JSGlobalObjectDebugger> m_debugger;

--- a/Source/JavaScriptCore/inspector/agents/InspectorAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorAgent.cpp
@@ -42,7 +42,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorAgent);
 InspectorAgent::InspectorAgent(AgentContext& context)
     : InspectorAgentBase("Inspector"_s)
     , m_environment(context.environment)
-    , m_frontendDispatcher(makeUnique<InspectorFrontendDispatcher>(context.frontendRouter))
+    , m_frontendDispatcher(makeUniqueRef<InspectorFrontendDispatcher>(context.frontendRouter))
     , m_backendDispatcher(InspectorBackendDispatcher::create(context.backendDispatcher, this))
 {
 }

--- a/Source/JavaScriptCore/inspector/agents/InspectorAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorAgent.h
@@ -64,7 +64,7 @@ public:
 
 private:
     InspectorEnvironment& m_environment;
-    std::unique_ptr<InspectorFrontendDispatcher> m_frontendDispatcher;
+    const UniqueRef<InspectorFrontendDispatcher> m_frontendDispatcher;
     const Ref<InspectorBackendDispatcher> m_backendDispatcher;
 
     Vector<String> m_pendingEvaluateTestCommands;

--- a/Source/JavaScriptCore/inspector/agents/InspectorAuditAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorAuditAgent.h
@@ -71,7 +71,7 @@ protected:
     virtual void unmuteConsole() { };
 
 private:
-    RefPtr<AuditBackendDispatcher> m_backendDispatcher;
+    const Ref<AuditBackendDispatcher> m_backendDispatcher;
     InjectedScriptManager& m_injectedScriptManager;
     JSC::Debugger& m_debugger;
 

--- a/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp
@@ -45,7 +45,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorConsoleAgent);
 InspectorConsoleAgent::InspectorConsoleAgent(AgentContext& context)
     : InspectorAgentBase("Console"_s)
     , m_injectedScriptManager(context.injectedScriptManager)
-    , m_frontendDispatcher(makeUnique<ConsoleFrontendDispatcher>(context.frontendRouter))
+    , m_frontendDispatcher(makeUniqueRef<ConsoleFrontendDispatcher>(context.frontendRouter))
     , m_backendDispatcher(ConsoleBackendDispatcher::create(context.backendDispatcher, this))
 {
 }
@@ -76,11 +76,11 @@ Protocol::ErrorStringOr<void> InspectorConsoleAgent::enable()
 
     if (m_expiredConsoleMessageCount) {
         ConsoleMessage expiredMessage(MessageSource::Other, MessageType::Log, MessageLevel::Warning, makeString(m_expiredConsoleMessageCount, " console messages are not shown."_s));
-        expiredMessage.addToFrontend(*m_frontendDispatcher, m_injectedScriptManager, false);
+        expiredMessage.addToFrontend(m_frontendDispatcher, m_injectedScriptManager, false);
     }
 
     for (auto& message : m_consoleMessages)
-        message->addToFrontend(*m_frontendDispatcher, m_injectedScriptManager, false);
+        message->addToFrontend(m_frontendDispatcher, m_injectedScriptManager, false);
 
     return { };
 }
@@ -252,13 +252,13 @@ void InspectorConsoleAgent::addConsoleMessage(std::unique_ptr<ConsoleMessage> co
     if (previousMessage && previousMessage->isEqual(consoleMessage.get())) {
         previousMessage->incrementCount();
         if (m_enabled)
-            previousMessage->updateRepeatCountInConsole(*m_frontendDispatcher);
+            previousMessage->updateRepeatCountInConsole(m_frontendDispatcher);
     } else {
         if (m_enabled) {
             auto generatePreview = !m_isAddingMessageToFrontend;
             SetForScope isAddingMessageToFrontend(m_isAddingMessageToFrontend, true);
 
-            consoleMessage->addToFrontend(*m_frontendDispatcher, m_injectedScriptManager, generatePreview);
+            consoleMessage->addToFrontend(m_frontendDispatcher, m_injectedScriptManager, generatePreview);
         }
 
         m_consoleMessages.append(WTFMove(consoleMessage));

--- a/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.h
@@ -90,8 +90,8 @@ protected:
     void clearMessages(Protocol::Console::ClearReason);
 
     InjectedScriptManager& m_injectedScriptManager;
-    std::unique_ptr<ConsoleFrontendDispatcher> m_frontendDispatcher;
-    RefPtr<ConsoleBackendDispatcher> m_backendDispatcher;
+    const UniqueRef<ConsoleFrontendDispatcher> m_frontendDispatcher;
+    const Ref<ConsoleBackendDispatcher> m_backendDispatcher;
     InspectorHeapAgent* m_heapAgent { nullptr };
 
     Vector<std::unique_ptr<ConsoleMessage>> m_consoleMessages;

--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
@@ -240,7 +240,7 @@ RefPtr<JSC::Breakpoint> InspectorDebuggerAgent::debuggerBreakpointFromPayload(Pr
 
 InspectorDebuggerAgent::InspectorDebuggerAgent(AgentContext& context)
     : InspectorAgentBase("Debugger"_s)
-    , m_frontendDispatcher(makeUnique<DebuggerFrontendDispatcher>(context.frontendRouter))
+    , m_frontendDispatcher(makeUniqueRef<DebuggerFrontendDispatcher>(context.frontendRouter))
     , m_backendDispatcher(DebuggerBackendDispatcher::create(context.backendDispatcher, this))
     , m_debugger(*context.environment.debugger())
     , m_injectedScriptManager(context.injectedScriptManager)

--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
@@ -246,8 +246,8 @@ private:
     using AsyncCallIdentifier = std::pair<unsigned, uint64_t>;
     static AsyncCallIdentifier asyncCallIdentifier(AsyncCallType, uint64_t callbackId);
 
-    std::unique_ptr<DebuggerFrontendDispatcher> m_frontendDispatcher;
-    RefPtr<DebuggerBackendDispatcher> m_backendDispatcher;
+    const UniqueRef<DebuggerFrontendDispatcher> m_frontendDispatcher;
+    const Ref<DebuggerBackendDispatcher> m_backendDispatcher;
 
     JSC::Debugger& m_debugger;
     InjectedScriptManager& m_injectedScriptManager;

--- a/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.cpp
@@ -45,7 +45,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorHeapAgent);
 InspectorHeapAgent::InspectorHeapAgent(AgentContext& context)
     : InspectorAgentBase("Heap"_s)
     , m_injectedScriptManager(context.injectedScriptManager)
-    , m_frontendDispatcher(makeUnique<HeapFrontendDispatcher>(context.frontendRouter))
+    , m_frontendDispatcher(makeUniqueRef<HeapFrontendDispatcher>(context.frontendRouter))
     , m_backendDispatcher(HeapBackendDispatcher::create(context.backendDispatcher, this))
     , m_environment(context.environment)
 {

--- a/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.h
@@ -80,8 +80,8 @@ private:
     std::optional<JSC::HeapSnapshotNode> nodeForHeapObjectIdentifier(Protocol::ErrorString&, unsigned heapObjectIdentifier);
 
     InjectedScriptManager& m_injectedScriptManager;
-    std::unique_ptr<HeapFrontendDispatcher> m_frontendDispatcher;
-    RefPtr<HeapBackendDispatcher> m_backendDispatcher;
+    const UniqueRef<HeapFrontendDispatcher> m_frontendDispatcher;
+    const Ref<HeapBackendDispatcher> m_backendDispatcher;
     InspectorEnvironment& m_environment;
 
     bool m_enabled { false };

--- a/Source/JavaScriptCore/inspector/agents/InspectorScriptProfilerAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorScriptProfilerAgent.cpp
@@ -42,7 +42,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorScriptProfilerAgent);
 
 InspectorScriptProfilerAgent::InspectorScriptProfilerAgent(AgentContext& context)
     : InspectorAgentBase("ScriptProfiler"_s)
-    , m_frontendDispatcher(makeUnique<ScriptProfilerFrontendDispatcher>(context.frontendRouter))
+    , m_frontendDispatcher(makeUniqueRef<ScriptProfilerFrontendDispatcher>(context.frontendRouter))
     , m_backendDispatcher(ScriptProfilerBackendDispatcher::create(context.backendDispatcher, this))
     , m_environment(context.environment)
 {

--- a/Source/JavaScriptCore/inspector/agents/InspectorScriptProfilerAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorScriptProfilerAgent.h
@@ -63,8 +63,8 @@ private:
     void trackingComplete();
     void stopSamplingWhenDisconnecting();
 
-    std::unique_ptr<ScriptProfilerFrontendDispatcher> m_frontendDispatcher;
-    RefPtr<ScriptProfilerBackendDispatcher> m_backendDispatcher;
+    const UniqueRef<ScriptProfilerFrontendDispatcher> m_frontendDispatcher;
+    const Ref<ScriptProfilerBackendDispatcher> m_backendDispatcher;
     InspectorEnvironment& m_environment;
     bool m_tracking { false };
 #if ENABLE(SAMPLING_PROFILER)

--- a/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp
@@ -36,7 +36,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorTargetAgent);
 InspectorTargetAgent::InspectorTargetAgent(FrontendRouter& frontendRouter, BackendDispatcher& backendDispatcher)
     : InspectorAgentBase("Target"_s)
     , m_router(frontendRouter)
-    , m_frontendDispatcher(makeUnique<TargetFrontendDispatcher>(frontendRouter))
+    , m_frontendDispatcher(makeUniqueRef<TargetFrontendDispatcher>(frontendRouter))
     , m_backendDispatcher(TargetBackendDispatcher::create(backendDispatcher, this))
 {
 }

--- a/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.h
@@ -69,7 +69,7 @@ private:
     void disconnectFromTargets();
 
     Inspector::FrontendRouter& m_router;
-    std::unique_ptr<TargetFrontendDispatcher> m_frontendDispatcher;
+    const UniqueRef<TargetFrontendDispatcher> m_frontendDispatcher;
     const Ref<TargetBackendDispatcher> m_backendDispatcher;
     UncheckedKeyHashMap<String, InspectorTarget*> m_targets;
     bool m_isConnected { false };

--- a/Source/JavaScriptCore/inspector/agents/JSGlobalObjectRuntimeAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/JSGlobalObjectRuntimeAgent.cpp
@@ -38,7 +38,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(JSGlobalObjectRuntimeAgent);
 
 JSGlobalObjectRuntimeAgent::JSGlobalObjectRuntimeAgent(JSAgentContext& context)
     : InspectorRuntimeAgent(context)
-    , m_frontendDispatcher(makeUnique<RuntimeFrontendDispatcher>(context.frontendRouter))
+    , m_frontendDispatcher(makeUniqueRef<RuntimeFrontendDispatcher>(context.frontendRouter))
     , m_backendDispatcher(RuntimeBackendDispatcher::create(context.backendDispatcher, this))
     , m_globalObject(context.inspectedGlobalObject)
 {

--- a/Source/JavaScriptCore/inspector/agents/JSGlobalObjectRuntimeAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/JSGlobalObjectRuntimeAgent.h
@@ -50,8 +50,8 @@ private:
     void muteConsole() final { }
     void unmuteConsole() final { }
 
-    std::unique_ptr<RuntimeFrontendDispatcher> m_frontendDispatcher;
-    RefPtr<RuntimeBackendDispatcher> m_backendDispatcher;
+    const UniqueRef<RuntimeFrontendDispatcher> m_frontendDispatcher;
+    const Ref<RuntimeBackendDispatcher> m_backendDispatcher;
     JSC::JSGlobalObject& m_globalObject;
 };
 

--- a/Source/JavaScriptCore/inspector/augmentable/AlternateDispatchableAgent.h
+++ b/Source/JavaScriptCore/inspector/augmentable/AlternateDispatchableAgent.h
@@ -44,7 +44,7 @@ public:
         , m_backendDispatcher(TBackendDispatcher::create(controller.backendDispatcher(), nullptr))
     {
         m_backendDispatcher->setAlternateDispatcher(m_alternateDispatcher.get());
-        m_alternateDispatcher->setBackendDispatcher(&controller.backendDispatcher());
+        m_alternateDispatcher->setBackendDispatcher(controller.backendDispatcher());
     }
 
     virtual ~AlternateDispatchableAgent()
@@ -62,7 +62,7 @@ public:
 
 private:
     std::unique_ptr<TAlternateDispatcher> m_alternateDispatcher;
-    RefPtr<TBackendDispatcher> m_backendDispatcher;
+    const Ref<TBackendDispatcher> m_backendDispatcher;
 };
 
 } // namespace Inspector

--- a/Source/WebCore/inspector/InspectorController.cpp
+++ b/Source/WebCore/inspector/InspectorController.cpp
@@ -133,8 +133,8 @@ PageAgentContext InspectorController::pageAgentContext()
     AgentContext baseContext = {
         *this,
         m_injectedScriptManager,
-        m_frontendRouter.get(),
-        m_backendDispatcher.get()
+        m_frontendRouter,
+        m_backendDispatcher
     };
 
     WebAgentContext webContext = {
@@ -266,7 +266,7 @@ void InspectorController::connectFrontend(Inspector::FrontendChannel& frontendCh
 
     if (connectedFirstFrontend) {
         InspectorInstrumentation::registerInstrumentingAgents(m_instrumentingAgents.get());
-        m_agents.didCreateFrontendAndBackend(&m_frontendRouter.get(), &m_backendDispatcher.get());
+        m_agents.didCreateFrontendAndBackend(m_frontendRouter.ptr(), m_backendDispatcher.ptr());
     }
 
     m_inspectorClient->frontendCountChanged(m_frontendRouter->frontendCount());

--- a/Source/WebCore/inspector/WorkerInspectorController.cpp
+++ b/Source/WebCore/inspector/WorkerInspectorController.cpp
@@ -139,7 +139,7 @@ void WorkerInspectorController::connectFrontend(bool isAutomaticInspection, bool
 
     m_forwardingChannel = makeUnique<WorkerToPageFrontendChannel>(m_globalScope);
     m_frontendRouter->connectFrontend(*m_forwardingChannel.get());
-    m_agents.didCreateFrontendAndBackend(&m_frontendRouter.get(), &m_backendDispatcher.get());
+    m_agents.didCreateFrontendAndBackend(m_frontendRouter.ptr(), m_backendDispatcher.ptr());
 
     updateServiceWorkerPageFrontendCount();
 }
@@ -196,8 +196,8 @@ WorkerAgentContext WorkerInspectorController::workerAgentContext()
     AgentContext baseContext = {
         *this,
         m_injectedScriptManager,
-        m_frontendRouter.get(),
-        m_backendDispatcher.get(),
+        m_frontendRouter,
+        m_backendDispatcher,
     };
 
     WebAgentContext webContext = {

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.h
@@ -94,7 +94,7 @@ private:
     void stopTrackingStyleOriginatedAnimation(StyleOriginatedAnimation&);
 
     const UniqueRef<Inspector::AnimationFrontendDispatcher> m_frontendDispatcher;
-    const RefPtr<Inspector::AnimationBackendDispatcher> m_backendDispatcher;
+    const Ref<Inspector::AnimationBackendDispatcher> m_backendDispatcher;
 
     Inspector::InjectedScriptManager& m_injectedScriptManager;
     WeakRef<Page> m_inspectedPage;

--- a/Source/WebCore/inspector/agents/InspectorCPUProfilerAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCPUProfilerAgent.h
@@ -54,7 +54,7 @@ private:
     void collectSample(const ResourceUsageData&);
 
     const UniqueRef<Inspector::CPUProfilerFrontendDispatcher> m_frontendDispatcher;
-    const RefPtr<Inspector::CPUProfilerBackendDispatcher> m_backendDispatcher;
+    const Ref<Inspector::CPUProfilerBackendDispatcher> m_backendDispatcher;
     bool m_tracking { false };
 };
 

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.h
@@ -188,7 +188,7 @@ private:
     void resetPseudoStates();
 
     const UniqueRef<Inspector::CSSFrontendDispatcher> m_frontendDispatcher;
-    const RefPtr<Inspector::CSSBackendDispatcher> m_backendDispatcher;
+    const Ref<Inspector::CSSBackendDispatcher> m_backendDispatcher;
 
     WeakRef<Page> m_inspectedPage;
     IdToInspectorStyleSheet m_idToInspectorStyleSheet;

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
@@ -152,7 +152,7 @@ private:
     RefPtr<InspectorShaderProgram> findInspectorProgram(WebGLProgram&);
 #endif // ENABLE(WEBGL)
 
-    const RefPtr<Inspector::CanvasBackendDispatcher> m_backendDispatcher;
+    const Ref<Inspector::CanvasBackendDispatcher> m_backendDispatcher;
 
     Inspector::InjectedScriptManager& m_injectedScriptManager;
 

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
@@ -279,7 +279,7 @@ private:
 
     Inspector::InjectedScriptManager& m_injectedScriptManager;
     const UniqueRef<Inspector::DOMFrontendDispatcher> m_frontendDispatcher;
-    const RefPtr<Inspector::DOMBackendDispatcher> m_backendDispatcher;
+    const Ref<Inspector::DOMBackendDispatcher> m_backendDispatcher;
     WeakRef<Page> m_inspectedPage;
     WeakRef<InspectorOverlay> m_overlay;
     WeakHashMap<Node, Inspector::Protocol::DOM::NodeId, WeakPtrImplWithEventTargetData> m_nodeToId;

--- a/Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.h
@@ -99,7 +99,7 @@ protected:
 private:
     void breakOnURLIfNeeded(const String&);
 
-    RefPtr<Inspector::DOMDebuggerBackendDispatcher> m_backendDispatcher;
+    const Ref<Inspector::DOMDebuggerBackendDispatcher> m_backendDispatcher;
     Inspector::InjectedScriptManager& m_injectedScriptManager;
 
     struct EventBreakpoint {

--- a/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.h
@@ -76,7 +76,7 @@ private:
     RefPtr<StorageArea> findStorageArea(Inspector::Protocol::ErrorString&, Ref<JSON::Object>&& storageId, LocalFrame*&);
 
     const UniqueRef<Inspector::DOMStorageFrontendDispatcher> m_frontendDispatcher;
-    const RefPtr<Inspector::DOMStorageBackendDispatcher> m_backendDispatcher;
+    const Ref<Inspector::DOMStorageBackendDispatcher> m_backendDispatcher;
 
     WeakRef<Page> m_inspectedPage;
 };

--- a/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.h
@@ -65,7 +65,7 @@ public:
 
 private:
     Inspector::InjectedScriptManager& m_injectedScriptManager;
-    RefPtr<Inspector::IndexedDBBackendDispatcher> m_backendDispatcher;
+    const Ref<Inspector::IndexedDBBackendDispatcher> m_backendDispatcher;
 
     WeakRef<Page> m_inspectedPage;
 };

--- a/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.h
@@ -85,7 +85,7 @@ private:
     void unbindPseudoElement(PseudoElement*);
 
     const UniqueRef<Inspector::LayerTreeFrontendDispatcher> m_frontendDispatcher;
-    const RefPtr<Inspector::LayerTreeBackendDispatcher> m_backendDispatcher;
+    const Ref<Inspector::LayerTreeBackendDispatcher> m_backendDispatcher;
 
     HashMap<const RenderLayer*, Inspector::Protocol::LayerTree::LayerId> m_documentLayerToIdMap;
     HashMap<Inspector::Protocol::LayerTree::LayerId, const RenderLayer*> m_idToLayer;

--- a/Source/WebCore/inspector/agents/InspectorMemoryAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorMemoryAgent.h
@@ -60,7 +60,7 @@ private:
     void collectSample(const ResourceUsageData&);
 
     const UniqueRef<Inspector::MemoryFrontendDispatcher> m_frontendDispatcher;
-    const RefPtr<Inspector::MemoryBackendDispatcher> m_backendDispatcher;
+    const Ref<Inspector::MemoryBackendDispatcher> m_backendDispatcher;
     bool m_tracking { false };
 };
 

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
@@ -234,7 +234,7 @@ private:
     };
 
     const UniqueRef<Inspector::NetworkFrontendDispatcher> m_frontendDispatcher;
-    const RefPtr<Inspector::NetworkBackendDispatcher> m_backendDispatcher;
+    const Ref<Inspector::NetworkBackendDispatcher> m_backendDispatcher;
     Inspector::InjectedScriptManager& m_injectedScriptManager;
 
     const UniqueRef<NetworkResourcesData> m_resourcesData;

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.h
@@ -170,7 +170,7 @@ private:
     Ref<Inspector::Protocol::Page::FrameResourceTree> buildObjectForFrameTree(LocalFrame*);
 
     const UniqueRef<Inspector::PageFrontendDispatcher> m_frontendDispatcher;
-    const RefPtr<Inspector::PageBackendDispatcher> m_backendDispatcher;
+    const Ref<Inspector::PageBackendDispatcher> m_backendDispatcher;
 
     WeakRef<Page> m_inspectedPage;
     InspectorClient* m_client { nullptr };

--- a/Source/WebCore/inspector/agents/InspectorTimelineAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorTimelineAgent.h
@@ -193,7 +193,7 @@ private:
     void addRecordToTimeline(Ref<JSON::Object>&&, TimelineRecordType);
 
     const UniqueRef<Inspector::TimelineFrontendDispatcher> m_frontendDispatcher;
-    const RefPtr<Inspector::TimelineBackendDispatcher> m_backendDispatcher;
+    const Ref<Inspector::TimelineBackendDispatcher> m_backendDispatcher;
 
     Vector<TimelineRecordEntry> m_recordStack;
     Vector<TimelineRecordEntry> m_pendingConsoleProfileRecords;

--- a/Source/WebCore/inspector/agents/InspectorWorkerAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorWorkerAgent.h
@@ -49,7 +49,7 @@ class InspectorWorkerAgent : public InspectorAgentBase, public Inspector::Worker
 public:
     ~InspectorWorkerAgent();
 
-    Inspector::WorkerFrontendDispatcher& frontendDispatcher() { return *m_frontendDispatcher; }
+    Inspector::WorkerFrontendDispatcher& frontendDispatcher() { return m_frontendDispatcher; }
 
     // InspectorAgentBase
     void didCreateFrontendAndBackend(Inspector::FrontendRouter*, Inspector::BackendDispatcher*);
@@ -100,7 +100,7 @@ private:
     const Ref<PageChannel> m_pageChannel;
 
     const UniqueRef<Inspector::WorkerFrontendDispatcher> m_frontendDispatcher;
-    const RefPtr<Inspector::WorkerBackendDispatcher> m_backendDispatcher;
+    const Ref<Inspector::WorkerBackendDispatcher> m_backendDispatcher;
 
     MemoryCompactRobinHoodHashMap<String, WeakPtr<WorkerInspectorProxy>> m_connectedProxies;
     bool m_enabled { false };

--- a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.h
@@ -72,7 +72,7 @@ private:
     void notifyContextCreated(const Inspector::Protocol::Network::FrameId&, JSC::JSGlobalObject*, const DOMWrapperWorld&, SecurityOrigin* = nullptr);
 
     const UniqueRef<Inspector::RuntimeFrontendDispatcher> m_frontendDispatcher;
-    const RefPtr<Inspector::RuntimeBackendDispatcher> m_backendDispatcher;
+    const Ref<Inspector::RuntimeBackendDispatcher> m_backendDispatcher;
 
     InstrumentingAgents& m_instrumentingAgents;
 

--- a/Source/WebCore/inspector/agents/worker/ServiceWorkerAgent.h
+++ b/Source/WebCore/inspector/agents/worker/ServiceWorkerAgent.h
@@ -49,7 +49,7 @@ public:
 
 private:
     WeakRef<ServiceWorkerGlobalScope, WeakPtrImplWithEventTargetData> m_serviceWorkerGlobalScope;
-    const RefPtr<Inspector::ServiceWorkerBackendDispatcher> m_backendDispatcher;
+    const Ref<Inspector::ServiceWorkerBackendDispatcher> m_backendDispatcher;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/agents/worker/WorkerRuntimeAgent.h
+++ b/Source/WebCore/inspector/agents/worker/WorkerRuntimeAgent.h
@@ -53,7 +53,7 @@ private:
     void muteConsole() { }
     void unmuteConsole() { }
 
-    RefPtr<Inspector::RuntimeBackendDispatcher> m_backendDispatcher;
+    const Ref<Inspector::RuntimeBackendDispatcher> m_backendDispatcher;
     WeakRef<WorkerOrWorkletGlobalScope> m_globalScope;
 };
 

--- a/Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.h
+++ b/Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.h
@@ -59,7 +59,7 @@ public:
 
 private:
     const UniqueRef<Inspector::BrowserFrontendDispatcher> m_frontendDispatcher;
-    const RefPtr<Inspector::BrowserBackendDispatcher> m_backendDispatcher;
+    const Ref<Inspector::BrowserBackendDispatcher> m_backendDispatcher;
     WeakRef<WebPageProxy> m_inspectedPage;
 };
 

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
@@ -57,7 +57,7 @@ WebPageInspectorController::WebPageInspectorController(WebPageProxy& inspectedPa
     , m_backendDispatcher(BackendDispatcher::create(m_frontendRouter.copyRef()))
     , m_inspectedPage(inspectedPage)
 {
-    auto targetAgent = makeUnique<InspectorTargetAgent>(m_frontendRouter.get(), m_backendDispatcher.get());
+    auto targetAgent = makeUnique<InspectorTargetAgent>(m_frontendRouter, m_backendDispatcher);
     m_targetAgent = targetAgent.get();
     m_agents.append(WTFMove(targetAgent));
 }
@@ -96,7 +96,7 @@ void WebPageInspectorController::connectFrontend(Inspector::FrontendChannel& fro
     m_frontendRouter->connectFrontend(frontendChannel);
 
     if (connectingFirstFrontend)
-        m_agents.didCreateFrontendAndBackend(&m_frontendRouter.get(), &m_backendDispatcher.get());
+        m_agents.didCreateFrontendAndBackend(m_frontendRouter.ptr(), m_backendDispatcher.ptr());
 
     Ref inspectedPage = m_inspectedPage.get();
     inspectedPage->didChangeInspectorFrontendCount(m_frontendRouter->frontendCount());


### PR DESCRIPTION
#### 9de4e9c32d93dab9d7f4e68f42575c2700cd7a7e
<pre>
Adopt UniqueRef in JavaScriptCore/inspector
<a href="https://bugs.webkit.org/show_bug.cgi?id=295452">https://bugs.webkit.org/show_bug.cgi?id=295452</a>

Reviewed by Youenn Fablet.

Also mark some additional member variables const and make inspector
code more consistent throughout.

Helps with <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/297041@main">https://commits.webkit.org/297041@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86957b7042e52c1f31c0b72ce9b33c0f15b10fd5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110318 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29977 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20409 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116342 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60567 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112281 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30656 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38564 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83880 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24458 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99341 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64326 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23818 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17480 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60138 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/102809 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93838 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17536 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119132 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/108872 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37358 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27706 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92851 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37730 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95611 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92677 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37675 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15407 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33252 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17804 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37252 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42723 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/133147 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36914 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35989 "Found 2 new JSC stress test failures: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js.default, wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40254 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38623 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->