### PR TITLE
Add operator<< to JavaScriptEvaluationResult::NullType

### DIFF
--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.h
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.h
@@ -128,4 +128,8 @@ private:
 #endif
 };
 
+#if PLATFORM(COCOA)
+WTF::TextStream& operator<<(WTF::TextStream&, JavaScriptEvaluationResult::NullType);
+#endif
+
 }

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.mm
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.mm
@@ -339,4 +339,11 @@ JSValueRef JavaScriptEvaluationResult::toJS(JSGlobalContextRef context)
     return JSValueMakeUndefined(context);
 }
 
+WTF::TextStream& operator<<(WTF::TextStream& stream, JavaScriptEvaluationResult::NullType nullType)
+{
+    stream << (nullType == JavaScriptEvaluationResult::NullType::NullPointer ? "nil" : "NSNull");
+    return stream;
+}
+
+
 }


### PR DESCRIPTION
#### ff184c3a00ba7dd7e06ead5a9d39f8a20c36f6eb
<pre>
Add operator&lt;&lt; to JavaScriptEvaluationResult::NullType
<a href="https://bugs.webkit.org/show_bug.cgi?id=295606">https://bugs.webkit.org/show_bug.cgi?id=295606</a>
<a href="https://rdar.apple.com/155376029">rdar://155376029</a>

Reviewed by NOBODY (OOPS!).

This makes it easier to log `JavaScriptEvaluationResult::Variant` variants.

* Source/WebKit/Shared/JavaScriptEvaluationResult.h:
* Source/WebKit/Shared/JavaScriptEvaluationResult.mm:
(WebKit::operator&lt;&lt;):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff184c3a00ba7dd7e06ead5a9d39f8a20c36f6eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110674 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30333 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20766 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116701 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60941 "Failed to checkout and rebase branch from PR 47741") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31012 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38922 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84154 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/60941 "Failed to checkout and rebase branch from PR 47741") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113622 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24772 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99654 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64595 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24135 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60495 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94161 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17851 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119490 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37714 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28017 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93115 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38088 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95923 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92939 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37968 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15710 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33691 "Failed to checkout and rebase branch from PR 47741") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37610 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43082 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37272 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40611 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38980 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->