### PR TITLE
A non-invertible gradient/patternTransform make the paintserver invalid

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7694,8 +7694,6 @@ imported/w3c/web-platform-tests/svg/pservers/scripted/pattern-transform-clear.sv
 imported/w3c/web-platform-tests/svg/pservers/reftests/fill-fallback-none-1.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/pservers/reftests/fill-fallback-currentcolor-1.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/pservers/reftests/gradient-color-interpolation.svg [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/pservers/reftests/gradient-transform-01.svg [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/pservers/reftests/gradient-transform-02.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/pservers/reftests/gradient-transform-03.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/pservers/reftests/meshgradient-basic-001.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/pservers/reftests/meshgradient-basic-002.svg [ ImageOnlyFailure ]

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp
@@ -97,6 +97,9 @@ GradientData* LegacyRenderSVGResourceGradient::gradientDataForRenderer(RenderEle
         return makeUnique<GradientData>();
     }).iterator->value;
 
+    if (!gradientTransform().isInvertible())
+        return nullptr;
+
     if (gradientData.invalidate(inputs)) {
         gradientData.gradient = buildGradient(style);
         ASSERT(gradientData.userspaceTransform.isIdentity());

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp
@@ -131,6 +131,9 @@ PatternData* LegacyRenderSVGResourcePattern::buildPattern(RenderElement& rendere
     patternData->transform.scale(tileBoundaries.size() / tileImageSize);
 
     AffineTransform patternTransform = m_attributes.patternTransform();
+    if (!patternTransform.isInvertible())
+        return nullptr;
+
     if (!patternTransform.isIdentity())
         patternData->transform = patternTransform * patternData->transform;
 

--- a/Source/WebCore/svg/GradientAttributes.h
+++ b/Source/WebCore/svg/GradientAttributes.h
@@ -36,7 +36,7 @@ struct GradientAttributes {
 
     SVGSpreadMethodType spreadMethod() const { return static_cast<SVGSpreadMethodType>(m_spreadMethod); }
     SVGUnitTypes::SVGUnitType gradientUnits() const { return static_cast<SVGUnitTypes::SVGUnitType>(m_gradientUnits); }
-    AffineTransform gradientTransform() const { return m_gradientTransform; }
+    const AffineTransform& gradientTransform() const { return m_gradientTransform; }
     const GradientColorStops& stops() const { return m_stops; }
 
     void setSpreadMethod(SVGSpreadMethodType value)

--- a/Source/WebCore/svg/PatternAttributes.h
+++ b/Source/WebCore/svg/PatternAttributes.h
@@ -40,7 +40,7 @@ struct PatternAttributes {
     SVGPreserveAspectRatioValue preserveAspectRatio() const { return m_preserveAspectRatio; }
     SVGUnitTypes::SVGUnitType patternUnits() const { return m_patternUnits; }
     SVGUnitTypes::SVGUnitType patternContentUnits() const { return m_patternContentUnits; }
-    AffineTransform patternTransform() const { return m_patternTransform; }
+    const AffineTransform& patternTransform() const { return m_patternTransform; }
     const SVGPatternElement* patternContentElement() const { return m_patternContentElement.get(); }
 
     void setX(SVGLengthValue value)


### PR DESCRIPTION
#### c67c7b9ec47881a5a3f9888bed261db5b9871f5e
<pre>
A non-invertible gradient/patternTransform make the paintserver invalid
<a href="https://bugs.webkit.org/show_bug.cgi?id=295491">https://bugs.webkit.org/show_bug.cgi?id=295491</a>

Reviewed by Simon Fraser.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium-review.googlesource.com/c/chromium/src/+/5272857">https://chromium-review.googlesource.com/c/chromium/src/+/5272857</a>

The gradient/patternTransform properties follow the rules of the CSS
transforms spec:

&quot;If a transform function causes the current transformation matrix of an
object to be non-invertible, the object and its content do not get
displayed.&quot; [1]

Check if the relevant transform is non-invertible and flag the paintserver
as invalid if it is.

[1] <a href="https://drafts.csswg.org/css-transforms/#transform-function-lists">https://drafts.csswg.org/css-transforms/#transform-function-lists</a>

* LayoutTests/TestExpectations:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp:
(WebCore::LegacyRenderSVGResourceGradient::gradientDataForRenderer):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp:
(WebCore::LegacyRenderSVGResourcePattern::buildPattern):
* Source/WebCore/svg/GradientAttributes.h:
(WebCore::GradientAttributes::gradientTransform const):
* Source/WebCore/svg/PatternAttributes.h:
(WebCore::PatternAttributes::patternTransform const):

Canonical link: <a href="https://commits.webkit.org/297053@main">https://commits.webkit.org/297053@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b17f08d29000e7b1baa178c5124d7a097b7171bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110381 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30040 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20473 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116405 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60635 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112344 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30719 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38627 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83932 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113329 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24511 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99393 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64373 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23872 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17533 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60202 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93892 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17589 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119197 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37421 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27760 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92901 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37794 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95662 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92724 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23630 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37725 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15459 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33360 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37316 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42787 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36978 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40318 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38686 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->