### PR TITLE
[Liquid Glass] Introduce new API to specify obscured content insets on WKWebView

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.h
@@ -701,6 +701,21 @@ typedef NS_OPTIONS(NSUInteger, WKWebViewDataType) {
  */
 - (void)restoreData:(NSData *)data completionHandler:(WK_SWIFT_UI_ACTOR void(^)(NSError * _Nullable error))completionHandler NS_SWIFT_NAME(restoreData(_:completionHandler:)) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
+/*! @abstract Edge insets on all sides, relative to the web view's coordinate space, which shrink
+ * the bounds of the layout viewport. Obscured content areas (that is, parts of the web view that
+ * overlap with obscured content insets) should be covered by UI elements managed by the client,
+ * such as a navigation bar or buttons. The web view automatically adjusts how fixed and sticky
+ * elements are rendered near edges with non-zero obscured insets, to ensure compatibility and
+ * legibility.
+ *
+ * All edge insets must be non-negative. Defaults to 0 on all sides.
+ */
+#if TARGET_OS_OSX
+@property (nonatomic) NSEdgeInsets obscuredContentInsets API_AVAILABLE(macos(26.0));
+#else
+@property (nonatomic) UIEdgeInsets obscuredContentInsets API_AVAILABLE(ios(26.0), visionos(26.0));
+#endif
+
 @end
 
 #if !TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3411,6 +3411,43 @@ static WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::Fixe
 
 #endif // ENABLE(CONTENT_INSET_BACKGROUND_FILL)
 
+- (CocoaEdgeInsets)obscuredContentInsets
+{
+#if PLATFORM(IOS_FAMILY)
+    return self._obscuredInsets;
+#else
+    return self._obscuredContentInsets;
+#endif
+}
+
+- (void)setObscuredContentInsets:(CocoaEdgeInsets)insets
+{
+    if (insets.top < 0 || insets.left < 0 || insets.right < 0 || insets.bottom < 0) {
+#if PLATFORM(IOS_FAMILY)
+        [NSException raise:NSInvalidArgumentException format:@"-obscuredContentInsets cannot be negative: %@", NSStringFromUIEdgeInsets(insets)];
+#else
+        [NSException raise:NSInvalidArgumentException format:@"-obscuredContentInsets cannot be negative: { top=%f, left=%f, bottom=%f, right=%f }"
+            , insets.top, insets.left, insets.bottom, insets.right];
+#endif
+    }
+
+#if PLATFORM(IOS_FAMILY)
+    if (UIEdgeInsetsEqualToEdgeInsets(_obscuredInsets, insets))
+        return;
+
+    [self _setObscuredInsetsInternal:insets];
+    _automaticallyAdjustsViewLayoutSizesWithObscuredInset = !UIEdgeInsetsEqualToEdgeInsets(insets, UIEdgeInsetsZero);
+
+    [self _frameOrBoundsMayHaveChanged];
+#else
+    if (NSEdgeInsetsEqual(self._obscuredContentInsets, insets))
+        return;
+
+    self._automaticallyAdjustsContentInsets = NO;
+    [self _setObscuredContentInsets:insets immediate:NO];
+#endif
+}
+
 namespace WebKit {
 enum class WebViewDataType : uint32_t {
     SessionStorage

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -346,6 +346,7 @@ struct PerWebProcessState {
     std::optional<OverriddenLayoutParameters> _overriddenLayoutParameters;
 #if PLATFORM(IOS_FAMILY)
     BOOL _forcesInitialScaleFactor;
+    BOOL _automaticallyAdjustsViewLayoutSizesWithObscuredInset;
 #endif
     CGRect _inputViewBoundsInWindow;
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -210,6 +210,8 @@ enum class TapHandlingResult : uint8_t;
 @property (nonatomic, readonly, getter=_isRetainingActiveFocusedState) BOOL _retainingActiveFocusedState;
 @property (nonatomic, readonly) WebCore::IntDegrees _deviceOrientationIgnoringOverrides;
 
+- (void)_setObscuredInsetsInternal:(UIEdgeInsets)obscuredInsets;
+
 #if HAVE(UIKIT_RESIZABLE_WINDOWS)
 @property (nonatomic, readonly) BOOL _isWindowResizingEnabled;
 #endif

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.h
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.h
@@ -87,6 +87,7 @@ namespace WebKit {
 RetainPtr<UIAlertController> createUIAlertController(NSString *title, NSString *message);
 UIScrollView *scrollViewForTouches(NSSet<UITouch *> *);
 UIRectEdge uiRectEdgeForSide(WebCore::BoxSide);
+UIEdgeInsets maxEdgeInsets(const UIEdgeInsets&, const UIEdgeInsets&);
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
@@ -400,6 +400,16 @@ UIRectEdge uiRectEdgeForSide(WebCore::BoxSide side)
     return UIRectEdgeNone;
 }
 
+UIEdgeInsets maxEdgeInsets(const UIEdgeInsets& a, const UIEdgeInsets& b)
+{
+    return UIEdgeInsetsMake(
+        std::max<CGFloat>(a.top, b.top),
+        std::max<CGFloat>(a.left, b.left),
+        std::max<CGFloat>(a.bottom, b.bottom),
+        std::max<CGFloat>(a.right, b.right)
+    );
+}
+
 } // namespace WebKit
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -418,6 +418,9 @@ void WebPageProxy::handleAcceptsFirstMouse(bool acceptsFirstMouse)
 
 void WebPageProxy::setAutomaticallyAdjustsContentInsets(bool automaticallyAdjustsContentInsets)
 {
+    if (m_automaticallyAdjustsContentInsets == automaticallyAdjustsContentInsets)
+        return;
+
     m_automaticallyAdjustsContentInsets = automaticallyAdjustsContentInsets;
     updateContentInsetsIfAutomatic();
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ObscuredContentInsets.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ObscuredContentInsets.mm
@@ -191,21 +191,20 @@ TEST(ObscuredContentInsets, SetAndGetObscuredContentInsets)
     [webView _setAutomaticallyAdjustsContentInsets:NO];
 
     auto initialInsets = NSEdgeInsetsMake(100, 150, 0, 10);
-    [webView _setObscuredContentInsets:initialInsets immediate:NO];
+    [webView setObscuredContentInsets:initialInsets];
     [webView synchronouslyLoadTestPageNamed:@"simple"];
     EXPECT_TRUE(NSEdgeInsetsEqual([webView _obscuredContentInsets], initialInsets));
 
     auto finalInsets = NSEdgeInsetsMake(50, 100, 0, 10);
-    [webView _setObscuredContentInsets:finalInsets immediate:NO];
+    [webView setObscuredContentInsets:finalInsets];
     EXPECT_TRUE(NSEdgeInsetsEqual([webView _obscuredContentInsets], finalInsets));
 }
 
 TEST(ObscuredContentInsets, ScrollViewFrameWithObscuredInsets)
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
-    [webView _setAutomaticallyAdjustsContentInsets:NO];
 
-    [webView _setObscuredContentInsets:NSEdgeInsetsMake(100, 150, 30, 10) immediate:NO];
+    [webView setObscuredContentInsets:NSEdgeInsetsMake(100, 150, 30, 10)];
     [webView synchronouslyLoadTestPageNamed:@"simple"];
 
     EXPECT_EQ([webView scrollViewFrame], NSMakeRect(150, 0, 640, 600));
@@ -216,8 +215,7 @@ TEST(ObscuredContentInsets, ScrollViewFrameWithObscuredInsets)
 TEST(ObscuredContentInsets, ResizeScrollPocket)
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 600)]);
-    [webView _setAutomaticallyAdjustsContentInsets:NO];
-    [webView _setObscuredContentInsets:NSEdgeInsetsMake(100, 100, 0, 0) immediate:NO];
+    [webView setObscuredContentInsets:NSEdgeInsetsMake(100, 100, 0, 0)];
     [webView synchronouslyLoadTestPageNamed:@"simple"];
     [webView waitForNextPresentationUpdate];
     EXPECT_EQ(NSMakeRect(0, 0, 400, 100), [webView _topScrollPocket].frame);
