### PR TITLE
Reduce unsafeness in WebCore/xml some more

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
@@ -118,5 +118,3 @@ style/values/color/StyleColorResolutionState.h
 svg/properties/SVGPropertyOwnerRegistry.h
 workers/DedicatedWorkerThread.h
 workers/service/ServiceWorkerContainer.h
-xml/XMLHttpRequestProgressEventThrottle.h
-xml/XMLHttpRequestUpload.h

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -92,7 +92,5 @@ workers/WorkerNotificationClient.h
 workers/WorkerOrWorkletGlobalScope.h
 workers/service/ServiceWorkerContainer.h
 workers/service/background-fetch/ServiceWorkerRegistrationBackgroundFetchAPI.h
-xml/XMLHttpRequestProgressEventThrottle.h
-xml/XMLHttpRequestUpload.h
 xml/XPathGrammar.cpp
 xml/XPathGrammar.h

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -828,11 +828,7 @@ workers/service/server/SWRegistrationDatabase.cpp
 workers/shared/context/SharedWorkerThreadProxy.cpp
 worklets/PaintWorkletGlobalScope.cpp
 worklets/WorkletGlobalScope.cpp
-xml/XMLHttpRequestProgressEventThrottle.cpp
-xml/XMLHttpRequestUpload.cpp
-xml/XPathExpression.cpp
 xml/XPathFunctions.cpp
-xml/XPathValue.cpp
 xml/XSLImportRule.cpp
 xml/XSLStyleSheetLibxslt.cpp
 xml/XSLTProcessorLibxslt.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1153,13 +1153,8 @@ worklets/PaintWorkletGlobalScope.cpp
 worklets/WorkletGlobalScope.cpp
 worklets/WorkletPendingTasks.cpp
 xml/XMLHttpRequest.cpp
-xml/XMLHttpRequestProgressEventThrottle.cpp
-xml/XMLHttpRequestUpload.cpp
 xml/XPathEvaluator.cpp
-xml/XPathExpression.cpp
 xml/XPathFunctions.cpp
-xml/XPathParser.cpp
-xml/XPathValue.cpp
 xml/XSLImportRule.cpp
 xml/XSLStyleSheetLibxslt.cpp
 xml/XSLTProcessorLibxslt.cpp

--- a/Source/WebCore/xml/XMLHttpRequest.h
+++ b/Source/WebCore/xml/XMLHttpRequest.h
@@ -61,6 +61,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
+
     static Ref<XMLHttpRequest> create(ScriptExecutionContext&);
     WEBCORE_EXPORT ~XMLHttpRequest();
 

--- a/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp
+++ b/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp
@@ -34,7 +34,6 @@
 #include "EventTargetInlines.h"
 #include "ScriptExecutionContext.h"
 #include "ScriptExecutionContextInlines.h"
