### PR TITLE
Collapsing borders disallow padding on table

### DIFF
--- a/LayoutTests/fast/repaint/table-with-padding-row-invalidation-expected.txt
+++ b/LayoutTests/fast/repaint/table-with-padding-row-invalidation-expected.txt
@@ -1,0 +1,4 @@
+(repaint rects
+  (rect 0 0 260 50)
+)
+

--- a/LayoutTests/fast/repaint/table-with-padding-row-invalidation.html
+++ b/LayoutTests/fast/repaint/table-with-padding-row-invalidation.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<style>
+body {
+    margin: 0;
+}
+table {
+    border-collapse: collapse;
+    padding: 4px;
+}
+tr {
+    background: red;
+}
+td {
+    width: 260px;
+    height: 50px;
+    padding: 0;
+}
+</style>
+<script>
+function repaintTest() {
+   const output = document.getElementById("repaintRects");
+
+   if (!window.testRunner) {
+      alert("This test requires testRunner to run!");
+      return;
+   }
+
+   if (!window.internals) {
+      alert("This test requires window.interals to run!");
+      return;
+   }
+
+   window.internals.startTrackingRepaints();
+   window.testRunner.dumpAsText();
+
+   const row = document.querySelector("tr");
+   row.style.background = "green";
+
+   // Force layout for repainting.
+   row.offsetTop;
+
+   const repaintRects = window.internals.repaintRectsAsText();
+   window.internals.stopTrackingRepaints();
+
+   output.textContent = repaintRects;
+}
+
+window.onload = repaintTest;
+</script>
+<body>
+<table>
+    <tr>
+        <td></td>
+    </tr>
+</table>
+<pre id="repaintRects"></pre>
+</body>
+</html>

