### PR TITLE
Fix static analyzer warnings in WKPage

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -7,7 +7,6 @@ Platform/IPC/Connection.cpp
 Platform/IPC/Connection.h
 Platform/IPC/StreamClientConnection.cpp
 Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
-UIProcess/API/C/WKPage.cpp
 UIProcess/API/C/mac/WKPagePrivateMac.mm
 UIProcess/API/Cocoa/WKContentWorld.mm
 UIProcess/API/Cocoa/WKDownload.mm

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1076,6 +1076,11 @@ RefPtr<WebFrameProxy> WebPageProxy::protectedMainFrame() const
     return m_mainFrame;
 }
 
+RefPtr<WebFrameProxy> WebPageProxy::protectedFocusedFrame() const
+{
+    return m_focusedFrame;
+}
+
 RefPtr<DrawingAreaProxy> WebPageProxy::protectedDrawingArea() const
 {
     return m_drawingArea;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -675,6 +675,7 @@ public:
     WebFrameProxy* mainFrame() const { return m_mainFrame.get(); }
     RefPtr<WebFrameProxy> protectedMainFrame() const;
     WebFrameProxy* focusedFrame() const { return m_focusedFrame.get(); }
+    RefPtr<WebFrameProxy> protectedFocusedFrame() const;
     WebFrameProxy* focusedOrMainFrame() const { return m_focusedFrame ? m_focusedFrame.get() : m_mainFrame.get(); }
 
     DrawingAreaProxy* drawingArea() const { return m_drawingArea.get(); }


### PR DESCRIPTION
#### 3fbec4363b8205c7cdbbb209ab6a241e8db3e0bb
<pre>
Fix static analyzer warnings in WKPage
<a href="https://bugs.webkit.org/show_bug.cgi?id=295471">https://bugs.webkit.org/show_bug.cgi?id=295471</a>
<a href="https://rdar.apple.com/155068409">rdar://155068409</a>

Reviewed by Chris Dumez.

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageGetContext):
(WKPageCopyPageConfiguration):
(WKPageLoadURL):
(WKPageLoadURLWithShouldOpenExternalURLsPolicy):
(WKPageLoadURLWithUserData):
(WKPageLoadURLRequest):
(WKPageLoadURLRequestWithUserData):
(WKPageLoadFile):
(WKPageLoadFileWithUserData):
(WKPageLoadData):
(WKPageLoadDataWithUserData):
(loadString):
(WKPageLoadAlternateHTMLStringWithUserData):
(WKPageStopLoading):
(WKPageReload):
(WKPageReloadWithoutContentBlockers):
(WKPageReloadFromOrigin):
(WKPageReloadExpiredOnly):
(WKPageTryClose):
(WKPageClose):
(WKPageIsClosed):
(WKPageGoForward):
(WKPageCanGoForward):
(WKPageGoBack):
(WKPageCanGoBack):
(WKPageGoToBackForwardListItem):
(WKPageTryRestoreScrollPosition):
(WKPageGetBackForwardList):
(WKPageWillHandleHorizontalScrollEvents):
(WKPageUpdateWebsitePolicies):
(WKPageCopyTitle):
(WKPageGetMainFrame):
(WKPageGetFocusedFrame):
(WKPageGetRenderTreeSize):
(WKPageGetWebsiteDataStore):
(WKPageGetInspector):
(WKPageGetEstimatedProgress):
(WKPageCopyUserAgent):
(WKPageCopyApplicationNameForUserAgent):
(WKPageSetApplicationNameForUserAgent):
(WKPageCopyCustomUserAgent):
(WKPageSetCustomUserAgent):
(WKPageSupportsTextEncoding):
(WKPageCopyCustomTextEncodingName):
(WKPageSetCustomTextEncodingName):
(WKPageTerminate):
(WKPageResetStateBetweenTests):
(WKPageCopySessionState):
(restoreFromSessionState):
(WKPageGetTextZoomFactor):
(WKPageGetBackingScaleFactor):
(WKPageSetCustomBackingScaleFactor):
(WKPageSetCustomBackingScaleFactorWithCallback):
(WKPageSupportsTextZoom):
(WKPageSetTextZoomFactor):
(WKPageGetPageZoomFactor):
(WKPageSetPageZoomFactor):
(WKPageSetPageAndTextZoomFactors):
(WKPageSetScaleFactor):
(WKPageGetScaleFactor):
(WKPageSetUseFixedLayout):
(WKPageSetFixedLayoutSize):
(WKPageUseFixedLayout):
(WKPageFixedLayoutSize):
(WKPageListenForLayoutMilestones):
(WKPageHasHorizontalScrollbar):
(WKPageHasVerticalScrollbar):
(WKPageSetSuppressScrollbarAnimations):
(WKPageAreScrollbarAnimationsSuppressed):
(WKPageIsPinnedToLeftSide):
(WKPageIsPinnedToRightSide):
(WKPageIsPinnedToTopSide):
(WKPageIsPinnedToBottomSide):
(WKPageRubberBandsAtLeft):
(WKPageSetRubberBandsAtLeft):
(WKPageRubberBandsAtRight):
(WKPageSetRubberBandsAtRight):
(WKPageRubberBandsAtTop):
(WKPageSetRubberBandsAtTop):
(WKPageRubberBandsAtBottom):
(WKPageSetRubberBandsAtBottom):
(WKPageVerticalRubberBandingIsEnabled):
(WKPageSetEnableVerticalRubberBanding):
(WKPageHorizontalRubberBandingIsEnabled):
(WKPageSetEnableHorizontalRubberBanding):
(WKPageSetBackgroundExtendsBeyondPage):
(WKPageBackgroundExtendsBeyondPage):
(WKPageSetPaginationMode):
(WKPageGetPaginationMode):
(WKPageSetPaginationBehavesLikeColumns):
(WKPageGetPaginationBehavesLikeColumns):
(WKPageSetPageLength):
(WKPageGetPageLength):
(WKPageSetGapBetweenPages):
(WKPageGetGapBetweenPages):
(WKPageGetPageCount):
(WKPageCanDelete):
(WKPageHasSelectedRange):
(WKPageIsContentEditable):
(WKPageSetMaintainsInactiveSelection):
(WKPageCenterSelectionInVisibleArea):
(WKPageFindStringMatches):
(WKPageGetImageForFindMatch):
(WKPageSelectFindMatch):
(WKPageIndicateFindMatch):
(WKPageFindString):
(WKPageHideFindUI):
(WKPageCountStringMatches):
(WKPageSetPageContextMenuClient):
(WKPageSetPageDiagnosticLoggingClient):
(WKPageSetPageFindClient):
(WKPageSetPageFindMatchesClient):
(WKPageSetPageInjectedBundleClient):
(WKCompletionListenerComplete):
(WKPageSetFullScreenClientForTesting):
(WKPageRequestExitFullScreen):
(WKPageSetPageFormClient):
(WKPageSetPageLoaderClient):
(WKPageSetPagePolicyClient):
(WKPageRunBeforeUnloadConfirmPanelResultListenerCall):
(WKPageRunJavaScriptAlertResultListenerCall):
(WKPageRunJavaScriptConfirmResultListenerCall):
(WKPageRunJavaScriptPromptResultListenerCall):
(WKPageRequestStorageAccessConfirmResultListenerCall):
(WKPageSetPageUIClient):
(WKPageSetPageStateClient):
(WKPageEvaluateJavaScriptInMainFrame):
(WKPageRenderTreeExternalRepresentation):
(WKPageGetSourceForFrame):
(WKPageGetContentsAsString):
(WKPageGetBytecodeProfile):
(WKPageGetSamplingProfilerOutput):
(WKPageGetSelectionAsWebArchiveData):
(WKPageGetContentsAsMHTMLData):
(WKPageForceRepaint):
(WKPageCopyPendingAPIRequestURL):
(WKPageCopyActiveURL):
(WKPageCopyProvisionalURL):
(WKPageCopyCommittedURL):
(WKPageCopyStandardUserAgentWithApplicationName):
(WKPageValidateCommand):
(WKPageExecuteCommand):
(WKPageComputePagesForPrinting):
(WKPageDrawPagesToPDF):
(WKPageBeginPrinting):
(WKPageEndPrinting):
(WKPageGetIsControlledByAutomation):
(WKPageSetControlledByAutomation):
(WKPageGetAllowsRemoteInspection):
(WKPageSetAllowsRemoteInspection):
(WKPageShowWebInspectorForTesting):
(WKPageSetMediaVolume):
(WKPageSetMuted):
(WKPageSetMediaCaptureEnabled):
(WKPageGetMediaCaptureEnabled):
(WKPageDidAllowPointerLock):
(WKPageClearUserMediaState):
(WKPageDidDenyPointerLock):
(WKPagePostMessageToInjectedBundle):
(WKPageCopyRelatedPages):
(WKPageLookUpFrameFromHandle):
(WKPageSetMayStartMediaWhenInWindow):
(WKPageSelectContextMenuItem):
(WKPageGetScrollPinningBehavior):
(WKPageSetScrollPinningBehavior):
(WKPageGetAddsVisitedLinks):
(WKPageSetAddsVisitedLinks):
(WKPageIsPlayingAudio):
(WKPageGetMediaState):
(WKPageClearWheelEventTestMonitor):
(WKPageCallAfterNextPresentationUpdate):
(WKPageSetIgnoresViewportScaleLimits):
(WKPageSetUseDarkAppearanceForTesting):
(WKPageGetProcessIdentifier):
(WKPageGetGPUProcessIdentifier):
(WKPageGetApplicationManifest):
(WKPageDumpPrivateClickMeasurement):
(WKPageClearPrivateClickMeasurement):
(WKPageSetPrivateClickMeasurementOverrideTimerForTesting):
(WKPageMarkAttributedPrivateClickMeasurementsAsExpiredForTesting):
(WKPageSetPrivateClickMeasurementEphemeralMeasurementForTesting):
(WKPageSimulatePrivateClickMeasurementSessionRestart):
(WKPageSetPrivateClickMeasurementTokenPublicKeyURLForTesting):
(WKPageSetPrivateClickMeasurementTokenSignatureURLForTesting):
(WKPageSetPrivateClickMeasurementAttributionReportURLsForTesting):
(WKPageMarkPrivateClickMeasurementsAsExpiredForTesting):
(WKPageSetPCMFraudPreventionValuesForTesting):
(WKPageSetPrivateClickMeasurementAppBundleIDForTesting):
(WKPageSetMockCameraOrientationForTesting):
(WKPageSetMockCaptureDevicesInterrupted):
(WKPageTriggerMockCaptureConfigurationChange):
(WKPageLoadedSubresourceDomains):
(WKPageClearLoadedSubresourceDomains):
(WKPageSetMediaCaptureReportingDelayForTesting):
(WKPageDispatchActivityStateUpdateForTesting):
(WKPageClearNotificationPermissionState):
(WKPageExecuteCommandForTesting):
(WKPageIsEditingCommandEnabledForTesting):
(WKPageSetPermissionLevelForTesting):
(WKPageSetObscuredContentInsetsForTesting):
(WKPageSetPageScaleFactorForTesting):
(WKPageClearBackForwardListForTesting):
(WKPageSetTracksRepaintsForTesting):
(WKPageDisplayAndTrackRepaintsForTesting):
(WKPageFindStringForTesting):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::protectedFocusedFrame const):
* Source/WebKit/UIProcess/WebPageProxy.h:

Canonical link: <a href="https://commits.webkit.org/297036@main">https://commits.webkit.org/297036@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9eb9f6d03d770180fa56bac01f78cc8703c93da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110335 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29994 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20426 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116359 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60585 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30673 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38581 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83897 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113283 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24475 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99356 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64342 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23834 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60155 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93854 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17551 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119149 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37375 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27723 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92864 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37747 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95624 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92690 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23617 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37690 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15422 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33274 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37269 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42740 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36932 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40271 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38640 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->