### PR TITLE
[GStreamer] Simplify API of VideoFrameGStreamer::create functions

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -4028,7 +4028,7 @@ void MediaPlayerPrivateGStreamer::paint(GraphicsContext& context, const FloatRec
     if (!presentationSize)
         return;
 
-    auto frame = VideoFrameGStreamer::create(WTFMove(sample), { *m_videoInfo }, IntSize(*presentationSize));
+    auto frame = VideoFrameGStreamer::create(WTFMove(sample), { IntSize(*presentationSize), { *m_videoInfo } });
     frame->draw(context, rect, m_videoSourceOrientation, false);
 }
 
@@ -4053,7 +4053,7 @@ RefPtr<VideoFrame> MediaPlayerPrivateGStreamer::videoFrameForCurrentTime()
         return nullptr;
 
     auto size = getVideoResolutionFromCaps(gst_sample_get_caps(m_sample.get())).value_or(FloatSize { 0, 0 });
-    return VideoFrameGStreamer::create(WTFMove(convertedSample), { }, IntSize(size));
+    return VideoFrameGStreamer::create(WTFMove(convertedSample), { IntSize(size) });
 }
 
 bool MediaPlayerPrivateGStreamer::setVideoSourceOrientation(ImageOrientation orientation)

--- a/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
@@ -246,7 +246,10 @@ GStreamerInternalVideoDecoder::GStreamerInternalVideoDecoder(const String& codec
             m_videoInfo = VideoFrameGStreamer::infoFromCaps(GRefPtr(gst_sample_get_caps(outputSample.get())));
 
         GST_TRACE_OBJECT(m_harness->element(), "Handling decoded frame with PTS: %" GST_TIME_FORMAT " and duration: %" GST_TIME_FORMAT, GST_TIME_ARGS(timestamp), GST_TIME_ARGS(duration));
-        auto videoFrame = VideoFrameGStreamer::create(WTFMove(outputSample), { *m_videoInfo }, IntSize(m_presentationSize), fromGstClockTime(timestamp), VideoFrame::Rotation::None, false, { }, { }, VideoFrameContentHint::WebCodecs);
+        VideoFrameGStreamer::CreateOptions options(IntSize(m_presentationSize), { *m_videoInfo });
+        options.presentationTime = fromGstClockTime(timestamp);
+        options.contentHint = VideoFrameContentHint::WebCodecs;
+        auto videoFrame = VideoFrameGStreamer::create(WTFMove(outputSample), options);
         m_outputCallback(VideoDecoder::DecodedFrame { WTFMove(videoFrame), timestamp, duration });
     }, std::nullopt, WTFMove(allowedSinkCaps));
 

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -94,7 +94,7 @@ VideoFrameGStreamer::Info VideoFrameGStreamer::infoFromCaps(const GRefPtr<GstCap
 
 RefPtr<VideoFrame> VideoFrame::createFromPixelBuffer(Ref<PixelBuffer>&& pixelBuffer, PlatformVideoColorSpace&& colorSpace)
 {
-    return VideoFrameGStreamer::createFromPixelBuffer(WTFMove(pixelBuffer), VideoFrame::Rotation::None, MediaTime::invalidTime(), { }, 1, false, { }, WTFMove(colorSpace), VideoFrameContentHint::None);
+    return VideoFrameGStreamer::createFromPixelBuffer(WTFMove(pixelBuffer), { }, 1, { }, WTFMove(colorSpace));
 }
 
 static RefPtr<ImageGStreamer> convertSampleToImage(const GRefPtr<GstSample>& sample, const GstVideoInfo& videoInfo)
@@ -184,8 +184,7 @@ RefPtr<VideoFrame> VideoFrame::fromNativeImage(NativeImage& image)
     auto caps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, gst_video_format_to_string(format), "width", G_TYPE_INT, width, "height", G_TYPE_INT, height, nullptr));
     auto info = VideoFrameGStreamer::infoFromCaps(caps);
     auto sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
-    IntSize presentationSize { width, height };
-    return VideoFrameGStreamer::create(WTFMove(sample), WTFMove(info), presentationSize);
+    return VideoFrameGStreamer::create(WTFMove(sample), { { width, height }, WTFMove(info) });
 }
 
 static void copyToGstBufferPlane(std::span<uint8_t> destination, const GstVideoInfo& info, size_t planeIndex, std::span<const uint8_t> source, size_t height, uint32_t bytesPerRowSource)
