### PR TITLE
ANGLE: Support generating parser copyright statement

### DIFF
--- a/Source/ThirdParty/ANGLE/src/compiler/generate_parser_tools.py
+++ b/Source/ThirdParty/ANGLE/src/compiler/generate_parser_tools.py
@@ -16,6 +16,10 @@ is_linux = platform.system() == 'Linux'
 is_mac = platform.system() == 'Darwin'
 is_windows = platform.system() == 'Windows'
 
+license_note = """/* Apple Note: For the avoidance of doubt, Apple elects to distribute this file under the terms of
+ * the BSD license. */
+
+"""
 
 def get_tool_path_platform(tool_name, platform):
     exe_path = os.path.join(sys.path[0], '..', '..', '..', 'tools', 'flex-bison', platform)
@@ -122,6 +126,15 @@ def run_bison(basename, generate_header):
 
     process = subprocess.Popen(bison_args, env=bison_env, cwd=sys.path[0])
     process.communicate()
+
+    for fn in [output_source] + ([output_header] if generate_header else []):
+        with open(fn, 'r') as output_file:
+            text = output_file.read()
+
+        with open(fn, 'w') as output_file:
+            output_file.write(license_note)
+            output_file.write(text)
+
     return process.returncode
 
 


### PR DESCRIPTION
#### ce95d7e3b571a82d1e5f48216b2412abf73c1854
<pre>
ANGLE: Support generating parser copyright statement
<a href="https://bugs.webkit.org/show_bug.cgi?id=295460">https://bugs.webkit.org/show_bug.cgi?id=295460</a>
<a href="https://rdar.apple.com/155039257">rdar://155039257</a>

Reviewed by Cameron McCormack.

Support generating the Apple-specific copyright message to
*_tab_autogen.cpp/.h files. The generate_parser_tools needs to add
the text, so that the hashes get taken with the note present.

* Source/ThirdParty/ANGLE/src/compiler/generate_parser_tools.py:
(run_bison):

Canonical link: <a href="https://commits.webkit.org/297327@main">https://commits.webkit.org/297327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7f2e8c0dc7cc22665213df9ed907b4c89bde5ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110296 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29955 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20387 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116320 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60545 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112259 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30634 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38542 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83860 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113244 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24438 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99322 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64308 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23798 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17458 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60114 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93819 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17516 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119110 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37336 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27687 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92833 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37708 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95592 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92659 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23796 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37653 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15388 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33228 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37230 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36892 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40232 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38601 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->