### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in WTF::FastBitVector

### DIFF
--- a/Source/WTF/wtf/FastBitVector.cpp
+++ b/Source/WTF/wtf/FastBitVector.cpp
@@ -40,7 +40,7 @@ void FastBitVectorWordOwner::setEqualsSlow(const FastBitVectorWordOwner& other)
         FastBitVectorMalloc::free(m_words);
     m_words = static_cast<uint32_t*>(FastBitVectorMalloc::malloc(other.arrayLength() * sizeof(uint32_t)));
     m_numBits = other.m_numBits;
-    memcpySpan(wordsSpan(), other.wordsSpan());
+    memcpySpan(words(), other.words());
 }
 
 void FastBitVectorWordOwner::resizeSlow(size_t numBits)
@@ -53,7 +53,7 @@ void FastBitVectorWordOwner::resizeSlow(size_t numBits)
     // use case for this method to be initializing the size of the bitvector.
     
     auto newArray = unsafeMakeSpan(static_cast<uint32_t*>(FastBitVectorMalloc::malloc(newLength * sizeof(uint32_t))), newLength);
-    memcpySpan(newArray, wordsSpan());
+    memcpySpan(newArray, words());
     zeroSpan(newArray.subspan(oldLength));
     if (m_words)
         FastBitVectorMalloc::free(m_words);


### PR DESCRIPTION
#### 51eb56ff86f6f7f4b89f2ba3054d4cc9cc2aa8c6
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in WTF::FastBitVector
<a href="https://bugs.webkit.org/show_bug.cgi?id=295562">https://bugs.webkit.org/show_bug.cgi?id=295562</a>

Reviewed by Darin Adler.

Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in WTF::FastBitVector, for safety.
This tested as performance neutral on JetStream and Speedometer.

* Source/WTF/wtf/FastBitVector.cpp:
(WTF::FastBitVectorWordOwner::setEqualsSlow):
(WTF::FastBitVectorWordOwner::resizeSlow):
* Source/WTF/wtf/FastBitVector.h:
(WTF::FastBitVectorWordView::numBits const):
(WTF::FastBitVectorWordView::word const):
(WTF::FastBitVectorWordView::words const):
(WTF::FastBitVectorWordOwner::operator=):
(WTF::FastBitVectorWordOwner::setAll):
(WTF::FastBitVectorWordOwner::clearAll):
(WTF::FastBitVectorWordOwner::set):
(WTF::FastBitVectorWordOwner::numBits const):
(WTF::FastBitVectorWordOwner::arrayLength const):
(WTF::FastBitVectorWordOwner::word const):
(WTF::FastBitVectorWordOwner::word):
(WTF::FastBitVectorWordOwner::words):
(WTF::FastBitVectorWordOwner::words const):
(WTF::FastBitVectorWordOwner::wordsSpan): Deleted.
(WTF::FastBitVectorWordOwner::wordsSpan const): Deleted.

Canonical link: <a href="https://commits.webkit.org/297176@main">https://commits.webkit.org/297176@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aedc784ea1ea4df430acec317780db2cc6e6f4ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110747 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30410 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20842 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116775 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61015 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31090 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38996 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84221 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113695 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24834 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99730 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64662 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24203 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17864 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60569 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/103239 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94227 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17923 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119564 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109301 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37792 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28088 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/93189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38168 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95994 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93013 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23707 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38032 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15781 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33766 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37685 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43155 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/133576 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37346 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36078 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40684 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39053 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->