@@ -225,21 +224,19 @@ RefPtr<VideoFrame> VideoFrame::createNV12(std::span<const uint8_t> span, size_t 
 
     auto caps = adoptGRef(gst_video_info_to_caps(&info));
     auto sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
-    IntSize presentationSize { static_cast<int>(width), static_cast<int>(height) };
-    return VideoFrameGStreamer::create(WTFMove(sample), { { info } }, presentationSize);
+    return VideoFrameGStreamer::create(WTFMove(sample), { { static_cast<int>(width), static_cast<int>(height) }, { { info } } }, WTFMove(colorSpace));
 }
 
-#define CREATE_RGBA_FRAME(format)                                       \
-    GstVideoInfo info;                                                  \
-    gst_video_info_set_format(&info, format, width, height);            \
-    fillVideoInfoColorimetryFromColorSpace(&info, colorSpace);          \
+#define CREATE_RGBA_FRAME(format)                                                                   \
+    GstVideoInfo info;                                                                              \
+    gst_video_info_set_format(&info, format, width, height);                                        \
+    fillVideoInfoColorimetryFromColorSpace(&info, colorSpace);                                      \
     auto buffer = adoptGRef(gst_buffer_new_allocate(nullptr, GST_VIDEO_INFO_SIZE(&info), nullptr)); \
-    gst_buffer_fill(buffer.get(), plane.destinationOffset, span.data(), span.size_bytes()); \
-    gst_buffer_add_video_meta(buffer.get(), GST_VIDEO_FRAME_FLAG_NONE, format, width, height); \
-    auto caps = adoptGRef(gst_video_info_to_caps(&info));               \
-    auto sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr)); \
-    IntSize presentationSize { static_cast<int>(width), static_cast<int>(height) }; \
-    return VideoFrameGStreamer::create(WTFMove(sample), { { info } }, presentationSize)
+    gst_buffer_fill(buffer.get(), plane.destinationOffset, span.data(), span.size_bytes());         \
+    gst_buffer_add_video_meta(buffer.get(), GST_VIDEO_FRAME_FLAG_NONE, format, width, height);      \
+    auto caps = adoptGRef(gst_video_info_to_caps(&info));                                           \
+    auto sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));            \
+    return VideoFrameGStreamer::create(WTFMove(sample), { { static_cast<int>(width), static_cast<int>(height) }, { { info } } }, WTFMove(colorSpace))
 
 RefPtr<VideoFrame> VideoFrame::createRGBA(std::span<const uint8_t> span, size_t width, size_t height, const ComputedPlaneLayout& plane, PlatformVideoColorSpace&& colorSpace)
 {
@@ -282,8 +279,7 @@ RefPtr<VideoFrame> VideoFrame::createI420(std::span<const uint8_t> span, size_t 
 
     auto caps = adoptGRef(gst_video_info_to_caps(&info));
     auto sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
-    IntSize presentationSize { static_cast<int>(width), static_cast<int>(height) };
-    return VideoFrameGStreamer::create(WTFMove(sample), { { info } }, presentationSize, MediaTime::invalidTime(), Rotation::None, false, std::nullopt, WTFMove(colorSpace));
+    return VideoFrameGStreamer::create(WTFMove(sample), { { static_cast<int>(width), static_cast<int>(height) }, { { info } } }, WTFMove(colorSpace));
 }
 
 RefPtr<VideoFrame> VideoFrame::createI420A(std::span<const uint8_t> span, size_t width, size_t height, const ComputedPlaneLayout& planeY, const ComputedPlaneLayout& planeU, const ComputedPlaneLayout& planeV, const ComputedPlaneLayout& planeA, PlatformVideoColorSpace&& colorSpace)
@@ -311,8 +307,7 @@ RefPtr<VideoFrame> VideoFrame::createI420A(std::span<const uint8_t> span, size_t
 
     auto caps = adoptGRef(gst_video_info_to_caps(&info));
     auto sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
-    IntSize presentationSize { static_cast<int>(width), static_cast<int>(height) };
-    return VideoFrameGStreamer::create(WTFMove(sample), { { info } }, presentationSize, MediaTime::invalidTime(), Rotation::None, false, std::nullopt, WTFMove(colorSpace));
+    return VideoFrameGStreamer::create(WTFMove(sample), { { static_cast<int>(width), static_cast<int>(height) }, { { info } } }, WTFMove(colorSpace));
 }
 
 static inline void setBufferFields(GstBuffer* buffer, const MediaTime& presentationTime, double frameRate)
@@ -331,37 +326,34 @@ static MediaTime presentationTimeFromSample(const GRefPtr<GstSample>& sample)
     return MediaTime::invalidTime();
 }
 
