### PR TITLE
Harden IPInt dispatch more for ARM64E.

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -124,6 +124,7 @@ end
 # 1.2: Constant definitions
 # -------------------------
 
+const IPIntDispatchPtrTag = constexpr IPIntDispatchPtrTag
 const PtrSize = constexpr (sizeof(void*))
 const MachineRegisterSize = constexpr (sizeof(CPURegister))
 const SlotSize = constexpr (sizeof(Register))

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
@@ -62,11 +62,11 @@ do { \
 void initialize()
 {
 #if !ENABLE(C_LOOP) && ((CPU(ADDRESS64) && (CPU(ARM64) || CPU(X86_64))) || (CPU(ADDRESS32) && CPU(ARM_THUMB2)))
-    g_jscConfig.ipint_dispatch_base = CodePtr<CFunctionPtrTag>::fromTaggedPtr(reinterpret_cast<void*>(ipint_unreachable_validate)).template untaggedPtr<>();
-    g_jscConfig.ipint_gc_dispatch_base = CodePtr<CFunctionPtrTag>::fromTaggedPtr(reinterpret_cast<void*>(ipint_struct_new_validate)).template untaggedPtr<>();
-    g_jscConfig.ipint_conversion_dispatch_base = CodePtr<CFunctionPtrTag>::fromTaggedPtr(reinterpret_cast<void*>(ipint_i32_trunc_sat_f32_s_validate)).template untaggedPtr<>();
-    g_jscConfig.ipint_simd_dispatch_base = CodePtr<CFunctionPtrTag>::fromTaggedPtr(reinterpret_cast<void*>(ipint_simd_v128_load_mem_validate)).template untaggedPtr<>();
-    g_jscConfig.ipint_atomic_dispatch_base = CodePtr<CFunctionPtrTag>::fromTaggedPtr(reinterpret_cast<void*>(ipint_memory_atomic_notify_validate)).template untaggedPtr<>();
+    g_jscConfig.ipint_dispatch_base = CodePtr<CFunctionPtrTag>::fromTaggedPtr(reinterpret_cast<void*>(ipint_unreachable_validate)).template retaggedPtr<IPIntDispatchPtrTag>();
+    g_jscConfig.ipint_gc_dispatch_base = CodePtr<CFunctionPtrTag>::fromTaggedPtr(reinterpret_cast<void*>(ipint_struct_new_validate)).template retaggedPtr<IPIntDispatchPtrTag>();
+    g_jscConfig.ipint_conversion_dispatch_base = CodePtr<CFunctionPtrTag>::fromTaggedPtr(reinterpret_cast<void*>(ipint_i32_trunc_sat_f32_s_validate)).template retaggedPtr<IPIntDispatchPtrTag>();
+    g_jscConfig.ipint_simd_dispatch_base = CodePtr<CFunctionPtrTag>::fromTaggedPtr(reinterpret_cast<void*>(ipint_simd_v128_load_mem_validate)).template retaggedPtr<IPIntDispatchPtrTag>();
+    g_jscConfig.ipint_atomic_dispatch_base = CodePtr<CFunctionPtrTag>::fromTaggedPtr(reinterpret_cast<void*>(ipint_memory_atomic_notify_validate)).template retaggedPtr<IPIntDispatchPtrTag>();
 
     FOR_EACH_IPINT_OPCODE(VALIDATE_IPINT_OPCODE);
     FOR_EACH_IPINT_GC_OPCODE(VALIDATE_IPINT_GC_OPCODE);

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -69,7 +69,14 @@ macro nextIPIntInstruction()
     loadb [PC], t0
 if ARM64 or ARM64E
     # x0 = opcode
-    pcrtoaddr ipint_dispatch_base, t7
+    if ARM64
+        pcrtoaddr ipint_dispatch_base, t7
+    else
+        leap _g_config, t7
+        loadp JSCConfigOffset + JSC::Config::ipint_dispatch_base[t7], t7
+        move IPIntDispatchPtrTag, t1
+        emit "autib x7, x1"
+    end
     emit "add x0, x7, x0, lsl #8"
     emit "br x0"
 elsif X86_64
@@ -3153,7 +3160,14 @@ ipintOp(_gc_prefix, macro()
     # Security guarantee: always less than 30 (0x00 -> 0x1e)
     biaeq t0, 0x1f, .ipint_gc_nonexistent
     if ARM64 or ARM64E
-        pcrtoaddr ipint_gc_dispatch_base, t1
+        if ARM64
+            pcrtoaddr ipint_gc_dispatch_base, t1
+        else
+            leap _g_config, t1
+            loadp JSCConfigOffset + JSC::Config::ipint_gc_dispatch_base[t1], t1
+            move IPIntDispatchPtrTag, t2
+            emit "autib x1, x2"
+        end
         emit "add x0, x1, x0, lsl 8"
         emit "br x0"
     elsif X86_64
@@ -3173,7 +3187,14 @@ ipintOp(_conversion_prefix, macro()
     # Security guarantee: always less than 18 (0x00 -> 0x11)
     biaeq t0, 0x12, .ipint_conversion_nonexistent
     if ARM64 or ARM64E
-        pcrtoaddr ipint_conversion_dispatch_base, t1
+        if ARM64
+            pcrtoaddr ipint_conversion_dispatch_base, t1
+        else
+            leap _g_config, t1
+            loadp JSCConfigOffset + JSC::Config::ipint_conversion_dispatch_base[t1], t1
+            move IPIntDispatchPtrTag, t2
+            emit "autib x1, x2"
+        end
         emit "add x0, x1, x0, lsl 8"
         emit "br x0"
     elsif X86_64
@@ -3193,7 +3214,14 @@ ipintOp(_simd_prefix, macro()
     # Security guarantee: always less than 256 (0x00 -> 0xff)
     biaeq t0, 0x100, .ipint_simd_nonexistent
     if ARM64 or ARM64E
-        pcrtoaddr ipint_simd_dispatch_base, t1
+        if ARM64
+            pcrtoaddr ipint_simd_dispatch_base, t1
+        else
+            leap _g_config, t1
+            loadp JSCConfigOffset + JSC::Config::ipint_simd_dispatch_base[t1], t1
+            move IPIntDispatchPtrTag, t2
+            emit "autib x1, x2"
+        end
         emit "add x0, x1, x0, lsl 8"
         emit "br x0"
     elsif X86_64
@@ -3213,7 +3241,14 @@ ipintOp(_atomic_prefix, macro()
     # Security guarantee: always less than 78 (0x00 -> 0x4e)
     biaeq t0, 0x4f, .ipint_atomic_nonexistent
     if ARM64 or ARM64E
-        pcrtoaddr ipint_atomic_dispatch_base, t1
+        if ARM64
+            pcrtoaddr ipint_atomic_dispatch_base, t1
+        else
+            leap _g_config, t1
+            loadp JSCConfigOffset + JSC::Config::ipint_atomic_dispatch_base[t1], t1
+            move IPIntDispatchPtrTag, t2
+            emit "autib x1, x2"
+        end
         emit "add x0, x1, x0, lsl 8"
         emit "br x0"
     elsif X86_64

--- a/Source/JavaScriptCore/llint/LLIntData.cpp
+++ b/Source/JavaScriptCore/llint/LLIntData.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -89,6 +89,17 @@ static void neuterOpcodeMaps()
         SET_CRASH_TARGET(g_opcodeMapWide32[i]);
     }
 #undef SET_CRASH_TARGET
+
+#if ENABLE(WEBASSEMBLY)
+    {
+        void* crash_target = CodePtr<CFunctionPtrTag>::fromTaggedPtr(reinterpret_cast<void*>(llint_check_vm_entry_permission)).template retaggedPtr<IPIntDispatchPtrTag>();
+        g_jscConfig.ipint_dispatch_base = crash_target;
+        g_jscConfig.ipint_gc_dispatch_base = crash_target;
+        g_jscConfig.ipint_conversion_dispatch_base = crash_target;
+        g_jscConfig.ipint_simd_dispatch_base = crash_target;
+        g_jscConfig.ipint_atomic_dispatch_base = crash_target;
+    }
+#endif
 }
 #endif
 

--- a/Source/JavaScriptCore/runtime/JSCPtrTag.h
+++ b/Source/JavaScriptCore/runtime/JSCPtrTag.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -50,6 +50,7 @@ using PtrTag = WTF::PtrTag;
     v(YarrMatchOnly16BitPtrTag, PtrTagCalleeType::JIT, PtrTagCallerType::None) \
     /* Callee:Native Caller:Native */ \
     v(BytecodePtrTag, PtrTagCalleeType::Native, PtrTagCallerType::Native) \
+    v(IPIntDispatchPtrTag, PtrTagCalleeType::Native, PtrTagCallerType::Native) \
     v(CustomAccessorPtrTag, PtrTagCalleeType::Native, PtrTagCallerType::Native) \
     v(GetValueFuncPtrTag, PtrTagCalleeType::Native, PtrTagCallerType::Native) \
     v(GetValueFuncWithPtrPtrTag, PtrTagCalleeType::Native, PtrTagCallerType::Native) \


### PR DESCRIPTION
#### 1babc234626e7ba50f4e160aba133861bacd557d
<pre>
Harden IPInt dispatch more for ARM64E.
<a href="https://bugs.webkit.org/show_bug.cgi?id=295595">https://bugs.webkit.org/show_bug.cgi?id=295595</a>
<a href="https://rdar.apple.com/155356829">rdar://155356829</a>

Reviewed by NOBODY (OOPS!).

Use ARM64E ptrauth for authentication IPInt dispatches.  This gives us the ability to neuter
the IPInt dispatch when not in use.  This change is perf neutral.

* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/llint/InPlaceInterpreter.cpp:
(JSC::IPInt::initialize):
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Source/JavaScriptCore/llint/LLIntData.cpp:
(JSC::LLInt::neuterOpcodeMaps):
* Source/JavaScriptCore/runtime/JSCPtrTag.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1babc234626e7ba50f4e160aba133861bacd557d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110655 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30314 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20747 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116681 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60922 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38903 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84143 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113603 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99640 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64584 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24115 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17778 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60476 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/103146 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94141 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17837 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119471 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109209 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37695 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28000 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93108 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38069 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95909 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92932 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37951 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15696 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33672 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37591 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43063 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/133484 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37253 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36064 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40592 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38961 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->