### PR TITLE
Web Automation: Automation.performInteractionSequence needs Max Safe Integer check for duration parameter

### DIFF
--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -2265,8 +2265,7 @@ void WebAutomationSession::performInteractionSequence(const Inspector::Protocol:
 
     // Parse and validate Automation protocol arguments. By this point, the driver has
     // already performed the steps in §17.3 Processing Actions Requests.
-    if (!inputSources->length())
-        ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS(InvalidParameter, "The parameter 'inputSources' was not found or empty."_s);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(!inputSources->length(), InvalidParameter, "The parameter 'inputSources' was not found or empty."_s);
 
     HashSet<String> sourceIdSet;
     for (const auto& inputSourceValue : inputSources.get()) {
@@ -2404,11 +2403,7 @@ void WebAutomationSession::performInteractionSequence(const Inspector::Protocol:
             }
 
             if (auto duration = stateObject->getInteger("duration"_s)) {
-                if (!isValidSafeInteger(duration.value())) {
-                    ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS(InvalidParameter, "Invalid duration outside safe integer range"_s);
-                    return;
-                }
-                
+                ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(!isValidSafeInteger(duration.value()), InvalidParameter, "Invalid duration outside safe integer range"_s);
                 sourceState.duration = Seconds::fromMilliseconds(*duration);
             }
 

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -2241,6 +2241,14 @@ static std::optional<char32_t> pressedCharKey(const String& pressedCharKeyString
 #endif // !ENABLE(WEBDRIVER_KEYBOARD_GRAPHEME_CLUSTERS)
 #endif // ENABLE(WEBDRIVER_ACTIONS_API)
 
+static bool isValidSafeInteger(int value)
+{
+    // Defined in ECMA 2015, §20.1.2.6 Number.MAX_SAFE_INTEGER.
+    // https://www.ecma-international.org/ecma-262/6.0/#sec-number.max_safe_integer
+    int maximumSafeInteger = pow(2.0, 53.0) - 1;
+    return value > maximumSafeInteger * -1 && value <= maximumSafeInteger;
+}
+
 void WebAutomationSession::performInteractionSequence(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, Ref<JSON::Array>&& inputSources, Ref<JSON::Array>&& steps, CommandCallback<void>&& callback)
 {
     // This command implements WebKit support for §17.5 Perform Actions.
@@ -2395,8 +2403,14 @@ void WebAutomationSession::performInteractionSequence(const Inspector::Protocol:
                     sourceState.scrollDelta = WebCore::IntSize(*deltaX, *deltaY);
             }
 
-            if (auto duration = stateObject->getInteger("duration"_s))
+            if (auto duration = stateObject->getInteger("duration"_s)) {
+                if (!isValidSafeInteger(duration.value())) {
+                    ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS(InvalidParameter, "Invalid duration outside safe integer range"_s);
+                    return;
+                }
+                
                 sourceState.duration = Seconds::fromMilliseconds(*duration);
+            }
 
             entries.append(std::pair<SimulatedInputSource&, SimulatedInputSourceState> { inputSource, sourceState });
         }


### PR DESCRIPTION
#### b4d7ae1116619a0357741415e31981132faffadc
<pre>
Web Automation: Automation.performInteractionSequence needs Max Safe Integer check for duration parameter
<a href="https://bugs.webkit.org/show_bug.cgi?id=295596">https://bugs.webkit.org/show_bug.cgi?id=295596</a>
<a href="https://rdar.apple.com/155358109">rdar://155358109</a>

Reviewed by NOBODY (OOPS!).

This is needed to pass some invalid input tests in invalid.py.

* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::performInteractionSequence):
</pre>
----------------------------------------------------------------------
#### fb289b0ea25f68b741f754471daae5419fb9174f
<pre>
Web Automation: Automation.performInteractionSequence needs Max Safe Integer check for duration parameter
<a href="https://bugs.webkit.org/show_bug.cgi?id=295596">https://bugs.webkit.org/show_bug.cgi?id=295596</a>

Reviewed by NOBODY (OOPS!).

Refuse to perform an interaction if the duration parameter is out of safe integer bounds.

* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::isValidSafeInteger): Added.
(WebKit::WebAutomationSession::performInteractionSequence):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4d7ae1116619a0357741415e31981132faffadc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110650 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30309 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20742 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116676 "Hash b4d7ae11 for PR 47730 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60917 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30988 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38898 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/116676 "Hash b4d7ae11 for PR 47730 does not build (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113598 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24749 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99636 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/116676 "Hash b4d7ae11 for PR 47730 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24112 "Passed tests") | | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60471 "Hash b4d7ae11 for PR 47730 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94138 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17832 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119466 "Hash b4d7ae11 for PR 47730 does not build (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37690 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27997 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/119466 "Hash b4d7ae11 for PR 47730 does not build (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38064 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95904 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/119466 "Hash b4d7ae11 for PR 47730 does not build (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37945 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15691 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33667 "Hash b4d7ae11 for PR 47730 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37586 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43058 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37248 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40587 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38956 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->