-Ref<VideoFrameGStreamer> VideoFrameGStreamer::create(GRefPtr<GstSample>&& sample, std::optional<Info>&& info, const IntSize& presentationSize, const MediaTime& presentationTime, Rotation videoRotation, bool videoMirrored, std::optional<VideoFrameTimeMetadata>&& metadata, std::optional<PlatformVideoColorSpace>&& colorSpace, VideoFrameContentHint hint)
+Ref<VideoFrameGStreamer> VideoFrameGStreamer::create(GRefPtr<GstSample>&& sample, const CreateOptions& options, PlatformVideoColorSpace&& colorSpace)
 {
+    CreateOptions newOptions = options;
     auto caps = gst_sample_get_caps(sample.get());
-    PlatformVideoColorSpace platformColorSpace;
-    if (colorSpace)
-        platformColorSpace = *colorSpace;
-    else if (doCapsHaveType(caps, GST_VIDEO_CAPS_TYPE_PREFIX))
-        platformColorSpace = videoColorSpaceFromCaps(caps);
+    if (!colorSpace.primaries && doCapsHaveType(caps, GST_VIDEO_CAPS_TYPE_PREFIX))
+        colorSpace = videoColorSpaceFromCaps(caps);
 
-    MediaTime timeStamp = presentationTime;
-    if (presentationTime.isInvalid())
-        timeStamp = presentationTimeFromSample(sample);
+    if (options.presentationTime.isInvalid())
+        newOptions.presentationTime = presentationTimeFromSample(sample);
 
-    return adoptRef(*new VideoFrameGStreamer(WTFMove(sample), WTFMove(info), presentationSize, timeStamp, videoRotation, videoMirrored, WTFMove(metadata), WTFMove(platformColorSpace), hint));
+    return adoptRef(*new VideoFrameGStreamer(WTFMove(sample), newOptions, WTFMove(colorSpace)));
 }
 
 Ref<VideoFrameGStreamer> VideoFrameGStreamer::createWrappedSample(const GRefPtr<GstSample>& sample, const MediaTime& presentationTime, Rotation videoRotation)
 {
     auto* caps = gst_sample_get_caps(sample.get());
-    auto presentationSize = getVideoResolutionFromCaps(caps);
-    RELEASE_ASSERT(presentationSize);
-    auto colorSpace = videoColorSpaceFromCaps(caps);
-    MediaTime timeStamp = presentationTime;
-    if (presentationTime.isInvalid())
-        timeStamp = presentationTimeFromSample(sample);
+    auto size = getVideoResolutionFromCaps(caps);
+    RELEASE_ASSERT(size);
+    CreateOptions options({ static_cast<int>(size->width()), static_cast<int>(size->height()) }, infoFromCaps(GRefPtr(caps)));
+    options.presentationTime = presentationTime;
+    if (options.presentationTime.isInvalid())
+        options.presentationTime = presentationTimeFromSample(sample);
 
-    auto info = infoFromCaps(GRefPtr(caps));
-    return adoptRef(*new VideoFrameGStreamer(sample, WTFMove(info), IntSize(*presentationSize), timeStamp, videoRotation, WTFMove(colorSpace)));
+    options.rotation = videoRotation;
+    return adoptRef(*new VideoFrameGStreamer(sample, options, videoColorSpaceFromCaps(caps)));
 }
 
