### PR TITLE
[WebDriver][BiDi] Move event subscription inside the browser.

### DIFF
--- a/Source/WebDriver/Session.cpp
+++ b/Source/WebDriver/Session.cpp
@@ -3308,8 +3308,6 @@ void Session::dispatchBidiMessage(RefPtr<JSON::Object>&& message)
         return;
     }
 
-    // FIXME: Move event subscription into the browser, so we can just forward the events to the client
-    // https://bugs.webkit.org/show_bug.cgi?id=295497
     if (bidiMessage->getString("type"_s) == "event"_s) {
         if (bidiMessage->size() < 3 || (bidiMessage->find("method"_s) == bidiMessage->end()) || (bidiMessage->find("params"_s) == bidiMessage->end())) {
             RELEASE_LOG(WebDriverBiDi, "Session::dispatchBidiMessage: Malformed bidi event: %s", bidiMessageValue->toJSONString().utf8().data());
@@ -3317,10 +3315,6 @@ void Session::dispatchBidiMessage(RefPtr<JSON::Object>&& message)
         }
 
         auto bidiMethod = bidiMessage->getString("method"_s);
-        if (!eventIsEnabled(bidiMethod, { })) {
-            RELEASE_LOG(WebDriverBiDi, "Message %s is an unknown event or not enabled, ignoring.", bidiMethod.utf8().data());
-            return;
-        }
         if (bidiMethod == "log.entryAdded"_s)
             bidiMessage = processLogEntryAdded(WTF::move(bidiMessage));
 
@@ -3403,125 +3397,6 @@ RefPtr<JSON::Object> Session::processLogEntryAdded(RefPtr<JSON::Object>&& messag
     // https://bugs.webkit.org/show_bug.cgi?id=282980
 
     return body;
-}
-
-bool Session::eventIsEnabled(const String& eventName, const Vector<String>&)
-{
-    // https://w3c.github.io/webdriver-bidi/#event-is-enabled
-
-    AtomString atomEventName { eventName };
-
-    if (!m_eventSubscriptionCounts.contains(atomEventName))
-        return false;
-
-    for (const auto& subscription : m_eventSubscriptions) {
-        // FIXME: Add support to subscribe to specific browsing contexts
-        // https://bugs.webkit.org/show_bug.cgi?id=282981
-        if (!subscription.value.isGlobal())
-            continue;
-
-        if (subscription.value.events.contains(atomEventName))
-            return true;
-    }
-
-    return false;
-}
-
-void Session::subscribeForEvents(const Vector<String>& events, Vector<String>&& browsingContextIDs, Vector<String>&& userContextIDs, Function<void(CommandResult&&)>&& completionHandler)
-{
-    // FIXME: Process/validate list of event names (e.g. expanding if given only the module name)
-    // https://bugs.webkit.org/show_bug.cgi?id=291371
-    auto subscriptionID = WTF::createVersion4UUIDString();
-
-    for (const auto& event : events) {
-        auto addResult = m_eventSubscriptionCounts.add(AtomString { event }, 1);
-        if (!addResult.isNewEntry)
-            addResult.iterator->value++;
-    }
-
-    Vector<AtomString> atomEventNames;
-    for (const auto& event : events)
-        atomEventNames.append(AtomString { event });
-
-    m_eventSubscriptions.add(subscriptionID, EventSubscription { subscriptionID, WTF::move(atomEventNames), WTF::move(browsingContextIDs), WTF::move(userContextIDs) });
-    completionHandler(CommandResult::success(JSON::Value::create(subscriptionID)));
-}
-
-void Session::unsubscribeByIDs(const Vector<EventSubscriptionID>& subscriptionIDs, Function<void(CommandResult&&)>&& completionHandler)
-{
-    for (const auto& id : subscriptionIDs) {
-        if (!m_eventSubscriptions.contains(id)) {
-            completionHandler(CommandResult::fail(CommandResult::ErrorCode::InvalidArgument, "At least one subscription id is unknown"_s));
-            return;
-        }
-    }
-
-    for (const auto& id : subscriptionIDs) {
-        const auto& subscription = m_eventSubscriptions.get(id);
-
-        for (const auto& event : subscription.events) {
-            auto removeResult = m_eventSubscriptionCounts.find(event);
-            if (removeResult != m_eventSubscriptionCounts.end()) {
-                if (!(--removeResult->value))
-                    m_eventSubscriptionCounts.remove(event);
-            }
-        }
-        m_eventSubscriptions.remove(id);
-    }
-    completionHandler(CommandResult::success());
-}
-
-void Session::unsubscribeByEventName(const Vector<String>& eventNames, Function<void(CommandResult&&)>&& completionHandler)
-
-{
-    HashMap<String, EventSubscription> subscriptionsToKeep;
-    HashSet<String> matchedEvents;
-    // FIXME: Process/validate list of event names (e.g. expanding if given only the module name)
-    // https://bugs.webkit.org/show_bug.cgi?id=291371
-    for (const auto& eventName : eventNames) {
-        auto atomEventName = AtomString { eventName };
-        for (const auto& subscription : m_eventSubscriptions) {
-            if (!subscription.value.events.contains(atomEventName)) {
-                subscriptionsToKeep.add(subscription.value.id, subscription.value);
-                continue;
-            }
-
-            // FIXME: Add support to subscribe to specific browsing contexts
-            // https://bugs.webkit.org/show_bug.cgi?id=282981
-            // In this case, only process them if we were given the "contexts" parameter
-            if (!subscription.value.isGlobal()) {
-                subscriptionsToKeep.add(subscription.value.id, subscription.value);
-                continue;
-            }
-
-            auto currentSubscriptionEventNames = subscription.value.events;
-            currentSubscriptionEventNames.removeAll(atomEventName);
-            matchedEvents.add(eventName);
-            if (!currentSubscriptionEventNames.isEmpty()) {
-                auto clonedSubscription = subscription.value;
-                clonedSubscription.events = currentSubscriptionEventNames;
-                subscriptionsToKeep.add(clonedSubscription.id, WTF::move(clonedSubscription));
-            }
-        }
-    }
-
-    if (matchedEvents.size() != eventNames.size()) {
-        completionHandler(CommandResult::fail(CommandResult::ErrorCode::InvalidArgument));
-        return;
-    }
-
-    // Only modify the actual subscriptions after we validated all requested events.
-    m_eventSubscriptions = WTF::move(subscriptionsToKeep);
-    m_eventSubscriptionCounts.clear();
-    for (const auto& subscription : m_eventSubscriptions.values()) {
-        for (const auto& event : subscription.events) {
-            auto addResult = m_eventSubscriptionCounts.add(event, 1);
-            if (!addResult.isNewEntry)
-                addResult.iterator->value++;
-        }
-    }
-
-    completionHandler(CommandResult::success());
 }
 
 void Session::relayBidiCommand(const String& message, unsigned commandId, Function<void(WebSocketMessageHandler::Message&&)>&& completionHandler)

--- a/Source/WebDriver/Session.h
+++ b/Source/WebDriver/Session.h
@@ -49,22 +49,6 @@ namespace WebDriver {
 class CommandResult;
 class SessionHost;
 
-#if ENABLE(WEBDRIVER_BIDI)
-using EventSubscriptionID = String;
-
-struct EventSubscription {
-    EventSubscriptionID id;
-    Vector<AtomString> events;
-    Vector<String> browsingContextIDs;
-    Vector<String> userContextIDs;
-
-    bool isGlobal() const
-    {
-        return browsingContextIDs.isEmpty() && userContextIDs.isEmpty();
-    }
-};
-#endif
-
 class Session :
 #if ENABLE(WEBDRIVER_BIDI)
 public BidiMessageHandler // Inherits RefCounted
@@ -175,9 +159,6 @@ public:
     void takeScreenshot(std::optional<String> elementID, std::optional<bool> scrollIntoView, Function<void(CommandResult&&)>&&);
 
 #if ENABLE(WEBDRIVER_BIDI)
-    void subscribeForEvents(const Vector<String>& events, Vector<String>&& browsingContextIDs, Vector<String>&& userContextIDs, Function<void(CommandResult&&)>&&);
-    void unsubscribeByIDs(const Vector<EventSubscriptionID>&, Function<void(CommandResult&&)>&&);
-    void unsubscribeByEventName(const Vector<String>& events, Function<void(CommandResult&&)>&&);
     void dispatchBidiMessage(RefPtr<JSON::Object>&&);
     void relayBidiCommand(const String&, unsigned commandId, Function<void(WebSocketMessageHandler::Message&&)>&&);
 #endif
@@ -291,14 +272,7 @@ private:
 #if ENABLE(WEBDRIVER_BIDI)
     bool m_hasBiDiEnabled { false };
 
-    // https://w3c.github.io/webdriver-bidi/#events
-    HashMap<AtomString, unsigned> m_eventSubscriptionCounts;
-    HashMap<EventSubscriptionID, EventSubscription> m_eventSubscriptions;
     WeakPtr<WebSocketServer> m_bidiServer;
-
-    bool eventIsEnabled(const String&, const Vector<String>&);
-    void emitEvent(const String&, RefPtr<JSON::Object>&&);
-    String toInternalEventName(const String&);
 
     // Actual event handlers
     RefPtr<JSON::Object> processLogEntryAdded(RefPtr<JSON::Object>&&);

--- a/Source/WebDriver/WebDriverService.cpp
+++ b/Source/WebDriver/WebDriverService.cpp
@@ -297,8 +297,6 @@ const WebDriverService::Command WebDriverService::s_commands[] = {
 #if ENABLE(WEBDRIVER_BIDI)
 const WebDriverService::BidiCommand WebDriverService::s_bidiCommands[] = {
     { "session.status"_s, &WebDriverService::bidiSessionStatus },
-    { "session.subscribe"_s, &WebDriverService::bidiSessionSubscribe },
-    { "session.unsubscribe"_s, &WebDriverService::bidiSessionUnsubscribe },
 };
 #endif
 
@@ -2737,95 +2735,6 @@ void WebDriverService::bidiSessionStatus(unsigned id, RefPtr<JSON::Object>&&, Fu
         result->setString("message"_s, "Maximum number of sessions created"_s);
 
     completionHandler(WebSocketMessageHandler::Message::reply("success"_s, id, WTF::move(result)));
-}
-
-void WebDriverService::bidiSessionSubscribe(unsigned id, RefPtr<JSON::Object>&&parameters, Function<void(WebSocketMessageHandler::Message&&)>&& completionHandler)
-{
-    // https://w3c.github.io/webdriver-bidi/#command-session-subscribe
-    auto eventNamesJSON = parameters->getArray("events"_s);
-
-    if (!eventNamesJSON) {
-        completionHandler(WebSocketMessageHandler::Message::fail(CommandResult::ErrorCode::InvalidArgument, std::nullopt, "Missing 'events' parameter"_s, id));
-        return;
-    }
-
-    // FIXME: Support event priorities.
-    // https://bugs.webkit.org/show_bug.cgi?id=282436
-    // FIXME: Support by-context subscriptions.
-    // https://bugs.webkit.org/show_bug.cgi?id=282981
-    Vector<String> eventNames;
-    for (auto& eventNameJS : *eventNamesJSON) {
-        auto eventName = eventNameJS->asString();
-        if (!eventName) {
-            completionHandler(WebSocketMessageHandler::Message::fail(CommandResult::ErrorCode::InvalidArgument, std::nullopt, "Invalid event name"_s, id));
-            return;
-        }
-        eventNames.append(eventName);
-    }
-    m_session->subscribeForEvents(eventNames, { }, { }, [id, completionHandler = WTF::move(completionHandler)](CommandResult&& subscriptionResult) mutable {
-        if (subscriptionResult.isError()) {
-            auto errorMessage = subscriptionResult.errorMessage() ? subscriptionResult.errorMessage() : "Failed to subscribe"_s;
-            completionHandler(WebSocketMessageHandler::Message::fail(CommandResult::ErrorCode::InvalidArgument, std::nullopt, errorMessage, id));
-            return;
-        }
-        auto result = JSON::Object::create();
-        result->setString("subscription"_s, subscriptionResult.result()->asString());
-
-        completionHandler(WebSocketMessageHandler::Message::reply("success"_s, id, WTF::move(result)));
-    });
-}
-
-void WebDriverService::bidiSessionUnsubscribe(unsigned id, RefPtr<JSON::Object>&&parameters, Function<void(WebSocketMessageHandler::Message&&)>&& completionHandler)
-{
-    // https://w3c.github.io/webdriver-bidi/#command-session-unsubscribe
-    auto subscriptions = parameters->getArray("subscriptions"_s);
-    if (!subscriptions) {
-        auto events = parameters->getArray("events"_s);
-        if (!events) {
-            completionHandler(WebSocketMessageHandler::Message::fail(CommandResult::ErrorCode::InvalidArgument, std::nullopt, "Missing either 'events' or 'subscriptions' parameter"_s, id));
-            return;
-        }
-
-        Vector<String> eventNames;
-        for (auto& event : *events) {
-            auto eventName = event->asString();
-            if (!eventName) {
-                completionHandler(WebSocketMessageHandler::Message::fail(CommandResult::ErrorCode::InvalidArgument, std::nullopt, "Invalid event name"_s, id));
-                return;
-            }
-
-            eventNames.append(eventName);
-        }
-
-        m_session->unsubscribeByEventName(eventNames, [id, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
-            if (result.isError()) {
-                auto errorMessage = result.errorMessage() ? result.errorMessage() : "Failed to unsubscribe"_s;
-                completionHandler(WebSocketMessageHandler::Message::fail(result.errorCode(), std::nullopt, errorMessage, id));
-                return;
-            }
-            completionHandler(WebSocketMessageHandler::Message::reply("success"_s, id, JSON::Value::null()));
-        });
-        return;
-    }
-
-    Vector<String> subscriptionsIDs;
-    for (auto& subscription : *subscriptions) {
-        auto subscriptionID = subscription->asString();
-        if (!subscriptionID) {
-            completionHandler(WebSocketMessageHandler::Message::fail(CommandResult::ErrorCode::InvalidArgument, std::nullopt, "Invalid subscription ID"_s, id));
-            return;
-        }
-        subscriptionsIDs.append(subscriptionID);
-    }
-
-    m_session->unsubscribeByIDs(WTF::move(subscriptionsIDs), [id, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
-        if (result.isError()) {
-            auto errorMessage = result.errorMessage() ? result.errorMessage() : "Failed to unsubscribe"_s;
-            completionHandler(WebSocketMessageHandler::Message::fail(result.errorCode(), std::nullopt, errorMessage, id));
-            return;
-        }
-        completionHandler(WebSocketMessageHandler::Message::reply("success"_s, id, JSON::Value::null()));
-    });
 }
 
 void WebDriverService::clientDisconnected(const WebSocketMessageHandler::Connection& connection)

--- a/Source/WebDriver/WebDriverService.h
+++ b/Source/WebDriver/WebDriverService.h
@@ -139,8 +139,6 @@ private:
 
 #if ENABLE(WEBDRIVER_BIDI)
     void bidiSessionStatus(unsigned id, RefPtr<JSON::Object>&&, Function<void (WebSocketMessageHandler::Message&&)>&&);
-    void bidiSessionSubscribe(unsigned id, RefPtr<JSON::Object>&&, Function<void (WebSocketMessageHandler::Message&&)>&&);
-    void bidiSessionUnsubscribe(unsigned id, RefPtr<JSON::Object>&&, Function<void (WebSocketMessageHandler::Message&&)>&&);
 #endif
 
     static Capabilities platformCapabilities();

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -594,6 +594,7 @@ UIProcess/Automation/BidiBrowserAgent.cpp @no-unify
 UIProcess/Automation/BidiBrowsingContextAgent.cpp @no-unify
 UIProcess/Automation/BidiPermissionsAgent.cpp @no-unify
 UIProcess/Automation/BidiScriptAgent.cpp @no-unify
+UIProcess/Automation/BidiSessionAgent.cpp @no-unify
 UIProcess/Automation/BidiStorageAgent.cpp @no-unify
 UIProcess/Automation/BidiUserContext.cpp @no-unify
 UIProcess/Automation/SimulatedInputDispatcher.cpp @no-unify

--- a/Source/WebKit/UIProcess/Automation/BidiEventNames.h
+++ b/Source/WebKit/UIProcess/Automation/BidiEventNames.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/text/ASCIILiteral.h>
+
+namespace WebKit {
+namespace BidiEventNames {
+namespace BrowsingContext {
+static constexpr auto ContextCreated = "browsingContext.contextCreated"_s;
+static constexpr auto ContextDestroyed = "browsingContext.contextDestroyed"_s;
+static constexpr auto DomContentLoaded = "browsingContext.domContentLoaded"_s;
+static constexpr auto FragmentNavigated = "browsingContext.fragmentNavigated"_s;
+static constexpr auto Load = "browsingContext.load"_s;
+static constexpr auto NavigationAborted = "browsingContext.navigationAborted"_s;
+static constexpr auto NavigationCommitted = "browsingContext.navigationCommitted"_s;
+static constexpr auto NavigationFailed = "browsingContext.navigationFailed"_s;
+static constexpr auto NavigationStarted = "browsingContext.navigationStarted"_s;
+static constexpr auto UserPromptClosed = "browsingContext.userPromptClosed"_s;
+static constexpr auto UserPromptOpened = "browsingContext.userPromptOpened"_s;
+} // namespace BrowsingContext
+
+namespace Log {
+static constexpr auto EntryAdded = "log.entryAdded"_s;
+} // namespace Log
+
+} // namespace BidiEventNames
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/Automation/BidiSessionAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiSessionAgent.cpp
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2025 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "BidiSessionAgent.h"
+
+#if ENABLE(WEBDRIVER_BIDI)
+
+#include "Logging.h"
+#include "WebAutomationSession.h"
+#include "WebAutomationSessionMacros.h"
+#include "WebDriverBidiProtocolObjects.h"
+#include "WebPageProxy.h"
+#include <wtf/HashSet.h>
+#include <wtf/UUID.h>
+
+namespace WebKit {
+
+using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BidiSessionAgent);
+
+BidiSessionAgent::BidiSessionAgent(WebAutomationSession& session, BackendDispatcher& backendDispatcher)
+    : m_session(session)
+    , m_sessionDomainDispatcher(BidiSessionBackendDispatcher::create(backendDispatcher, this))
+{
+}
+
+BidiSessionAgent::~BidiSessionAgent() = default;
+
+void BidiSessionAgent::subscribe(Ref<JSON::Array>&& events, RefPtr<JSON::Array>&& contexts, RefPtr<JSON::Array>&& userContexts, Inspector::CommandCallback<Inspector::Protocol::BidiSession::SubscriptionID>&& callback)
+{
+    // FIXME: Process/validate list of event names (e.g. expanding if given only the module name)
+    // https://bugs.webkit.org/show_bug.cgi?id=291371
+
+    auto subscriptionID = WTF::createVersion4UUIDString();
+
+    HashSet<AtomString> atomEventNames;
+    for (const auto& event : events.get()) {
+        auto eventName = event->asString();
+
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(eventName.isEmpty(), InvalidParameter, "Event name must be a valid string."_s);
+        atomEventNames.add(AtomString { eventName });
+    }
+
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(contexts && userContexts && (contexts->length() > 0) && (userContexts->length() > 0), InvalidParameter, "Contexts and user contexts cannot be used together."_s);
+
+    // FIXME: Support by-context subscriptions.
+    // https://webkit.org/b/282981
+    // Also: spec says we need to convert into top-level browsing contexts.
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(contexts && contexts->length(), NotImplemented, "Subscriptions by context are not supported yet."_s);
+
+    // FIXME: Support by-userContext subscriptions
+    // https://webkit.org/b/309502
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(userContexts && userContexts->length(), NotImplemented, "Subscriptions by userContext are not supported yet."_s);
+
+    for (const auto& event : atomEventNames) {
+        auto addResult = m_eventSubscriptionCounts.add(event, 1);
+        if (!addResult.isNewEntry)
+            addResult.iterator->value++;
+    }
+
+    LOG(Automation, "BidiSessionAgent::subscribe: adding subscriptionID=%s, events=%s",
+        subscriptionID.utf8().data(),
+        events->toJSONString().utf8().data());
+    m_eventSubscriptions.add(subscriptionID, BidiEventSubscription { subscriptionID, WTF::move(atomEventNames), { }, { } });
+
+    callback({ subscriptionID });
+}
+
+void BidiSessionAgent::unsubscribeByEventName(RefPtr<JSON::Array>&& events, Inspector::CommandCallback<void>&& callback)
+{
+IGNORE_GCC_WARNINGS_BEGIN("format-overflow")
+    LOG(Automation, "BidiSessionAgent::unsubscribeByEventName: events=%s",
+        events ? events->toJSONString().utf8().data() : "null");
+IGNORE_GCC_WARNINGS_END
+
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(!events || !events->length(), InvalidParameter, "At least one event name must be provided."_s);
+
+    HashMap<String, BidiEventSubscription> subscriptionsToKeep;
+    HashSet<String> matchedEvents;
+    // FIXME: Process/validate list of event names (e.g. expanding if given only the module name)
+    // https://bugs.webkit.org/show_bug.cgi?id=291371
+    HashSet<AtomString> eventNames;
+    for (const auto& event : *events) {
+        auto eventName = event->asString();
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(eventName.isEmpty(), InvalidParameter, "Event name must be a valid non-empty string."_s);
+        eventNames.add(AtomString { eventName });
+    }
+
+    for (const auto& subscription : m_eventSubscriptions) {
+        auto commonEventNames = eventNames.intersectionWith(subscription.value.events);
+        if (!commonEventNames.size()) {
+            subscriptionsToKeep.add(subscription.value.id, subscription.value);
+            continue;
+        }
+
+        auto currentSubscriptionEventNames = subscription.value.events;
+        for (const auto& eventName : commonEventNames) {
+            matchedEvents.add(eventName);
+            currentSubscriptionEventNames.remove(eventName);
+        }
+        if (!currentSubscriptionEventNames.isEmpty()) {
+            auto clonedSubscription = subscription.value;
+            clonedSubscription.events = currentSubscriptionEventNames;
+            subscriptionsToKeep.add(clonedSubscription.id, WTF::move(clonedSubscription));
+        }
+    }
+
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(matchedEvents.size() != eventNames.size(), InvalidParameter, "Some events are not subscribed to."_s);
+
+    // Only modify the actual subscriptions after we validated all requested events.
+    m_eventSubscriptions = WTF::move(subscriptionsToKeep);
+    m_eventSubscriptionCounts.clear();
+    for (const auto& subscription : m_eventSubscriptions.values()) {
+        for (const auto& event : subscription.events) {
+            auto addResult = m_eventSubscriptionCounts.add(event, 1);
+            if (!addResult.isNewEntry)
+                addResult.iterator->value++;
+        }
+    }
+
+    callback({ });
+}
+
+void BidiSessionAgent::unsubscribe(RefPtr<JSON::Array>&& subscriptions, RefPtr<JSON::Array>&& events, Inspector::CommandCallback<void>&& callback)
+{
+IGNORE_GCC_WARNINGS_BEGIN("format-overflow")
+    LOG(Automation, "BidiSessionAgent::unsubscribe: subscriptions=%s, events=%s",
+        subscriptions ? subscriptions->toJSONString().utf8().data() : "null",
+        events ? events->toJSONString().utf8().data() : "null");
+IGNORE_GCC_WARNINGS_END
+
+    if (!subscriptions) {
+        unsubscribeByEventName(WTF::move(events), WTF::move(callback));
+        return;
+    }
+
+    Vector<String> subscriptionIDs;
+    for (auto& subscription : *subscriptions) {
+        auto subscriptionID = subscription->asString();
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(!subscriptionID, InvalidParameter, "Subscription ID must be a valid string."_s);
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(!m_eventSubscriptions.contains(subscriptionID), InvalidParameter, "At least one subscription ID is unknown."_s);
+        subscriptionIDs.append(subscriptionID);
+    }
+
+    for (const auto& id : subscriptionIDs) {
+        const auto& subscription = m_eventSubscriptions.get(id);
+
+        for (const auto& event : subscription.events) {
+            auto findResult = m_eventSubscriptionCounts.find(event);
+            if (findResult != m_eventSubscriptionCounts.end()) {
+                if (!(--findResult->value))
+                    m_eventSubscriptionCounts.remove(event);
+            }
+        }
+        m_eventSubscriptions.remove(id);
+    }
+
+    callback({ });
+}
+
+bool BidiSessionAgent::eventIsEnabled(const String& eventName, const HashSet<String>& browsingContexts)
+{
+    // https://w3c.github.io/webdriver-bidi/#event-is-enabled
+    AtomString atomEventName { eventName };
+
+    if (!m_eventSubscriptionCounts.contains(atomEventName))
+        return false;
+
+    for (const auto& subscription : m_eventSubscriptions) {
+        // FIXME: Add support to subscribe to specific browsing contexts
+        // https://bugs.webkit.org/show_bug.cgi?id=282981
+        if (!subscription.value.isGlobal())
+            continue;
+
+        if (subscription.value.events.contains(atomEventName))
+            return true;
+    }
+
+    return false;
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBDRIVER_BIDI)

--- a/Source/WebKit/UIProcess/Automation/BidiSessionAgent.h
+++ b/Source/WebKit/UIProcess/Automation/BidiSessionAgent.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2025 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBDRIVER_BIDI)
+
+#include "AutomationProtocolObjects.h"
+#include "WebDriverBidiBackendDispatchers.h"
+#include <JavaScriptCore/InspectorBackendDispatcher.h>
+#include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/WeakPtr.h>
+#include <wtf/text/AtomString.h>
+#include <wtf/text/AtomStringHash.h>
+
+namespace WebKit {
+
+class WebAutomationSession;
+
+using BrowsingContext = Inspector::Protocol::BidiBrowsingContext::BrowsingContext;
+using SubscriptionID = Inspector::Protocol::BidiSession::SubscriptionID;
+using UserContext = Inspector::Protocol::BidiBrowser::UserContext;
+
+struct BidiEventSubscription {
+    SubscriptionID id;
+    HashSet<AtomString> events;
+    HashSet<BrowsingContext> browsingContextIDs;
+    HashSet<UserContext> userContextIDs;
+
+    bool isGlobal() const
+    {
+        return browsingContextIDs.isEmpty() && userContextIDs.isEmpty();
+    }
+};
+
+class BidiSessionAgent final : public Inspector::BidiSessionBackendDispatcherHandler {
+    WTF_MAKE_TZONE_ALLOCATED(BidiSessionAgent);
+public:
+    BidiSessionAgent(WebAutomationSession&, Inspector::BackendDispatcher&);
+    ~BidiSessionAgent() override;
+
+    void subscribe(Ref<JSON::Array>&& events, RefPtr<JSON::Array>&& contexts, RefPtr<JSON::Array>&& userContexts, Inspector::CommandCallback<Inspector::Protocol::BidiSession::SubscriptionID>&&) override;
+    void unsubscribe(RefPtr<JSON::Array>&& subscriptions, RefPtr<JSON::Array>&& events, Inspector::CommandCallback<void>&&) override;
+
+    bool eventIsEnabled(const String& eventName, const HashSet<String>& browsingContexts);
+
+private:
+
+    void unsubscribeByEventName(RefPtr<JSON::Array>&& events, Inspector::CommandCallback<void>&&);
+
+    WeakPtr<WebAutomationSession> m_session;
+    Ref<Inspector::BidiSessionBackendDispatcher> m_sessionDomainDispatcher;
+
+    // https://w3c.github.io/webdriver-bidi/#events
+    HashMap<AtomString, unsigned> m_eventSubscriptionCounts;
+    HashMap<SubscriptionID, BidiEventSubscription> m_eventSubscriptions;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBDRIVER_BIDI)

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -71,6 +71,7 @@
 
 #if ENABLE(WEBDRIVER_BIDI)
 #include "BidiBrowserAgent.h"
+#include "BidiEventNames.h"
 #include "WebDriverBidiProcessor.h"
 #endif
 
@@ -821,7 +822,9 @@ void WebAutomationSession::willShowJavaScriptDialog(WebPageProxy& page, const St
 
         // FIXME: propagate the 'userPromptHandler' from session capabilities.
         auto userPromptHandlerType = Inspector::Protocol::BidiSession::UserPromptHandlerType::Accept;
-        m_bidiProcessor->browsingContextDomainNotifier().userPromptOpened(handleForWebPageProxy(page), userPromptType, userPromptHandlerType, message, m_client->defaultTextOfCurrentJavaScriptDialogOnPage(*this, page).value_or(defaultText.value_or(emptyString())));
+        m_bidiProcessor->emitEventIfEnabled(BidiEventNames::BrowsingContext::UserPromptOpened, { }, [&]() {
+            m_bidiProcessor->browsingContextDomainNotifier().userPromptOpened(handleForWebPageProxy(page), userPromptType, userPromptHandlerType, message, m_client->defaultTextOfCurrentJavaScriptDialogOnPage(*this, page).value_or(defaultText.value_or(emptyString())));
+        });
 #endif
 
         if (page->pageLoadState().isLoading()) {
@@ -1007,7 +1010,9 @@ static String navigationIDToProtocolString(std::optional<WebCore::NavigationIden
 void WebAutomationSession::documentLoadedForFrame(const WebFrameProxy& frame, std::optional<WebCore::NavigationIdentifier> navigationID, WallTime timestamp)
 {
 #if ENABLE(WEBDRIVER_BIDI)
-    m_bidiProcessor->browsingContextDomainNotifier().domContentLoaded(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), std::trunc(timestamp.secondsSinceEpoch().milliseconds()), frame.url().string());
+    m_bidiProcessor->emitEventIfEnabled(BidiEventNames::BrowsingContext::DomContentLoaded, { }, [&]() {
+        m_bidiProcessor->browsingContextDomainNotifier().domContentLoaded(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), std::trunc(timestamp.secondsSinceEpoch().milliseconds()), frame.url().string());
+    });
 #endif
 
     if (frame.isMainFrame()) {
@@ -1030,7 +1035,9 @@ void WebAutomationSession::documentLoadedForFrame(const WebFrameProxy& frame, st
 void WebAutomationSession::loadCompletedForFrame(const WebFrameProxy& frame, std::optional<WebCore::NavigationIdentifier> navigationID, WallTime timestamp)
 {
 #if ENABLE(WEBDRIVER_BIDI)
-    m_bidiProcessor->browsingContextDomainNotifier().load(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), std::trunc(timestamp.secondsSinceEpoch().milliseconds()), frame.url().string());
+    m_bidiProcessor->emitEventIfEnabled(BidiEventNames::BrowsingContext::Load, { }, [&]() {
+        m_bidiProcessor->browsingContextDomainNotifier().load(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), std::trunc(timestamp.secondsSinceEpoch().milliseconds()), frame.url().string());
+    });
 #endif
 }
 
@@ -1079,27 +1086,37 @@ void WebAutomationSession::didCreatePage(WebPageProxy& page)
 
 void WebAutomationSession::navigationStartedForFrame(const WebFrameProxy& frame, std::optional<WebCore::NavigationIdentifier> navigationID)
 {
-    m_bidiProcessor->browsingContextDomainNotifier().navigationStarted(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), WallTime::now().secondsSinceEpoch().milliseconds(), frame.url().string());
+    m_bidiProcessor->emitEventIfEnabled(BidiEventNames::BrowsingContext::NavigationStarted, { }, [&]() {
+        m_bidiProcessor->browsingContextDomainNotifier().navigationStarted(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), WallTime::now().secondsSinceEpoch().milliseconds(), frame.url().string());
+    });
 }
 
 void WebAutomationSession::navigationCommittedForFrame(const WebFrameProxy& frame, std::optional<WebCore::NavigationIdentifier> navigationID)
 {
-    m_bidiProcessor->browsingContextDomainNotifier().navigationCommitted(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), WallTime::now().secondsSinceEpoch().milliseconds(), frame.url().string());
+    m_bidiProcessor->emitEventIfEnabled(BidiEventNames::BrowsingContext::NavigationCommitted, { }, [&]() {
+        m_bidiProcessor->browsingContextDomainNotifier().navigationCommitted(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), WallTime::now().secondsSinceEpoch().milliseconds(), frame.url().string());
+    });
 }
 
 void WebAutomationSession::navigationFailedForFrame(const WebFrameProxy& frame, std::optional<WebCore::NavigationIdentifier> navigationID)
 {
-    m_bidiProcessor->browsingContextDomainNotifier().navigationFailed(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), WallTime::now().secondsSinceEpoch().milliseconds(), frame.url().string());
+    m_bidiProcessor->emitEventIfEnabled(BidiEventNames::BrowsingContext::NavigationFailed, { }, [&]() {
+        m_bidiProcessor->browsingContextDomainNotifier().navigationFailed(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), WallTime::now().secondsSinceEpoch().milliseconds(), frame.url().string());
+    });
 }
 
 void WebAutomationSession::navigationAbortedForFrame(const WebFrameProxy& frame, std::optional<WebCore::NavigationIdentifier> navigationID)
 {
-    m_bidiProcessor->browsingContextDomainNotifier().navigationAborted(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), WallTime::now().secondsSinceEpoch().milliseconds(), frame.url().string());
+    m_bidiProcessor->emitEventIfEnabled(BidiEventNames::BrowsingContext::NavigationAborted, { }, [&]() {
+        m_bidiProcessor->browsingContextDomainNotifier().navigationAborted(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), WallTime::now().secondsSinceEpoch().milliseconds(), frame.url().string());
+    });
 }
 
 void WebAutomationSession::fragmentNavigatedForFrame(const WebFrameProxy& frame, std::optional<WebCore::NavigationIdentifier> navigationID)
 {
-    m_bidiProcessor->browsingContextDomainNotifier().fragmentNavigated(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), WallTime::now().secondsSinceEpoch().milliseconds(), frame.url().string());
+    m_bidiProcessor->emitEventIfEnabled(BidiEventNames::BrowsingContext::FragmentNavigated, { }, [&]() {
+        m_bidiProcessor->browsingContextDomainNotifier().fragmentNavigated(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), WallTime::now().secondsSinceEpoch().milliseconds(), frame.url().string());
+    });
 }
 
 void WebAutomationSession::emitContextCreatedEvent(const WebPageProxy& page)
