### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in WTF::HashSet

### DIFF
--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -730,11 +730,8 @@ public:
         }
         // Propagate closed variable candidates downwards within the same function.
         // Cross function captures will be realized via m_usedVariables propagation.
-        if (shouldTrackClosedVariables && !nestedScope->m_isFunctionBoundary && nestedScope->m_closedVariableCandidates.size()) {
-            auto end = nestedScope->m_closedVariableCandidates.end();
-            auto begin = nestedScope->m_closedVariableCandidates.begin();
-            m_closedVariableCandidates.add(begin, end);
-        }
+        if (shouldTrackClosedVariables && !nestedScope->m_isFunctionBoundary && nestedScope->m_closedVariableCandidates.size())
+            m_closedVariableCandidates.addAll(nestedScope->m_closedVariableCandidates);
     }
     
     void mergeInnerArrowFunctionFeatures(InnerArrowFunctionCodeFeatures arrowFunctionCodeFeatures)

--- a/Source/JavaScriptCore/yarr/YarrParser.h
+++ b/Source/JavaScriptCore/yarr/YarrParser.h
@@ -163,13 +163,13 @@ private:
 
         void nextAlternative()
         {
-            m_nestedCaptureGroupNames.last().formUnion(m_activeCaptureGroupNames.last());
+            m_nestedCaptureGroupNames.last().addAll(m_activeCaptureGroupNames.last());
             m_activeCaptureGroupNames.last().clear();
 
             // For nested parenthesis, we need to seed the new alternative with the already seen
             // named captures from the containing alternative.
             if (m_activeCaptureGroupNames.size() > 1)
-                m_activeCaptureGroupNames.last().formUnion(m_activeCaptureGroupNames[m_activeCaptureGroupNames.size() - 2]);
+                m_activeCaptureGroupNames.last().addAll(m_activeCaptureGroupNames[m_activeCaptureGroupNames.size() - 2]);
         }
 
         void pushParenthesis()
@@ -183,10 +183,10 @@ private:
         {
             ASSERT(m_nestedCaptureGroupNames.size() > 1);
             ASSERT(m_activeCaptureGroupNames.size() > 1);
-            m_nestedCaptureGroupNames.last().formUnion(m_activeCaptureGroupNames.last());
+            m_nestedCaptureGroupNames.last().addAll(m_activeCaptureGroupNames.last());
 
             // Add all the names seen in this parenthesis to the containing alternative.
-            m_activeCaptureGroupNames[m_activeCaptureGroupNames.size() - 2].formUnion(m_nestedCaptureGroupNames.last());
+            m_activeCaptureGroupNames[m_activeCaptureGroupNames.size() - 2].addAll(m_nestedCaptureGroupNames.last());
 
             m_nestedCaptureGroupNames.removeLast();
             m_activeCaptureGroupNames.removeLast();

--- a/Source/WTF/wtf/HashSet.h
+++ b/Source/WTF/wtf/HashSet.h
@@ -20,11 +20,8 @@
 
 #pragma once
 
-#include <wtf/Compiler.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 #include <initializer_list>
+#include <wtf/Compiler.h>
 #include <wtf/Forward.h>
 #include <wtf/GetPtr.h>
 #include <wtf/HashTable.h>
@@ -122,10 +119,10 @@ public:
 
     // Attempts to add a list of things to the set. Returns true if any of
     // them are new to the set. Returns false if the set is unchanged.
-    template<typename IteratorType>
-    bool add(IteratorType begin, IteratorType end);
-    template<typename IteratorType>
-    bool remove(IteratorType begin, IteratorType end);
+    template<typename ContainerType>
+    bool addAll(ContainerType&&);
+    template<typename ContainerType>
+    bool removeAll(const ContainerType&);
 
     bool remove(const ValueType&);
     bool remove(iterator);
@@ -162,10 +159,6 @@ public:
     // in the given collection, but not in both. (a.k.a. XOR).
     template<typename OtherCollection>
     HashSet symmetricDifferenceWith(const OtherCollection&) const;
-
-    // Adds the elements of the given collection to the set (a.k.a. OR).
-    template<typename OtherCollection>
-    void formUnion(const OtherCollection&);
 
     // Removes the elements of this set that are in the given collection (a.k.a. A - B).
     //
@@ -354,22 +347,22 @@ inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey
 }
 
 template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
-template<typename IteratorType>
-inline bool HashSet<T, U, V, W, shouldValidateKey>::add(IteratorType begin, IteratorType end)
+template<typename ContainerType>
+inline bool HashSet<T, U, V, W, shouldValidateKey>::addAll(ContainerType&& container)
 {
     bool changed = false;
-    for (IteratorType iter = begin; iter != end; ++iter)
-        changed |= add(*iter).isNewEntry;
+    for (auto&& item : std::forward<ContainerType>(container))
+        changed |= add(std::forward<decltype(item)>(item)).isNewEntry;
     return changed;
 }
 
 template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
