### PR TITLE
Fixed unchecked local variables safercpp errors in UserMediaController.cpp

### DIFF
--- a/Source/WebCore/Modules/mediastream/UserMediaClient.h
+++ b/Source/WebCore/Modules/mediastream/UserMediaClient.h
@@ -34,6 +34,7 @@
 #if ENABLE(MEDIA_STREAM)
 
 #include "MediaProducer.h"
+#include <wtf/AbstractRefCounted.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/ObjectIdentifier.h>
 
@@ -47,10 +48,8 @@ class UserMediaRequest;
 
 struct MediaDeviceHashSalts;
 
-class UserMediaClient {
+class UserMediaClient : public AbstractRefCounted {
 public:
-    virtual void pageDestroyed() = 0;
-
     virtual void requestUserMediaAccess(UserMediaRequest&) = 0;
     virtual void cancelUserMediaAccessRequest(UserMediaRequest&) = 0;
 
@@ -65,11 +64,13 @@ public:
     virtual void updateCaptureState(const Document&, bool isActive, MediaProducerMediaCaptureKind, CompletionHandler<void(std::optional<Exception>&&)>&&) = 0;
     virtual void setShouldListenToVoiceActivity(bool) = 0;
 
-protected:
     virtual ~UserMediaClient() = default;
+
+protected:
+    UserMediaClient() = default;
 };
 
-WEBCORE_EXPORT void provideUserMediaTo(Page*, UserMediaClient*);
+WEBCORE_EXPORT void provideUserMediaTo(Page*, Ref<UserMediaClient>&&);
 
 } // namespace WebCore
 

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -9,7 +9,6 @@ Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
 Modules/indexeddb/server/SQLiteIDBCursor.cpp
 Modules/mediarecorder/MediaRecorder.cpp
 Modules/mediastream/RTCPeerConnection.cpp
-Modules/mediastream/UserMediaController.cpp
 Modules/mediastream/UserMediaRequest.cpp
 Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
 Modules/model-element/HTMLModelElement.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -23,7 +23,6 @@ Modules/mediastream/PeerConnectionBackend.cpp
 Modules/mediastream/RTCController.cpp
 Modules/mediastream/RTCPeerConnection.cpp
 Modules/mediastream/RTCRtpScriptTransformer.cpp
-Modules/mediastream/UserMediaController.cpp
 Modules/mediastream/UserMediaRequest.cpp
 Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
 Modules/model-element/HTMLModelElement.cpp

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebUserMediaClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebUserMediaClient.cpp
@@ -40,49 +40,47 @@ WebUserMediaClient::WebUserMediaClient(WebPage& page)
 {
 }
 
-Ref<WebPage> WebUserMediaClient::protectedPage() const
-{
-    return m_page.get();
-}
-
-void WebUserMediaClient::pageDestroyed()
-{
-    delete this;
-}
-
 void WebUserMediaClient::requestUserMediaAccess(UserMediaRequest& request)
 {
-    protectedPage()->userMediaPermissionRequestManager().startUserMediaRequest(request);
+    if (RefPtr page = m_page.get())
+        page->userMediaPermissionRequestManager().startUserMediaRequest(request);
 }
 
 void WebUserMediaClient::cancelUserMediaAccessRequest(UserMediaRequest& request)
 {
-    protectedPage()->userMediaPermissionRequestManager().cancelUserMediaRequest(request);
+    if (RefPtr page = m_page.get())
+        page->userMediaPermissionRequestManager().cancelUserMediaRequest(request);
 }
 
 void WebUserMediaClient::enumerateMediaDevices(Document& document, UserMediaClient::EnumerateDevicesCallback&& completionHandler)
 {
-    protectedPage()->userMediaPermissionRequestManager().enumerateMediaDevices(document, WTFMove(completionHandler));
+    if (RefPtr page = m_page.get())
+        page->userMediaPermissionRequestManager().enumerateMediaDevices(document, WTFMove(completionHandler));
 }
 
 WebUserMediaClient::DeviceChangeObserverToken WebUserMediaClient::addDeviceChangeObserver(WTF::Function<void()>&& observer)
 {
-    return protectedPage()->userMediaPermissionRequestManager().addDeviceChangeObserver(WTFMove(observer));
+    if (RefPtr page = m_page.get())
+        return page->userMediaPermissionRequestManager().addDeviceChangeObserver(WTFMove(observer));
+    return DeviceChangeObserverToken { 0 };
 }
 
 void WebUserMediaClient::removeDeviceChangeObserver(DeviceChangeObserverToken token)
 {
-    protectedPage()->userMediaPermissionRequestManager().removeDeviceChangeObserver(token);
+    if (RefPtr page = m_page.get())
+        page->userMediaPermissionRequestManager().removeDeviceChangeObserver(token);
 }
 
 void WebUserMediaClient::updateCaptureState(const WebCore::Document& document, bool isActive, WebCore::MediaProducerMediaCaptureKind kind, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&& completionHandler)
 {
-    protectedPage()->userMediaPermissionRequestManager().updateCaptureState(document, isActive, kind, WTFMove(completionHandler));
+    if (RefPtr page = m_page.get())
+        page->userMediaPermissionRequestManager().updateCaptureState(document, isActive, kind, WTFMove(completionHandler));
 }
 
 void WebUserMediaClient::setShouldListenToVoiceActivity(bool shouldListen)
 {
-    protectedPage()->send(Messages::WebPageProxy::SetShouldListenToVoiceActivity { shouldListen });
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::SetShouldListenToVoiceActivity { shouldListen });
 }
 
 } // namespace WebKit;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebUserMediaClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebUserMediaClient.h
