### PR TITLE
Apply dynamic-range-limit to HDR WebGPU canvas

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/web_platform/canvas/dynamic-range-limit-constrained-disabled-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/web_platform/canvas/dynamic-range-limit-constrained-disabled-expected.txt
@@ -1,0 +1,4 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/webgpu/webgpu/web_platform/canvas/dynamic-range-limit-constrained-disabled.html
+++ b/LayoutTests/http/tests/webgpu/webgpu/web_platform/canvas/dynamic-range-limit-constrained-disabled.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SupportHDRDisplayEnabled=true CSSConstrainedDynamicRangeLimitEnabled=false ] -->
+<html id="html">
+<body>
+<script src='../../resources/js-test-pre.js'></script>
+<canvas id="canvasd"></canvas>
+<canvas id="canvasn" style="dynamic-range-limit: no-limit"></canvas>
+<canvas id="canvasc" style="dynamic-range-limit: constrained"></canvas>
+<canvas id="canvass" style="dynamic-range-limit: standard"></canvas>
+<script>
+var canvasd;
+var canvasn;
+var canvasc;
+var canvass;
+var canvas2;
+
+const quiet = true; // So that the non-failure output is the same if dynamic-range-limit is not supported.
+
+function verifyCanvas(expectations)
+{
+    shouldBe(expectations.canvas + '.style["dynamic-range-limit"]', expectations.limit, quiet);
+    shouldBe('getComputedStyle(' + expectations.canvas + ')["dynamic-range-limit"]', expectations.computed, quiet);
+    shouldBe('internals.getContextEffectiveDynamicRangeLimitValue(' + expectations.canvas + ')', expectations.value, quiet);
+}
+
+if (!window.internals) {
+    failTest('This test requires window.internals.');
+} else if (CSS.supports("dynamic-range-limit", "standard") && CSS.supports("dynamic-range-limit", "no-limit")) {
+    shouldBe('CSS.supports("dynamic-range-limit", "constrained")', 'false', quiet);
+
+    canvasd = document.getElementById("canvasd");
+    canvasn = document.getElementById("canvasn");
+    canvasc = document.getElementById("canvasc");
+    canvass = document.getElementById("canvass");
+
+    const contextd = canvasd.getContext("webgpu");
+    const contextn = canvasn.getContext("webgpu");
+    const contextc = canvasc.getContext("webgpu");
+    const contexts = canvass.getContext("webgpu");
+
+    verifyCanvas({canvas: 'canvasd', limit: '""', computed: '"no-limit"', value: '1.0'});
+    verifyCanvas({canvas: 'canvasn', limit: '"no-limit"', computed: '"no-limit"', value: '1.0'});
+    verifyCanvas({canvas: 'canvasc', limit: '""', computed: '"no-limit"', value: '1.0'});
+    verifyCanvas({canvas: 'canvass', limit: '"standard"', computed: '"standard"', value: '0.0'});
+
+    canvas2 = document.createElement("canvas");
+    canvasn.append(canvas2);
+    const context2 = canvas2.getContext("webgpu");
+    verifyCanvas({canvas: 'canvas2', limit: '""', computed: '"no-limit"', value: '1.0'});
+}
+</script>
+<script src='../../resources/js-test-post.js'></script>
+</body>
+</html>

