### PR TITLE
[JSC] Implement `Set.prototype.intersection` in C++

### DIFF
--- a/JSTests/microbenchmarks/set-prototype-intersection-large-other.js
+++ b/JSTests/microbenchmarks/set-prototype-intersection-large-other.js
@@ -1,0 +1,26 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const n1 = 512;
+const array1 = [];
+for (let i = 0; i < n1; i++) {
+    array1[i] = i;
+}
+
+const n2 = 1024;
+const array2 = [];
+for (let i = 0; i < n2; i++) {
+    array2[i] = i;
+}
+
+const s1 = new Set(array1);
+const s2 = new Set(array2);
+
+let r;
+for (let i = 0; i < 1e5; i++) {
+    r = s1.intersection(s2);
+}
+
+shouldBe(r.size, n2 / 2);

--- a/JSTests/microbenchmarks/set-prototype-intersection-large-this.js
+++ b/JSTests/microbenchmarks/set-prototype-intersection-large-this.js
@@ -1,0 +1,26 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const n1 = 1024;
+const array1 = [];
+for (let i = 0; i < n1; i++) {
+    array1[i] = i;
+}
+
+const n2 = 512;
+const array2 = [];
+for (let i = 0; i < n2; i++) {
+    array2[i] = i;
+}
+
+const s1 = new Set(array1);
+const s2 = new Set(array2);
+
+let r;
+for (let i = 0; i < 1e5; i++) {
+    r = s1.intersection(s2);
+}
+
+shouldBe(r.size, n1 / 2);

--- a/JSTests/microbenchmarks/set-prototype-intersection.js
+++ b/JSTests/microbenchmarks/set-prototype-intersection.js
@@ -1,0 +1,26 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const n = 1024;
+
+const array1 = [];
+for (let i = 0; i < n; i++) {
+    array1[i] = i;
+}
+const array2 = [];
+for (let i = 0; i < n; i++) {
+    array2[i] = i + n / 2;
+}
+
+const s1 = new Set(array1);
+const s2 = new Set(array2);
+
+let r;
+for (let i = 0; i < 1e5; i++) {
+    r = s1.intersection(s2);
+}
+
+shouldBe(r.size, n / 2);
+

--- a/JSTests/stress/set-prototype-intersection-larger-other-effects-1.js
+++ b/JSTests/stress/set-prototype-intersection-larger-other-effects-1.js
@@ -1,0 +1,46 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const set1 = new Set([1, 2, 3, 4, 5]);
+const set2 = new Set([3, 4, 5, 6, 7, 8]);
+
+let hasGet = 0;
+let hasCall = 0;
+Object.defineProperty(set2, "has", {
+    get() {
+        hasGet++;
+        return function (...args) {
+            hasCall++;
+            return Set.prototype.has.call(set2, ...args);
+        }
+    }
+});
+
+let keysGet = 0;
+let keysCall = 0;
+Object.defineProperty(set2, "keys", {
+    get() {
+        keysGet++;
+        return function (...args) {
+            keysCall++;
+            return Set.prototype.keys.call(set2, ...args);
+        }
+    }
+});
+
+
+const result = set1.intersection(set2);
+
+shouldBe(result.size, 3);
+
+shouldBe(result.has(3), true);
+shouldBe(result.has(4), true);
+shouldBe(result.has(5), true);
+
+shouldBe(hasGet, 1);
+shouldBe(hasCall, 5);
+
+shouldBe(keysGet, 1);
+shouldBe(keysCall, 0);

