### PR TITLE
[CSS] Support @scope(:host)

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7072,9 +7072,8 @@ imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-range-update
 imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-range-update.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-subject-bounds-update.html [ Skip ]
 
-# CSS @scope with shadow DOM
+# CSS @scope
 imported/w3c/web-platform-tests/css/css-cascade/scope-visited.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-cascade/scope-shadow-sharing.html [ ImageOnlyFailure ]
 
 webkit.org/b/263923 animations/transition-and-animation-2.html [ Failure Pass ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-shadow-expected.txt
@@ -1,11 +1,11 @@
 
-FAIL @scope can match :host assert_equals: expected "1" but got "auto"
-FAIL @scope can match :host(...) assert_equals: expected "1" but got "auto"
-FAIL :scope matches host via the scoping root assert_equals: expected "1" but got "auto"
-FAIL :scope within :is() matches host via the scoping root assert_equals: expected "1" but got "auto"
-FAIL Implicit @scope as direct child of shadow root assert_equals: expected "1" but got "auto"
+PASS @scope can match :host
+PASS @scope can match :host(...)
+PASS :scope matches host via the scoping root
+PASS :scope within :is() matches host via the scoping root
+PASS Implicit @scope as direct child of shadow root
 FAIL Implicit @scope in construted stylesheet assert_equals: expected "1" but got "auto"
-FAIL Matching :host via &, :scope (subject) assert_equals: expected "1" but got "auto"
-FAIL Matching :host via &, :scope (non-subject) assert_equals: expected "1" but got "auto"
-FAIL Matching :host via &, :scope (non-subject, >) assert_equals: expected "1" but got "auto"
+PASS Matching :host via &, :scope (subject)
+PASS Matching :host via &, :scope (non-subject)
+PASS Matching :host via &, :scope (non-subject, >)
 

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -909,4 +909,9 @@ bool CSSSelector::isHostPseudoClass() const
     return match() == Match::PseudoClass && pseudoClass() == PseudoClass::Host;
 }
 
