### PR TITLE
[WebGPU] Enable Swift strict-memory-safety

### DIFF
--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -328,6 +328,7 @@ set(WTF_PUBLIC_HEADERS
     StringPrintStream.h
     StructDump.h
     SuspendableWorkQueue.h
+    SwiftBridging.h
     SynchronizedFixedQueue.h
     SystemFree.h
     SystemMalloc.h

--- a/Source/WTF/wtf/RangeSet.h
+++ b/Source/WTF/wtf/RangeSet.h
@@ -28,6 +28,7 @@
 #include <wtf/ListDump.h>
 #include <wtf/MathExtras.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/SwiftBridging.h>
 #include <wtf/Vector.h>
 
 namespace WTF {
@@ -207,7 +208,7 @@ private:
     
     VectorType m_ranges;
     bool m_isCompact { true };
-};
+} SWIFT_ESCAPABLE;
 
 } // namespace WTF
 

--- a/Source/WTF/wtf/SwiftBridging.h
+++ b/Source/WTF/wtf/SwiftBridging.h
@@ -29,6 +29,22 @@
 
 #include <swift/bridging>
 
+#ifndef SWIFT_NONESCAPABLE
+#define SWIFT_NONESCAPABLE
+#endif
+
+#ifndef SWIFT_ESCAPABLE
+#define SWIFT_ESCAPABLE
+#endif
+
+#ifndef SWIFT_ESCAPABLE_IF
+#define SWIFT_ESCAPABLE_IF(...)
+#endif
+
+#ifndef SWIFT_PRIVATE_FILEID
+#define SWIFT_PRIVATE_FILEID(_fileID)
+#endif
+
 #else
 
 // Copied from https://github.com/swiftlang/swift/blob/ff8b9f145320b02bc6de75163d78528f210bdba6/lib/ClangImporter/SwiftBridging/swift/bridging

--- a/Source/WTF/wtf/ThreadSafeWeakPtr.h
+++ b/Source/WTF/wtf/ThreadSafeWeakPtr.h
@@ -29,6 +29,7 @@
 #include <wtf/Lock.h>
 #include <wtf/MainThread.h>
 #include <wtf/RefPtr.h>
+#include <wtf/SwiftBridging.h>
 #include <wtf/TaggedPtr.h>
 
 namespace WTF {
@@ -443,7 +444,7 @@ private:
     // from ThreadSafeWeakPtrControlBlock::m_object and don't support structs larger than 65535.
     // https://bugs.webkit.org/show_bug.cgi?id=283929
     ControlBlockRefPtr m_controlBlock;
-};
+} SWIFT_ESCAPABLE;
 
 template<class T> ThreadSafeWeakPtr(const T&) -> ThreadSafeWeakPtr<T>;
 template<class T> ThreadSafeWeakPtr(const T*) -> ThreadSafeWeakPtr<T>;

--- a/Source/WebGPU/Configurations/WebGPU.xcconfig
+++ b/Source/WebGPU/Configurations/WebGPU.xcconfig
@@ -93,7 +93,10 @@ SWIFT_INSTALL_OBJC_HEADER = NO;
 SWIFT_OBJC_INTEROP_MODE = $(WK_SWIFT_OBJC_INTEROP_MODE_$(ENABLE_WEBGPU_SWIFT))
 WK_SWIFT_OBJC_INTEROP_MODE_ENABLE_WEBGPU_SWIFT = objcxx;
 
-OTHER_SWIFT_FLAGS = $(inherited) @$(BUILT_PRODUCTS_DIR)/DerivedSources/WebGPU/platform-enabled-swift-args.$(arch).resp $(OTHER_SWIFT_FLAGS_$(WK_PLATFORM_NAME));
+// FIXME: reenable this once rdar://154887575 lands
+// SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES
+
+OTHER_SWIFT_FLAGS = $(inherited) @$(BUILT_PRODUCTS_DIR)/DerivedSources/WebGPU/platform-enabled-swift-args.$(arch).resp $(OTHER_SWIFT_FLAGS_$(WK_PLATFORM_NAME)) -strict-memory-safety -enable-experimental-feature Lifetimes -enable-experimental-feature LifetimeDependence -enable-experimental-feature SafeInteropWrappers;
 OTHER_SWIFT_FLAGS_macosx = $(OTHER_SWIFT_FLAGS$(WK_MACOS_1400));
 OTHER_SWIFT_FLAGS_maccatalyst = $(OTHER_SWIFT_FLAGS$(WK_MACCATALYST_14));
 OTHER_SWIFT_FLAGS_iphoneos = $(OTHER_SWIFT_FLAGS$(WK_IOS_17));

--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -194,7 +194,8 @@ private:
     bool m_mappedAtCreation { false };
 #endif
     HashMap<uint64_t, bool, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_didReadOOB;
-} SWIFT_SHARED_REFERENCE(refBuffer, derefBuffer);
+// FIXME: remove @safe once rdar://151039766 lands
+} __attribute__((swift_attr("@safe"))) SWIFT_SHARED_REFERENCE(refBuffer, derefBuffer);
 
 } // namespace WebGPU
 

--- a/Source/WebGPU/WebGPU/Buffer.swift
+++ b/Source/WebGPU/WebGPU/Buffer.swift
@@ -26,23 +26,20 @@
 import WebGPU_Internal
 
 extension WebGPU.Buffer {
-    var bufferContents: UnsafeMutableRawBufferPointer {
-        UnsafeMutableRawBufferPointer(start: m_buffer.contents(), count: m_buffer.length)
-    }
-
-    func copy(from data: SpanConstUInt8, offset: Int) {
-        let slice = bufferContents[offset...]
-        // copyBytes(from:) checks bounds in debug builds only.
+    func copy(from data: Span<UInt8>, offset: Int) {
         // FIXME: Use a bounds-checking implementation when one is available.
-        precondition(slice.count >= data.size_bytes())
-        slice.copyBytes(from: data)
+        var bufferContents = unsafe MutableSpan<UInt8>(_unsafeCxxSpan: getBufferContents());
+        precondition(bufferContents.count >= offset + data.count)
+        for i in 0..<data.count {
+            bufferContents[offset + i] = data[i]
+        }
     }
 }
 
 // FIXME(emw): Find a way to generate thunks like these, maybe via a macro?
 @_expose(Cxx)
 public func Buffer_copyFrom_thunk(_ buffer: WebGPU.Buffer, from data: SpanConstUInt8, offset: Int) {
-    buffer.copy(from: data, offset: offset)
+    buffer.copy(from: unsafe Span<UInt8>(_unsafeCxxSpan: data), offset: offset)
 }
 
 @_expose(Cxx)
@@ -63,7 +60,7 @@ extension WebGPU.Buffer {
     public func getMappedRange(offset: Int, size: Int) -> SpanUInt8
     {
         if !isValid() {
-            return SpanUInt8()
+            return unsafe SpanUInt8()
         }
 
         var rangeSize = size
@@ -72,16 +69,16 @@ extension WebGPU.Buffer {
         }
 
         if !validateGetMappedRange(offset, rangeSize) {
-            return SpanUInt8()
+            return unsafe SpanUInt8()
         }
 
         m_mappedRanges.add(WTFRangeSizeT(UInt(offset), UInt(offset + rangeSize)))
         m_mappedRanges.compact()
 
         if m_buffer.storageMode == .private || m_buffer.storageMode == .memoryless || m_buffer.length == 0 {
-            return SpanUInt8()
+            return unsafe SpanUInt8()
         }
 
-        return getBufferContents().subspan(offset, rangeSize)
+        return unsafe getBufferContents().subspan(offset, rangeSize)
     }
 }

--- a/Source/WebGPU/WebGPU/CommandBuffer.h
+++ b/Source/WebGPU/WebGPU/CommandBuffer.h
@@ -92,7 +92,8 @@ private:
     // FIXME: we should not need this semaphore - https://bugs.webkit.org/show_bug.cgi?id=272353
     BinarySemaphore m_commandBufferComplete;
     RefPtr<CommandEncoder> m_commandEncoder;
-} SWIFT_SHARED_REFERENCE(refCommandBuffer, derefCommandBuffer);
+// FIXME: remove @safe once rdar://151039766 lands
+} __attribute__((swift_attr("@safe"))) SWIFT_SHARED_REFERENCE(refCommandBuffer, derefCommandBuffer);
 
 } // namespace WebGPU
 

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -207,7 +207,8 @@ private PUBLIC_IN_WEBGPU_SWIFT:
     uint32_t m_currentResidencySetCount { 0 };
 #endif
 private:
-} SWIFT_SHARED_REFERENCE(refCommandEncoder, derefCommandEncoder);
+// FIXME: remove @safe once rdar://151039766 lands
+} __attribute__((swift_attr("@safe"))) SWIFT_SHARED_REFERENCE(refCommandEncoder, derefCommandEncoder);
 
 } // namespace WebGPU
 

--- a/Source/WebGPU/WebGPU/CommandEncoder.swift
+++ b/Source/WebGPU/WebGPU/CommandEncoder.swift
@@ -76,7 +76,7 @@ public func CommandEncoder_beginComputePass_thunk(commandEncoder: WebGPU.Command
 public func CommandEncoder_runClearEncoder_thunk(commandEncoder: WebGPU.CommandEncoder, attachmentsToClear: NSMutableDictionary, depthStencilAttachmentToClear: inout MTLTexture?, depthAttachmentToClear: Bool, stencilAttachmentToClear: Bool, depthClearValue: Double, stencilClearValue: UInt32, existingEncoder: MTLRenderCommandEncoder?) {
     let dInput = attachmentsToClear as? [NSNumber: TextureAndClearColor]
     if dInput == nil {
-        WebGPU_Internal.logString("Dictionary not convertible")
+        unsafe WebGPU_Internal.logString("Dictionary not convertible")
         precondition(false, "Dictionary not convertible")
     } else {
         return commandEncoder.runClearEncoder(attachmentsToClear: dInput!, depthStencilAttachmentToClear: &depthStencilAttachmentToClear, depthAttachmentToClear: depthAttachmentToClear, stencilAttachmentToClear: stencilAttachmentToClear, depthClearValue: depthClearValue, stencilClearValue: stencilClearValue, existingEncoder: existingEncoder)
@@ -90,7 +90,7 @@ public func CommandEncoder_clearTextureIfNeeded_thunk(commandEncoder: WebGPU.Com
 
 @_expose(Cxx)
 public func CommandEncoder_finish_thunk(commandEncoder: WebGPU.CommandEncoder, descriptor: WGPUCommandBufferDescriptor) -> WebGPU_Internal.RefCommandBuffer {
-    return commandEncoder.finish(descriptor: descriptor)
+    return unsafe commandEncoder.finish(descriptor: descriptor)
 }
 
 extension WebGPU.CommandEncoder {
@@ -112,10 +112,10 @@ extension WebGPU.CommandEncoder {
         return nil
     }
     public func finish(descriptor: WGPUCommandBufferDescriptor) -> WebGPU_Internal.RefCommandBuffer {
-        if descriptor.nextInChain != nil ||  !isValid() || (m_existingCommandEncoder != nil && m_existingCommandEncoder !== m_blitCommandEncoder) {
+        if unsafe descriptor.nextInChain != nil ||  !isValid() || (m_existingCommandEncoder != nil && m_existingCommandEncoder !== m_blitCommandEncoder) {
             setEncoderState(WebGPU.CommandsMixin.EncoderState.Ended)
             discardCommandBuffer();
-            protectedDevice().ptr().generateAValidationError(m_lastErrorString != nil ? m_lastErrorString! as String : String("Invalid CommandEncoder"))
+            unsafe protectedDevice().ptr().generateAValidationError(m_lastErrorString != nil ? m_lastErrorString! as String : String("Invalid CommandEncoder"))
             return WebGPU.CommandBuffer.createInvalid(m_device.ptr())
         }
 
@@ -129,7 +129,7 @@ extension WebGPU.CommandEncoder {
         setEncoderState(WebGPU.CommandsMixin.EncoderState.Ended)
         if validationFailedError != nil {
             discardCommandBuffer()
-            protectedDevice().ptr().generateAValidationError(m_lastErrorString != nil ? m_lastErrorString! as String : validationFailedError);
+            unsafe protectedDevice().ptr().generateAValidationError(m_lastErrorString != nil ? m_lastErrorString! as String : validationFailedError);
             return WebGPU.CommandBuffer.createInvalid(m_device.ptr())
         }
 
@@ -139,7 +139,7 @@ extension WebGPU.CommandEncoder {
         m_commandBuffer = nil
         m_existingCommandEncoder = nil
 
-        commandBuffer?.label = WebGPU_Internal.convertWTFStringToNSString(WebGPU.fromAPI(descriptor.label))
+        commandBuffer?.label = unsafe WebGPU_Internal.convertWTFStringToNSString(WebGPU.fromAPI(descriptor.label))
 
     #if os(macOS) || targetEnvironment(macCatalyst)
         if m_managedBuffers.count != 0 || m_managedTextures.count != 0 {
@@ -169,7 +169,7 @@ extension WebGPU.CommandEncoder {
     }
     private func clearTextureIfNeeded(destination: WGPUImageCopyTexture , slice: UInt, device: WebGPU.Device , blitCommandEncoder: MTLBlitCommandEncoder?)
     {
-        let texture = WebGPU.fromAPI(destination.texture)
+        let texture = unsafe WebGPU.fromAPI(destination.texture)
         let mipLevel: UInt = UInt(destination.mipLevel)
         clearTextureIfNeeded(texture, mipLevel, slice, device, blitCommandEncoder)
     }
@@ -389,10 +389,12 @@ extension WebGPU.CommandEncoder {
         m_device.ptr().protectedQueue().ptr().endEncoding(clearRenderCommandEncoder, m_commandBuffer)
         setExistingEncoder(nil)
     }
+
     private func timestampWriteIndex(writeIndex: UInt32) -> UInt32
     {
         return writeIndex == WGPU_QUERY_SET_INDEX_UNDEFINED ? 0 : writeIndex
     }
+
     private func errorValidatingCopyBufferToBuffer(source: WebGPU.Buffer, sourceOffset: UInt64, destination: WebGPU.Buffer, destinationOffset: UInt64, size: UInt64) -> String? {
         func errorString(_ format: String) -> String {
             return "GPUCommandEncoder.copyBufferToBuffer: \(format)"
@@ -479,12 +481,12 @@ extension WebGPU.CommandEncoder {
         func errorString(_ error: String) -> String {
              "GPUCommandEncoder.copyTextureToTexture: \(error)"
         }
-        let sourceTexture = WebGPU.fromAPI(source.texture)
+        let sourceTexture = unsafe WebGPU.fromAPI(source.texture)
         if !WebGPU_Internal.isValidToUseWithTextureCommandEncoder(sourceTexture, self) {
             return errorString("source texture is not valid to use with this GPUCommandEncoder")
         }
 
-        let destinationTexture = WebGPU.fromAPI(destination.texture)
+        let destinationTexture = unsafe WebGPU.fromAPI(destination.texture)
         if !WebGPU_Internal.isValidToUseWithTextureCommandEncoder(destinationTexture, self) {
             return errorString("desintation texture is not valid to use with this GPUCommandEncoder")
         }
@@ -540,10 +542,10 @@ extension WebGPU.CommandEncoder {
         }
 
         // https://gpuweb.github.io/gpuweb/#abstract-opdef-set-of-subresources-for-texture-copy
-        if source.texture == destination.texture {
+        if unsafe source.texture == destination.texture {
             // Mip levels are never ranges.
             if source.mipLevel == destination.mipLevel {
-                switch (WebGPU.fromAPI(source.texture).dimension()) {
+                switch (unsafe WebGPU.fromAPI(source.texture).dimension()) {
                 case WGPUTextureDimension_1D:
                     return errorString("can't copy 1D texture to itself")
                 case WGPUTextureDimension_2D:
@@ -570,7 +572,7 @@ extension WebGPU.CommandEncoder {
         func errorString(_ error: String) -> String {
             return "GPUCommandEncoder.copyTextureToBuffer: \(error)"
         }
-        let sourceTexture = WebGPU.fromAPI(source.texture)
+        let sourceTexture = unsafe WebGPU.fromAPI(source.texture)
 
         if !WebGPU_Internal.isValidToUseWithTextureCommandEncoder(sourceTexture, self) {
             return errorString("source texture is not valid to use with this GPUCommandEncoder")
@@ -606,7 +608,7 @@ extension WebGPU.CommandEncoder {
             return errorString(error)
         }
 
-        if WebGPU.fromAPI(destination.buffer).usage() & WGPUBufferUsage_CopyDst.rawValue == 0 {
+        if unsafe WebGPU.fromAPI(destination.buffer).usage() & WGPUBufferUsage_CopyDst.rawValue == 0 {
             return errorString("destination buffer usage does not contain CopyDst")
         }
 
@@ -627,14 +629,14 @@ extension WebGPU.CommandEncoder {
             }
         }
 
-        if let error = WebGPU.Texture.errorValidatingLinearTextureData(destination.layout, WebGPU.fromAPI(destination.buffer).initialSize(), aspectSpecificFormat, copySize) {
+        if let error = WebGPU.Texture.errorValidatingLinearTextureData(destination.layout, unsafe WebGPU.fromAPI(destination.buffer).initialSize(), aspectSpecificFormat, copySize) {
             return errorString(error)
         }
         return nil
     }
     private func errorValidatingImageCopyBuffer(imageCopyBuffer: WGPUImageCopyBuffer) -> String? {
         // https://gpuweb.github.io/gpuweb/#abstract-opdef-validating-gpuimagecopybuffer
-        let buffer = WebGPU.fromAPI(imageCopyBuffer.buffer)
+        let buffer = unsafe WebGPU.fromAPI(imageCopyBuffer.buffer)
         if !WebGPU_Internal.isValidToUseWithBufferCommandEncoder(buffer, self) {
             return "buffer is not valid";
         }
@@ -650,8 +652,8 @@ extension WebGPU.CommandEncoder {
         func errorString(_ error: String) -> String {
             return "GPUCommandEncoder.copyBufferToTexture: \(error)"
         }
-        let destinationTexture = WebGPU.fromAPI(destination.texture)
-        let sourceBuffer = WebGPU.fromAPI(source.buffer)
+        let destinationTexture = unsafe WebGPU.fromAPI(destination.texture)
+        let sourceBuffer = unsafe WebGPU.fromAPI(source.buffer)
 
         if let error = errorValidatingImageCopyBuffer(imageCopyBuffer: source) {
             return errorString(error)
@@ -708,7 +710,7 @@ extension WebGPU.CommandEncoder {
             }
         }
 
-        if let error = WebGPU.Texture.errorValidatingLinearTextureData(source.layout, WebGPU.fromAPI(source.buffer).initialSize(), aspectSpecificFormat, copySize) {
+        if let error = WebGPU.Texture.errorValidatingLinearTextureData(source.layout, unsafe WebGPU.fromAPI(source.buffer).initialSize(), aspectSpecificFormat, copySize) {
             return errorString(error)
         }
         return nil
@@ -716,8 +718,8 @@ extension WebGPU.CommandEncoder {
 
 
     private func errorValidatingRenderPassDescriptor(descriptor: WGPURenderPassDescriptor) -> String? {
-        if let wgpuOcclusionQuery = descriptor.occlusionQuerySet {
-            let occlusionQuery = WebGPU.fromAPI(wgpuOcclusionQuery)
+        if let wgpuOcclusionQuery = unsafe descriptor.occlusionQuerySet {
+            let occlusionQuery = unsafe WebGPU.fromAPI(wgpuOcclusionQuery)
             if !WebGPU_Internal.isValidToUseWithQuerySetCommandEncoder(occlusionQuery, self) {
                 return "occlusion query does not match the device"
             }
@@ -725,19 +727,19 @@ extension WebGPU.CommandEncoder {
                 return "occlusion query type is not occlusion"
             }
         }
-        if descriptor.timestampWrites != nil {
-            return errorValidatingTimestampWrites(timestampWrites: WGPUComputePassTimestampWrites ( querySet: descriptor.timestampWrites.pointee.querySet, beginningOfPassWriteIndex: descriptor.timestampWrites.pointee.beginningOfPassWriteIndex, endOfPassWriteIndex: descriptor.timestampWrites.pointee.endOfPassWriteIndex))
+        if unsafe descriptor.timestampWrites != nil {
+            return unsafe errorValidatingTimestampWrites(timestampWrites: WGPUComputePassTimestampWrites ( querySet: descriptor.timestampWrites.pointee.querySet, beginningOfPassWriteIndex: descriptor.timestampWrites.pointee.beginningOfPassWriteIndex, endOfPassWriteIndex: descriptor.timestampWrites.pointee.endOfPassWriteIndex))
         }
         return nil
     }
 
     private func errorValidatingTimestampWrites(timestampWrites: WGPUComputePassTimestampWrites) -> String? {
 
-            if (!self.protectedDevice().ptr().hasFeature(WGPUFeatureName_TimestampQuery)) {
+            if (unsafe !self.protectedDevice().ptr().hasFeature(WGPUFeatureName_TimestampQuery)) {
                 return "device does not have timestamp query feature"
             }
 
-            let querySet = WebGPU.fromAPI(timestampWrites.querySet)
+            let querySet = unsafe WebGPU.fromAPI(timestampWrites.querySet)
             if (querySet.type() != WGPUQueryType_Timestamp) {
                 return "query type is not timestamp but \(querySet.type())"
             }
@@ -747,18 +749,18 @@ extension WebGPU.CommandEncoder {
             }
 
             let querySetCount = querySet.count()
-            let beginningOfPassWriteIndex = timestampWriteIndex(writeIndex: timestampWrites.beginningOfPassWriteIndex)
-            let endOfPassWriteIndex = timestampWriteIndex(writeIndex: timestampWrites.endOfPassWriteIndex)
-            if (beginningOfPassWriteIndex >= querySetCount || endOfPassWriteIndex >= querySetCount || timestampWrites.beginningOfPassWriteIndex == timestampWrites.endOfPassWriteIndex) {
-                return "writeIndices mismatch: beginningOfPassWriteIndex(\(beginningOfPassWriteIndex) >= querySetCount(\(querySetCount) || endOfPassWriteIndex(\(endOfPassWriteIndex)) >= querySetCount(\(querySetCount)) || timestampWrite.beginningOfPassWriteIndex(\(timestampWrites.beginningOfPassWriteIndex) == timestampWrite.endOfPassWriteIndex(\(timestampWrites.endOfPassWriteIndex))"
+            let beginningOfPassWriteIndex = unsafe timestampWriteIndex(writeIndex: timestampWrites.beginningOfPassWriteIndex)
+            let endOfPassWriteIndex = unsafe timestampWriteIndex(writeIndex: timestampWrites.endOfPassWriteIndex)
+            if (unsafe beginningOfPassWriteIndex >= querySetCount || endOfPassWriteIndex >= querySetCount || timestampWrites.beginningOfPassWriteIndex == timestampWrites.endOfPassWriteIndex) {
+                return unsafe "writeIndices mismatch: beginningOfPassWriteIndex(\(beginningOfPassWriteIndex) >= querySetCount(\(querySetCount) || endOfPassWriteIndex(\(endOfPassWriteIndex)) >= querySetCount(\(querySetCount)) || timestampWrite.beginningOfPassWriteIndex(\(timestampWrites.beginningOfPassWriteIndex) == timestampWrite.endOfPassWriteIndex(\(timestampWrites.endOfPassWriteIndex))"
             }
 
             return nil
     }
 
     private func errorValidatingComputePassDescriptor(descriptor: WGPUComputePassDescriptor) -> String? {
-        if descriptor.timestampWrites != nil {
-            return errorValidatingTimestampWrites(timestampWrites: descriptor.timestampWrites.pointee)
+        if unsafe descriptor.timestampWrites != nil {
+            return unsafe errorValidatingTimestampWrites(timestampWrites: descriptor.timestampWrites.pointee)
         }
         return nil
     }
@@ -808,12 +810,12 @@ extension WebGPU.CommandEncoder {
 
     public func beginRenderPass(descriptor: WGPURenderPassDescriptor) -> WebGPU_Internal.RefRenderPassEncoder {
         var maxDrawCount = UInt64.max
-        if descriptor.nextInChain != nil {
-            if descriptor.nextInChain.pointee.sType != WGPUSType_RenderPassDescriptorMaxDrawCount {
+        if unsafe descriptor.nextInChain != nil {
+            if unsafe descriptor.nextInChain.pointee.sType != WGPUSType_RenderPassDescriptorMaxDrawCount {
                 return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), "descriptor is corrupted")
             }
-            descriptor.nextInChain.withMemoryRebound(to: WGPURenderPassDescriptorMaxDrawCount.self, capacity: 1) {
-                maxDrawCount = $0.pointee.maxDrawCount
+            unsafe descriptor.nextInChain.withMemoryRebound(to: WGPURenderPassDescriptorMaxDrawCount.self, capacity: 1) {
+                maxDrawCount = unsafe $0.pointee.maxDrawCount
             }
         }
 
@@ -832,17 +834,17 @@ extension WebGPU.CommandEncoder {
 
         let mtlDescriptor = MTLRenderPassDescriptor()
         var counterSampleBuffer: MTLCounterSampleBuffer? = nil
-        if let wgpuTimestampWrites = descriptor.timestampWrites {
-            counterSampleBuffer = WebGPU.fromAPI(wgpuTimestampWrites.pointee.querySet).counterSampleBuffer()
+        if let wgpuTimestampWrites = unsafe descriptor.timestampWrites {
+            counterSampleBuffer = unsafe WebGPU.fromAPI(wgpuTimestampWrites.pointee.querySet).counterSampleBuffer()
         }
 
         if (m_device.ptr().enableEncoderTimestamps() || counterSampleBuffer != nil) {
             if (counterSampleBuffer != nil) {
                 mtlDescriptor.sampleBufferAttachments[0].sampleBuffer = counterSampleBuffer;
-                mtlDescriptor.sampleBufferAttachments[0].startOfVertexSampleIndex = Int(descriptor.timestampWrites.pointee.beginningOfPassWriteIndex)
-                mtlDescriptor.sampleBufferAttachments[0].endOfVertexSampleIndex = Int(descriptor.timestampWrites.pointee.endOfPassWriteIndex)
-                mtlDescriptor.sampleBufferAttachments[0].startOfFragmentSampleIndex = Int(descriptor.timestampWrites.pointee.endOfPassWriteIndex)
-                mtlDescriptor.sampleBufferAttachments[0].endOfFragmentSampleIndex = Int(descriptor.timestampWrites.pointee.endOfPassWriteIndex)
+                mtlDescriptor.sampleBufferAttachments[0].startOfVertexSampleIndex = unsafe Int(descriptor.timestampWrites.pointee.beginningOfPassWriteIndex)
+                mtlDescriptor.sampleBufferAttachments[0].endOfVertexSampleIndex = unsafe Int(descriptor.timestampWrites.pointee.endOfPassWriteIndex)
+                mtlDescriptor.sampleBufferAttachments[0].startOfFragmentSampleIndex = unsafe Int(descriptor.timestampWrites.pointee.endOfPassWriteIndex)
+                mtlDescriptor.sampleBufferAttachments[0].endOfFragmentSampleIndex = unsafe Int(descriptor.timestampWrites.pointee.endOfPassWriteIndex)
                 m_device.ptr().trackTimestampsBuffer(m_commandBuffer, counterSampleBuffer);
             } else {
                 mtlDescriptor.sampleBufferAttachments[0].sampleBuffer = counterSampleBuffer != nil ? counterSampleBuffer : m_device.ptr().timestampsBuffer(m_commandBuffer, 4)
@@ -865,11 +867,11 @@ extension WebGPU.CommandEncoder {
         let maxColorAttachmentBytesPerSample = m_device.ptr().limitsCopy().maxColorAttachmentBytesPerSample
         var textureWidth: UInt32 = 0, textureHeight: UInt32  = 0, sampleCount: UInt32 = 0
 
-        var depthSlices: [UnsafeRawPointer: Set<UInt64>] = [:]
-        for i in 0..<descriptor.colorAttachmentsSpan().count {
+        var depthSlices: [UnsafeRawPointer: Set<UInt64>] = unsafe [:]
+        for i in unsafe 0..<descriptor.colorAttachmentsSpan().count {
             let attachment = descriptor.colorAttachmentsSpan()[i]
 
-            if (attachment.view == nil) {
+            if (unsafe attachment.view == nil) {
                 continue
             }
 
@@ -881,7 +883,7 @@ extension WebGPU.CommandEncoder {
                 attachment.clearValue.b,
                 attachment.clearValue.a)
 
-            let texture = WebGPU.fromAPI(attachment.view)
+            let texture = unsafe WebGPU.fromAPI(attachment.view)
             if (!WebGPU_Internal.isValidToUseWithTextureViewCommandEncoder(texture, self)) {
                 return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), "device mismatch")
             }
@@ -938,27 +940,27 @@ extension WebGPU.CommandEncoder {
                 depthSliceOrArrayLayer = UInt64(textureIsDestroyed ? 0 : texture.baseArrayLayer())
             }
             var bridgedTexture: UnsafeRawPointer? = nil
-            withUnsafePointer(to: texture.parentTexture()) {
-                bridgedTexture = UnsafeRawPointer($0)
+            unsafe withUnsafePointer(to: texture.parentTexture()) {
+                unsafe bridgedTexture = unsafe UnsafeRawPointer($0)
             }
-            guard bridgedTexture != nil else {
+            guard unsafe bridgedTexture != nil else {
                 return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), "parent texture is nil")
             }
             let baseMipLevel = textureIsDestroyed ? 0 : texture.baseMipLevel()
             let depthAndMipLevel: UInt64 = depthSliceOrArrayLayer | (UInt64(baseMipLevel) << 32)
-            if depthSlices[bridgedTexture!] != nil {
-                if depthSlices[bridgedTexture!]!.contains(depthAndMipLevel) {
+            if unsafe depthSlices[bridgedTexture!] != nil {
+                if unsafe depthSlices[bridgedTexture!]!.contains(depthAndMipLevel) {
                     return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), "attempting to render to overlapping color attachment")
                 }
-                depthSlices[bridgedTexture!]!.insert(depthAndMipLevel)
+                unsafe depthSlices[bridgedTexture!]!.insert(depthAndMipLevel)
             } else {
-                depthSlices[bridgedTexture!] = [ depthAndMipLevel ]
+                unsafe depthSlices[bridgedTexture!] = [ depthAndMipLevel ]
             }
 
             mtlAttachment.depthPlane = Int(textureDimension == WGPUTextureViewDimension_3D ? depthSliceOrArrayLayer : 0)
             mtlAttachment.slice = 0
             mtlAttachment.loadAction = loadAction(loadOp: attachment.loadOp)
-            mtlAttachment.storeAction = storeAction(storeOp: attachment.storeOp, hasResolveTarget: attachment.resolveTarget != nil)
+            mtlAttachment.storeAction = unsafe storeAction(storeOp: attachment.storeOp, hasResolveTarget: attachment.resolveTarget != nil)
 
             zeroColorTargets = false
             var textureToClear: MTLTexture? = nil
@@ -966,8 +968,8 @@ extension WebGPU.CommandEncoder {
                 textureToClear = mtlAttachment.texture
             }
 
-            if attachment.resolveTarget != nil {
-                let resolveTarget = WebGPU.fromAPI(attachment.resolveTarget)
+            if unsafe attachment.resolveTarget != nil {
+                let resolveTarget = unsafe WebGPU.fromAPI(attachment.resolveTarget)
                 if !WebGPU_Internal.isValidToUseWithTextureViewCommandEncoder(resolveTarget, self) {
                     return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), "resolve target created from different device")
                 }
@@ -995,9 +997,9 @@ extension WebGPU.CommandEncoder {
                     // FIXME: rdar://138042799 remove default argument.
                     texture.setPreviouslyCleared(0, 0)
                 }
-                if (attachment.resolveTarget != nil) {
+                if (unsafe attachment.resolveTarget != nil) {
                     // FIXME: rdar://138042799 remove default argument.
-                    WebGPU.fromAPI(attachment.resolveTarget).setPreviouslyCleared(0, 0)
+                    unsafe WebGPU.fromAPI(attachment.resolveTarget).setPreviouslyCleared(0, 0)
                 }
             }
 
@@ -1006,8 +1008,8 @@ extension WebGPU.CommandEncoder {
         var hasStencilComponent = false
         var depthStencilAttachmentToClear: MTLTexture? = nil
         var depthAttachmentToClear = false
-        if let attachment = descriptor.depthStencilAttachment {
-            let textureView = WebGPU.fromAPI(attachment.pointee.view)
+        if let attachment = unsafe descriptor.depthStencilAttachment {
+            let textureView = unsafe WebGPU.fromAPI(attachment.pointee.view)
             if (!WebGPU_Internal.isValidToUseWithTextureViewCommandEncoder(textureView, self)) {
                 return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), "depth stencil texture device mismatch")
             }
@@ -1029,15 +1031,15 @@ extension WebGPU.CommandEncoder {
                 }
             }
 
-            depthReadOnly = attachment.pointee.depthReadOnly != 0
+            depthReadOnly = unsafe attachment.pointee.depthReadOnly != 0
             if hasDepthComponent {
                 let mtlAttachment = mtlDescriptor.depthAttachment
-                let clearDepth: Double = WebGPU_Internal.clampDouble(WebGPU.RenderPassEncoder.quantizedDepthValue(Double(attachment.pointee.depthClearValue), textureView.format()), 0.0, 1.0)
-                mtlAttachment!.clearDepth = attachment.pointee.depthLoadOp == WGPULoadOp_Clear ? clearDepth : 1.0
+                let clearDepth: Double = unsafe WebGPU_Internal.clampDouble(WebGPU.RenderPassEncoder.quantizedDepthValue(Double(attachment.pointee.depthClearValue), textureView.format()), 0.0, 1.0)
+                mtlAttachment!.clearDepth = unsafe attachment.pointee.depthLoadOp == WGPULoadOp_Clear ? clearDepth : 1.0
                 mtlAttachment!.texture = metalDepthStencilTexture
                 mtlAttachment!.level = 0
-                mtlAttachment!.loadAction = loadAction(loadOp: attachment.pointee.depthLoadOp)
-                mtlAttachment!.storeAction = storeAction(storeOp: attachment.pointee.depthStoreOp)
+                mtlAttachment!.loadAction = unsafe loadAction(loadOp: attachment.pointee.depthLoadOp)
+                mtlAttachment!.storeAction = unsafe storeAction(storeOp: attachment.pointee.depthStoreOp)
 
                 if mtlAttachment!.loadAction == MTLLoadAction.load && mtlAttachment!.storeAction == MTLStoreAction.dontCare && !textureView.previouslyCleared() {
                     depthStencilAttachmentToClear = mtlAttachment!.texture
@@ -1047,15 +1049,15 @@ extension WebGPU.CommandEncoder {
 
             if !isDestroyed {
                 if hasDepthComponent && !depthReadOnly {
-                    if attachment.pointee.depthLoadOp == WGPULoadOp_Undefined || attachment.pointee.depthStoreOp == WGPUStoreOp_Undefined {
+                    if unsafe attachment.pointee.depthLoadOp == WGPULoadOp_Undefined || attachment.pointee.depthStoreOp == WGPUStoreOp_Undefined {
                         return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), "depth load and store op were not specified")
                     }
-                } else if attachment.pointee.depthLoadOp != WGPULoadOp_Undefined || attachment.pointee.depthStoreOp != WGPUStoreOp_Undefined {
+                } else if unsafe attachment.pointee.depthLoadOp != WGPULoadOp_Undefined || attachment.pointee.depthStoreOp != WGPUStoreOp_Undefined {
                     return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), "depth load and store op were specified")
                 }
             }
 
-            if attachment.pointee.depthLoadOp == WGPULoadOp_Clear && (attachment.pointee.depthClearValue < 0 || attachment.pointee.depthClearValue > 1) {
+            if unsafe attachment.pointee.depthLoadOp == WGPULoadOp_Clear && (attachment.pointee.depthClearValue < 0 || attachment.pointee.depthClearValue > 1) {
                 return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), "depth clear value is invalid")
             }
 
@@ -1070,23 +1072,23 @@ extension WebGPU.CommandEncoder {
         }
 
         var stencilAttachmentToClear = false
-        if let attachment = descriptor.depthStencilAttachment {
+        if let attachment = unsafe descriptor.depthStencilAttachment {
             let mtlAttachment = mtlDescriptor.stencilAttachment
-            stencilReadOnly = attachment.pointee.stencilReadOnly != 0
-            let textureView = WebGPU.fromAPI(attachment.pointee.view)
+            stencilReadOnly = unsafe attachment.pointee.stencilReadOnly != 0
+            let textureView = unsafe WebGPU.fromAPI(attachment.pointee.view)
             if hasStencilComponent {
                 mtlAttachment!.texture = textureView.texture()
             }
-            mtlAttachment!.clearStencil = attachment.pointee.stencilClearValue
-            mtlAttachment!.loadAction = loadAction(loadOp: attachment.pointee.stencilLoadOp)
-            mtlAttachment!.storeAction = storeAction(storeOp: attachment.pointee.stencilStoreOp)
+            mtlAttachment!.clearStencil = unsafe attachment.pointee.stencilClearValue
+            mtlAttachment!.loadAction = unsafe loadAction(loadOp: attachment.pointee.stencilLoadOp)
+            mtlAttachment!.storeAction = unsafe storeAction(storeOp: attachment.pointee.stencilStoreOp)
             let isDestroyed = textureView.isDestroyed()
             if !isDestroyed {
                 if hasStencilComponent && !stencilReadOnly {
-                    if attachment.pointee.stencilLoadOp == WGPULoadOp_Undefined || attachment.pointee.stencilStoreOp == WGPUStoreOp_Undefined {
+                    if unsafe attachment.pointee.stencilLoadOp == WGPULoadOp_Undefined || attachment.pointee.stencilStoreOp == WGPUStoreOp_Undefined {
                         return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), "stencil load and store op were not specified")
                     }
-                } else if attachment.pointee.stencilLoadOp != WGPULoadOp_Undefined || attachment.pointee.stencilStoreOp != WGPUStoreOp_Undefined {
+                } else if unsafe attachment.pointee.stencilLoadOp != WGPULoadOp_Undefined || attachment.pointee.stencilStoreOp != WGPUStoreOp_Undefined {
                     return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), "stencil load and store op were specified")
                 }
             }
@@ -1105,8 +1107,8 @@ extension WebGPU.CommandEncoder {
 
         var visibilityResultBufferSize: UInt = 0
         var visibilityResultBuffer: MTLBuffer? = nil
-        if let wgpuOcclusionQuery = descriptor.occlusionQuerySet {
-            let occlusionQuery = WebGPU.fromAPI(wgpuOcclusionQuery)
+        if let wgpuOcclusionQuery = unsafe descriptor.occlusionQuerySet {
+            let occlusionQuery = unsafe WebGPU.fromAPI(wgpuOcclusionQuery)
             occlusionQuery.setCommandEncoder(self)
             if occlusionQuery.type() != WGPUQueryType_Occlusion {
                 return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), "querySet for occlusion query was not of type occlusion")
@@ -1117,10 +1119,10 @@ extension WebGPU.CommandEncoder {
         }
 
         if (attachmentsToClear.count != 0 || depthStencilAttachmentToClear != nil) {
-            let attachment = descriptor.depthStencilAttachment
-            if attachment != nil && depthStencilAttachmentToClear != nil {
+            let attachment = unsafe descriptor.depthStencilAttachment
+            if unsafe attachment != nil && depthStencilAttachmentToClear != nil {
                 // FIXME: rdar://138042799 remove default argument.
-                WebGPU.fromAPI(attachment.pointee.view).setPreviouslyCleared(0, 0)
+                unsafe WebGPU.fromAPI(attachment.pointee.view).setPreviouslyCleared(0, 0)
             }
             // FIXME: rdar://138042799 remove default argument.
             runClearEncoder(attachmentsToClear: attachmentsToClear, depthStencilAttachmentToClear: &depthStencilAttachmentToClear, depthAttachmentToClear: depthAttachmentToClear, stencilAttachmentToClear: stencilAttachmentToClear, depthClearValue: 0 ,stencilClearValue: 0 ,existingEncoder: nil)
@@ -1178,7 +1180,7 @@ extension WebGPU.CommandEncoder {
     }
 
     public func copyTextureToBuffer(source: WGPUImageCopyTexture, destination: WGPUImageCopyBuffer, copySize: WGPUExtent3D) {
-        guard source.nextInChain == nil && destination.nextInChain == nil && destination.layout.nextInChain == nil else {
+        guard unsafe source.nextInChain == nil && destination.nextInChain == nil && destination.layout.nextInChain == nil else {
             return
         }
 
@@ -1189,13 +1191,13 @@ extension WebGPU.CommandEncoder {
             return
         }
 
-        let sourceTexture = WebGPU.fromAPI(source.texture);
+        let sourceTexture = unsafe WebGPU.fromAPI(source.texture);
         if let error = self.errorValidatingCopyTextureToBuffer(source: source, destination: destination, copySize: copySize) {
             self.makeInvalid(error)
             return
         }
 
-        let apiDestinationBuffer = WebGPU.fromAPI(destination.buffer)
+        let apiDestinationBuffer = unsafe WebGPU.fromAPI(destination.buffer)
         sourceTexture.setCommandEncoder(self)
         apiDestinationBuffer.setCommandEncoder(self, false)
         apiDestinationBuffer.indirectBufferInvalidated(self)
@@ -1303,7 +1305,7 @@ extension WebGPU.CommandEncoder {
                     guard !didOverflow else {
                         return
                     }
-                    let newSource = WGPUImageCopyTexture(
+                    let newSource = unsafe WGPUImageCopyTexture(
                         nextInChain: nil,
                         texture: source.texture,
                         mipLevel: source.mipLevel,
@@ -1319,7 +1321,7 @@ extension WebGPU.CommandEncoder {
                     guard !didOverflow else {
                         return
                     }
-                    let newDestination = WGPUImageCopyBuffer(
+                    let newDestination = unsafe WGPUImageCopyBuffer(
                         nextInChain: nil,
                         layout: WGPUTextureDataLayout(
                             nextInChain: nil,
@@ -1462,20 +1464,20 @@ extension WebGPU.CommandEncoder {
     }
 
     public func copyBufferToTexture(source: WGPUImageCopyBuffer, destination: WGPUImageCopyTexture, copySize: WGPUExtent3D) {
-        guard source.nextInChain == nil && source.layout.nextInChain == nil && destination.nextInChain == nil else {
+        guard unsafe source.nextInChain == nil && source.layout.nextInChain == nil && destination.nextInChain == nil else {
             return
         }
         guard self.prepareTheEncoderState() else {
             self.generateInvalidEncoderStateError()
             return
         }
-        let destinationTexture = WebGPU.fromAPI(destination.texture)
+        let destinationTexture = unsafe WebGPU.fromAPI(destination.texture)
 
         if let error = self.errorValidatingCopyBufferToTexture(source: source, destination: destination, copySize: copySize) {
             self.makeInvalid(error)
             return
         }
-        let apiBuffer = WebGPU.fromAPI(source.buffer)
+        let apiBuffer = unsafe WebGPU.fromAPI(source.buffer)
         apiBuffer.setCommandEncoder(self, false) 
         destinationTexture.setCommandEncoder(self)
         guard copySize.width != 0 || copySize.height != 0 || copySize.depthOrArrayLayers != 0, !apiBuffer.isDestroyed(), !destinationTexture.isDestroyed() else {
@@ -1534,7 +1536,7 @@ extension WebGPU.CommandEncoder {
             default:
                 return
         }
-        let logicalSize = WebGPU.fromAPI(destination.texture).logicalMiplevelSpecificTextureExtent(destination.mipLevel)
+        let logicalSize = unsafe WebGPU.fromAPI(destination.texture).logicalMiplevelSpecificTextureExtent(destination.mipLevel)
         let widthForMetal = logicalSize.width < destination.origin.x ? 0 : min(copySize.width, logicalSize.width - destination.origin.x)
         let heightForMetal = logicalSize.height < destination.origin.y ? 0 : min(copySize.height, logicalSize.height - destination.origin.y)
         let depthForMetal = logicalSize.depthOrArrayLayers < destination.origin.z ? 0 : min(copySize.depthOrArrayLayers, logicalSize.depthOrArrayLayers - destination.origin.z)
@@ -1602,7 +1604,7 @@ extension WebGPU.CommandEncoder {
                     guard !didOverflow else {
                         return
                     }
-                    let newSource = WGPUImageCopyBuffer(
+                    let newSource = unsafe WGPUImageCopyBuffer(
                         nextInChain: nil,
                         layout: WGPUTextureDataLayout(
                             nextInChain: nil,
@@ -1616,7 +1618,7 @@ extension WebGPU.CommandEncoder {
                     guard !didOverflow else {
                         return
                     }
-                    let newDestination = WGPUImageCopyTexture(
+                    let newDestination = unsafe WGPUImageCopyTexture(
                         nextInChain: nil,
                         texture: destination.texture,
                         mipLevel: destination.mipLevel,
@@ -1854,7 +1856,7 @@ extension WebGPU.CommandEncoder {
     }
 
     public func copyTextureToTexture(source: WGPUImageCopyTexture, destination: WGPUImageCopyTexture, copySize: WGPUExtent3D) {
-        guard source.nextInChain == nil, destination.nextInChain == nil else {
+        guard unsafe source.nextInChain == nil, unsafe destination.nextInChain == nil else {
             return
         }
 
@@ -1869,8 +1871,8 @@ extension WebGPU.CommandEncoder {
             return
         }
 
-        let sourceTexture = WebGPU.fromAPI(source.texture)
-        let destinationTexture = WebGPU.fromAPI(destination.texture)
+        let sourceTexture = unsafe WebGPU.fromAPI(source.texture)
+        let destinationTexture = unsafe WebGPU.fromAPI(destination.texture)
         sourceTexture.setCommandEncoder(self)
         destinationTexture.setCommandEncoder(self)
 
@@ -1911,7 +1913,7 @@ extension WebGPU.CommandEncoder {
                 self.clearTextureIfNeeded(destination: destination, slice: destinationSlice)
             }
         }
-        guard let mtlDestinationTexture = destinationTexture.texture(), let mtlSourceTexture = WebGPU.fromAPI(source.texture).texture() else {
+        guard let mtlDestinationTexture = destinationTexture.texture(), let mtlSourceTexture = unsafe WebGPU.fromAPI(source.texture).texture() else {
             return
         }
 
@@ -2036,7 +2038,7 @@ extension WebGPU.CommandEncoder {
     }
 
     public func beginComputePass(descriptor: WGPUComputePassDescriptor) -> WebGPU_Internal.RefComputePassEncoder {
-        guard descriptor.nextInChain == nil else {
+        guard unsafe descriptor.nextInChain == nil else {
             return WebGPU.ComputePassEncoder.createInvalid(self, m_device.ptr(), "descriptor is corrupted")
         }
 
@@ -2062,15 +2064,15 @@ extension WebGPU.CommandEncoder {
         let computePassDescriptor = MTLComputePassDescriptor()
         computePassDescriptor.dispatchType = MTLDispatchType.serial
         var counterSampleBuffer: MTLCounterSampleBuffer? = nil
-        if let wgpuTimestampWrites = descriptor.timestampWrites {
-            counterSampleBuffer = WebGPU.fromAPI(wgpuTimestampWrites.pointee.querySet).counterSampleBuffer()
+        if let wgpuTimestampWrites = unsafe descriptor.timestampWrites {
+            counterSampleBuffer = unsafe WebGPU.fromAPI(wgpuTimestampWrites.pointee.querySet).counterSampleBuffer()
         }
 
         if m_device.ptr().enableEncoderTimestamps() || counterSampleBuffer != nil {
-            let timestampWrites = descriptor.timestampWrites
+            let timestampWrites = unsafe descriptor.timestampWrites
             computePassDescriptor.sampleBufferAttachments[0].sampleBuffer = counterSampleBuffer != nil ? computePassDescriptor.sampleBufferAttachments[0].sampleBuffer : m_device.ptr().timestampsBuffer(m_commandBuffer, 2)
-            computePassDescriptor.sampleBufferAttachments[0].startOfEncoderSampleIndex = timestampWrites != nil ? Int(timestampWrites.pointee.beginningOfPassWriteIndex) : 0
-            computePassDescriptor.sampleBufferAttachments[0].endOfEncoderSampleIndex = timestampWrites != nil ? Int(timestampWrites.pointee.endOfPassWriteIndex) : 1
+            computePassDescriptor.sampleBufferAttachments[0].startOfEncoderSampleIndex = unsafe timestampWrites != nil ? Int(timestampWrites.pointee.beginningOfPassWriteIndex) : 0
+            computePassDescriptor.sampleBufferAttachments[0].endOfEncoderSampleIndex = unsafe timestampWrites != nil ? Int(timestampWrites.pointee.endOfPassWriteIndex) : 1
             if counterSampleBuffer != nil {
                 m_device.ptr().trackTimestampsBuffer(m_commandBuffer, counterSampleBuffer);
             }
@@ -2082,7 +2084,7 @@ extension WebGPU.CommandEncoder {
         self.setExistingEncoder(computeCommandEncoder)
         // FIXME: Figure out a way so that WTFString does not override String in the global
         //        namespace. At the moment it is and that's why we need this.
-        computeCommandEncoder.label = String(cString: descriptor.label)
+        computeCommandEncoder.label = unsafe String(cString: descriptor.label)
 
         return WebGPU.ComputePassEncoder.create(computeCommandEncoder, descriptor, self, m_device.ptr())
 

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.h
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.h
@@ -111,7 +111,8 @@ private:
     std::array<uint32_t, 32> m_maxDynamicOffsetAtIndex;
     NSString *m_lastErrorString { nil };
     bool m_passEnded { false };
-} SWIFT_SHARED_REFERENCE(refComputePassEncoder, derefComputePassEncoder);
+// FIXME: remove @safe once rdar://151039766 lands
+} __attribute__((swift_attr("@safe"))) SWIFT_SHARED_REFERENCE(refComputePassEncoder, derefComputePassEncoder);
 
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -347,7 +347,8 @@ private:
     bool m_supressAllErrors { false };
     const uint32_t m_maxVerticesPerDrawCall { 0 };
     bool m_shaderValidationEnabled { true };
-} SWIFT_SHARED_REFERENCE(refDevice, derefDevice);
+// FIXME: remove @safe once rdar://151039766 lands
+} __attribute__((swift_attr("@safe"))) SWIFT_SHARED_REFERENCE(refDevice, derefDevice);
 
 } // namespace WebGPU
 

--- a/Source/WebGPU/WebGPU/QuerySet.h
+++ b/Source/WebGPU/WebGPU/QuerySet.h
@@ -102,7 +102,8 @@ private:
     };
     mutable Vector<uint64_t> m_commandEncoders;
     bool m_destroyed { false };
-} SWIFT_SHARED_REFERENCE(refQuerySet, derefQuerySet);
+// FIXME: remove @safe once rdar://151039766 lands
+} __attribute__((swift_attr("@safe"))) SWIFT_SHARED_REFERENCE(refQuerySet, derefQuerySet);
 
 } // namespace WebGPU
 

--- a/Source/WebGPU/WebGPU/Queue.h
+++ b/Source/WebGPU/WebGPU/Queue.h
@@ -137,7 +137,8 @@ private:
     const ThreadSafeWeakPtr<Instance> m_instance;
     id<MTLBuffer> m_temporaryBuffer;
     uint64_t m_temporaryBufferOffset;
-} SWIFT_SHARED_REFERENCE(refQueue, derefQueue);
+// FIXME: remove @safe once rdar://151039766 lands
+} __attribute__((swift_attr("@safe"))) SWIFT_SHARED_REFERENCE(refQueue, derefQueue);
 
 } // namespace WebGPU
 

--- a/Source/WebGPU/WebGPU/Queue.swift
+++ b/Source/WebGPU/WebGPU/Queue.swift
@@ -30,22 +30,22 @@ private let largeBufferSize = 32 * 1024 * 1024
 public func writeBuffer(
     queue: WebGPU.Queue, buffer: WebGPU.Buffer, bufferOffset: UInt64, data: SpanUInt8
 ) {
-    queue.writeBuffer(buffer, bufferOffset: bufferOffset, data: data)
+    unsafe queue.writeBuffer(buffer, bufferOffset: bufferOffset, data: data)
 }
 
 extension WebGPU.Queue {
     public func writeBuffer(_ buffer: WebGPU.Buffer, bufferOffset: UInt64, data: SpanUInt8) {
-        let device = self.device()
+        let device = unsafe self.device()
         guard let blitCommandEncoder = ensureBlitCommandEncoder() else {
             return
         }
-        let noCopy = data.size() >= largeBufferSize
+        let noCopy = unsafe data.size() >= largeBufferSize
         guard device.device() != nil else {
             return
         }
         guard
             let tempBuffer =
-                noCopy
+                unsafe noCopy
                 ? device.newBufferWithBytesNoCopy(
                     data.__dataUnsafe(), data.size(), MTLResourceOptions.storageModeShared)
                 : device.newBufferWithBytes(
@@ -53,7 +53,7 @@ extension WebGPU.Queue {
         else {
             return
         }
-        blitCommandEncoder.copy(
+        unsafe blitCommandEncoder.copy(
             from: tempBuffer, sourceOffset: 0, to: buffer.buffer(),
             destinationOffset: Int(bufferOffset),
             size: data.size())

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -214,7 +214,8 @@ private:
     bool m_passEnded { false };
     bool m_ignoreBufferCache { false };
     Vector<bool> m_bindGroupDynamicOffsetsChanged;
-} SWIFT_SHARED_REFERENCE(refRenderPassEncoder, derefRenderPassEncoder);
+// FIXME: remove @safe once rdar://151039766 lands
+} __attribute__((swift_attr("@safe"))) SWIFT_SHARED_REFERENCE(refRenderPassEncoder, derefRenderPassEncoder);
 
 } // namespace WebGPU
 

--- a/Source/WebGPU/WebGPU/ShaderModule.h
+++ b/Source/WebGPU/WebGPU/ShaderModule.h
@@ -27,6 +27,7 @@
 
 #import "ASTInterpolateAttribute.h"
 #import "WGSL.h"
+#import <variant>
 #import <wtf/FastMalloc.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCounted.h>

--- a/Source/WebGPU/WebGPU/Texture.h
+++ b/Source/WebGPU/WebGPU/Texture.h
@@ -170,7 +170,8 @@ private:
     mutable Vector<uint64_t> m_commandEncoders;
     id<MTLSharedEvent> m_sharedEvent { nil };
     uint64_t m_sharedEventSignalValue { 0 };
-} SWIFT_SHARED_REFERENCE(refTexture, derefTexture);
+// FIXME: remove @safe once rdar://151039766 lands
+} __attribute__((swift_attr("@safe"))) SWIFT_SHARED_REFERENCE(refTexture, derefTexture);
 
 } // namespace WebGPU
 

--- a/Source/WebGPU/WebGPU/TextureView.h
+++ b/Source/WebGPU/WebGPU/TextureView.h
@@ -103,7 +103,8 @@ private:
     const Ref<Device> m_device;
     Ref<Texture> m_parentTexture;
     mutable Vector<uint64_t> m_commandEncoders;
-} SWIFT_SHARED_REFERENCE(refTextureView, derefTextureView);
+// FIXME: remove @safe once rdar://151039766 lands
+} __attribute__((swift_attr("@safe"))) SWIFT_SHARED_REFERENCE(refTextureView, derefTextureView);
 
 } // namespace WebGPU
 

--- a/Source/WebGPU/WebGPU/WebGPU.h
+++ b/Source/WebGPU/WebGPU/WebGPU.h
@@ -30,6 +30,8 @@
 #ifndef WEBGPU_H_
 #define WEBGPU_H_
 
+#include <wtf/SwiftBridging.h>
+
 #ifdef __cplusplus
 
 #if defined(WGPU_SHARED_LIBRARY)
@@ -980,7 +982,7 @@ typedef struct WGPURenderPassDepthStencilAttachment {
     WGPUStoreOp stencilStoreOp;
     uint32_t stencilClearValue;
     WGPUBool stencilReadOnly;
-} WGPURenderPassDepthStencilAttachment WGPU_STRUCTURE_ATTRIBUTE;
+} SWIFT_ESCAPABLE WGPURenderPassDepthStencilAttachment WGPU_STRUCTURE_ATTRIBUTE;
 
 // Can be chained in WGPURenderPassDescriptor
 typedef struct WGPURenderPassDescriptorMaxDrawCount {
@@ -1134,7 +1136,7 @@ typedef struct WGPUTextureDataLayout {
     uint64_t offset;
     uint32_t bytesPerRow;
     uint32_t rowsPerImage;
-} WGPUTextureDataLayout WGPU_STRUCTURE_ATTRIBUTE;
+} SWIFT_ESCAPABLE WGPUTextureDataLayout WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUTextureViewDescriptor {
     WGPUChainedStruct const * nextInChain;
@@ -1195,7 +1197,7 @@ typedef struct WGPUComputePassDescriptor {
     WGPUChainedStruct const * nextInChain;
     WGPU_NULLABLE char const * label;
     WGPU_NULLABLE WGPUComputePassTimestampWrites const * timestampWrites;
-} WGPUComputePassDescriptor WGPU_STRUCTURE_ATTRIBUTE;
+} SWIFT_ESCAPABLE WGPUComputePassDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUDepthStencilState {
     WGPUChainedStruct const * nextInChain;
@@ -1215,7 +1217,7 @@ typedef struct WGPUImageCopyBuffer {
     WGPUChainedStruct const * nextInChain;
     WGPUTextureDataLayout layout;
     WGPUBuffer buffer;
-} WGPUImageCopyBuffer WGPU_STRUCTURE_ATTRIBUTE;
+} SWIFT_ESCAPABLE WGPUImageCopyBuffer WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUImageCopyTexture {
     WGPUChainedStruct const * nextInChain;
@@ -1223,7 +1225,7 @@ typedef struct WGPUImageCopyTexture {
     uint32_t mipLevel;
     WGPUOrigin3D origin;
     WGPUTextureAspect aspect;
-} WGPUImageCopyTexture WGPU_STRUCTURE_ATTRIBUTE;
+} SWIFT_ESCAPABLE WGPUImageCopyTexture WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUProgrammableStageDescriptor {
     WGPUChainedStruct const * nextInChain;
@@ -1243,7 +1245,7 @@ typedef struct WGPURenderPassColorAttachment {
     WGPULoadOp loadOp;
     WGPUStoreOp storeOp;
     WGPUColor clearValue;
-} WGPURenderPassColorAttachment WGPU_STRUCTURE_ATTRIBUTE;
+} SWIFT_ESCAPABLE WGPURenderPassColorAttachment WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPURequiredLimits {
     WGPUChainedStruct const * nextInChain;
@@ -1334,7 +1336,7 @@ typedef struct WGPURenderPassDescriptor {
     WGPU_NULLABLE WGPURenderPassTimestampWrites const * timestampWrites;
 
     auto colorAttachmentsSpan() const { return unsafeMakeSpan(colorAttachments, colorAttachmentCount); }
-} WGPURenderPassDescriptor WGPU_STRUCTURE_ATTRIBUTE;
+} SWIFT_ESCAPABLE WGPURenderPassDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUVertexState {
     WGPUChainedStruct const * nextInChain;


### PR DESCRIPTION
#### 307b45cf7dd7626d2713a03b75b07cd0c139d176
<pre>
[WebGPU] Enable Swift strict-memory-safety
<a href="https://bugs.webkit.org/show_bug.cgi?id=295584">https://bugs.webkit.org/show_bug.cgi?id=295584</a>
<a href="https://rdar.apple.com/155326286">rdar://155326286</a>

Reviewed by Mike Wyrzykowski.

Enable the Swift strict-memory-safe flag, along with the related experimental features.
For now, only fix what&apos;s trivial and sprinkle unsafe everywhere else. That gives us a
good overview what needs to be addressed going forward.

* Source/WTF/wtf/RangeSet.h:
* Source/WTF/wtf/ThreadSafeWeakPtr.h:
* Source/WebGPU/Configurations/WebGPU.xcconfig:
* Source/WebGPU/WebGPU/Buffer.h:
* Source/WebGPU/WebGPU/Buffer.swift:
(WebGPU.copy(from:offset:)):
(Buffer_copyFrom_thunk(_:from:offset:)):
(WebGPU.bufferContents): Deleted.
* Source/WebGPU/WebGPU/CommandBuffer.h:
* Source/WebGPU/WebGPU/CommandEncoder.h:
* Source/WebGPU/WebGPU/CommandEncoder.swift:
(CommandEncoder_runClearEncoder_thunk(_:attachmentsToClear:depthStencilAttachmentToClear:depthAttachmentToClear:stencilAttachmentToClear:depthClearValue:stencilClearValue:existingEncoder:)):
(CommandEncoder_finish_thunk(_:descriptor:)):
(WebGPU.finish(_:)):
(WebGPU.errorValidatingCopyTextureToTexture(_:destination:copySize:)):
(WebGPU.errorValidatingCopyTextureToBuffer(_:destination:copySize:)):
(WebGPU.errorValidatingImageCopyBuffer(_:)):
(WebGPU.errorValidatingCopyBufferToTexture(_:destination:copySize:)):
(WebGPU.errorValidatingRenderPassDescriptor(_:)):
(WebGPU.errorValidatingTimestampWrites(_:)):
(WebGPU.errorValidatingComputePassDescriptor(_:)):
(WebGPU.beginRenderPass(_:)):
(WebGPU.copyTextureToBuffer(_:destination:copySize:)):
(WebGPU.copyBufferToTexture(_:destination:copySize:)):
(WebGPU.copyTextureToTexture(_:destination:copySize:)):
(WebGPU.beginComputePass(_:)):
* Source/WebGPU/WebGPU/ComputePassEncoder.h:
* Source/WebGPU/WebGPU/Device.h:
* Source/WebGPU/WebGPU/QuerySet.h:
* Source/WebGPU/WebGPU/Queue.h:
* Source/WebGPU/WebGPU/Queue.swift:
(WebGPU.writeBuffer(_:bufferOffset:data:)):
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebGPU/WebGPU/ShaderModule.h:
* Source/WebGPU/WebGPU/Texture.h:
* Source/WebGPU/WebGPU/TextureView.h:
* Source/WebGPU/WebGPU/WebGPU.h:

Canonical link: <a href="https://commits.webkit.org/297398@main">https://commits.webkit.org/297398@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/019282d238e2b2fabeee59c69697d9b9ab449360

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110731 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20826 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116758 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60999 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31077 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38980 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84203 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113679 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24816 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99718 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64644 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24186 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17853 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60553 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/103223 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94209 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17912 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119548 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109285 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37773 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28075 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93169 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38148 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95983 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92993 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23847 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38018 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15770 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33750 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37667 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43139 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/133560 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37329 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36075 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40668 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39037 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->