### PR TITLE
Remove RemoteLayerBackingStoreProperties::m_cachedBuffer.

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -227,8 +227,7 @@ public:
     RemoteLayerBackingStoreProperties(ImageBufferBackendHandle&&, WebCore::RenderingResourceIdentifier, bool opaque);
 #endif
 
-    void applyBackingStoreToLayer(CALayer *, bool replayDynamicContentScalingDisplayListsIntoBackingStore, UIView * hostingView);
-    void updateCachedBuffers(RemoteLayerTreeNode&, UIView *);
+    void applyBackingStoreToNode(RemoteLayerTreeNode&, bool replayDynamicContentScalingDisplayListsIntoBackingStore, UIView* hostingView);
 
     const std::optional<ImageBufferBackendHandle>& bufferHandle() const { return m_bufferHandle; };
 
@@ -243,8 +242,10 @@ public:
 
 private:
     friend struct IPC::ArgumentCoder<RemoteLayerBackingStoreProperties, void>;
+
+    RetainPtr<id> lookupCachedBuffer(RemoteLayerTreeNode&);
+
     std::optional<ImageBufferBackendHandle> m_bufferHandle;
-    RetainPtr<id> m_contentsBuffer;
 
     std::optional<RemoteImageBufferSetIdentifier> m_bufferSet;
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
@@ -584,25 +584,27 @@ RetainPtr<id> RemoteLayerBackingStoreProperties::layerContentsBufferFromBackendH
     return contents;
 }
 