+bool CSSSelector::isScopePseudoClass() const
+{
+    return match() == Match::PseudoClass && pseudoClass() == PseudoClass::Scope;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -165,6 +165,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     bool isSiblingSelector() const;
     bool isAttributeSelector() const;
     bool isHostPseudoClass() const;
+    bool isScopePseudoClass() const;
 
     Relation relation() const { return static_cast<Relation>(m_relation); }
     Match match() const { return static_cast<Match>(m_match); }

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -1247,8 +1247,7 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
         return FunctionType::SimpleSelectorChecker;
 
     case CSSSelector::PseudoClass::Scope:
-        fragment.pseudoClasses.add(CSSSelector::PseudoClass::Scope);
-        return FunctionType::SelectorCheckerWithCheckingContext;
+        return FunctionType::CannotCompile;
 
     case CSSSelector::PseudoClass::Active:
     case CSSSelector::PseudoClass::Empty:

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -81,16 +81,16 @@ static unsigned rulesCountForName(const RuleSet::AtomRuleMap& map, const AtomStr
 
 // FIXME: Maybe we can unify both following functions
 
-static bool hasHostPseudoClassSubjectInSelectorList(const CSSSelectorList* selectorList)
+static bool hasHostOrScopePseudoClassSubjectInSelectorList(const CSSSelectorList* selectorList)
 {
     if (!selectorList)
         return false;
 
     for (auto& selector : *selectorList) {
-        if (selector.isHostPseudoClass())
+        if (selector.isHostPseudoClass() || selector.isScopePseudoClass())
             return true;
 
-        if (hasHostPseudoClassSubjectInSelectorList(selector.selectorList()))
+        if (hasHostOrScopePseudoClassSubjectInSelectorList(selector.selectorList()))
             return true;
     }
 
@@ -257,9 +257,12 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
             case CSSSelector::PseudoClass::Root:
                 rootElementSelector = selector;
                 break;
+            case CSSSelector::PseudoClass::Scope:
+                m_hasHostOrScopePseudoClassRulesInUniversalBucket = true;
+                break;
             default:
-                if (hasHostPseudoClassSubjectInSelectorList(selector->selectorList()))
-                    m_hasHostPseudoClassRulesInUniversalBucket = true;
+                if (hasHostOrScopePseudoClassSubjectInSelectorList(selector->selectorList()))
+                    m_hasHostOrScopePseudoClassRulesInUniversalBucket = true;
                 break;
             }
             break;

--- a/Source/WebCore/style/RuleSet.h
+++ b/Source/WebCore/style/RuleSet.h
@@ -120,7 +120,7 @@ public:
     bool hasAttributeRules() const { return !m_attributeLocalNameRules.isEmpty(); }
     bool hasUserAgentPartRules() const { return !m_userAgentPartRules.isEmpty(); }
     bool hasHostPseudoClassRulesMatchingInShadowTree() const { return m_hasHostPseudoClassRulesMatchingInShadowTree; }
-    bool hasHostPseudoClassRulesInUniversalBucket() const { return m_hasHostPseudoClassRulesInUniversalBucket; }
+    bool hasHostOrScopePseudoClassRulesInUniversalBucket() const { return m_hasHostOrScopePseudoClassRulesInUniversalBucket; }
 
     static constexpr auto cascadeLayerPriorityForPresentationalHints = std::numeric_limits<CascadeLayerPriority>::min();
     static constexpr auto cascadeLayerPriorityForUnlayered = std::numeric_limits<CascadeLayerPriority>::max();
@@ -238,7 +238,7 @@ private:
 
     bool m_hasHostPseudoClassRulesMatchingInShadowTree { false };
     bool m_hasViewportDependentMediaQueries { false };
-    bool m_hasHostPseudoClassRulesInUniversalBucket { false };
+    bool m_hasHostOrScopePseudoClassRulesInUniversalBucket { false };
 };
 
 inline const RuleSet::RuleDataVector* RuleSet::attributeRules(const AtomString& key, bool isHTMLName) const


### PR DESCRIPTION
#### dd222ded80fd90dcad76a793fde7357493ab2719
<pre>
[CSS] Support @scope(:host)
<a href="https://bugs.webkit.org/show_bug.cgi?id=294521">https://bugs.webkit.org/show_bug.cgi?id=294521</a>
<a href="https://rdar.apple.com/153443869">rdar://153443869</a>

Reviewed by Tim Nguyen.

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-shadow-expected.txt:
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::isScopePseudoClass const):
* Source/WebCore/css/CSSSelector.h:

Helper function

* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):

:scope can match :host

* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::addPseudoClassType):

Disable selector compilation for :scope

* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::matchHostPseudoClassRules):
(WebCore::Style::ElementRuleCollector::scopeRulesMatch):

Allow traversing the Shadow DOM boundary and track it for matching

* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::hasHostOrScopePseudoClassSubjectInSelectorList):
(WebCore::Style::RuleSet::addRule):
(WebCore::Style::hasHostPseudoClassSubjectInSelectorList): Deleted.
* Source/WebCore/style/RuleSet.h:
(WebCore::Style::RuleSet::hasHostOrScopePseudoClassRulesInUniversalBucket const):
(WebCore::Style::RuleSet::hasHostPseudoClassRulesInUniversalBucket const): Deleted.

Add rules with :scope subject (which can potentially represent :host) to the special
case for :host subject

Canonical link: <a href="https://commits.webkit.org/297670@main">https://commits.webkit.org/297670@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efe2e6cb97c1ceb23e42336a0e151b87b8d2140f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110728 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30387 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20823 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116755 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60996 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112691 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31073 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38977 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84196 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113676 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24818 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99714 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64637 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24188 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17849 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60550 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94211 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17908 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119545 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37768 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28067 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93164 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38153 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95979 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92988 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24054 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38020 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15766 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33747 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37664 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43136 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37326 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40665 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39034 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->