### PR TITLE
[GStreamer][MediaStream] Fix time metadata handling in CanvasCaptureMediaStreamTrack

### DIFF
--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
@@ -233,6 +233,9 @@ void CanvasCaptureMediaStreamTrack::Source::captureCanvas()
     if (!videoFrame)
         return;
 
+    VideoFrameTimeMetadata metadata;
+    metadata.captureTime = MonotonicTime::now().secondsSinceEpoch();
+
 #if USE(GSTREAMER)
     auto gstVideoFrame = downcast<VideoFrameGStreamer>(videoFrame);
     if (m_frameRequestRate)
@@ -241,12 +244,11 @@ void CanvasCaptureMediaStreamTrack::Source::captureCanvas()
         static const double s_frameRate = 60;
         gstVideoFrame->setMaxFrameRate(s_frameRate);
         gstVideoFrame->setPresentationTime(m_presentationTimeStamp);
+        gstVideoFrame->setMetadata({ metadata });
         m_presentationTimeStamp = m_presentationTimeStamp + MediaTime::createWithDouble(1.0 / s_frameRate);
     }
 #endif
 
-    VideoFrameTimeMetadata metadata;
-    metadata.captureTime = MonotonicTime::now().secondsSinceEpoch();
     videoFrameAvailable(*videoFrame, metadata);
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
@@ -56,6 +56,8 @@ public:
 
     void setPresentationTime(const MediaTime&);
 
+    void setMetadata(std::optional<VideoFrameTimeMetadata>&&);
+
     RefPtr<VideoFrameGStreamer> resizeTo(const IntSize&);
 
     GRefPtr<GstSample> resizedSample(const IntSize&);


### PR DESCRIPTION
#### 3b16cd0d821fe7622340e846c15040a18e1ccfc8
<pre>
[GStreamer][MediaStream] Fix time metadata handling in CanvasCaptureMediaStreamTrack
<a href="https://bugs.webkit.org/show_bug.cgi?id=295466">https://bugs.webkit.org/show_bug.cgi?id=295466</a>

Reviewed by Xabier Rodriguez-Calvar.

Metadata is attached to the GStreamer buffer associated with each video frame. In case of canvas
capture the captureTime was lost, because our implementation of videoFrameAvailable doesn&apos;t use
it.

* Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp:
(WebCore::CanvasCaptureMediaStreamTrack::Source::captureCanvas):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::VideoFrameGStreamer::VideoFrameGStreamer):
(WebCore::VideoFrameGStreamer::setMetadata):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/297043@main">https://commits.webkit.org/297043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7b88c4069621c1654d59eae6292038835afb988

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110311 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29970 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116335 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60560 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112274 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30649 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38557 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83874 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113259 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24454 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99334 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64320 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23814 "Found 1 new test failure: imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-timing.https.sub.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17471 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60131 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93834 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17529 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119125 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37351 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27699 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92845 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37723 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95604 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92671 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23622 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37668 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15400 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33243 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37245 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42716 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36907 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40247 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38616 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->