### PR TITLE
REGRESSION (296901@main): Debug assertion under `ScrollingTreeStickyNode::findConstrainingRect` when opening Web Inspector

### DIFF
--- a/LayoutTests/compositing/scrolling/async-overflow-scrolling/sticky-in-overflow-scroller-expected.html
+++ b/LayoutTests/compositing/scrolling/async-overflow-scrolling/sticky-in-overflow-scroller-expected.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+<style>
+body, html {
+    padding: 0;
+    margin: 0;
+    background-color: #f4f4f4;
+}
+
+.scroller {
+    width: 640px;
+    height: 480px;
+    box-sizing: border-box;
+    line-height: 1.8em;
+    background-color: white;
+    outline: none;
+    margin: 1em auto;
+    display: block;
+    overflow: scroll;
+}
+
+.sticky {
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 60px;
+    z-index: 1;
+    background-color: tomato;
+    position: sticky;
+}
+
+.vertical-space {
+    width: 100%;
+    height: 400px;
+}
+</style>
+</head>
+<body>
+    <div class="scroller">
+        <div class="vertical-space"></div>
+        <header class="sticky"></header>
+        <div class="vertical-space"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/scrolling/async-overflow-scrolling/sticky-in-overflow-scroller.html
+++ b/LayoutTests/compositing/scrolling/async-overflow-scrolling/sticky-in-overflow-scroller.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+body, html {
+    padding: 0;
+    margin: 0;
+    background-color: #f4f4f4;
+}
+
+.scroller {
+    width: 640px;
+    height: 480px;
+    box-sizing: border-box;
+    line-height: 1.8em;
+    background-color: white;
+    outline: none;
+    margin: 1em auto;
+    display: block;
+    overflow: scroll;
+}
+
+.sticky {
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 60px;
+    z-index: -1;
+    background-color: tomato;
+    position: sticky;
+}
+
+.vertical-space {
+    width: 100%;
+    height: 400px;
+}
+</style>
+</head>
+<body>
+    <div class="scroller">
+        <div class="vertical-space"></div>
+        <header class="sticky"></header>
+        <div class="vertical-space"></div>
+    </div>
+    <script>
+    window.testRunner?.waitUntilDone();
+    addEventListener("load", async () => {
+        await UIHelper.renderingUpdate();
+        document.querySelector(".sticky").style.zIndex = 1;
+        window.testRunner?.notifyDone();
+    });
+    </script>
+</body>
+</html>

