### PR TITLE
Update FloatRect::isNaN() to check y value

### DIFF
--- a/LayoutTests/fast/svg/line-NaN-bounding-box-crash-expected.txt
+++ b/LayoutTests/fast/svg/line-NaN-bounding-box-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it does not crash
+
+

--- a/LayoutTests/fast/svg/line-NaN-bounding-box-crash.html
+++ b/LayoutTests/fast/svg/line-NaN-bounding-box-crash.html
@@ -1,0 +1,21 @@
+<p>This test passes if it does not crash</p>
+<script>
+    if (testRunner)
+        testRunner.dumpAsText();
+</script>
+<head>
+    <style>
+        :read-only {
+            transform: rotate(90deg) skewX(90deg);
+        }
+    </style>
+</head>
+<body>
+    <svg width="200" height="200">
+        <line id="myline"
+              x1="0" y1="0"
+              x2="0" y2="0" 
+              stroke="green"
+              vector-effect="non-scaling-stroke" />
+    </svg>
+</body>

--- a/Source/WebCore/platform/graphics/FloatRect.h
+++ b/Source/WebCore/platform/graphics/FloatRect.h
@@ -353,7 +353,7 @@ constexpr FloatRect FloatRect::nanRect()
 
 constexpr bool FloatRect::isNaN() const
 {
-    return isNaNConstExpr(x());
+    return isNaNConstExpr(x()) || isNaNConstExpr(y());
 }
 
 inline void FloatRect::inflate(float deltaX, float deltaY, float deltaMaxX, float deltaMaxY)


### PR DESCRIPTION
#### 3836c5c786a295151b6ec22b967fba7ad827b5bd
<pre>
Update FloatRect::isNaN() to check y value
<a href="https://bugs.webkit.org/show_bug.cgi?id=295622">https://bugs.webkit.org/show_bug.cgi?id=295622</a>
<a href="https://rdar.apple.com/153081510">rdar://153081510</a>

Reviewed by Simon Fraser.

Handle edge case in LegacyRenderSVGShape::calculateStrokeBoundingBox()
where the stroke bounding rectagle has +Inf for the x-value and is not
caught by the check FloatRect::isNan(). Check the y-value to prevent
the crash identified in the <a href="https://rdar.apple.com/153081510">rdar://153081510</a>.

* LayoutTests/fast/svg/line-NaN-bounding-box-crash-expected.txt: Added.
* LayoutTests/fast/svg/line-NaN-bounding-box-crash.html: Added.
* Source/WebCore/platform/graphics/FloatRect.h:
(WebCore::FloatRect::isNaN const):

Canonical link: <a href="https://commits.webkit.org/297179@main">https://commits.webkit.org/297179@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/422f0308867f97f6ef754cda794c54da438d7360

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110703 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30362 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116730 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60970 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112666 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38951 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84180 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113651 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24798 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99690 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64621 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24163 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17828 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60524 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94188 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17887 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119520 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37743 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28046 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93145 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38117 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95958 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92969 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23710 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37997 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15745 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33721 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37639 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43111 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37301 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40640 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39009 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->