### PR TITLE
[WPE][GTK] Dispatch display refreshes earlier when skipping frames

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
@@ -47,6 +47,15 @@ void CoordinatedBackingStore::updateTile(uint32_t id, const IntRect& sourceRect,
     it->value.addUpdate({ WTFMove(buffer), sourceRect, tileRect, offset });
 }
 
+bool CoordinatedBackingStore::hasPendingUpdates() const
+{
+    for (const auto& tile : m_tiles.values()) {
+        if (tile.hasPendingUpdates())
+            return true;
+    }
+    return false;
+}
+
 void CoordinatedBackingStore::processPendingUpdates(TextureMapper& textureMapper)
 {
     for (auto& tile : m_tiles.values())

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
@@ -43,6 +43,7 @@ public:
     void removeTile(uint32_t tileID);
     void updateTile(uint32_t tileID, const IntRect&, const IntRect&, Ref<CoordinatedTileBuffer>&&, const IntPoint&);
 
+    bool hasPendingUpdates() const;
     void processPendingUpdates(TextureMapper&);
 
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix&, float) override;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.h
@@ -47,6 +47,7 @@ public:
     };
     void addUpdate(Update&&);
 
+    bool hasPendingUpdates() const { return !m_updates.isEmpty(); }
     void processPendingUpdates(TextureMapper&);
 
     bool canBePainted() const { return !!m_texture; }

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -860,9 +860,10 @@ void CoordinatedPlatformLayer::waitUntilPaintingComplete()
         m_backingStoreProxy->waitUntilPaintingComplete();
 }
 
-void CoordinatedPlatformLayer::flushCompositingState(TextureMapper& textureMapper)
+void CoordinatedPlatformLayer::flushCompositingState()
 {
     ASSERT(!isMainThread());
+    ASSERT(!m_pendingBackingStoreUpdate);
     Locker locker { m_lock };
     if (m_pendingChanges.isEmpty() && !m_backingStoreProxy)
         return;
@@ -993,7 +994,7 @@ void CoordinatedPlatformLayer::flushCompositingState(TextureMapper& textureMappe
         for (const auto& tileUpdate : update.tilesToUpdate())
             m_backingStore->updateTile(tileUpdate.tileID, tileUpdate.dirtyRect, tileUpdate.tileRect, tileUpdate.buffer.copyRef(), { });
 
-        m_backingStore->processPendingUpdates(textureMapper);
+        m_pendingBackingStoreUpdate = m_backingStore->hasPendingUpdates();
     }
 
     if (m_contentsBuffer.committed)
@@ -1004,6 +1005,15 @@ void CoordinatedPlatformLayer::flushCompositingState(TextureMapper& textureMappe
         layer.setContentsLayer(nullptr);
 
     m_pendingChanges = { };
+}
+
+void CoordinatedPlatformLayer::processPendingBackingStoreUpdates(TextureMapper& textureMapper)
+{
+    ASSERT(!isMainThread());
+    ASSERT(m_backingStore);
+    ASSERT(m_pendingBackingStoreUpdate);
+    m_backingStore->processPendingUpdates(textureMapper);
+    m_pendingBackingStoreUpdate = false;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -175,7 +175,9 @@ public:
     void updateContents(bool affectedByTransformAnimation);
     void updateBackingStore();
 
-    void flushCompositingState(TextureMapper&);
+    void flushCompositingState();
+    bool hasPendingBackingStoreUpdates() const { return m_pendingBackingStoreUpdate; }
+    void processPendingBackingStoreUpdates(TextureMapper&);
 
     bool hasPendingTilesCreation() const { return m_pendingTilesCreation; }
     bool isCompositionRequiredOrOngoing() const;
@@ -247,6 +249,7 @@ private:
     GraphicsLayerCoordinated* m_owner { nullptr };
     std::unique_ptr<TextureMapperLayer> m_target;
     bool m_pendingTilesCreation { false };
+    bool m_pendingBackingStoreUpdate { false };
     bool m_needsTilesUpdate { false };
 
 #if ENABLE(DAMAGE_TRACKING)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -167,6 +167,9 @@ void LayerTreeHost::scheduleLayerFlush()
         return;
     }
 
+    if (m_isWaitingForComposition && m_isCommitSceneStatePending)
+        return;
+
     if (!m_layerFlushTimer.isActive())
         m_layerFlushTimer.startOneShot(0_s);
 }