--- a/Source/WebCore/page/scrolling/ScrollingStateStickyNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateStickyNode.cpp
@@ -104,7 +104,7 @@ void ScrollingStateStickyNode::updateConstraints(const StickyPositionViewportCon
 
 FloatPoint ScrollingStateStickyNode::computeAnchorLayerPosition(const LayoutRect& viewportRect) const
 {
-    // This logic follows ScrollingTreeStickyNode::computeAnchorLayerPosition().
+    // This logic follows ScrollingTreeStickyNode::computeConstrainingRectAndAnchorLayerPosition().
     FloatSize offsetFromStickyAncestors;
     auto computeLayerPositionForScrollingNode = [&](ScrollingStateNode& scrollingStateNode) {
         FloatRect constrainingRect;

--- a/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.h
@@ -54,19 +54,15 @@ protected:
 
     FloatPoint computeClippingLayerPosition() const;
     std::optional<FloatRect> findConstrainingRect() const;
-    FloatPoint computeAnchorLayerPosition() const;
+    std::pair<std::optional<FloatRect>, FloatPoint> computeConstrainingRectAndAnchorLayerPosition() const;
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
 
     virtual FloatPoint layerTopLeft() const = 0;
     virtual bool hasViewportClippingLayer() const { return false; }
     const ViewportConstraints& constraints() const final { return m_constraints; }
 
-private:
-    void updateIsSticking();
+    bool isCurrentlySticking(const FloatRect& constrainingRect) const;
 
-    bool m_isSticking { false };
-
-protected:
     StickyPositionViewportConstraints m_constraints;
 };
 

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h
@@ -50,7 +50,9 @@ private:
     FloatPoint layerTopLeft() const final;
     CALayer *layer() const final { return m_layer.get(); }
     bool hasViewportClippingLayer() const final;
+    void setIsSticking(bool) WTF_REQUIRES_LOCK(scrollingTree()->treeLock());
 
+    bool m_isSticking { false };
     RetainPtr<CALayer> m_layer;
     RetainPtr<CALayer> m_viewportAnchorLayer;
 };

--- a/Source/WebCore/page/scrolling/coordinated/ScrollingTreeStickyNodeCoordinated.cpp
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollingTreeStickyNodeCoordinated.cpp
@@ -62,7 +62,7 @@ bool ScrollingTreeStickyNodeCoordinated::commitStateBeforeChildren(const Scrolli
 
 void ScrollingTreeStickyNodeCoordinated::applyLayerPositions()
 {
-    auto layerPosition = computeAnchorLayerPosition();
+    auto layerPosition = computeConstrainingRectAndAnchorLayerPosition().second;
 
     LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeStickyNodeCoordinated " << scrollingNodeID() << " constrainingRectAtLastLayout " << m_constraints.constrainingRectAtLastLayout() << " last layer pos " << m_constraints.layerPositionAtLastLayout() << " layerPosition " << layerPosition);
 

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -174,6 +174,9 @@ void WebPageProxy::didCommitLayerTree(const RemoteLayerTreeTransaction& layerTre
             stopMakingViewBlankDueToLackOfRenderingUpdateIfNecessary();
             internals().lastVisibleContentRectUpdate = { };
         }
+
+        if (std::exchange(internals().needsFixedContainerEdgesUpdateAfterNextCommit, false))
+            protectedLegacyMainFrameProcess()->send(Messages::WebPage::SetNeedsFixedContainerEdgesUpdate(), webPageIDInMainFrameProcess());
     }
 
     if (RefPtr pageClient = this->pageClient())

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -90,7 +90,6 @@ const RemoteLayerTreeHost* RemoteScrollingCoordinatorProxy::layerTreeHost() cons
 
 std::optional<RequestedScrollData> RemoteScrollingCoordinatorProxy::commitScrollingTreeState(IPC::Connection& connection, const RemoteScrollingCoordinatorTransaction& transaction, std::optional<LayerHostingContextIdentifier> identifier)
 {
-    m_stickyScrollingTreeNodesBeganSticking = false;
     m_requestedScroll = { };
 
     auto stateTree = WTFMove(const_cast<RemoteScrollingCoordinatorTransaction&>(transaction).scrollingStateTree());
@@ -114,15 +113,12 @@ std::optional<RequestedScrollData> RemoteScrollingCoordinatorProxy::commitScroll
     if (transaction.clearScrollLatching())
         m_scrollingTree->clearLatchedNode();
 
-    if (std::exchange(m_stickyScrollingTreeNodesBeganSticking, false))
-        protectedWebPageProxy()->stickyScrollingTreeNodeBeganSticking();
-
     return std::exchange(m_requestedScroll, { });
 }
 
 void RemoteScrollingCoordinatorProxy::stickyScrollingTreeNodeBeganSticking(ScrollingNodeID)
 {
-    m_stickyScrollingTreeNodesBeganSticking = true;
+    protectedWebPageProxy()->stickyScrollingTreeNodeBeganSticking();
 }
 
 void RemoteScrollingCoordinatorProxy::handleWheelEvent(const WebWheelEvent& wheelEvent, RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -204,7 +204,6 @@ protected:
     std::optional<unsigned> m_currentHorizontalSnapPointIndex;
     std::optional<unsigned> m_currentVerticalSnapPointIndex;
     bool m_waitingForDidScrollReply { false };
-    bool m_stickyScrollingTreeNodesBeganSticking { false };
     HashSet<WebCore::PlatformLayerIdentifier> m_layersWithScrollingRelations;
 };
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11496,6 +11496,8 @@ void WebPageProxy::resetState(ResetStateReason resetStateReason)
 
     internals().visibleScrollerThumbRect = IntRect();
 
+    internals().needsFixedContainerEdgesUpdateAfterNextCommit = false;
+
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     if (RefPtr playbackSessionManager = std::exchange(m_playbackSessionManager, nullptr))
         playbackSessionManager->invalidate();
@@ -15935,7 +15937,7 @@ void WebPageProxy::stickyScrollingTreeNodeBeganSticking()
     if (!protectedPreferences()->contentInsetBackgroundFillEnabled())
         return;
 
-    send(Messages::WebPage::SetNeedsFixedContainerEdgesUpdate());
+    internals().needsFixedContainerEdgesUpdateAfterNextCommit = true;
 }
 
 void WebPageProxy::adjustLayersForLayoutViewport(const FloatPoint& scrollPosition, const WebCore::FloatRect& layoutViewport, double scale)

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -438,6 +438,8 @@ public:
     std::optional<VisibleContentRectUpdateInfo> lastVisibleContentRectUpdate;
 #endif
 
+    bool needsFixedContainerEdgesUpdateAfterNextCommit { false };
+
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     RunLoop::Timer fullscreenVideoTextRecognitionTimer;
     std::optional<PlaybackSessionContextIdentifier> currentFullscreenVideoSessionIdentifier;


### PR DESCRIPTION
#### a13640cea30b69809a8ad998a5ccf27420a94a1f
<pre>
REGRESSION (296901@main): Debug assertion under `ScrollingTreeStickyNode::findConstrainingRect` when opening Web Inspector
<a href="https://bugs.webkit.org/show_bug.cgi?id=295533">https://bugs.webkit.org/show_bug.cgi?id=295533</a>
<a href="https://rdar.apple.com/155225837">rdar://155225837</a>

Reviewed by Abrar Rahman Protyasha.

After the changes in 296901@main, opening Web Inspector with a debug macOS build of WebKit causes an
instant debug assertion to be hit under `findConstrainingRect()`. This happens because:

1.  The logic to `updateIsSticking` currently resides in `commitStateBeforeChildren`.

2.  `updateIsSticking` indirectly calls into `findConstrainingRect`, which may need to look up
    enclosing UI-side scrolling tree scrolling nodes by ID. If the enclosing scrolling node ID fails
    to map to its corresponding scrolling node in the tree, we end up hitting this debug assert.

3.  Scrolling tree scrolling nodes are registered (by ID) with the UI-side scrolling tree when
    committing tree state.

…so in the case where we&apos;ve already visited (i.e. committed state for) the enclosing scroller of a
sticky node by the time we visit the sticky node, the lookup in (2) succeeds, and we don&apos;t assert.
However, in the case where the sticky node is *before* the enclosing scrolling node in tree order,
we&apos;ll crash with the debug assert because (3) hasn&apos;t happened by the time we attempt to commit state
for the sticky node.

To fix this, we move logic to update the &quot;sticking&quot; state out of `commitStateBeforeChildren`, and
instead move it into `applyLayerPositions` (the same codepath that handles UI-side layer blitting
when scrolling). We also ensure that at most 1 IPC message is sent back to the web page per main-
frame rendering update, by moving the batching mechanism onto `WebPageProxy`.

* LayoutTests/compositing/scrolling/async-overflow-scrolling/sticky-in-overflow-scroller-expected.html: Added.
* LayoutTests/compositing/scrolling/async-overflow-scrolling/sticky-in-overflow-scroller.html: Added.

Add a layout test to exercise the assertion; the key piece here is to have sticky nodes with a
negative initial `z-index` relative to its parent overflow scroller. This ensures that when
traversing the scrolling tree during the scroll commit, we&apos;ll visit the sticky node *before*
visiting its enclosing overflow scroller.

* Source/WebCore/page/scrolling/ScrollingStateStickyNode.cpp:
(WebCore::ScrollingStateStickyNode::computeAnchorLayerPosition const):
* Source/WebCore/page/scrolling/ScrollingTreeStickyNode.cpp:
(WebCore::ScrollingTreeStickyNode::commitStateBeforeChildren):
(WebCore::ScrollingTreeStickyNode::computeConstrainingRectAndAnchorLayerPosition const):

Rename `computeAnchorLayerPosition` to `computeConstrainingRectAndAnchorLayerPosition`, and make it
return both the constraining rect as well as the anchor layer position. The call site in

(WebCore::ScrollingTreeStickyNode::scrollDeltaSinceLastCommit const):
(WebCore::ScrollingTreeStickyNode::isCurrentlySticking const):

Split this into a second method that takes a precomputed `constrainingRect`, which we can call from
`applyLayerPositions()` below to avoid redundant work to compute the constraining rect.

(WebCore::ScrollingTreeStickyNode::updateIsSticking): Deleted.

Move this into `ScrollingTreeStickyNodeCocoa` as `setIsSticking`, and make it take a `bool`; see
below.

(WebCore::ScrollingTreeStickyNode::computeAnchorLayerPosition const): Deleted.
* Source/WebCore/page/scrolling/ScrollingTreeStickyNode.h:
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h:
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.mm:
(WebCore::ScrollingTreeStickyNodeCocoa::applyLayerPositions):

Move logic to notify the scrolling tree when a sticky scrolling node has begun to stick out of
`commitStateBeforeChildren` and into `applyLayerPositions` instead. This allows us to:

1.  Fix the bug by ensuring that `findConstrainingRect()` is only called when the scrolling tree
    nodes have already finished attaching.

2.  Avoid having to recompute the constraining rect, since `applyLayerPositions` already computes it
    in the process of repositioning the anchor/clipping layer.

3.  Ensure that we still observe that sticky scrolling nodes begin sticking during UI-side
    scrolling, without having to wait for layout in the web process to reconcile layer positions for
    scrolling state nodes.

(WebCore::ScrollingTreeStickyNodeCocoa::setIsSticking):

Use `ensureOnMainRunLoop` here to make sure we don&apos;t try to mutate any state downstream on the
scrolling thread, and instead hop to the main thread if needed.

* Source/WebCore/page/scrolling/coordinated/ScrollingTreeStickyNodeCoordinated.cpp:
(WebCore::ScrollingTreeStickyNodeCoordinated::applyLayerPositions):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::didCommitLayerTree):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::commitScrollingTreeState):
(WebKit::RemoteScrollingCoordinatorProxy::stickyScrollingTreeNodeBeganSticking):

Remove `m_stickyScrollingTreeNodesBeganSticking` here, and instead add a flag to `WebPageProxy`
(below) to send at most one IPC message to invalidate `m_needsFixedContainerEdgesUpdate`, even if
a large number of sticky scrolling nodes begin sticking during the same rendering update.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::resetState):
(WebKit::WebPageProxy::stickyScrollingTreeNodeBeganSticking):
* Source/WebKit/UIProcess/WebPageProxyInternals.h:

Canonical link: <a href="https://commits.webkit.org/297097@main">https://commits.webkit.org/297097@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4bdb04d76287448d5a73d71da64aee588b9abee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110513 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30172 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20605 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116539 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/60780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112476 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30851 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38760 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84035 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/60780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113461 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24622 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99510 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64476 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23984 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17649 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60334 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94003 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17709 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119329 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37553 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27869 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93003 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37927 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95781 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92826 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23655 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37826 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15572 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33526 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37448 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42919 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37110 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40450 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38819 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->