### PR TITLE
rtp_packetizer_h265_fuzzer needs to check the result of NextPacket for each call

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/rtp_format_h265_fuzzer.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/rtp_format_h265_fuzzer.cc
@@ -46,7 +46,9 @@ void FuzzOneInput(const uint8_t* data, size_t size) {
   RtpPacketToSend rtp_packet(nullptr);
   // Single packet.
   if (num_packets == 1) {
-    RTC_CHECK(packetizer.NextPacket(&rtp_packet));
+    bool result = packetizer.NextPacket(&rtp_packet);
+    if (!result)
+      return;
     RTC_CHECK_LE(rtp_packet.payload_size(),
                  limits.max_payload_len - std::min(limits.single_packet_reduction_len, limits.first_packet_reduction_len));
     depacketizer.Parse(rtp_packet.PayloadBuffer());
@@ -62,15 +64,20 @@ void FuzzOneInput(const uint8_t* data, size_t size) {
   // Middle packets.
   for (size_t i = 1; i < num_packets - 1; ++i) {
     rtp_packet.Clear();
-    RTC_CHECK(packetizer.NextPacket(&rtp_packet))
-        << "Failed to get packet#" << i;
+    bool result = packetizer.NextPacket(&rtp_packet);
+    if (!result)
+      return;
+
     RTC_CHECK_LE(rtp_packet.payload_size(), limits.max_payload_len)
         << "Packet #" << i << " exceeds it's limit";
     depacketizer.Parse(rtp_packet.PayloadBuffer());
   }
   // Last packet.
   rtp_packet.Clear();
-  RTC_CHECK(packetizer.NextPacket(&rtp_packet));
+  result = packetizer.NextPacket(&rtp_packet);
+  if (!result)
+    return;
+
   RTC_CHECK_LE(rtp_packet.payload_size(),
                limits.max_payload_len - limits.last_packet_reduction_len);
   depacketizer.Parse(rtp_packet.PayloadBuffer());


### PR DESCRIPTION
#### 74b841f47fc1ec9bfaac8a80c7603c280eddde1a
<pre>
rtp_packetizer_h265_fuzzer needs to check the result of NextPacket for each call
<a href="https://rdar.apple.com/155057458">rdar://155057458</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=295515">https://bugs.webkit.org/show_bug.cgi?id=295515</a>

Reviewed by Eric Carlson.

In <a href="https://commits.webkit.org/296793@main">https://commits.webkit.org/296793@main</a>, we checked the result of a NextPacket in case there were several packets.
This is not sufficient as, based on the fuzzer&apos;s input, the packetizer may generate aggregated packets elsewhere.

We update all call sites as done in <a href="https://commits.webkit.org/296793@main.">https://commits.webkit.org/296793@main.</a>

* Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/rtp_format_h265_fuzzer.cc:

Canonical link: <a href="https://commits.webkit.org/297062@main">https://commits.webkit.org/297062@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3344d765958038f91e1f4bb407e48e325ecc9f42

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110444 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30103 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20536 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116469 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60698 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30782 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38690 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83989 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113392 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24567 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99449 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64430 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23930 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17588 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60265 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93951 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17644 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119260 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37484 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27817 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92956 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37857 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95717 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92779 "Found 2 new API test failures: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23636 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37780 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15514 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33430 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37379 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37041 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40381 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38749 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->