--- a/JSTests/stress/set-prototype-intersection-larger-other-effects-2.js
+++ b/JSTests/stress/set-prototype-intersection-larger-other-effects-2.js
@@ -1,0 +1,49 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const setPrototypeHas = Set.prototype.has;
+const setPrototypeKeys = Set.prototype.keys;
+
+const set1 = new Set([1, 2, 3, 4, 5]);
+const set2 = new Set([3, 4, 5, 6, 7, 8]);
+
+let hasGet = 0;
+let hasCall = 0;
+Object.defineProperty(Set.prototype, "has", {
+    get() {
+        hasGet++;
+        return function (...args) {
+            hasCall++;
+            return setPrototypeHas.call(set2, ...args);
+        }
+    }
+});
+
+let keysGet = 0;
+let keysCall = 0;
+Object.defineProperty(Set.prototype, "keys", {
+    get() {
+        keysGet++;
+        return function (...args) {
+            keysCall++;
+            return setPrototypeKeys.call(set2, ...args);
+        }
+    }
+});
+
+
+const result = set1.intersection(set2);
+
+shouldBe(result.size, 3);
+
+shouldBe(result.has(3), true);
+shouldBe(result.has(4), true);
+shouldBe(result.has(5), true);
+
+shouldBe(hasGet, 4);
+shouldBe(hasCall, 8);
+
+shouldBe(keysGet, 1);
+shouldBe(keysCall, 0);

--- a/JSTests/stress/set-prototype-intersection-larger-this-effects-1.js
+++ b/JSTests/stress/set-prototype-intersection-larger-this-effects-1.js
@@ -1,0 +1,46 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const set1 = new Set([1, 2, 3, 4, 5, 6, 7, 8]);
+const set2 = new Set([3, 4, 5]);
+
+let hasGet = 0;
+let hasCall = 0;
+Object.defineProperty(set2, "has", {
+    get() {
+        hasGet++;
+        return function (...args) {
+            hasCall++;
+            return Set.prototype.has.call(set2, ...args);
+        }
+    }
+});
+
+let keysGet = 0;
+let keysCall = 0;
+Object.defineProperty(set2, "keys", {
+    get() {
+        keysGet++;
+        return function (...args) {
+            keysCall++;
+            return Set.prototype.keys.call(set2, ...args);
+        }
+    }
+});
+
+
+const result = set1.intersection(set2);
+
+shouldBe(result.size, 3);
+
+shouldBe(result.has(3), true);
+shouldBe(result.has(4), true);
+shouldBe(result.has(5), true);
+
+shouldBe(hasGet, 1);
+shouldBe(hasCall, 0);
+
+shouldBe(keysGet, 1);
+shouldBe(keysCall, 1);

--- a/JSTests/stress/set-prototype-intersection-larger-this-effects-2.js
+++ b/JSTests/stress/set-prototype-intersection-larger-this-effects-2.js
@@ -1,0 +1,49 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const setPrototypeHas = Set.prototype.has;
+const setPrototypeKeys = Set.prototype.keys;
+
+const set1 = new Set([1, 2, 3, 4, 5, 6, 7, 8]);
+const set2 = new Set([3, 4, 5]);
+
+let hasGet = 0;
+let hasCall = 0;
+Object.defineProperty(Set.prototype, "has", {
+    get() {
+        hasGet++;
+        return function (...args) {
+            hasCall++;
+            return setPrototypeHas.call(set2, ...args);
+        }
+    }
+});
+
+let keysGet = 0;
+let keysCall = 0;
+Object.defineProperty(Set.prototype, "keys", {
+    get() {
+        keysGet++;
+        return function (...args) {
+            keysCall++;
+            return setPrototypeKeys.call(set2, ...args);
+        }
+    }
+});
+
+
+const result = set1.intersection(set2);
+
+shouldBe(result.size, 3);
+
+shouldBe(result.has(3), true);
+shouldBe(result.has(4), true);
+shouldBe(result.has(5), true);
+
+shouldBe(hasGet, 4);
+shouldBe(hasCall, 3);
+
+shouldBe(keysGet, 1);
+shouldBe(keysCall, 1);

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.h
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.h
@@ -328,6 +328,7 @@
     macro(move) \
     macro(AsyncDisposableStack) \
     macro(disposeAsync) \
+    macro(keys) \
 
 #define JSC_COMMON_IDENTIFIERS_EACH_PRIVATE_FIELD(macro) \
     macro(constructor)

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -1959,6 +1959,8 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, m_regExpPrototype.get(), vm.propertyNames->unicode), m_regExpPrimordialPropertiesWatchpointSet);
     installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, m_regExpPrototype.get(), vm.propertyNames->unicodeSets), m_regExpPrimordialPropertiesWatchpointSet);
     installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, m_regExpPrototype.get(), vm.propertyNames->replaceSymbol), m_regExpPrimordialPropertiesWatchpointSet);
