### PR TITLE
[Liquid Glass] theguardian.com: scroll edge effect makes crossword puzzle hints unreadable on some iPhone models

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1647,6 +1647,14 @@ bool Quirks::needsChromeMediaControlsPseudoElement() const
 
 #if PLATFORM(IOS_FAMILY)
 
+bool Quirks::shouldHideSoftTopScrollEdgeEffectDuringFocus(const Element& focusedElement) const
+{
+    if (!needsQuirks() || !m_quirksData.shouldHideSoftTopScrollEdgeEffectDuringFocusQuirk)
+        return false;
+
+    return focusedElement.getIdAttribute().contains("crossword"_s);
+}
+
 // store.steampowered.com: rdar://142573562
 bool Quirks::shouldTreatAddingMouseOutEventListenerAsContentChange() const
 {
@@ -2206,6 +2214,14 @@ static void handleDisneyPlusQuirks(QuirksData& quirksData, const URL& quirksURL,
     // disneyplus rdar://151715964
     quirksData.needsZeroMaxTouchPointsQuirk = true;
 #endif
+}
+
+static void handleGuardianQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(quirksDomainString);
+    UNUSED_PARAM(documentURL);
+    quirksData.shouldHideSoftTopScrollEdgeEffectDuringFocusQuirk = true;
 }
 #endif // PLATFORM(IOS_FAMILY)
 
@@ -3001,6 +3017,7 @@ void Quirks::determineRelevantQuirks()
         { "state"_s, &handleCEACStateGovQuirks },
 #endif
 #if PLATFORM(IOS_FAMILY)
+        { "theguardian"_s, &handleGuardianQuirks },
         { "thesaurus"_s, &handleScriptToEvaluateBeforeRunningScriptFromURLQuirk },
 #endif
 #if PLATFORM(MAC)

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -243,6 +243,7 @@ public:
     WEBCORE_EXPORT bool shouldSynthesizeTouchEventsAfterNonSyntheticClick(const Element&) const;
     WEBCORE_EXPORT bool needsPointerTouchCompatibility(const Element&) const;
     bool shouldTreatAddingMouseOutEventListenerAsContentChange() const;