--- a/LayoutTests/http/tests/webgpu/webgpu/web_platform/canvas/dynamic-range-limit-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/web_platform/canvas/dynamic-range-limit-expected.txt
@@ -1,0 +1,4 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/webgpu/webgpu/web_platform/canvas/dynamic-range-limit.html
+++ b/LayoutTests/http/tests/webgpu/webgpu/web_platform/canvas/dynamic-range-limit.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SupportHDRDisplayEnabled=true CSSConstrainedDynamicRangeLimitEnabled=true ] -->
+<html id="html">
+<body>
+<script src='../../resources/js-test-pre.js'></script>
+<canvas id="canvasd"></canvas>
+<canvas id="canvasn" style="dynamic-range-limit: no-limit"></canvas>
+<canvas id="canvasc" style="dynamic-range-limit: constrained"></canvas>
+<canvas id="canvass" style="dynamic-range-limit: standard"></canvas>
+<script>
+var canvasd;
+var canvasn;
+var canvasc;
+var canvass;
+var canvas2;
+
+const quiet = true; // So that the non-failure output is the same if dynamic-range-limit is not supported.
+
+function verifyCanvas(expectations)
+{
+    shouldBe(expectations.canvas + '.style["dynamic-range-limit"]', expectations.limit, quiet);
+    shouldBe('getComputedStyle(' + expectations.canvas + ')["dynamic-range-limit"]', expectations.computed, quiet);
+    shouldBe('internals.getContextEffectiveDynamicRangeLimitValue(' + expectations.canvas + ')', expectations.value, quiet);
+}
+
+if (!window.internals) {
+    failTest('This test requires window.internals.');
+} else if (CSS.supports("dynamic-range-limit", "standard") && CSS.supports("dynamic-range-limit", "no-limit")) {
+    shouldBe('CSS.supports("dynamic-range-limit", "constrained")', 'true', quiet);
+
+    canvasd = document.getElementById("canvasd");
+    canvasn = document.getElementById("canvasn");
+    canvasc = document.getElementById("canvasc");
+    canvass = document.getElementById("canvass");
+
+    const contextd = canvasd.getContext("webgpu");
+    const contextn = canvasn.getContext("webgpu");
+    const contextc = canvasc.getContext("webgpu");
+    const contexts = canvass.getContext("webgpu");
+
+    verifyCanvas({canvas: 'canvasd', limit: '""', computed: '"no-limit"', value: '1.0'});
+    verifyCanvas({canvas: 'canvasn', limit: '"no-limit"', computed: '"no-limit"', value: '1.0'});
+    verifyCanvas({canvas: 'canvasc', limit: '"constrained"', computed: '"constrained"', value: '0.5'});
+    verifyCanvas({canvas: 'canvass', limit: '"standard"', computed: '"standard"', value: '0.0'});
+
+    canvas2 = document.createElement("canvas");
+    canvasn.append(canvas2);
+    const context2 = canvas2.getContext("webgpu");
+    verifyCanvas({canvas: 'canvas2', limit: '""', computed: '"no-limit"', value: '1.0'});
+}
+</script>
+<script src='../../resources/js-test-post.js'></script>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -542,6 +542,9 @@ GPUCanvasContext* HTMLCanvasElement::createContextWebGPU(const String& type, GPU
     if (m_context) {
         // Need to make sure a RenderLayer and compositing layer get created for the Canvas.
         invalidateStyleAndLayerComposition();
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+        m_context->setDynamicRangeLimit(m_dynamicRangeLimit);
+#endif // ENABLE(PIXEL_FORMAT_RGBA16F)
     }
 
     return downcast<GPUCanvasContext>(m_context.get());
@@ -1011,6 +1014,25 @@ void HTMLCanvasElement::prepareForDisplay()
     if (m_context)
         m_context->prepareForDisplay();
     notifyObserversCanvasDisplayBufferPrepared();
+}
+
+void HTMLCanvasElement::dynamicRangeLimitDidChange(PlatformDynamicRangeLimit dynamicRangeLimit)
+{
+    if (m_dynamicRangeLimit == dynamicRangeLimit)
+        return;
+
+    m_dynamicRangeLimit = dynamicRangeLimit;
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    if (m_context)
+        m_context->setDynamicRangeLimit(dynamicRangeLimit);
+#endif // ENABLE(PIXEL_FORMAT_RGBA16F)
+}
+
+std::optional<double> HTMLCanvasElement::getContextEffectiveDynamicRangeLimitValue() const
+{
+    if (m_context)
+        return m_context->getEffectiveDynamicRangeLimitValue();
+    return std::nullopt;
 }
 
 bool HTMLCanvasElement::isControlledByOffscreen() const

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -33,6 +33,7 @@
 #include "FloatRect.h"
 #include "GraphicsTypes.h"
 #include "HTMLElement.h"
+#include "PlatformDynamicRangeLimit.h"
 #include <memory>
 #include <wtf/Forward.h>
 
@@ -134,6 +135,8 @@ public:
 
     bool needsPreparationForDisplay();
     void prepareForDisplay();
