### PR TITLE
Stop serializing CGFloat

### DIFF
--- a/LayoutTests/ipc/serialized-type-info.html
+++ b/LayoutTests/ipc/serialized-type-info.html
@@ -136,7 +136,6 @@
             "uint16_t",
             "int64_t",
             "pid_t",
-            "CGFloat",
             "String",
             "uint32_t",
             "int16_t",

--- a/Source/WebCore/editing/cocoa/AttributedString.h
+++ b/Source/WebCore/editing/cocoa/AttributedString.h
@@ -119,26 +119,26 @@ struct ParagraphStyleTextList {
 };
 
 struct ParagraphStyleCommonTableAttributes {
-    CGFloat width { 0 };
-    CGFloat minimumWidth { 0 };
-    CGFloat maximumWidth { 0 };
-    CGFloat minimumHeight { 0 };
-    CGFloat maximumHeight { 0 };
+    double width { 0 };
+    double minimumWidth { 0 };
+    double maximumWidth { 0 };
+    double minimumHeight { 0 };
+    double maximumHeight { 0 };
 
-    CGFloat paddingMinXEdge { 0 };
-    CGFloat paddingMinYEdge { 0 };
-    CGFloat paddingMaxXEdge { 0 };
-    CGFloat paddingMaxYEdge { 0 };
+    double paddingMinXEdge { 0 };
+    double paddingMinYEdge { 0 };
+    double paddingMaxXEdge { 0 };
+    double paddingMaxYEdge { 0 };
 
-    CGFloat borderMinXEdge { 0 };
-    CGFloat borderMinYEdge { 0 };
-    CGFloat borderMaxXEdge { 0 };
-    CGFloat borderMaxYEdge { 0 };
+    double borderMinXEdge { 0 };
+    double borderMinYEdge { 0 };
+    double borderMaxXEdge { 0 };
+    double borderMaxYEdge { 0 };
 
-    CGFloat marginMinXEdge { 0 };
-    CGFloat marginMinYEdge { 0 };
-    CGFloat marginMaxXEdge { 0 };
-    CGFloat marginMaxYEdge { 0 };
+    double marginMinXEdge { 0 };
+    double marginMinYEdge { 0 };
+    double marginMaxXEdge { 0 };
+    double marginMaxYEdge { 0 };
 
     RetainPtr<PlatformColor> backgroundColor;
     RetainPtr<PlatformColor> borderMinXEdgeColor;
@@ -166,7 +166,7 @@ struct TextTableBlock : ParagraphStyleCommonTableAttributes {
 };
 
 struct TextTab {
-    CGFloat location { 0 };
+    double location { 0 };
     ParagraphStyleAlignment alignment { ParagraphStyleAlignment::Natural };
 };
 
@@ -175,11 +175,11 @@ struct ParagraphStyle {
     ParagraphStyleAlignment alignment { ParagraphStyleAlignment::Natural };
     ParagraphStyleWritingDirection writingDirection { ParagraphStyleWritingDirection::Natural };
     float hyphenationFactor { 0 };
-    CGFloat firstLineHeadIndent { 0 };
-    CGFloat headIndent { 0 };
+    double firstLineHeadIndent { 0 };
+    double headIndent { 0 };
     int64_t headerLevel { 0 };
-    CGFloat tailIndent { 0 };
-    CGFloat paragraphSpacing { 0 };
+    double tailIndent { 0 };
+    double paragraphSpacing { 0 };
     Vector<AttributedStringTextTableBlockID> textTableBlockIDs;
     Vector<AttributedStringTextListID> textListIDs;
     Vector<TextTableBlock> textTableBlocks;

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -489,6 +489,7 @@ $(PROJECT_DIR)/Shared/cf/CoreIPCSecAccessControl.serialization.in
 $(PROJECT_DIR)/Shared/cf/CoreIPCSecCertificate.serialization.in
 $(PROJECT_DIR)/Shared/cf/CoreIPCSecKeychainItem.serialization.in
 $(PROJECT_DIR)/Shared/cf/CoreIPCSecTrust.serialization.in
+$(PROJECT_DIR)/Shared/graphics/DoubleGeometry.serialization.in
 $(PROJECT_DIR)/Shared/graphics/HostingContext.serialization.in
 $(PROJECT_DIR)/Shared/graphics/RemoteImageBufferSetConfiguration.serialization.in
 $(PROJECT_DIR)/Shared/ios/CursorContext.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -815,6 +815,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/cf/CoreIPCSecCertificate.serialization.in \
 	Shared/cf/CoreIPCSecKeychainItem.serialization.in \
 	Shared/cf/CoreIPCSecTrust.serialization.in \
+	Shared/graphics/DoubleGeometry.serialization.in \
 	Shared/graphics/RemoteImageBufferSetConfiguration.serialization.in \
 	Shared/mac/PDFContextMenuItem.serialization.in \
 	Shared/mac/SecItemRequestData.serialization.in \

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
@@ -289,9 +289,9 @@ void RemoteDisplayListRecorder::setLineCap(LineCap lineCap)
     context().setLineCap(lineCap);
 }
 
-void RemoteDisplayListRecorder::setLineDash(DashArray&& dashArray, float dashOffset)
+void RemoteDisplayListRecorder::setLineDash(FixedVector<double>&& dashArray, float dashOffset)
 {
-    context().setLineDash(dashArray, dashOffset);
+    context().setLineDash(DashArray(dashArray.span()), dashOffset);
 }
 
 void RemoteDisplayListRecorder::setLineJoin(LineJoin lineJoin)
@@ -404,7 +404,7 @@ void RemoteDisplayListRecorder::drawFilteredImageBuffer(std::optional<RenderingR
     drawFilteredImageBufferInternal(sourceImageIdentifier, sourceImageRect, *cachedSVGFilter, results);
 }
 
-void RemoteDisplayListRecorder::drawGlyphs(RenderingResourceIdentifier fontIdentifier, IPC::ArrayReferenceTuple<GlyphBufferGlyph, GlyphBufferAdvance> glyphsAdvances, FloatPoint localAnchor, FontSmoothingMode fontSmoothingMode)
+void RemoteDisplayListRecorder::drawGlyphs(RenderingResourceIdentifier fontIdentifier, IPC::ArrayReferenceTuple<GlyphBufferGlyph, FloatSize> glyphsAdvances, FloatPoint localAnchor, FontSmoothingMode fontSmoothingMode)
 {
     RefPtr font = resourceCache().cachedFont(fontIdentifier);
     if (!font) {
@@ -412,7 +412,7 @@ void RemoteDisplayListRecorder::drawGlyphs(RenderingResourceIdentifier fontIdent
         return;
     }
 
-    context().drawGlyphs(*font, Vector(glyphsAdvances.span<0>()), Vector(glyphsAdvances.span<(1)>()), localAnchor, fontSmoothingMode);
+    context().drawGlyphs(*font, glyphsAdvances.span<0>(), Vector<GlyphBufferAdvance>(glyphsAdvances.span<1>()), localAnchor, fontSmoothingMode);
 }
 
 void RemoteDisplayListRecorder::drawDecomposedGlyphs(RenderingResourceIdentifier fontIdentifier, RenderingResourceIdentifier decomposedGlyphsIdentifier)

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
@@ -93,7 +93,7 @@ public:
     void setShadowsIgnoreTransforms(bool);
     void setDrawLuminanceMask(bool);
     void setLineCap(WebCore::LineCap);
-    void setLineDash(WebCore::DashArray&&, float dashOffset);
+    void setLineDash(FixedVector<double>&&, float dashOffset);
     void setLineJoin(WebCore::LineJoin);
     void setMiterLimit(float);
     void clip(const WebCore::FloatRect&);
@@ -104,7 +104,7 @@ public:
     void clipOutToPath(const WebCore::Path&);
     void clipPath(const WebCore::Path&, WebCore::WindRule);
     void resetClip();
-    void drawGlyphs(WebCore::RenderingResourceIdentifier fontIdentifier, IPC::ArrayReferenceTuple<WebCore::GlyphBufferGlyph, WebCore::GlyphBufferAdvance>, WebCore::FloatPoint localAnchor, WebCore::FontSmoothingMode);
+    void drawGlyphs(WebCore::RenderingResourceIdentifier fontIdentifier, IPC::ArrayReferenceTuple<WebCore::GlyphBufferGlyph, WebCore::FloatSize>, WebCore::FloatPoint localAnchor, WebCore::FontSmoothingMode);
     void drawDecomposedGlyphs(WebCore::RenderingResourceIdentifier fontIdentifier, WebCore::RenderingResourceIdentifier decomposedGlyphsIdentifier);
     void drawFilteredImageBuffer(std::optional<WebCore::RenderingResourceIdentifier> sourceImageIdentifier, const WebCore::FloatRect& sourceImageRect, Ref<WebCore::Filter>&&);
     void drawImageBuffer(WebCore::RenderingResourceIdentifier imageBufferIdentifier, const WebCore::FloatRect& destinationRect, const WebCore::FloatRect& srcRect, WebCore::ImagePaintingOptions);

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
@@ -61,7 +61,7 @@ messages -> RemoteDisplayListRecorder Stream {
     SetShadowsIgnoreTransforms(bool shouldIgnore) StreamBatched
     SetDrawLuminanceMask(bool shouldDraw) StreamBatched
     SetLineCap(enum:uint8_t WebCore::LineCap lineCap) StreamBatched
-    SetLineDash(WebCore::DashArray dashArray, float dashOffset) StreamBatched
+    SetLineDash(FixedVector<double> dashArray, float dashOffset) StreamBatched
     SetLineJoin(enum:uint8_t WebCore::LineJoin lineJoin) StreamBatched
     SetMiterLimit(float limit) StreamBatched
     Clip(WebCore::FloatRect rect)
@@ -72,7 +72,7 @@ messages -> RemoteDisplayListRecorder Stream {
     ClipOutToPath(WebCore::Path path)
     ClipPath(WebCore::Path path, enum:bool WebCore::WindRule windRule)
     ResetClip()
-    DrawGlyphs(WebCore::RenderingResourceIdentifier fontIdentifier, IPC::ArrayReferenceTuple<WebCore::GlyphBufferGlyph, WebCore::GlyphBufferAdvance> glyphsAdvances, WebCore::FloatPoint localAnchor, enum:uint8_t WebCore::FontSmoothingMode smoothingMode)
+    DrawGlyphs(WebCore::RenderingResourceIdentifier fontIdentifier, IPC::ArrayReferenceTuple<WebCore::GlyphBufferGlyph, WebCore::FloatSize> glyphsAdvances, WebCore::FloatPoint localAnchor, enum:uint8_t WebCore::FontSmoothingMode smoothingMode)
     DrawDecomposedGlyphs(WebCore::RenderingResourceIdentifier fontIdentifier, WebCore::RenderingResourceIdentifier decomposedGlyphsIdentifier)
     DrawFilteredImageBuffer(std::optional<WebCore::RenderingResourceIdentifier> sourceImageIdentifier, WebCore::FloatRect sourceImageRect, Ref<WebCore::Filter> filter)
     DrawImageBuffer(WebCore::RenderingResourceIdentifier imageBufferIdentifier, WebCore::FloatRect destinationRect, WebCore::FloatRect srcRect, struct WebCore::ImagePaintingOptions options)

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -399,10 +399,10 @@ void RemoteRenderingBackend::releaseFontCustomPlatformData(WebCore::RenderingRes
     MESSAGE_CHECK(success, "FontCustomPlatformData released before being cached.");
 }
 
-void RemoteRenderingBackend::cacheDecomposedGlyphs(IPC::ArrayReferenceTuple<WebCore::GlyphBufferGlyph, GlyphBufferAdvance> glyphsAdvances, FloatPoint localAnchor, FontSmoothingMode smoothingMode, RenderingResourceIdentifier identifier)
+void RemoteRenderingBackend::cacheDecomposedGlyphs(IPC::ArrayReferenceTuple<WebCore::GlyphBufferGlyph, FloatSize> glyphsAdvances, FloatPoint localAnchor, FontSmoothingMode smoothingMode, RenderingResourceIdentifier identifier)
 {
     assertIsCurrent(workQueue());
-    m_remoteResourceCache.cacheDecomposedGlyphs(DecomposedGlyphs::create(Vector(glyphsAdvances.span<0>()), Vector(glyphsAdvances.span<1>()), localAnchor, smoothingMode, identifier));
+    m_remoteResourceCache.cacheDecomposedGlyphs(DecomposedGlyphs::create(Vector(glyphsAdvances.span<0>()), Vector<GlyphBufferAdvance>(glyphsAdvances.span<1>()), localAnchor, smoothingMode, identifier));
 }
 
 void RemoteRenderingBackend::releaseDecomposedGlyphs(RenderingResourceIdentifier identifier)

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -151,7 +151,7 @@ private:
     void destroyGetPixelBufferSharedMemory();
     void cacheNativeImage(WebCore::ShareableBitmap::Handle&&, WebCore::RenderingResourceIdentifier);
     void releaseNativeImage(WebCore::RenderingResourceIdentifier);
-    void cacheDecomposedGlyphs(IPC::ArrayReferenceTuple<WebCore::GlyphBufferGlyph, WebCore::GlyphBufferAdvance>, WebCore::FloatPoint localAnchor, WebCore::FontSmoothingMode, WebCore::RenderingResourceIdentifier);
+    void cacheDecomposedGlyphs(IPC::ArrayReferenceTuple<WebCore::GlyphBufferGlyph, WebCore::FloatSize>, WebCore::FloatPoint localAnchor, WebCore::FontSmoothingMode, WebCore::RenderingResourceIdentifier);
     void releaseDecomposedGlyphs(WebCore::RenderingResourceIdentifier);
     void cacheGradient(Ref<WebCore::Gradient>&&, WebCore::RenderingResourceIdentifier);
     void releaseGradient(WebCore::RenderingResourceIdentifier);

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -38,7 +38,7 @@ messages -> RemoteRenderingBackend Stream {
     ReleaseFont(WebCore::RenderingResourceIdentifier identifier)
     CacheFontCustomPlatformData(struct WebCore::FontCustomPlatformSerializedData fontCustomPlatformData) NotStreamEncodable
     ReleaseFontCustomPlatformData(WebCore::RenderingResourceIdentifier identifier)
-    CacheDecomposedGlyphs(IPC::ArrayReferenceTuple<WebCore::GlyphBufferGlyph, WebCore::GlyphBufferAdvance> glyphsAdvances, WebCore::FloatPoint localAnchor, enum:uint8_t WebCore::FontSmoothingMode smoothingMode, WebCore::RenderingResourceIdentifier identifier)
+    CacheDecomposedGlyphs(IPC::ArrayReferenceTuple<WebCore::GlyphBufferGlyph, WebCore::FloatSize> glyphsAdvances, WebCore::FloatPoint localAnchor, enum:uint8_t WebCore::FontSmoothingMode smoothingMode, WebCore::RenderingResourceIdentifier identifier)
     ReleaseDecomposedGlyphs(WebCore::RenderingResourceIdentifier identifier) StreamBatched
     CacheGradient(Ref<WebCore::Gradient> gradient, WebCore::RenderingResourceIdentifier identifier)
     ReleaseGradient(WebCore::RenderingResourceIdentifier identifier)

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -527,7 +527,6 @@ def types_that_cannot_be_forward_declared():
         'WebCore::DOMCacheIdentifier',
         'WebCore::DOMCacheEngine::CacheIdentifierOrError',
         'WebCore::DOMCacheEngine::RemoveCacheIdentifierOrError',
-        'WebCore::DashArray',
         'WebCore::DestinationColorSpace',
         'WebCore::DiagnosticLoggingDomain',
         'WebCore::DictationContext',
@@ -890,6 +889,7 @@ def class_template_headers(template_string):
         'RetainPtr': {'headers': ['<wtf/RetainPtr.h>'], 'argument_coder_headers': []},
         'WebCore::ProcessQualified': {'headers': ['<WebCore/ProcessQualified.h>'], 'argument_coder_headers': ['"ArgumentCoders.h"']},
         'std::unique_ptr': {'headers': ['<memory>'], 'argument_coder_headers': ['"ArgumentCoders.h"']},
+        'FixedVector': {'headers': ['<wtf/FixedVector.h>'], 'argument_coder_headers': ['"ArgumentCoders.h"']},
     }
 
     match = re.match('(?P<template_name>.+?)<(?P<parameter_string>.+)>', template_string)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSShadow.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSShadow.mm
@@ -28,6 +28,7 @@
 
 #if PLATFORM(COCOA)
 
+#import "DoubleGeometry.h"
 #import <WebCore/AttributedString.h>
 
 #if USE(APPKIT)
@@ -50,7 +51,7 @@ CoreIPCNSShadow::CoreIPCNSShadow(NSShadow *shadow)
 RetainPtr<id> CoreIPCNSShadow::toID() const
 {
     RetainPtr<NSShadow> result = adoptNS([PlatformNSShadow new]);
-    [result setShadowOffset:m_shadowOffset];
+    [result setShadowOffset:m_shadowOffset.toCG()];
     [result setShadowBlurRadius:m_shadowBlurRadius];
     [result setShadowColor:m_shadowColor.get()];
     return result;

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSShadow.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSShadow.serialization.in
@@ -30,8 +30,8 @@ webkit_platform_headers: "CoreIPCNSShadow.h" <UIKit/NSShadow.h>
 #endif
 
 [WebKitPlatform] class WebKit::CoreIPCNSShadow {
-    CGSize m_shadowOffset;
-    CGFloat m_shadowBlurRadius;
+    WebKit::DoubleSize m_shadowOffset;
+    double m_shadowBlurRadius;
     RetainPtr<WebCore::CocoaColor> m_shadowColor;
 }
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSValue.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSValue.h
@@ -28,6 +28,7 @@
 #if PLATFORM(COCOA)
 
 #include "ArgumentCodersCocoa.h"
+#include "DoubleGeometry.h"
 #include <CoreGraphics/CGGeometry.h>
 #include <wtf/RetainPtr.h>
 
@@ -54,7 +55,7 @@ public:
 
     static bool shouldWrapValue(NSValue *);
 
-    using Value = Variant<IPCRange, CGRect, UniqueRef<CoreIPCNSCFObject>>;
+    using Value = Variant<IPCRange, DoubleRect, UniqueRef<CoreIPCNSCFObject>>;
 
 private:
     friend struct IPC::ArgumentCoder<CoreIPCNSValue, void>;

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSValue.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSValue.mm
@@ -70,8 +70,8 @@ RetainPtr<id> CoreIPCNSValue::toID() const
 
         WTF::switchOn(wrappedValue, [&](const IPCRange& range) {
             result = [NSValue valueWithRange:NSMakeRange(range.location, range.length)];
-        }, [&](const CGRect& rect) {
-            result = [NSValue valueWithRect:rect];
+        }, [&](const DoubleRect& rect) {
+            result = [NSValue valueWithRect:rect.toCG()];
         }, [&](const UniqueRef<CoreIPCNSCFObject>& object) {
             result = object->toID();
         });

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -158,26 +158,26 @@ header: <WebCore/AttributedString.h>
 
 header: <WebCore/AttributedString.h>
 [CustomHeader] struct WebCore::ParagraphStyleCommonTableAttributes {
-    CGFloat width;
-    CGFloat minimumWidth;
-    CGFloat maximumWidth;
-    CGFloat minimumHeight;
-    CGFloat maximumHeight;
+    double width;
+    double minimumWidth;
+    double maximumWidth;
+    double minimumHeight;
+    double maximumHeight;
 
-    CGFloat paddingMinXEdge;
-    CGFloat paddingMinYEdge;
-    CGFloat paddingMaxXEdge;
-    CGFloat paddingMaxYEdge;
+    double paddingMinXEdge;
+    double paddingMinYEdge;
+    double paddingMaxXEdge;
+    double paddingMaxYEdge;
 
-    CGFloat borderMinXEdge;
-    CGFloat borderMinYEdge;
-    CGFloat borderMaxXEdge;
-    CGFloat borderMaxYEdge;
+    double borderMinXEdge;
+    double borderMinYEdge;
+    double borderMaxXEdge;
+    double borderMaxYEdge;
 
-    CGFloat marginMinXEdge;
-    CGFloat marginMinYEdge;
-    CGFloat marginMaxXEdge;
-    CGFloat marginMaxYEdge;
+    double marginMinXEdge;
+    double marginMinYEdge;
+    double marginMaxXEdge;
+    double marginMaxYEdge;
 
     RetainPtr<WebCore::CocoaColor> backgroundColor;
     RetainPtr<WebCore::CocoaColor> borderMinXEdgeColor;
@@ -208,7 +208,7 @@ header: <WebCore/AttributedString.h>
 
 header: <WebCore/AttributedString.h>
 [CustomHeader] struct WebCore::TextTab {
-    CGFloat location;
+    double location;
     WebCore::ParagraphStyleAlignment alignment;
 }
 
@@ -218,11 +218,11 @@ header: <WebCore/AttributedString.h>
     WebCore::ParagraphStyleAlignment alignment;
     WebCore::ParagraphStyleWritingDirection writingDirection;
     float hyphenationFactor;
-    CGFloat firstLineHeadIndent;
-    CGFloat headIndent;
+    double firstLineHeadIndent;
+    double headIndent;
     [Validator='headerLevel >= 0'] int64_t headerLevel;
-    CGFloat tailIndent;
-    CGFloat paragraphSpacing;
+    double tailIndent;
+    double paragraphSpacing;
     Vector<WebCore::AttributedStringTextTableBlockID> textTableBlockIDs;
     Vector<WebCore::AttributedStringTextListID> textListIDs;
     Vector<WebCore::TextTableBlock> textTableBlocks;
@@ -518,7 +518,6 @@ UIColor wrapped by CoreIPCColor
 
 using CFTimeInterval = double
 using CGGlyph = uint16_t
-using NSRect = CGRect
 
 #if ENABLE(WRITING_TOOLS)
 using WebCore::WritingTools::TextSuggestion::ID = WTF::UUID

--- a/Source/WebKit/Shared/Extensions/WebExtensionTab.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionTab.serialization.in
@@ -33,7 +33,7 @@ struct WebKit::WebExtensionTabParameters {
     std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier;
     std::optional<uint64_t> index;
 #if PLATFORM(COCOA)
-    std::optional<CGSize> size;
+    std::optional<WebKit::DoubleSize> size;
 #endif
 
     std::optional<WebKit::WebExtensionTabIdentifier> parentTabIdentifier;

--- a/Source/WebKit/Shared/Extensions/WebExtensionTabParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionTabParameters.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#include "DoubleGeometry.h"
 #include "WebExtensionTabIdentifier.h"
 #include "WebExtensionWindowIdentifier.h"
 #include <wtf/Forward.h>
@@ -42,7 +43,7 @@ struct WebExtensionTabParameters {
     std::optional<WebExtensionWindowIdentifier> windowIdentifier;
     std::optional<uint64_t> index;
 #if PLATFORM(COCOA)
-    std::optional<CGSize> size;
+    std::optional<DoubleSize> size;
 #endif
 
     std::optional<WebExtensionTabIdentifier> parentTabIdentifier;

--- a/Source/WebKit/Shared/Extensions/WebExtensionWindow.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionWindow.serialization.in
@@ -33,7 +33,7 @@ struct WebKit::WebExtensionWindowParameters {
     std::optional<Vector<WebKit::WebExtensionTabParameters>> tabs;
 
 #if PLATFORM(COCOA)
-    std::optional<CGRect> frame;
+    std::optional<WebKit::DoubleRect> frame;
 #endif
 
     std::optional<bool> focused;

--- a/Source/WebKit/Shared/Extensions/WebExtensionWindowParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionWindowParameters.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#include "DoubleGeometry.h"
 #include "WebExtensionTabParameters.h"
 #include "WebExtensionWindow.h"
 #include "WebExtensionWindowIdentifier.h"
@@ -43,7 +44,7 @@ struct WebExtensionWindowParameters {
     std::optional<Vector<WebExtensionTabParameters>> tabs;
 
 #if PLATFORM(COCOA)
-    std::optional<CGRect> frame;
+    std::optional<DoubleRect> frame;
 #endif
 
     std::optional<bool> focused;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -722,33 +722,6 @@ enum class WebCore::IndexedDB::RequestType : uint8_t {
     Other,
 };
 
-#if USE(CG)
-headers: <CoreGraphics/CGGeometry.h> <CoreGraphics/CGAffineTransform.h>
-[WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] struct CGSize {
-    CGFloat width
-    CGFloat height
-};
-
-[WebKitPlatform] struct CGPoint {
-    CGFloat x
-    CGFloat y
-};
-
-[WebKitPlatform] struct CGRect {
-    CGPoint origin
-    CGSize size
-};
-
-struct CGAffineTransform {
-  CGFloat a
-  CGFloat b
-  CGFloat c
-  CGFloat d
-  CGFloat tx
-  CGFloat ty
-};
-#endif
-
 [AdditionalEncoder=StreamConnectionEncoder] class WebCore::FloatRect {
     WebCore::FloatPoint location()
     WebCore::FloatSize size()
@@ -8753,10 +8726,8 @@ using WebCore::GraphicsStyle = Variant<WebCore::GraphicsDropShadow, WebCore::Gra
 enum class WebCore::ScrollBehaviorForFixedElements : bool
 #if USE(CG)
 using WebCore::GlyphBufferGlyph = CGGlyph
-using WebCore::GlyphBufferAdvance = CGSize
 #else
 using WebCore::GlyphBufferGlyph = WebCore::Glyph
-using WebCore::GlyphBufferAdvance = WebCore::FloatSize
 #endif
 using WebCore::Glyph = unsigned short
 
@@ -8839,16 +8810,6 @@ enum class WebCore::PlatformMediaError : uint8_t {
     NotSupportedError,
     NetworkError,
 };
-#endif
-
-#if USE(CG)
-using WebCore::DashArray = FixedVector<CGFloat>;
-#endif
-#if USE(CAIRO)
-using WebCore::DashArray = FixedVector<double>;
-#endif
-#if !USE(CG) && !USE(CAIRO)
-using WebCore::DashArray = FixedVector<float>;
 #endif
 
 [WebKitPlatform] enum class WebCore::NotificationDirection : uint8_t {

--- a/Source/WebKit/Shared/graphics/DoubleGeometry.h
+++ b/Source/WebKit/Shared/graphics/DoubleGeometry.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,42 +25,79 @@
 
 #pragma once
 
-#if PLATFORM(COCOA)
-
-#include "ArgumentCodersCocoa.h"
-#include "DoubleGeometry.h"
-#include <WebCore/ColorCocoa.h>
-#include <wtf/RetainPtr.h>
-
-OBJC_CLASS NSShadow;
+#if USE(CG)
+#import <CoreGraphics/CGGeometry.h>
+#endif
 
 namespace WebKit {
 
-class CoreIPCNSShadow {
-public:
-    CoreIPCNSShadow(NSShadow *);
-    CoreIPCNSShadow(const RetainPtr<NSShadow>& shadow)
-        : CoreIPCNSShadow(shadow.get())
+struct DoublePoint {
+#if USE(CG)
+    DoublePoint(const CGPoint& point)
+        : DoublePoint(point.x, point.y)
     {
     }
 
-    CoreIPCNSShadow(DoubleSize shadowOffset, double shadowBlurRadius, RetainPtr<WebCore::CocoaColor>&& shadowColor)
-        : m_shadowOffset(shadowOffset)
-        , m_shadowBlurRadius(shadowBlurRadius)
-        , m_shadowColor(WTFMove(shadowColor))
+    CGPoint toCG() const
+    {
+        return { static_cast<CGFloat>(x), static_cast<CGFloat>(y) };
+    }
+#endif
+
+    DoublePoint(double x, double y)
+        : x(x)
+        , y(y)
     {
     }
 
-    RetainPtr<id> toID() const;
+    double x { 0 };
+    double y { 0 };
+};
 
-private:
-    friend struct IPC::ArgumentCoder<CoreIPCNSShadow, void>;
+struct DoubleSize {
+#if USE(CG)
+    DoubleSize(const CGSize& size)
+        : DoubleSize(size.width, size.height)
+    {
+    }
 
-    DoubleSize m_shadowOffset;
-    double m_shadowBlurRadius;
-    RetainPtr<WebCore::CocoaColor> m_shadowColor;
+    CGSize toCG() const
+    {
+        return { static_cast<CGFloat>(width), static_cast<CGFloat>(height) };
+    }
+#endif
+
+    DoubleSize(double width, double height)
+        : width(width)
+        , height(height)
+    {
+    }
+
+    double width { 0 };
+    double height { 0 };
+};
+
+struct DoubleRect {
+#if USE(CG)
+    DoubleRect(const CGRect& rect)
+        : DoubleRect(rect.origin, rect.size)
+    {
+    }
+
+    CGRect toCG() const
+    {
+        return { origin.toCG(), size.toCG() };
+    }
+#endif
+
+    DoubleRect(DoublePoint origin, DoubleSize size)
+        : origin(origin)
+        , size(size)
+    {
+    }
+
+    DoublePoint origin;
+    DoubleSize size;
 };
 
 } // namespace WebKit
-
-#endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/graphics/DoubleGeometry.serialization.in
+++ b/Source/WebKit/Shared/graphics/DoubleGeometry.serialization.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Apple Inc. All rights reserved.
+# Copyright (C) 2025 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -20,17 +20,19 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#if PLATFORM(COCOA)
+webkit_platform_headers: "DoubleGeometry.h"
 
-webkit_platform_headers: "CoreIPCNSValue.h"
-
-[WebKitPlatform, CustomHeader] struct WebKit::IPCRange {
-    uint64_t location;
-    uint64_t length;
+[WebKitPlatform, CustomHeader] struct WebKit::DoublePoint {
+    double x;
+    double y;
 }
 
-[WebKitPlatform] class WebKit::CoreIPCNSValue {
-    Variant<WebKit::IPCRange, WebKit::DoubleRect, UniqueRef<WebKit::CoreIPCNSCFObject>> m_value
+[WebKitPlatform, CustomHeader] struct WebKit::DoubleSize {
+    double width;
+    double height;
 }
 
-#endif // PLATFORM(COCOA)
+[WebKitPlatform, CustomHeader] struct WebKit::DoubleRect {
+    WebKit::DoublePoint origin;
+    WebKit::DoubleSize size;
+}

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm
@@ -62,7 +62,7 @@ void WebExtensionContext::windowsCreate(const WebExtensionWindowParameters& crea
     configuration.shouldBePrivate = creationParameters.privateBrowsing.value_or(false);
 
     if (creationParameters.frame) {
-        CGRect desiredFrame = creationParameters.frame.value();
+        CGRect desiredFrame = creationParameters.frame.value().toCG();
 
 #if PLATFORM(MAC)
         // Window coordinates on macOS have the origin in the bottom-left corner.
@@ -242,7 +242,7 @@ void WebExtensionContext::windowsUpdate(WebExtensionWindowIdentifier windowIdent
             return;
         }
 
-        CGRect desiredFrame = updateParameters.frame.value();
+        CGRect desiredFrame = updateParameters.frame.value().toCG();
 
         if (std::isnan(desiredFrame.size.width))
             desiredFrame.size.width = currentFrame.size.width;

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -140,6 +140,7 @@
 		029D6BAC2C40609D0068CF99 /* WebExtensionAPISidebarAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 029D6BAB2C4060920068CF99 /* WebExtensionAPISidebarAction.h */; };
 		029D6BB32C407AA30068CF99 /* JSWebExtensionAPISidebarAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 029D6BAD2C407AA30068CF99 /* JSWebExtensionAPISidebarAction.h */; };
 		029D6BB42C407AA30068CF99 /* JSWebExtensionAPISidePanel.h in Headers */ = {isa = PBXBuildFile; fileRef = 029D6BAF2C407AA30068CF99 /* JSWebExtensionAPISidePanel.h */; };
+		02DCA0BD2E1DB2EC00157740 /* DoubleGeometry.h in Headers */ = {isa = PBXBuildFile; fileRef = 02DCA0BB2E1DB2DC00157740 /* DoubleGeometry.h */; };
 		0701789E23BE9CFC005F0FAA /* RemoteMediaPlayerMIMETypeCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0701789B23BAE261005F0FAA /* RemoteMediaPlayerMIMETypeCache.cpp */; };
 		0712654928EE06F800AE69D7 /* WebChromeClientCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0712654728EE06F800AE69D7 /* WebChromeClientCocoa.mm */; };
 		071467782DFE84E500F77867 /* WebPage+Transferable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 071467772DFE84E500F77867 /* WebPage+Transferable.swift */; };
@@ -3231,6 +3232,8 @@
 		029D6BAE2C407AA30068CF99 /* JSWebExtensionAPISidebarAction.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPISidebarAction.mm; sourceTree = "<group>"; };
 		029D6BAF2C407AA30068CF99 /* JSWebExtensionAPISidePanel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPISidePanel.h; sourceTree = "<group>"; };
 		029D6BB02C407AA30068CF99 /* JSWebExtensionAPISidePanel.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPISidePanel.mm; sourceTree = "<group>"; };
+		02DCA0BB2E1DB2DC00157740 /* DoubleGeometry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DoubleGeometry.h; sourceTree = "<group>"; };
+		02DCA0BC2E1DB2E000157740 /* DoubleGeometry.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = DoubleGeometry.serialization.in; sourceTree = "<group>"; };
 		02EFD6012C404E8700D7277F /* WebExtensionAPISidebarAction.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPISidebarAction.idl; sourceTree = "<group>"; };
 		02EFD6022C404E8700D7277F /* WebExtensionAPISidePanel.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPISidePanel.idl; sourceTree = "<group>"; };
 		02F705E328D1B4AD008C89EF /* WebGPUObjectDescriptorBase.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebGPUObjectDescriptorBase.serialization.in; sourceTree = "<group>"; };
@@ -14348,6 +14351,8 @@
 		A71DC05D2B266DA3001C3075 /* graphics */ = {
 			isa = PBXGroup;
 			children = (
+				02DCA0BB2E1DB2DC00157740 /* DoubleGeometry.h */,
+				02DCA0BC2E1DB2E000157740 /* DoubleGeometry.serialization.in */,
 				A7D5005A2B266DF200D3497E /* ImageBufferSet.cpp */,
 				A7D5005C2B266E0600D3497E /* ImageBufferSet.h */,
 				2D0440922D58810D00E98A2E /* RemoteImageBufferSetConfiguration.h */,
@@ -17206,6 +17211,7 @@
 				7AFA6F6D2A9F58440055322A /* DisplayLink.h in Headers */,
 				0F189CAC24749F2F00E58D81 /* DisplayLinkObserverID.h in Headers */,
 				7AFA6F6E2A9F584A0055322A /* DisplayLinkProcessProxyClient.h in Headers */,
+				02DCA0BD2E1DB2EC00157740 /* DoubleGeometry.h in Headers */,
 				5C1427021C23F84C00D41183 /* Download.h in Headers */,
 				5C1427051C23F84C00D41183 /* DownloadID.h in Headers */,
 				5C1427071C23F84C00D41183 /* DownloadManager.h in Headers */,

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
@@ -122,7 +122,7 @@ static NSDictionary *toWebAPI(const WebExtensionWindowParameters& parameters)
     } mutableCopy];
 
     if (parameters.frame) {
-        CGRect frame = parameters.frame.value();
+        CGRect frame = parameters.frame.value().toCG();
         [result addEntriesFromDictionary:@{
             topKey: @(frame.origin.y),
             leftKey: @(frame.origin.x),

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -168,7 +168,7 @@ void RemoteDisplayListRecorderProxy::setLineCap(LineCap lineCap)
 
 void RemoteDisplayListRecorderProxy::setLineDash(const DashArray& array, float dashOffset)
 {
-    send(Messages::RemoteDisplayListRecorder::SetLineDash(array, dashOffset));
+    send(Messages::RemoteDisplayListRecorder::SetLineDash(FixedVector<double>(array.span()), dashOffset));
 }
 
 void RemoteDisplayListRecorderProxy::setLineJoin(LineJoin lineJoin)
@@ -271,7 +271,7 @@ void RemoteDisplayListRecorderProxy::drawGlyphsImmediate(const Font& font, std::
     ASSERT(glyphs.size() == advances.size());
     appendStateChangeItemIfNecessary();
     recordResourceUse(const_cast<Font&>(font));
-    send(Messages::RemoteDisplayListRecorder::DrawGlyphs(font.renderingResourceIdentifier(), { glyphs.data(), advances.data(), glyphs.size() }, localAnchor, smoothingMode));
+    send(Messages::RemoteDisplayListRecorder::DrawGlyphs(font.renderingResourceIdentifier(), { glyphs.data(), Vector<FloatSize>(advances).span().data(), glyphs.size() }, localAnchor, smoothingMode));
 }
 
 void RemoteDisplayListRecorderProxy::drawDecomposedGlyphs(const Font& font, const DecomposedGlyphs& decomposedGlyphs)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -436,7 +436,7 @@ void RemoteRenderingBackendProxy::releaseFontCustomPlatformData(RenderingResourc
 
 void RemoteRenderingBackendProxy::cacheDecomposedGlyphs(const DecomposedGlyphs& glyphs)
 {
-    send(Messages::RemoteRenderingBackend::CacheDecomposedGlyphs({ glyphs.glyphs().data(), glyphs.advances().data(), glyphs.glyphs().size() }, glyphs.localAnchor(), glyphs.fontSmoothingMode(), glyphs.renderingResourceIdentifier()));
+    send(Messages::RemoteRenderingBackend::CacheDecomposedGlyphs({ glyphs.glyphs().data(), Vector<FloatSize>(glyphs.advances()).span().data(), glyphs.glyphs().size() }, glyphs.localAnchor(), glyphs.fontSmoothingMode(), glyphs.renderingResourceIdentifier()));
 }
 
 void RemoteRenderingBackendProxy::releaseDecomposedGlyphs(RenderingResourceIdentifier identifier)


### PR DESCRIPTION
#### 697bceba2d974bed1415abe4ee1efbfc4236c870
<pre>
Stop serializing CGFloat
<a href="https://bugs.webkit.org/show_bug.cgi?id=295571">https://bugs.webkit.org/show_bug.cgi?id=295571</a>
<a href="https://rdar.apple.com/155295427">rdar://155295427</a>

Reviewed by Alex Christensen.

In the watchOS 26 beta, legacy apps have a UI process that runs as arm64_32 but has arm64 child
processes. CGFloat serialization is not symmetric between these architectures, so we need to remove it.

Add DoubleGeometry to replace CoreGraphics types using CGFloat without losing precision.
GlyphBufferAdvance is already constructed using floats, so no precision will be lost when switching to
FloatSize.

* LayoutTests/ipc/serialized-type-info.html:
* Source/WebCore/editing/cocoa/AttributedString.h:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp:
(WebKit::RemoteDisplayListRecorder::setLineDash):
(WebKit::RemoteDisplayListRecorder::drawGlyphs):
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h:
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::cacheDecomposedGlyphs):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
* Source/WebKit/Scripts/webkit/messages.py:
(types_that_cannot_be_forward_declared):
(class_template_headers):
* Source/WebKit/Shared/Cocoa/CoreIPCNSShadow.h:
(WebKit::CoreIPCNSShadow::CoreIPCNSShadow):
* Source/WebKit/Shared/Cocoa/CoreIPCNSShadow.mm:
(WebKit::CoreIPCNSShadow::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCNSShadow.serialization.in:
* Source/WebKit/Shared/Cocoa/CoreIPCNSValue.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSValue.mm:
(WebKit::CoreIPCNSValue::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCNSValue.serialization.in:
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:
* Source/WebKit/Shared/Extensions/WebExtensionTab.serialization.in:
* Source/WebKit/Shared/Extensions/WebExtensionTabParameters.h:
* Source/WebKit/Shared/Extensions/WebExtensionWindow.serialization.in:
* Source/WebKit/Shared/Extensions/WebExtensionWindowParameters.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/graphics/DoubleGeometry.h: Copied from Source/WebKit/Shared/Cocoa/CoreIPCNSShadow.h.
(WebKit::DoublePoint::DoublePoint):
(WebKit::DoublePoint::toCG const):
(WebKit::DoubleSize::DoubleSize):
(WebKit::DoubleSize::toCG const):
(WebKit::DoubleRect::DoubleRect):
(WebKit::DoubleRect::toCG const):
* Source/WebKit/Shared/graphics/DoubleGeometry.serialization.in: Copied from Source/WebKit/Shared/Cocoa/CoreIPCNSValue.serialization.in.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm:
(WebKit::WebExtensionContext::windowsCreate):
(WebKit::WebExtensionContext::windowsUpdate):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm:
(WebKit::toWebAPI):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::setLineDash):
(WebKit::RemoteDisplayListRecorderProxy::drawGlyphsImmediate):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::cacheDecomposedGlyphs):

Canonical link: <a href="https://commits.webkit.org/297177@main">https://commits.webkit.org/297177@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/911567bf2e683c4b999338adf78da9e2fc6d76dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110777 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30440 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20872 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116806 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/61045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112740 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31120 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39026 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/84231 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/61045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113725 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/99759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64672 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/110209 "Passed tests") | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/17895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/60599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/17955 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119596 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37822 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/28110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/93192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38198 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96026 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/93016 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/38053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/15807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/33796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17871 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37715 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43185 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/37376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/40714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/39083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->