@@ -30,16 +30,20 @@ namespace WebKit {
 
 class WebPage;
 
-class WebUserMediaClient : public WebCore::UserMediaClient {
+class WebUserMediaClient final: public WebCore::UserMediaClient, public RefCounted<WebUserMediaClient> {
     WTF_MAKE_TZONE_ALLOCATED(WebUserMediaClient);
 public:
-    WebUserMediaClient(WebPage&);
-    ~WebUserMediaClient() { }
+
+    static Ref<WebUserMediaClient> create(WebPage& page)
+    {
+        return adoptRef(*new WebUserMediaClient(page));
+    }
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
 private:
-    Ref<WebPage> protectedPage() const;
-
-    void pageDestroyed() override;
+    explicit WebUserMediaClient(WebPage&);
 
     void requestUserMediaAccess(WebCore::UserMediaRequest&) override;
     void cancelUserMediaAccessRequest(WebCore::UserMediaRequest&) override;
@@ -53,10 +57,10 @@ private:
 
     void initializeFactories();
 
-    WeakRef<WebPage> m_page;
+    WeakPtr<WebPage> m_page;
 };
 
-} // namespace WebCore
+} // namespace WebKit
 
 #endif // ENABLE(MEDIA_STREAM)
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -973,7 +973,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     WebCore::provideNotification(page.ptr(), new WebNotificationClient(this));
 #endif
 #if ENABLE(MEDIA_STREAM)
-    WebCore::provideUserMediaTo(page.ptr(), new WebUserMediaClient(*this));
+    WebCore::provideUserMediaTo(page.ptr(), WebUserMediaClient::create(*this));
 #endif
 #if ENABLE(ENCRYPTED_MEDIA)
     WebCore::provideMediaKeySystemTo(page, *new WebMediaKeySystemClient(*this));


### PR DESCRIPTION
#### 3ba158e16f44332473094ce255d8fed3b90bf494
<pre>
Fixed unchecked local variables safercpp errors in UserMediaController.cpp
<a href="https://rdar.apple.com/155265597">rdar://155265597</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=295552">https://bugs.webkit.org/show_bug.cgi?id=295552</a>

Reviewed by Chris Dumez and Jean-Yves Avenard.

Deleted the destructors in UserMediaController and WebUserMediaClient as they were unnecessary.
Moved the create method implementation into the body of the WebUserMediaClient class. Marked
WebUserMediaClient as final to prevent further subclassing.

* Source/WebCore/Modules/mediastream/UserMediaController.cpp:
(WebCore::UserMediaController::~UserMediaController): Deleted.
* Source/WebCore/Modules/mediastream/UserMediaController.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebUserMediaClient.h:
(WebKit::WebUserMediaClient::create): Deleted.

Canonical link: <a href="https://commits.webkit.org/297277@main">https://commits.webkit.org/297277@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ccb35603f2bf828980da974444498a07d010315

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111038 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30704 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117068 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61305 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113000 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31385 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39286 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84413 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113985 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25070 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99968 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64859 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24416 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18111 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60884 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94452 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18176 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119953 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38087 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28302 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93375 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38463 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96243 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93199 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23763 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38257 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15994 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/34068 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37976 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43452 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37640 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40974 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39343 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->