-#include "XMLHttpRequest.h"
 #include "XMLHttpRequestProgressEvent.h"
 
 namespace WebCore {
@@ -54,7 +53,11 @@ void XMLHttpRequestProgressEventThrottle::updateProgress(bool isAsync, bool leng
     m_loaded = loaded;
     m_total = total;
 
-    if (!isAsync || !m_target.hasEventListeners(eventNames().progressEvent))
+    if (!isAsync)
+        return;
+
+    Ref target = m_target.get();
+    if (!target->hasEventListeners(eventNames().progressEvent))
         return;
 
     if (!m_shouldDeferEventsDueToSuspension && !m_dispatchThrottledProgressEventTimer) {
@@ -64,7 +67,7 @@ void XMLHttpRequestProgressEventThrottle::updateProgress(bool isAsync, bool leng
         ASSERT(!m_hasPendingThrottledProgressEvent);
 
         dispatchEventWhenPossible(XMLHttpRequestProgressEvent::create(eventNames().progressEvent, lengthComputable, loaded, total));
-        m_dispatchThrottledProgressEventTimer = m_target.protectedScriptExecutionContext()->checkedEventLoop()->scheduleRepeatingTask(
+        m_dispatchThrottledProgressEventTimer = target->protectedScriptExecutionContext()->checkedEventLoop()->scheduleRepeatingTask(
             minimumProgressEventDispatchingInterval, minimumProgressEventDispatchingInterval, TaskSource::Networking, [weakThis = WeakPtr { *this }] {
                 if (weakThis)
                     weakThis->dispatchThrottledProgressEventTimerFired();
@@ -87,10 +90,11 @@ void XMLHttpRequestProgressEventThrottle::dispatchReadyStateChangeEvent(Event& e
 
 void XMLHttpRequestProgressEventThrottle::dispatchEventWhenPossible(Event& event)
 {
+    Ref target = m_target.get();
     if (m_shouldDeferEventsDueToSuspension)
-        m_target.queueTaskToDispatchEvent(m_target, TaskSource::Networking, event);
+        target->queueTaskToDispatchEvent(target.get(), TaskSource::Networking, event);
     else
-        m_target.dispatchEvent(event);
+        target->dispatchEvent(event);
 }
 
 void XMLHttpRequestProgressEventThrottle::dispatchProgressEvent(const AtomString& type)
@@ -103,7 +107,7 @@ void XMLHttpRequestProgressEventThrottle::dispatchProgressEvent(const AtomString
         m_total = 0;
     }
 
-    if (m_target.hasEventListeners(type))
+    if (protectedTarget()->hasEventListeners(type))
         dispatchEventWhenPossible(XMLHttpRequestProgressEvent::create(type, m_lengthComputable, m_loaded, m_total));
 }
 
@@ -111,7 +115,7 @@ void XMLHttpRequestProgressEventThrottle::dispatchErrorProgressEvent(const AtomS
 {
     ASSERT(type == eventNames().loadendEvent || type == eventNames().abortEvent || type == eventNames().errorEvent || type == eventNames().timeoutEvent);
 
-    if (m_target.hasEventListeners(type))
+    if (protectedTarget()->hasEventListeners(type))
         dispatchEventWhenPossible(XMLHttpRequestProgressEvent::create(type, false, 0, 0));
 }
 
@@ -145,7 +149,7 @@ void XMLHttpRequestProgressEventThrottle::suspend()
     m_shouldDeferEventsDueToSuspension = true;
 
     if (m_hasPendingThrottledProgressEvent) {
-        ActiveDOMObject::queueTaskKeepingObjectAlive(m_target, TaskSource::Networking, [this](auto&) {
+        ActiveDOMObject::queueTaskKeepingObjectAlive(protectedTarget().get(), TaskSource::Networking, [this](auto&) {
             flushProgressEvent();
         });
     }
@@ -153,7 +157,7 @@ void XMLHttpRequestProgressEventThrottle::suspend()
 
 void XMLHttpRequestProgressEventThrottle::resume()
 {
-    ActiveDOMObject::queueTaskKeepingObjectAlive(m_target, TaskSource::Networking, [this](auto&) {
+    ActiveDOMObject::queueTaskKeepingObjectAlive(protectedTarget().get(), TaskSource::Networking, [this](auto&) {
         m_shouldDeferEventsDueToSuspension = false;
     });
 }

--- a/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.h
+++ b/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "EventLoop.h"
+#include "XMLHttpRequest.h"
 #include <wtf/Forward.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
@@ -72,8 +73,10 @@ private:
     void flushProgressEvent();
     void dispatchEventWhenPossible(Event&);
 
-    // Weak pointer to our XMLHttpRequest object as it is the one holding us.
-    XMLHttpRequest& m_target;
+    Ref<XMLHttpRequest> protectedTarget() { return m_target.get(); }
+
+    // Weak reference to our XMLHttpRequest object as it is the one holding us.
+    WeakRef<XMLHttpRequest, WeakPtrImplWithEventTargetData> m_target;
 
     unsigned long long m_loaded { 0 };
     unsigned long long m_total { 0 };

--- a/Source/WebCore/xml/XMLHttpRequestUpload.cpp
+++ b/Source/WebCore/xml/XMLHttpRequestUpload.cpp
@@ -46,7 +46,7 @@ XMLHttpRequestUpload::XMLHttpRequestUpload(XMLHttpRequest& request)
 
 void XMLHttpRequestUpload::eventListenersDidChange()
 {
-    m_request.updateHasRelevantEventListener();
+    Ref { m_request.get() }->updateHasRelevantEventListener();
 }
 
 bool XMLHttpRequestUpload::hasRelevantEventListener() const

--- a/Source/WebCore/xml/XMLHttpRequestUpload.h
+++ b/Source/WebCore/xml/XMLHttpRequestUpload.h
@@ -38,8 +38,8 @@ class XMLHttpRequestUpload final : public XMLHttpRequestEventTarget {
 public:
     explicit XMLHttpRequestUpload(XMLHttpRequest&);
 
-    void ref() { m_request.ref(); }
-    void deref() { m_request.deref(); }
+    void ref() { m_request->ref(); }
+    void deref() { m_request->deref(); }
 
     void dispatchProgressEvent(const AtomString& type, unsigned long long loaded, unsigned long long total);
 
@@ -52,9 +52,9 @@ private:
     void derefEventTarget() final { deref(); }
 
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::XMLHttpRequestUpload; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return m_request.scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final { return m_request->scriptExecutionContext(); }
 
-    XMLHttpRequest& m_request;
+    WeakRef<XMLHttpRequest, WeakPtrImplWithEventTargetData> m_request;
 };
 
 WebCoreOpaqueRoot root(XMLHttpRequestUpload*);

--- a/Source/WebCore/xml/XPathExpression.cpp
+++ b/Source/WebCore/xml/XPathExpression.cpp
@@ -62,7 +62,7 @@ ExceptionOr<Ref<XPathResult>> XPathExpression::evaluate(Node& contextNode, unsig
     evaluationContext.size = 1;
     evaluationContext.position = 1;
     evaluationContext.hadTypeConversionError = false;
-    auto result = XPathResult::create(contextNode.document(), m_topExpression->evaluate());
+    auto result = XPathResult::create(contextNode.protectedDocument().get(), m_topExpression->evaluate());
     evaluationContext.node = nullptr; // Do not hold a reference to the context node, as this may prevent the whole document from being destroyed in time.
 
     if (evaluationContext.hadTypeConversionError)

--- a/Source/WebCore/xml/XPathParser.h
+++ b/Source/WebCore/xml/XPathParser.h
@@ -75,7 +75,7 @@ private:
     Token nextTokenInternal();
 
     const String& m_data;
-    RefPtr<XPathNSResolver> m_resolver;
+    const RefPtr<XPathNSResolver> m_resolver;
 
     unsigned m_nextPos { 0 };
     int m_lastTokenType { 0 };

--- a/Source/WebCore/xml/XPathValue.cpp
+++ b/Source/WebCore/xml/XPathValue.cpp
@@ -117,7 +117,7 @@ String Value::toString() const
     case Type::NodeSet:
         if (m_data->nodeSet.isEmpty())
             return emptyString();
-        return stringValue(m_data->nodeSet.firstNode());
+        return stringValue(RefPtr { m_data->nodeSet.firstNode() }.get());
     case Type::String:
         return m_data->string;
     case Type::Number:


### PR DESCRIPTION
#### 6255629e282868120f6afbca98fe44699d866463
<pre>
Reduce unsafeness in WebCore/xml some more
<a href="https://bugs.webkit.org/show_bug.cgi?id=295484">https://bugs.webkit.org/show_bug.cgi?id=295484</a>

Reviewed by Chris Dumez.

Helps with <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/297055@main">https://commits.webkit.org/297055@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5009e924a538adc6322f70924b850a7a7489a5a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110452 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30111 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20544 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116477 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60706 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112415 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30790 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38698 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/83997 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113400 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/24575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/99457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64438 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/23939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/17596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60273 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/93960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/17652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119268 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37492 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27824 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/92965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37866 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/95725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/92788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/37787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/15522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/33438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17808 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37387 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42858 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37049 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40389 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38758 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->