### PR TITLE
Test PR

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -153,6 +153,10 @@ class PullRequest(Command):
 
         # Then, see if we already have a commit associated with this branch we need to modify
         has_commit = repository.commit(include_log=False, include_identifier=False).branch == repository.branch and repository.branch != repository.default_branch
+        print(f'\nhas_commit={has_commit}, modified={modified}')
+        print(f'\nremote: {repository.remote()}, url={repository.url()}')
+        print(f'\nbranch1: {repository.commit(include_log=False, include_identifier=False).branch}, branch2: {repository.branch}, default: {repository.default_branch}')
+
         if not modified and has_commit:
             log.info('Using committed changes...')
             return 0


### PR DESCRIPTION
#### 6598e4ac047140fa4fc4765644b7854369ce2630
<pre>
Test PR
<a href="https://bugs.webkit.org/show_bug.cgi?id=295590">https://bugs.webkit.org/show_bug.cgi?id=295590</a>

Reviewed by NOBODY (OOPS!).

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.create_commit):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cee53248b233c4092c7ff20c263375794e8140c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [⏳ style ](None "Waiting in queue, processing has not started yet") | [⏳ ios ](None "Waiting in queue, processing has not started yet") | [⏳ mac ](None "Waiting in queue, processing has not started yet") | [⏳ wpe ](None "Waiting in queue, processing has not started yet") | [⏳ win ](None "Waiting in queue, processing has not started yet") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9a854591-d2e8-4a9b-aee2-3f641765d83d) 
| [⏳ bindings ](None "Waiting in queue, processing has not started yet") | [⏳ ios-sim ](None "Waiting in queue, processing has not started yet") | [⏳ mac-AS-debug ](None "Waiting in queue, processing has not started yet") | [⏳ wpe-wk2 ](None "Waiting in queue, processing has not started yet") | [⏳ win-tests ](None "Waiting in queue, processing has not started yet") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2e1f729b-cb85-4215-912e-03bf343510d8) 
| [⏳ webkitperl ](None "Waiting in queue, processing has not started yet") | [⏳ ios-wk2 ](None "Waiting in queue, processing has not started yet") | [⏳ api-mac ](None "Waiting in queue, processing has not started yet") | [⏳ api-wpe ](None "Waiting in queue, processing has not started yet") | | 
| [⏳ webkitpy ](None "Waiting in queue, processing has not started yet") | [⏳ ios-wk2-wpt ](None "Waiting in queue, processing has not started yet") | [⏳ mac-wk1 ](None "Waiting in queue, processing has not started yet") | [⏳ wpe-cairo ](None "Waiting in queue, processing has not started yet") | | 
| [⏳ jsc ](None "Waiting in queue, processing has not started yet") | [⏳ api-ios ](None "Waiting in queue, processing has not started yet") | [⏳ mac-wk2 ](None "Waiting in queue, processing has not started yet") | [⏳ gtk ](None "Waiting in queue, processing has not started yet") | | 
| [⏳ jsc-arm64 ](None "Waiting in queue, processing has not started yet") | [⏳ vision ](None "Waiting in queue, processing has not started yet") | [⏳ mac-AS-debug-wk2 ](None "Waiting in queue, processing has not started yet") | [⏳ gtk-wk2 ](None "Waiting in queue, processing has not started yet") | | 
| [⏳ services ](None "Waiting in queue, processing has not started yet") | [⏳ vision-sim ](None "Waiting in queue, processing has not started yet") | [⏳ mac-wk2-stress ](None "Waiting in queue, processing has not started yet") | [⏳ api-gtk ](None "Waiting in queue, processing has not started yet") | | 
| | [⏳ vision-wk2 ](None "Waiting in queue, processing has not started yet") | [⏳ mac-intel-wk2 ](None "Waiting in queue, processing has not started yet") | [⏳ playstation ](None "Waiting in queue, processing has not started yet") | | 
| | [⏳ tv ](None "Waiting in queue, processing has not started yet") | [⏳ mac-safer-cpp ](None "Waiting in queue, processing has not started yet") | [⏳ jsc-armv7 ](None "Waiting in queue, processing has not started yet") | | 
| | [⏳ tv-sim ](None "Waiting in queue, processing has not started yet") | | [⏳ jsc-armv7-tests ](None "Waiting in queue, processing has not started yet") | | 
| | [⏳ watch ](None "Waiting in queue, processing has not started yet") | | | | 
| | [⏳ watch-sim ](None "Waiting in queue, processing has not started yet") | | | | 
<!--EWS-Status-Bubble-End-->