### PR TITLE
[JSC] Fix order of function's special properties returned by `Object.keys` / `Object.entries`

### DIFF
--- a/JSTests/stress/object-entries-function-special-properties.js
+++ b/JSTests/stress/object-entries-function-special-properties.js
@@ -1,0 +1,19 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+var fn = () => {};
+fn.a = 1;
+Object.defineProperty(fn, "name", {enumerable: true});
+Object.defineProperty(fn, "length", {enumerable: true});
+
+const result = Object.entries(fn);
+
+shouldBe(result.length, 3);
+shouldBe(result[0][0], "length");
+shouldBe(result[0][1], 0);
+shouldBe(result[1][0], "name");
+shouldBe(result[1][1], "fn");
+shouldBe(result[2][0], "a");
+shouldBe(result[2][1], 1);

--- a/JSTests/stress/object-keys-function-special-properties.js
+++ b/JSTests/stress/object-keys-function-special-properties.js
@@ -1,0 +1,16 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+var fn = () => {};
+fn.a = 1;
+Object.defineProperty(fn, "name", {enumerable: true});
+Object.defineProperty(fn, "length", {enumerable: true});
+
+const result = Object.keys(fn);
+
+shouldBe(result.length, 3);
+shouldBe(result[0], "length");
+shouldBe(result[1], "name");
+shouldBe(result[2], "a");

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -28,9 +28,6 @@ test/built-ins/Iterator/concat/next-method-returns-throwing-value.js:
 test/built-ins/Map/prototype/getOrInsertComputed/canonical-key-passed-to-callback.js:
   default: 'Test262Error: Expected SameValue(«0», «-0») to be true'
   strict mode: 'Test262Error: Expected SameValue(«0», «-0») to be true'
-test/built-ins/Object/keys/order-after-define-property-with-function.js:
-  default: 'Test262Error: Actual [a, length] and expected [length, a] should have the same contents. '
-  strict mode: 'Test262Error: Actual [a, length] and expected [length, a] should have the same contents. '
 test/built-ins/Proxy/apply/arguments-realm.js:
   default: 'Test262Error: Expected SameValue(«function Array() {'
   strict mode: 'Test262Error: Expected SameValue(«function Array() {'

--- a/Source/JavaScriptCore/runtime/JSFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSFunction.cpp
@@ -405,6 +405,20 @@ void JSFunction::getOwnSpecialPropertyNames(JSObject* object, JSGlobalObject* gl
             propertyNames.add(vm.propertyNames->name);
         if (!thisObject->isHostOrBuiltinFunction() && thisObject->jsExecutable()->hasPrototypeProperty())
             propertyNames.add(vm.propertyNames->prototype);
+    } else if (mode == DontEnumPropertiesMode::Exclude) {
+        PropertyDescriptor descriptor;
+
+        thisObject->getOwnPropertyDescriptor(globalObject, vm.propertyNames->length, descriptor);
+        if (scope.exception()) [[unlikely]]
+            scope.clearException();
+        else if (descriptor.enumerable())
+            propertyNames.add(vm.propertyNames->length);
+
+        thisObject->getOwnPropertyDescriptor(globalObject, vm.propertyNames->name, descriptor);
+        if (scope.exception()) [[unlikely]]
+            scope.clearException();
+        else if (descriptor.enumerable())
+            propertyNames.add(vm.propertyNames->name);
     }
 }
 


### PR DESCRIPTION
#### 1f495933fd51c09f46759e319f696028318540f5
<pre>
[JSC] Fix order of function&apos;s special properties returned by `Object.keys` / `Object.entries`
<a href="https://bugs.webkit.org/show_bug.cgi?id=295485">https://bugs.webkit.org/show_bug.cgi?id=295485</a>

Reviewed by Yusuke Suzuki.

According to the specification, `OrdinaryOwnPropertyKeys` called by
`Object.keys` or `Object.entries` on function objects should return
properties in ascending chronological order[1]. This order should not
be affected by `Object.defineProperty`. Therefore, when the `length`
and `name` properties of function objects are enumerable, they should
always come first.

However, in the current JSC implementation, they come last. This patch
fixes this behavior.

Note that the `prototype` property doesn&apos;t need to be considered here
as it is not configurable[2].

[1]: <a href="https://tc39.es/ecma262/#sec-ordinaryownpropertykeys">https://tc39.es/ecma262/#sec-ordinaryownpropertykeys</a>
[2]: <a href="https://tc39.es/ecma262/#sec-function-instances">https://tc39.es/ecma262/#sec-function-instances</a>

* JSTests/stress/object-entries-function-special-properties.js: Added.
(shouldBe):
(fn):
* JSTests/stress/object-keys-function-special-properties.js: Added.
(shouldBe):
(fn):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/JSFunction.cpp:
(JSC::JSFunction::getOwnSpecialPropertyNames):

Canonical link: <a href="https://commits.webkit.org/297260@main">https://commits.webkit.org/297260@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5fb7b7ba09371f30d189fb10e8ac2f57e3736b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111058 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30724 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21155 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117089 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61325 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31405 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39306 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84427 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114005 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25090 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99989 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64873 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24433 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18134 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60908 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/103549 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94469 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18199 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119931 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109611 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38107 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28316 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93370 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38483 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96266 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93194 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23754 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38270 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16015 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34088 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37996 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43472 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/133887 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37660 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36123 "Found 2 new JSC stress test failures: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js.default, wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40994 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39363 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->