-template<typename IteratorType>
-inline bool HashSet<T, U, V, W, shouldValidateKey>::remove(IteratorType begin, IteratorType end)
+template<typename ContainerType>
+inline bool HashSet<T, U, V, W, shouldValidateKey>::removeAll(const ContainerType& container)
 {
     bool changed = false;
-    for (IteratorType iter = begin; iter != end; ++iter)
-        changed |= remove(*iter);
+    for (auto& item : container)
+        changed |= remove(item);
     return changed;
 }
 
@@ -429,7 +422,7 @@ template<typename OtherCollection>
 inline auto HashSet<T, U, V, W, shouldValidateKey>::unionWith(const OtherCollection& other) const -> HashSet<T, U, V, W, shouldValidateKey>
 {
     auto copy = *this;
-    copy.add(other.begin(), other.end());
+    copy.addAll(other);
     return copy;
 }
 
@@ -464,13 +457,6 @@ inline auto HashSet<T, U, V, W, shouldValidateKey>::symmetricDifferenceWith(cons
     auto copy = *this;
     copy.formSymmetricDifference(other);
     return copy;
-}
-
-template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
-template<typename OtherCollection>
-inline void HashSet<T, U, V, W, shouldValidateKey>::formUnion(const OtherCollection& other)
-{
-    add(other.begin(), other.end());
 }
 
 template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
@@ -606,5 +592,3 @@ inline void HashSet<T, U, V, W, shouldValidateKey>::checkConsistency() const
 } // namespace WTF
 
 using WTF::HashSet;
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -371,7 +371,7 @@ void AXIsolatedTree::queueRemovalsLocked(Vector<AXID>&& subtreeRemovals)
     ASSERT(m_changeLogLock.isLocked());
 
     m_pendingSubtreeRemovals.appendVector(WTFMove(subtreeRemovals));
-    m_pendingProtectedFromDeletionIDs.formUnion(std::exchange(m_protectedFromDeletionIDs, { }));
+    m_pendingProtectedFromDeletionIDs.addAll(std::exchange(m_protectedFromDeletionIDs, { }));
 }
 
 void AXIsolatedTree::queueRemovalsAndUnresolvedChanges()
@@ -1482,7 +1482,7 @@ void AXIsolatedTree::queueNodeUpdate(AXID objectID, const NodeUpdateOptions& opt
 
         auto addResult = m_needsPropertyUpdates.add(objectID, options.properties);
         if (!addResult.isNewEntry)
-            addResult.iterator->value.formUnion(options.properties);
+            addResult.iterator->value.addAll(options.properties);
     }
 
     if (options.shouldUpdateChildren)

--- a/Source/WebCore/animation/BlendingKeyframes.cpp
+++ b/Source/WebCore/animation/BlendingKeyframes.cpp
@@ -204,7 +204,7 @@ void BlendingKeyframes::fillImplicitKeyframes(const KeyframeEffect& effect, cons
                 implicitZeroKeyframe = &keyframe;
         }
         if (keyframe.hasResolvedOffset())
-            expectedExplicitProperties.formUnion(keyframe.properties());
+            expectedExplicitProperties.addAll(keyframe.properties());
     }
 
     auto addImplicitKeyframe = [&](double key, const HashSet<AnimatableCSSProperty>& implicitProperties, const StyleRuleKeyframe& keyframeRule, BlendingKeyframe* existingImplicitBlendingKeyframe) {
@@ -398,9 +398,9 @@ void BlendingKeyframes::analyzeKeyframe(const BlendingKeyframe& keyframe)
     auto analyzeKeyframeForExplicitProperties = [&] {
         auto& properties = keyframe.properties();
         if (!keyframe.offset())
-            m_explicitFromProperties.add(properties.begin(), properties.end());
+            m_explicitFromProperties.addAll(properties);
         if (keyframe.offset() == 1)
-            m_explicitToProperties.add(properties.begin(), properties.end());
+            m_explicitToProperties.addAll(properties);
     };
 
     auto analyzeKeyframeRangeOffset = [&] {

--- a/Source/WebCore/animation/KeyframeEffectStack.cpp
+++ b/Source/WebCore/animation/KeyframeEffectStack.cpp
@@ -182,7 +182,7 @@ OptionSet<AnimationImpact> KeyframeEffectStack::applyKeyframeEffects(RenderStyle
                 timeline->animationTimingDidChange(animation.get());
         }
 
-        affectedProperties.formUnion(effect->animatedProperties());
+        affectedProperties.addAll(effect->animatedProperties());
     }
 
     return impact;
@@ -241,7 +241,7 @@ bool KeyframeEffectStack::allowsAcceleration() const
                 return false;
             }
         }
-        allAcceleratedProperties.add(acceleratedProperties.begin(), acceleratedProperties.end());
+        allAcceleratedProperties.addAll(acceleratedProperties);
     }
 
     return true;

