### PR TITLE
Remove UniqueRef's operator*

### DIFF
--- a/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
@@ -301,9 +301,9 @@ JSAgentContext JSGlobalObjectInspectorController::jsAgentContext()
 {
     AgentContext baseContext = {
         *this,
-        *m_injectedScriptManager,
-        m_frontendRouter.get(),
-        m_backendDispatcher.get()
+        m_injectedScriptManager,
+        m_frontendRouter,
+        m_backendDispatcher
     };
 
     JSAgentContext context = {

--- a/Source/WTF/wtf/UniqueRef.h
+++ b/Source/WTF/wtf/UniqueRef.h
@@ -84,7 +84,6 @@ public:
     T* operator->() const { ASSERT(m_ref); return m_ref.get(); }
 
     operator T&() const { ASSERT(m_ref); return *m_ref; }
-    T& operator*() const { ASSERT(m_ref); return *m_ref.get(); }
 
     std::unique_ptr<T> moveToUniquePtr() { return WTFMove(m_ref); }
 

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.h
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.h
@@ -67,12 +67,12 @@ public:
 
     JSDOMStructureMap& structures() WTF_REQUIRES_LOCK(m_gcLock) { return m_structures; }
     DOMGuardedObjectSet& guardedObjects() WTF_REQUIRES_LOCK(m_gcLock) { return m_guardedObjects; }
-    DOMConstructors& constructors() { return *m_constructors; }
+    DOMConstructors& constructors() { return m_constructors; }
 
     // No locking is necessary for call sites that do not mutate the containers and are not on the GC thread.
     const JSDOMStructureMap& structures() const WTF_IGNORES_THREAD_SAFETY_ANALYSIS { ASSERT(!Thread::mayBeGCThread()); return m_structures; }
     const DOMGuardedObjectSet& guardedObjects() const WTF_IGNORES_THREAD_SAFETY_ANALYSIS { ASSERT(!Thread::mayBeGCThread()); return m_guardedObjects; }
-    const DOMConstructors& constructors() const { ASSERT(!Thread::mayBeGCThread()); return *m_constructors; }
+    const DOMConstructors& constructors() const { ASSERT(!Thread::mayBeGCThread()); return m_constructors; }
 
     // The following don't require grabbing the gcLock first and should only be called when the Heap says that mutators don't have to be fenced.
     inline JSDOMStructureMap& structures(NoLockingNecessaryTag);

--- a/Source/WebCore/css/calc/CSSCalcTree.h
+++ b/Source/WebCore/css/calc/CSSCalcTree.h
@@ -180,12 +180,12 @@ template<typename Op> struct IndirectNode {
     UniqueRef<Op> op;
 
     // Forward * and -> to the operation for convenience.
-    const Op& operator*() const { return *op; }
-    Op& operator*() { return *op; }
+    const Op& operator*() const { return op.get(); }
+    Op& operator*() { return op.get(); }
     const Op* operator->() const { return op.ptr(); }
     Op* operator->() { return op.ptr(); }
-    operator const Op&() const { return *op; }
-    operator Op&() { return *op; }
+    operator const Op&() const { return op.get(); }
+    operator Op&() { return op.get(); }
 
     bool operator==(const IndirectNode<Op>& other) const { return type == other.type && arePointingToEqualData(op, other.op); }
 };

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -979,7 +979,7 @@ void ViewTransition::updatePseudoElementStylesWrite()
 
     bool changed = false;
     for (auto& [name, capturedElement] : m_namedElements.map())
-        changed |= updatePropertiesForGroupPseudo(*capturedElement, name);
+        changed |= updatePropertiesForGroupPseudo(capturedElement, name);
 
     if (changed) {
         if (RefPtr documentElement = document->documentElement())

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -1443,7 +1443,7 @@ bool Editor::insertTextWithoutSendingTextEvent(const String& text, bool selectIn
     if (text.length() == 1 && u_ispunct(text[0]) && !isAmbiguousBoundaryCharacter(text[0]))
         shouldConsiderApplyingAutocorrection = true;
 
-    bool autocorrectionWasApplied = shouldConsiderApplyingAutocorrection && didApplyAutocorrection(document(), *m_alternativeTextController);
+    bool autocorrectionWasApplied = shouldConsiderApplyingAutocorrection && didApplyAutocorrection(document(), m_alternativeTextController);
 
     // Get the selection to use for the event that triggered this insertText.
     // If the event handler changed the selection, we may want to use a different selection

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -454,8 +454,8 @@ public:
 
     VisibleSelection selectionForCommand(Event*);
 
-    PAL::KillRing& killRing() const { return *m_killRing; }
-    SpellChecker& spellChecker() const { return *m_spellChecker; }
+    PAL::KillRing& killRing() const { return m_killRing; }
+    SpellChecker& spellChecker() const { return m_spellChecker; }
 
     EditingBehavior behavior() const;
 

--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -403,7 +403,7 @@ void BackForwardCache::markPagesForCaptionPreferencesChanged()
             ASSERT(!m_items.contains(item.key));
             continue;
         }
-        CheckedRef { **cachedPage }->markForCaptionPreferencesChanged();
+        CheckedRef { (*cachedPage).get() }->markForCaptionPreferencesChanged();
     }
 }
 #endif

--- a/Source/WebCore/platform/calc/CalculationTree.h
+++ b/Source/WebCore/platform/calc/CalculationTree.h
@@ -123,12 +123,12 @@ template<typename Op> struct IndirectNode {
     UniqueRef<Op> op;
 
     // Forward * and -> to the operation for convenience.
-    const Op& operator*() const { return *op; }
-    Op& operator*() { return *op; }
+    const Op& operator*() const { return op.get(); }
+    Op& operator*() { return op.get(); }
     const Op* operator->() const { return op.ptr(); }
     Op* operator->() { return op.ptr(); }
-    operator const Op&() const { return *op; }
-    operator Op&() { return *op; }
+    operator const Op&() const { return op.get(); }
+    operator Op&() { return op.get(); }
 
     bool operator==(const IndirectNode<Op>& other) const { return op.get() == other.op.get(); }
 };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -715,7 +715,7 @@ void SourceBufferPrivateAVFObjC::setCDMInstance(CDMInstance* instance)
             for (auto& pair : m_audioRenderers)
                 [cdmInstance->contentKeySession() removeContentKeyRecipient:pair.second.get()];
         }
