### PR TITLE
Assertion in PaddingEdge::PaddingEdge(WebCore::Length&&)

### DIFF
--- a/LayoutTests/fast/css/recursive_zoom_crash-expected.txt
+++ b/LayoutTests/fast/css/recursive_zoom_crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/fast/css/recursive_zoom_crash.html
+++ b/LayoutTests/fast/css/recursive_zoom_crash.html
@@ -1,0 +1,27 @@
+<style>
+    .class7, #htmlvar00001 { 1pt; -webkit-padding-after: 0px; }
+    :not(dl) { zoom: 95; }
+</style>
+<script>
+    window.testRunner?.dumpAsText();
+</script>
+<body>
+<mfenced contain"><mi mathsize="0">
+    <mi class="class4">
+    <mspace />
+    <mtr groupalign="center">
+    <mtd columnalign="left">
+    <mmultiscripts mathcolor="green">
+    <msup mathbackground="green">
+    <mn mathvariant="normal">
+    <mmultiscripts class="class2">
+    <munderover id="1">
+    <mphantom id="0">
+    <mover mathbackground="white">
+    <munderover accentunder="true">
+    <mn mathsize="0.6927361940374979">
+    <none />
+    <mtd columnalign="center">
+    <menclose class="class7">
+    <p>This test passes if WebKit does not crash.</p>
+</body>

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h
@@ -106,7 +106,10 @@ template<Range range, std::floating_point T> constexpr T clampToRange(T value)
 // Clamps a floating point value to within `range` and within additional provided range.
 template<Range range, std::floating_point T> constexpr T clampToRange(T value, T additionalMinimum, T additionalMaximum)
 {
-    return std::clamp<T>(value, std::max<T>(range.min, additionalMinimum), std::min<T>(range.max, additionalMaximum));
+    if (std::isnan(value))
+        return std::min<T>(range.max, additionalMaximum);
+
+    return clampTo<T>(value, std::max<T>(0, additionalMinimum), std::min<T>(range.max, additionalMaximum));
 }
 
 


### PR DESCRIPTION
#### cd525f4f8f637469a9ceaea38afe39a15e3008a9
<pre>
Assertion in PaddingEdge::PaddingEdge(WebCore::Length&amp;&amp;)
<a href="https://bugs.webkit.org/show_bug.cgi?id=295543">https://bugs.webkit.org/show_bug.cgi?id=295543</a>
<a href="https://rdar.apple.com/153541031">rdar://153541031</a>

Reviewed by NOBODY (OOPS!).

The isssue is caused by recursice zoom that makes the dimensions
to reach beyond max int value, which results in the value being
NaN. This was causing as an invalid value.
The fix is to have a bound check using clampTo function and also
check using std::isnan(value) in clampToRange function