--- a/Source/WebCore/contentextensions/CombinedURLFilters.cpp
+++ b/Source/WebCore/contentextensions/CombinedURLFilters.cpp
@@ -252,7 +252,7 @@ static void generateSuffixWithReverseSuffixTree(NFA& nfa, Vector<ActiveSubtree>&
     auto rootAddResult = reverseSuffixTreeRoots.add(hashableActionList, ReverseSuffixTreeVertex());
     if (rootAddResult.isNewEntry) {
         ImmutableCharNFANodeBuilder newNode(nfa);
-        newNode.setActions(actionList.begin(), actionList.end());
+        newNode.setActions(actionList);
         rootAddResult.iterator->value.nodeId = newNode.nodeId();
     }
 

--- a/Source/WebCore/contentextensions/ImmutableNFANodeBuilder.h
+++ b/Source/WebCore/contentextensions/ImmutableNFANodeBuilder.h
@@ -139,13 +139,13 @@ public:
         m_epsilonTransitionTargets.add(targetNodeId);
     }
 
-    template<typename ActionIterator>
-    void setActions(ActionIterator begin, ActionIterator end)
+    template<typename ActionContainer>
+    void setActions(const ActionContainer& actions)
     {
         ASSERT(!m_finalized);
         ASSERT(m_immutableNFA);
 
-        m_actions.add(begin, end);
+        m_actions.addAll(actions);
     }
 
     ImmutableNFANodeBuilder& operator=(ImmutableNFANodeBuilder&& other)

--- a/Source/WebCore/contentextensions/NFAToDFA.cpp
+++ b/Source/WebCore/contentextensions/NFAToDFA.cpp
@@ -90,7 +90,7 @@ static ALWAYS_INLINE void extendSetWithClosure(const NFANodeClosures& nfaNodeClo
     ASSERT(set.contains(nodeId));
     const UniqueNodeList& nodeClosure = nfaNodeClosures[nodeId];
     if (!nodeClosure.isEmpty())
-        set.add(nodeClosure.begin(), nodeClosure.end());
+        set.addAll(nodeClosure);
 }
 
 struct UniqueNodeIdSetImpl {
@@ -275,7 +275,7 @@ struct DataConverterWithEpsilonClosure {
         for (unsigned nodeId : iterable) {
             result.add(nodeId);
             const UniqueNodeList& nodeClosure = nfaNodeclosures[nodeId];
-            result.add(nodeClosure.begin(), nodeClosure.end());
+            result.addAll(nodeClosure);
         }
         return result;
     }
@@ -287,7 +287,7 @@ struct DataConverterWithEpsilonClosure {
             auto addResult = destination.add(nodeId);
             if (addResult.isNewEntry) {
                 const UniqueNodeList& nodeClosure = nfaNodeclosures[nodeId];
-                destination.add(nodeClosure.begin(), nodeClosure.end());
+                destination.addAll(nodeClosure);
             }
         }
     }