+    installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, jsSetPrototype(), vm.propertyNames->has), m_setPrimordialPropertiesWatchpointSet);
+    installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, jsSetPrototype(), vm.propertyNames->keys), m_setPrimordialPropertiesWatchpointSet);
 
     // Detect property absence.
     installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, m_stringPrototype.get(), vm.propertyNames->replaceSymbol, objectPrototype()), m_stringSymbolReplaceWatchpointSet);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -487,6 +487,7 @@ public:
     InlineWatchpointSet m_regExpPrimordialPropertiesWatchpointSet { IsWatched };
     InlineWatchpointSet m_mapSetWatchpointSet { IsWatched };
     InlineWatchpointSet m_setAddWatchpointSet { IsWatched };
+    InlineWatchpointSet m_setPrimordialPropertiesWatchpointSet { IsWatched };
     InlineWatchpointSet m_arraySpeciesWatchpointSet { ClearWatchpoint };
     InlineWatchpointSet m_arrayJoinWatchpointSet { IsWatched };
     InlineWatchpointSet m_arrayToStringWatchpointSet { IsWatched };
@@ -553,6 +554,7 @@ public:
     InlineWatchpointSet& regExpPrimordialPropertiesWatchpointSet() { return m_regExpPrimordialPropertiesWatchpointSet; }
     InlineWatchpointSet& mapSetWatchpointSet() { return m_mapSetWatchpointSet; }
     InlineWatchpointSet& setAddWatchpointSet() { return m_setAddWatchpointSet; }
+    InlineWatchpointSet& setPrimordialPropertiesWatchpointSet() { return m_setPrimordialPropertiesWatchpointSet; }
     InlineWatchpointSet& arraySpeciesWatchpointSet() { return m_arraySpeciesWatchpointSet; }
     InlineWatchpointSet& arrayPrototypeChainIsSaneWatchpointSet() { return m_arrayPrototypeChainIsSaneWatchpointSet; }
     InlineWatchpointSet& objectPrototypeChainIsSaneWatchpointSet() { return m_objectPrototypeChainIsSaneWatchpointSet; }

--- a/Source/JavaScriptCore/runtime/SetPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/SetPrototype.cpp
@@ -26,11 +26,16 @@
 #include "config.h"
 #include "SetPrototype.h"
 
+#include "CachedCall.h"
+#include "InterpreterInlines.h"
 #include "BuiltinNames.h"
 #include "GetterSetter.h"
+#include "IteratorOperations.h"
 #include "JSCInlines.h"
 #include "JSSet.h"
 #include "JSSetIterator.h"