@@ -232,8 +230,7 @@ TEST(ObscuredContentInsets, ScrollPocketCaptureColor)
 {
     RetainPtr webView = adoptNS([TestWKWebView new]);
 
-    [webView _setAutomaticallyAdjustsContentInsets:NO];
-    [webView _setObscuredContentInsets:NSEdgeInsetsMake(100, 0, 0, 0) immediate:NO];
+    [webView setObscuredContentInsets:NSEdgeInsetsMake(100, 0, 0, 0)];
     [webView setFrame:NSMakeRect(0, 0, 600, 400)];
     [webView waitForNextPresentationUpdate];
 
@@ -259,8 +256,7 @@ TEST(ObscuredContentInsets, TopOverhangColorExtensionLayer)
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 400)]);
 
     [webView setAllowsMagnification:YES];
-    [webView _setAutomaticallyAdjustsContentInsets:NO];
-    [webView _setObscuredContentInsets:NSEdgeInsetsMake(100, 0, 0, 0) immediate:NO];
+    [webView setObscuredContentInsets:NSEdgeInsetsMake(100, 0, 0, 0)];
     [webView waitForNextPresentationUpdate];
 
     [webView synchronouslyLoadTestPageNamed:@"top-fixed-element"];
@@ -308,15 +304,15 @@ TEST(ObscuredContentInsets, TopScrollPocketKVO)
     EXPECT_NULL([webView _topScrollPocket]);
     EXPECT_EQ([observer changeCount], 0u);
 