@@ -1166,7 +1183,9 @@ void WebAutomationSession::contextCreatedForFrame(const WebFrameProxy& frame)
         userContext = contextId;
     }
 
-    m_bidiProcessor->browsingContextDomainNotifier().contextCreated(contextHandle, url, "null"_s, parentHandle, JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>::create(), clientWindow, userContext);
+    m_bidiProcessor->emitEventIfEnabled(BidiEventNames::BrowsingContext::ContextCreated, { }, [&]() {
+        m_bidiProcessor->browsingContextDomainNotifier().contextCreated(contextHandle, url, "null"_s, parentHandle, JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>::create(), clientWindow, userContext);
+    });
 }
 
 void WebAutomationSession::recursivelyEmitContextCreatedEvent(const FrameTreeNodeData& tree, std::optional<String>&& parentContext)
@@ -1195,7 +1214,9 @@ void WebAutomationSession::recursivelyEmitContextCreatedEvent(const FrameTreeNod
     // FIXME: Use JSON null instead of string "null" when Inspector::Protocol supports RefPtr<String> or std::optional<String>
     String parentContextHandle = parentContext.value_or("null"_s);
 
-    m_bidiProcessor->browsingContextDomainNotifier().contextCreated(contextHandle, url, originalOpenerHandle, parentContextHandle, WTF::move(children), clientWindow, userContext);
+    m_bidiProcessor->emitEventIfEnabled(BidiEventNames::BrowsingContext::ContextCreated, { }, [&]() {
+        m_bidiProcessor->browsingContextDomainNotifier().contextCreated(contextHandle, url, originalOpenerHandle, parentContextHandle, WTF::move(children), clientWindow, userContext);
+    });
 
     for (const auto& child : tree.children)
         recursivelyEmitContextCreatedEvent(child, contextHandle);
@@ -1218,7 +1239,9 @@ void WebAutomationSession::contextDestroyedForPage(const WebPageProxy& page)
 
     auto [clientWindow, userContext] = getClientWindowAndUserContext(page);
 
-    m_bidiProcessor->browsingContextDomainNotifier().contextDestroyed(contextHandle, url, originalOpenerHandle, parentContext, JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>::create(), clientWindow, userContext);
+    m_bidiProcessor->emitEventIfEnabled(BidiEventNames::BrowsingContext::ContextDestroyed, { }, [&]() {
+        m_bidiProcessor->browsingContextDomainNotifier().contextDestroyed(contextHandle, url, originalOpenerHandle, parentContext, JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>::create(), clientWindow, userContext);
+    });
 
     m_handleWebPageMap.remove(contextHandle);
     m_webPageHandleMap.remove(page.identifier());
@@ -1241,7 +1264,9 @@ void WebAutomationSession::contextDestroyedForFrame(const WebFrameProxy& frame)
         userContext = contextId;
     }
 