* LayoutTests/fast/css/recursive_zoom_crash-expected.txt: Added.
* LayoutTests/fast/css/recursive_zoom_crash.html: Added.
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h:
(WebCore::CSS::clampToRange):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd525f4f8f637469a9ceaea38afe39a15e3008a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110654 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30313 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20746 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116680 "Hash cd525f4f for PR 47728 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60921 "Failed to checkout and rebase branch from PR 47728") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112617 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38902 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/116680 "Hash cd525f4f for PR 47728 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/60921 "Failed to checkout and rebase branch from PR 47728") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113602 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24751 "Found 60 new test failures: compositing/backing/animate-into-view-with-descendant.html compositing/backing/animate-into-view.html compositing/backing/backing-store-attachment-with-rotation.html compositing/backing/no-backing-for-clip-overlap.html compositing/backing/no-backing-for-offscreen-children-of-position-fixed.html compositing/cocoa/clip-fixed-element-to-viewport.html compositing/cocoa/clip-sticky-element-to-viewport.html compositing/columns/untransformed-composited-in-paginated.html compositing/contents-scale/rounded-contents-scale.html compositing/filters/backdrop-filter-rect-border-radius.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99639 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/116680 "Hash cd525f4f for PR 47728 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24114 "Found 60 new test failures: imported/w3c/web-platform-tests/css/CSS2/floats/floats-wrap-bfc-007.xht imported/w3c/web-platform-tests/css/CSS2/floats/floats-wrap-bfc-with-margin-001.html imported/w3c/web-platform-tests/css/CSS2/floats/floats-wrap-bfc-with-margin-010.html imported/w3c/web-platform-tests/css/CSS2/floats/hit-test-floats-002.html imported/w3c/web-platform-tests/css/CSS2/floats/hit-test-floats-004.html imported/w3c/web-platform-tests/css/CSS2/floats/negative-block-margin-pushing-float-out-of-block-formatting-context.html imported/w3c/web-platform-tests/css/CSS2/floats/negative-margin-float-positioning.html imported/w3c/web-platform-tests/css/CSS2/floats/new-fc-beside-adjoining-float-2.html imported/w3c/web-platform-tests/css/CSS2/floats/new-fc-relayout.html imported/w3c/web-platform-tests/css/CSS2/floats/zero-width-floats.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17777 "Found 60 new test failures: compositing/backing/animate-into-view-with-descendant.html compositing/backing/animate-into-view.html compositing/backing/backing-store-attachment-empty-keyframe.html compositing/backing/backing-store-attachment-with-rotation.html compositing/backing/no-backing-for-clip-overlap.html compositing/backing/no-backing-for-offscreen-children-of-position-fixed.html compositing/columns/untransformed-composited-in-paginated.html compositing/contents-scale/rounded-contents-scale.html compositing/filters/backdrop-filter-rect-border-radius.html compositing/filters/backdrop-filter-rect.html ... (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60475 "Hash cd525f4f for PR 47728 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94140 "Found 1 new API test failure: TestWebKitAPI.DragAndDropTests.DoNotCrashWhenSelectionMovesOffscreenAfterDragStart (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17836 "Found 60 new test failures: compositing/backing/animate-into-view-with-descendant.html compositing/backing/animate-into-view.html compositing/backing/backing-store-attachment-with-rotation.html compositing/backing/no-backing-for-clip-overlap.html compositing/backing/no-backing-for-offscreen-children-of-position-fixed.html compositing/cocoa/clip-fixed-element-to-viewport.html compositing/cocoa/clip-sticky-element-to-viewport.html compositing/columns/untransformed-composited-in-paginated.html compositing/contents-scale/rounded-contents-scale.html compositing/filters/backdrop-filter-rect-border-radius.html ... (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119470 "Hash cd525f4f for PR 47728 does not build (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37694 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27999 "Found 60 new test failures: compositing/backing/animate-into-view-with-descendant.html compositing/backing/animate-into-view.html compositing/backing/backing-store-attachment-with-rotation.html compositing/backing/no-backing-for-clip-overlap.html compositing/backing/no-backing-for-offscreen-children-of-position-fixed.html compositing/cocoa/clip-fixed-element-to-viewport.html compositing/cocoa/clip-sticky-element-to-viewport.html compositing/columns/untransformed-composited-in-paginated.html compositing/contents-scale/rounded-contents-scale.html compositing/filters/backdrop-filter-rect-border-radius.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/119470 "Hash cd525f4f for PR 47728 does not build (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38068 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95908 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/119470 "Hash cd525f4f for PR 47728 does not build (failure)") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37950 "Found 2 new test failures: interaction-region/clip-path.html interaction-region/svg.html (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15695 "Found 60 new test failures: compositing/backing/animate-into-view-with-descendant.html compositing/backing/animate-into-view.html compositing/backing/backing-store-attachment-with-rotation.html compositing/backing/no-backing-for-clip-overlap.html compositing/backing/no-backing-for-offscreen-children-of-position-fixed.html compositing/cocoa/clip-fixed-element-to-viewport.html compositing/cocoa/clip-sticky-element-to-viewport.html compositing/columns/untransformed-composited-in-paginated.html compositing/contents-scale/rounded-contents-scale.html compositing/filters/backdrop-filter-rect-border-radius.html ... (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/33671 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37590 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43062 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37252 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40591 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38960 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->