### PR TITLE
[SwiftUI] The content size reported by webViewOnScrollGeometryChange can be incorrect

### DIFF
--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -1322,7 +1322,168 @@ void LocalFrameView::updateScrollGeometryContentSize()
     if (!page || !page->chrome().client().needsScrollGeometryUpdates())
         return;
 
-    m_scrollGeometryContentSize = contentsSize();
+    RefPtr document = m_frame->document();
+    if (!document)
+        return;
+
+    IntSize scrollGeometryContentSize;
+    bool heightDeterminingBoxIsPositioned = false;
+    bool hasViewportConstrainedHeight = false;
+
+    auto updateScrollGeometryContentSizeWithBoxAndPosition = [&scrollGeometryContentSize, &heightDeterminingBoxIsPositioned](const RenderBox& box, IntPoint position) {
+        scrollGeometryContentSize.setWidth(std::max(scrollGeometryContentSize.width(), position.x()));
+
+        auto oldHeight = scrollGeometryContentSize.height();
+        scrollGeometryContentSize.setHeight(std::max(scrollGeometryContentSize.height(), position.y()));
+
+        if (oldHeight != scrollGeometryContentSize.height())
+            heightDeterminingBoxIsPositioned = box.isPositioned();
+    };
+
+    auto maxPositionForBox = [](const RenderBox& box) {
+        auto rect = snappedIntRect(box.borderBoxRect());
+
+        auto borderBoxRectMaxCorner = rect.maxXMaxYCorner();
+
+        auto layoutOverflowRect = snappedIntRect(box.layoutOverflowRect());
+        auto layoutOverflowRectMaxCorner = layoutOverflowRect.maxXMaxYCorner();
+
+        if (box.effectiveOverflowX() == Overflow::Visible && layoutOverflowRectMaxCorner.x() > borderBoxRectMaxCorner.x())
+            rect.setWidth(rect.width() + layoutOverflowRectMaxCorner.x() - borderBoxRectMaxCorner.x());
+
+        if (box.effectiveOverflowY() == Overflow::Visible && layoutOverflowRectMaxCorner.y() > borderBoxRectMaxCorner.y())
+            rect.setHeight(rect.height() + layoutOverflowRectMaxCorner.y() - borderBoxRectMaxCorner.y());
+
+        auto point = roundedIntPoint(box.localToAbsolute(rect.location()));
+        rect.setLocation(point);
+
+        return rect.maxXMaxYCorner();
+    };
+
+    IntSize documentSize = layoutSize();
+    CheckedPtr<RenderBox> documentRenderer;
+
+    IntSize bodySize;
+    CheckedPtr<RenderBox> bodyRenderer;
+
+    auto adjustMaxPositionForBodyOrDocument = [&](RenderBox& box, IntPoint& maxPosition) {
+        if (box.isBody()) {
+            bodySize = { maxPosition.x(), maxPosition.y() };
+            bodyRenderer = &box;
+        } else
+            documentRenderer = &box;
+
+        CheckedRef style = box.style();
+
+        if (style->width().isAuto())
+            maxPosition.setX(0);
+
+        if (style->height().isAuto())
+            maxPosition.setY(0);
+    };
+
+    auto determineScrollGeometryForRendererWithNonVisibleOverflow = [&](const RenderBox& renderer) {
+        CheckedPtr descendant = renderer.firstChild();
+        CheckedPtr stop = renderer.nextInPreOrderAfterChildren();
+
+        while (descendant && descendant != stop) {
+            CheckedPtr descendantBox = dynamicDowncast<RenderBox>(*descendant);
+            if (!descendantBox) {
+                descendant = descendant->nextInPreOrder();
+                continue;
+            }
+
+            if (!descendantBox->isOutOfFlowPositioned()) {
+                descendant = descendant->nextInPreOrder();
+                continue;
+            }
+
+            auto position = maxPositionForBox(*descendantBox);
+            updateScrollGeometryContentSizeWithBoxAndPosition(*descendantBox, position);
+            descendant = descendant->nextInPreOrderAfterChildren();
+        }
+    };
+
+    auto constrainScrollGeometryContentSizeToViewportSizeIfNeeded = [&] {
+        auto viewportContrainedSize = scrollGeometryContentSize;
+
+        if (documentRenderer->effectiveOverflowX() != Overflow::Visible) {
+            if (bodyRenderer->effectiveOverflowX() != Overflow::Visible)
+                viewportContrainedSize.setWidth(bodySize.width());
+            else if (documentRenderer->effectiveOverflowX() == Overflow::Clip || documentRenderer->effectiveOverflowX() == Overflow::Hidden)
+                viewportContrainedSize.setWidth(documentSize.width());
+        }
+
+        if (documentRenderer->effectiveOverflowY() != Overflow::Visible) {
+            if (bodyRenderer->effectiveOverflowY() != Overflow::Visible)
+                viewportContrainedSize.setHeight(bodySize.height());
+            else if (documentRenderer->effectiveOverflowY() == Overflow::Clip || documentRenderer->effectiveOverflowY() == Overflow::Hidden)
+                viewportContrainedSize.setHeight(documentSize.height());
+        }
+
+        hasViewportConstrainedHeight = scrollGeometryContentSize.height() != viewportContrainedSize.height();
+
+        scrollGeometryContentSize.setWidth(std::min(scrollGeometryContentSize.width(), viewportContrainedSize.width()));
+        scrollGeometryContentSize.setHeight(std::min(scrollGeometryContentSize.height(), viewportContrainedSize.height()));
+    };
+
+    auto applyBodyMarginToScrollGeometryContentSizeIfNeeded = [&] {
+        if (!hasViewportConstrainedHeight && !scrollGeometryContentSize.isZero() && scrollGeometryContentSize.height() <= bodySize.height() && !heightDeterminingBoxIsPositioned)
+            scrollGeometryContentSize.setHeight(scrollGeometryContentSize.height() + bodyRenderer->collapsedMarginAfter());
+    };
+
+    // Determine the minimum view size needed such that no scrolling is necessary to reach
+    // any content.
+    //
+    // This is achieved by traversing the render tree and determining the bottom right corner
+    // of each renderer, after accounting for overflow.
+
+    CheckedPtr renderer = renderView()->firstChild();
+    while (renderer) {
+        CheckedPtr box = dynamicDowncast<RenderBox>(*renderer);
+        if (!box) {
+            renderer = renderer->nextInPreOrder();
+            continue;
+        }
+
+        auto maxPosition = maxPositionForBox(*box);
+
+        // The body and document renderers are special since their height is sized to fit
+        // the view in quirks mode. In this case, their size should not determine the
+        // scroll geometry content size, which could be smaller.
+        bool isBodyOrDocumentRenderer = box->isBody() || box->isDocumentElementRenderer();
+        if (isBodyOrDocumentRenderer)
+            adjustMaxPositionForBodyOrDocument(*box, maxPosition);
+
+        updateScrollGeometryContentSizeWithBoxAndPosition(*box, maxPosition);
+
+        if (!isBodyOrDocumentRenderer) {
+            // The children of positioned elements may be skipped, since the renderer itself
+            // already has the necessary geometry information.
+            if (box->isPositioned()) {
+                renderer = renderer->nextInPreOrderAfterChildren();
+                continue;
+            }
+
+            // Only out-of-flow positioned children need to be consulted if the current
+            // renderer has non-visible overflow. In-flow children would contribute to
+            // the current renderer's geometry information and may be ignored.
+            bool hasNonVisibleOverflow = isNonVisibleOverflow(box->effectiveOverflowX()) || isNonVisibleOverflow(box->effectiveOverflowY());
+            if (hasNonVisibleOverflow) {
+                determineScrollGeometryForRendererWithNonVisibleOverflow(*box);
+                renderer = renderer->nextInPreOrderAfterChildren();
+                continue;
+            }
+        }
+
+        renderer = renderer->nextInPreOrder();
+    }
+
+    constrainScrollGeometryContentSizeToViewportSizeIfNeeded();
+
+    applyBodyMarginToScrollGeometryContentSizeIfNeeded();
+
+    m_scrollGeometryContentSize = scrollGeometryContentSize;
 }
 
 bool LocalFrameView::shouldDeferScrollUpdateAfterContentSizeChange()


