### PR TITLE
[webkitapipy] Add build-tool style reporting

### DIFF
--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/reporter.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/reporter.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+from fnmatch import fnmatch
+from . import program
+from .sdkdb import SDKDB, Diagnostic, MissingName, UnusedAllowedName, UnnecessaryAllowedName, SYMBOL, OBJC_CLS, OBJC_SEL
+
+
+class Reporter:
+    def __init__(self, args: program.Options):
+        self.print_names = len(args.input_files) > 1
+        self.issues: list[Diagnostic] = []
+
+    def emit_diagnostic(self, diag: Diagnostic) -> bool:
+        ignored = False
+        if isinstance(diag, MissingName):
+            if diag.kind is SYMBOL:
+                ignored = diag.name in program.ALLOWED_SYMBOLS
+                if not ignored:
+                    ignored = any(fnmatch(diag.name, pattern)
+                                  for pattern in program.ALLOWED_SYMBOL_GLOBS)
+            elif diag.kind is OBJC_CLS:
+                ignored = f'_OBJC_CLASS_$_{diag.name}' in program.ALLOWED_SYMBOLS
+        if not ignored:
+            self.issues.append(diag)
+            print(self.format_diagnostic(diag))
+            return True
+        return False
+
+    def format_diagnostic(self, diag: Diagnostic) -> str:
+        raise NotImplementedError
+
+    def finished(self):
+        pass
+
+
+class TSVReporter(Reporter):
+    def format_diagnostic(self, diag: Diagnostic) -> str:
+        if isinstance(diag, MissingName):
+            name_prefix = f'{diag.file}({diag.arch})\t' if self.print_names else ''
+            return f'{name_prefix}{diag.kind}\t{diag.name}'
+        elif isinstance(diag, (UnusedAllowedName, UnnecessaryAllowedName)):
+            name_prefix = f'{diag.file}\t' if self.print_names else ''
+            return f'{name_prefix}allowlist\t{diag.name}'
+
+
+class BuildToolReporter(Reporter):
+    bug_placeholder = 'https://webkit.org/b/OOPS!'
+
+    def __init__(self, args: program.Options):
+        super().__init__(args)
+        self.emit_errors = args.errors
+        self.suggested_allowlists = [path for path in (args.allowlists or ())
+                                     if 'legacy' not in path.name]
+
+    def format_diagnostic(self, diag: Diagnostic) -> str:
+        severity = 'error' if self.emit_errors else 'warning'
+        if isinstance(diag, MissingName):
+            return (f'{diag.file}({diag.arch}): {severity}: unrecognized '
+                    f'{diag.kind} "{diag.name}"')
+        elif isinstance(diag, UnusedAllowedName):
+            return (f'{diag.file}: {severity}: allowed {diag.kind} '
+                    f'"{diag.name}" is not used')
+        elif isinstance(diag, UnnecessaryAllowedName):
+            # FIXME: exported_in is the name of the loaded file, which can be a
+            # .sdkdb or .tbd that doesn't correspond to the library name on the
+            # system. It would be preferable to track the install name that the
+            # declaration will be implemented in, and surface that here.
+            return (f'{diag.file}: {severity}: allowed {diag.kind} '
+                    f'"{diag.name}" is exported from '
+                    f'"{diag.exported_in.name}" and can be removed')
+
+    def allowlist_entry(self):
+        missing_names = [d for d in self.issues if isinstance(d, MissingName)]
+        clss = '\n    '.join(f'"{d.name}",'
+                             for d in missing_names if d.kind == OBJC_CLS)
+        sels = '\n    '.join(f'"{d.name}",'
+                             for d in missing_names if d.kind == OBJC_SEL)
+        syms = '\n    '.join(f'"{d.name}",'
+                             for d in missing_names if d.kind == SYMBOL)
+        entry = f'[<category>."{self.bug_placeholder}"]'
+        if clss:
+            entry += f'\nclasses = [\n    {clss}\n]'
+        if sels:
+            entry += f'\nselectors = [\n    {sels}\n]'
+        if syms:
+            entry += f'\nsymbols = [\n    {syms}\n]'
+        return entry
+
+    def finished(self):
+        if self.issues:
+            if self.suggested_allowlists:
+                allowlists = '│ \n    '.join(map(str, self.suggested_allowlists))
+                allowlist_entry = self.allowlist_entry().replace('\n', '\n│     ')
+                print(f'''\
+│ If new SPI usage is intentional, please update one of this configuration's
+│ allowlists:
+│
+│     {allowlists}
+│
+│ with the following entry:
+│
+│     {allowlist_entry}
+│
+│ Pick a <category> name based on how the SPI is being used, and file a bug
+│ to track this SPI's removal.''')
+
+
+def configure_reporter(args: program.Options, db: SDKDB) -> Reporter:
+    cls = {
+        'tsv': TSVReporter,
+        'build-tool': BuildToolReporter,
+    }[args.format]
+    return cls(args)