@@ -180,6 +183,9 @@ void LayerTreeHost::flushLayers()
 {
     RELEASE_ASSERT(!m_isFlushingLayers);
     if (m_layerTreeStateIsFrozen)
+        return;
+
+    if (m_isCommitSceneStatePending)
         return;
 
     SetForScope<bool> reentrancyProtector(m_isFlushingLayers, true);
@@ -250,7 +256,7 @@ void LayerTreeHost::flushLayers()
 
 void LayerTreeHost::layerFlushTimerFired()
 {
-    WTFBeginSignpost(this, LayerFlushTimerFired, "isWaitingForRenderer %i", m_isWaitingForRenderer);
+    WTFBeginSignpost(this, LayerFlushTimerFired, "isWaitingForRenderer %i isWaitingForComposition %i", m_isWaitingForRenderer, m_isWaitingForComposition);
 
     if (m_isSuspended) {
         WTFEndSignpost(this, LayerFlushTimerFired);
@@ -319,7 +325,7 @@ void LayerTreeHost::forceRepaint()
     if (!m_isWaitingForRenderer)
         flushLayers();
 #else
-    if (m_isWaitingForRenderer) {
+    if (m_isWaitingForRenderer || m_isWaitingForComposition || m_isCommitSceneStatePending) {
         if (m_forceRepaintAsync.callback)
             m_pendingForceRepaint = true;
         return;
@@ -526,6 +532,18 @@ void LayerTreeHost::didRenderFrame()
 }
 
 #if HAVE(DISPLAY_LINK)
+void LayerTreeHost::didUpdateSceneState()
+{
+    WTFBeginSignpost(this, DidUpdateScene);
+
+    m_isWaitingForRenderer = false;
+    bool scheduledWhileWaitingForRenderer = std::exchange(m_scheduledWhileWaitingForRenderer, false);
+    if (!m_isSuspended && !m_layerTreeStateIsFrozen && (scheduledWhileWaitingForRenderer && !m_layerFlushTimer.isActive()))
+        scheduleLayerFlush();
+
+    WTFEndSignpost(this, DidUpdateScene);
+}
+
 void LayerTreeHost::didComposite(uint32_t compositionResponseID)
 {
     WTFBeginSignpost(this, DidComposite, "compositionRequestID %i, compositionResponseID %i", m_compositionRequestID, compositionResponseID);
@@ -535,9 +553,8 @@ void LayerTreeHost::didComposite(uint32_t compositionResponseID)
         m_forceRepaintAsync.compositionRequestID = std::nullopt;
     }
 
-    if (!m_isWaitingForRenderer || m_compositionRequestID == compositionResponseID) {
-        m_isWaitingForRenderer = false;
-        bool scheduledWhileWaitingForRenderer = std::exchange(m_scheduledWhileWaitingForRenderer, false);
+    if (m_compositionRequestID == compositionResponseID) {
+        m_isWaitingForComposition = false;
         if (m_pendingForceRepaint) {
             if (m_layerTreeStateIsFrozen) {
                 if (m_forceRepaintAsync.callback) {
@@ -549,18 +566,31 @@ void LayerTreeHost::didComposite(uint32_t compositionResponseID)
                 if (m_forceRepaintAsync.callback)
                     m_forceRepaintAsync.compositionRequestID = m_compositionRequestID;
             }
-        } else if (!m_isSuspended && !m_layerTreeStateIsFrozen && (scheduledWhileWaitingForRenderer || m_layerFlushTimer.isActive())) {
-            cancelPendingLayerFlush();
-            flushLayers();
         }
     }
+
+    bool isCommitSceneStatePending = std::exchange(m_isCommitSceneStatePending, false);
+    if (!m_isSuspended && !m_layerTreeStateIsFrozen && isCommitSceneStatePending) {
+        commitSceneState();
+        if (!m_layerFlushTimer.isActive())
+            scheduleLayerFlush();
+    }
+
     WTFEndSignpost(this, DidComposite);
 }
 #endif
 
 void LayerTreeHost::commitSceneState()
 {
+    ASSERT(!m_isWaitingForRenderer);
+    if (m_isWaitingForComposition) {
+        m_isCommitSceneStatePending = true;
+        return;
+    }
+
+    m_isCommitSceneStatePending = false;
     m_isWaitingForRenderer = true;
+    m_isWaitingForComposition = true;
     m_compositionRequestID = m_compositor->requestComposition();
     WTFEmitSignpost(this, CommitSceneState, "compositionRequestID %i", m_compositionRequestID);
 }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
@@ -114,6 +114,7 @@ public:
     void willRenderFrame();
     void didRenderFrame();
 #if HAVE(DISPLAY_LINK)
+    void didUpdateSceneState();
     void didComposite(uint32_t);
 #endif
 
@@ -194,6 +195,8 @@ private:
     bool m_isFlushingLayers { false };
     bool m_waitUntilPaintingComplete { false };
     bool m_isSuspended { false };
+    bool m_isCommitSceneStatePending { false };
+    bool m_isWaitingForComposition { false };
     bool m_isWaitingForRenderer { false };
     bool m_scheduledWhileWaitingForRenderer { false };
     bool m_forceFrameSync { false };

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -88,7 +88,8 @@ ThreadedCompositor::ThreadedCompositor(LayerTreeHost& layerTreeHost, ThreadedDis
     , m_flipY(m_surface->shouldPaintMirrored())
     , m_compositingRunLoop(makeUnique<CompositingRunLoop>([this] { renderLayerTree(); }))
 #if HAVE(DISPLAY_LINK)
-    , m_didRenderFrameTimer(RunLoop::mainSingleton(), "ThreadedCompositor::DidRenderFrameTimer"_s, this, &ThreadedCompositor::didRenderFrameTimerFired)
+    , m_didUpdateSceneStateTimer(RunLoop::mainSingleton(), "ThreadedCompositor::DidUpdateSceneStateTimer"_s, this, &ThreadedCompositor::didUpdateSceneStateTimerFired)
+    , m_didCompositeTimer(RunLoop::mainSingleton(), "ThreadedCompositor::DidCompositeTimer"_s, this, &ThreadedCompositor::didCompositeTimerFired)
 #else
     , m_displayRefreshMonitor(ThreadedDisplayRefreshMonitor::create(displayID, displayRefreshMonitorClient, WebCore::DisplayUpdate { 0, c_defaultRefreshRate / 1000 }))
 #endif
@@ -107,7 +108,8 @@ ThreadedCompositor::ThreadedCompositor(LayerTreeHost& layerTreeHost, ThreadedDis
 
 #if HAVE(DISPLAY_LINK)
 #if USE(GLIB_EVENT_LOOP)
-    m_didRenderFrameTimer.setPriority(RunLoopSourcePriority::RunLoopTimer - 1);
+    m_didUpdateSceneStateTimer.setPriority(RunLoopSourcePriority::RunLoopTimer - 1);
+    m_didCompositeTimer.setPriority(RunLoopSourcePriority::RunLoopTimer - 1);
 #endif
 #else
     m_display.displayID = displayID;
@@ -150,7 +152,8 @@ void ThreadedCompositor::invalidate()
     ASSERT(RunLoop::isMain());
     m_compositingRunLoop->stopUpdates();
 #if HAVE(DISPLAY_LINK)
-    m_didRenderFrameTimer.stop();
+    m_didUpdateSceneStateTimer.stop();
+    m_didCompositeTimer.stop();
 #else
     m_displayRefreshMonitor->invalidate();
 #endif
@@ -248,9 +251,23 @@ void ThreadedCompositor::updateSceneState()
     if (!m_textureMapper)
         m_textureMapper = TextureMapper::create();
 
-    m_sceneState->rootLayer().flushCompositingState(*m_textureMapper);
-    for (auto& layer : m_sceneState->committedLayers())
-        layer->flushCompositingState(*m_textureMapper);
+    m_sceneState->rootLayer().flushCompositingState();
+    ASSERT(!m_sceneState->rootLayer().hasPendingBackingStoreUpdates()); // rootLayer() doesn't have a backing store.
+
+    Vector<Ref<CoordinatedPlatformLayer>, 16> layersWithPendingBackingStoreUpdates;
+    for (auto& layer : m_sceneState->committedLayers()) {
+        layer->flushCompositingState();
+        if (layer->hasPendingBackingStoreUpdates())
+            layersWithPendingBackingStoreUpdates.append(layer);
+    }
+
+#if HAVE(DISPLAY_LINK)
+    if (!m_didUpdateSceneStateTimer.isActive())
+        m_didUpdateSceneStateTimer.startOneShot(0_s);
+#endif
+
+    for (auto& layer : layersWithPendingBackingStoreUpdates)
+        layer->processPendingBackingStoreUpdates(*m_textureMapper);
 }
 
 void ThreadedCompositor::paintToCurrentGLContext(const TransformationMatrix& matrix, const IntSize& size)
@@ -374,8 +391,8 @@ void ThreadedCompositor::renderLayerTree()
     uint32_t compositionRequestID = m_compositionRequestID.load();
 #if HAVE(DISPLAY_LINK)
     m_compositionResponseID = compositionRequestID;
-    if (!m_didRenderFrameTimer.isActive())
-        m_didRenderFrameTimer.startOneShot(0_s);
+    if (!m_didCompositeTimer.isActive())
+        m_didCompositeTimer.startOneShot(0_s);
 #elif !HAVE(OS_SIGNPOST) && !USE(SYSPROF_CAPTURE)
     UNUSED_VARIABLE(compositionRequestID);
 #endif
@@ -428,7 +445,13 @@ void ThreadedCompositor::frameComplete()
 }
 
 #if HAVE(DISPLAY_LINK)
-void ThreadedCompositor::didRenderFrameTimerFired()
+void ThreadedCompositor::didUpdateSceneStateTimerFired()
+{
+    if (m_layerTreeHost)
+        m_layerTreeHost->didUpdateSceneState();
+}
+
+void ThreadedCompositor::didCompositeTimerFired()
 {
     if (m_layerTreeHost)
         m_layerTreeHost->didComposite(m_compositionResponseID);

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
@@ -114,7 +114,8 @@ private:
     void frameComplete();
 
 #if HAVE(DISPLAY_LINK)
-    void didRenderFrameTimerFired();
+    void didUpdateSceneStateTimerFired();
+    void didCompositeTimerFired();
 #else
     void displayUpdateFired();
     void sceneUpdateFinished();
@@ -166,7 +167,8 @@ private:
     std::atomic<uint32_t> m_compositionRequestID { 0 };
 #if HAVE(DISPLAY_LINK)
     std::atomic<uint32_t> m_compositionResponseID { 0 };
-    RunLoop::Timer m_didRenderFrameTimer;
+    RunLoop::Timer m_didUpdateSceneStateTimer;
+    RunLoop::Timer m_didCompositeTimer;
 #else
     struct {
         WebCore::PlatformDisplayID displayID;


### PR DESCRIPTION
#### b2484c8b7130adb3b1b78d7362d945ac1e979aae
<pre>
[WPE][GTK] Dispatch display refreshes earlier when skipping frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=233312">https://bugs.webkit.org/show_bug.cgi?id=233312</a>

Reviewed by NOBODY (OOPS!).

WIP: Another stab at this old problem.

Covered by existing tests.

* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::flushCompositingState):
(WebCore::CoordinatedPlatformLayer::postFlushCompositingState):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::scheduleLayerFlush):
(WebKit::LayerTreeHost::flushLayers):
(WebKit::LayerTreeHost::layerFlushTimerFired):
(WebKit::LayerTreeHost::forceRepaint):
(WebKit::LayerTreeHost::didUpdateSceneState):
(WebKit::LayerTreeHost::didComposite):
(WebKit::LayerTreeHost::commitSceneState):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::invalidate):
(WebKit::ThreadedCompositor::updateSceneState):
(WebKit::ThreadedCompositor::paintToCurrentGLContext):
(WebKit::ThreadedCompositor::renderLayerTree):
(WebKit::ThreadedCompositor::didUpdateSceneStateTimerFired):
(WebKit::ThreadedCompositor::didCompositeTimerFired):
(WebKit::ThreadedCompositor::didRenderFrameTimerFired): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2484c8b7130adb3b1b78d7362d945ac1e979aae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117860 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28170 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124004 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69889 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119738 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38230 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46120 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89438 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59057 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30442 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105678 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69933 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29506 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23794 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67667 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99862 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23973 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127087 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44763 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33706 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98104 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45123 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101903 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97892 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43285 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21258 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41183 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44635 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50309 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44094 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47440 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45784 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->