-RefPtr<VideoFrameGStreamer> VideoFrameGStreamer::createFromPixelBuffer(Ref<PixelBuffer>&& pixelBuffer, Rotation videoRotation, const MediaTime& presentationTime, const IntSize& destinationSize, double frameRate, bool videoMirrored, std::optional<VideoFrameTimeMetadata>&& metadata, PlatformVideoColorSpace&& colorSpace, VideoFrameContentHint hint)
+RefPtr<VideoFrameGStreamer> VideoFrameGStreamer::createFromPixelBuffer(Ref<PixelBuffer>&& pixelBuffer, const IntSize& destinationSize, double frameRate, const CreateOptions& options, PlatformVideoColorSpace&& colorSpace)
 {
     ensureGStreamerInitialized();
 
@@ -427,52 +419,53 @@ RefPtr<VideoFrameGStreamer> VideoFrameGStreamer::createFromPixelBuffer(Ref<Pixel
 
         info = infoFromCaps(outputCaps);
         GRefPtr buffer = gst_sample_get_buffer(sample.get());
-        auto outputBuffer = webkitGstBufferSetVideoFrameMetadata(WTFMove(buffer), WTFMove(metadata), videoRotation, videoMirrored, hint);
+        auto outputBuffer = webkitGstBufferSetVideoFrameMetadata(WTFMove(buffer), options.timeMetadata, options.rotation, options.isMirrored, options.contentHint);
         gst_buffer_add_video_meta(outputBuffer.get(), GST_VIDEO_FRAME_FLAG_NONE, format, width, height);
-        setBufferFields(outputBuffer.get(), presentationTime, frameRate);
+        setBufferFields(outputBuffer.get(), options.presentationTime, frameRate);
         sample = adoptGRef(gst_sample_make_writable(sample.leakRef()));
         gst_sample_set_buffer(sample.get(), outputBuffer.get());
     } else {
-        auto outputBuffer = webkitGstBufferSetVideoFrameMetadata(WTFMove(buffer), WTFMove(metadata), videoRotation, videoMirrored, hint);
+        auto outputBuffer = webkitGstBufferSetVideoFrameMetadata(WTFMove(buffer), options.timeMetadata, options.rotation, options.isMirrored, options.contentHint);
         gst_buffer_add_video_meta(outputBuffer.get(), GST_VIDEO_FRAME_FLAG_NONE, format, width, height);
-        setBufferFields(outputBuffer.get(), presentationTime, frameRate);
+        setBufferFields(outputBuffer.get(), options.presentationTime, frameRate);
         sample = adoptGRef(gst_sample_new(outputBuffer.get(), caps.get(), nullptr, nullptr));
         info = infoFromCaps(caps);
     }
 
-    return adoptRef(*new VideoFrameGStreamer(WTFMove(sample), WTFMove(info), IntSize(width, height), presentationTime, videoRotation, videoMirrored, { }, WTFMove(colorSpace), hint));
+    CreateOptions newOptions = options;
+    newOptions.info = WTFMove(info);
+    newOptions.presentationSize = IntSize(width, height);
+    return adoptRef(*new VideoFrameGStreamer(WTFMove(sample), newOptions, WTFMove(colorSpace)));
 }
 
-VideoFrameGStreamer::VideoFrameGStreamer(GRefPtr<GstSample>&& sample, std::optional<Info>&& info, const IntSize& presentationSize, const MediaTime& presentationTime, Rotation videoRotation, bool videoMirrored, std::optional<VideoFrameTimeMetadata>&& metadata, PlatformVideoColorSpace&& colorSpace, VideoFrameContentHint hint)
-    : VideoFrame(presentationTime, videoMirrored, videoRotation, WTFMove(colorSpace))
+VideoFrameGStreamer::VideoFrameGStreamer(GRefPtr<GstSample>&& sample, const CreateOptions& options, PlatformVideoColorSpace&& colorSpace)
+    : VideoFrame(options.presentationTime, options.isMirrored, options.rotation, WTFMove(colorSpace))
     , m_sample(WTFMove(sample))
-    , m_presentationSize(presentationSize)
+    , m_presentationSize(options.presentationSize)
 {
     ensureVideoFrameDebugCategoryInitialized();
     ASSERT(m_sample);
 
-    if (info)
-        m_info = WTFMove(*info);
-    else
-        m_info = infoFromCaps(GRefPtr(gst_sample_get_caps(m_sample.get())));
+    m_info = options.info.value_or(infoFromCaps(GRefPtr(gst_sample_get_caps(m_sample.get()))));
 
     setMemoryTypeFromCaps();
 
-    setMetadataAndContentHint(WTFMove(metadata), hint);
+    setMetadataAndContentHint(options.timeMetadata, options.contentHint);
 }
 