-    [webView _setAutomaticallyAdjustsContentInsets:NO];
-    [webView _setObscuredContentInsets:NSEdgeInsetsMake(100, 0, 0, 0) immediate:YES];
+    [webView setObscuredContentInsets:NSEdgeInsetsMake(100, 0, 0, 0)];
     [webView waitForNextPresentationUpdate];
 
     [webView synchronouslyLoadTestPageNamed:@"top-fixed-element"];
     EXPECT_NOT_NULL([webView _topScrollPocket]);
     EXPECT_EQ([observer changeCount], 1u);
 
-    [webView _setObscuredContentInsets:NSEdgeInsetsMake(0, 0, 0, 0) immediate:YES];
+    [webView setObscuredContentInsets:NSEdgeInsetsMake(0, 0, 0, 0)];
+    [webView waitForNextPresentationUpdate];
     EXPECT_NULL([webView _topScrollPocket]);
     EXPECT_EQ([observer changeCount], 2u);
 }
@@ -338,8 +334,7 @@ TEST(ObscuredContentInsets, AdjustedColorForTopContentInsetColor)
 
     [webView setUIDelegate:delegate.get()];
     [webView setAppearance:[NSAppearance appearanceNamed:NSAppearanceNameAqua]];
-    [webView _setAutomaticallyAdjustsContentInsets:NO];
-    [webView _setObscuredContentInsets:NSEdgeInsetsMake(100, 0, 0, 0) immediate:YES];
+    [webView setObscuredContentInsets:NSEdgeInsetsMake(100, 0, 0, 0)];
     [webView synchronouslyLoadTestPageNamed:@"top-fixed-element"];
     [webView waitForNextPresentationUpdate];
 

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
@@ -99,6 +99,8 @@ private:
 
     JSObjectRef fixedContainerEdgeColors() const final;
     void cancelFixedColorExtensionFadeAnimations() const final;
+
+    void setObscuredInsets(double top, double right, double bottom, double left) final;
 };
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -451,4 +451,15 @@ void UIScriptControllerCocoa::cancelFixedColorExtensionFadeAnimations() const
     [webView() _cancelFixedColorExtensionFadeAnimationsForTesting];
 }
 
+void UIScriptControllerCocoa::setObscuredInsets(double top, double right, double bottom, double left)
+{
+#if PLATFORM(IOS_FAMILY)
+    auto insets = UIEdgeInsetsMake(top, left, bottom, right);
+    [webView() scrollView].contentInset = insets;
+#else
+    auto insets = NSEdgeInsetsMake(top, left, bottom, right);
+#endif
+    [webView() setObscuredContentInsets:insets];
+}
+
 } // namespace WTR

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
@@ -179,7 +179,6 @@ private:
 
     void beginInteractiveObscuredInsetsChange() final;
     void endInteractiveObscuredInsetsChange() final;
-    void setObscuredInsets(double top, double right, double bottom, double left) final;
 
     bool suppressSoftwareKeyboard() const final;
     void setSuppressSoftwareKeyboard(bool) final;

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -1395,18 +1395,6 @@ void UIScriptControllerIOS::beginInteractiveObscuredInsetsChange()
     [webView() _beginInteractiveObscuredInsetsChange];
 }
 