-        cdmInstance->removeKeyStatusesChangedObserver(*m_keyStatusesChangedObserver);
+        cdmInstance->removeKeyStatusesChangedObserver(m_keyStatusesChangedObserver);
     }
 
     m_cdmInstance = fpsInstance;
@@ -728,7 +728,7 @@ void SourceBufferPrivateAVFObjC::setCDMInstance(CDMInstance* instance)
             for (auto& pair : m_audioRenderers)
                 [cdmInstance->contentKeySession() addContentKeyRecipient:pair.second.get()];
         }
-        cdmInstance->addKeyStatusesChangedObserver(*m_keyStatusesChangedObserver);
+        cdmInstance->addKeyStatusesChangedObserver(m_keyStatusesChangedObserver);
     }
 
     attemptToDecrypt();

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -83,7 +83,7 @@ RenderView::RenderView(Document& document, RenderStyle&& style)
     : RenderBlockFlow(Type::View, document, WTFMove(style))
     , m_frameView(*document.view())
     , m_initialContainingBlock(makeUniqueRef<Layout::InitialContainingBlock>(RenderStyle::clone(this->style())))
-    , m_layoutState(makeUniqueRef<Layout::LayoutState>(document, *m_initialContainingBlock, Layout::LayoutState::Type::Primary, LayoutIntegration::layoutWithFormattingContextForBox, LayoutIntegration::formattingContextRootLogicalWidthForType, LayoutIntegration::formattingContextRootLogicalHeightForType))
+    , m_layoutState(makeUniqueRef<Layout::LayoutState>(document, m_initialContainingBlock, Layout::LayoutState::Type::Primary, LayoutIntegration::layoutWithFormattingContextForBox, LayoutIntegration::formattingContextRootLogicalWidthForType, LayoutIntegration::formattingContextRootLogicalHeightForType))
     , m_selection(*this)
 {
     // FIXME: We should find a way to enforce this at compile time.

--- a/Source/WebCore/rendering/RenderView.h
+++ b/Source/WebCore/rendering/RenderView.h
@@ -79,7 +79,7 @@ public:
 
     Layout::InitialContainingBlock& initialContainingBlock() { return m_initialContainingBlock.get(); }
     const Layout::InitialContainingBlock& initialContainingBlock() const { return m_initialContainingBlock.get(); }
-    Layout::LayoutState& layoutState() { return *m_layoutState; }
+    Layout::LayoutState& layoutState() { return m_layoutState; }
     void updateQuirksMode();
 
     bool needsRepaintHackAfterCompositingLayerUpdateForDebugOverlaysOnly() const { return m_needsRepaintHackAfterCompositingLayerUpdateForDebugOverlaysOnly; };

--- a/Source/WebCore/style/MatchResultCache.cpp
+++ b/Source/WebCore/style/MatchResultCache.cpp
@@ -146,7 +146,7 @@ const std::optional<CachedMatchResult> MatchResultCache::resultWithCurrentInline
     if (it == m_entries.end())
         return { };
 
-    auto& entry = *it->value;
+    auto& entry = it->value;
 
     auto* styledElement = dynamicDowncast<StyledElement>(element);
     RefPtr inlineStyle = styledElement ? styledElement->inlineStyle() : nullptr;
@@ -159,9 +159,9 @@ const std::optional<CachedMatchResult> MatchResultCache::resultWithCurrentInline
     auto changedProperties = computeAndUpdateChangedProperties(entry);
 
     return CachedMatchResult {
-        .unadjustedStyle = copy(entry.unadjustedStyle),
+        .unadjustedStyle = copy(entry->unadjustedStyle),
         .changedProperties = WTFMove(changedProperties),
-        .styleToUpdate = *entry.unadjustedStyle.style
+        .styleToUpdate = *entry->unadjustedStyle.style
     };
 }
 

