### PR TITLE
[Liquid Glass] Websites that have fixed/sticky headers after scrolling should not extend color into pocket

### DIFF
--- a/LayoutTests/fast/page-color-sampling/color-sampling-for-sticky-element-after-scrolling.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-for-sticky-element-after-scrolling.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true TopContentInsetBackgroundCanChangeAfterScrolling=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
 <html>
 <head>
 <script src="../../resources/ui-helper.js"></script>

--- a/LayoutTests/fast/page-color-sampling/no-resampling-after-scrolling-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/no-resampling-after-scrolling-expected.txt
@@ -1,0 +1,8 @@
+PASS colors.top is null
+PASS colors.left is null
+PASS colors.right is null
+PASS colors.bottom is null
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/page-color-sampling/no-resampling-after-scrolling.html
+++ b/LayoutTests/fast/page-color-sampling/no-resampling-after-scrolling.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true TopContentInsetBackgroundCanChangeAfterScrolling=false pageTopColorSamplingEnabled=false useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<style>
+body, html {
+    font-family: system-ui;
+    font-size: 16px;
+    margin: 0;
+}
+
+.sticky {
+    position: sticky;
+    z-index: 100;
+    pointer-events: none;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 50px;
+    background: rgb(255, 59, 48);
+}
+
+.short-vertical-space {
+    width: 100%;
+    height: 100px;
+}
+
+.tall-vertical-space {
+    width: 100%;
+    height: 2000px;
+}
+</style>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    await UIHelper.setObscuredInsets(50, 0, 0, 0);
+    await UIHelper.ensurePresentationUpdate();
+    await UIHelper.scrollDown();
+    await UIHelper.waitForZoomingOrScrollingToEnd();
+
+    colors = await UIHelper.fixedContainerEdgeColors();
+    shouldBeNull("colors.top");
+    shouldBeNull("colors.left");
+    shouldBeNull("colors.right");
+    shouldBeNull("colors.bottom");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div class="short-vertical-space"></div>
+    <div class="sticky"></div>
+    <div class="tall-vertical-space"></div>
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -807,7 +807,7 @@ window.UIHelper = class UIHelper {
     {
         do {
             await this.ensureStablePresentationUpdate();
-        } while (await this.isZoomingOrScrolling());
+        } while (this.isIOSFamily() && await this.isZoomingOrScrolling());
     }
 
     static deactivateFormControl(element)

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7612,6 +7612,19 @@ TiledScrollingIndicatorVisible:
     WebCore:
       default: false
 
+TopContentInsetBackgroundCanChangeAfterScrolling:
+  type: bool
+  status: internal
+  humanReadableName: "Top Content Inset Background Can Change After Scrolling"
+  humanReadableDescription: "Top content inset background can change after scrolling"
+  defaultValue:
+    WebKit:
+      default: WebKit::defaultTopContentInsetBackgroundCanChangeAfterScrolling()
+    WebKitLegacy:
+      default: false
+    WebCore:
+      default: false
+
 TouchEventDOMAttributesEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -262,6 +262,7 @@ void LocalFrameView::reset()
     m_contentIsOpaque = false;
     m_updateEmbeddedObjectsTimer.stop();
     m_lastUserScrollType = std::nullopt;
+    m_wasEverScrolledExplicitlyByUser = false;
     m_delayedScrollEventTimer.stop();
     m_shouldScrollToFocusedElement = false;
     m_delayedScrollToFocusedElementTimer.stop();
@@ -3750,6 +3751,7 @@ void LocalFrameView::show()
         // Note that adjustTiledBackingCoverage() kicks the (500ms) timer to re-enable it.
         m_speculativeTilingEnabled = false;
         m_lastUserScrollType = std::nullopt;
+        m_wasEverScrolledExplicitlyByUser = false;
         adjustTiledBackingCoverage();
     }
 }
@@ -5187,6 +5189,9 @@ void LocalFrameView::setLastUserScrollType(std::optional<UserScrollType> userScr
         return;
     m_lastUserScrollType = userScrollType;
     adjustTiledBackingCoverage();
+
+    if (userScrollType == UserScrollType::Explicit)
+        m_wasEverScrolledExplicitlyByUser = true;
 }
 
 void LocalFrameView::willPaintContents(GraphicsContext& context, const IntRect&, PaintingState& paintingState, RegionContext* regionContext)

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -405,6 +405,7 @@ public:
     WEBCORE_EXPORT void updateControlTints();
 
     WEBCORE_EXPORT bool wasScrolledByUser() const;
+    bool wasEverScrolledExplicitlyByUser() const { return m_wasEverScrolledExplicitlyByUser; }
 
     enum class UserScrollType : uint8_t { Explicit, Implicit };
     WEBCORE_EXPORT void setLastUserScrollType(std::optional<UserScrollType>);
