### PR TITLE
[GTK][WPE] Use mpark::variant to reduce built library sizes

### DIFF
--- a/Source/WTF/wtf/Variant.h
+++ b/Source/WTF/wtf/Variant.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if PLATFORM(COCOA)
+#if PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)
 
 // MPark.Variant
 //
@@ -420,11 +420,10 @@ namespace mpark {
       template <typename T, std::size_t N>
       struct array {
         constexpr const T &operator[](std::size_t index) const {
-          RELEASE_ASSERT(index < N == 0 ? 1 : N);
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
+          RELEASE_ASSERT(index < ((N == 0) ? 1 : N));
+          WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
           return data[index];
-#pragma clang diagnostic pop
+          WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         }
 
         T data[N == 0 ? 1 : N];

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.h
@@ -74,7 +74,7 @@ private:
         RTCDataChannelState state;
         std::optional<GError*> error;
     };
-    using Message = std::variant<StateChange, String, Ref<FragmentedSharedBuffer>>;
+    using Message = Variant<StateChange, String, Ref<FragmentedSharedBuffer>>;
     using PendingMessages = Vector<Message>;
 
     Lock m_clientLock;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.h
@@ -45,7 +45,7 @@ class GStreamerRtpSenderBackend final : public RTCRtpSenderBackend {
     WTF_MAKE_TZONE_ALLOCATED(GStreamerRtpSenderBackend);
 public:
     GStreamerRtpSenderBackend(WeakPtr<GStreamerPeerConnectionBackend>&&, GRefPtr<GstWebRTCRTPSender>&&);
-    using Source = std::variant<std::nullptr_t, Ref<RealtimeOutgoingAudioSourceGStreamer>, Ref<RealtimeOutgoingVideoSourceGStreamer>>;
+    using Source = Variant<std::nullptr_t, Ref<RealtimeOutgoingAudioSourceGStreamer>, Ref<RealtimeOutgoingVideoSourceGStreamer>>;
     GStreamerRtpSenderBackend(WeakPtr<GStreamerPeerConnectionBackend>&&, GRefPtr<GstWebRTCRTPSender>&&, Source&&, GUniquePtr<GstStructure>&& initData);
 
     void setRTCSender(GRefPtr<GstWebRTCRTPSender>&& rtcSender) { m_rtcSender = WTFMove(rtcSender); }

--- a/Source/WebCore/Scripts/tests/ProcessSyncData.h
+++ b/Source/WebCore/Scripts/tests/ProcessSyncData.h
@@ -27,7 +27,6 @@
 #include "DOMAudioSession.h"
 #include <wtf/URL.h>
 #include "StringifyThis"
-#include <variant>
 
 namespace WebCore {
 
@@ -57,7 +56,7 @@ static const ProcessSyncDataType allFrameTreeSyncDataTypes[] = {
 using DOMAudioSessionType = bool;
 #endif
 
-using ProcessSyncDataVariant = std::variant<
+using ProcessSyncDataVariant = Variant<
     WebCore::DOMAudioSessionType,
     URL,
     bool,

--- a/Source/WebCore/Scripts/tests/ProcessSyncData.serialization.in
+++ b/Source/WebCore/Scripts/tests/ProcessSyncData.serialization.in
@@ -51,7 +51,7 @@ enum class WebCore::ProcessSyncDataType : uint8_t {
 using WebCore::DOMAudioSessionType = bool;
 #endif
 
-using WebCore::ProcessSyncDataVariant = std::variant<WebCore::DOMAudioSessionType, URL, bool, bool, StringifyThis>;
+using WebCore::ProcessSyncDataVariant = Variant<WebCore::DOMAudioSessionType, URL, bool, bool, StringifyThis>;
 
 struct WebCore::ProcessSyncData {
     WebCore::ProcessSyncDataType type;

--- a/Source/WebCore/accessibility/atspi/AccessibilityAtspi.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityAtspi.h
@@ -89,7 +89,7 @@ public:
     static const char* localizedRoleName(AccessibilityRole);
 
 #if ENABLE(DEVELOPER_MODE)
-    using NotificationObserverParameter = std::variant<std::nullptr_t, String, bool, unsigned, Ref<AccessibilityObjectAtspi>>;
+    using NotificationObserverParameter = Variant<std::nullptr_t, String, bool, unsigned, Ref<AccessibilityObjectAtspi>>;
     using NotificationObserver = Function<void(AccessibilityObjectAtspi&, const char*, NotificationObserverParameter)>;
     WEBCORE_EXPORT void addNotificationObserver(void*, NotificationObserver&&);
     WEBCORE_EXPORT void removeNotificationObserver(void*);

--- a/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
@@ -190,7 +190,7 @@ size_t PlatformRawAudioDataGStreamer::memoryCost() const
     return gst_buffer_get_size(gst_sample_get_buffer(m_sample.get()));
 }
 
-std::optional<std::variant<Vector<std::span<uint8_t>>, Vector<std::span<int16_t>>, Vector<std::span<int32_t>>, Vector<std::span<float>>>> PlatformRawAudioDataGStreamer::planesOfSamples(size_t samplesOffset)
+std::optional<Variant<Vector<std::span<uint8_t>>, Vector<std::span<int16_t>>, Vector<std::span<int32_t>>, Vector<std::span<float>>>> PlatformRawAudioDataGStreamer::planesOfSamples(size_t samplesOffset)
 {
     GstMappedAudioBuffer mappedBuffer(m_sample, GST_MAP_READ);
     if (!mappedBuffer)

--- a/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.h
+++ b/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.h
@@ -50,7 +50,7 @@ public:
     const GstAudioInfo* info() const { return &m_info; }
 
     bool isInterleaved() const;
-    std::optional<std::variant<Vector<std::span<uint8_t>>, Vector<std::span<int16_t>>, Vector<std::span<int32_t>>, Vector<std::span<float>>>> planesOfSamples(size_t);
+    std::optional<Variant<Vector<std::span<uint8_t>>, Vector<std::span<int16_t>>, Vector<std::span<int32_t>>, Vector<std::span<float>>>> planesOfSamples(size_t);
 
 private:
     PlatformRawAudioDataGStreamer(GRefPtr<GstSample>&&);

--- a/Source/WebCore/platform/generic/KeyedDecoderGeneric.cpp
+++ b/Source/WebCore/platform/generic/KeyedDecoderGeneric.cpp
@@ -27,7 +27,6 @@
 #include "KeyedDecoderGeneric.h"
 
 #include "KeyedEncoderGeneric.h"
-#include <variant>
 #include <wtf/HashMap.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
@@ -40,7 +39,7 @@ typedef KeyedDecoderGeneric::Dictionary KeyedDecoderGenericDictionary;
 class KeyedDecoderGeneric::Dictionary {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(KeyedDecoderGenericDictionary);
 public:
-    using Node = std::variant<Vector<uint8_t>, bool, uint32_t, uint64_t, int32_t, int64_t, float, double, String, std::unique_ptr<Dictionary>, std::unique_ptr<Array>>;
+    using Node = Variant<Vector<uint8_t>, bool, uint32_t, uint64_t, int32_t, int64_t, float, double, String, std::unique_ptr<Dictionary>, std::unique_ptr<Array>>;
 
     template <typename T>
     void add(const String& key, T&& value) { m_map.add(key, makeUniqueWithoutFastMallocCheck<Node>(std::forward<T>(value))); }

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -1175,7 +1175,7 @@ void MediaPlayerPrivateGStreamer::notifyPlayerOfTrack()
     ASSERT(m_isLegacyPlaybin);
 
     using TrackType = TrackPrivateBaseGStreamer::TrackType;
-    std::variant<TrackIDHashMap<Ref<AudioTrackPrivateGStreamer>>*, TrackIDHashMap<Ref<VideoTrackPrivateGStreamer>>*, TrackIDHashMap<Ref<InbandTextTrackPrivateGStreamer>>*> variantTracks = static_cast<TrackIDHashMap<Ref<TrackPrivateType>>*>(0);
+    Variant<TrackIDHashMap<Ref<AudioTrackPrivateGStreamer>>*, TrackIDHashMap<Ref<VideoTrackPrivateGStreamer>>*, TrackIDHashMap<Ref<InbandTextTrackPrivateGStreamer>>*> variantTracks = static_cast<TrackIDHashMap<Ref<TrackPrivateType>>*>(0);
     auto type(static_cast<TrackType>(variantTracks.index()));
     const char* typeName;
     bool* hasType;
@@ -1255,7 +1255,7 @@ void MediaPlayerPrivateGStreamer::notifyPlayerOfTrack()
         if (!track->trackIndex() && (type == TrackType::Audio || type == TrackType::Video))
             track->setActive(true);
 
-        std::variant<AudioTrackPrivate*, VideoTrackPrivate*, InbandTextTrackPrivate*> variantTrack(&track.get());
+        Variant<AudioTrackPrivate*, VideoTrackPrivate*, InbandTextTrackPrivate*> variantTrack(&track.get());
         switch (variantTrack.index()) {
         case TrackType::Audio:
             player->addAudioTrack(*std::get<AudioTrackPrivate*>(variantTrack));

--- a/Source/WebCore/platform/network/curl/CurlProxySettings.h
+++ b/Source/WebCore/platform/network/curl/CurlProxySettings.h
@@ -74,7 +74,7 @@ public:
 
 private:
     friend struct IPC::ArgumentCoder<CurlProxySettings, void>;
-    using IPCData = std::variant<DefaultData, NoProxyData, CustomData>;
+    using IPCData = Variant<DefaultData, NoProxyData, CustomData>;
     WEBCORE_EXPORT IPCData toIPCData() const;
     WEBCORE_EXPORT static CurlProxySettings fromIPCData(IPCData&&);
 

--- a/Source/WebCore/platform/network/curl/CurlSSLHandle.h
+++ b/Source/WebCore/platform/network/curl/CurlSSLHandle.h
@@ -28,7 +28,6 @@
 
 #include "CertificateInfo.h"
 #include <openssl/crypto.h>
-#include <variant>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/NeverDestroyed.h>
@@ -48,7 +47,7 @@ class CurlSSLHandle {
     friend NeverDestroyed<CurlSSLHandle>;
 
 public:
-    using CACertInfo = std::variant<std::monostate, String, CertificateInfo::Certificate>;
+    using CACertInfo = Variant<std::monostate, String, CertificateInfo::Certificate>;
 
     CurlSSLHandle();
 

--- a/Source/WebCore/platform/network/soup/CredentialSoup.h
+++ b/Source/WebCore/platform/network/soup/CredentialSoup.h
@@ -61,7 +61,7 @@ public:
         CredentialPersistence persistence;
     };
 
-    using IPCData = std::variant<NonPlatformData, PlatformData>;
+    using IPCData = Variant<NonPlatformData, PlatformData>;
     WEBCORE_EXPORT static Credential fromIPCData(IPCData&&);
     WEBCORE_EXPORT IPCData ipcData() const;
 

--- a/Source/WebCore/platform/network/soup/ResourceRequest.h
+++ b/Source/WebCore/platform/network/soup/ResourceRequest.h
@@ -40,7 +40,7 @@ struct ResourceRequestPlatformData {
     bool acceptEncoding;
     uint16_t redirectCount;
 };
-using ResourceRequestData = std::variant<ResourceRequestBase::RequestData, ResourceRequestPlatformData>;
+using ResourceRequestData = Variant<ResourceRequestBase::RequestData, ResourceRequestPlatformData>;
 
 class ResourceRequest : public ResourceRequestBase {
 public:

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCurl.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCurl.cpp
@@ -33,13 +33,13 @@ namespace WebKit {
 namespace NetworkCache {
 
 Data::Data(std::span<const uint8_t> data)
-    : m_buffer(Box<std::variant<Vector<uint8_t>, FileSystem::MappedFileData>>::create(Vector<uint8_t>(data.size())))
+    : m_buffer(Box<Variant<Vector<uint8_t>, FileSystem::MappedFileData>>::create(Vector<uint8_t>(data.size())))
 {
     memcpySpan(std::get<Vector<uint8_t>>(*m_buffer).mutableSpan(), data);
 }
 
-Data::Data(std::variant<Vector<uint8_t>, FileSystem::MappedFileData>&& data)
-    : m_buffer(Box<std::variant<Vector<uint8_t>, FileSystem::MappedFileData>>::create(WTFMove(data)))
+Data::Data(Variant<Vector<uint8_t>, FileSystem::MappedFileData>&& data)
+    : m_buffer(Box<Variant<Vector<uint8_t>, FileSystem::MappedFileData>>::create(WTFMove(data)))
     , m_isMap(std::holds_alternative<FileSystem::MappedFileData>(*m_buffer))
 {
 }

--- a/Source/WebKit/Shared/curl/WebCoreArgumentCodersCurl.serialization.in
+++ b/Source/WebKit/Shared/curl/WebCoreArgumentCodersCurl.serialization.in
@@ -23,7 +23,7 @@
 #if USE(CURL)
 
 [CreateUsing=fromIPCData] class WebCore::CurlProxySettings {
-    std::variant<WebCore::CurlProxySettings::DefaultData, WebCore::CurlProxySettings::NoProxyData, WebCore::CurlProxySettings::CustomData> toIPCData();
+    Variant<WebCore::CurlProxySettings::DefaultData, WebCore::CurlProxySettings::NoProxyData, WebCore::CurlProxySettings::CustomData> toIPCData();
 };
 
 [Nested] struct WebCore::CurlProxySettings::DefaultData {

--- a/Source/WebKit/Shared/glib/UserMessage.h
+++ b/Source/WebKit/Shared/glib/UserMessage.h
@@ -90,7 +90,7 @@ struct UserMessage {
 private:
     friend struct IPC::ArgumentCoder<UserMessage, void>;
 
-    using IPCData = std::variant<NullMessage, ErrorMessage, DataMessage>;
+    using IPCData = Variant<NullMessage, ErrorMessage, DataMessage>;
     static UserMessage fromIPCData(IPCData&&);
     IPCData toIPCData() const;
 };

--- a/Source/WebKit/Shared/glib/UserMessage.serialization.in
+++ b/Source/WebKit/Shared/glib/UserMessage.serialization.in
@@ -23,7 +23,7 @@
 #
 
 [CreateUsing=fromIPCData] struct WebKit::UserMessage {
-    std::variant<WebKit::UserMessage::NullMessage, WebKit::UserMessage::ErrorMessage, WebKit::UserMessage::DataMessage> toIPCData();
+    Variant<WebKit::UserMessage::NullMessage, WebKit::UserMessage::ErrorMessage, WebKit::UserMessage::DataMessage> toIPCData();
 }
 
 [Nested] struct WebKit::UserMessage::NullMessage {

--- a/Source/WebKit/UIProcess/API/libwpe/TouchGestureController.h
+++ b/Source/WebKit/UIProcess/API/libwpe/TouchGestureController.h
@@ -28,7 +28,6 @@
 #if USE(LIBWPE) && ENABLE(TOUCH_EVENTS)
 
 #include "WebWheelEvent.h"
-#include <variant>
 #include <wpe/wpe.h>
 #include <wtf/TZoneMalloc.h>
 
@@ -65,7 +64,7 @@ public:
         WebWheelEvent::Phase phase;
     };
 
-    using EventVariant = std::variant<NoEvent, ClickEvent, ContextMenuEvent, AxisEvent>;
+    using EventVariant = Variant<NoEvent, ClickEvent, ContextMenuEvent, AxisEvent>;
 
     GesturedEvent gesturedEvent() const { return m_gesturedEvent; }
     EventVariant handleEvent(const struct wpe_input_touch_event_raw*);

--- a/Source/WebKit/UIProcess/Automation/gtk/WebAutomationSessionGtk.cpp
+++ b/Source/WebKit/UIProcess/Automation/gtk/WebAutomationSessionGtk.cpp
@@ -289,7 +289,7 @@ static unsigned modifiersForKeyCode(unsigned keyCode)
     return 0;
 }
 
-void WebAutomationSession::platformSimulateKeyboardInteraction(WebPageProxy& page, KeyboardInteraction interaction, std::variant<VirtualKey, CharKey>&& key)
+void WebAutomationSession::platformSimulateKeyboardInteraction(WebPageProxy& page, KeyboardInteraction interaction, Variant<VirtualKey, CharKey>&& key)
 {
     unsigned keyCode;
     WTF::switchOn(key,

--- a/Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionLibWPE.cpp
+++ b/Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionLibWPE.cpp
@@ -319,7 +319,7 @@ static uint32_t modifiersForKeyCode(unsigned keyCode)
     return 0;
 }
 
-void platformSimulateKeyboardInteractionLibWPE(WebPageProxy& page, KeyboardInteraction interaction, std::variant<VirtualKey, CharKey>&& key, unsigned& currentModifiers)
+void platformSimulateKeyboardInteractionLibWPE(WebPageProxy& page, KeyboardInteraction interaction, Variant<VirtualKey, CharKey>&& key, unsigned& currentModifiers)
 {
     uint32_t keyCode;
     WTF::switchOn(key,

--- a/Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionLibWPE.h
+++ b/Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionLibWPE.h
@@ -35,7 +35,7 @@ namespace WebKit {
 void platformSimulateMouseInteractionLibWPE(WebPageProxy&, MouseInteraction, MouseButton, const WebCore::IntPoint& locationInView, OptionSet<WebEventModifier> keyModifiers, const String& pointerType, unsigned& currentModifiers);
 #endif
 #if ENABLE(WEBDRIVER_KEYBOARD_INTERACTIONS)
-void platformSimulateKeyboardInteractionLibWPE(WebPageProxy&, KeyboardInteraction, std::variant<VirtualKey, CharKey>&&, unsigned& currentModifiers);
+void platformSimulateKeyboardInteractionLibWPE(WebPageProxy&, KeyboardInteraction, Variant<VirtualKey, CharKey>&&, unsigned& currentModifiers);
 void platformSimulateKeySequenceLibWPE(WebPageProxy&, const String& keySequence, unsigned& currentModifiers);
 #endif
 #if ENABLE(WEBDRIVER_WHEEL_INTERACTIONS)

--- a/Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionWPE.cpp
+++ b/Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionWPE.cpp
@@ -418,7 +418,7 @@ static uint32_t modifiersForKeyVal(unsigned keyVal)
 }
 #endif // ENABLE(WPE_PLATFORM)
 
-void WebAutomationSession::platformSimulateKeyboardInteraction(WebPageProxy& page, KeyboardInteraction interaction, std::variant<VirtualKey, CharKey>&& key)
+void WebAutomationSession::platformSimulateKeyboardInteraction(WebPageProxy& page, KeyboardInteraction interaction, Variant<VirtualKey, CharKey>&& key)
 {
     if (page.viewBackend()) {
         platformSimulateKeyboardInteractionLibWPE(page, interaction, WTFMove(key), m_currentModifiers);

--- a/Source/WebKit/UIProcess/Automation/win/WebAutomationSessionWin.cpp
+++ b/Source/WebKit/UIProcess/Automation/win/WebAutomationSessionWin.cpp
@@ -296,7 +296,7 @@ static unsigned modifiersForKeyCode(unsigned keyCode)
     return 0;
 }
 
-void WebAutomationSession::platformSimulateKeyboardInteraction(WebPageProxy& page, KeyboardInteraction interaction, std::variant<VirtualKey, CharKey>&& key)
+void WebAutomationSession::platformSimulateKeyboardInteraction(WebPageProxy& page, KeyboardInteraction interaction, Variant<VirtualKey, CharKey>&& key)
 {
     int keyCode;
     WTF::switchOn(key,

--- a/Source/WebKit/UIProcess/Notifications/glib/NotificationService.cpp
+++ b/Source/WebKit/UIProcess/Notifications/glib/NotificationService.cpp
@@ -296,7 +296,7 @@ public:
     }
 
 private:
-    HashMap<String, std::pair<uint32_t, std::variant<CString, GRefPtr<GBytes>>>> m_iconCache;
+    HashMap<String, std::pair<uint32_t, Variant<CString, GRefPtr<GBytes>>>> m_iconCache;
     RunLoop::Timer m_timer;
 };
 

--- a/Source/WebKit/UIProcess/gtk/ClipboardGtk4.cpp
+++ b/Source/WebKit/UIProcess/gtk/ClipboardGtk4.cpp
@@ -34,7 +34,6 @@
 #include <WebCore/SelectionData.h>
 #include <WebCore/SharedBuffer.h>
 #include <gtk/gtk.h>
-#include <variant>
 #include <wtf/RefCounted.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/GUniquePtr.h>
@@ -238,7 +237,7 @@ private:
     GRefPtr<GCancellable> m_cancellable;
     GRefPtr<GMainLoop> m_mainLoop;
     unsigned m_timeoutSourceID { 0 };
-    std::variant<ReadTextCompletionHandler, ReadFilePathsCompletionHandler, ReadBufferCompletionHandler, ReadURLCompletionHandler> m_completionHandler;
+    Variant<ReadTextCompletionHandler, ReadFilePathsCompletionHandler, ReadBufferCompletionHandler, ReadURLCompletionHandler> m_completionHandler;
 };
 
 void Clipboard::readText(CompletionHandler<void(String&&)>&& completionHandler, ReadMode readMode)

--- a/Source/WebKit/WPEPlatform/wpe/WPEEvent.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEEvent.cpp
@@ -26,7 +26,6 @@
 #include "config.h"
 #include "WPEEvent.h"
 
-#include <variant>
 #include <wtf/FastMalloc.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/glib/GRefPtr.h>
@@ -93,7 +92,7 @@ struct _WPEEvent {
         GDestroyNotify destroyFunction { nullptr };
     } userData;
 
-    std::variant<WPEEventPointerButton, WPEEventPointerMove, WPEEventScroll, WPEEventKeyboard, WPEEventTouch> variant;
+    Variant<WPEEventPointerButton, WPEEventPointerMove, WPEEventScroll, WPEEventKeyboard, WPEEventTouch> variant;
 
     int referenceCount { 1 };
 };

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLSelectElement.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLSelectElement.cpp
@@ -361,7 +361,7 @@ void webkit_dom_html_select_element_add(WebKitDOMHTMLSelectElement* self, WebKit
     WebCore::HTMLSelectElement* item = WebKit::core(self);
     WebCore::HTMLElement* convertedElement = WebKit::core(element);
     WebCore::HTMLElement* convertedBefore = WebKit::core(before);
-    std::variant<RefPtr<WebCore::HTMLOptionElement>, RefPtr<WebCore::HTMLOptGroupElement>> variantElement;
+    Variant<RefPtr<WebCore::HTMLOptionElement>, RefPtr<WebCore::HTMLOptGroupElement>> variantElement;
     if (is<WebCore::HTMLOptionElement>(convertedElement))
         variantElement = downcast<WebCore::HTMLOptionElement>(*convertedElement);
     else if (is<WebCore::HTMLOptGroupElement>(convertedElement))

--- a/Source/WebKit/WebProcess/WebCoreSupport/gtk/WebEditorClientGtk.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/gtk/WebEditorClientGtk.cpp
@@ -31,7 +31,6 @@
 #include <WebCore/TextIterator.h>
 #include <WebCore/markup.h>
 #include <WebPage.h>
-#include <variant>
 #include <wtf/glib/GRefPtr.h>
 
 namespace WebKit {
@@ -51,7 +50,7 @@ bool WebEditorClient::handleGtkEditorCommand(LocalFrame& frame, const String& co
 
 bool WebEditorClient::executePendingEditorCommands(LocalFrame& frame, const Vector<WTF::String>& pendingEditorCommands, bool allowTextInsertion)
 {
-    Vector<std::variant<Editor::Command, String>> commands;
+    Vector<Variant<Editor::Command, String>> commands;
     for (auto& commandString : pendingEditorCommands) {
         if (commandString.startsWith("Gtk"_s))
             commands.append(commandString);


### PR DESCRIPTION
#### cc1ccfa7793fee2b5acc7b679c687deefc5ccb71
<pre>
[GTK][WPE] Use mpark::variant to reduce built library sizes
<a href="https://bugs.webkit.org/show_bug.cgi?id=295461">https://bugs.webkit.org/show_bug.cgi?id=295461</a>

Reviewed by Alex Christensen and Patrick Griffis.

Enable mpark::variant for the GTK and WPE ports. For example, library
sizes before and after for a WPE release build on x86_64 are:

 - Unstripped: 176373.2 KiB -&gt; 168988.1 KiB (reduction: 7385.1 KiB)
 - Stripped..: 132520.7 KiB -&gt; 131912.8 KiB (reduction:  607.9 KiB)

On top of the preprocessor guards, this needed a small change in
Source/WTF/wtf/Variant.h: be explicit with parens in in assertion
expression, and use WTF_ALLOW_UNSAFE_BUFFER_USAGE_{BEGIN,END} to avoid
GCC complaining. The rest of the changes take care of replacing
remaining std::variant uses with the WTF::Variant type alias.

Canonical link: <a href="https://commits.webkit.org/297077@main">https://commits.webkit.org/297077@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ade824bfd2d224f241427e8d0d5c0f86af749435

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110299 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20390 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116323 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60548 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112262 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30637 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38545 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83866 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113247 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24443 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99326 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64313 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23803 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17462 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60117 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/102790 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93821 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17520 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119113 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/108853 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37339 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27690 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92839 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37711 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95596 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92665 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23645 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37660 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15392 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33231 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37233 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42704 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/133128 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36895 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35984 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40235 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38604 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->