### PR TITLE
Under some circumstances, like repeated application, CSS zoom can overflow and this results in crashes later

### DIFF
--- a/LayoutTests/fast/css/repeated-application-CSS-zoom-can-overflow-expected.txt
+++ b/LayoutTests/fast/css/repeated-application-CSS-zoom-can-overflow-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/fast/css/repeated-application-CSS-zoom-can-overflow.html
+++ b/LayoutTests/fast/css/repeated-application-CSS-zoom-can-overflow.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+    window.testRunner?.dumpAsText();
+</script>
+<style>
+:not(filter), :root { 
+    7; 
+    -webkit-flex: 0 0 0; 
+    zoom: 96; 
+}
+</style>
+</head>
+<body>
+<form focused="false">
+</th>
+<marker color="ThreeDHighlight">
+    <metadata xlink:show="replace">
+        <marker />
+        <marker />
+        <feMergeNode />
+        <animate />
+        <textPath k4="0">
+            <textPath limitingConeAngle="1">
+                <radialGradient />
+                <textPath y2="0">
+                    <text filterUnits="objectBoundingBox">
+                        <tref />
+                        <tspan />
+                        <textPath flood-opacity="0">
+                            <text />
+                            <font-face-format fill="black">
+                                <font-face-src itemref="htmlvar00001">
+                            </font-face-format>
+                        </textPath>
+                    </text>
+                </textPath>
+            </textPath>
+        </textPath>
+    </metadata>
+</marker>
+</form>
+<p>This test passes if WebKit does not crash.</p>
+</body>
+</html>

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -224,7 +224,17 @@ inline void BuilderCustom::applyValueDirection(BuilderState& builderState, CSSVa
 inline void BuilderCustom::resetUsedZoom(BuilderState& builderState)
 {
     // Reset the zoom in effect. This allows the setZoom method to accurately compute a new zoom in effect.
-    builderState.setUsedZoom(builderState.parentStyle().usedZoom());
+    float parentZoom = builderState.parentStyle().usedZoom();
+
+    constexpr float maxSafeZoom = 1000.0f;
+    constexpr float minSafeZoom = 0.001f;
+
+    if (!std::isnormal(parentZoom))
+        RELEASE_ASSERT("Invalid zoom value.");
+
+    parentZoom = std::clamp(parentZoom, minSafeZoom, maxSafeZoom);
+
+    builderState.setUsedZoom(parentZoom);
 }
 
 inline void BuilderCustom::applyInitialZoom(BuilderState& builderState)


### PR DESCRIPTION
#### dd0a713f6f4e7880821ca9a72174ba6b49c335f4
<pre>
Under some circumstances, like repeated application, CSS zoom can overflow and this results in crashes later
<a href="https://bugs.webkit.org/show_bug.cgi?id=295593">https://bugs.webkit.org/show_bug.cgi?id=295593</a>
<a href="https://rdar.apple.com/153541188">rdar://153541188</a>

Reviewed by NOBODY (OOPS!).

This fixes the issue by clamping zoom in the correct direction when we reset it to the parent zoom

* LayoutTests/fast/css/repeated-application-CSS-zoom-can-overflow-expected.txt: Added.
* LayoutTests/fast/css/repeated-application-CSS-zoom-can-overflow.html: Added.
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::resetUsedZoom):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd0a713f6f4e7880821ca9a72174ba6b49c335f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110643 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20735 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116669 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60910 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112606 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30981 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38891 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84131 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113591 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24740 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99629 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64572 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24102 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17768 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60464 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94127 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17827 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119459 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37683 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27989 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93098 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38057 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95899 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92922 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37940 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15686 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33660 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37579 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43051 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37241 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40580 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38949 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->