@@ -1071,6 +1072,7 @@ private:
     std::unique_ptr<ScrollAnchoringController> m_scrollAnchoringController;
 
     std::optional<UserScrollType> m_lastUserScrollType;
+    bool m_wasEverScrolledExplicitlyByUser { false };
 
     bool m_shouldUpdateWhileOffscreen { true };
     bool m_overflowStatusDirty { true };

--- a/Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm
@@ -31,6 +31,7 @@
 #import "ImageAnalysisUtilities.h"
 #import <Foundation/NSBundle.h>
 #import <pal/spi/cocoa/FeatureFlagsSPI.h>
+#import <pal/system/ios/UserInterfaceIdiom.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #import <wtf/text/WTFString.h>
@@ -83,6 +84,15 @@ bool defaultRemoveBackgroundEnabled()
 }
 
 #endif // ENABLE(IMAGE_ANALYSIS)
+
+bool defaultTopContentInsetBackgroundCanChangeAfterScrolling()
+{
+#if PLATFORM(IOS_FAMILY)
+    return PAL::currentUserInterfaceIdiomIsSmallScreen();
+#else
+    return false;
+#endif
+}
 
 } // namespace WebKit
 

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
@@ -415,4 +415,11 @@ bool defaultContentInsetBackgroundFillEnabled()
 }
 #endif
 
+#if !PLATFORM(COCOA)
+bool defaultTopContentInsetBackgroundCanChangeAfterScrolling()
+{
+    return false;
+}
+#endif
+
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.h
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.h
@@ -177,6 +177,7 @@ bool defaultRequiresPageVisibilityForVideoToBeNowPlaying();
 bool defaultCookieStoreAPIEnabled();
 
 bool defaultContentInsetBackgroundFillEnabled();
+bool defaultTopContentInsetBackgroundCanChangeAfterScrolling();
 
 #if ENABLE(SCREEN_TIME)
 bool defaultScreenTimeEnabled();


### PR DESCRIPTION
#### c9f1bebd8e25c4d0c16472d4c046be474632f23e
<pre>
[Liquid Glass] Websites that have fixed/sticky headers after scrolling should not extend color into pocket
<a href="https://bugs.webkit.org/show_bug.cgi?id=295569">https://bugs.webkit.org/show_bug.cgi?id=295569</a>
<a href="https://rdar.apple.com/155267492">rdar://155267492</a>

Reviewed by Abrar Rahman Protyasha.

Add support for a new internal setting, `TopContentInsetBackgroundCanChangeAfterScrolling`, that
controls whether or not the top sampled fixed/sticky element background color is allowed to change
as the user scrolls the page. By default, this is only enabled on iPhone (based on a user interface
idiom check).

* LayoutTests/fast/page-color-sampling/color-sampling-for-sticky-element-after-scrolling.html:

Force the flag on in this layout test, whose purpose is to check that we&apos;re able to resample when
scrolling. This test still has user-facing impact when running under iPhone UI idiom.

* LayoutTests/fast/page-color-sampling/no-resampling-after-scrolling-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/no-resampling-after-scrolling.html: Added.

Add a new layout test that exercises this behavior, by forcing the flag off and scrolling with a
sticky-positioned header.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.async waitForZoomingOrScrollingToEnd):
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::reset):
(WebCore::LocalFrameView::show):
(WebCore::LocalFrameView::setLastUserScrollType):

Add a flag to keep track of whether we&apos;ve observed _any_ user-driven explicit scrolling since the
page load committed.

* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateFixedContainerEdges):

Implement the main fix here — in the case where:

1.  `TopContentInsetBackgroundCanChangeAfterScrolling` is disabled (i.e. macOS or iPadOS).
2.  The main frame has been scrolled explicitly by the user.
3.  Document load has finished (i.e. the main document is no longer parsing).

...avoid resampling the top viewport edge; this naturally falls back to the last sampled color, or
no color at all if we haven&apos;t seen a fixed element near the top edge yet.

* Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm:
(WebKit::defaultTopContentInsetBackgroundCanChangeAfterScrolling):
* Source/WebKit/Shared/WebPreferencesDefaultValues.cpp:
(WebKit::defaultTopContentInsetBackgroundCanChangeAfterScrolling):
* Source/WebKit/Shared/WebPreferencesDefaultValues.h:

Canonical link: <a href="https://commits.webkit.org/297118@main">https://commits.webkit.org/297118@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a16495beff344a4a2071138458d14b83ed4ad008

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110596 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30255 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20688 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116622 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60863 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112559 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30934 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38844 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84102 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113544 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24704 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99587 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64543 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24067 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17727 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60417 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/103087 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/94090 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17786 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119412 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109150 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37636 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27951 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93068 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38010 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95858 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92890 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23668 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37904 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15647 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33613 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37531 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43002 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/133425 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37194 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36052 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40533 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38902 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->