--- a/Source/WebCore/contentextensions/Term.h
+++ b/Source/WebCore/contentextensions/Term.h
@@ -384,7 +384,7 @@ inline ImmutableCharNFANodeBuilder Term::generateGraph(NFA& nfa, ImmutableCharNF
 {
     ImmutableCharNFANodeBuilder newEnd(nfa);
     generateGraph(nfa, source, newEnd.nodeId());
-    newEnd.setActions(finalActions.begin(), finalActions.end());
+    newEnd.setActions(finalActions);
     return newEnd;
 }
 

--- a/Source/WebCore/css/MutableStyleProperties.cpp
+++ b/Source/WebCore/css/MutableStyleProperties.cpp
@@ -289,7 +289,7 @@ bool MutableStyleProperties::removeProperties(std::span<const CSSPropertyID> pro
 
     // FIXME: This is always used with static sets and in that case constructing the hash repeatedly is pretty pointless.
     HashSet<CSSPropertyID> toRemove;
-    toRemove.add(properties.begin(), properties.end());
+    toRemove.addAll(properties);
 
     return m_propertyVector.removeAllMatching([&toRemove](const CSSProperty& property) {
         return toRemove.contains(property.id());

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -305,7 +305,7 @@ static constexpr std::array supportedTypesOESTextureHalfFloat {
 };
 
 #define ADD_VALUES_TO_SET(set, array) \
-    set.add(std::begin(array), std::end(array))
+    set.addAll(array)
 
 // Counter for determining which context has the earliest active ordinal number.
 static std::atomic<uint64_t> s_lastActiveOrdinal;

--- a/Source/WebCore/loader/CanvasActivityRecord.cpp
+++ b/Source/WebCore/loader/CanvasActivityRecord.cpp
@@ -40,7 +40,7 @@ bool CanvasActivityRecord::recordWrittenOrMeasuredText(const String& text)
 
 void CanvasActivityRecord::mergeWith(const CanvasActivityRecord& otherCanvasActivityRecord)
 {
-    textWritten.add(otherCanvasActivityRecord.textWritten.begin(), otherCanvasActivityRecord.textWritten.end());
+    textWritten.addAll(otherCanvasActivityRecord.textWritten);
     wasDataRead |= otherCanvasActivityRecord.wasDataRead;
 }
 } // namespace WebCore

--- a/Source/WebCore/page/ElementTargetingController.cpp
+++ b/Source/WebCore/page/ElementTargetingController.cpp
@@ -906,7 +906,7 @@ Vector<ElementIdentifier> ElementTargetingController::topologicallySortElements(
     HashSet<ElementIdentifier> unprocessedIDs;
 
     const auto elementIDs = elementIDToOccludedElementIDs.keys();
-    unprocessedIDs.add(elementIDs.begin(), elementIDs.end());
+    unprocessedIDs.addAll(elementIDs);
 
     while (!unprocessedIDs.isEmpty() || !processingIDs.isEmpty()) {
         if (unprocessedIDs.isEmpty()) {

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -248,7 +248,7 @@ void ContentSecurityPolicy::didReceiveHeaders(const ContentSecurityPolicy& other
     m_referrer = other.m_referrer;
     m_httpStatusCode = other.m_httpStatusCode;
     m_upgradeInsecureRequests = other.m_upgradeInsecureRequests;
-    m_insecureNavigationRequestsToUpgrade.add(other.m_insecureNavigationRequestsToUpgrade.begin(), other.m_insecureNavigationRequestsToUpgrade.end());
+    m_insecureNavigationRequestsToUpgrade.addAll(other.m_insecureNavigationRequestsToUpgrade);
 }
 
 void ContentSecurityPolicy::didReceiveHeader(const String& header, ContentSecurityPolicyHeaderType type, ContentSecurityPolicy::PolicyFrom policyFrom, String&& referrer, int httpStatusCode)
@@ -1220,7 +1220,7 @@ void ContentSecurityPolicy::setUpgradeInsecureRequests(bool upgradeInsecureReque
 
 void ContentSecurityPolicy::inheritInsecureNavigationRequestsToUpgradeFromOpener(const ContentSecurityPolicy& other)
 {
-    m_insecureNavigationRequestsToUpgrade.add(other.m_insecureNavigationRequestsToUpgrade.begin(), other.m_insecureNavigationRequestsToUpgrade.end());
+    m_insecureNavigationRequestsToUpgrade.addAll(other.m_insecureNavigationRequestsToUpgrade);
 }
 
 HashSet<SecurityOriginData> ContentSecurityPolicy::takeNavigationRequestsToUpgrade()

--- a/Source/WebCore/page/mac/ServicesOverlayController.h
+++ b/Source/WebCore/page/mac/ServicesOverlayController.h
@@ -74,7 +74,7 @@ private:
     void invalidateHighlightsOfType(DataDetectorHighlight::Type);
     void buildPotentialHighlightsIfNeeded();
 
-    void replaceHighlightsOfTypePreservingEquivalentHighlights(HashSet<RefPtr<DataDetectorHighlight>>&, DataDetectorHighlight::Type);
+    void replaceHighlightsOfTypePreservingEquivalentHighlights(HashSet<RefPtr<DataDetectorHighlight>>&&, DataDetectorHighlight::Type);
     void removeAllPotentialHighlightsOfType(DataDetectorHighlight::Type);
     void buildPhoneNumberHighlights();
     void buildSelectionHighlight();

--- a/Source/WebCore/page/mac/ServicesOverlayController.mm
+++ b/Source/WebCore/page/mac/ServicesOverlayController.mm
@@ -399,7 +399,7 @@ void ServicesOverlayController::buildPhoneNumberHighlights()
         newPotentialHighlights.add(WTFMove(highlight));
     }
 
-    replaceHighlightsOfTypePreservingEquivalentHighlights(newPotentialHighlights, DataDetectorHighlight::Type::TelephoneNumber);
+    replaceHighlightsOfTypePreservingEquivalentHighlights(WTFMove(newPotentialHighlights), DataDetectorHighlight::Type::TelephoneNumber);
 }
 
 void ServicesOverlayController::buildSelectionHighlight()
@@ -439,10 +439,10 @@ void ServicesOverlayController::buildSelectionHighlight()
         }
     }
 
-    replaceHighlightsOfTypePreservingEquivalentHighlights(newPotentialHighlights, DataDetectorHighlight::Type::Selection);
+    replaceHighlightsOfTypePreservingEquivalentHighlights(WTFMove(newPotentialHighlights), DataDetectorHighlight::Type::Selection);
 }
 
-void ServicesOverlayController::replaceHighlightsOfTypePreservingEquivalentHighlights(HashSet<RefPtr<DataDetectorHighlight>>& newPotentialHighlights, DataDetectorHighlight::Type type)
+void ServicesOverlayController::replaceHighlightsOfTypePreservingEquivalentHighlights(HashSet<RefPtr<DataDetectorHighlight>>&& newPotentialHighlights, DataDetectorHighlight::Type type)
 {
     // If any old Highlights are equivalent (by Range) to a new Highlight, reuse the old
     // one so that any metadata is retained.
@@ -466,8 +466,8 @@ void ServicesOverlayController::replaceHighlightsOfTypePreservingEquivalentHighl
 
     removeAllPotentialHighlightsOfType(type);
 
-    m_potentialHighlights.add(newPotentialHighlights.begin(), newPotentialHighlights.end());
-    m_potentialHighlights.add(reusedPotentialHighlights.begin(), reusedPotentialHighlights.end());
+    m_potentialHighlights.addAll(WTFMove(newPotentialHighlights));
+    m_potentialHighlights.addAll(WTFMove(reusedPotentialHighlights));
 }
 
 bool ServicesOverlayController::hasRelevantSelectionServices()

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -1245,7 +1245,7 @@ void MediaPlayer::getSupportedTypes(HashSet<String>& types)
     for (auto& engine : installedMediaEngines()) {
         HashSet<String> engineTypes;
         engine->getSupportedTypes(engineTypes);
-        types.add(engineTypes.begin(), engineTypes.end());
+        types.addAll(WTFMove(engineTypes));
     }
 } 
 
@@ -1405,7 +1405,7 @@ static void addToHash(HashSet<T>& toHash, HashSet<T>&& fromHash)
     if (toHash.isEmpty())
         toHash = WTFMove(fromHash);
     else
-        toHash.add(fromHash.begin(), fromHash.end());
+        toHash.addAll(WTFMove(fromHash));
 }
     
 HashSet<SecurityOriginData> MediaPlayer::originsInMediaCache(const String& path)