-    m_bidiProcessor->browsingContextDomainNotifier().contextDestroyed(contextHandle, url, "null"_s, parentHandle, JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>::create(), clientWindow, userContext);
+    m_bidiProcessor->emitEventIfEnabled(BidiEventNames::BrowsingContext::ContextDestroyed, { }, [&]() {
+        m_bidiProcessor->browsingContextDomainNotifier().contextDestroyed(contextHandle, url, "null"_s, parentHandle, JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>::create(), clientWindow, userContext);
+    });
 
     // Note: Frame handle cleanup is done by didDestroyFrame(), so we don't duplicate that here
 }
@@ -1619,7 +1644,9 @@ CommandResult<void> WebAutomationSession::dismissCurrentJavaScriptDialog(const I
     auto apiDialogType = m_client->typeOfCurrentJavaScriptDialogOnPage(*this, *page);
     SYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!apiDialogType, InternalError);
 
-    m_bidiProcessor->browsingContextDomainNotifier().userPromptClosed(handleForWebPageProxy(*page), toProtocolUserPromptType(apiDialogType.value()), false, m_client->userInputOfCurrentJavaScriptDialogOnPage(*this, *page).value_or(emptyString()));
+    m_bidiProcessor->emitEventIfEnabled(BidiEventNames::BrowsingContext::UserPromptClosed, { }, [&]() {
+        m_bidiProcessor->browsingContextDomainNotifier().userPromptClosed(handleForWebPageProxy(*page), toProtocolUserPromptType(apiDialogType.value()), false, m_client->userInputOfCurrentJavaScriptDialogOnPage(*this, *page).value_or(emptyString()));
+    });
 #endif
     m_client->dismissCurrentJavaScriptDialogOnPage(*this, *page);
 