+#include "SetPrototypeInlines.h"
+#include "VMEntryScopeInlines.h"
 
 namespace JSC {
 
@@ -42,6 +47,7 @@ static JSC_DECLARE_HOST_FUNCTION(setProtoFuncDelete);
 static JSC_DECLARE_HOST_FUNCTION(setProtoFuncHas);
 static JSC_DECLARE_HOST_FUNCTION(setProtoFuncValues);
 static JSC_DECLARE_HOST_FUNCTION(setProtoFuncEntries);
+static JSC_DECLARE_HOST_FUNCTION(setProtoFuncIntersection);
 
 static JSC_DECLARE_HOST_FUNCTION(setProtoFuncSize);
 
@@ -90,7 +96,7 @@ void SetPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().unionPublicName(), setPrototypeUnionCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
-    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().intersectionPublicName(), setPrototypeIntersectionCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("intersection"_s, setProtoFuncIntersection, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().differencePublicName(), setPrototypeDifferenceCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().symmetricDifferencePublicName(), setPrototypeSymmetricDifferenceCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().isSubsetOfPublicName(), setPrototypeIsSubsetOfCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
@@ -173,6 +179,173 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncSize, (JSGlobalObject* globalObject, CallFr
     RETURN_IF_EXCEPTION(scope, JSValue::encode(jsUndefined()));
 
     return JSValue::encode(jsNumber(set->size()));
+}
+
+// https://tc39.es/ecma262/#sec-getsetrecord ( Step 1 ~ Step 7 )
+static uint32_t getSetSizeAsInt(JSGlobalObject* globalObject, JSValue value)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (!value.isObject()) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "Set operation expects first argument to be an object");
+
+    JSObject* obj = asObject(value);
+
+    JSValue rawSize = obj->get(globalObject, vm.propertyNames->size);
+    RETURN_IF_EXCEPTION(scope, 0);
+
+    double numSize = rawSize.toNumber(globalObject);
+    RETURN_IF_EXCEPTION(scope, 0);
+
+    if (std::isnan(numSize)) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "Set operation expects first argument to have non-NaN 'size' property"_s);
+
+    double intOrInfSize = jsNumber(numSize).toIntegerOrInfinity(globalObject);
+
+    if (intOrInfSize < 0) [[unlikely]]
+        return throwVMRangeError(globalObject, scope, "Set operation expects first argument to have non-negative 'size' property"_s);
+
+    if (std::isinf(intOrInfSize)) [[unlikely]]
+        return std::numeric_limits<uint32_t>::max();
+    return static_cast<uint32_t>(intOrInfSize);
+}
+
+static EncodedJSValue fastSetIntersection(JSGlobalObject* globalObject, JSSet* thisSet, JSSet* otherSet)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSSet* result = JSSet::create(vm, globalObject->setStructure());
+
+    JSSet* sourceSet = thisSet->size() <= otherSet->size() ? thisSet : otherSet;
+    JSSet* targetSet = thisSet->size() <= otherSet->size() ? otherSet : thisSet;
+
+    JSCell* sourceStorageCell = sourceSet->storageOrSentinel(vm);
+    if (sourceStorageCell == vm.orderedHashTableSentinel())
+        return JSValue::encode(result);
+
+    JSSet::Storage& sourceStorage = *jsCast<JSSet::Storage*>(sourceStorageCell);
+    JSSet::Helper::Entry entry = 0;
+
+    while (true) {
+        sourceStorageCell = JSSet::Helper::nextAndUpdateIterationEntry(vm, sourceStorage, entry);
+        if (sourceStorageCell == vm.orderedHashTableSentinel())
+            break;
+
+        JSSet::Storage& currentStorage = *jsCast<JSSet::Storage*>(sourceStorageCell);
+        entry = JSSet::Helper::iterationEntry(currentStorage) + 1;
+        JSValue entryKey = JSSet::Helper::getIterationEntryKey(currentStorage);
+
+        bool targetHasEntry = targetSet->has(globalObject, entryKey);
+        RETURN_IF_EXCEPTION(scope, { });
+        if (targetHasEntry) {
+            result->add(globalObject, entryKey);
+            RETURN_IF_EXCEPTION(scope, { });
+        }
+
+        sourceStorage = currentStorage;
+    }
+    return JSValue::encode(result);
+}
+
+JSC_DEFINE_HOST_FUNCTION(setProtoFuncIntersection, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSSet* thisSet = getSet(globalObject, callFrame->thisValue());
+    RETURN_IF_EXCEPTION(scope, { });
+
+    JSValue otherValue = callFrame->argument(0);
+
+    if (otherValue.isCell()) [[likely]] {
+        if (auto* otherSet = jsDynamicCast<JSSet*>(otherValue.asCell())) [[likely]] {
+            if (setPrimordialWatchpointIsValid(vm, otherSet)) [[likely]] {
+                scope.release();
+                return fastSetIntersection(globalObject, thisSet, otherSet);
+            }
+        }
+    }
+
+    uint32_t size = getSetSizeAsInt(globalObject, otherValue);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    ASSERT(otherValue.isObject());
+    JSObject* otherObject = asObject(otherValue);
+
+    JSValue has = otherObject->get(globalObject, vm.propertyNames->has);
+    RETURN_IF_EXCEPTION(scope, { });
+    if (!has.isCallable()) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "Set.prototype.intersection expects other.has to be callable");
+
+    JSValue keys = otherObject->get(globalObject, vm.propertyNames->keys);
+    RETURN_IF_EXCEPTION(scope, { });
+    if (!keys.isCallable()) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "Set.prototype.intersection expects other.keys to be callable");
+
+    JSSet* result = JSSet::create(vm, globalObject->setStructure());
+    if (thisSet->size() <= size) {
+        JSCell* storageCell = thisSet->storageOrSentinel(vm);
+        if (storageCell == vm.orderedHashTableSentinel())
+            return JSValue::encode(result);
+
+        JSSet::Storage& storage = *jsCast<JSSet::Storage*>(storageCell);
+        JSSet::Helper::Entry entry = 0;
+        CallData hasCallData = JSC::getCallData(has);
+
+        std::optional<CachedCall> cachedHasCall;
+        if (hasCallData.type == CallData::Type::JS) [[likely]] {
+            cachedHasCall.emplace(globalObject, jsCast<JSFunction*>(has), 1);
+            RETURN_IF_EXCEPTION(scope, { });
+        }
+
+        while (true) {
+            storageCell = JSSet::Helper::nextAndUpdateIterationEntry(vm, storage, entry);
+            if (storageCell == vm.orderedHashTableSentinel())
+                break;
+
+            storage = *jsCast<JSSet::Storage*>(storageCell);
+            entry = JSSet::Helper::iterationEntry(storage) + 1;
+            JSValue entryKey = JSSet::Helper::getIterationEntryKey(storage);
+
+            JSValue hasResult;
+            if (cachedHasCall) [[likely]] {
+                hasResult = cachedHasCall->callWithArguments(globalObject, otherValue, entryKey);
+                RETURN_IF_EXCEPTION(scope, { });
+            } else {
+                MarkedArgumentBuffer args;
+                args.append(entryKey);
+                ASSERT(!args.hasOverflowed());
+                hasResult = call(globalObject, has, hasCallData, otherValue, args);
+                RETURN_IF_EXCEPTION(scope, { });
+            }
+
+            bool hasResultBool = hasResult.toBoolean(globalObject);
+            RETURN_IF_EXCEPTION(scope, { });
+            if (hasResultBool) {
+                result->add(globalObject, entryKey);
+                RETURN_IF_EXCEPTION(scope, { });
+            }
+        }
+    } else {
+        CallData keysCallData = JSC::getCallData(keys);
+        MarkedArgumentBuffer args;
+        ASSERT(!args.hasOverflowed());
+        JSValue iterator = call(globalObject, keys, keysCallData, otherValue, args);
+        RETURN_IF_EXCEPTION(scope, { });
+        scope.release();
+        forEachInIteratorProtocol(globalObject, iterator, [&](VM&, JSGlobalObject* globalObject, JSValue key) -> void {
+            bool thisSetHasKey = thisSet->has(globalObject, key);
+            RETURN_IF_EXCEPTION(scope, void());
+            if (thisSetHasKey) {
+                result->add(globalObject, key);
+                RETURN_IF_EXCEPTION(scope, void());
+            }
+        });
+    }
+
+    return JSValue::encode(result);
 }
 
 inline JSValue createSetIteratorObject(JSGlobalObject* globalObject, CallFrame* callFrame, IterationKind kind)