-VideoFrameGStreamer::VideoFrameGStreamer(const GRefPtr<GstSample>& sample, Info&& info, const IntSize& presentationSize, const MediaTime& presentationTime, Rotation videoRotation, PlatformVideoColorSpace&& colorSpace)
-    : VideoFrame(presentationTime, false, videoRotation, WTFMove(colorSpace))
+VideoFrameGStreamer::VideoFrameGStreamer(const GRefPtr<GstSample>& sample, const CreateOptions& options, PlatformVideoColorSpace&& colorSpace)
+    : VideoFrame(options.presentationTime, false, options.rotation, WTFMove(colorSpace))
     , m_sample(sample)
-    , m_info(WTFMove(info))
-    , m_presentationSize(presentationSize)
+    , m_presentationSize(options.presentationSize)
 {
     ensureVideoFrameDebugCategoryInitialized();
     setMemoryTypeFromCaps();
 
+    m_info = options.info.value_or(infoFromCaps(GRefPtr(gst_sample_get_caps(m_sample.get()))));
+
     auto buffer = gst_sample_get_buffer(sample.get());
     auto [videoRotationFromMeta, isMirrored] = webkitGstBufferGetVideoRotation(buffer);
-    initializeCharacteristics(presentationTime, isMirrored, videoRotationFromMeta);
+    initializeCharacteristics(options.presentationTime, isMirrored, videoRotationFromMeta);
 }
 
 void VideoFrameGStreamer::setFrameRate(double frameRate)
@@ -506,11 +499,11 @@ void VideoFrameGStreamer::setPresentationTime(const MediaTime& presentationTime)
     GST_BUFFER_PTS(buffer) = GST_BUFFER_DTS(buffer) = toGstClockTime(1_s / presentationTime.toDouble());
 }
 
-void VideoFrameGStreamer::setMetadataAndContentHint(std::optional<VideoFrameTimeMetadata>&& metadata, VideoFrameContentHint hint)
+void VideoFrameGStreamer::setMetadataAndContentHint(std::optional<VideoFrameTimeMetadata> metadata, VideoFrameContentHint hint)
 {
     GRefPtr buffer = gst_sample_get_buffer(m_sample.get());
     RELEASE_ASSERT(buffer);
-    auto modifiedBuffer = webkitGstBufferSetVideoFrameMetadata(WTFMove(buffer), WTFMove(metadata), rotation(), isMirrored(), hint);
+    auto modifiedBuffer = webkitGstBufferSetVideoFrameMetadata(WTFMove(buffer), metadata, rotation(), isMirrored(), hint);
     m_sample = adoptGRef(gst_sample_make_writable(m_sample.leakRef()));
     gst_sample_set_buffer(m_sample.get(), modifiedBuffer.get());
 }
