### PR TITLE
Date/time input editable component tests are failing on macOS 26

### DIFF
--- a/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-mouse-events.html
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-mouse-events.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../resources/common.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="../../../../resources/ui-helper.js"></script>
 <style>
 input {
@@ -34,21 +35,23 @@ function mouseClickOn(x, y) {
 input.addEventListener("click", onClickEvent);
 const center = input.offsetHeight / 2;
 
+const shadowRoot = internals.shadowRoot(input);
+const monthField = getElementByPseudoId(shadowRoot, "-webkit-datetime-edit-month-field");
+const dayField = getElementByPseudoId(shadowRoot, "-webkit-datetime-edit-day-field");
+const yearField = getElementByPseudoId(shadowRoot, "-webkit-datetime-edit-year-field");
+
 debug("Enabled Input\n");
 
-// Click on month field.
-mouseClickOn(20, center);
+UIHelper.activateElement(monthField);
 UIHelper.keyDown("9");
 shouldBeEqualToString("input.value", "2020-09-26");
 
-// Click on day field.
-mouseClickOn(60, center);
+UIHelper.activateElement(dayField);
 UIHelper.keyDown("1");
 UIHelper.keyDown("2");
 shouldBeEqualToString("input.value", "2020-09-12");
 
-// Click on year field.
-mouseClickOn(120, center);
+UIHelper.activateElement(yearField);
 UIHelper.keyDown("3");
 UIHelper.keyDown("0");
 UIHelper.keyDown("3");
@@ -72,12 +75,9 @@ clickEventsFired = 0;
 input.disabled = true;
 input.readOnly = false;
 
-// Click on month field.
-mouseClickOn(20, center);
-// Click on day field.
-mouseClickOn(60, center);
-// Click on year field.
-mouseClickOn(120, center);
+UIHelper.activateElement(monthField);
+UIHelper.activateElement(dayField);
+UIHelper.activateElement(yearField);
 // Click on control, but not a specific field, defaults to first field.
 mouseClickOn(250, center);
 // Click outside control.
@@ -90,12 +90,9 @@ clickEventsFired = 0;
 input.disabled = false;
 input.readOnly = true;
 
-// Click on month field.
-mouseClickOn(20, center);
-// Click on day field.
-mouseClickOn(60, center);
-// Click on year field.
-mouseClickOn(120, center);
+UIHelper.activateElement(monthField);
+UIHelper.activateElement(dayField);
+UIHelper.activateElement(yearField);
 // Click on control, but not a specific field, defaults to first field.
 mouseClickOn(250, center);
 // Click outside control.
@@ -104,7 +101,5 @@ mouseClickOn(input.offsetWidth + 5, input.offsetHeight + 5);
 shouldBe("clickEventsFired", "4");
 
 </script>
-
-<script src="../../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-mouse-events.html
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-mouse-events.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../resources/common.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="../../../../resources/ui-helper.js"></script>
 <style>
 input {
@@ -34,40 +35,42 @@ function mouseClickOn(x, y) {
 input.addEventListener("click", onClickEvent);
 const center = input.offsetHeight / 2;
 
+const shadowRoot = internals.shadowRoot(input);
+const monthField = getElementByPseudoId(shadowRoot, "-webkit-datetime-edit-month-field");
+const dayField = getElementByPseudoId(shadowRoot, "-webkit-datetime-edit-day-field");
+const yearField = getElementByPseudoId(shadowRoot, "-webkit-datetime-edit-year-field");
+const hourField = getElementByPseudoId(shadowRoot, "-webkit-datetime-edit-hour-field");
+const minuteField = getElementByPseudoId(shadowRoot, "-webkit-datetime-edit-minute-field");
+const meridiemField = getElementByPseudoId(shadowRoot, "-webkit-datetime-edit-meridiem-field");
+
 debug("Enabled Input\n");
 
-// Click on month field.
-mouseClickOn(20, center);
+UIHelper.activateElement(monthField);
 UIHelper.keyDown("9");
 shouldBeEqualToString("input.value", "2020-09-20T05:30");
 
-// Click on day field.
-mouseClickOn(60, center);
+UIHelper.activateElement(dayField);
 UIHelper.keyDown("1");
 UIHelper.keyDown("2");
 shouldBeEqualToString("input.value", "2020-09-12T05:30");
 
-// Click on year field.
-mouseClickOn(120, center);
+UIHelper.activateElement(yearField);
 UIHelper.keyDown("3");
 UIHelper.keyDown("0");
 UIHelper.keyDown("3");
 UIHelper.keyDown("0");
 shouldBeEqualToString("input.value", "3030-09-12T05:30");
 
-// Click on hour field.
-mouseClickOn(200, center);
+UIHelper.activateElement(hourField);
 UIHelper.keyDown("8");
 shouldBeEqualToString("input.value", "3030-09-12T08:30");
 
-// Click on minute field.
-mouseClickOn(240, center);
+UIHelper.activateElement(minuteField);
 UIHelper.keyDown("4");
 UIHelper.keyDown("5");
 shouldBeEqualToString("input.value", "3030-09-12T08:45");
 
-// Click on meridiem field.
-mouseClickOn(300, center);
+UIHelper.activateElement(meridiemField);
 UIHelper.keyDown("P");
 shouldBeEqualToString("input.value", "3030-09-12T20:45");
 
@@ -88,18 +91,12 @@ clickEventsFired = 0;
 input.disabled = true;
 input.readOnly = false;
 
-// Click on month field.
-mouseClickOn(20, center);
-// Click on day field.
-mouseClickOn(60, center);
-// Click on year field.
-mouseClickOn(120, center);
-// Click on hour field.
-mouseClickOn(200, center);
-// Click on minute field.
-mouseClickOn(240, center);
-// Click on meridiem field.
-mouseClickOn(300, center);
+UIHelper.activateElement(monthField);
+UIHelper.activateElement(dayField);
+UIHelper.activateElement(yearField);
+UIHelper.activateElement(hourField);
+UIHelper.activateElement(minuteField);
+UIHelper.activateElement(meridiemField);
 // Click on control, but not a specific field, defaults to first field.
 mouseClickOn(550, center);
 // Click outside control.
@@ -112,18 +109,12 @@ clickEventsFired = 0;
 input.disabled = false;
 input.readOnly = true;
 
-// Click on month field.
-mouseClickOn(20, center);
-// Click on day field.
-mouseClickOn(60, center);
-// Click on year field.
-mouseClickOn(120, center);
-// Click on hour field.
-mouseClickOn(200, center);
-// Click on minute field.
-mouseClickOn(240, center);
-// Click on meridiem field.
-mouseClickOn(300, center);
+UIHelper.activateElement(monthField);
+UIHelper.activateElement(dayField);
+UIHelper.activateElement(yearField);
+UIHelper.activateElement(hourField);
+UIHelper.activateElement(minuteField);
+UIHelper.activateElement(meridiemField);
 // Click on control, but not a specific field, defaults to first field.
 mouseClickOn(550, center);
 // Click outside control.
@@ -132,7 +123,5 @@ mouseClickOn(input.offsetWidth + 5, input.offsetHeight + 5);
 shouldBe("clickEventsFired", "7");
 
 </script>
-
-<script src="../../../../resources/js-test-post.js"></script>
 </body>
 </html>


### PR DESCRIPTION
#### 02f19675366af13932d7eb5bc4573e23a60c399d
<pre>
Date/time input editable component tests are failing on macOS 26
<a href="https://bugs.webkit.org/show_bug.cgi?id=295525">https://bugs.webkit.org/show_bug.cgi?id=295525</a>
<a href="https://rdar.apple.com/154986830">rdar://154986830</a>

Reviewed by Abrar Rahman Protyasha and Tim Nguyen.

Mouse event tests for date/time inputs with editable components currently rely
on hardcoded coordinates for clicking. With the control redesign on macOS 26,
the introduction of padding has changed the position of editable components.
Consequently, the hardcoded coordinates are no longer correct.

Fix by obtaining the elements themselves from the shadow tree and clicking on
them after obtaining their position programmatically.

* LayoutTests/fast/forms/date/date-editable-components/date-editable-components-mouse-events.html:
* LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-mouse-events.html:

Canonical link: <a href="https://commits.webkit.org/297080@main">https://commits.webkit.org/297080@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c82e966ade61456d13a509880cb54f451bd00edf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30124 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20557 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116490 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/60729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30803 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38711 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84003 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/60729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113413 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24585 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99464 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64444 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23949 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17604 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60286 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93970 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17660 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119281 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37505 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/27886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92970 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37879 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95732 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92793 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37795 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15529 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/33463 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17823 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37400 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37062 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40402 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38771 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->