+    void dynamicRangeLimitDidChange(PlatformDynamicRangeLimit);
+    WEBCORE_EXPORT std::optional<double> getContextEffectiveDynamicRangeLimitValue() const;
 
     void setIsSnapshotting(bool isSnapshotting) { m_isSnapshotting = isSnapshotting; }
     bool isSnapshotting() const { return m_isSnapshotting; }
@@ -190,6 +193,7 @@ private:
     bool m_isSnapshotting { false };
 
     std::unique_ptr<CanvasRenderingContext> m_context;
+    PlatformDynamicRangeLimit m_dynamicRangeLimit { PlatformDynamicRangeLimit::initialValue() };
     mutable RefPtr<Image> m_copiedImage; // FIXME: This is temporary for platforms that have to copy the image buffer to render (and for CSSCanvasValue).
 };
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -122,7 +122,9 @@ public:
 
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
     bool isHDR() const { return pixelFormat() == ImageBufferPixelFormat::RGBA16F; }
+    virtual void setDynamicRangeLimit(PlatformDynamicRangeLimit) { };
 #endif
+    virtual std::optional<double> getEffectiveDynamicRangeLimitValue() const { return std::nullopt; };
 
     void setIsInPreparationForDisplayOrFlush(bool flag) { m_isInPreparationForDisplayOrFlush = flag; }
     bool isInPreparationForDisplayOrFlush() const { return m_isInPreparationForDisplayOrFlush; }

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -76,6 +76,11 @@ public:
     ExceptionOr<RefPtr<GPUTexture>> getCurrentTexture() override;
     RefPtr<ImageBuffer> transferToImageBuffer() override;
 
+#if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGBA16F)
+    void setDynamicRangeLimit(PlatformDynamicRangeLimit) override;
+    std::optional<double> getEffectiveDynamicRangeLimitValue() const override;
+#endif
+
 private:
     explicit GPUCanvasContextCocoa(CanvasBase&, Ref<GPUCompositorIntegration>&&, Ref<GPUPresentationContext>&&, Document*);
 
@@ -89,7 +94,12 @@ private:
     CanvasType htmlOrOffscreenCanvas() const;
     ExceptionOr<void> configure(GPUCanvasConfiguration&&, bool);
     void present(uint32_t frameIndex);
-    void updateContentsHeadroom(float);
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    float computeContentsHeadroom();
+    void updateContentsHeadroom();
+    void updateScreenHeadroom(float, bool suppressEDR);
+    void updateScreenHeadroomFromScreenProperties();
+#endif // HAVE(SUPPORT_HDR_DISPLAY)
 
     struct Configuration {
         Ref<GPUDevice> device;
@@ -111,9 +121,13 @@ private:
 
     GPUIntegerCoordinate m_width { 0 };
     GPUIntegerCoordinate m_height { 0 };
-    float m_contentsHeadroom { 0.f };
+#if HAVE(SUPPORT_HDR_DISPLAY)
     using ScreenPropertiesChangedObserver = Observer<void(PlatformDisplayID)>;
     std::optional<ScreenPropertiesChangedObserver> m_screenPropertiesChangedObserver;
+    PlatformDynamicRangeLimit m_dynamicRangeLimit { PlatformDynamicRangeLimit::initialValue() };
+    float m_currentEDRHeadroom { 1 };
+    bool m_suppressEDR { false };
+#endif // HAVE(SUPPORT_HDR_DISPLAY)
     bool m_compositingResultsNeedsUpdating { false };
 };
 

--- a/Source/WebCore/rendering/RenderHTMLCanvas.cpp
+++ b/Source/WebCore/rendering/RenderHTMLCanvas.cpp
@@ -120,4 +120,12 @@ void RenderHTMLCanvas::canvasSizeChanged()
     setNeedsLayoutIfNeededAfterIntrinsicSizeChange();
 }
 
+void RenderHTMLCanvas::styleDidChange(StyleDifference difference, const RenderStyle* oldStyle)
+{
+    RenderReplaced::styleDidChange(difference, oldStyle);
+
+    if (!oldStyle || style().dynamicRangeLimit() != oldStyle->dynamicRangeLimit())
+        canvasElement().dynamicRangeLimitDidChange(style().dynamicRangeLimit().toPlatformDynamicRangeLimit());
+}
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderHTMLCanvas.h
+++ b/Source/WebCore/rendering/RenderHTMLCanvas.h
@@ -48,6 +48,7 @@ private:
     ASCIILiteral renderName() const override { return "RenderHTMLCanvas"_s; }
     void paintReplaced(PaintInfo&, const LayoutPoint&) override;
     void intrinsicSizeChanged() override { canvasSizeChanged(); }