@@ -681,7 +674,12 @@ GRefPtr<GstSample> VideoFrameGStreamer::downloadSample(std::optional<GstVideoFor
 
 RefPtr<VideoFrameGStreamer> VideoFrameGStreamer::resizeTo(const IntSize& destinationSize)
 {
-    return VideoFrameGStreamer::create(resizedSample(destinationSize), std::nullopt, destinationSize, presentationTime(), rotation(), isMirrored());
+    CreateOptions options { IntSize(destinationSize) };
+    options.presentationTime = presentationTime();
+    options.rotation = rotation();
+    options.isMirrored = isMirrored();
+    auto colorSpace = this->colorSpace();
+    return VideoFrameGStreamer::create(resizedSample(destinationSize), options, WTFMove(colorSpace));
 }
 
 RefPtr<ImageGStreamer> VideoFrameGStreamer::convertToImage()

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp
@@ -113,7 +113,7 @@ const GstMetaInfo* videoFrameMetadataGetInfo()
 
 // NOTE: The buffer here cannot be a const GRefPtr<>&, that would mean its refcount would be greater
 // than 1, hence it wouldn't be writable.
-void webkitGstBufferAddVideoFrameMetadata(GstBuffer* buffer, std::optional<WebCore::VideoFrameTimeMetadata>&& metadata, VideoFrame::Rotation rotation, bool isMirrored, VideoFrameContentHint hint)
+void webkitGstBufferAddVideoFrameMetadata(GstBuffer* buffer, std::optional<WebCore::VideoFrameTimeMetadata> metadata, VideoFrame::Rotation rotation, bool isMirrored, VideoFrameContentHint hint)
 {
     if (!gst_buffer_is_writable(buffer)) {
         GST_ERROR("Unable to add video frame metadata on read-only buffer");
@@ -132,18 +132,18 @@ void webkitGstBufferAddVideoFrameMetadata(GstBuffer* buffer, std::optional<WebCo
     }
 
     meta = VIDEO_FRAME_METADATA_CAST(gst_buffer_add_meta(buffer, videoFrameMetadataGetInfo(), nullptr));
-    meta->priv->videoSampleMetadata = WTFMove(metadata);
+    meta->priv->videoSampleMetadata = metadata;
     meta->priv->rotation = rotation;
     meta->priv->isMirrored = isMirrored;
     meta->priv->contentHint = hint;
 }
 
-GRefPtr<GstBuffer> webkitGstBufferSetVideoFrameMetadata(GRefPtr<GstBuffer>&& buffer, std::optional<WebCore::VideoFrameTimeMetadata>&& metadata, VideoFrame::Rotation rotation, bool isMirrored, VideoFrameContentHint hint)
+GRefPtr<GstBuffer> webkitGstBufferSetVideoFrameMetadata(GRefPtr<GstBuffer>&& buffer, std::optional<WebCore::VideoFrameTimeMetadata> metadata, VideoFrame::Rotation rotation, bool isMirrored, VideoFrameContentHint hint)
 {
     IGNORE_WARNINGS_BEGIN("cast-align");
     auto modifiedBuffer = adoptGRef(gst_buffer_make_writable(buffer.leakRef()));
     IGNORE_WARNINGS_END;
-    webkitGstBufferAddVideoFrameMetadata(modifiedBuffer.get(), WTFMove(metadata), rotation, isMirrored, hint);
+    webkitGstBufferAddVideoFrameMetadata(modifiedBuffer.get(), metadata, rotation, isMirrored, hint);
     return modifiedBuffer;
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.h
@@ -28,10 +28,10 @@
 #include "VideoFrameTimeMetadata.h"
 
 // Modifies the buffer in-place.
-void webkitGstBufferAddVideoFrameMetadata(GstBuffer*, std::optional<WebCore::VideoFrameTimeMetadata>&&, WebCore::VideoFrame::Rotation, bool isMirrored, WebCore::VideoFrameContentHint);
+void webkitGstBufferAddVideoFrameMetadata(GstBuffer*, std::optional<WebCore::VideoFrameTimeMetadata>, WebCore::VideoFrame::Rotation, bool isMirrored, WebCore::VideoFrameContentHint);
 
 // Makes the buffer writable before modifying it.
-WARN_UNUSED_RETURN GRefPtr<GstBuffer> webkitGstBufferSetVideoFrameMetadata(GRefPtr<GstBuffer>&&, std::optional<WebCore::VideoFrameTimeMetadata>&&, WebCore::VideoFrame::Rotation = WebCore::VideoFrame::Rotation::None, bool isMirrored = false, WebCore::VideoFrameContentHint = WebCore::VideoFrameContentHint::None);
+WARN_UNUSED_RETURN GRefPtr<GstBuffer> webkitGstBufferSetVideoFrameMetadata(GRefPtr<GstBuffer>&&, std::optional<WebCore::VideoFrameTimeMetadata>, WebCore::VideoFrame::Rotation = WebCore::VideoFrame::Rotation::None, bool isMirrored = false, WebCore::VideoFrameContentHint = WebCore::VideoFrameContentHint::None);
 
 void webkitGstTraceProcessingTimeForElement(GstElement*);
 WebCore::VideoFrameMetadata webkitGstBufferGetVideoFrameMetadata(GstBuffer*);

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -186,8 +186,12 @@ bool GraphicsContextGLTextureMapperANGLE::copyTextureFromVideoFrame(VideoFrame&,
 RefPtr<VideoFrame> GraphicsContextGLTextureMapperANGLE::surfaceBufferToVideoFrame(SurfaceBuffer)
 {
 #if USE(GSTREAMER)
-    if (auto pixelBuffer = readCompositedResults())
-        return VideoFrameGStreamer::createFromPixelBuffer(pixelBuffer.releaseNonNull(), VideoFrameGStreamer::Rotation::UpsideDown, MediaTime::invalidTime(), { }, 30, true, { });
+    if (auto pixelBuffer = readCompositedResults()) {
+        VideoFrameGStreamer::CreateOptions options;
+        options.rotation = VideoFrameGStreamer::Rotation::UpsideDown;
+        options.isMirrored = true;
+        return VideoFrameGStreamer::createFromPixelBuffer(pixelBuffer.releaseNonNull(), { }, 30, options);
+    }
 #endif
     return nullptr;
 }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
@@ -318,7 +318,7 @@ void GStreamerIncomingTrackProcessor::installRtpBufferPadProbe(const GRefPtr<Gst
             videoFrameTimeMetadata.captureTime = Seconds::fromNanoseconds(gst_rtcp_ntp_to_unix(ntpTimestamp));
         }
 
-        auto modifiedBuffer = webkitGstBufferSetVideoFrameMetadata(GRefPtr(buffer), WTFMove(videoFrameTimeMetadata));
+        auto modifiedBuffer = webkitGstBufferSetVideoFrameMetadata(GRefPtr(buffer), videoFrameTimeMetadata);
         GST_PAD_PROBE_INFO_DATA(info) = modifiedBuffer.leakRef();
         return GST_PAD_PROBE_OK;
     }, gst_caps_new_empty_simple("timestamp/x-ntp"), reinterpret_cast<GDestroyNotify>(gst_caps_unref));

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
@@ -72,8 +72,13 @@ void GStreamerVideoCapturer::setSinkVideoFrameCallback(SinkVideoFrameCallback&& 
             presentationTime = fromGstClockTime(GST_BUFFER_PTS(buffer));
 
         auto rotationFromMeta = webkitGstBufferGetVideoRotation(buffer);
-        auto& size = capturer->size();
-        capturer->m_sinkVideoFrameCallback.second(VideoFrameGStreamer::create(WTFMove(sample), std::nullopt, size, presentationTime, rotationFromMeta.first, rotationFromMeta.second, WTFMove(metadata)));
+        auto size = capturer->size();
+        VideoFrameGStreamer::CreateOptions options(WTFMove(size));
+        options.presentationTime = presentationTime;
+        options.rotation = rotationFromMeta.first;
+        options.isMirrored = rotationFromMeta.second;
+        options.timeMetadata = WTFMove(metadata);
+        capturer->m_sinkVideoFrameCallback.second(VideoFrameGStreamer::create(WTFMove(sample), options));
         return GST_FLOW_OK;
     }), this);
 }