@@ -1641,7 +1668,9 @@ CommandResult<void> WebAutomationSession::acceptCurrentJavaScriptDialog(const In
     auto apiDialogType = m_client->typeOfCurrentJavaScriptDialogOnPage(*this, *page);
     SYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!apiDialogType, InternalError);
 
-    m_bidiProcessor->browsingContextDomainNotifier().userPromptClosed(handleForWebPageProxy(*page), toProtocolUserPromptType(apiDialogType.value()), true, m_client->userInputOfCurrentJavaScriptDialogOnPage(*this, *page).value_or(emptyString()));
+    m_bidiProcessor->emitEventIfEnabled(BidiEventNames::BrowsingContext::UserPromptClosed, { }, [&]() {
+        m_bidiProcessor->browsingContextDomainNotifier().userPromptClosed(handleForWebPageProxy(*page), toProtocolUserPromptType(apiDialogType.value()), true, m_client->userInputOfCurrentJavaScriptDialogOnPage(*this, *page).value_or(emptyString()));
+    });
 #endif
 
     m_client->acceptCurrentJavaScriptDialogOnPage(*this, *page);
@@ -2954,18 +2983,20 @@ static String logEntryTypeForMessage(const JSC::MessageSource& messageSource)
 void WebAutomationSession::logEntryAdded(const JSC::MessageSource& messageSource, const JSC::MessageLevel& messageLevel, const String& messageText, const JSC::MessageType& messageType, const WallTime& timestamp)
 {
 #if ENABLE(WEBDRIVER_BIDI)
-    // FIXME Support getting source information
-    // https://bugs.webkit.org/show_bug.cgi?id=282978
-    String sourceString;
+    m_bidiProcessor->emitEventIfEnabled(BidiEventNames::Log::EntryAdded, { }, [&]() {
+        // FIXME Support getting source information
+        // https://bugs.webkit.org/show_bug.cgi?id=282978
+        String sourceString;
 
-    auto level = logEntryLevelForMessage(messageType, messageLevel);
-    auto method = logEntryMethodNameForMessage(messageType, messageLevel);
-    auto type = logEntryTypeForMessage(messageSource);
-    auto milliseconds =  timestamp.secondsSinceEpoch().milliseconds();
+        auto level = logEntryLevelForMessage(messageType, messageLevel);
+        auto method = logEntryMethodNameForMessage(messageType, messageLevel);
+        auto type = logEntryTypeForMessage(messageSource);
+        auto milliseconds = timestamp.secondsSinceEpoch().milliseconds();
 
-    // FIXME Get browsing context handle and source info
-    // https://bugs.webkit.org/show_bug.cgi?id=282981
-    m_bidiProcessor->logDomainNotifier().entryAdded(level, sourceString, messageText, milliseconds, type, method);
+        // FIXME Get browsing context handle and source info
+        // https://bugs.webkit.org/show_bug.cgi?id=282981
+        m_bidiProcessor->logDomainNotifier().entryAdded(level, sourceString, messageText, milliseconds, type, method);
+    });
 #else
     UNUSED_PARAM(messageSource);
     UNUSED_PARAM(messageLevel);

--- a/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp
@@ -35,6 +35,7 @@
 #include "BidiBrowsingContextAgent.h"
 #include "BidiPermissionsAgent.h"
 #include "BidiScriptAgent.h"
+#include "BidiSessionAgent.h"
 #include "BidiStorageAgent.h"
 #include "Logging.h"
 #include "WebAutomationSession.h"
@@ -57,6 +58,7 @@ WebDriverBidiProcessor::WebDriverBidiProcessor(WebAutomationSession& session)
     , m_browsingContextAgent(makeUniqueRef<BidiBrowsingContextAgent>(session, m_backendDispatcher))
     , m_permissionsAgent(makeUniqueRef<BidiPermissionsAgent>(session, m_backendDispatcher))
     , m_scriptAgent(makeUniqueRef<BidiScriptAgent>(session, m_backendDispatcher))
+    , m_sessionAgent(makeUniqueRef<BidiSessionAgent>(session, m_backendDispatcher))
     , m_storageAgent(makeUniqueRef<BidiStorageAgent>(session, m_backendDispatcher))
     , m_browsingContextDomainNotifier(makeUniqueRef<BidiBrowsingContextFrontendDispatcher>(m_frontendRouter))
     , m_logDomainNotifier(makeUniqueRef<BidiLogFrontendDispatcher>(m_frontendRouter))
@@ -213,6 +215,16 @@ void WebDriverBidiProcessor::sendBidiMessage(const String& message)
     session->sendBidiMessage(msgObj->toJSONString());
 }
 
