### PR TITLE
[JSC] Fix Date Constructor Overflow

### DIFF
--- a/JSTests/stress/date-two-digit-years.js
+++ b/JSTests/stress/date-two-digit-years.js
@@ -1,0 +1,77 @@
+function shouldBe(actual, expected) {
+    if (Number.isNaN(expected)) {
+        if (!Number.isNaN(actual)) {
+            throw new Error(`Actual: ${actual}, Expected: ${expected}`);
+        }
+    } else if (actual !== expected) {
+        throw new Error(`Actual: ${actual}, Expected: ${expected}`);
+    }
+}
+
+for (let year of Array(100).keys()) {
+    for (let month of Array(12).keys()) {
+        for (let day of Array(31).keys()) {
+            let fullYear = year >= 50 ? year + 1900 : year + 2000;
+            let fullDate = new Date(`${month + 1}/${day + 1}/${fullYear}`);
+
+            // mm/dd/yy
+            let d1 = new Date(`${month + 1}/${day + 1}/${year}`);
+            shouldBe(d1.getTime(), fullDate.getTime());
+
+            // yy/mm/dd
+            let d2 = new Date(`${year}/${month + 1}/${day + 1}`);
+            if (year > 31) {
+                shouldBe(d2.getTime(), fullDate.getTime());
+            } else if (year > 12) {
+                shouldBe(d2.getTime(), new Date(NaN).getTime());
+            }
+        }
+    }
+}
+
+shouldBe(new Date("99/1/99").getTime(), new Date(NaN).getTime());
+shouldBe(new Date("13/13/13").getTime(), new Date(NaN).getTime());
+shouldBe(new Date("0/10/0").getTime(), new Date(NaN).getTime());
+
+for (let year of Array(1000).keys()) {
+    let fullDate = new Date(`5/1/${year}`);
+    let d1 = new Date(`may 1 ${year}`);
+    let d1_1 = new Date(`mayrandomstring 1 ${year}`);
+
+    shouldBe(d1.getTime(), fullDate.getTime());
+    shouldBe(d1_1.getTime(), fullDate.getTime());
+}
+
+shouldBe(new Date("may 1999 1999").getTime(), new Date(NaN).getTime());
+shouldBe(new Date("may 0 0").getTime(), new Date(NaN).getTime());
+
+shouldBe(new Date("00/2/29").getTime(), new Date(NaN).getTime());
+shouldBe(new Date("00/2/30").getTime(), new Date(NaN).getTime());
+shouldBe(new Date("00/4/31").getTime(), new Date(NaN).getTime());
+shouldBe(new Date("00/4/0").getTime(), new Date(NaN).getTime());
+shouldBe(new Date("00/4/-1").getTime(), new Date(NaN).getTime());
+
+// leap years
+shouldBe(new Date("80/2/29").getTime(), 320659200000);
+shouldBe(new Date("80/2/30").getTime(), new Date("1980/2/30").getTime());
+shouldBe(new Date("80/2/30").getTime(), new Date("1980/3/1").getTime());
+shouldBe(new Date("80/2/30").getTime(), 320745600000);
+shouldBe(new Date("80/2/31").getTime(), new Date("1980/3/2").getTime());
+shouldBe(new Date("80/2/31").getTime(), 320832000000);
+shouldBe(new Date("80/2/32").getTime(), new Date(NaN).getTime());
+shouldBe(new Date("80/4/31").getTime(), new Date("1980/4/31").getTime());
+shouldBe(new Date("80/4/31").getTime(), 326012400000);
+shouldBe(new Date("80/4/32").getTime(), new Date(NaN).getTime());
+
+for (let year = 50; year <= 99; ++year) {
+    for (let month = 0; month < 12; ++month) {
+        for (let day = 1; day <= 100; ++day) {
+            const date = `${year}/${month + 1}/${day}`;
+            if (day <= 31) {
+                shouldBe(new Date(year, month, day).getTime(), new Date(date).getTime());
+            } else {
+                shouldBe(Number.isNaN(new Date(date).getTime()), true);
+            }
+        }
+    }
+}

--- a/Source/WTF/wtf/DateMath.cpp
+++ b/Source/WTF/wtf/DateMath.cpp
@@ -971,6 +971,9 @@ double parseDate(std::span<const Latin1Character> dateString, bool& isLocalTime)
     }
     ASSERT(year);
 
+    if (day <= 0 || day > 31)
+        return std::numeric_limits<double>::quiet_NaN();
+
     return ymdhmsToMilliseconds(year.value(), month + 1, day, hour, minute, second, 0) - offset * (secondsPerMinute * msPerSecond);
 }
 


### PR DESCRIPTION
#### a4eb552518cc22e23282c530a1944dd72162f466
<pre>
[JSC] Fix Date Constructor Overflow
<a href="https://bugs.webkit.org/show_bug.cgi?id=295513">https://bugs.webkit.org/show_bug.cgi?id=295513</a>

Reviewed by Darin Adler.

When day is not in the range, Date Constructor did not return the correct value.
This patch fixes Date Constructor overflow to align with the behavior from test262[1].

[1]: <a href="https://github.com/tc39/test262/blob/3e26311d42ad7d971b0a2f6755d083e19c2050d8/test/staging/sm/Date/two-digit-years.js">https://github.com/tc39/test262/blob/3e26311d42ad7d971b0a2f6755d083e19c2050d8/test/staging/sm/Date/two-digit-years.js</a>

* JSTests/stress/date-two-digit-years.js: Added.
(shouldBe):
(let.year.of.Array.100.keys):
(let.year.of.Array.1000.keys):
* Source/WTF/wtf/DateMath.cpp:
(WTF::parseDate):

Canonical link: <a href="https://commits.webkit.org/303582@main">https://commits.webkit.org/303582@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7d2daebb5a0e368becfbb6f34d6592444c47495

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132258 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4751 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43289 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139773 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84191 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5257 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4512 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101098 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68404 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135204 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3706 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118461 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/81893 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3593 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1193 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82993 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/124321 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112508 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36580 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142420 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/130765 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4420 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37160 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109475 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4501 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/3918 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/109658 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27931 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3350 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/114733 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/57677 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4474 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33106 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/163732 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4306 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67920 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/42569 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4565 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4433 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->