--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp
@@ -128,8 +128,12 @@ void MockRealtimeVideoSourceGStreamer::updateSampleBuffer()
     VideoFrameTimeMetadata metadata;
     metadata.captureTime = MonotonicTime::now().secondsSinceEpoch();
 
-    auto presentationTime = fromGstClockTime(gst_util_uint64_scale(m_frameNumber, frameRateDenominator * GST_SECOND, frameRateNumerator));
-    auto videoFrame = VideoFrameGStreamer::createFromPixelBuffer(pixelBuffer.releaseNonNull(), videoFrameRotation(), presentationTime, m_capturer->size(), frameRate(), false, WTFMove(metadata));
+    VideoFrameGStreamer::CreateOptions options;
+    options.presentationTime = fromGstClockTime(gst_util_uint64_scale(m_frameNumber, frameRateDenominator * GST_SECOND, frameRateNumerator));
+    options.rotation = videoFrameRotation();
+    options.timeMetadata = WTFMove(metadata);
+
+    auto videoFrame = VideoFrameGStreamer::createFromPixelBuffer(pixelBuffer.releaseNonNull(), m_capturer->size(), frameRate(), options);
     if (!videoFrame)
         return;
 

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp
@@ -103,7 +103,12 @@ void RealtimeIncomingVideoSourceGStreamer::dispatchSample(GRefPtr<GstSample>&& s
     ensureSizeAndFramerate(GRefPtr<GstCaps>(caps));
     auto [rotation, isMirrored] = webkitGstBufferGetVideoRotation(buffer);
 
-    videoFrameAvailable(VideoFrameGStreamer::create(WTFMove(sample), std::nullopt, intrinsicSize(), fromGstClockTime(GST_BUFFER_PTS(buffer)), rotation, isMirrored, { }, { }, VideoFrameContentHint::WebRTC), { });
+    VideoFrameGStreamer::CreateOptions options(intrinsicSize());
+    options.presentationTime = fromGstClockTime(GST_BUFFER_PTS(buffer));
+    options.rotation = rotation;
+    options.isMirrored = isMirrored;
+    options.contentHint = VideoFrameContentHint::WebRTC;
+    videoFrameAvailable(VideoFrameGStreamer::create(WTFMove(sample), options), { });
 }
 
 const GstStructure* RealtimeIncomingVideoSourceGStreamer::stats()

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingVideoSourceLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingVideoSourceLibWebRTC.cpp
@@ -64,8 +64,11 @@ void RealtimeIncomingVideoSourceLibWebRTC::OnFrame(const webrtc::VideoFrame& fra
         videoFrameAvailable(VideoFrameGStreamer::createWrappedSample(framebuffer->getSample(), presentationTime, static_cast<VideoFrame::Rotation>(frame.rotation())), { });
     } else {
         auto gstSample = convertLibWebRTCVideoFrameToGStreamerSample(frame);
-        auto metadata = std::make_optional(metadataFromVideoFrame(frame));
-        videoFrameAvailable(VideoFrameGStreamer::create(WTFMove(gstSample), std::nullopt, { }, presentationTime, static_cast<VideoFrame::Rotation>(frame.rotation()), false, WTFMove(metadata)), { });
+        VideoFrameGStreamer::CreateOptions options;
+        options.timeMetadata = std::make_optional(metadataFromVideoFrame(frame));
+        options.presentationTime = presentationTime;
+        options.rotation = static_cast<VideoFrame::Rotation>(frame.rotation());
+        videoFrameAvailable(VideoFrameGStreamer::create(WTFMove(gstSample), options), { });
     }
 }
 