+bool WebDriverBidiProcessor::eventIsEnabled(const String& eventName, const HashSet<String>& contexts)
+{
+    return m_sessionAgent->eventIsEnabled(eventName, contexts);
+}
+
+void WebDriverBidiProcessor::emitEventIfEnabled(const String& eventName, const HashSet<String>& browsingContexts, NOESCAPE const Function<void()>& callback)
+{
+    if (m_sessionAgent->eventIsEnabled(eventName, browsingContexts)) [[unlikely]]
+        callback();
+}
 
 // MARK: Inspector::FrontendChannel methods.
 

--- a/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h
+++ b/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h
@@ -40,6 +40,7 @@ class BidiBrowserAgent;
 class BidiBrowsingContextAgent;
 class BidiPermissionsAgent;
 class BidiScriptAgent;
+class BidiSessionAgent;
 class BidiStorageAgent;
 class WebAutomationSession;
 class WebPageProxy;
@@ -64,6 +65,9 @@ public:
     Inspector::BidiBrowsingContextFrontendDispatcher& browsingContextDomainNotifier() const LIFETIME_BOUND { return m_browsingContextDomainNotifier; }
     Inspector::BidiLogFrontendDispatcher& logDomainNotifier() const LIFETIME_BOUND { return m_logDomainNotifier; }
 
