### PR TITLE
[Liquid Glass] Prevent color resampling when switching tabs back to a page where the user had scrolled

### DIFF
--- a/LayoutTests/fast/page-color-sampling/no-resampling-after-scrolling-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/no-resampling-after-scrolling-expected.txt
@@ -1,7 +1,11 @@
-PASS colors.top is null
-PASS colors.left is null
-PASS colors.right is null
-PASS colors.bottom is null
+PASS colorsBeforeReparenting.top is null
+PASS colorsBeforeReparenting.left is null
+PASS colorsBeforeReparenting.right is null
+PASS colorsBeforeReparenting.bottom is null
+PASS colorsAfterReparenting.top is null
+PASS colorsAfterReparenting.left is null
+PASS colorsAfterReparenting.right is null
+PASS colorsAfterReparenting.bottom is null
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/page-color-sampling/no-resampling-after-scrolling.html
+++ b/LayoutTests/fast/page-color-sampling/no-resampling-after-scrolling.html
@@ -41,11 +41,25 @@ addEventListener("load", async () => {
     await UIHelper.scrollDown();
     await UIHelper.waitForZoomingOrScrollingToEnd();
 
-    colors = await UIHelper.fixedContainerEdgeColors();
-    shouldBeNull("colors.top");
-    shouldBeNull("colors.left");
-    shouldBeNull("colors.right");
-    shouldBeNull("colors.bottom");
+    colorsBeforeReparenting = await UIHelper.fixedContainerEdgeColors();
+    shouldBeNull("colorsBeforeReparenting.top");
+    shouldBeNull("colorsBeforeReparenting.left");
+    shouldBeNull("colorsBeforeReparenting.right");
+    shouldBeNull("colorsBeforeReparenting.bottom");
+
+    await UIHelper.removeViewFromWindow();
+    await UIHelper.addViewToWindow();
+    await UIHelper.ensurePresentationUpdate();
+
+    document.querySelector(".short-vertical-space").remove();
+    await UIHelper.scrollDown();
+    await UIHelper.ensurePresentationUpdate();
+
+    colorsAfterReparenting = await UIHelper.fixedContainerEdgeColors();
+    shouldBeNull("colorsAfterReparenting.top");
+    shouldBeNull("colorsAfterReparenting.left");
+    shouldBeNull("colorsAfterReparenting.right");
+    shouldBeNull("colorsAfterReparenting.bottom");
 
     finishJSTest();
 });

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -1536,7 +1536,11 @@ window.UIHelper = class UIHelper {
         if (!this.isWebKit2())
             return Promise.resolve();
 
-        return new Promise(resolve => testRunner.runUIScript(`uiController.removeViewFromWindow()`, resolve));
+        const scriptToRun = `(function() {
+            uiController.removeViewFromWindow();
+            uiController.uiScriptComplete();
+        })()`;
+        return new Promise(resolve => testRunner.runUIScript(scriptToRun, resolve));
     }
 
     static addViewToWindow()
@@ -1544,7 +1548,11 @@ window.UIHelper = class UIHelper {
         if (!this.isWebKit2())
             return Promise.resolve();
 
-        return new Promise(resolve => testRunner.runUIScript(`uiController.addViewToWindow()`, resolve));
+        const scriptToRun = `(function() {
+            uiController.addViewToWindow();
+            uiController.uiScriptComplete();
+        })()`;
+        return new Promise(resolve => testRunner.runUIScript(scriptToRun, resolve));
     }
 
     static minimumZoomScale()

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -3751,7 +3751,6 @@ void LocalFrameView::show()
         // Note that adjustTiledBackingCoverage() kicks the (500ms) timer to re-enable it.
         m_speculativeTilingEnabled = false;
         m_lastUserScrollType = std::nullopt;
-        m_wasEverScrolledExplicitlyByUser = false;
         adjustTiledBackingCoverage();
     }
 }


### PR DESCRIPTION
#### bd9c00a97c47881bb539c7ad4935f3065c61c8c3
<pre>
[Liquid Glass] Prevent color resampling when switching tabs back to a page where the user had scrolled
<a href="https://bugs.webkit.org/show_bug.cgi?id=295603">https://bugs.webkit.org/show_bug.cgi?id=295603</a>

Reviewed by Abrar Rahman Protyasha.

Fix a remaining edge case as a followup to 297118@main — when switching away from a tab and then
switching back, we may attempt to resample the top fixed element until the user scrolls again, due
to the fact that the last user scroll state is currently reset along with
`m_wasEverScrolledExplicitlyByUser` under `LocalFrameView::show()` (i.e., when a view is reinserted
into the view hierarchy).

Avoid resampling in this scenario as well, by not clearing out `m_wasEverScrolledExplicitlyByUser`
when the frame view is shown.

* LayoutTests/fast/page-color-sampling/no-resampling-after-scrolling-expected.txt:
* LayoutTests/fast/page-color-sampling/no-resampling-after-scrolling.html:

Augment an existing test to exercise this scenario, by removing and reinserting the web view into
the window, scrolling, and then verifying that the sampled top color remains null.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.removeViewFromWindow.const.scriptToRun):
(window.UIHelper.removeViewFromWindow):
(window.UIHelper.addViewToWindow.const.scriptToRun):
(window.UIHelper.addViewToWindow):

Make these testing helpers usable on macOS without causing a timeout, by invoking `uiScriptComplete`
afterwards. See the FIXME in `UIScriptControllerCocoa::removeViewFromWindow` for more details.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::show):

Canonical link: <a href="https://commits.webkit.org/297142@main">https://commits.webkit.org/297142@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a9b0c315612fe527af390e3017058c06ccfad42

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110665 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30324 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20757 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116691 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/60932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112628 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38913 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84148 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/60932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113613 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24766 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99646 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64589 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24129 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17785 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60486 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94155 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17843 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119481 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37705 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28008 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93111 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38079 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95915 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92935 "Found 2 new API test failures: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23681 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37961 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15702 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33682 "Failed to checkout and rebase branch from PR 47737") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37601 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43073 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37263 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40602 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38971 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->