--- a/LayoutTests/fast/table/table-in-table-percent-width-collapsing-border-expected.txt
+++ b/LayoutTests/fast/table/table-in-table-percent-width-collapsing-border-expected.txt
@@ -6,8 +6,8 @@ layer at (0,0) size 800x538
       RenderTable {DIV} at (0,0) size 522x522 [border: (1px solid #000000)]
         RenderTableSection (anonymous) at (11,11) size 500x500
           RenderTableRow {DIV} at (0,0) size 500x500 [border: (1px solid #FF0000)]
-            RenderTableCell {DIV} at (0,0) size 500x480 [border: (1px solid #0000FF)] [r=0 c=0 rs=1 cs=1]
-              RenderTable {DIV} at (1,1) size 498x478 [border: none]
-                RenderTableSection (anonymous) at (0,0) size 477x477
-                  RenderTableRow {DIV} at (0,0) size 477x477 [border: (1px solid #00FFFF)]
+            RenderTableCell {DIV} at (0,0) size 500x500 [border: (1px solid #0000FF)] [r=0 c=0 rs=1 cs=1]
+              RenderTable {DIV} at (1,1) size 498x498 [border: none]
+                RenderTableSection (anonymous) at (0,0) size 497x497
+                  RenderTableRow {DIV} at (0,0) size 497x497 [border: (1px solid #00FFFF)]
                     RenderTableCell {DIV} at (0,0) size 497x1 [border: (1px solid #FF00FF)] [r=0 c=0 rs=1 cs=1]

--- a/LayoutTests/fast/table/table-in-table-percent-width-collapsing-border-quirks-mode-expected.txt
+++ b/LayoutTests/fast/table/table-in-table-percent-width-collapsing-border-quirks-mode-expected.txt
@@ -6,8 +6,8 @@ layer at (0,0) size 800x600
       RenderTable {DIV} at (0,0) size 522x522 [border: (1px solid #000000)]
         RenderTableSection (anonymous) at (11,11) size 500x500
           RenderTableRow {DIV} at (0,0) size 500x500 [border: (1px solid #FF0000)]
-            RenderTableCell {DIV} at (0,0) size 500x480 [border: (1px solid #0000FF)] [r=0 c=0 rs=1 cs=1]
-              RenderTable {DIV} at (1,1) size 498x478 [border: none]
-                RenderTableSection (anonymous) at (0,0) size 477x477
-                  RenderTableRow {DIV} at (0,0) size 477x477 [border: (1px solid #00FFFF)]
+            RenderTableCell {DIV} at (0,0) size 500x500 [border: (1px solid #0000FF)] [r=0 c=0 rs=1 cs=1]
+              RenderTable {DIV} at (1,1) size 498x498 [border: none]
+                RenderTableSection (anonymous) at (0,0) size 497x497
+                  RenderTableRow {DIV} at (0,0) size 497x497 [border: (1px solid #00FFFF)]
                     RenderTableCell {DIV} at (0,0) size 497x1 [border: (1px solid #FF00FF)] [r=0 c=0 rs=1 cs=1]

--- a/LayoutTests/platform/ios/fast/table/table-in-table-percent-width-collapsing-border-expected.txt
+++ b/LayoutTests/platform/ios/fast/table/table-in-table-percent-width-collapsing-border-expected.txt
@@ -6,8 +6,8 @@ layer at (0,0) size 800x538
       RenderTable {DIV} at (0,0) size 522x522 [border: (1px solid #000000)]
         RenderTableSection (anonymous) at (11,11) size 500x500
           RenderTableRow {DIV} at (0,0) size 500x500 [border: (1px solid #FF0000)]
-            RenderTableCell {DIV} at (0,0) size 500x480 [border: (1px solid #0000FF)] [r=0 c=0 rs=1 cs=1]
-              RenderTable {DIV} at (1,1) size 498x478 [border: (0.50px solid #008000)]
-                RenderTableSection (anonymous) at (0,0) size 478x478
-                  RenderTableRow {DIV} at (0,0) size 477x477 [border: (1px solid #00FFFF)]
+            RenderTableCell {DIV} at (0,0) size 500x500 [border: (1px solid #0000FF)] [r=0 c=0 rs=1 cs=1]
+              RenderTable {DIV} at (1,1) size 498x498 [border: (0.50px solid #008000)]
+                RenderTableSection (anonymous) at (0,0) size 498x498
+                  RenderTableRow {DIV} at (0,0) size 497x497 [border: (1px solid #00FFFF)]
                     RenderTableCell {DIV} at (0,0) size 497x1 [border: (0.50px solid #FF00FF)] [r=0 c=0 rs=1 cs=1]

--- a/LayoutTests/platform/ios/fast/table/table-in-table-percent-width-collapsing-border-quirks-mode-expected.txt
+++ b/LayoutTests/platform/ios/fast/table/table-in-table-percent-width-collapsing-border-quirks-mode-expected.txt
@@ -6,8 +6,8 @@ layer at (0,0) size 800x600
       RenderTable {DIV} at (0,0) size 522x522 [border: (1px solid #000000)]
         RenderTableSection (anonymous) at (11,11) size 500x500
           RenderTableRow {DIV} at (0,0) size 500x500 [border: (1px solid #FF0000)]
-            RenderTableCell {DIV} at (0,0) size 500x480 [border: (1px solid #0000FF)] [r=0 c=0 rs=1 cs=1]
-              RenderTable {DIV} at (1,1) size 498x478 [border: (0.50px solid #008000)]
-                RenderTableSection (anonymous) at (0,0) size 478x478
-                  RenderTableRow {DIV} at (0,0) size 477x477 [border: (1px solid #00FFFF)]
+            RenderTableCell {DIV} at (0,0) size 500x500 [border: (1px solid #0000FF)] [r=0 c=0 rs=1 cs=1]
+              RenderTable {DIV} at (1,1) size 498x498 [border: (0.50px solid #008000)]
+                RenderTableSection (anonymous) at (0,0) size 498x498
+                  RenderTableRow {DIV} at (0,0) size 497x497 [border: (1px solid #00FFFF)]
                     RenderTableCell {DIV} at (0,0) size 497x1 [border: (0.50px solid #FF00FF)] [r=0 c=0 rs=1 cs=1]

--- a/Source/WebCore/rendering/RenderTable.h
+++ b/Source/WebCore/rendering/RenderTable.h
@@ -154,6 +154,18 @@ public:
         return 0;
     }
 
+    // The collapsing border model dissallows paddings on table, which is why we
+    // override those functions.
+    // See http://www.w3.org/TR/CSS2/tables.html#collapsing-borders
+    inline LayoutUnit paddingTop() const override;
+    inline LayoutUnit paddingBottom() const override;
+    inline LayoutUnit paddingLeft() const override;
+    inline LayoutUnit paddingRight() const override;
+    inline LayoutUnit paddingAfter() const override;
+    inline LayoutUnit paddingBefore() const override;
+    inline LayoutUnit paddingStart() const override;
+    inline LayoutUnit paddingEnd() const override;
+
     inline LayoutUnit bordersPaddingAndSpacingInRowDirection() const;
 
     // Return the first column or column-group.

--- a/Source/WebCore/rendering/RenderTableInlines.h
+++ b/Source/WebCore/rendering/RenderTableInlines.h
@@ -63,6 +63,62 @@ inline RectEdges<LayoutUnit> RenderTable::borderWidths() const
     };
 }
 
+inline LayoutUnit RenderTable::paddingTop() const
+{
+    if (collapseBorders())
+        return { };
+    return RenderBlock::paddingTop();
+}
+
+inline LayoutUnit RenderTable::paddingBottom() const
+{
+    if (collapseBorders())
+        return { };
+    return RenderBlock::paddingBottom();
+}
+
+inline LayoutUnit RenderTable::paddingLeft() const
+{
+    if (collapseBorders())
+        return { };
+    return RenderBlock::paddingLeft();
+}
+
+inline LayoutUnit RenderTable::paddingRight() const
+{
+    if (collapseBorders())
+        return { };
+    return RenderBlock::paddingRight();
+}
+
+inline LayoutUnit RenderTable::paddingAfter() const
+{
+    if (collapseBorders())
+        return { };
+    return RenderBlock::paddingAfter();
+}
+
+inline LayoutUnit RenderTable::paddingBefore() const
+{
+    if (collapseBorders())
+        return { };
+    return RenderBlock::paddingBefore();
+}
+
+inline LayoutUnit RenderTable::paddingStart() const
+{
+    if (collapseBorders())
+        return { };
+    return RenderBlock::paddingStart();
+}
+
+inline LayoutUnit RenderTable::paddingEnd() const
+{
+    if (collapseBorders())
+        return { };
+    return RenderBlock::paddingEnd();
+}
+
 inline LayoutUnit RenderTable::bordersPaddingAndSpacingInRowDirection() const
 {
     // 'border-spacing' only applies to separate borders (see 17.6.1 The separated borders model).


### PR DESCRIPTION
#### 755b208ecfa8021bbedc5b312397af010e87f6ee
<pre>
Collapsing borders disallow padding on table
<a href="https://bugs.webkit.org/show_bug.cgi?id=295479">https://bugs.webkit.org/show_bug.cgi?id=295479</a>
<a href="https://rdar.apple.com/problem/155693380">rdar://problem/155693380</a>

Reviewed by Alan Baradlay.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/a489de4b9d41cb02aac1e52a2d3e367fdab31a17">https://chromium.googlesource.com/chromium/src.git/+/a489de4b9d41cb02aac1e52a2d3e367fdab31a17</a>

This patch fixes bug where we would wrongly remove the padding from the
available space for table-row-group and table-row when collapsing borders.
CSS [1] is clear that paddings are not allowed on table with collapsing
borders.

[1] <a href="https://www.w3.org/TR/CSS2/tables.html#collapsing-borders">https://www.w3.org/TR/CSS2/tables.html#collapsing-borders</a>

&quot;Also, in this model, a table does not have padding...&quot;

* Source/WebCore/rendering/RenderTable.h:
* Source/WebCore/rendering/RenderTableInlines.h:
(WebCore::RenderTable::paddingTop const):
(WebCore::RenderTable::paddingBottom const):
(WebCore::RenderTable::paddingLeft const):
(WebCore::RenderTable::paddingRight const):
(WebCore::RenderTable::paddingAfter const):
(WebCore::RenderTable::paddingBefore const):
(WebCore::RenderTable::paddingStart const):
(WebCore::RenderTable::paddingEnd const):
* LayoutTests/fast/repaint/table-with-padding-row-invalidation.html:
* LayoutTests/fast/repaint/table-with-padding-row-invalidation-expected.txt:

&gt; Rebaselines:
* LayoutTests/fast/table/table-in-table-percent-width-collapsing-border-expected.txt:
* LayoutTests/fast/table/table-in-table-percent-width-collapsing-border-quirks-mode-expected.txt:
* LayoutTests/platform/ios/fast/table/table-in-table-percent-width-collapsing-border-expected.txt:
* LayoutTests/platform/ios/fast/table/table-in-table-percent-width-collapsing-border-quirks-mode-expected.txt:

Canonical link: <a href="https://commits.webkit.org/297946@main">https://commits.webkit.org/297946@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ba55028049ad14c7af22b79ddaac74e5ce6e400

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113149 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32884 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119357 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64144 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115111 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33536 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41447 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86123 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116096 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26786 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101785 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66443 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26059 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19913 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63111 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96170 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19989 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122574 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40227 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30010 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94972 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40611 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98001 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94714 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24228 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39859 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17665 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36359 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40113 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45612 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39754 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43087 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41491 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->