+    bool eventIsEnabled(const String& eventName, const HashSet<String>& contexts);
+    void emitEventIfEnabled(const String& eventName, const HashSet<String>& browsingContexts, NOESCAPE const Function<void()>&);
+
 private:
     WeakPtr<WebAutomationSession> m_session;
 
@@ -74,6 +78,7 @@ private:
     const UniqueRef<BidiBrowsingContextAgent> m_browsingContextAgent;
     const UniqueRef<BidiPermissionsAgent> m_permissionsAgent;
     const UniqueRef<BidiScriptAgent> m_scriptAgent;
+    const UniqueRef<BidiSessionAgent> m_sessionAgent;
     const UniqueRef<BidiStorageAgent> m_storageAgent;
     const UniqueRef<Inspector::BidiBrowsingContextFrontendDispatcher> m_browsingContextDomainNotifier;
     const UniqueRef<Inspector::BidiLogFrontendDispatcher> m_logDomainNotifier;

--- a/Source/WebKit/UIProcess/Automation/protocol/BidiSession.json
+++ b/Source/WebKit/UIProcess/Automation/protocol/BidiSession.json
@@ -7,11 +7,45 @@
     "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/session",
     "types": [
         {
+            "id": "SubscriptionID",
+            "description": "A unique identifier for a subscription.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#type-session-Subscription",
+            "type": "string"
+        },
+        {
             "id": "UserPromptHandlerType",
             "description": "A type that represents the behavior of the user prompt handler.",
             "spec": "https://w3c.github.io/webdriver-bidi/#type-script-Target",
             "type": "string",
             "enum": [ "accept", "dismiss", "ignore" ]
+        }
+    ],
+    "commands": [
+        {
+            "name": "subscribe",
+            "description": "Subscribes to events from the remote end.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-session-subscribe",
+            "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/session/subscribe/",
+            "async": true,
+            "parameters": [
+                { "name": "events", "type": "array", "items": { "type": "string" }, "description": "The list of events to subscribe to." },
+                { "name": "contexts", "type": "array", "items": { "$ref": "BidiBrowsingContext.BrowsingContext" }, "description": "Browsing contexts to subscribe to. To be implemented in https://webkit.org/b/282981", "optional": true },
+                { "name": "userContexts", "type": "array", "items": { "$ref": "BidiBrowser.UserContext" }, "description": "User contexts to subscribe to. To be implemented in https://webkit.org/b/309502", "optional": true }
+            ],
+            "returns": [
+                { "name": "subscription", "$ref": "SubscriptionID", "description": "A unique identifier for the subscription." }
+            ]
+        },
+        {
+            "name": "unsubscribe",
+            "description": "Unsubscribes from events from the remote end.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-session-unsubscribe",
+            "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/session/unsubscribe/",
+            "async": true,
+            "parameters": [
+                { "name": "subscriptions", "type": "array", "items": { "$ref": "SubscriptionID" }, "description": "A unique identifier for the subscription.", "optional": true },
+                { "name": "events", "type": "array", "items": { "type": "string" }, "description": "The list of fully qualified domain.eventNames to unsubscribe from.", "optional": true }
+            ]
         }
     ]
 }

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1602,6 +1602,9 @@
 		5CFFD8482DEF511C00C421F5 /* SwiftDemoLogo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CFFD8472DEF511B00C421F5 /* SwiftDemoLogo.swift */; };
 		5EEC724C2DC1B30700D012DD /* BidiStorageAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5EEC724B2DC1B30700D012DD /* BidiStorageAgent.cpp */; };
 		5EEC724E2DC1B31800D012DD /* BidiStorageAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = 5EEC724D2DC1B31300D012DD /* BidiStorageAgent.h */; };
