### PR TITLE
[Model Element] Update stagemode transform subscription calls to use latest API

### DIFF
--- a/Source/WebKit/WebKitSwift/StageMode/WKStageMode.swift
+++ b/Source/WebKit/WebKitSwift/StageMode/WKStageMode.swift
@@ -26,7 +26,7 @@
 import Combine
 import Spatial
 import Foundation
-@_spi(Observation) @_spi(RealityKit) import RealityKit
+@_spi(RealityKit) import RealityKit
 import os
 import simd
 
@@ -208,9 +208,9 @@ import simd
     
     private func subscribeToPitchChanges() {
         withObservationTracking {
-#if canImport(RealityFoundation, _version: 395)
-            _ = interactionContainer.proto_observable.components[Transform.self]
-#endif
+            #if canImport(RealityFoundation, _version: "403.0.4")
+            _ = interactionContainer.observable.components[Transform.self]
+            #endif
         } onChange: { [self] in
             Task { @MainActor in
                 guard allowAnimationObservation else {
@@ -229,10 +229,10 @@ import simd
     
     private func subscribeToYawChanges() {
         withObservationTracking {
-#if canImport(RealityFoundation, _version: 395)
+            #if canImport(RealityFoundation, _version: "403.0.4")
             // By default, we do not care about the proxy, but we use the update to set the deceleration of the turntable container
-            _ = turntableAnimationProxyEntity.proto_observable.components[Transform.self]
-#endif
+            _ = turntableAnimationProxyEntity.observable.components[Transform.self]
+            #endif
         } onChange: { [self] in
             Task { @MainActor in
                 guard allowAnimationObservation else {


### PR DESCRIPTION
#### 524af8e68a6a8c25da3c48d2d90459aa1d1d8c3c
<pre>
[Model Element] Update stagemode transform subscription calls to use latest API
<a href="https://bugs.webkit.org/show_bug.cgi?id=295492">https://bugs.webkit.org/show_bug.cgi?id=295492</a>
<a href="https://rdar.apple.com/154402854">rdar://154402854</a>

Reviewed by Mike Wyrzykowski.

Adopt the latest RealityKit Entity API for observing transform changes.

* Source/WebKit/WebKitSwift/StageMode/WKStageMode.swift:
(WKStageModeInteractionDriver.subscribeToPitchChanges):
(WKStageModeInteractionDriver.subscribeToYawChanges):

Canonical link: <a href="https://commits.webkit.org/297089@main">https://commits.webkit.org/297089@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4d5d040d30df16c8ccb5143dcd60620e6f75d5f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110385 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30044 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116410 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60639 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30723 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38631 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83936 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113333 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24514 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99396 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64378 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23875 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60206 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93895 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17592 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119201 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37425 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27763 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92904 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37798 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95665 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92727 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23651 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37728 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15462 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33368 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37320 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42791 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36982 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40322 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38690 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->