### PR DESCRIPTION
#### 3c2e8b44b99b51d40ac1e4921897bba8daaa5ed5
<pre>
[SwiftUI] The content size reported by webViewOnScrollGeometryChange can be incorrect
<a href="https://bugs.webkit.org/show_bug.cgi?id=295528">https://bugs.webkit.org/show_bug.cgi?id=295528</a>
<a href="https://rdar.apple.com/146576790">rdar://146576790</a>

Reviewed by Alan Baradlay and Richard Robinson.

Currently, `webViewOnScrollGeometryChange` reports the content size using
`LocalFrameView::contentsSize`. However, this is semantically different from
the content size reported by SwiftUI ScrollView. ScrollView&apos;s content size
represents the minimum width and height needed to avoid making the content
scrollable. `LocalFrameView::contentsSize` does not do this – the contents size
can be viewport sized in cases where the content itself is actually smaller.
Additionally, standards/quirks mode can affect the used content size.
`webViewOnScrollGeometryChange` should be agnostic of standards/quirks mode.

Fix by implementing a new algorithm to determine the maximum x and y position
of an element that can be reached by scrolling the body.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::updateScrollGeometryContentSize):

Traverse the render tree to obtain the maximum x and y position of objects in
the tree.

The body/document renderer&apos;s width/height is not used when it is `auto`. This
is because it may be expanded beyond the actual size needed for scrolling.

If the box is positioned skip its descendants, since it will already have the
full geometry information.

Finally, account for overflow that clips to the viewport, and apply the used
margin from the body when necessary.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKScrollGeometryTests.mm:

Canonical link: <a href="https://commits.webkit.org/297282@main">https://commits.webkit.org/297282@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a62169f69c0a83cbf08e5932f89b2d70688179c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111080 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30746 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21177 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117111 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61347 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113042 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39328 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84446 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114027 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25108 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100007 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64892 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24452 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18152 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60931 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94487 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18217 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119993 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38129 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28336 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93385 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38505 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96284 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93209 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38292 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16032 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34110 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17929 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38018 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43494 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37682 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41016 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39385 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->