### PR TITLE
Adopt smart pointers in IPC/Connection.cpp

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -1,5 +1,4 @@
 Platform/IPC/ArgumentCoders.h
-Platform/IPC/Connection.h
 Platform/IPC/Encoder.h
 Platform/IPC/MessageSenderInlines.h
 Platform/cocoa/WebPrivacyHelpers.h

--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -8,7 +8,6 @@ NetworkProcess/cocoa/WebSocketTaskCocoa.mm
 NetworkProcess/storage/NetworkStorageManager.cpp
 NetworkProcess/storage/SQLiteStorageArea.cpp
 Platform/IPC/ArgumentCoders.h
-Platform/IPC/Connection.cpp
 Platform/cocoa/_WKWebViewTextInputNotifications.mm
 Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
 Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -2,8 +2,6 @@ AutomationFrontendDispatchers.cpp
 AutomationProtocolObjects.h
 GeneratedSerializers.mm
 Platform/IPC/ArgumentCoders.h
-Platform/IPC/Connection.cpp
-Platform/IPC/Connection.h
 Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
 UIProcess/API/C/mac/WKPagePrivateMac.mm
 UIProcess/API/Cocoa/WKContentWorld.mm


### PR DESCRIPTION
#### 1fb7628eb55842bf6b3a1df043508c350067e3c0
<pre>
Adopt smart pointers in IPC/Connection.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=295502">https://bugs.webkit.org/show_bug.cgi?id=295502</a>
<a href="https://rdar.apple.com/155195400">rdar://155195400</a>

Reviewed by Chris Dumez and Rupin Mittal.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines.">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines.</a>

* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::dispatchSyncMessage):
(IPC::Connection::dispatchDidReceiveInvalidMessage):
(IPC::Connection::dispatchDidCloseAndInvalidate):
(IPC::Connection::protectedClient const):
(IPC::Connection::enqueueIncomingMessage):
(IPC::Connection::dispatchMessage):
(IPC::Connection::WaitForMessageState::WaitForMessageState): Deleted.
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::WaitForMessageState::WaitForMessageState):
(IPC::Connection::waitForAndDispatchImmediately):
* Source/WebKit/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/297194@main">https://commits.webkit.org/297194@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/236ea2a836ba664a610e086c0f56f2bd26704eea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110795 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20891 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116824 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/61063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31138 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39044 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84245 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/61063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113743 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24870 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99773 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64686 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24236 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60619 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94263 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17970 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119614 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37840 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/28122 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93205 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38216 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96041 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93029 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38065 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15821 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/33814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17881 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37733 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43203 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37394 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40732 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39101 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->