### PR TITLE
[Style] Convert clip to use strong style types

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2789,6 +2789,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     style/values/inline/StyleLineBoxContain.h
 
+    style/values/masking/StyleClip.h
     style/values/masking/StyleClipPath.h
 
     style/values/motion/StyleOffsetDistance.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3180,6 +3180,7 @@ style/values/flexbox/StyleFlexBasis.cpp
 style/values/grid/StyleGridNamedLinesMap.cpp
 style/values/grid/StyleGridTemplateAreas.cpp
 style/values/images/StyleGradient.cpp
+style/values/masking/StyleClip.cpp
 style/values/masking/StyleClipPath.cpp
 style/values/motion/StyleOffsetAnchor.cpp
 style/values/motion/StyleOffsetPath.cpp

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -3888,10 +3888,8 @@
             ],
             "codegen-properties": {
                 "accepts-quirky-length": true,
-                "animation-wrapper": "ClipWrapper",
-                "animation-wrapper-requires-override-parameters": [],
-                "style-builder-custom": "All",
-                "style-extractor-custom": true,
+                "animation-wrapper": "StyleTypeWrapper",
+                "style-converter": "StyleType<Clip>",
                 "parser-grammar": "<rect()> | auto"
             },
             "specification": {

--- a/Source/WebCore/css/values/CSSValueAggregates.h
+++ b/Source/WebCore/css/values/CSSValueAggregates.h
@@ -801,6 +801,43 @@ template<size_t I, typename T> const auto& get(const SpaceSeparatedRectEdges<T>&
 template<typename T> inline constexpr auto TreatAsTupleLike<SpaceSeparatedRectEdges<T>> = true;
 template<typename T> inline constexpr auto SerializationSeparator<SpaceSeparatedRectEdges<T>> = SerializationSeparatorType::Space;
 
+// Wraps a quad of elements of a single type representing the edges of a rect, semantically marking them as serializing as "comma separated".
+template<typename T> struct CommaSeparatedRectEdges : RectEdges<T> {
+    using value_type = T;
+
+    constexpr CommaSeparatedRectEdges(T repeat)
+        : RectEdges<T> { repeat, repeat, repeat, repeat }
+    {
+    }
+
+    constexpr CommaSeparatedRectEdges(T top, T right, T bottom, T left)
+        : RectEdges<T> { WTFMove(top), WTFMove(right), WTFMove(bottom), WTFMove(left) }
+    {
+    }
+
+    constexpr CommaSeparatedRectEdges(RectEdges<T>&& rectEdges)
+        : RectEdges<T> { WTFMove(rectEdges) }
+    {
+    }
+
+    constexpr bool operator==(const CommaSeparatedRectEdges<T>&) const = default;
+};
+
+template<size_t I, typename T> const auto& get(const CommaSeparatedRectEdges<T>& rectEdges)
+{
+    if constexpr (!I)
+        return rectEdges.top();
+    else if constexpr (I == 1)
+        return rectEdges.right();
+    else if constexpr (I == 2)
+        return rectEdges.bottom();
+    else if constexpr (I == 3)
+        return rectEdges.left();
+}
+
+template<typename T> inline constexpr auto TreatAsTupleLike<CommaSeparatedRectEdges<T>> = true;
+template<typename T> inline constexpr auto SerializationSeparator<CommaSeparatedRectEdges<T>> = SerializationSeparatorType::Comma;
+
 
 // A set of 4 values parsed and interpreted in the same manner as defined for the margin shorthand.
 //
@@ -1016,6 +1053,12 @@ public:
 
 template<typename T> class tuple_size<WebCore::SpaceSeparatedRectEdges<T>> : public std::integral_constant<size_t, 4> { };
 template<size_t I, typename T> class tuple_element<I, WebCore::SpaceSeparatedRectEdges<T>> {
+public:
+    using type = T;
+};
+
+template<typename T> class tuple_size<WebCore::CommaSeparatedRectEdges<T>> : public std::integral_constant<size_t, 4> { };
+template<size_t I, typename T> class tuple_element<I, WebCore::CommaSeparatedRectEdges<T>> {
 public:
     using type = T;
 };

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -2123,8 +2123,9 @@ void RenderLayerCompositor::logLayerInfo(const RenderLayer& layer, ASCIILiteral 
 
 static bool clippingChanged(const RenderStyle& oldStyle, const RenderStyle& newStyle)
 {
-    return oldStyle.overflowX() != newStyle.overflowX() || oldStyle.overflowY() != newStyle.overflowY()
-        || oldStyle.hasClip() != newStyle.hasClip() || oldStyle.clip() != newStyle.clip();
+    return oldStyle.overflowX() != newStyle.overflowX()
+        || oldStyle.overflowY() != newStyle.overflowY()
+        || oldStyle.clip() != newStyle.clip();
 }
 
 static bool styleAffectsLayerGeometry(const RenderStyle& style)

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1202,7 +1202,7 @@ bool RenderStyle::changeRequiresLayerRepaint(const RenderStyle& other, OptionSet
 
         if (position() != PositionType::Static) {
             if (m_nonInheritedData->rareData.ptr() != other.m_nonInheritedData->rareData.ptr()) {
-                if (m_nonInheritedData->rareData->clip != other.m_nonInheritedData->rareData->clip || m_nonInheritedData->rareData->hasClip != other.m_nonInheritedData->rareData->hasClip) {
+                if (m_nonInheritedData->rareData->clip != other.m_nonInheritedData->rareData->clip) {
                     changedContextSensitiveProperties.add(StyleDifferenceContextSensitiveProperty::ClipRect);
                     return true;
                 }
@@ -1920,6 +1920,8 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
             changingProperties.m_properties.set(CSSPropertyShapeImageThreshold);
         if (first.perspective != second.perspective)
             changingProperties.m_properties.set(CSSPropertyPerspective);
+        if (first.clip != second.clip)
+            changingProperties.m_properties.set(CSSPropertyClip);
         if (first.clipPath != second.clipPath)
             changingProperties.m_properties.set(CSSPropertyClipPath);
         if (first.textDecorationColor != second.textDecorationColor)
@@ -1978,8 +1980,6 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
             changingProperties.m_properties.set(CSSPropertyTextBoxTrim);
         if (first.overflowAnchor != second.overflowAnchor)
             changingProperties.m_properties.set(CSSPropertyOverflowAnchor);
-        if (first.hasClip != second.hasClip)
-            changingProperties.m_properties.set(CSSPropertyClip);
         if (first.viewTransitionClasses != second.viewTransitionClasses)
             changingProperties.m_properties.set(CSSPropertyViewTransitionClass);
         if (first.viewTransitionName != second.viewTransitionName)
@@ -2245,15 +2245,6 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
 
     if (m_svgStyle.ptr() != other.m_svgStyle.ptr())
         m_svgStyle->conservativelyCollectChangedAnimatableProperties(*other.m_svgStyle, changingProperties);
-}
-
-void RenderStyle::setClip(Length&& top, Length&& right, Length&& bottom, Length&& left)
-{
-    auto& data = m_nonInheritedData.access().rareData.access();
-    data.clip.top() = WTFMove(top);
-    data.clip.right() = WTFMove(right);
-    data.clip.bottom() = WTFMove(bottom);
-    data.clip.left() = WTFMove(left);
 }
 
 void RenderStyle::addCursor(RefPtr<StyleImage>&& image, const std::optional<IntPoint>& hotSpot)

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -284,6 +284,7 @@ struct AnchorNames;
 struct AspectRatio;
 struct BorderRadius;
 struct BoxShadow;
+struct Clip;
 struct ClipPath;
 struct Color;
 struct ColorScheme;
@@ -643,11 +644,7 @@ public:
     VerticalAlign verticalAlign() const;
     const Length& verticalAlignLength() const;
 
-    inline const Length& clipLeft() const;
-    inline const Length& clipRight() const;
-    inline const Length& clipTop() const;
-    inline const Length& clipBottom() const;
-    inline const LengthBox& clip() const;
+    inline const Style::Clip& clip() const;
     inline bool hasClip() const;
 
     UnicodeBidi unicodeBidi() const { return static_cast<UnicodeBidi>(m_nonInheritedFlags.unicodeBidi); }
@@ -1334,13 +1331,7 @@ public:
     void setVerticalAlign(VerticalAlign);
     void setVerticalAlignLength(Length&&);
 
-    inline void setHasClip(bool = true);
-    inline void setClipLeft(Length&&);
-    inline void setClipRight(Length&&);
-    inline void setClipTop(Length&&);
-    inline void setClipBottom(Length&&);
-    void setClip(Length&& top, Length&& right, Length&& bottom, Length&& left);
-    inline void setClip(LengthBox&&);
+    inline void setClip(Style::Clip&&);
 
     void setUnicodeBidi(UnicodeBidi v) { m_nonInheritedFlags.unicodeBidi = static_cast<unsigned>(v); }
 
@@ -1966,6 +1957,7 @@ public:
     static constexpr OverscrollBehavior initialOverscrollBehaviorY();
 
     static constexpr Clear initialClear();
+    static inline Style::Clip initialClip();
     static constexpr DisplayType initialDisplay();
     static constexpr UnicodeBidi initialUnicodeBidi();
     static constexpr PositionType initialPosition();

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -169,12 +169,8 @@ inline BreakBetween RenderStyle::breakBefore() const { return static_cast<BreakB
 inline BreakInside RenderStyle::breakInside() const { return static_cast<BreakInside>(m_nonInheritedData->rareData->breakInside); }
 inline LineCap RenderStyle::capStyle() const { return static_cast<LineCap>(m_rareInheritedData->capStyle); }
 inline const Style::Color& RenderStyle::caretColor() const { return m_rareInheritedData->caretColor; }
-inline const LengthBox& RenderStyle::clip() const { return m_nonInheritedData->rareData->clip; }
-inline const Length& RenderStyle::clipBottom() const { return m_nonInheritedData->rareData->clip.bottom(); }
-inline const Length& RenderStyle::clipLeft() const { return m_nonInheritedData->rareData->clip.left(); }
+inline const Style::Clip& RenderStyle::clip() const { return m_nonInheritedData->rareData->clip; }
 inline const Style::ClipPath& RenderStyle::clipPath() const { return m_nonInheritedData->rareData->clipPath; }
-inline const Length& RenderStyle::clipRight() const { return m_nonInheritedData->rareData->clip.right(); }
-inline const Length& RenderStyle::clipTop() const { return m_nonInheritedData->rareData->clip.top(); }
 inline bool RenderStyle::collapseWhiteSpace() const { return collapseWhiteSpace(whiteSpaceCollapse()); }
 inline ColumnAxis RenderStyle::columnAxis() const { return static_cast<ColumnAxis>(m_nonInheritedData->miscData->multiCol->axis); }
 inline unsigned short RenderStyle::columnCount() const { return m_nonInheritedData->miscData->multiCol->count; }
@@ -289,7 +285,7 @@ inline bool RenderStyle::hasBorder() const { return border().hasBorder(); }
 inline bool RenderStyle::hasBorderImage() const { return border().hasBorderImage(); }
 inline bool RenderStyle::hasBorderImageOutsets() const { return borderImage().hasImage() && !borderImage().outset().isZero(); }
 inline bool RenderStyle::hasBorderRadius() const { return border().hasBorderRadius(); }
-inline bool RenderStyle::hasClip() const { return m_nonInheritedData->rareData->hasClip; }
+inline bool RenderStyle::hasClip() const { return !clip().isAuto(); }
 inline bool RenderStyle::hasClipPath() const { return !WTF::holdsAlternative<CSS::Keyword::None>(m_nonInheritedData->rareData->clipPath); }
 inline bool RenderStyle::hasContent() const { return contentData(); }
 inline bool RenderStyle::hasDisplayAffectedByAnimations() const { return m_nonInheritedData->miscData->hasDisplayAffectedByAnimations; }
@@ -377,6 +373,7 @@ constexpr BreakInside RenderStyle::initialBreakInside() { return BreakInside::Au
 constexpr LineCap RenderStyle::initialCapStyle() { return LineCap::Butt; }
 constexpr CaptionSide RenderStyle::initialCaptionSide() { return CaptionSide::Top; }
 constexpr Clear RenderStyle::initialClear() { return Clear::None; }
+inline Style::Clip RenderStyle::initialClip() { return CSS::Keyword::Auto { }; }
 inline Style::ClipPath RenderStyle::initialClipPath() { return CSS::Keyword::None { }; }
 inline Color RenderStyle::initialColor() { return Color::black; }
 constexpr ColumnAxis RenderStyle::initialColumnAxis() { return ColumnAxis::Auto; }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -129,11 +129,7 @@ inline void RenderStyle::setBreakBefore(BreakBetween behavior) { SET_NESTED(m_no
 inline void RenderStyle::setBreakInside(BreakInside behavior) { SET_NESTED(m_nonInheritedData, rareData, breakInside, static_cast<unsigned>(behavior)); }
 inline void RenderStyle::setCapStyle(LineCap style) { SET(m_rareInheritedData, capStyle, static_cast<unsigned>(style)); }
 inline void RenderStyle::setCaretColor(Style::Color&& color) { SET_PAIR(m_rareInheritedData, caretColor, WTFMove(color), hasAutoCaretColor, false); }
-inline void RenderStyle::setClip(LengthBox&& box) { SET_NESTED(m_nonInheritedData, rareData, clip, WTFMove(box)); }
-inline void RenderStyle::setClipBottom(Length&& length) { SET_NESTED(m_nonInheritedData, rareData, clip.bottom(), WTFMove(length)); }
-inline void RenderStyle::setClipLeft(Length&& length) { SET_NESTED(m_nonInheritedData, rareData, clip.left(), WTFMove(length)); }
-inline void RenderStyle::setClipRight(Length&& length) { SET_NESTED(m_nonInheritedData, rareData, clip.right(), WTFMove(length)); }
-inline void RenderStyle::setClipTop(Length&& length) { SET_NESTED(m_nonInheritedData, rareData, clip.top(), WTFMove(length)); }
+inline void RenderStyle::setClip(Style::Clip&& clip) { SET_NESTED(m_nonInheritedData, rareData, clip, WTFMove(clip)); }
 inline void RenderStyle::setColumnAxis(ColumnAxis axis) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, multiCol, axis, static_cast<unsigned>(axis)); }
 inline void RenderStyle::setColumnFill(ColumnFill fill) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, multiCol, fill, static_cast<unsigned>(fill)); }
 inline void RenderStyle::setColumnGap(Style::GapGutter&& gap) { SET_NESTED(m_nonInheritedData, rareData, columnGap, WTFMove(gap)); }
@@ -175,7 +171,6 @@ inline void RenderStyle::setHasAutoOrphans() { SET_PAIR(m_rareInheritedData, has
 inline void RenderStyle::setHasAutoSpecifiedZIndex() { SET_NESTED_PAIR(m_nonInheritedData, boxData, m_hasAutoSpecifiedZIndex, true, m_specifiedZIndex, 0); }
 inline void RenderStyle::setHasAutoUsedZIndex() { SET_NESTED_PAIR(m_nonInheritedData, boxData, m_hasAutoUsedZIndex, true, m_usedZIndex, 0); }
 inline void RenderStyle::setHasAutoWidows() { SET_PAIR(m_rareInheritedData, hasAutoWidows, true, widows, initialWidows()); }
-inline void RenderStyle::setHasClip(bool hasClip) { SET_NESTED(m_nonInheritedData, rareData, hasClip, hasClip); }
 inline void RenderStyle::setHasContentNone(bool value) { m_nonInheritedFlags.hasContentNone = value; }
 inline void RenderStyle::setHasDisplayAffectedByAnimations() { SET_NESTED(m_nonInheritedData, miscData, hasDisplayAffectedByAnimations, true); }
 inline void RenderStyle::setHasExplicitlySetBorderBottomLeftRadius(bool value) { SET_NESTED(m_nonInheritedData, surroundData, hasExplicitlySetBorderBottomLeftRadius, value); }

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -56,7 +56,7 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     , backdropFilter(StyleFilterData::create())
     , grid(StyleGridData::create())
     , gridItem(StyleGridItemData::create())
-    // clip
+    , clip(RenderStyle::initialClip())
     // scrollMargin
     // scrollPadding
     // counterDirectives
@@ -132,7 +132,6 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     , containerType(static_cast<unsigned>(RenderStyle::initialContainerType()))
     , textBoxTrim(static_cast<unsigned>(RenderStyle::initialTextBoxTrim()))
     , overflowAnchor(static_cast<unsigned>(RenderStyle::initialOverflowAnchor()))
-    , hasClip(false)
     , positionTryOrder(static_cast<unsigned>(RenderStyle::initialPositionTryOrder()))
     , positionVisibility(RenderStyle::initialPositionVisibility().toRaw())
     , fieldSizing(static_cast<unsigned>(RenderStyle::initialFieldSizing()))
@@ -239,7 +238,6 @@ inline StyleRareNonInheritedData::StyleRareNonInheritedData(const StyleRareNonIn
     , containerType(o.containerType)
     , textBoxTrim(o.textBoxTrim)
     , overflowAnchor(o.overflowAnchor)
-    , hasClip(o.hasClip)
     , positionTryOrder(o.positionTryOrder)
     , positionVisibility(o.positionVisibility)
     , fieldSizing(o.fieldSizing)
@@ -353,7 +351,6 @@ bool StyleRareNonInheritedData::operator==(const StyleRareNonInheritedData& o) c
         && overflowAnchor == o.overflowAnchor
         && viewTransitionClasses == o.viewTransitionClasses
         && viewTransitionName == o.viewTransitionName
-        && hasClip == o.hasClip
         && positionTryOrder == o.positionTryOrder
         && positionVisibility == o.positionVisibility
         && fieldSizing == o.fieldSizing
@@ -525,7 +522,6 @@ void StyleRareNonInheritedData::dumpDifferences(TextStream& ts, const StyleRareN
     LOG_IF_DIFFERENT_WITH_CAST(ContainerType, containerType);
     LOG_IF_DIFFERENT_WITH_CAST(TextBoxTrim, textBoxTrim);
     LOG_IF_DIFFERENT_WITH_CAST(OverflowAnchor, overflowAnchor);
-    LOG_IF_DIFFERENT_WITH_CAST(bool, hasClip);
     LOG_IF_DIFFERENT_WITH_CAST(Style::PositionTryOrder, positionTryOrder);
     LOG_IF_DIFFERENT(fieldSizing);
 

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -38,6 +38,7 @@
 #include "ScrollbarGutter.h"
 #include "ShapeValue.h"
 #include "StyleAnchorName.h"
+#include "StyleClip.h"
 #include "StyleClipPath.h"
 #include "StyleColor.h"
 #include "StyleContainIntrinsicSize.h"
@@ -161,8 +162,7 @@ public:
     DataRef<StyleGridData> grid;
     DataRef<StyleGridItemData> gridItem;
 
-    // Only meaningful when `hasClip` is true.
-    LengthBox clip;
+    Style::Clip clip { CSS::Keyword::Auto { } };
 
     Style::ScrollMarginBox scrollMargin { 0_css_px };
     Style::ScrollPaddingBox scrollPadding { CSS::Keyword::Auto { } };
@@ -266,7 +266,6 @@ public:
     PREFERRED_TYPE(ContainerType) unsigned containerType : 2;
     PREFERRED_TYPE(TextBoxTrim) unsigned textBoxTrim : 2;
     PREFERRED_TYPE(OverflowAnchor) unsigned overflowAnchor : 1;
-    PREFERRED_TYPE(bool) unsigned hasClip : 1;
     PREFERRED_TYPE(Style::PositionTryOrder) unsigned positionTryOrder : 3;
     PREFERRED_TYPE(OptionSet<PositionVisibility>) unsigned positionVisibility : 3;
     PREFERRED_TYPE(FieldSizing) unsigned fieldSizing : 1;

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -102,6 +102,7 @@ inline MinimumSize forwardInheritedValue(const MinimumSize& value) { auto copy =
 inline MaximumSize forwardInheritedValue(const MaximumSize& value) { auto copy = value; return copy; }
 inline FlexBasis forwardInheritedValue(const FlexBasis& value) { auto copy = value; return copy; }
 inline DynamicRangeLimit forwardInheritedValue(const DynamicRangeLimit& value) { auto copy = value; return copy; }
+inline Clip forwardInheritedValue(const Clip& value) { auto copy = value; return copy; }
 inline ClipPath forwardInheritedValue(const ClipPath& value) { auto copy = value; return copy; }
 inline CornerShapeValue forwardInheritedValue(const CornerShapeValue& value) { auto copy = value; return copy; }
 inline GridTemplateAreas forwardInheritedValue(const GridTemplateAreas& value) { auto copy = value; return copy; }
@@ -145,7 +146,6 @@ public:
     DECLARE_PROPERTY_CUSTOM_HANDLERS(BorderImageWidth);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(BoxShadow);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(CaretColor);
-    DECLARE_PROPERTY_CUSTOM_HANDLERS(Clip);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(Color);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(Content);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(CounterIncrement);
@@ -558,51 +558,6 @@ inline void BuilderCustom::applyValueCaretColor(BuilderState& builderState, CSSV
             builderState.style().setHasVisitedLinkAutoCaretColor();
         else
             builderState.style().setVisitedLinkCaretColor(toStyleFromCSSValue<Color>(builderState, value, ForVisitedLink::Yes));
-    }
-}
-
-inline void BuilderCustom::applyInitialClip(BuilderState& builderState)
-{
-    builderState.style().setClip(WebCore::Length(), WebCore::Length(), WebCore::Length(), WebCore::Length());
-    builderState.style().setHasClip(false);
-}
-
-inline void BuilderCustom::applyInheritClip(BuilderState& builderState)
-{
-    auto& parentStyle = builderState.parentStyle();
-    if (!parentStyle.hasClip())
-        return applyInitialClip(builderState);
-    builderState.style().setClip(WebCore::Length { parentStyle.clipTop() }, WebCore::Length { parentStyle.clipRight() },
-        WebCore::Length { parentStyle.clipBottom() }, WebCore::Length { parentStyle.clipLeft() });
-    builderState.style().setHasClip(true);
-}
-
-inline void BuilderCustom::applyValueClip(BuilderState& builderState, CSSValue& value)
-{
-    if (value.isRect()) {
-        auto primitiveValueTop = requiredDowncast<CSSPrimitiveValue>(builderState, value.rect().top());
-        if (!primitiveValueTop)
-            return;
-        auto primitiveValueRight = requiredDowncast<CSSPrimitiveValue>(builderState, value.rect().right());
-        if (!primitiveValueRight)
-            return;
-        auto primitiveValueBottom = requiredDowncast<CSSPrimitiveValue>(builderState, value.rect().bottom());
-        if (!primitiveValueBottom)
-            return;
-        auto primitiveValueLeft = requiredDowncast<CSSPrimitiveValue>(builderState, value.rect().left());
-        if (!primitiveValueLeft)
-            return;
-
-        auto top = BuilderConverter::convertLengthOrAuto(builderState, *primitiveValueTop);
-        auto right = BuilderConverter::convertLengthOrAuto(builderState, *primitiveValueRight);
-        auto bottom = BuilderConverter::convertLengthOrAuto(builderState, *primitiveValueBottom);
-        auto left = BuilderConverter::convertLengthOrAuto(builderState, *primitiveValueLeft);
-
-        builderState.style().setClip(WTFMove(top), WTFMove(right), WTFMove(bottom), WTFMove(left));
-        builderState.style().setHasClip(true);
-    } else {
-        ASSERT(value.valueID() == CSSValueAuto);
-        applyInitialClip(builderState);
     }
 }
 

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -47,7 +47,6 @@ public:
     static Ref<CSSValue> extractDirection(ExtractorState&);
     static Ref<CSSValue> extractWritingMode(ExtractorState&);
     static Ref<CSSValue> extractFloat(ExtractorState&);
-    static Ref<CSSValue> extractClip(ExtractorState&);
     static Ref<CSSValue> extractContent(ExtractorState&);
     static Ref<CSSValue> extractCursor(ExtractorState&);
     static Ref<CSSValue> extractBaselineShift(ExtractorState&);
@@ -149,7 +148,6 @@ public:
     static void extractDirectionSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractWritingModeSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractFloatSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
-    static void extractClipSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractContentSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractCursorSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractBaselineShiftSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
@@ -1244,49 +1242,6 @@ inline void ExtractorCustom::extractFloatSerialization(ExtractorState& state, St
     }
 
     ExtractorSerializer::serialize(state, builder, context, state.style.floating());
-}
-
-inline Ref<CSSValue> ExtractorCustom::extractClip(ExtractorState& state)
-{
-    if (!state.style.hasClip())
-        return CSSPrimitiveValue::create(CSSValueAuto);
-
-    auto& clip = state.style.clip();
-
-    if (clip.allOf([](auto& side) { return side.isAuto(); }))
-        return CSSPrimitiveValue::create(CSSValueAuto);
-
-    return CSSRectValue::create({
-        ExtractorConverter::convertLengthOrAuto(state, clip.top()),
-        ExtractorConverter::convertLengthOrAuto(state, clip.right()),
-        ExtractorConverter::convertLengthOrAuto(state, clip.bottom()),
-        ExtractorConverter::convertLengthOrAuto(state, clip.left())
-    });
-}
-
-inline void ExtractorCustom::extractClipSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
-{
-    if (!state.style.hasClip()) {
-        CSS::serializationForCSS(builder, context, CSS::Keyword::Auto { });
-        return;
-    }
-
-    auto& clip = state.style.clip();
-
-    if (clip.allOf([](auto& side) { return side.isAuto(); })) {
-        CSS::serializationForCSS(builder, context, CSS::Keyword::Auto { });
-        return;
-    }
-
-    builder.append(nameLiteral(CSSValueRect), '(');
-    ExtractorSerializer::serializeLengthOrAuto(state, builder, context, clip.top());
-    builder.append(", "_s);
-    ExtractorSerializer::serializeLengthOrAuto(state, builder, context, clip.right());
-    builder.append(", "_s);
-    ExtractorSerializer::serializeLengthOrAuto(state, builder, context, clip.bottom());
-    builder.append(", "_s);
-    ExtractorSerializer::serializeLengthOrAuto(state, builder, context, clip.left());
-    builder.append(')');
 }
 
 inline Ref<CSSValue> ExtractorCustom::extractContent(ExtractorState& state)

--- a/Source/WebCore/style/StyleInterpolationWrappers.h
+++ b/Source/WebCore/style/StyleInterpolationWrappers.h
@@ -836,26 +836,6 @@ private:
     OptionSet<Flags> m_flags;
 };
 
-class ClipWrapper final : public LengthBoxWrapper {
-    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Animation);
-public:
-    ClipWrapper()
-        : LengthBoxWrapper(CSSPropertyClip, &RenderStyle::clip, &RenderStyle::setClip, { LengthBoxWrapper::Flags::AllowsNegativeValues })
-    {
-    }
-
-    bool canInterpolate(const RenderStyle& from, const RenderStyle& to, CompositeOperation compositeOperation) const final
-    {
-        return from.hasClip() && to.hasClip() && LengthBoxWrapper::canInterpolate(from, to, compositeOperation);
-    }
-
-    void interpolate(RenderStyle& destination, const RenderStyle& from, const RenderStyle& to, const Context& context) const final
-    {
-        LengthBoxWrapper::interpolate(destination, from, to, context);
-        destination.setHasClip(true);
-    }
-};
-
 #if ENABLE(VARIATION_FONTS)
 
 class FontVariationSettingsWrapper final : public Wrapper<FontVariationSettings> {

--- a/Source/WebCore/style/values/StyleValueTypes.h
+++ b/Source/WebCore/style/values/StyleValueTypes.h
@@ -129,6 +129,7 @@ template<typename... Ts> struct ToCSSMapping<CommaSeparatedTuple<Ts...>> { using
 template<typename T> struct ToCSSMapping<SpaceSeparatedPoint<T>> { using type = SpaceSeparatedPoint<CSSType<T>>; };
 template<typename T> struct ToCSSMapping<SpaceSeparatedSize<T>> { using type = SpaceSeparatedSize<CSSType<T>>; };
 template<typename T> struct ToCSSMapping<SpaceSeparatedRectEdges<T>> { using type = SpaceSeparatedRectEdges<CSSType<T>>; };
+template<typename T> struct ToCSSMapping<CommaSeparatedRectEdges<T>> { using type = CommaSeparatedRectEdges<CSSType<T>>; };
 template<typename T> struct ToCSSMapping<MinimallySerializingSpaceSeparatedSize<T>> { using type = MinimallySerializingSpaceSeparatedSize<CSSType<T>>; };
 template<typename T> struct ToCSSMapping<MinimallySerializingSpaceSeparatedRectEdges<T>> { using type = MinimallySerializingSpaceSeparatedRectEdges<CSSType<T>>; };
 
@@ -260,6 +261,7 @@ template<typename... Ts> struct ToStyleMapping<CommaSeparatedTuple<Ts...>> { usi
 template<typename T> struct ToStyleMapping<SpaceSeparatedPoint<T>> { using type = SpaceSeparatedPoint<StyleType<T>>; };
 template<typename T> struct ToStyleMapping<SpaceSeparatedSize<T>> { using type = SpaceSeparatedSize<StyleType<T>>; };
 template<typename T> struct ToStyleMapping<SpaceSeparatedRectEdges<T>> { using type = SpaceSeparatedRectEdges<StyleType<T>>; };
+template<typename T> struct ToStyleMapping<CommaSeparatedRectEdges<T>> { using type = CommaSeparatedRectEdges<StyleType<T>>; };
 template<typename T> struct ToStyleMapping<MinimallySerializingSpaceSeparatedSize<T>> { using type = MinimallySerializingSpaceSeparatedSize<StyleType<T>>; };
 template<typename T> struct ToStyleMapping<MinimallySerializingSpaceSeparatedRectEdges<T>> { using type = MinimallySerializingSpaceSeparatedRectEdges<StyleType<T>>; };
 

--- a/Source/WebCore/style/values/masking/StyleClip.cpp
+++ b/Source/WebCore/style/values/masking/StyleClip.cpp
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleClip.h"
+
+#include "AnimationUtilities.h"
+#include "CSSPrimitiveValue.h"
+#include "CSSRectValue.h"
+#include "StyleBuilderChecking.h"
+#include "StylePrimitiveNumericTypes+Blending.h"
+#include "StylePrimitiveNumericTypes+CSSValueConversion.h"
+
+namespace WebCore {
+namespace Style {
+
+// MARK: - Conversion
+
+auto CSSValueConversion<Clip>::operator()(BuilderState& state, const CSSValue& value) -> Clip
+{
+    if (isValueID(value, CSSValueAuto))
+        return CSS::Keyword::Auto { };
+
+    RefPtr rectValue = requiredDowncast<CSSRectValue>(state, value);
+    if (!rectValue)
+        return CSS::Keyword::Auto { };
+
+    RefPtr primitiveValueTop = requiredDowncast<CSSPrimitiveValue>(state, rectValue->rect().top());
+    if (!primitiveValueTop)
+        return CSS::Keyword::Auto { };
+    RefPtr primitiveValueRight = requiredDowncast<CSSPrimitiveValue>(state, rectValue->rect().right());
+    if (!primitiveValueRight)
+        return CSS::Keyword::Auto { };
+    RefPtr primitiveValueBottom = requiredDowncast<CSSPrimitiveValue>(state, rectValue->rect().bottom());
+    if (!primitiveValueBottom)
+        return CSS::Keyword::Auto { };
+    RefPtr primitiveValueLeft = requiredDowncast<CSSPrimitiveValue>(state, rectValue->rect().left());
+    if (!primitiveValueLeft)
+        return CSS::Keyword::Auto { };
+
+    auto convertEdge = [&](Ref<const CSSPrimitiveValue>&& primitiveValue) -> ClipEdge {
+        if (isValueID(primitiveValue.get(), CSSValueAuto))
+            return CSS::Keyword::Auto { };
+        return toStyleFromCSSValue<Length<>>(state, primitiveValue);
+    };
+
+    return ClipRect {
+        convertEdge(primitiveValueTop.releaseNonNull()),
+        convertEdge(primitiveValueRight.releaseNonNull()),
+        convertEdge(primitiveValueBottom.releaseNonNull()),
+        convertEdge(primitiveValueLeft.releaseNonNull()),
+    };
+}
+
+Ref<CSSValue> CSSValueCreation<ClipRect>::operator()(CSSValuePool& pool, const RenderStyle& style, const ClipRect& clipRect)
+{
+    return CSSRectValue::create({
+        createCSSValue(pool, style, clipRect.value->top()),
+        createCSSValue(pool, style, clipRect.value->right()),
+        createCSSValue(pool, style, clipRect.value->bottom()),
+        createCSSValue(pool, style, clipRect.value->left()),
+    });
+}
+
+// MARK: - Blending
+
+template<> struct Blending<ClipEdge> {
+    auto canBlend(const ClipEdge&, const ClipEdge&) -> bool;
+    auto requiresInterpolationForAccumulativeIteration(const ClipEdge&, const ClipEdge&) -> bool;
+    auto blend(const ClipEdge&, const ClipEdge&, const BlendingContext&) -> ClipEdge;
+};
+
+template<> struct Blending<ClipRect> {
+    auto canBlend(const ClipRect&, const ClipRect&) -> bool;
+    auto requiresInterpolationForAccumulativeIteration(const ClipRect&, const ClipRect&) -> bool;
+    auto blend(const ClipRect&, const ClipRect&, const BlendingContext&) -> ClipRect;
+};
+
+auto Blending<ClipEdge>::canBlend(const ClipEdge& a, const ClipEdge& b) -> bool
+{
+    return a.isAuto() == b.isAuto();
+}
+
+auto Blending<ClipEdge>::requiresInterpolationForAccumulativeIteration(const ClipEdge& a, const ClipEdge& b) -> bool
+{
+    return a.isAuto() != b.isAuto();
+}
+
+auto Blending<ClipEdge>::blend(const ClipEdge& a, const ClipEdge& b, const BlendingContext& context) -> ClipEdge
+{
+    if (a.isAuto() || b.isAuto())
+        return context.progress < 0.5 ? a : b;
+
+    ASSERT(canBlend(a, b));
+    return Style::blend(*a.value, *b.value, context);
+}
+
+auto Blending<ClipRect>::canBlend(const ClipRect& a, const ClipRect& b) -> bool
+{
+    return Style::canBlend(a.value->top(), b.value->top())
+        && Style::canBlend(a.value->right(), b.value->right())
+        && Style::canBlend(a.value->bottom(), b.value->bottom())
+        && Style::canBlend(a.value->left(), b.value->left());
+}
+
+auto Blending<ClipRect>::requiresInterpolationForAccumulativeIteration(const ClipRect& a, const ClipRect& b) -> bool
+{
+    return Style::requiresInterpolationForAccumulativeIteration(a.value->top(), b.value->top())
+        && Style::requiresInterpolationForAccumulativeIteration(a.value->right(), b.value->right())
+        && Style::requiresInterpolationForAccumulativeIteration(a.value->bottom(), b.value->bottom())
+        && Style::requiresInterpolationForAccumulativeIteration(a.value->left(), b.value->left());
+}
+
+auto Blending<ClipRect>::blend(const ClipRect& a, const ClipRect& b, const BlendingContext& context) -> ClipRect
+{
+    return ClipRect {
+        Style::blend(a.value->top(), b.value->top(), context),
+        Style::blend(a.value->right(), b.value->right(), context),
+        Style::blend(a.value->bottom(), b.value->bottom(), context),
+        Style::blend(a.value->left(), b.value->left(), context),
+    };
+}
+
+auto Blending<Clip>::canBlend(const Clip& a, const Clip& b) -> bool
+{
+    return !a.isAuto() && !b.isAuto() && Style::canBlend(*a.value, *b.value);
+}
+
+auto Blending<Clip>::requiresInterpolationForAccumulativeIteration(const Clip& a, const Clip& b) -> bool
+{
+    return Style::requiresInterpolationForAccumulativeIteration(
+        a.value.value_or(ClipRect { CSS::Keyword::Auto { } }),
+        b.value.value_or(ClipRect { CSS::Keyword::Auto { } })
+    );
+}
+
+auto Blending<Clip>::blend(const Clip& a, const Clip& b, const BlendingContext& context) -> Clip
+{
+    return Style::blend(
+        a.value.value_or(ClipRect { CSS::Keyword::Auto { } }),
+        b.value.value_or(ClipRect { CSS::Keyword::Auto { } }),
+        context
+    );
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/masking/StyleClip.h
+++ b/Source/WebCore/style/values/masking/StyleClip.h
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StylePrimitiveNumeric.h"
+#include "StyleValueTypes.h"
+#include <wtf/Markable.h>
+
+namespace WebCore {
+namespace Style {
+
+// <clip-edge> = <length> | auto
+struct ClipEdge {
+    ClipEdge(CSS::Keyword::Auto)
+        : value { }
+    {
+    }
+
+    ClipEdge(Length<> value)
+        : value { value }
+    {
+    }
+
+    bool isAuto() const { return !value; }
+    bool isLength() const { return !!value; }
+    std::optional<Length<>> tryLength() const { return value.asOptional(); }
+
+    template<typename... F> decltype(auto) switchOn(F&&... f) const
+    {
+        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
+
+        if (isAuto())
+            return visitor(CSS::Keyword::Auto { });
+        return visitor(*value);
+    }
+
+    bool operator==(const ClipEdge&) const = default;
+
+private:
+    friend struct Blending<ClipEdge>;
+
+    Markable<Length<>> value;
+};
+
+// <rect()> = rect( <clip-edge> , <clip-edge> , <clip-edge> , <clip-edge> )
+struct ClipRect {
+    FunctionNotation<CSSValueRect, CommaSeparatedRectEdges<ClipEdge>> value;
+
+    ClipRect(CSS::Keyword::Auto keyword)
+        : value { CommaSeparatedRectEdges<ClipEdge> { keyword } }
+    {
+    }
+
+    template<typename T> ClipRect(T top, T right, T bottom, T left)
+        : value { CommaSeparatedRectEdges<ClipEdge> { WTFMove(top), WTFMove(right), WTFMove(bottom), WTFMove(left) } }
+    {
+    }
+
+    bool isAllAuto() const { return value->allOf([](auto& side) { return side.isAuto(); }); }
+    bool isAnyAuto() const { return value->anyOf([](auto& side) { return side.isAuto(); }); }
+
+    bool operator==(const ClipRect&) const = default;
+};
+DEFINE_TYPE_WRAPPER_GET(ClipRect, value);
+
+// <'clip'> = <rect()> | auto
+// https://drafts.fxtf.org/css-masking/#propdef-clip
+struct Clip {
+    Clip(CSS::Keyword::Auto)
+        : value { }
+    {
+    }
+
+    Clip(const ClipRect& rect)
+        : value { rect }
+    {
+    }
+
+    Clip(ClipRect&& rect)
+        : value { WTFMove(rect) }
+    {
+    }
+
+    bool isAuto() const { return !value; }
+    bool isRect() const { return !isAuto(); }
+
+    template<typename... F> decltype(auto) switchOn(F&&... f) const
+    {
+        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
+
+        if (isAuto() || value->isAllAuto())
+            return visitor(CSS::Keyword::Auto { });
+        return visitor(*value);
+    }
+
+    bool operator==(const Clip&) const = default;
+
+private:
+    friend struct Blending<Clip>;
+
+    std::optional<ClipRect> value;
+};
+
+// MARK: Conversion
+
+template<> struct CSSValueConversion<Clip> { auto operator()(BuilderState&, const CSSValue&) -> Clip; };
+
+// `ClipRect` is special-cased to return a `CSSValueRect`.
+template<> struct CSSValueCreation<ClipRect> { Ref<CSSValue> operator()(CSSValuePool&, const RenderStyle&, const ClipRect&); };
+
+// MARK: - Blending
+
+template<> struct Blending<Clip> {
+    auto canBlend(const Clip&, const Clip&) -> bool;
+    auto requiresInterpolationForAccumulativeIteration(const Clip&, const Clip&) -> bool;
+    auto blend(const Clip&, const Clip&, const BlendingContext&) -> Clip;
+};
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_TUPLE_LIKE_CONFORMANCE_FOR_TYPE_WRAPPER(WebCore::Style::ClipRect);
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::ClipEdge);
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::Clip);

--- a/Source/WebCore/style/values/motion/StyleOffsetPosition.cpp
+++ b/Source/WebCore/style/values/motion/StyleOffsetPosition.cpp
@@ -26,6 +26,7 @@
 #include "StyleOffsetPosition.h"
 
 #include "CSSPositionValue.h"
+#include "RenderStyleInlines.h"
 #include "StyleBuilderChecking.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
 #include <wtf/text/TextStream.h>

--- a/Source/WebCore/style/values/motion/StyleOffsetPosition.h
+++ b/Source/WebCore/style/values/motion/StyleOffsetPosition.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "LengthPoint.h"
 #include "StylePosition.h"
 #include "StyleValueTypes.h"
 


### PR DESCRIPTION
#### 419613176073e3f8d6561980e7121ebebd78b149
<pre>
[Style] Convert clip to use strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=295639">https://bugs.webkit.org/show_bug.cgi?id=295639</a>

Reviewed by Darin Adler.

Bundles up the values for the `clip` property into a new
`Style::Clip` type, replacing external `hasClip` bit with
an explicit `auto` value.

Adds a new aggregated, `CommaSeparatedRectEdges`, complementing
the existing `SpaceSeparatedRectEdges`.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/values/CSSValueAggregates.h:
* Source/WebCore/rendering/RenderBox.cpp:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/style/StyleBuilderCustom.h:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/StyleInterpolationWrappers.h:
* Source/WebCore/style/values/StyleValueTypes.h:
* Source/WebCore/style/values/masking/StyleClip.cpp: Added.
* Source/WebCore/style/values/masking/StyleClip.h: Added.

Canonical link: <a href="https://commits.webkit.org/297315@main">https://commits.webkit.org/297315@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69cd4d107d08452d537d539e4f38fa161008f1f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111312 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30978 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21443 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117344 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61580 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113274 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31659 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39560 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84608 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114259 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25283 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100215 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65059 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24625 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18355 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61164 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94665 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18422 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120499 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38361 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28504 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93533 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38737 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96489 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93357 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23789 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38455 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16227 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34363 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38250 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43727 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37915 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41248 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39617 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->