### PR TITLE
ASAN_TRAP | Style::CSSValueConversion::operator; Style::BuilderFunctions::applyValueScrollPaddingRight; Style::BuilderGenerated::applyProperty

### DIFF
--- a/LayoutTests/fast/css/resolve-zero-length-with-infinite-zoom-factor-crash-expected.txt
+++ b/LayoutTests/fast/css/resolve-zero-length-with-infinite-zoom-factor-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/css/resolve-zero-length-with-infinite-zoom-factor-crash.html
+++ b/LayoutTests/fast/css/resolve-zero-length-with-infinite-zoom-factor-crash.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<style>
+  .scaled_up { zoom: 65536; }
+</style>
+<div class="scaled_up">
+  <div class="scaled_up">
+    <div class="scaled_up">
+      <div class="scaled_up">
+        <div class="scaled_up">
+          <div class="scaled_up">
+            <div class="scaled_up">
+              <div class="scaled_up">
+                <!-- Bug 295239 -->
+                <div style="-webkit-logical-height: 0px;"></div>
+                <div style="scroll-padding-right: 0px;"></div>
+
+                <!-- Bug 295240 -->
+                <div style="max-width: 0px;"></div>
+                <div style="flex-basis: 0px;"></div>
+
+                <!-- Bug 295241 -->
+                <div style="-webkit-padding-start: 0px;"></div>
+                <div style="-webkit-padding-end: 0px;"></div>
+                <div style="-webkit-padding-before: 0px;"></div>
+                <div style="-webkit-padding-after: 0px;"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<script>
+  onload = _ => {
+    window.testRunner?.dumpAsText();
+    document.body.innerHTML = "PASS if no crash."
+  }
+</script>

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -647,7 +647,7 @@ inline bool RenderStyle::setWritingMode(StyleWritingMode mode)
 
 inline bool RenderStyle::setZoom(float zoomLevel)
 {
-    setUsedZoom(std::max(std::numeric_limits<float>::epsilon(), usedZoom() * zoomLevel));
+    setUsedZoom(clampTo<float>(usedZoom() * zoomLevel, std::numeric_limits<float>::epsilon(), std::numeric_limits<float>::max()));
     if (compareEqual(m_nonInheritedData->rareData->zoom, zoomLevel))
         return false;
     m_nonInheritedData.access().rareData.access().zoom = zoomLevel;


### PR DESCRIPTION
#### 512db2970b3849fa5602ada60984e1d0eb4c0295
<pre>
ASAN_TRAP | Style::CSSValueConversion::operator; Style::BuilderFunctions::applyValueScrollPaddingRight; Style::BuilderGenerated::applyProperty
<a href="https://bugs.webkit.org/show_bug.cgi?id=295239">https://bugs.webkit.org/show_bug.cgi?id=295239</a>

Reviewed by Darin Adler and Ryosuke Niwa.

Adds a maximum value to the used zoom value (to go with the existing minimum value)
to avoid cases where the used zoom could become infinite, which would cause 0 length
values to become NaN (0.0 * +Infinity == NaN) when applying zoom in length resolution.

Adds an additional layer of protection to CSS numeric value clamping code, ensuring
all clamps ensure a finite value.

Test case by Frédéric Wang.

* LayoutTests/fast/css/resolve-zero-length-with-infinite-zoom-factor-crash-expected.txt: Added.
* LayoutTests/fast/css/resolve-zero-length-with-infinite-zoom-factor-crash.html: Added.
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:

Canonical link: <a href="https://commits.webkit.org/297165@main">https://commits.webkit.org/297165@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2f52029434d7e026502d71e9b4b3d5477193284

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110677 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30336 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20769 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116704 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60944 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112640 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31015 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38925 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84159 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113625 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24774 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99660 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64600 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24138 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17799 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60498 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94163 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17857 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119493 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37717 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28021 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93121 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38091 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95929 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92945 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23700 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37974 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15716 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33694 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37613 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43085 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37275 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40614 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38983 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->