### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in the WTF::BitSet

### DIFF
--- a/Source/WTF/wtf/BitSet.h
+++ b/Source/WTF/wtf/BitSet.h
@@ -30,8 +30,6 @@
 #include <string.h>
 #include <type_traits>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 template<size_t size>
@@ -209,7 +207,9 @@ ALWAYS_INLINE constexpr bool BitSet<bitSetSize, WordType>::concurrentTestAndSet(
 {
     WordType mask = one << (n % wordSize);
     size_t index = n / wordSize;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     WordType* data = dependency.consume(bits.data()) + index;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     // transactionRelaxed() returns true if the bit was changed. If the bit was changed,
     // then the previous bit must have been false since we're trying to set it. Hence,
     // the result of transactionRelaxed() is the inverse of our expected result.
@@ -228,7 +228,9 @@ ALWAYS_INLINE constexpr bool BitSet<bitSetSize, WordType>::concurrentTestAndClea
 {
     WordType mask = one << (n % wordSize);
     size_t index = n / wordSize;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     WordType* data = dependency.consume(bits.data()) + index;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     // transactionRelaxed() returns true if the bit was changed. If the bit was changed,
     // then the previous bit must have been true since we're trying to clear it. Hence,
     // the result of transactionRelaxed() matches our expected result.
@@ -251,7 +253,7 @@ inline constexpr void BitSet<bitSetSize, WordType>::clear(size_t n)
 template<size_t bitSetSize, typename WordType>
 inline constexpr void BitSet<bitSetSize, WordType>::clearAll()
 {
-    memset(bits.data(), 0, sizeof(bits));
+    zeroSpan(std::span { bits });
 }
 
 template<size_t bitSetSize, typename WordType>
@@ -267,7 +269,7 @@ inline void BitSet<bitSetSize, WordType>::cleanseLastWord()
 template<size_t bitSetSize, typename WordType>
 inline constexpr void BitSet<bitSetSize, WordType>::setAll()
 {
-    memset(bits.data(), 0xFF, sizeof(bits));
+    memsetSpan(std::span { bits }, 0xFF);
     cleanseLastWord();
 }
 
@@ -407,14 +409,14 @@ template<size_t bitSetSize, typename WordType>
 template<typename Func>
 ALWAYS_INLINE constexpr void BitSet<bitSetSize, WordType>::forEachSetBit(const Func& func) const
 {
-    WTF::forEachSetBit(std::span { bits.data(), bits.size() }, func);
+    WTF::forEachSetBit(std::span { bits }, func);
 }
 
 template<size_t bitSetSize, typename WordType>
 template<typename Func>
 ALWAYS_INLINE constexpr void BitSet<bitSetSize, WordType>::forEachSetBit(size_t startIndex, const Func& func) const
 {
-    WTF::forEachSetBit(std::span { bits.data(), bits.size() }, startIndex, func);
+    WTF::forEachSetBit(std::span { bits }, startIndex, func);
 }
 
 template<size_t bitSetSize, typename WordType>
@@ -534,5 +536,3 @@ inline void BitSet<bitSetSize, WordType>::dump(PrintStream& out) const
 } // namespace WTF
 
 // We can't do "using WTF::BitSet;" here because there is a function in the macOS SDK named BitSet() already.
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -1339,8 +1339,8 @@ template<typename Head, typename... Tail> auto tuple_zip(Head&& head, Tail&& ...
     );
 }
 
-template<typename WordType, typename Func>
-ALWAYS_INLINE constexpr void forEachSetBit(std::span<const WordType> bits, const Func& func)
+template<typename WordType, std::size_t Extent, typename Func>
+ALWAYS_INLINE constexpr void forEachSetBit(std::span<const WordType, Extent> bits, const Func& func)
 {
     constexpr size_t wordSize = sizeof(WordType) * CHAR_BIT;
     for (size_t i = 0; i < bits.size(); ++i) {
@@ -1378,8 +1378,8 @@ ALWAYS_INLINE constexpr void forEachSetBit(std::span<const WordType> bits, const
     }
 }
 
-template<typename WordType, typename Func>
-ALWAYS_INLINE constexpr void forEachSetBit(std::span<const WordType> bits, size_t startIndex, const Func& func)
+template<typename WordType, std::size_t Extent, typename Func>
+ALWAYS_INLINE constexpr void forEachSetBit(std::span<const WordType, Extent> bits, size_t startIndex, const Func& func)
 {
     constexpr size_t wordSize = sizeof(WordType) * CHAR_BIT;
     auto iterate = [&](WordType word, size_t i) ALWAYS_INLINE_LAMBDA {


### PR DESCRIPTION
#### d96ff66dafe2b3b46e7000bd4752bb73d5675877
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in the WTF::BitSet
<a href="https://bugs.webkit.org/show_bug.cgi?id=295594">https://bugs.webkit.org/show_bug.cgi?id=295594</a>

Reviewed by Darin Adler.

Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in the WTF::BitSet, for safety.
This tested as performance neutral on Speedometer and JetStream.

* Source/WTF/wtf/BitSet.h:
(WTF::WordType&gt;::concurrentTestAndSet):
(WTF::WordType&gt;::concurrentTestAndClear):
(WTF::WordType&gt;::clearAll):
(WTF::WordType&gt;::setAll):
(WTF::WordType&gt;::forEachSetBit const):
* Source/WTF/wtf/StdLibExtras.h:
(WTF::forEachSetBit):

Canonical link: <a href="https://commits.webkit.org/297145@main">https://commits.webkit.org/297145@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b521bba6a61936395e9a8d821e5f275e6991581

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110639 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30298 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20731 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116665 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60906 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30977 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38887 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84134 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113587 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24739 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99624 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64575 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24101 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17763 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60460 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/103130 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94126 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17822 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119455 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109193 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37679 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27986 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93097 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38053 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95894 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92921 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23685 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37938 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15681 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33656 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37575 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43046 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/133468 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37237 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36061 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40576 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38945 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->