--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy_additions/program.pyi
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy_additions/program.pyi
@@ -25,9 +25,10 @@
 
 import argparse
 
-from webkitapipy.program import TSVReporter
+from webkitapipy.program import Options
+from webkitapipy.reporter import Reporter
 from webkitapipy.sdkdb import SDKDB as SDKDB
 
 def get_parser() -> argparse.ArgumentParser: ...
-def configure_reporter(args: argparse.Namespace, db: SDKDB) -> TSVReporter: ...
+def configure_reporter(args: Options, db: SDKDB) -> Reporter: ...
 


### PR DESCRIPTION
#### 87ab1712d508fcfb076d63e39df84fa3c36cbc6b
<pre>
[webkitapipy] Add build-tool style reporting
<a href="https://bugs.webkit.org/show_bug.cgi?id=295501">https://bugs.webkit.org/show_bug.cgi?id=295501</a>
<a href="https://rdar.apple.com/155232286">rdar://155232286</a>

Reviewed by Sam Sneddon and Brianna Fan.

Refactor the TSV reporter into a base class which can support multiple
reporting formats. Create a new `BuildToolReporter` which formats
diagnostic messages in the &quot;&lt;path&gt;: error: &lt;message&gt;&quot; format common to
build tools. This makes validation messages visible in most IDEs, and in
the case of diagnostics on allowlists, attributed to files that can be
jumped to.

The output also emits a suggested allowlist entry, to show how
developers can unblock themselves when investigating new SPI use.

Add a --format argument to control which build tool is in use. The TSV
format stays around for non-build-time usage.

Remove the --print-details behavior and always print issues as they
occur. This behavior was useful before we had allowlists and therefore
had hundreds of validation issues, but I don&apos;t think it is valuable to
keep around.

* Tools/Scripts/libraries/webkitapipy/webkitapipy/program.py:
(get_parser):
(TSVReporter): Deleted.
(TSVReporter.__init__): Deleted.
(TSVReporter.emit_diagnostic): Deleted.
(TSVReporter.missing_selector): Deleted.
(TSVReporter.missing_class): Deleted.
(TSVReporter.missing_symbol): Deleted.
(TSVReporter.unused_allowed_name): Deleted.
(TSVReporter.finished): Deleted.
* Tools/Scripts/libraries/webkitapipy/webkitapipy/reporter.py: Added.
(Reporter):
(Reporter.__init__):
(Reporter.emit_diagnostic):
(Reporter.format_diagnostic): Replacement for the &quot;missing_*&quot; methods,
  to better match the new Diagnostic data class and avoid some repition.
  Notably, turning a Diagnostic into a string is now separate from
  deciding whether to print it.
(Reporter.finished):
(TSVReporter):
(TSVReporter.format_diagnostic):
(BuildToolReporter):
(BuildToolReporter.__init__):
(BuildToolReporter.format_diagnostic):
(BuildToolReporter.finished):
(configure_reporter): Factory method to produce a reporter from Options,
  similar to existing logic in webkitapipy_additions.

* Tools/Scripts/libraries/webkitapipy/webkitapipy_additions/program.pyi:

Canonical link: <a href="https://commits.webkit.org/297230@main">https://commits.webkit.org/297230@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8533a9d827199c7d564620fa4c1452ab8b125a04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111033 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30699 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21130 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/117063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/61300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112995 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39281 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/117063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/61300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113980 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/25065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/99972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/117063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/110464 "Found 2 webkitpy test failures: webkitapipy.program_unittest.CLITest.test_loads_partial_sdkdb_for_framework, webkitapipy.program_unittest.CLITest.test_loads_partial_sdkdb_for_main_file") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/24411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/18115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/60876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/94447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/18180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/119894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/38082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/28299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/119894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/38458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/96247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/119894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/15998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/34063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17907 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/37971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/37635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/40969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/39338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->