--- a/Source/WebCore/style/values/color/StyleDynamicRangeLimit.h
+++ b/Source/WebCore/style/values/color/StyleDynamicRangeLimit.h
@@ -126,7 +126,7 @@ inline DynamicRangeLimit::Kind DynamicRangeLimit::copyKind(const Kind& other)
             return Kind { keyword };
         },
         [](const UniqueRef<DynamicRangeLimitMixFunction>& mix) {
-            return Kind { WTF::makeUniqueRef<DynamicRangeLimitMixFunction>(*mix) };
+            return Kind { WTF::makeUniqueRef<DynamicRangeLimitMixFunction>(mix) };
         }
     );
 }

--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -330,7 +330,7 @@ template<typename T> struct ArgumentCoder<UniqueRef<T>> {
     static void encode(Encoder& encoder, U&& object)
     {
         static_assert(std::is_same_v<std::remove_cvref_t<U>, UniqueRef<T>>);
-        encoder << WTF::forward_like<U>(*object);
+        encoder << WTF::forward_like<U>(object.get());
     }
 
     template<typename Decoder>

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -842,7 +842,7 @@ template<typename T> Connection::SendSyncResult<T> Connection::sendSync(T&& mess
     if (decoder->messageName() == MessageName::CancelSyncMessageReply)
         return { Error::SyncMessageCancelled };
     std::optional<typename T::ReplyArguments> replyArguments;
-    *decoder >> replyArguments;
+    decoder.get() >> replyArguments;
     if (!replyArguments)
         return { Error::FailedToDecodeReplyArguments };
     return SendSyncResult<T> { WTFMove(decoder), WTFMove(*replyArguments) };

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.h
@@ -338,7 +338,7 @@ std::optional<StreamClientConnection::SendSyncResult<T>> StreamClientConnection:
     if (decoder->messageName() == MessageName::CancelSyncMessageReply)
         return { Error::SyncMessageCancelled };
     std::optional<typename T::ReplyArguments> replyArguments;
-    *decoder >> replyArguments;
+    decoder.get() >> replyArguments;
     if (!replyArguments)
         return { Error::FailedToDecodeReplyArguments };
     return { { WTFMove(decoder), WTFMove(*replyArguments) } };

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
@@ -129,7 +129,7 @@ RetainPtr<id> CoreIPCNSCFObject::toID() const
 {
     RetainPtr<id> result;
 
-    WTF::switchOn(*m_value, [&](auto& object) {
+    WTF::switchOn(m_value.get(), [&](auto& object) {
         result = object.toID();
     }, [](std::nullptr_t) {
         // result should be nil, which is the default value initialized above.
@@ -166,7 +166,7 @@ namespace IPC {
 
 void ArgumentCoder<UniqueRef<WebKit::ObjectValue>>::encode(Encoder& encoder, const UniqueRef<WebKit::ObjectValue>& object)
 {
-    encoder << *object;
+    encoder << object.get();
 }
 
 std::optional<UniqueRef<WebKit::ObjectValue>> ArgumentCoder<UniqueRef<WebKit::ObjectValue>>::decode(Decoder& decoder)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPlistObject.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPlistObject.mm
@@ -84,7 +84,7 @@ CoreIPCPlistObject::CoreIPCPlistObject(UniqueRef<PlistValue>&& value)
 
 RetainPtr<id> CoreIPCPlistObject::toID() const
 {
-    return WTF::switchOn(*m_value, [&](auto& object) {
+    return WTF::switchOn(m_value.get(), [&](auto& object) {
         return object.toID();
     });
 }
@@ -95,7 +95,7 @@ namespace IPC {
 
 void ArgumentCoder<UniqueRef<WebKit::PlistValue>>::encode(Encoder& encoder, const UniqueRef<WebKit::PlistValue>& object)
 {
-    encoder << *object;
+    encoder << object.get();
 }
 
 std::optional<UniqueRef<WebKit::PlistValue>> ArgumentCoder<UniqueRef<WebKit::PlistValue>>::decode(Decoder& decoder)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -196,9 +196,7 @@ bool RemoteLayerTreeHost::updateLayerTree(const IPC::Connection& connection, con
     Vector<LayerAndClone> clonesToUpdate;
 
     auto layerContentsType = this->layerContentsType();
-    for (auto& [layerID, propertiesPointer] : transaction.changedLayerProperties()) {
-        const auto& properties = *propertiesPointer;
-
+    for (auto& [layerID, properties] : transaction.changedLayerProperties()) {
         RefPtr node = nodeForID(layerID);
         ASSERT(node);
 
@@ -208,7 +206,7 @@ bool RemoteLayerTreeHost::updateLayerTree(const IPC::Connection& connection, con
             continue;
         }
 
-        RemoteLayerTreePropertyApplier::applyHierarchyUpdates(*node, properties, m_nodes);
+        RemoteLayerTreePropertyApplier::applyHierarchyUpdates(*node, properties.get(), m_nodes);
     }
 
     if (auto contextHostedID = transaction.remoteContextHostedIdentifier()) {
@@ -223,7 +221,7 @@ bool RemoteLayerTreeHost::updateLayerTree(const IPC::Connection& connection, con
 
     for (auto& changedLayer : transaction.changedLayerProperties()) {
         auto layerID = changedLayer.key;
-        const auto& properties = *changedLayer.value;
+        const auto& properties = changedLayer.value.get();
 
         RefPtr node = nodeForID(layerID);
         ASSERT(node);

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -691,7 +691,7 @@ public:
     RefPtr<DrawingAreaProxy> protectedDrawingArea() const;
     DrawingAreaProxy* provisionalDrawingArea() const;
 
-    WebNavigationState& navigationState() { return *m_navigationState; }
+    WebNavigationState& navigationState() { return m_navigationState; }
 
     WebsiteDataStore& websiteDataStore() { return m_websiteDataStore; }
     Ref<WebsiteDataStore> protectedWebsiteDataStore() const;

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -1267,7 +1267,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebViewImpl);
 WebViewImpl::WebViewImpl(WKWebView *view, WebProcessPool& processPool, Ref<API::PageConfiguration>&& configuration)
     : m_view(view)
     , m_pageClient(makeUniqueRefWithoutRefCountedCheck<PageClientImpl>(view, view))
-    , m_page(processPool.createWebPage(*m_pageClient, WTFMove(configuration)))
+    , m_page(processPool.createWebPage(m_pageClient, WTFMove(configuration)))
     , m_needsViewFrameInWindowCoordinates(false)
     , m_intrinsicContentSize(CGSizeMake(NSViewNoIntrinsicMetric, NSViewNoIntrinsicMetric))
     , m_layoutStrategy([WKViewLayoutStrategy layoutStrategyWithPage:m_page.get() view:view viewImpl:*this mode:kWKLayoutModeViewSize])
@@ -1279,7 +1279,7 @@ WebViewImpl::WebViewImpl(WKWebView *view, WebProcessPool& processPool, Ref<API::
     , m_primaryTrackingArea(adoptNS([[NSTrackingArea alloc] initWithRect:view.frame options:trackingAreaOptions() owner:m_mouseTrackingObserver.get() userInfo:nil]))
     , m_flagsChangedEventMonitorTrackingArea(adoptNS([[NSTrackingArea alloc] initWithRect:view.frame options:flagsChangedEventMonitorTrackingAreaOptions() owner:m_mouseTrackingObserver.get() userInfo:nil]))
 {
-    static_cast<PageClientImpl&>(*m_pageClient).setImpl(*this);
+    static_cast<PageClientImpl&>(m_pageClient.get()).setImpl(*this);
 
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
     [NSApp registerServicesMenuSendTypes:PasteboardTypes::forSelection() returnTypes:PasteboardTypes::forEditing()];

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
@@ -124,7 +124,7 @@ std::unique_ptr<CDMPrivateInterface> RemoteLegacyCDMFactory::createCDM(WebCore::
     if (!identifier)
         return nullptr;
     auto remoteCDM = makeUniqueRefWithoutRefCountedCheck<RemoteLegacyCDM>(*this, *identifier);
-    m_cdms.set(*identifier, Ref { *remoteCDM }.get());
+    m_cdms.set(*identifier, Ref { remoteCDM.get() }.get());
     return remoteCDM.moveToUniquePtr();
 }
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
@@ -85,8 +85,7 @@ public:
 
     void willStartAnimationOnLayer(PlatformCALayerRemote&);
 
-    RemoteLayerBackingStoreCollection& backingStoreCollection() { return *m_backingStoreCollection; }
-    Ref<RemoteLayerBackingStoreCollection> protectedBackingStoreCollection() { return *m_backingStoreCollection; }
+    RemoteLayerBackingStoreCollection& backingStoreCollection() { return m_backingStoreCollection; }
     
     void setNextRenderingUpdateRequiresSynchronousImageDecoding() { m_nextRenderingUpdateRequiresSynchronousImageDecoding = true; }
     bool nextRenderingUpdateRequiresSynchronousImageDecoding() const { return m_nextRenderingUpdateRequiresSynchronousImageDecoding; }

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -483,7 +483,7 @@ void RemoteLayerTreeDrawingArea::mainFrameContentSizeChanged(WebCore::FrameIdent
 
 void RemoteLayerTreeDrawingArea::tryMarkLayersVolatile(CompletionHandler<void(bool)>&& completionFunction)
 {
-    m_remoteLayerTreeContext->protectedBackingStoreCollection()->tryMarkAllBackingStoreVolatile(WTFMove(completionFunction));
+    m_remoteLayerTreeContext->backingStoreCollection().tryMarkAllBackingStoreVolatile(WTFMove(completionFunction));
 }
 
 Ref<RemoteLayerTreeDrawingArea::BackingStoreFlusher> RemoteLayerTreeDrawingArea::BackingStoreFlusher::create(Ref<IPC::Connection>&& connection)


### PR DESCRIPTION
#### bffd763c79061bbf16e3bfb94c4594f1f57f1a8b
<pre>
Remove UniqueRef&apos;s operator*
<a href="https://bugs.webkit.org/show_bug.cgi?id=295506">https://bugs.webkit.org/show_bug.cgi?id=295506</a>

Reviewed by Chris Dumez and Ryosuke Niwa.

This makes it more consistent with Ref and does not make it look like
it supports a null value.

* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h:
 (WebKit::RemoteLayerTreeContext::protectedBackingStoreCollection): Deleted.

This is unneeded as the underlying member is a const UniqueRef with a
trivial getter.

Canonical link: <a href="https://commits.webkit.org/297100@main">https://commits.webkit.org/297100@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02b6e2bf8df530bfe20a1b267b4b8fa6bc49b04f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110447 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30106 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20539 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116472 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60701 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112410 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30785 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38693 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83992 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113395 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24568 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99453 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64433 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23931 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17592 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60268 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/102938 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93952 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17648 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119263 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109001 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37487 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27904 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92959 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37861 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95721 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92782 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37783 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15518 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33433 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17834 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37382 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42853 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/133276 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37044 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36019 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40384 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38752 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->