-void RemoteLayerBackingStoreProperties::applyBackingStoreToLayer(CALayer *layer, bool replayDynamicContentScalingDisplayListsIntoBackingStore, UIView *hostingView)
+void RemoteLayerBackingStoreProperties::applyBackingStoreToNode(RemoteLayerTreeNode& node, bool replayDynamicContentScalingDisplayListsIntoBackingStore, UIView* hostingView)
 {
+    RetainPtr layer = node.layer();
     bool isDelegatedDisplay = !m_frontBufferInfo;
 
     // FIXME: Ideally we'd just infer wantsExtendedDynamicRangeContent
     // from the format of the buffer itself.
-    layer.contentsOpaque = m_isOpaque;
+    [layer setContentsOpaque:m_isOpaque];
+
 #if HAVE(SUPPORT_HDR_DISPLAY_APIS)
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     if (m_hasExtendedDynamicRange) {
-        layer.wantsExtendedDynamicRangeContent = true;
+        [layer setWantsExtendedDynamicRangeContent:true];
         // Delegated contents set headroom via surface properties, not RemoteLayerBackingStore state.
         if (isDelegatedDisplay)
-            layer.contentsHeadroom = 0.f;
+            [layer setContentsHeadroom:0.f];
         else
-            layer.contentsHeadroom = m_maxRequestedEDRHeadroom;
+            [layer setContentsHeadroom:m_maxRequestedEDRHeadroom];
     } else {
-        layer.wantsExtendedDynamicRangeContent = false;
-        layer.contentsHeadroom = 0.f;
+        [layer setWantsExtendedDynamicRangeContent:false];
+        [layer setContentsHeadroom:0.f];
     }
     ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
@@ -622,11 +624,9 @@ void RemoteLayerBackingStoreProperties::applyBackingStoreToLayer(CALayer *layer,
     }
 #endif
 
-    RetainPtr<id> contents;
+    RetainPtr<id> contents = lookupCachedBuffer(node);
     // m_bufferHandle can be unset here if IPC with the GPU process timed out.
-    if (m_contentsBuffer)
-        contents = m_contentsBuffer;
-    else if (m_bufferHandle)
+    if (!contents && m_bufferHandle)
         contents = layerContentsBufferFromBackendHandle(WTFMove(*m_bufferHandle), isDelegatedDisplay);
 
     if (!contents) {
@@ -640,14 +640,14 @@ void RemoteLayerBackingStoreProperties::applyBackingStoreToLayer(CALayer *layer,
         if (![layer isKindOfClass:[WKCompositingLayer class]])
             return;
 
-        layer.drawsAsynchronously = (m_type == RemoteLayerBackingStore::Type::IOSurface);
+        [layer setDrawsAsynchronously:(m_type == RemoteLayerBackingStore::Type::IOSurface)];
 
         if (!replayDynamicContentScalingDisplayListsIntoBackingStore) {
             [layer setValue:@1 forKeyPath:WKDynamicContentScalingEnabledKey];
             [layer setValue:@1 forKeyPath:WKDynamicContentScalingBifurcationEnabledKey];
             [layer setValue:@(layer.contentsScale) forKeyPath:WKDynamicContentScalingBifurcationScaleKey];
         }
-        [(WKCompositingLayer *)layer _setWKContents:contents.get() withDisplayList:WTFMove(*m_displayListBufferHandle) replayForTesting:replayDynamicContentScalingDisplayListsIntoBackingStore];
+        [(WKCompositingLayer *)layer.get() _setWKContents:contents.get() withDisplayList:WTFMove(*m_displayListBufferHandle) replayForTesting:replayDynamicContentScalingDisplayListsIntoBackingStore];
         return;
     } else
         [layer _web_clearDynamicContentScalingDisplayListIfNeeded];
@@ -655,37 +655,29 @@ void RemoteLayerBackingStoreProperties::applyBackingStoreToLayer(CALayer *layer,
     UNUSED_PARAM(replayDynamicContentScalingDisplayListsIntoBackingStore);
 #endif
 
-    layer.contents = contents.get();
+    [layer setContents:contents.get()];
     if ([CALayer instancesRespondToSelector:@selector(contentsDirtyRect)]) {
         if (m_paintedRect) {
             FloatRect painted = *m_paintedRect;
-            painted.scale(layer.contentsScale);
+            painted.scale([layer contentsScale]);
 
             // Most of the time layer.contentsDirtyRect should be the null rect, since CA clears this on every commit,
             // but in some scenarios we don't get a CA commit for every remote layer tree transaction.
-            auto existingDirtyRect = layer.contentsDirtyRect;
+            auto existingDirtyRect = [layer contentsDirtyRect];
             if (CGRectIsNull(existingDirtyRect))
-                layer.contentsDirtyRect = painted;
+                [layer setContentsDirtyRect:painted];
             else
-                layer.contentsDirtyRect = CGRectUnion(existingDirtyRect, painted);
+                [layer setContentsDirtyRect:CGRectUnion(existingDirtyRect, painted)];
         }
     }
 }
 
-void RemoteLayerBackingStoreProperties::updateCachedBuffers(RemoteLayerTreeNode& node, UIView *hostingView)
+RetainPtr<id> RemoteLayerBackingStoreProperties::lookupCachedBuffer(RemoteLayerTreeNode& node)
 {
-#if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
-    if (hostingView && [hostingView isKindOfClass:[WKSeparatedImageView class]])
-        return;
-#endif
-
-    if (m_contentsBuffer)
-        return;
-
     Vector<RemoteLayerTreeNode::CachedContentsBuffer> cachedBuffers = node.takeCachedContentsBuffers();
 
-    if (!m_frontBufferInfo || !m_bufferHandle || !std::holds_alternative<MachSendRight>(*m_bufferHandle))
-        return;
+    if (!m_frontBufferInfo)
+        return { };
 
     cachedBuffers.removeAllMatching([&](const RemoteLayerTreeNode::CachedContentsBuffer& current) {
         auto matches = [&](std::optional<BufferAndBackendInfo>& backendInfo) {
@@ -705,21 +697,23 @@ void RemoteLayerBackingStoreProperties::updateCachedBuffers(RemoteLayerTreeNode&
         return true;
     });
 
+    RetainPtr<id> result;
     for (auto& current : cachedBuffers) {
         if (m_frontBufferInfo->resourceIdentifier == current.imageBufferInfo.resourceIdentifier) {
-            m_contentsBuffer = current.buffer;
+            result = current.buffer;
             break;
         }
     }
 
-    if (!m_contentsBuffer) {
+    if (!result && m_bufferHandle && std::holds_alternative<MachSendRight>(*m_bufferHandle)) {
         if (auto surface = WebCore::IOSurface::createFromSendRight(std::get<MachSendRight>(*std::exchange(m_bufferHandle, std::nullopt)))) {
-            m_contentsBuffer = surface->asCAIOSurfaceLayerContents();
-            cachedBuffers.append({ *m_frontBufferInfo, m_contentsBuffer, WTFMove(surface) });
+            result = surface->asCAIOSurfaceLayerContents();
+            cachedBuffers.append({ *m_frontBufferInfo, result, WTFMove(surface) });
         }
     }
 
     node.setCachedContentsBuffers(WTFMove(cachedBuffers));
+    return result;
 }
 
 void RemoteLayerBackingStoreProperties::setBackendHandle(BufferSetBackendHandle& bufferSetHandle)

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -93,7 +93,6 @@ header: "RemoteLayerBackingStore.h"
 
 [RValue, CustomHeader, LegacyPopulateFromEmptyConstructor] class WebKit::RemoteLayerBackingStoreProperties {
     std::optional<WebKit::ImageBufferBackendHandle> m_bufferHandle;
-    [NotSerialized] RetainPtr<id> m_contentsBuffer;
     std::optional<WebKit::RemoteImageBufferSetIdentifier> m_bufferSet;
     std::optional<WebKit::BufferAndBackendInfo> m_frontBufferInfo;
     std::optional<WebKit::BufferAndBackendInfo> m_backBufferInfo;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
@@ -140,8 +140,7 @@ void RemoteLayerTreeNode::applyBackingStore(RemoteLayerTreeHost* host, RemoteLay
     hostingView = uiView();
 #endif
 
-    properties.updateCachedBuffers(*this, hostingView);
-    properties.applyBackingStoreToLayer(layer(), host->replayDynamicContentScalingDisplayListsIntoBackingStore(), hostingView);
+    properties.applyBackingStoreToNode(*this, host->replayDynamicContentScalingDisplayListsIntoBackingStore(), hostingView);
 
     if (auto identifier = properties.contentsRenderingResourceIdentifier())
         setAsyncContentsIdentifier(*identifier);


### PR DESCRIPTION
#### 424418b2d5c30eb23387020e2740bd9ef075b198
<pre>
Remove RemoteLayerBackingStoreProperties::m_cachedBuffer.
<a href="https://bugs.webkit.org/show_bug.cgi?id=295505">https://bugs.webkit.org/show_bug.cgi?id=295505</a>

Reviewed by Kimmo Kinnunen.

This is unnecessary state, that would be less confusing as a stack variable.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStoreProperties::applyBackingStoreToNode):
(WebKit::RemoteLayerBackingStoreProperties::lookupCachedBuffer):
(WebKit::RemoteLayerBackingStoreProperties::applyBackingStoreToLayer): Deleted.
(WebKit::RemoteLayerBackingStoreProperties::updateCachedBuffers): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm:
(WebKit::RemoteLayerTreeNode::applyBackingStore):

Canonical link: <a href="https://commits.webkit.org/297369@main">https://commits.webkit.org/297369@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5f973e16366acb1b6b1e50b4558192937c82fde

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111538 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31204 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21669 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117570 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/61809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31885 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39786 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84757 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/61809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114485 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25455 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100396 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65197 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24809 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61402 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94852 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18596 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120808 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38587 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28674 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/93672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38963 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96663 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93495 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23827 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38617 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16406 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34627 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38476 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43953 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38143 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41479 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39845 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->