### PR TITLE
Nullptr crash in WebCore::Path::strokeContains

### DIFF
--- a/LayoutTests/fast/svg/invalid-svg-shape-path-crash-expected.txt
+++ b/LayoutTests/fast/svg/invalid-svg-shape-path-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/fast/svg/invalid-svg-shape-path-crash.html
+++ b/LayoutTests/fast/svg/invalid-svg-shape-path-crash.html
@@ -1,0 +1,19 @@
+<style>
+	:not(abbr) { position: fixed; }
+</style>
+<script>
+	if (window.testRunner)
+		testRunner.dumpAsText();
+	function runMain() {
+		let point 
+		point2 = testPolyline.isPointInStroke(point);
+	}
+</script>
+<body onload=runMain()>
+	<p>This test passes if WebKit does not crash.</p>
+	<details scrollamount="0">
+		<table background="b1/#b&gt;1qDm_" framespacing="1">
+		</th>
+		<svg rx="-1">
+			<polyline id="testPolyline" stroke="url(#gradient)" />
+</body>

--- a/Source/WebCore/rendering/svg/RenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.cpp
@@ -266,6 +266,8 @@ bool RenderSVGShape::isPointInFill(const FloatPoint& point)
 
 bool RenderSVGShape::isPointInStroke(const FloatPoint& point)
 {
+    updateShapeFromElement();
+
     if (!style().svgStyle().hasStroke())
         return false;
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
@@ -320,6 +320,8 @@ bool LegacyRenderSVGShape::isPointInFill(const FloatPoint& point)
 
 bool LegacyRenderSVGShape::isPointInStroke(const FloatPoint& point)
 {
+    updateShapeFromElement();
+
     if (!style().svgStyle().hasStroke())
         return false;
 


### PR DESCRIPTION
#### 2efd9a3673fb6527191030e63baf253dee7d8eec
<pre>
Nullptr crash in WebCore::Path::strokeContains
<a href="https://bugs.webkit.org/show_bug.cgi?id=295493">https://bugs.webkit.org/show_bug.cgi?id=295493</a>
<a href="https://rdar.apple.com/153081244">rdar://153081244</a>

Reviewed by NOBODY (OOPS!).

Ensure the SVG shape has a valid path before checking geometry.

* LayoutTests/fast/svg/invalid-svg-shape-path-crash-expected.txt: Added.
* LayoutTests/fast/svg/invalid-svg-shape-path-crash.html: Added.
* Source/WebCore/rendering/svg/RenderSVGShape.cpp:
(WebCore::RenderSVGShape::isPointInStroke):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
(WebCore::LegacyRenderSVGShape::isPointInStroke):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2efd9a3673fb6527191030e63baf253dee7d8eec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30785 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21216 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117150 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61387 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113081 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31466 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39367 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84479 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114066 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25143 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100046 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64925 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24488 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18190 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60970 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94523 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18254 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120094 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38168 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28372 "Found 1 new test failure: fast/svg/invalid-svg-shape-path-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93418 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38544 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96321 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93242 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38328 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16069 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34153 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38057 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43534 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37722 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41055 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39424 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->