+    void styleDidChange(StyleDifference, const RenderStyle* oldStyle) override;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1222,6 +1222,11 @@ bool RenderStyle::changeRequiresLayerRepaint(const RenderStyle& other, OptionSet
             return true;
     }
 
+    if (m_rareInheritedData.ptr() != other.m_rareInheritedData.ptr()
+        && m_rareInheritedData->dynamicRangeLimit != other.m_rareInheritedData->dynamicRangeLimit) {
+        return true;
+    }
+
 #if HAVE(CORE_MATERIAL)
     if (m_rareInheritedData.ptr() != other.m_rareInheritedData.ptr()
         && m_rareInheritedData->usedAppleVisualEffectForSubtree != other.m_rareInheritedData->usedAppleVisualEffectForSubtree) {

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4685,6 +4685,14 @@ double Internals::effectiveDynamicRangeLimitValue(const HTMLMediaElement& media)
 
 #endif
 
+ExceptionOr<double> Internals::getContextEffectiveDynamicRangeLimitValue(const HTMLCanvasElement& canvas)
+{
+    auto value = canvas.getContextEffectiveDynamicRangeLimitValue();
+    if (value.has_value())
+        return *value;
+    return Exception { ExceptionCode::InvalidStateError };
+}
+
 ExceptionOr<void> Internals::setPageShouldSuppressHDR(bool shouldSuppressHDR)
 {
     Document* document = contextDocument();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -818,6 +818,7 @@ public:
 
     double effectiveDynamicRangeLimitValue(const HTMLMediaElement&);
 #endif
+    ExceptionOr<double> getContextEffectiveDynamicRangeLimitValue(const HTMLCanvasElement&);
 
     ExceptionOr<void> setPageShouldSuppressHDR(bool);
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -979,6 +979,7 @@ enum ContentsFormat {
     [Conditional=VIDEO] undefined enableGStreamerHolePunching(HTMLVideoElement element);
 
     [Conditional=VIDEO] double effectiveDynamicRangeLimitValue(HTMLMediaElement media);
+    double getContextEffectiveDynamicRangeLimitValue(HTMLCanvasElement canvas);
     undefined setPageShouldSuppressHDR(boolean shouldSuppressHDR);
 
     undefined setIsPlayingToBluetoothOverride(optional boolean? isPlaying = null);

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -1261,13 +1261,10 @@ void WebProcessPool::screenPropertiesChanged()
 #if HAVE(SUPPORT_HDR_DISPLAY)
     if (m_suppressEDR) {
         for (auto& properties : screenProperties.screenDataMap.values()) {
-            constexpr auto maxStudioDisplayHeadroom = 2.f;
-            constexpr auto threeQuartersStudioDisplayHeadroom = 1.5f;
-            constexpr auto halfMaxHeadroomMultiplier = 0.5f;
-            auto maxHeadroom = std::clamp(properties.maxEDRHeadroom * halfMaxHeadroomMultiplier, std::min(properties.maxEDRHeadroom, threeQuartersStudioDisplayHeadroom), maxStudioDisplayHeadroom);
-            properties.currentEDRHeadroom = maxHeadroom;
-            properties.maxEDRHeadroom = maxHeadroom;
-            properties.suppressEDR = m_suppressEDR;
+            constexpr auto maxSuppressedHeadroom = 1.6f;
+            auto suppressedHeadroom = std::min(maxSuppressedHeadroom, properties.currentEDRHeadroom);
+            properties.currentEDRHeadroom = suppressedHeadroom;
+            properties.suppressEDR = true;
         }
     }
 #endif


### PR DESCRIPTION
#### b1b230d5f85067a615d51119501fd54a2c391141
<pre>
Apply dynamic-range-limit to HDR WebGPU canvas
<a href="https://bugs.webkit.org/show_bug.cgi?id=295600">https://bugs.webkit.org/show_bug.cgi?id=295600</a>
<a href="https://rdar.apple.com/155371680">rdar://155371680</a>

Reviewed by Mike Wyrzykowski.

Handle both dynamic-range-limit and suppress-HDR, to apply whichever
constrains the most.

* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::createContextWebGPU):
(WebCore::HTMLCanvasElement::dynamicRangeLimitDidChange):
Stores the current dynamic-range-limit, and sets the effective limit
(which accounts for the suppress-HDR state) in the rendering context.

(WebCore::HTMLCanvasElement::getContextEffectiveDynamicRangeLimitValue const):
For testing.

* Source/WebCore/html/canvas/CanvasRenderingContext.h:
(WebCore::CanvasRenderingContext::setDynamicRangeLimit):
Default dynamic-range-limit handler, does nothing.

(WebCore::CanvasRenderingContext::getEffectiveDynamicRangeLimitValue const):
For testing.

* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::GPUCanvasContextCocoa):
Observer now also passes suppressHDR to updateScreenHeadroom().

(WebCore::interpolateHeadroom):
(WebCore::GPUCanvasContextCocoa::computeContentsHeadroom):
Computes the headroom based on the screen headroom (which may already
be suppressed), and the dynamic-range-limit.

(WebCore::GPUCanvasContextCocoa::updateContentsHeadroom):
Computes the headroom and updates the compositorIntegration with it.

(WebCore::GPUCanvasContextCocoa::updateScreenHeadroom):
Called by observer, stores current headroom and suppressHDR, and
calls updateContentsHeadroom.

(WebCore::GPUCanvasContextCocoa::updateScreenHeadroomFromScreenProperties):
Fetches suppressHDR and current headroom from all screen properties, and
calls updateContentsHeadroom.

(WebCore::GPUCanvasContextCocoa::setDynamicRangeLimit):
WebGPU dynamic-range-limit handler, stores the new limits and:
- If there&apos;s no current screen data, calls
updateScreenHeadroomFromScreenProperties, because dynamic-range-limit
needs the current headroom and suppres-HDR flag to work,
- Otherwise just calls updateContentsHeadroom.

(WebCore::GPUCanvasContextCocoa::getEffectiveDynamicRangeLimitValue const):
For testing, combines dynamic-range-limit with suppress-HDR.

(WebCore::GPUCanvasContextCocoa::surfaceBufferToImageBuffer):
Refactored into updateScreenHeadroomFromScreenProperties.

(WebCore::GPUCanvasContextCocoa::configure):
Resets both current headroom and suppressHDR.

* Source/WebCore/rendering/RenderHTMLCanvas.h:
* Source/WebCore/rendering/RenderHTMLCanvas.cpp:
(WebCore::RenderHTMLCanvas::styleDidChange):
Catches dynamic-range-limit changes and notifies element.

* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::changeRequiresLayerRepaint const):
Ensures that dynamic-range-limit changes repaint the element, as its
effective colors may change.

* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::getContextEffectiveDynamicRangeLimitValue):
For testing: `internals.getContextEffectiveDynamicRangeLimitValue(canvas)`.

* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::screenPropertiesChanged):
Reworked suppress-headroom computation: Always 1.6, or current headroom
if lower.

* LayoutTests/http/tests/webgpu/webgpu/web_platform/canvas/dynamic-range-limit-constrained-disabled-expected.txt: Added.
* LayoutTests/http/tests/webgpu/webgpu/web_platform/canvas/dynamic-range-limit-constrained-disabled.html: Added.
* LayoutTests/http/tests/webgpu/webgpu/web_platform/canvas/dynamic-range-limit-expected.txt: Added.
* LayoutTests/http/tests/webgpu/webgpu/web_platform/canvas/dynamic-range-limit.html: Added.

Canonical link: <a href="https://commits.webkit.org/297140@main">https://commits.webkit.org/297140@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55e850a3938efae2fdfe7d182886391d3e5d723e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110661 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30320 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116687 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/60928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112624 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30999 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38909 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84147 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/60928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113609 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24757 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99647 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64588 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24120 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17786 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60482 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94146 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17844 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119477 "") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37701 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28006 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/119477 "") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38075 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95916 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/119477 "") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23677 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37960 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15703 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33678 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37597 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43069 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37259 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40598 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38967 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->