+		5EEC72542DC1B32500D012DD /* BidiEventNames.h in Headers */ = {isa = PBXBuildFile; fileRef = 5EEC72532DC1B32400D012DD /* BidiEventNames.h */; };
+		5EEC72522DC1B32300D012DD /* BidiSessionAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = 5EEC72512DC1B32200D012DD /* BidiSessionAgent.h */; };
+		5EEC72502DC1B32100D012DD /* BidiSessionAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5EEC724F2DC1B32000D012DD /* BidiSessionAgent.cpp */; };
 		5F4D67D682584880B7E5A569 /* RemoteLayerTreeCommitBundle.h in Headers */ = {isa = PBXBuildFile; fileRef = A6EB76B251B844C7BCAAAF04 /* RemoteLayerTreeCommitBundle.h */; };
 		63108F961F96719C00A0DB84 /* _WKApplicationManifest.h in Headers */ = {isa = PBXBuildFile; fileRef = 63108F941F96719C00A0DB84 /* _WKApplicationManifest.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		63108F991F9671F700A0DB84 /* _WKApplicationManifestInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 63108F981F9671F700A0DB84 /* _WKApplicationManifestInternal.h */; };
@@ -6843,6 +6846,9 @@
 		5EB592AB2DC2049A0058664B /* BidiStorage.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = BidiStorage.json; sourceTree = "<group>"; };
 		5EEC724B2DC1B30700D012DD /* BidiStorageAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BidiStorageAgent.cpp; sourceTree = "<group>"; };
 		5EEC724D2DC1B31300D012DD /* BidiStorageAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BidiStorageAgent.h; sourceTree = "<group>"; };
+		5EEC72532DC1B32400D012DD /* BidiEventNames.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BidiEventNames.h; sourceTree = "<group>"; };
+		5EEC724F2DC1B32000D012DD /* BidiSessionAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BidiSessionAgent.cpp; sourceTree = "<group>"; };
+		5EEC72512DC1B32200D012DD /* BidiSessionAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BidiSessionAgent.h; sourceTree = "<group>"; };
 		63108F941F96719C00A0DB84 /* _WKApplicationManifest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKApplicationManifest.h; sourceTree = "<group>"; };
 		63108F951F96719C00A0DB84 /* _WKApplicationManifest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKApplicationManifest.mm; sourceTree = "<group>"; };
 		63108F981F9671F700A0DB84 /* _WKApplicationManifestInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKApplicationManifestInternal.h; sourceTree = "<group>"; };
@@ -15323,10 +15329,13 @@
 				F3EEEE572DB318270038CC1D /* BidiBrowserAgent.h */,
 				F3272B7D2DB997C6007B3A9A /* BidiBrowsingContextAgent.cpp */,
 				F3272B7C2DB997C6007B3A9A /* BidiBrowsingContextAgent.h */,
+				5EEC72532DC1B32400D012DD /* BidiEventNames.h */,
 				997EB9D92E5544FC002CFED7 /* BidiPermissionsAgent.cpp */,
 				997EB9D82E5544FC002CFED7 /* BidiPermissionsAgent.h */,
 				F3272B7F2DB997C6007B3A9A /* BidiScriptAgent.cpp */,
 				F3272B7E2DB997C6007B3A9A /* BidiScriptAgent.h */,
+				5EEC724F2DC1B32000D012DD /* BidiSessionAgent.cpp */,
+				5EEC72512DC1B32200D012DD /* BidiSessionAgent.h */,
 				5EEC724B2DC1B30700D012DD /* BidiStorageAgent.cpp */,
 				5EEC724D2DC1B31300D012DD /* BidiStorageAgent.h */,
 				F3A94F002DB6F3310023CE9D /* BidiUserContext.cpp */,
@@ -18036,8 +18045,10 @@
 				95C943912523C0D00054F3D5 /* BaseBoardSPI.h in Headers */,
 				F3EEEE592DB318270038CC1D /* BidiBrowserAgent.h in Headers */,
 				F3272B822DB997C6007B3A9A /* BidiBrowsingContextAgent.h in Headers */,
+				5EEC72542DC1B32500D012DD /* BidiEventNames.h in Headers */,
 				997EB9DA2E5544FC002CFED7 /* BidiPermissionsAgent.h in Headers */,
 				F3272B832DB997C6007B3A9A /* BidiScriptAgent.h in Headers */,
+				5EEC72522DC1B32300D012DD /* BidiSessionAgent.h in Headers */,
 				5EEC724E2DC1B31800D012DD /* BidiStorageAgent.h in Headers */,
 				F3A94F022DB6F3310023CE9D /* BidiUserContext.h in Headers */,
 				E164A2F2191AF14E0010737D /* BlobDataFileReferenceWithSandboxExtension.h in Headers */,
@@ -21830,6 +21841,7 @@
 				F3272B802DB997C6007B3A9A /* BidiBrowsingContextAgent.cpp in Sources */,
 				997EB9DB2E5544FC002CFED7 /* BidiPermissionsAgent.cpp in Sources */,
 				F3272B812DB997C6007B3A9A /* BidiScriptAgent.cpp in Sources */,