+    WEBCORE_EXPORT bool shouldHideSoftTopScrollEdgeEffectDuringFocus(const Element&) const;
 #endif
 
     bool needsMozillaFileTypeForDataTransfer() const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -140,6 +140,7 @@ struct WEBCORE_EXPORT QuirksData {
 
 #if PLATFORM(IOS_FAMILY)
     bool shouldHideCoarsePointerCharacteristicsQuirk : 1 { false };
+    bool shouldHideSoftTopScrollEdgeEffectDuringFocusQuirk : 1 { false };
 #endif
 
 #if ENABLE(FLIP_SCREEN_DIMENSIONS_QUIRKS)

--- a/Source/WebKit/Shared/FocusedElementInformation.h
+++ b/Source/WebKit/Shared/FocusedElementInformation.h
@@ -135,6 +135,7 @@ struct FocusedElementInformation {
     bool shouldAvoidResizingWhenInputViewBoundsChange { false };
     bool shouldAvoidScrollingWhenFocusedContentIsVisible { false };
     bool shouldUseLegacySelectPopoverDismissalBehaviorInDataActivation { false };
+    bool shouldHideSoftTopScrollEdgeEffect { false };
     bool isFocusingWithValidationMessage { false };
     bool preventScroll { false };
 

--- a/Source/WebKit/Shared/FocusedElementInformation.serialization.in
+++ b/Source/WebKit/Shared/FocusedElementInformation.serialization.in
@@ -103,6 +103,7 @@ enum class WebKit::InputType : uint8_t {
     bool shouldAvoidResizingWhenInputViewBoundsChange;
     bool shouldAvoidScrollingWhenFocusedContentIsVisible;
     bool shouldUseLegacySelectPopoverDismissalBehaviorInDataActivation;
+    bool shouldHideSoftTopScrollEdgeEffect;
     bool isFocusingWithValidationMessage;
     bool preventScroll;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -139,8 +139,9 @@ class WebViewImpl;
 class ViewGestureController;
 #endif
 enum class HideScrollPocketReason : uint8_t {
-    FullScreen      = 1 << 0,
-    ScrolledToTop   = 1 << 1,
+    FullScreen          = 1 << 0,
+    ScrolledToTop       = 1 << 1,
+    SiteSpecificQuirk   = 1 << 2,
 };
 }
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -2408,7 +2408,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         if ([_scrollView _wk_isScrolledBeyondTopExtent])
             return NO;
 
-        if ([[_scrollView topEdgeEffect].style isEqual:UIScrollEdgeEffectStyle.hardStyle])
+        if ([_scrollView _wk_usesHardTopScrollEdgeEffect])
             return NO;
 
         return [_scrollView contentOffset].y < 0;

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.h
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.h
@@ -45,6 +45,9 @@ enum class BoxSide : uint8_t;
 @property (readonly, nonatomic) CGFloat _wk_contentHeightIncludingInsets;
 @property (readonly, nonatomic) BOOL _wk_isScrollAnimating;
 @property (readonly, nonatomic) BOOL _wk_isZoomAnimating;
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+@property (readonly, nonatomic) BOOL _wk_usesHardTopScrollEdgeEffect;
+#endif
 - (void)_wk_setContentOffsetAndShowScrollIndicators:(CGPoint)offset animated:(BOOL)animated;
 - (void)_wk_setTransfersHorizontalScrollingToParent:(BOOL)value;
 - (void)_wk_setTransfersVerticalScrollingToParent:(BOOL)value;

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
@@ -224,6 +224,15 @@ static UIAxis axesForDelta(WebCore::FloatSize delta)
     [self _flashScrollIndicatorsForAxes:axes persistingPreviousFlashes:YES];
 }
 
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+
+- (BOOL)_wk_usesHardTopScrollEdgeEffect
+{
+    return [self.topEdgeEffect.style isEqual:UIScrollEdgeEffectStyle.hardStyle];
+}
+
+#endif
+
 @end
 
 @implementation UIView (WebKitInternal)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -8453,6 +8453,13 @@ static RetainPtr<NSObject <WKFormPeripheral>> createInputPeripheralWithView(WebK
     if (![self isFirstResponder])
         [self becomeFirstResponder];
 
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+    if (_focusedElementInformation.shouldHideSoftTopScrollEdgeEffect && ![[_webView scrollView] _wk_usesHardTopScrollEdgeEffect])
+        [_webView _addReasonToHideTopScrollPocket:WebKit::HideScrollPocketReason::SiteSpecificQuirk];
+    else
+        [_webView _removeReasonToHideTopScrollPocket:WebKit::HideScrollPocketReason::SiteSpecificQuirk];
+#endif
+
     if (!_suppressSelectionAssistantReasons && requiresKeyboard && activityStateChanges.contains(WebCore::ActivityState::IsFocused)) {
         _treatAsContentEditableUntilNextEditorStateUpdate = YES;
         [_textInteractionWrapper activateSelection];
@@ -8542,6 +8549,11 @@ static RetainPtr<NSObject <WKFormPeripheral>> createInputPeripheralWithView(WebK
 
     [self _endEditing];
 
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+    if (!_isChangingFocus)
+        [_webView _removeReasonToHideTopScrollPocket:WebKit::HideScrollPocketReason::SiteSpecificQuirk];
+#endif
+
     [_formInputSession invalidate];
     _formInputSession = nil;
 
@@ -8556,6 +8568,7 @@ static RetainPtr<NSObject <WKFormPeripheral>> createInputPeripheralWithView(WebK
     _focusedElementInformation.shouldSynthesizeKeyEventsForEditing = false;
     _focusedElementInformation.shouldAvoidResizingWhenInputViewBoundsChange = false;
     _focusedElementInformation.shouldAvoidScrollingWhenFocusedContentIsVisible = false;
+    _focusedElementInformation.shouldHideSoftTopScrollEdgeEffect = false;
     _focusedElementInformation.shouldUseLegacySelectPopoverDismissalBehaviorInDataActivation = false;
     _focusedElementInformation.isFocusingWithValidationMessage = false;
     _focusedElementInformation.preventScroll = false;

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -4350,6 +4350,7 @@ std::optional<FocusedElementInformation> WebPage::focusedElementInformation()
     information.shouldAvoidResizingWhenInputViewBoundsChange = quirks.shouldAvoidResizingWhenInputViewBoundsChange();
     information.shouldAvoidScrollingWhenFocusedContentIsVisible = quirks.shouldAvoidScrollingWhenFocusedContentIsVisible();
     information.shouldUseLegacySelectPopoverDismissalBehaviorInDataActivation = quirks.shouldUseLegacySelectPopoverDismissalBehaviorInDataActivation();
+    information.shouldHideSoftTopScrollEdgeEffect = quirks.shouldHideSoftTopScrollEdgeEffectDuringFocus(*focusedElement);
 
     return information;
 }


### PR DESCRIPTION
#### 5f9de3d7d20770fedf23d17e2471795515914eb9
<pre>
[Liquid Glass] theguardian.com: scroll edge effect makes crossword puzzle hints unreadable on some iPhone models
<a href="https://bugs.webkit.org/show_bug.cgi?id=295613">https://bugs.webkit.org/show_bug.cgi?id=295613</a>
<a href="https://rdar.apple.com/153818837">rdar://153818837</a>

Reviewed by Aditya Keerthi.

Add a site-specific quirk on `theguardian.*` to hide the top scroll edge effect when focusing on
input fields in a crossword puzzle. On smaller phones, this prevents the top scroll edge effect&apos;s
variable blur from extending down and overlapping the top hint text.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldHideSoftTopScrollEdgeEffectDuringFocus const):
(WebCore::handleGuardianQuirks):

Add support for the new quirk, based on the ID of the focused element.

(WebCore::Quirks::determineRelevantQuirks):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:
* Source/WebKit/Shared/FocusedElementInformation.h:
* Source/WebKit/Shared/FocusedElementInformation.serialization.in:

Add a flag that stores whether or not the top scroll pocket should be hidden when focusing this
element.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:

Add a new reason to hide the top scroll pocket — `SiteSpecificQuirk`. One flag should suffice for
now, assuming we don&apos;t end up with multiple site-specific quirks that need to be active at the same
time, on the same site.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _updateNeedsTopScrollPocketDueToVisibleContentInset]):
* Source/WebKit/UIProcess/ios/UIKitUtilities.h:
* Source/WebKit/UIProcess/ios/UIKitUtilities.mm:
(-[UIScrollView _wk_usesHardTopScrollEdgeEffect]):

Add a helper method to return whether or not the top scroll edge effect uses the hard scroll edge
effect style.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _continueElementDidFocus:requiresStrongPasswordAssistance:focusedElementInfo:activityStateChanges:restoreValues:]):
(-[WKContentView _elementDidBlur]):

Implement the main fix here, by adding or removing the new `SiteSpecificQuirk` reason based on the
value of `shouldHideSoftTopScrollEdgeEffect` from the incoming focused element info. We only remove
the hiding reason here if `!_isChangingFocus`, to prevent the reason flag from being thrashed
(removed and immediately re-introduced) in the case where we&apos;re moving from one quirked text input
to another.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::focusedElementInformation):

Canonical link: <a href="https://commits.webkit.org/297153@main">https://commits.webkit.org/297153@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7af6148f547840334b1eb7d221a0aa8abc8266e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110700 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30359 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116727 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60967 "Failed to checkout and rebase branch from PR 47749") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112663 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31038 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38948 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84176 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/60967 "Failed to checkout and rebase branch from PR 47749") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113648 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24795 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99685 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64617 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24160 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17823 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60521 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94185 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17882 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119517 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37740 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28043 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93138 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38114 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95953 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92962 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23690 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37994 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15740 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33718 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37636 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43108 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37298 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40637 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39006 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->