-void UIScriptControllerIOS::setObscuredInsets(double top, double right, double bottom, double left)
-{
-    RetainPtr webView = this->webView();
-
-    auto insets = UIEdgeInsetsMake(top, left, bottom, right);
-    auto insetSize = UIEdgeInsetsInsetRect([webView bounds], insets).size;
-
-    [webView scrollView].contentInset = insets;
-    [webView _setObscuredInsets:insets];
-    [webView _overrideLayoutParametersWithMinimumLayoutSize:insetSize minimumUnobscuredSizeOverride:insetSize maximumUnobscuredSizeOverride:insetSize];
-}
-
 void UIScriptControllerIOS::endInteractiveObscuredInsetsChange()
 {
     [webView() _endInteractiveObscuredInsetsChange];


### PR DESCRIPTION
#### 4233e371219bf7f7637cd489f5417baabc64d0a9
<pre>
[Liquid Glass] Introduce new API to specify obscured content insets on WKWebView
<a href="https://bugs.webkit.org/show_bug.cgi?id=294685">https://bugs.webkit.org/show_bug.cgi?id=294685</a>
<a href="https://rdar.apple.com/153876011">rdar://153876011</a>

Reviewed by Abrar Rahman Protyasha.

Add support for a new `-obscuredContentInsets` property on `WKWebView`. This property is nearly
identical to the existing `-_obscuredInset` property on iOS and the `-_topContentInset` property on
macOS, both of which are currently used to inset the layout viewport (relative to the web view&apos;s
bounds) to account for overlapping browser UI, such as the tab bar or unified field.

On macOS, this is just a thin wrapper around `-_setObscuredContentInsets:… immediate:NO`. However,
on iOS, this effectively wraps *both* `-_setObscuredInsets:` and
`-_overrideLayoutParametersWithMinimumLayoutSize:…:`. When this API is used (and notably, when the
existing SPI is _not_ used), the active view layout size will be automatically inset, such that the
layout viewport fits within the unobscured area.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView obscuredContentInsets]):
(-[WKWebView setObscuredContentInsets:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView activeViewLayoutSize:]):

Automatically inset the view layout size by obscured content insets, only if the new API was used to
specify obscured insets.

(-[WKWebView _setObscuredInsets:]):
(-[WKWebView _setObscuredInsetsInternal:]):

Add a new flag, `_automaticallyAdjustsViewLayoutSizesWithObscuredInset`, that determines whether
we should automatically shrink the layout viewport by the client-specified obscured inset, relative
to the web view bounds. This flag is enabled once the WebKit client specifies non-zero insets with
the new API, but it&apos;s actually turned off when using the legacy `-_obscuredInsets` SPI to maintain
compatibility with clients that use `-_overrideLayoutParametersWithMinimumLayoutSize:…:`.

* Source/WebKit/UIProcess/ios/UIKitUtilities.h:
* Source/WebKit/UIProcess/ios/UIKitUtilities.mm:
(WebKit::maxEdgeInsets):

Add a helper function to compute the max extents of two `UIEdgeInsets`.

* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::setAutomaticallyAdjustsContentInsets):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ObscuredContentInsets.mm:
(TestWebKitAPI::TEST(ObscuredContentInsets, SetAndGetObscuredContentInsets)):
(TestWebKitAPI::TEST(ObscuredContentInsets, ScrollViewFrameWithObscuredInsets)):
(TestWebKitAPI::TEST(ObscuredContentInsets, ResizeScrollPocket)):
(TestWebKitAPI::TEST(ObscuredContentInsets, ScrollPocketCaptureColor)):
(TestWebKitAPI::TEST(ObscuredContentInsets, TopOverhangColorExtensionLayer)):
(TestWebKitAPI::TEST(ObscuredContentInsets, TopScrollPocketKVO)):
(TestWebKitAPI::TEST(ObscuredContentInsets, AdjustedColorForTopContentInsetColor)):

Add test coverage by deploying the new API in tests, in place of the SPI
`-_setObscuredContentInsets:immediate:`.

* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h:
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::setObscuredInsets):
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h:
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::setObscuredInsets): Deleted.

Add test coverage by deploying the new API in layout tests, in place of the SPI
`-_setObscuredInset:`. Note that we no longer need to separately override layout parameters here,
because this new API takes care of both obscured insets and layout size override.

Canonical link: <a href="https://commits.webkit.org/297319@main">https://commits.webkit.org/297319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2beaff80dd09488ac95e87ed68740e33995b3411

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111369 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31035 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117401 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61637 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113331 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31716 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39617 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84642 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114316 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25320 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100257 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65089 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24663 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18395 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61221 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94704 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18462 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120588 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38418 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28547 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93565 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38794 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96529 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93389 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23792 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38496 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16269 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34434 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38307 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43784 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37972 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41305 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39674 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->