+				5EEC72502DC1B32100D012DD /* BidiSessionAgent.cpp in Sources */,
 				5EEC724C2DC1B30700D012DD /* BidiStorageAgent.cpp in Sources */,
 				F3A94F012DB6F3310023CE9D /* BidiUserContext.cpp in Sources */,
 				49DC1DE127E5129100C1CB36 /* CSPExtensionUtilities.mm in Sources */,

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -1971,22 +1971,22 @@
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288104"}},
         "subtests": {
             "test_simple_prompts[alert-accept]": {
-                "expected": { "all": { "status": ["PASS"]}}
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/282981"}}
             },
             "test_simple_prompts[confirm-accept]": {
-                "expected": { "all": { "status": ["PASS"]}}
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/282981"}}
             },
             "test_simple_prompts[prompt-accept]": {
-                "expected": { "all": { "status": ["PASS"]}}
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/282981"}}
             },
             "test_default_handler[alert-accept]": {
-                "expected": { "all": { "status": ["PASS"]}}
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/282981"}}
             },
             "test_default_handler[confirm-accept]": {
-                "expected": { "all": { "status": ["PASS"]}}
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/282981"}}
             },
             "test_default_handler[prompt-accept]": {
-                "expected": { "all": { "status": ["PASS"]}}
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/282981"}}
             },
             "test_file[accept]": {
                 "expected": { "all": { "status": ["PASS"]}}
@@ -2703,10 +2703,10 @@
     "imported/w3c/webdriver/tests/bidi/browsing_context/reload/wait.py": {
         "subtests": {
             "test_slow_page[none-False]": {
-                "expected": { "all": { "status": ["PASS"] }}
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/282981"}}
             },
             "test_slow_script_blocks_domContentLoaded[none-False]": {
-                "expected": { "all": { "status": ["PASS"] }}
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/282981"}}
             }
         },
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288332"}}
@@ -3943,13 +3943,13 @@
     "imported/w3c/webdriver/tests/bidi/session/subscribe/contexts.py": {
         "subtests": {
             "test_subscribe_to_all_context_and_then_to_one_again": {
-                "expected": { "all": { "status": ["PASS"], "bug": "webkit.org/b/287929"}}
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/282981"}}
             },
             "test_subscribe_to_top_context_with_iframes": {
-                "expected": { "all": { "status": ["PASS"] }}
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/282981"}}
             },
             "test_subscribe_to_child_context": {
-                "expected": { "all": { "status": ["PASS"] }}
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/282981"}}
             }
         },
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/283784"}}
@@ -3971,7 +3971,12 @@
     "imported/w3c/webdriver/tests/bidi/session/subscribe/invalid.py": {
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286763"}},
         "subtests": {
+            "test_params_contexts_invalid_type[True]": {"expected": {"all": {"status": ["PASS"]}}},
+            "test_params_contexts_invalid_type[foo]": {"expected": {"all": {"status": ["PASS"]}}},
+            "test_params_contexts_invalid_type[42]": {"expected": {"all": {"status": ["PASS"]}}},
+            "test_params_contexts_invalid_type[value3]": {"expected": {"all": {"status": ["PASS"]}}},
             "test_params_empty": {"expected": {"all": {"status": ["PASS"]}}},
+            "test_params_events_value_invalid_event_name[]": {"expected": {"all": {"status": ["PASS"]}}},
             "test_params_events_invalid_type[None]": {"expected": {"all": {"status": ["PASS"]}}},
             "test_params_events_invalid_type[True]": {"expected": {"all": {"status": ["PASS"]}}},
             "test_params_events_invalid_type[foo]": {"expected": {"all": {"status": ["PASS"]}}},
@@ -3991,13 +3996,20 @@
             },
             "test_params_events_value_invalid_type[value4]": {
                 "expected": { "all": { "status": ["PASS"], "bug": "webkit.org/b/286793"}}
-            }
+            },
+            "test_params_user_context_and_contexts": {
+                "expected": { "all": { "status": ["PASS"], "bug": "webkit.org/b/286793"}}
+            },
+            "test_params_user_context_invalid_type[True]": {"expected": {"all": {"status": ["PASS"]}}},
+            "test_params_user_context_invalid_type[foo]": {"expected": {"all": {"status": ["PASS"]}}},
+            "test_params_user_context_invalid_type[42]": {"expected": {"all": {"status": ["PASS"]}}},
+            "test_params_user_context_invalid_type[value3]": {"expected": {"all": {"status": ["PASS"]}}}
         }
     },
     "imported/w3c/webdriver/tests/bidi/session/subscribe/user_contexts.py": {
         "subtests": {
             "test_subscribe_multiple_user_contexts": {
-                "expected": {"all": {"status": ["PASS"]}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/309502"}}
             },
             "test_buffered_event": {
                 "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/288107"}}
@@ -4020,6 +4032,7 @@
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/287930"}},
         "subtests": {
             "test_params_empty": {"expected": {"all": {"status": ["PASS"]}}},
+            "test_params_events_empty": {"expected": {"all": {"status": ["PASS"]}}},
             "test_params_events_invalid_type[None]": {"expected": {"all": {"status": ["PASS"]}}},
             "test_params_events_invalid_type[True]": {"expected": {"all": {"status": ["PASS"]}}},
             "test_params_events_invalid_type[foo]": {"expected": {"all": {"status": ["PASS"]}}},
@@ -4064,13 +4077,13 @@
     "imported/w3c/webdriver/tests/bidi/session/unsubscribe/subscriptions.py": {
         "subtests": {
             "test_unsubscribe_with_subscription_id": {
-                "expected": {"all": {"status": ["PASS"]}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/282981"}}
             },
             "test_unsubscribe_with_multiple_subscription_ids": {
                 "expected": {"all": {"status": ["PASS"]}}
             },
             "test_unsubscribe_from_closed_context": {
-                "expected": {"all": {"status": ["PASS"]}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/282981"}}
             },
             "test_unsubscribe_with_event_and_subscriptions": {
                 "expected": {"all": {"status": ["PASS"]}}


### PR DESCRIPTION
#### 763d3d51da9cb47ec02636021caa3536e2b86d9a
<pre>
[WebDriver][BiDi] Move event subscription inside the browser.
<a href="https://bugs.webkit.org/show_bug.cgi?id=295497">https://bugs.webkit.org/show_bug.cgi?id=295497</a>

Reviewed by BJ Burg.

Moving the implementation from Source/WebDriver into the
UIProcess&apos;s Bidi automation code.

Having subscription on the browser will make it easier checking which
events are enabled, especially non-global events, alongside avoiding
excessive message exchange between the browser and driver from the
increasing number of events supported.

For example, as of around 302979@main, without this patch, the Selenium
`api_example_tests.py` alone sends 303 events back to the driver,
despite not enabling any WebDriver-BiDi event. With this patch, all
events are filtered at the browser level.

In this commit, we also replace the Vectors used to track the
subscription fields with HashSets, preparing the way to support
subscriptions by individual browsing contexts. This helped refactor the
unsubscription logic to better match the spec, looping through the
current subscriptions instead of through the individual event names.

This commit also removes the &apos;context&apos; parameter from
session.unsubscribe, as it was removed from the spec, and simplified the
implementation.

Previously, the context and userContexts parameters to session.subscribe
were ignored. Now, we raised NotImplemented errors, as support for them will be
added in follow up commits. Tests expectations were updated accordingly.

We&apos;ll also improve the protocol generator to generate
a helper method that take care of checking whether a given event is
enabled and dispatch it, instead of the current
eventIsEnabled()+dispatch procedure. It can also generate the list of
event names, which is currently manually kept.

* Source/WebDriver/Session.cpp:
(WebDriver::Session::dispatchBidiMessage):
(WebDriver::Session::eventIsEnabled): Deleted.
(WebDriver::Session::subscribeForEvents): Deleted.
(WebDriver::Session::unsubscribeByIDs): Deleted.
(WebDriver::Session::unsubscribeByEventName): Deleted.
* Source/WebDriver/Session.h:
(WebDriver::EventSubscription::isGlobal const): Deleted.
* Source/WebDriver/WebDriverService.cpp:
(WebDriver::WebDriverService::bidiSessionSubscribe): Deleted.
(WebDriver::WebDriverService::bidiSessionUnsubscribe): Deleted.
* Source/WebDriver/WebDriverService.h:
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/Automation/BidiEventNames.h: Added.
* Source/WebKit/UIProcess/Automation/BidiSessionAgent.cpp: Added.
(WebKit::BidiSessionAgent::BidiSessionAgent):
(WebKit::BidiSessionAgent::subscribe):
(WebKit::BidiSessionAgent::unsubscribeByEventName):
(WebKit::BidiSessionAgent::unsubscribe):
(WebKit::BidiSessionAgent::eventIsEnabled):
* Source/WebKit/UIProcess/Automation/BidiSessionAgent.h: Added.
(WebKit::BidiEventSubscription::isGlobal const):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::willShowJavaScriptDialog):
(WebKit::WebAutomationSession::documentLoadedForFrame):
(WebKit::WebAutomationSession::loadCompletedForFrame):
(WebKit::WebAutomationSession::navigationStartedForFrame):
(WebKit::WebAutomationSession::navigationCommittedForFrame):
(WebKit::WebAutomationSession::navigationFailedForFrame):
(WebKit::WebAutomationSession::navigationAbortedForFrame):
(WebKit::WebAutomationSession::fragmentNavigatedForFrame):
(WebKit::WebAutomationSession::contextCreatedForFrame):
(WebKit::WebAutomationSession::recursivelyEmitContextCreatedEvent):
(WebKit::WebAutomationSession::contextDestroyedForPage):
(WebKit::WebAutomationSession::contextDestroyedForFrame):
(WebKit::WebAutomationSession::dismissCurrentJavaScriptDialog):
(WebKit::WebAutomationSession::acceptCurrentJavaScriptDialog):
(WebKit::WebAutomationSession::logEntryAdded):
* Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp:
(WebKit::WebDriverBidiProcessor::WebDriverBidiProcessor):
(WebKit::WebDriverBidiProcessor::eventIsEnabled):
(WebKit::WebDriverBidiProcessor::emitEventIfEnabled):
* Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h:
* Source/WebKit/UIProcess/Automation/protocol/BidiSession.json:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* WebDriverTests/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/310494@main">https://commits.webkit.org/310494@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71eed6f5c104564e283e07bb35f27e5cfa248595

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154011 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/27266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20426 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162763 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/107477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/27399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27119 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119104 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/107477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156970 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/27399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/138298 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99804 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/27399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/18426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10596 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/27399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16150 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165236 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/8436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17751 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127195 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/26813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22460 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127348 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34546 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/26737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137944 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83316 "Built successfully") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/26737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14732 "Passed tests") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/26428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/90520 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/26009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/26239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/26081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->