--- a/Source/WebCore/platform/graphics/cg/UTIRegistry.mm
+++ b/Source/WebCore/platform/graphics/cg/UTIRegistry.mm
@@ -152,7 +152,7 @@ void setAdditionalSupportedImageTypes(const Vector<String>& imageTypes)
     for (const auto& imageType : imageTypes) {
         additionalSupportedImageTypes().add(imageType);
         auto mimeTypes = RequiredMIMETypesFromUTI(imageType);
-        MIMETypeRegistry::additionalSupportedImageMIMETypes().add(mimeTypes.begin(), mimeTypes.end());
+        MIMETypeRegistry::additionalSupportedImageMIMETypes().addAll(WTFMove(mimeTypes));
     }
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -168,10 +168,8 @@ MediaPlayerPrivateWebM::~MediaPlayerPrivateWebM()
 static HashSet<String>& mimeTypeCache()
 {
     static NeverDestroyed cache = HashSet<String>();
-    if (cache->isEmpty()) {
-        auto types = SourceBufferParserWebM::supportedMIMETypes();
-        cache->add(types.begin(), types.end());
-    }
+    if (cache->isEmpty())
+        cache->addAll(SourceBufferParserWebM::supportedMIMETypes());
     return cache;
 }
 

--- a/Source/WebCore/platform/network/NetworkStorageSession.cpp
+++ b/Source/WebCore/platform/network/NetworkStorageSession.cpp
@@ -269,7 +269,7 @@ void NetworkStorageSession::setAgeCapForClientSideCookies(std::optional<Seconds>
 void NetworkStorageSession::setPrevalentDomainsToBlockAndDeleteCookiesFor(const Vector<RegistrableDomain>& domains)
 {
     m_registrableDomainsToBlockAndDeleteCookiesFor.clear();
-    m_registrableDomainsToBlockAndDeleteCookiesFor.add(domains.begin(), domains.end());
+    m_registrableDomainsToBlockAndDeleteCookiesFor.addAll(domains);
     if (m_thirdPartyCookieBlockingMode == ThirdPartyCookieBlockingMode::OnlyAccordingToPerDomainPolicy)
         cookieEnabledStateMayHaveChanged();
 }
@@ -277,7 +277,7 @@ void NetworkStorageSession::setPrevalentDomainsToBlockAndDeleteCookiesFor(const 
 void NetworkStorageSession::setPrevalentDomainsToBlockButKeepCookiesFor(const Vector<RegistrableDomain>& domains)
 {
     m_registrableDomainsToBlockButKeepCookiesFor.clear();
-    m_registrableDomainsToBlockButKeepCookiesFor.add(domains.begin(), domains.end());
+    m_registrableDomainsToBlockButKeepCookiesFor.addAll(domains);
     if (m_thirdPartyCookieBlockingMode == ThirdPartyCookieBlockingMode::OnlyAccordingToPerDomainPolicy)
         cookieEnabledStateMayHaveChanged();
 }
@@ -285,7 +285,7 @@ void NetworkStorageSession::setPrevalentDomainsToBlockButKeepCookiesFor(const Ve
 void NetworkStorageSession::setDomainsWithUserInteractionAsFirstParty(const Vector<RegistrableDomain>& domains)
 {
     m_registrableDomainsWithUserInteractionAsFirstParty.clear();
-    m_registrableDomainsWithUserInteractionAsFirstParty.add(domains.begin(), domains.end());
+    m_registrableDomainsWithUserInteractionAsFirstParty.addAll(domains);
     if (m_thirdPartyCookieBlockingMode == ThirdPartyCookieBlockingMode::AllOnSitesWithoutUserInteraction)
         cookieEnabledStateMayHaveChanged();
 }

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -474,11 +474,11 @@ void RuleFeatureSet::collectFeatures(const RuleData& ruleData, const Vector<Ref<
 
 void RuleFeatureSet::add(const RuleFeatureSet& other)
 {
-    idsInRules.add(other.idsInRules.begin(), other.idsInRules.end());
-    idsMatchingAncestorsInRules.add(other.idsMatchingAncestorsInRules.begin(), other.idsMatchingAncestorsInRules.end());
-    attributeLowercaseLocalNamesInRules.add(other.attributeLowercaseLocalNamesInRules.begin(), other.attributeLowercaseLocalNamesInRules.end());
-    attributeLocalNamesInRules.add(other.attributeLocalNamesInRules.begin(), other.attributeLocalNamesInRules.end());
-    contentAttributeNamesInRules.add(other.contentAttributeNamesInRules.begin(), other.contentAttributeNamesInRules.end());
+    idsInRules.addAll(other.idsInRules);
+    idsMatchingAncestorsInRules.addAll(other.idsMatchingAncestorsInRules);
+    attributeLowercaseLocalNamesInRules.addAll(other.attributeLowercaseLocalNamesInRules);
+    attributeLocalNamesInRules.addAll(other.attributeLocalNamesInRules);
+    contentAttributeNamesInRules.addAll(other.contentAttributeNamesInRules);
 
     auto addMap = [&](auto& map, auto& otherMap) {
         for (auto& keyValuePair : otherMap) {
@@ -491,14 +491,14 @@ void RuleFeatureSet::add(const RuleFeatureSet& other)
     addMap(idRules, other.idRules);
 
     addMap(classRules, other.classRules);
-    classesAffectingHost.add(other.classesAffectingHost.begin(), other.classesAffectingHost.end());
+    classesAffectingHost.addAll(other.classesAffectingHost);
 
     addMap(attributeRules, other.attributeRules);
-    attributesAffectingHost.add(other.attributesAffectingHost.begin(), other.attributesAffectingHost.end());
+    attributesAffectingHost.addAll(other.attributesAffectingHost);
 
     addMap(pseudoClassRules, other.pseudoClassRules);
-    pseudoClassesAffectingHost.add(other.pseudoClassesAffectingHost.begin(), other.pseudoClassesAffectingHost.end());
-    pseudoClasses.add(other.pseudoClasses.begin(), other.pseudoClasses.end());
+    pseudoClassesAffectingHost.addAll(other.pseudoClassesAffectingHost);
+    pseudoClasses.addAll(other.pseudoClasses);
 
     addMap(hasPseudoClassRules, other.hasPseudoClassRules);
     scopeBreakingHasPseudoClassRules.appendVector(other.scopeBreakingHasPseudoClassRules);

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -266,7 +266,7 @@ void Builder::applyCustomPropertyImpl(const AtomString& name, const PropertyCasc
 
     AtomString takenName = m_state.m_inProgressCustomProperties.take(name);
     m_state.m_appliedCustomProperties.add(WTFMove(takenName));
-    m_state.m_inCycleCustomProperties.formUnion(savedInCycleProperties);
+    m_state.m_inCycleCustomProperties.addAll(WTFMove(savedInCycleProperties));
 }
 
 inline void Builder::applyCascadeProperty(const PropertyCascade::Property& property)

--- a/Source/WebCore/workers/service/server/SWServerRegistration.cpp
+++ b/Source/WebCore/workers/service/server/SWServerRegistration.cpp
@@ -429,12 +429,12 @@ std::optional<ExceptionData> SWServerRegistration::setNavigationPreloadHeaderVal
 
 void SWServerRegistration::addCookieChangeSubscriptions(Vector<CookieChangeSubscription>&& subscriptions)
 {
-    m_cookieChangeSubscriptions.add(subscriptions.begin(), subscriptions.end());
+    m_cookieChangeSubscriptions.addAll(WTFMove(subscriptions));
 }
 
 void SWServerRegistration::removeCookieChangeSubscriptions(Vector<CookieChangeSubscription>&& subscriptions)
 {
-    m_cookieChangeSubscriptions.remove(subscriptions.begin(), subscriptions.end());
+    m_cookieChangeSubscriptions.removeAll(subscriptions);
 }
 
 Vector<CookieChangeSubscription> SWServerRegistration::cookieChangeSubscriptions() const

--- a/Source/WebKit/GPUProcess/media/RemoteRemoteCommandListenerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteRemoteCommandListenerProxy.cpp
@@ -51,7 +51,7 @@ RemoteRemoteCommandListenerProxy::~RemoteRemoteCommandListenerProxy() = default;
 void RemoteRemoteCommandListenerProxy::updateSupportedCommands(Vector<WebCore::PlatformMediaSession::RemoteControlCommandType>&& registeredCommands, bool supportsSeeking)
 {
     m_supportedCommands.clear();
-    m_supportedCommands.add(registeredCommands.begin(), registeredCommands.end());
+    m_supportedCommands.addAll(WTFMove(registeredCommands));
     m_supportsSeeking = supportsSeeking;
 
     if (auto connection = m_gpuConnection.get())

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -1428,12 +1428,12 @@ void NetworkStorageManager::registerTemporaryBlobFilePaths(IPC::Connection& conn
     ASSERT(RunLoop::isMain());
     ASSERT(!m_closed);
 
-    workQueue().dispatch([this, protectedThis = Ref { *this }, connectionID = connection.uniqueID(), filePaths = crossThreadCopy(filePaths)] {
+    workQueue().dispatch([this, protectedThis = Ref { *this }, connectionID = connection.uniqueID(), filePaths = crossThreadCopy(filePaths)]() mutable {
         assertIsCurrent(workQueue());
         auto& temporaryBlobPaths = m_temporaryBlobPathsByConnection.ensure(connectionID, [] {
             return HashSet<String> { };
         }).iterator->value;
-        temporaryBlobPaths.add(filePaths.begin(), filePaths.end());
+        temporaryBlobPaths.addAll(WTFMove(filePaths));
     });
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
@@ -272,7 +272,7 @@ UIScrollView *findActingScrollParent(UIScrollView *scrollView, const RemoteLayer
                     return scrollView;
             }
 
-            scrollersToSkip.add(node->stationaryScrollContainerIDs().begin(), node->stationaryScrollContainerIDs().end());
+            scrollersToSkip.addAll(node->stationaryScrollContainerIDs());
         }
     }
     return nil;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -16443,7 +16443,7 @@ void WebPageProxy::adjustVisibilityForTargetedElements(const Vector<Ref<API::Tar
             info->selectors().map([](auto& selectors) {
                 HashSet<String> result;
                 result.reserveInitialCapacity(selectors.size());
-                result.add(selectors.begin(), selectors.end());
+                result.addAll(selectors);
                 return result;
             })
         };

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
@@ -185,8 +185,8 @@ bool WebExtensionAPIPermissions::verifyRequestedPermissions(HashSet<String>& per
         }
     }
 
-    allowedPermissions.add(extension->optionalPermissions().begin(), extension->optionalPermissions().end());
-    allowedHostPermissions.add(extension->optionalPermissionMatchPatterns().begin(), extension->optionalPermissionMatchPatterns().end());
+    allowedPermissions.addAll(extension->optionalPermissions());
+    allowedHostPermissions.addAll(extension->optionalPermissionMatchPatterns());
 
     bool requestingPermissionsNotDeclaredInManifest = (permissions.size() && !permissions.isSubset(allowedPermissions)) || (matchPatterns.size() && !allowedHostPermissions.size());
     if (requestingPermissionsNotDeclaredInManifest) {

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp
@@ -47,7 +47,7 @@ RemoteMediaPlayerMIMETypeCache::RemoteMediaPlayerMIMETypeCache(RemoteMediaPlayer
 
 void RemoteMediaPlayerMIMETypeCache::addSupportedTypes(const Vector<String>& newTypes)
 {
-    m_supportedTypesCache.add(newTypes.begin(), newTypes.end());
+    m_supportedTypesCache.addAll(newTypes);
 }
 
 bool RemoteMediaPlayerMIMETypeCache::isEmpty() const

--- a/Tools/TestWebKitAPI/Tests/WTF/HashSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/HashSet.cpp
@@ -619,43 +619,43 @@ TEST(WTF_HashSet, FormUnion)
 
     {
         auto result = emptySet;
-        result.formUnion(set1);
+        result.addAll(set1);
         EXPECT_EQ(result, set1);
     }
 
     {
         auto result = set1;
-        result.formUnion(emptySet);
+        result.addAll(emptySet);
         EXPECT_EQ(result, set1);
     }
 
     {
         auto result = emptySet;
-        result.formUnion(emptySet);
+        result.addAll(emptySet);
         EXPECT_EQ(result, emptySet);
     }
 
     {
         auto result = set1;
-        result.formUnion(set1);
+        result.addAll(set1);
         EXPECT_EQ(result, set1);
     }
 
     {
         auto result = set1;
-        result.formUnion(set2);
+        result.addAll(set2);
         EXPECT_EQ(result, set3);
     }
 
     {
         auto result = set2;
-        result.formUnion(set1);
+        result.addAll(set1);
         EXPECT_EQ(result, set3);
     }
 
     {
         auto result = set1;
-        result.formUnion(sequence);
+        result.addAll(sequence);
         EXPECT_EQ(result, set3);
     }
 }


### PR DESCRIPTION
#### 432b319392e8baf556f4cbd4842b426e452f06a1
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in WTF::HashSet
<a href="https://bugs.webkit.org/show_bug.cgi?id=295643">https://bugs.webkit.org/show_bug.cgi?id=295643</a>

Reviewed by Justin Michaud.

* Source/JavaScriptCore/parser/Parser.h:
(JSC::Scope::collectFreeVariables):
* Source/JavaScriptCore/yarr/YarrParser.h:
(JSC::Yarr::Parser::NamedCaptureGroups::nextAlternative):
(JSC::Yarr::Parser::NamedCaptureGroups::popParenthesis):
* Source/WTF/wtf/HashSet.h:
(WTF::shouldValidateKey&gt;::addAll):
(WTF::shouldValidateKey&gt;::removeAll):
(WTF::shouldValidateKey&gt;::unionWith const):
(WTF::shouldValidateKey&gt;::formUnion): Deleted.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::queueRemovalsLocked):
(WebCore::AXIsolatedTree::queueNodeUpdate):
* Source/WebCore/animation/BlendingKeyframes.cpp:
(WebCore::BlendingKeyframes::fillImplicitKeyframes):
(WebCore::BlendingKeyframes::analyzeKeyframe):
* Source/WebCore/animation/KeyframeEffectStack.cpp:
(WebCore::KeyframeEffectStack::applyKeyframeEffects):
(WebCore::KeyframeEffectStack::allowsAcceleration const):
* Source/WebCore/contentextensions/CombinedURLFilters.cpp:
(WebCore::ContentExtensions::generateSuffixWithReverseSuffixTree):
* Source/WebCore/contentextensions/ImmutableNFANodeBuilder.h:
(WebCore::ContentExtensions::ImmutableNFANodeBuilder::setActions):
* Source/WebCore/contentextensions/NFAToDFA.cpp:
(WebCore::ContentExtensions::extendSetWithClosure):
(WebCore::ContentExtensions::DataConverterWithEpsilonClosure::convert):
(WebCore::ContentExtensions::DataConverterWithEpsilonClosure::extend):
* Source/WebCore/contentextensions/Term.h:
(WebCore::ContentExtensions::Term::generateGraph const):
* Source/WebCore/css/MutableStyleProperties.cpp:
(WebCore::MutableStyleProperties::removeProperties):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
* Source/WebCore/loader/CanvasActivityRecord.cpp:
(WebCore::CanvasActivityRecord::mergeWith):
* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::ElementTargetingController::topologicallySortElements):
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::didReceiveHeaders):
(WebCore::ContentSecurityPolicy::inheritInsecureNavigationRequestsToUpgradeFromOpener):
* Source/WebCore/page/mac/ServicesOverlayController.h:
* Source/WebCore/page/mac/ServicesOverlayController.mm:
(WebCore::ServicesOverlayController::buildPhoneNumberHighlights):
(WebCore::ServicesOverlayController::buildSelectionHighlight):
(WebCore::ServicesOverlayController::replaceHighlightsOfTypePreservingEquivalentHighlights):
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::getSupportedTypes):
(WebCore::addToHash):
* Source/WebCore/platform/graphics/cg/UTIRegistry.mm:
(WebCore::setAdditionalSupportedImageTypes):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::mimeTypeCache):
* Source/WebCore/platform/network/NetworkStorageSession.cpp:
(WebCore::NetworkStorageSession::setPrevalentDomainsToBlockAndDeleteCookiesFor):
(WebCore::NetworkStorageSession::setPrevalentDomainsToBlockButKeepCookiesFor):
(WebCore::NetworkStorageSession::setDomainsWithUserInteractionAsFirstParty):
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::RuleFeatureSet::add):
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyCustomPropertyImpl):
* Source/WebCore/workers/service/server/SWServerRegistration.cpp:
(WebCore::SWServerRegistration::addCookieChangeSubscriptions):
(WebCore::SWServerRegistration::removeCookieChangeSubscriptions):
* Source/WebKit/GPUProcess/media/RemoteRemoteCommandListenerProxy.cpp:
(WebKit::RemoteRemoteCommandListenerProxy::updateSupportedCommands):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::registerTemporaryBlobFilePaths):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm:
(WebKit::findActingScrollParent):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::adjustVisibilityForTargetedElements):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm:
(WebKit::WebExtensionAPIPermissions::verifyRequestedPermissions):
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp:
(WebKit::RemoteMediaPlayerMIMETypeCache::addSupportedTypes):
* Tools/TestWebKitAPI/Tests/WTF/HashSet.cpp:
(TestWebKitAPI::TEST(WTF_HashSet, FormUnion)):

Canonical link: <a href="https://commits.webkit.org/297196@main">https://commits.webkit.org/297196@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b25b534225c8467026320c0d1f518ce7e4afc39

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110776 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20871 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116805 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61044 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112739 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31119 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39025 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84239 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113724 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24863 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99758 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64680 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24230 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17894 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60598 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/103268 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94256 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17954 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119595 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109330 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37821 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28112 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93198 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38197 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96025 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93022 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23716 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38054 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15806 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33795 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37714 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43184 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/133605 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37375 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36084 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40713 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39082 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->