--- a/Source/JavaScriptCore/runtime/SetPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/SetPrototypeInlines.h
@@ -25,9 +25,27 @@
 
 #pragma once
 
+#include "JSGlobalObject.h"
 #include "SetPrototype.h"
 
 namespace JSC {
+
+ALWAYS_INLINE bool setPrimordialWatchpointIsValid(VM& vm, JSObject* object)
+{
+    JSGlobalObject* globalObject = object->globalObject();
+
+    if (globalObject->jsSetPrototype() != object->getPrototypeDirect())
+        return false;
+
+    ASSERT(globalObject->setPrimordialPropertiesWatchpointSet().state() != ClearWatchpoint);
+    if (globalObject->setPrimordialPropertiesWatchpointSet().state() != IsWatched)
+        return false;
+
+    if (!object->hasCustomProperties())
+        return true;
+
+    return object->getDirectOffset(vm, vm.propertyNames->has) == invalidOffset && object->getDirectOffset(vm, vm.propertyNames->keys) == invalidOffset;
+}
 
 inline Structure* SetPrototype::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
 {


### PR DESCRIPTION
#### 736aa4a741da8973040b68b30bb002d3752ef89b
<pre>
[JSC] Implement `Set.prototype.intersection` in C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=295476">https://bugs.webkit.org/show_bug.cgi?id=295476</a>

Reviewed by Yusuke Suzuki.

This patch implements `Set.prototype.intersection` in C++. The C++
implementation enters a fast path when `otherSet` is in an ideal state.
This significantly improves performance, especially in the baseline JIT.
There are also some performance improvements in DFG/FTL.

Baseline:
                                                TipOfTree                  Patched

set-prototype-intersection-large-this      2794.4450+-41.3768    ^    936.5865+-34.5267       ^ definitely 2.9836x faster
set-prototype-intersection-large-other     1930.2733+-23.6332    ^    927.6492+-26.7125       ^ definitely 2.0808x faster
set-prototype-intersection                 2937.9777+-19.6155    ^   1152.9432+-36.6889       ^ definitely 2.5482x faster

with DFG only:
                                                TipOfTree                  Patched

set-prototype-intersection-large-this      1386.4293+-24.1653    ^    915.1607+-10.0156       ^ definitely 1.5150x faster
set-prototype-intersection-large-other     1263.0578+-9.4375     ^    932.4156+-30.8533       ^ definitely 1.3546x faster
set-prototype-intersection                 1794.7610+-24.5289    ^   1143.6836+-25.1361       ^ definitely 1.5693x faster

with DFG and FTL:
                                                TipOfTree                  Patched

set-prototype-intersection-large-this       994.4368+-28.4201    ^    927.9790+-17.3331       ^ definitely 1.0716x faster
set-prototype-intersection-large-other     1117.0381+-12.4878    ^    930.5520+-19.9727       ^ definitely 1.2004x faster
set-prototype-intersection                 1553.9095+-16.2586    ^   1147.2663+-38.2916       ^ definitely 1.3544x faster

* JSTests/microbenchmarks/set-prototype-intersection-large-other.js: Added.
(shouldBe):
* JSTests/microbenchmarks/set-prototype-intersection-large-this.js: Added.
(shouldBe):
* JSTests/microbenchmarks/set-prototype-intersection.js: Added.
(shouldBe):
* JSTests/stress/set-prototype-intersection-larger-other-effects-1.js: Added.
(shouldBe):
(get hasGet):
(get keysGet):
* JSTests/stress/set-prototype-intersection-larger-other-effects-2.js: Added.
(shouldBe):
(get hasGet):
(get keysGet):
* JSTests/stress/set-prototype-intersection-larger-this-effects-1.js: Added.
(shouldBe):
(get hasGet):
(get keysGet):
* JSTests/stress/set-prototype-intersection-larger-this-effects-2.js: Added.
(shouldBe):
(get hasGet):
(get keysGet):
* Source/JavaScriptCore/runtime/CommonIdentifiers.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::setPrimordialPropertiesWatchpointSet):
* Source/JavaScriptCore/runtime/SetPrototype.cpp:
(JSC::SetPrototype::finishCreation):
(JSC::getSetSizeAsInt):
(JSC::fastSetIntersection):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/SetPrototypeInlines.h:
(JSC::setPrimordialWatchpointIsValid):

Canonical link: <a href="https://commits.webkit.org/297882@main">https://commits.webkit.org/297882@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f255ffc055305502736eb3ec708df8e0e6b644ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113166 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32901 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23379 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119374 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/63938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33553 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41464 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86140 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41146 "Unexpected infrastructure issue, retrying build") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116113 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26802 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101803 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66460 "Found 142 new API test failures: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration, /WPE/TestBackForwardList:/webkit/WebKitWebView/navigation-after-session-restore, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/reset, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /WPE/TestLoaderClient:/webkit/WebKitURIResponse/http-headers, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone-worker, /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/injected-script, /WPE/TestLoaderClient:/webkit/WebKitWebView/unfinished-subresource-load, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/cookies ... (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26075 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19931 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63128 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/105683 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96186 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20006 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122591 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/111782 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40244 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30024 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94991 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40628 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98018 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94733 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24183 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39876 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17682 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36376 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40130 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45629 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/136012 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39771 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36498 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43104 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41508 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->