### PR TITLE
Reduce use of Vector::resize()

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
@@ -1145,7 +1145,7 @@ private:
                 worklist.append(data.subGroup1);
                 worklist.append(data.subGroup0);
             } else if (func(tmp) == IterationStatus::Done) {
-                worklist.resize(0);
+                worklist.shrink(0);
                 return IterationStatus::Done;
             }
         }

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -42,9 +42,8 @@ class PredictionPropagationPhase : public Phase {
 public:
     PredictionPropagationPhase(Graph& graph)
         : Phase(graph, "prediction propagation"_s)
-        , m_tupleSpeculations(graph.m_tupleData.size())
+        , m_tupleSpeculations(graph.m_tupleData.size(), SpecNone)
     {
-        m_tupleSpeculations.fill(SpecNone);
     }
     
     bool run()

--- a/Source/JavaScriptCore/dfg/DFGValidate.cpp
+++ b/Source/JavaScriptCore/dfg/DFGValidate.cpp
@@ -47,9 +47,8 @@ public:
         : m_graph(graph)
         , m_graphDumpMode(graphDumpMode)
         , m_graphDumpBeforePhase(graphDumpBeforePhase)
-        , m_myTupleRefCounts(m_graph.m_tupleData.size())
+        , m_myTupleRefCounts(m_graph.m_tupleData.size(), 0)
     {
-        m_myTupleRefCounts.fill(0);
     }
     
     #define VALIDATE(context, assertion) do { \

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -554,7 +554,7 @@ public:
                 allocationRoom = 1;
             int count = cryptographicallyRandomNumber<uint32_t>() % allocationRoom;
 
-            randomAllocations.resize(count);
+            randomAllocations.grow(count);
 
             for (int i = 0; i < count; ++i) {
                 void* result = jit_heap_try_allocate(sizeInBytes);
@@ -562,7 +562,7 @@ public:
                     // We are running out of memory, so make sure this allocation will succeed.
                     for (int j = 0; j < i; ++j)
                         jit_heap_deallocate(randomAllocations[j]);
-                    randomAllocations.resize(0);
+                    randomAllocations.shrink(0);
                     break;
                 }
                 randomAllocations[i] = result;

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -836,7 +836,7 @@ auto SectionParser::parseFunctionType(uint32_t position, RefPtr<TypeDefinition>&
     Vector<Type, 16> argumentTypes;
     WASM_PARSER_FAIL_IF(!argumentTypes.tryReserveInitialCapacity(argumentCount), "can't allocate enough memory for Type section's "_s, position, "th signature"_s);
 
-    argumentTypes.resize(argumentCount);
+    argumentTypes.grow(argumentCount);
     for (unsigned i = 0; i < argumentCount; ++i) {
         Type argumentType;
         WASM_PARSER_FAIL_IF(!parseValueType(m_info, argumentType), "can't get "_s, i, "th argument Type"_s);
@@ -849,7 +849,7 @@ auto SectionParser::parseFunctionType(uint32_t position, RefPtr<TypeDefinition>&
 
     Vector<Type, 16> returnTypes;
     WASM_PARSER_FAIL_IF(!returnTypes.tryReserveInitialCapacity(returnCount), "can't allocate enough memory for Type section's "_s, position, "th signature"_s);
-    returnTypes.resize(returnCount);
+    returnTypes.grow(returnCount);
     for (unsigned i = 0; i < returnCount; ++i) {
         Type value;
         WASM_PARSER_FAIL_IF(!parseValueType(m_info, value), "can't get "_s, i, "th Type's return value"_s);
@@ -895,7 +895,7 @@ auto SectionParser::parseStructType(uint32_t position, RefPtr<TypeDefinition>& s
     WASM_PARSER_FAIL_IF(fieldCount > maxStructFieldCount, "number of fields for struct type at position "_s, position, " is too big "_s, fieldCount, " maximum "_s, maxStructFieldCount);
     Vector<FieldType> fields;
     WASM_PARSER_FAIL_IF(!fields.tryReserveInitialCapacity(fieldCount), "can't allocate enough memory for struct fields "_s, fieldCount, " entries"_s);
-    fields.resize(fieldCount);
+    fields.grow(fieldCount);
 
     Checked<unsigned, RecordOverflow> structInstancePayloadSize { 0 };
     for (uint32_t fieldIndex = 0; fieldIndex < fieldCount; ++fieldIndex) {

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -2186,7 +2186,7 @@ class YarrGenerator final : public YarrJITInfo {
             if (!currOp) {
                 // If we have characters, break out
                 if (foundFirstCharTerm) {
-                    opList.resize(i);
+                    opList.shrink(i);
                     break;
                 }
                 // Otherwise, we're still in the non-character prefix

--- a/Source/WTF/wtf/Assertions.cpp
+++ b/Source/WTF/wtf/Assertions.cpp
@@ -309,8 +309,7 @@ void WTFReportBacktraceWithStackDepth(int framesToShow)
 void WTFReportBacktraceWithPrefixAndStackDepth(const char* prefix, int framesToShow)
 {
     int frames = framesToShow + kDefaultFramesToSkip;
-    Vector<void*> samples;
-    samples.resize(frames);
+    Vector<void*> samples(frames);
 
     WTFGetBacktrace(samples.mutableSpan().data(), &frames);
     CrashLogPrintStream out;

--- a/Source/WTF/wtf/Dominators.h
+++ b/Source/WTF/wtf/Dominators.h
@@ -662,7 +662,7 @@ private:
             // Allocate storage for the dense dominance matrix. 
             m_results.grow(numBlocks);
             for (unsigned i = numBlocks; i--;)
-                m_results[i].resize(numBlocks);
+                m_results[i].grow(numBlocks);
             m_scratch.resize(numBlocks);
 
             // We know that the entry block is only dominated by itself.

--- a/Source/WebCore/Modules/mediastream/STUNMessageParsing.cpp
+++ b/Source/WebCore/Modules/mediastream/STUNMessageParsing.cpp
@@ -78,7 +78,7 @@ static inline Vector<uint8_t> extractSTUNOrTURNMessages(Vector<uint8_t>&& buffer
                 return { };
 
             memcpySpan(buffered.mutableSpan(), data);
-            buffered.resize(data.size());
+            buffered.shrink(data.size());
             return WTFMove(buffered);
         }
 

--- a/Source/WebCore/contentextensions/DFAMinimizer.cpp
+++ b/Source/WebCore/contentextensions/DFAMinimizer.cpp
@@ -257,8 +257,7 @@ public:
         }
 
         // Count the number of incoming transitions per node.
-        m_flattenedTransitionsStartOffsetPerNode.resize(dfa.nodes.size());
-        m_flattenedTransitionsStartOffsetPerNode.fill(0);
+        m_flattenedTransitionsStartOffsetPerNode.fill(0, dfa.nodes.size());
 
         auto singularTransitionsFirsts = WTF::map<0, ContentExtensionsOverflowHandler>(singularTransitions, [&](auto& transition) {
             return transition.first;

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmRSA_OAEPMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmRSA_OAEPMac.cpp
@@ -57,7 +57,7 @@ static ExceptionOr<Vector<uint8_t>> decryptRSA_OAEP(CryptoAlgorithmIdentifier ha
     if (CCRSACryptorDecrypt(key, ccOAEPPadding, data.span().data(), data.size(), plainText.mutableSpan().data(), &plainTextLength, label.span().data(), label.size(), digestAlgorithm))
         return Exception { ExceptionCode::OperationError };
 
-    plainText.resize(plainTextLength);
+    plainText.shrink(plainTextLength);
     return WTFMove(plainText);
 }
 

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -162,7 +162,7 @@ void WebGL2RenderingContext::initializeContextState()
     m_maxArrayTextureLayers = context->getInteger(GraphicsContextGL::MAX_ARRAY_TEXTURE_LAYERS);
 
     m_boundSamplers.clear();
-    m_boundSamplers.resize(m_textureUnits.size());
+    m_boundSamplers.grow(m_textureUnits.size());
 }
 
 long long WebGL2RenderingContext::getInt64Parameter(GCGLenum pname)

--- a/Source/WebCore/platform/audio/AudioResampler.cpp
+++ b/Source/WebCore/platform/audio/AudioResampler.cpp
@@ -62,7 +62,7 @@ void AudioResampler::configureChannels(unsigned numberOfChannels)
         for (unsigned i = currentSize; i < numberOfChannels; ++i)
             m_kernels.append(makeUnique<AudioResamplerKernel>(this));
     } else
-        m_kernels.resize(numberOfChannels);
+        m_kernels.shrink(numberOfChannels);
 
     // Reconfigure our source bus to the new channel size.
     m_sourceBus = AudioBus::create(numberOfChannels, 0, false);

--- a/Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.mm
+++ b/Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.mm
@@ -97,7 +97,7 @@ unsigned MultiGamepadProvider::indexForNewlyConnectedDevice()
     ASSERT(index <= m_gamepadVector.size());
 
     if (index == m_gamepadVector.size())
-        m_gamepadVector.resize(index + 1);
+        m_gamepadVector.grow(index + 1);
 
     return index;
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -1354,7 +1354,7 @@ RetainPtr<NSDictionary> CDMInstanceSessionFairPlayStreamingAVFObjC::optionsForKe
             seedData.append(toASCIIHexValue(character));
     }
     if (seedData.size() > kMaximumDeviceIdentifierSeedSize)
-        seedData.resize(kMaximumDeviceIdentifierSeedSize);
+        seedData.shrink(kMaximumDeviceIdentifierSeedSize);
     else if (seedData.size() < kMaximumDeviceIdentifierSeedSize)
         seedData.insertFill(seedData.size(), 0, kMaximumDeviceIdentifierSeedSize - seedData.size());
 

--- a/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
+++ b/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
@@ -295,8 +295,7 @@ void MockAudioSharedInternalUnit::reconfigure()
     m_formatDescription = adoptCF(formatDescription);
 
     size_t sampleCount = 2 * rate;
-    m_bipBopBuffer.resize(sampleCount);
-    m_bipBopBuffer.fill(0);
+    m_bipBopBuffer.fill(0, sampleCount);
 
     size_t bipBopSampleCount = ceil(BipBopDuration * rate);
     size_t bipStart = 0;

--- a/Source/WebCore/rendering/GridMasonryLayout.cpp
+++ b/Source/WebCore/rendering/GridMasonryLayout.cpp
@@ -67,8 +67,7 @@ void GridMasonryLayout::performMasonryPlacement(const GridTrackSizingAlgorithm& 
 
 void GridMasonryLayout::resizeAndResetRunningPositions()
 {
-    m_runningPositions.resize(m_gridAxisTracksCount);
-    m_runningPositions.fill(LayoutUnit());
+    m_runningPositions.fill(LayoutUnit(), m_gridAxisTracksCount);
 }
 
 void GridMasonryLayout::placeMasonryItems(const GridTrackSizingAlgorithm& algorithm, GridMasonryLayout::MasonryLayoutPhase layoutPhase)

--- a/Source/WebCore/rendering/RenderFrameSet.cpp
+++ b/Source/WebCore/rendering/RenderFrameSet.cpp
@@ -153,8 +153,7 @@ void RenderFrameSet::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
 void RenderFrameSet::GridAxis::resize(int size)
 {
     m_sizes.resize(size);
-    m_deltas.resize(size);
-    m_deltas.fill(0);
+    m_deltas.fill(0, size);
     
     // To track edges for resizability and borders, we need to be (size + 1). This is because a parent frameset
     // may ask us for information about our left/top/right/bottom edges in order to make its own decisions about

--- a/Source/WebCore/rendering/svg/SVGTextLayoutAttributes.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutAttributes.cpp
@@ -36,7 +36,7 @@ SVGTextLayoutAttributes::SVGTextLayoutAttributes(RenderSVGInlineText& context)
 void SVGTextLayoutAttributes::clear()
 {
     m_characterDataMap.clear();
-    m_textMetricsValues.resize(0);
+    m_textMetricsValues.shrink(0);
 }
 
 RenderSVGInlineText& SVGTextLayoutAttributes::context() { return m_context.get(); }

--- a/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp
@@ -157,7 +157,7 @@ std::tuple<unsigned, UChar> SVGTextMetricsBuilder::measureTextRenderer(RenderSVG
         if (data.allCharactersMap)
             attributes->clear();
         else
-            textMetricsValues->resize(0);
+            textMetricsValues->shrink(0);
     }
 
     initializeMeasurementWithTextRenderer(text);

--- a/Source/WebCore/testing/MockGamepadProvider.cpp
+++ b/Source/WebCore/testing/MockGamepadProvider.cpp
@@ -67,7 +67,7 @@ void MockGamepadProvider::stopMonitoringGamepads(GamepadProviderClient& client)
 void MockGamepadProvider::setMockGamepadDetails(unsigned index, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble)
 {
     if (index >= m_mockGamepadVector.size())
-        m_mockGamepadVector.resize(index + 1);
+        m_mockGamepadVector.grow(index + 1);
 
     if (m_mockGamepadVector[index])
         m_mockGamepadVector[index]->updateDetails(gamepadID, mapping, axisCount, buttonCount, supportsDualRumble);

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -515,8 +515,7 @@ void ComputePassEncoder::setPipeline(const ComputePipeline& pipeline)
     }
 
     m_pipeline = pipeline;
-    m_computeDynamicOffsets.resize(m_pipeline->protectedPipelineLayout()->sizeOfComputeDynamicOffsets());
-    m_computeDynamicOffsets.fill(0);
+    m_computeDynamicOffsets.fill(0, m_pipeline->protectedPipelineLayout()->sizeOfComputeDynamicOffsets());
     m_maxDynamicOffsetAtIndex.fill(0);
 
     ASSERT(pipeline.computePipelineState());

--- a/Source/WebGPU/WebGPU/HardwareCapabilities.mm
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.mm
@@ -452,7 +452,7 @@ static Vector<WGPUFeatureName> mergeFeatures(const Vector<WGPUFeatureName>& prev
 
     Vector<WGPUFeatureName> result(previous.size() + next.size());
     auto end = mergeDeduplicatedSorted(previous.begin(), previous.end(), next.begin(), next.end(), result.begin());
-    result.resize(end - result.begin());
+    result.shrink(end - result.begin());
     return result;
 }
 

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -1538,10 +1538,8 @@ void RenderPassEncoder::setPipeline(const RenderPipeline& pipeline)
         m_maxDynamicOffsetAtIndex.fill(0);
     }
 
-    m_vertexDynamicOffsets.resize(pipeline.protectedPipelineLayout()->sizeOfVertexDynamicOffsets());
-    m_vertexDynamicOffsets.fill(0);
-    m_fragmentDynamicOffsets.resize(pipeline.protectedPipelineLayout()->sizeOfFragmentDynamicOffsets() + RenderBundleEncoder::startIndexForFragmentDynamicOffsets);
-    m_fragmentDynamicOffsets.fill(0);
+    m_vertexDynamicOffsets.fill(0, pipeline.protectedPipelineLayout()->sizeOfVertexDynamicOffsets());
+    m_fragmentDynamicOffsets.fill(0, pipeline.protectedPipelineLayout()->sizeOfFragmentDynamicOffsets() + RenderBundleEncoder::startIndexForFragmentDynamicOffsets);
 
     if (m_fragmentDynamicOffsets.size() < RenderBundleEncoder::startIndexForFragmentDynamicOffsets)
         m_fragmentDynamicOffsets.grow(RenderBundleEncoder::startIndexForFragmentDynamicOffsets);


### PR DESCRIPTION
#### d5c8c97b14855f39820c6337bfbffea2f7693f39
<pre>
Reduce use of Vector::resize()
<a href="https://bugs.webkit.org/show_bug.cgi?id=295565">https://bugs.webkit.org/show_bug.cgi?id=295565</a>

Reviewed by Darin Adler.

Reduce use of Vector::resize(), in favor of more efficient alternatives.

* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp:
(JSC::B3::Air::Greedy::GreedyAllocator::forEachTmpInGroup):
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGValidate.cpp:
* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseFunctionType):
(JSC::Wasm::SectionParser::parseStructType):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/WTF/wtf/Assertions.cpp:
* Source/WTF/wtf/Dominators.h:
(WTF::Dominators::NaiveDominators::NaiveDominators):
* Source/WebCore/Modules/mediastream/STUNMessageParsing.cpp:
(WebCore::WebRTC::extractSTUNOrTURNMessages):
* Source/WebCore/contentextensions/DFAMinimizer.cpp:
* Source/WebCore/crypto/cocoa/CryptoAlgorithmRSA_OAEPMac.cpp:
(WebCore::decryptRSA_OAEP):
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::initializeContextState):
* Source/WebCore/platform/audio/AudioResampler.cpp:
(WebCore::AudioResampler::configureChannels):
* Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.mm:
(WebCore::MultiGamepadProvider::indexForNewlyConnectedDevice):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::optionsForKeyRequestWithHashSalt):
* Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm:
(WebCore::MockAudioSharedInternalUnit::reconfigure):
* Source/WebCore/rendering/GridMasonryLayout.cpp:
(WebCore::GridMasonryLayout::resizeAndResetRunningPositions):
* Source/WebCore/rendering/RenderFrameSet.cpp:
(WebCore::RenderFrameSet::GridAxis::resize):
* Source/WebCore/rendering/svg/SVGTextLayoutAttributes.cpp:
(WebCore::SVGTextLayoutAttributes::clear):
* Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp:
(WebCore::SVGTextMetricsBuilder::measureTextRenderer):
* Source/WebCore/testing/MockGamepadProvider.cpp:
(WebCore::MockGamepadProvider::setMockGamepadDetails):
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::setPipeline):
* Source/WebGPU/WebGPU/HardwareCapabilities.mm:
(WebGPU::mergeFeatures):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::setPipeline):

Canonical link: <a href="https://commits.webkit.org/297166@main">https://commits.webkit.org/297166@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f562d7b06ad28abb1a2ecd319cf9a783d6eebe1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110543 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30202 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116569 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60810 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112506 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30881 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38790 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84063 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113491 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24654 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99539 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64504 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24017 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17679 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60364 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/103034 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94037 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17738 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119359 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109097 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37583 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27899 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93026 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37957 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95810 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92849 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23701 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37857 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15599 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33556 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37478 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42949 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/133372 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37141 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36039 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40480 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38849 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->