### PR DESCRIPTION
#### e13ef62d1f72f245674f610130e1e6c4d6333e9a
<pre>
[GStreamer] Simplify API of VideoFrameGStreamer::create functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=295540">https://bugs.webkit.org/show_bug.cgi?id=295540</a>

Reviewed by Xabier Rodriguez-Calvar.

Move most optional parameters from our ::create functions to a structure. That makes the API a bit
easier to comprehend. This is mostly a refactoring and is covered by existing tests.

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::paint):
(WebCore::MediaPlayerPrivateGStreamer::videoFrameForCurrentTime):
* Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp:
(WebCore::GStreamerInternalVideoDecoder::GStreamerInternalVideoDecoder):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::VideoFrame::createFromPixelBuffer):
(WebCore::VideoFrame::fromNativeImage):
(WebCore::VideoFrame::createNV12):
(WebCore::VideoFrame::createI420):
(WebCore::VideoFrame::createI420A):
(WebCore::VideoFrameGStreamer::create):
(WebCore::VideoFrameGStreamer::createWrappedSample):
(WebCore::VideoFrameGStreamer::createFromPixelBuffer):
(WebCore::VideoFrameGStreamer::VideoFrameGStreamer):
(WebCore::VideoFrameGStreamer::setMetadataAndContentHint):
(WebCore::VideoFrameGStreamer::resizeTo):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp:
(webkitGstBufferAddVideoFrameMetadata):
(webkitGstBufferSetVideoFrameMetadata):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.h:
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp:
(WebCore::GraphicsContextGLTextureMapperANGLE::surfaceBufferToVideoFrame):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp:
(WebCore::GStreamerIncomingTrackProcessor::installRtpBufferPadProbe):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp:
(WebCore::GStreamerVideoCapturer::setSinkVideoFrameCallback):
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp:
(WebCore::MockRealtimeVideoSourceGStreamer::updateSampleBuffer):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp:
(WebCore::RealtimeIncomingVideoSourceGStreamer::dispatchSample):
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingVideoSourceLibWebRTC.cpp:
(WebCore::RealtimeIncomingVideoSourceLibWebRTC::OnFrame):

Canonical link: <a href="https://commits.webkit.org/297158@main">https://commits.webkit.org/297158@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e80892b92dfcd1e95f9c0122d1956d0b94b66d77

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110711 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20806 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116738 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60978 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112674 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31049 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38960 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84186 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113659 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24803 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99696 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64627 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24168 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17833 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60532 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94193 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17892 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119528 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37751 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28052 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93149 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38125 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95963 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92973 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23697 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38002 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15750 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33729 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37647 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43119 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37309 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40648 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39017 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->