### PR TITLE
[Model Element] Implement lazy loading and unloading based on viewport intersection

### DIFF
--- a/LayoutTests/model-element/model-element-animations-replace-sources.html
+++ b/LayoutTests/model-element/model-element-animations-replace-sources.html
@@ -8,6 +8,7 @@
 <body>
 <script>
 'use strict';
+internals.disableModelLoadDelaysForTesting();
 
 promise_test(async t => {
     const [model, source] = createModelAndSource(t, "resources/stopwatch-60s.usdz");

--- a/LayoutTests/model-element/model-element-bounding-box.html
+++ b/LayoutTests/model-element/model-element-bounding-box.html
@@ -8,6 +8,7 @@
 <body>
 <script>
 'use strict';
+internals.disableModelLoadDelaysForTesting();
 
 promise_test(async t => {
     const [model, source] = createModelAndSource(t);

--- a/LayoutTests/model-element/model-element-contents-layer-updates-with-clipping.html
+++ b/LayoutTests/model-element/model-element-contents-layer-updates-with-clipping.html
@@ -6,6 +6,8 @@
 </model>
 <pre id="layers"></pre>
 <script>
+    internals.disableModelLoadDelaysForTesting();
+
     window.testRunner?.waitUntilDone();
     window.testRunner?.dumpAsText();
 

--- a/LayoutTests/model-element/model-element-contents-layer-updates.html
+++ b/LayoutTests/model-element/model-element-contents-layer-updates.html
@@ -6,6 +6,8 @@
 </model>
 <pre id="layers"></pre>
 <script>
+    internals.disableModelLoadDelaysForTesting();
+
     window.testRunner?.waitUntilDone();
     window.testRunner?.dumpAsText();
 

--- a/LayoutTests/model-element/model-element-entity-transform.html
+++ b/LayoutTests/model-element/model-element-entity-transform.html
@@ -9,6 +9,7 @@
 <body>
 <script>
 'use strict';
+internals.disableModelLoadDelaysForTesting();
 
 promise_test(async t => {
     const [model, source] = createModelAndSource(t);

--- a/LayoutTests/model-element/model-element-environment-map-ready.html
+++ b/LayoutTests/model-element/model-element-environment-map-ready.html
@@ -7,6 +7,7 @@
 <body>
 <script>
 'use strict';
+internals.disableModelLoadDelaysForTesting();
 
 promise_test(async t => {
     const [model, source] = createModelWithAttributesAndSource(t, {environmentmap: "resources/does-not-exist.hdr" }, "resources/heart.usdz");

--- a/LayoutTests/model-element/model-element-lazy-loading-unloading-expected.txt
+++ b/LayoutTests/model-element/model-element-lazy-loading-unloading-expected.txt
@@ -1,0 +1,6 @@
+
+PASS <model> main load/unload transitions
+PASS <model> jump back to deferred when quickly scrolled through
+PASS <model> invalid state if usdz does not exist
+PASS <model> invalid state for incorrect usdz file
+

--- a/LayoutTests/model-element/model-element-lazy-loading-unloading.html
+++ b/LayoutTests/model-element/model-element-lazy-loading-unloading.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>&lt;model> state transitions</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="resources/model-element-test-utils.js"></script>
+<script src="resources/model-utils.js"></script>
+<style>
+.spacer {
+    height: 200vh;
+}
+.model-element {
+    width: 300px;
+    height: 300px;
+}
+</style>
+<body>
+<div class="spacer"></div>
+<script>
+'use strict';
+
+promise_test(async t => {
+    const [model, source] = createModelAndSource(t, "resources/heart.usdz");
+    model.className = "model-element";
+    assert_equals(internals.modelElementState(model), "Deferred");
+    assert_false(internals.isModelElementIntersectingViewport(model));
+
+    scrollElementIntoView(model);
+
+    await waitForModelState(model, "Loaded");
+    assert_true(internals.isModelElementIntersectingViewport(model));
+
+    window.scrollTo(0, 0)
+
+    await waitForModelState(model, "Unloaded");
+    assert_false(internals.isModelElementIntersectingViewport(model));
+}, `<model> main load/unload transitions`);
+
+promise_test(async t => {
+    const [model, source] = createModelAndSource(t, "resources/heart.usdz");
+    model.className = "model-element";
+    assert_equals(internals.modelElementState(model), "Deferred");
+    assert_false(internals.isModelElementIntersectingViewport(model));
+
+    scrollElementIntoView(model);
+
+    const intermediateState = internals.modelElementState(model);
+    assert_true(intermediateState !== "Loaded");
+
+    window.scrollTo(0, 0)
+
+    await waitForModelState(model, "Deferred");
+    assert_false(internals.isModelElementIntersectingViewport(model));
+}, `<model> jump back to deferred when quickly scrolled through`);
+
+promise_test(async t => {
+    const [model, source] = createModelAndSource(t, "resources/does-not-exist.usdz");
+    model.className = "model-element";
+    assert_equals(internals.modelElementState(model), "Deferred");
+    assert_false(internals.isModelElementIntersectingViewport(model));
+
+    scrollElementIntoView(model);
+    await sleepForSeconds(2.0);
+
+    const failedState = internals.modelElementState(model);
+    assert_true(failedState !== "Loading" && failedState !== "Loaded", "Model should not be loaded");
+    assert_true(internals.isModelElementIntersectingViewport(model));
+    return model.ready.then(
+        value => assert_unreached("Unexpected ready promise resolution."),
+        reason => assert_true(reason.toString().includes("NetworkError"), "The ready promise is rejected with a NetworkError.")
+    );
+}, `<model> invalid state if usdz does not exist`);
+
+promise_test(async t => {
+    const [model, source] = createModelAndSource(t, "resources/error-case.usdz");
+    model.className = "model-element";
+    assert_equals(internals.modelElementState(model), "Deferred");
+    assert_false(internals.isModelElementIntersectingViewport(model));
+
+    scrollElementIntoView(model);
+    await sleepForSeconds(2.0);
+
+    const failedState = internals.modelElementState(model);
+
+    assert_true(failedState !== "Loaded", "Model should not be loaded");
+    assert_true(internals.isModelElementIntersectingViewport(model));
+    return model.ready.then(
+        value => assert_unreached("Unexpected ready promise resolution."),
+        reason => assert_true(reason.toString().includes("AbortError"), "The ready promise is rejected with an AbortError.")
+    );
+}, `<model> invalid state for incorrect usdz file`);
+
+</script>
+</body>

--- a/LayoutTests/model-element/model-element-on-hidden-page-with-delays-expected.txt
+++ b/LayoutTests/model-element/model-element-on-hidden-page-with-delays-expected.txt
@@ -1,0 +1,4 @@
+
+PASS <model> remains deferred if page is hidden, loads after becoming visible
+PASS <model> should not load if scroll and hide the page, loads after becoming visible
+

--- a/LayoutTests/model-element/model-element-on-hidden-page-with-delays.html
+++ b/LayoutTests/model-element/model-element-on-hidden-page-with-delays.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ModelElementEnabled=true ModelProcessEnabled=true ] -->
+<meta charset="utf-8">
+<title>&lt;model> state while page is hidden playback</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="resources/model-element-test-utils.js"></script>
+<script src="resources/model-utils.js"></script>
+<style>
+.spacer {
+    height: 200vh;
+}
+.model-element {
+    width: 300px;
+    height: 300px;
+}
+</style>
+<body>
+<script>
+
+promise_test(async t => {
+    testRunner.setPageVisibility("hidden");
+    await sleepForSeconds(0.1);
+    assert_true(document.hidden, "Page should be hidden");
+
+    const [model, source] = createModelAndSource(t, "resources/heart.usdz");
+    model.className = 'model-element';
+    assert_equals(internals.modelElementState(model), "Deferred");
+    assert_false(internals.isModelElementIntersectingViewport(model));
+
+    testRunner.setPageVisibility("visible");
+    await sleepForSeconds(0.1);
+    assert_true(!document.hidden, "Page should be visible");
+
+    await waitForModelState(model, "Loaded");
+}, `<model> remains deferred if page is hidden, loads after becoming visible`);
+
+promise_test(async t => {
+    const spacerDiv = document.createElement('div');
+    spacerDiv.className = 'spacer';
+    document.body.appendChild(spacerDiv);
+
+    const [model, source] = createModelAndSource(t, "resources/heart.usdz");
+    model.className = 'model-element';
+
+    scrollElementIntoView(model);
+    await sleepForSeconds(0.1);
+
+    testRunner.setPageVisibility("hidden");
+    await sleepForSeconds(0.1);
+    assert_true(document.hidden, "Page should be hidden");
+    const intermediateState = internals.modelElementState(model);
+    assert_true(intermediateState !== "Loaded", "Model should not be loaded");
+
+    await sleepForSeconds(0.5);
+
+    testRunner.setPageVisibility("visible");
+    await sleepForSeconds(0.1);
+    assert_true(!document.hidden, "Page should be visible");
+
+    await waitForModelState(model, "Loaded");
+}, `<model> should not load if scroll and hide the page, loads after becoming visible`);
+
+</script>
+</body>

--- a/LayoutTests/model-element/model-element-ready.html
+++ b/LayoutTests/model-element/model-element-ready.html
@@ -7,6 +7,7 @@
 <body>
 <script>
 'use strict';
+internals.disableModelLoadDelaysForTesting();
 
 promise_test(async t => {
     const [model, source] = createModelAndSource(t, "resources/does-not-exist.usdz");

--- a/LayoutTests/model-element/model-element-stagemode.html
+++ b/LayoutTests/model-element/model-element-stagemode.html
@@ -8,6 +8,7 @@
 <body>
 <script>
 'use strict';
+internals.disableModelLoadDelaysForTesting();
 
 promise_test(async t => {
     const [model, source] = createModelAndSource(t, "resources/cube.usdz");

--- a/LayoutTests/model-element/resources/model-element-test-utils.js
+++ b/LayoutTests/model-element/resources/model-element-test-utils.js
@@ -32,3 +32,39 @@ const makeSource = (src, type) => {
         source.type = type;
     return source;
 }
+
+async function waitForModelState(element, expectedState, timeout = 5000) {
+    return new Promise((resolve, reject) => {
+        const startTime = Date.now();
+
+        function checkState() {
+            try {
+                const currentState = window.internals.modelElementState(element);
+                if (currentState === expectedState) {
+                    resolve(currentState);
+                    return;
+                }
+
+                if (Date.now() - startTime > timeout) {
+                    reject(new Error(`Timeout waiting for state ${expectedState}, current state: ${currentState}`));
+                    return;
+                }
+
+                setTimeout(checkState, 100);
+            } catch (error) {
+                reject(error);
+            }
+        }
+
+        checkState();
+    });
+}
+
+function scrollElementIntoView(element) {
+    const rect = element.getBoundingClientRect();
+    const elementTop = rect.top + window.pageYOffset;
+    const elementCenter = elementTop + (rect.height / 2);
+    const viewportCenter = window.innerHeight / 2;
+
+    window.scrollTo(0, elementCenter - viewportCenter);
+}

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -36,6 +36,7 @@
 #include "HTMLModelElementCamera.h"
 #include "IDLTypes.h"
 #include "LayerHostingContextIdentifier.h"
+#include "ModelPlayer.h"
 #include "ModelPlayerClient.h"
 #include "PlatformLayer.h"
 #include "PlatformLayerIdentifier.h"
@@ -57,7 +58,6 @@ class GraphicsLayer;
 class LayoutPoint;
 class LayoutSize;
 class Model;
-class ModelPlayer;
 class ModelPlayerProvider;
 class MouseEvent;
 
@@ -184,6 +184,11 @@ public:
     size_t externalMemoryCost() const;
 #endif
 
+    void viewportIntersectionChanged(bool isIntersecting);
+    bool isIntersectingViewport() const final { return m_isIntersectingViewport; }
+
+    WEBCORE_EXPORT String modelElementStateForTesting() const;
+
 private:
     HTMLModelElement(const QualifiedName&, Document&);
 
@@ -194,8 +199,8 @@ private:
     void deleteModelPlayer();
     void unloadModelPlayer(bool onSuspend);
     void reloadModelPlayer();
-    void startReloadModelTimer();
-    void reloadModelTimerFired();
+    void startLoadModelTimer();
+    void loadModelTimerFired();
 
     RefPtr<GraphicsLayer> graphicsLayer() const;
 
@@ -273,6 +278,13 @@ private:
     void updateStageMode();
 #endif
     void modelResourceFinished();
+    void sourceRequestResource();
+    bool shouldDeferLoading() const;
+    bool isModelDeferred() const;
+    bool isModelLoading() const;
+    bool isModelLoaded() const;
+    bool isModelUnloading() const;
+    bool isModelUnloaded() const;
 
     URL m_sourceURL;
     CachedResourceHandle<CachedRawResource> m_resource;
@@ -285,9 +297,10 @@ private:
     bool m_dataComplete { false };
     bool m_isDragging { false };
     bool m_shouldCreateModelPlayerUponRendererAttachment { false };
+    bool m_isIntersectingViewport { false };
 
     RefPtr<ModelPlayer> m_modelPlayer;
-    EventLoopTimerHandle m_reloadModelTimer;
+    EventLoopTimerHandle m_loadModelTimer;
 #if ENABLE(MODEL_PROCESS)
     Ref<DOMMatrixReadOnly> m_entityTransform;
     Ref<DOMPointReadOnly> m_boundingBoxCenter;

--- a/Source/WebCore/Modules/model-element/LazyLoadModelObserver.cpp
+++ b/Source/WebCore/Modules/model-element/LazyLoadModelObserver.cpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "LazyLoadModelObserver.h"
+
+#if ENABLE(MODEL_ELEMENT)
+
+#include "DocumentInlines.h"
+#include "HTMLModelElement.h"
+#include "IntersectionObserverCallback.h"
+#include "IntersectionObserverEntry.h"
+#include "LocalFrame.h"
+#include "Logging.h"
+#include <limits>
+#include <wtf/TZoneMallocInlines.h>
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LazyLoadModelObserver);
+
+class LazyModelLoadIntersectionObserverCallback final : public IntersectionObserverCallback {
+public:
+    static Ref<LazyModelLoadIntersectionObserverCallback> create(Document& document)
+    {
+        return adoptRef(*new LazyModelLoadIntersectionObserverCallback(document));
+    }
+
+private:
+    LazyModelLoadIntersectionObserverCallback(Document& document)
+        : IntersectionObserverCallback(&document)
+    {
+    }
+
+    bool hasCallback() const final { return true; }
+
+    CallbackResult<void> invoke(IntersectionObserver&, const Vector<Ref<IntersectionObserverEntry>>& entries, IntersectionObserver&) final
+    {
+        ASSERT(!entries.isEmpty());
+
+        for (auto& entry : entries) {
+            if (RefPtr element = dynamicDowncast<HTMLModelElement>(entry->target()))
+                element->viewportIntersectionChanged(entry->isIntersecting());
+        }
+        return { };
+    }
+
+    CallbackResult<void> invokeRethrowingException(IntersectionObserver& thisObserver, const Vector<Ref<IntersectionObserverEntry>>& entries, IntersectionObserver& observer) final
+    {
+        return invoke(thisObserver, entries, observer);
+    }
+};
+
+void LazyLoadModelObserver::observe(Element& element)
+{
+    RefPtr document = element.document();
+    if (!document)
+        return;
+
+    auto& observer = document->lazyLoadModelObserver();
+    RefPtr intersectionObserver = observer.intersectionObserver(*document);
+    if (!intersectionObserver)
+        return;
+    intersectionObserver->observe(element);
+}
+
+void LazyLoadModelObserver::unobserve(Element& element, Document& document)
+{
+    if (auto& intersectionObserver = document.lazyLoadModelObserver().m_observer)
+        intersectionObserver->unobserve(element);
+}
+
+IntersectionObserver* LazyLoadModelObserver::intersectionObserver(Document& document)
+{
+    if (!m_observer) {
+        auto callback = LazyModelLoadIntersectionObserverCallback::create(document);
+        static NeverDestroyed<const String> lazyLoadingScrollMarginFallback(MAKE_STATIC_STRING_IMPL("100%"));
+        IntersectionObserver::Init options { std::nullopt, { }, lazyLoadingScrollMarginFallback, { } };
+        auto observer = IntersectionObserver::create(document, WTFMove(callback), WTFMove(options));
+        if (observer.hasException())
+            return nullptr;
+        m_observer = observer.returnValue().ptr();
+    }
+    return m_observer.get();
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(MODEL_ELEMENT)

--- a/Source/WebCore/Modules/model-element/LazyLoadModelObserver.h
+++ b/Source/WebCore/Modules/model-element/LazyLoadModelObserver.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(MODEL_ELEMENT)
+
+#include "IntersectionObserver.h"
+#include <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+
+class Document;
+class Element;
+
+class LazyLoadModelObserver {
+    WTF_MAKE_TZONE_ALLOCATED(LazyLoadModelObserver);
+public:
+    static void observe(Element&);
+    static void unobserve(Element&, Document&);
+
+private:
+    IntersectionObserver* intersectionObserver(Document&);
+
+    RefPtr<IntersectionObserver> m_observer;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(MODEL_ELEMENT)

--- a/Source/WebCore/Modules/model-element/ModelPlayerClient.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayerClient.h
@@ -61,6 +61,7 @@ public:
 #endif
     virtual std::optional<PlatformLayerIdentifier> modelContentsLayerID() const = 0;
     virtual bool isVisible() const = 0;
+    virtual bool isIntersectingViewport() const = 0;
     virtual void logWarning(ModelPlayer&, const String& warningMessage) = 0;
 };
 

--- a/Source/WebCore/Modules/notifications/NotificationResourcesLoader.cpp
+++ b/Source/WebCore/Modules/notifications/NotificationResourcesLoader.cpp
@@ -30,6 +30,7 @@
 #if ENABLE(NOTIFICATIONS)
 
 #include "BitmapImage.h"
+#include "EventTargetInlines.h"
 #include "GraphicsContext.h"
 #include "NotificationResources.h"
 #include "ResourceRequest.h"

--- a/Source/WebCore/Modules/permissions/NavigatorPermissions.h
+++ b/Source/WebCore/Modules/permissions/NavigatorPermissions.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "Supplementable.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
@@ -46,7 +47,7 @@ private:
     static ASCIILiteral supplementName();
 
     const RefPtr<Permissions> m_permissions;
-    const CheckedRef<Navigator> m_navigator;
+    const WTF::CheckedRef<Navigator> m_navigator;
 };
 
 }

--- a/Source/WebCore/Modules/permissions/PermissionStatus.cpp
+++ b/Source/WebCore/Modules/permissions/PermissionStatus.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "PermissionStatus.h"
 
+#include "ContextDestructionObserverInlines.h"
 #include "ClientOrigin.h"
 #include "Document.h"
 #include "DocumentInlines.h"
@@ -111,6 +112,11 @@ bool PermissionStatus::virtualHasPendingActivity() const
         return document->hasBrowsingContext();
 
     return true;
+}
+
+ScriptExecutionContext* PermissionStatus::scriptExecutionContext() const
+{
+    return ActiveDOMObject::scriptExecutionContext();
 }
 
 void PermissionStatus::eventListenersDidChange()

--- a/Source/WebCore/Modules/permissions/PermissionStatus.h
+++ b/Source/WebCore/Modules/permissions/PermissionStatus.h
@@ -62,7 +62,7 @@ private:
     bool virtualHasPendingActivity() const final;
 
     // EventTarget
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::PermissionStatus; }
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.cpp
@@ -27,6 +27,7 @@
 #include "WakeLockSentinel.h"
 
 #include "Document.h"
+#include "Event.h"
 #include "EventNames.h"
 #include "EventTargetInlines.h"
 #include "Exception.h"

--- a/Source/WebCore/Modules/speech/LocalDOMWindowSpeechSynthesis.cpp
+++ b/Source/WebCore/Modules/speech/LocalDOMWindowSpeechSynthesis.cpp
@@ -33,7 +33,9 @@
 
 #if ENABLE(SPEECH_SYNTHESIS)
 
+#include "Document.h"
 #include "LocalDOMWindow.h"
+#include "LocalFrame.h"
 #include "Page.h"
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/Modules/webaudio/ConvolverNode.cpp
+++ b/Source/WebCore/Modules/webaudio/ConvolverNode.cpp
@@ -33,6 +33,8 @@
 #include "AudioNodeInput.h"
 #include "AudioNodeOutput.h"
 #include "AudioUtilities.h"
+#include "ExceptionCode.h"
+#include "ExceptionOr.h"
 #include "Reverb.h"
 #include <JavaScriptCore/TypedArrays.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/Modules/webaudio/IIRFilterNode.cpp
+++ b/Source/WebCore/Modules/webaudio/IIRFilterNode.cpp
@@ -29,6 +29,8 @@
 #include "IIRFilterNode.h"
 
 #include "BaseAudioContext.h"
+#include "ExceptionCode.h"
+#include "ExceptionOr.h"
 #include "IIRFilter.h"
 #include "ScriptExecutionContext.h"
 #include <JavaScriptCore/ConsoleTypes.h>

--- a/Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.cpp
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.cpp
@@ -35,6 +35,7 @@
 #include "AudioUtilities.h"
 #include "AudioWorklet.h"
 #include "AudioWorkletMessagingProxy.h"
+#include "Exception.h"
 #include "HRTFDatabaseLoader.h"
 #include "OfflineAudioContext.h"
 #include "WorkerRunLoop.h"

--- a/Source/WebCore/Modules/webaudio/WaveShaperNode.cpp
+++ b/Source/WebCore/Modules/webaudio/WaveShaperNode.cpp
@@ -28,6 +28,8 @@
 #if ENABLE(WEB_AUDIO)
 
 #include "AudioContext.h"
+#include "ExceptionCode.h"
+#include "ExceptionOr.h"
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/TypedArrayInlines.h>
 #include <JavaScriptCore/TypedArrays.h>

--- a/Source/WebCore/Modules/webdatabase/SQLResultSetRowList.cpp
+++ b/Source/WebCore/Modules/webdatabase/SQLResultSetRowList.cpp
@@ -29,6 +29,9 @@
 #include "config.h"
 #include "SQLResultSetRowList.h"
 
+#include "ExceptionCode.h"
+#include "ExceptionOr.h"
+
 namespace WebCore {
 
 unsigned SQLResultSetRowList::length() const

--- a/Source/WebCore/Modules/webdriver/NavigatorWebDriver.cpp
+++ b/Source/WebCore/Modules/webdriver/NavigatorWebDriver.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "NavigatorWebDriver.h"
 
+#include "FrameInlines.h"
 #include "LocalFrame.h"
 #include "Navigator.h"
 #include "Page.h"

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -293,6 +293,7 @@ Modules/mediastream/UserMediaController.cpp
 Modules/mediastream/UserMediaRequest.cpp
 Modules/mediastream/VideoTrackGenerator.cpp
 Modules/model-element/HTMLModelElement.cpp
+Modules/model-element/LazyLoadModelObserver.cpp
 Modules/model-element/ModelPlayer.cpp
 Modules/model-element/ModelPlayerAnimationState.cpp
 Modules/model-element/ModelPlayerClient.cpp

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -397,6 +397,10 @@
 #include "MediaStreamTrack.h"
 #endif
 
+#if ENABLE(MODEL_ELEMENT)
+#include "LazyLoadModelObserver.h"
+#endif
+
 #if USE(QUICK_LOOK)
 #include "QuickLook.h"
 #endif
@@ -11143,6 +11147,15 @@ LazyLoadImageObserver& Document::lazyLoadImageObserver()
         m_lazyLoadImageObserver = makeUnique<LazyLoadImageObserver>();
     return *m_lazyLoadImageObserver;
 }
+
+#if ENABLE(MODEL_ELEMENT)
+LazyLoadModelObserver& Document::lazyLoadModelObserver()
+{
+    if (!m_lazyLoadModelObserver)
+        m_lazyLoadModelObserver = makeUnique<LazyLoadModelObserver>();
+    return *m_lazyLoadModelObserver;
+}
+#endif
 
 const CrossOriginOpenerPolicy& Document::crossOriginOpenerPolicy() const
 {

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -347,6 +347,10 @@ enum class EventTrackingRegionsEventType : uint8_t;
 enum class MediaSessionAction : uint8_t;
 #endif
 
+#if ENABLE(MODEL_ELEMENT)
+class LazyLoadModelObserver;
+#endif
+
 using IntDegrees = int32_t;
 using MediaProducerMediaStateFlags = OptionSet<MediaProducerMediaState>;
 using MediaProducerMutedStateFlags = OptionSet<MediaProducerMutedState>;
@@ -1913,6 +1917,9 @@ public:
     bool allowsContentJavaScript() const;
 
     LazyLoadImageObserver& lazyLoadImageObserver();
+#if ENABLE(MODEL_ELEMENT)
+    LazyLoadModelObserver& lazyLoadModelObserver();
+#endif
 
     ContentVisibilityDocumentState& contentVisibilityDocumentState();
 
@@ -2272,6 +2279,9 @@ private:
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_cssTarget;
 
     std::unique_ptr<LazyLoadImageObserver> m_lazyLoadImageObserver;
+#if ENABLE(MODEL_ELEMENT)
+    std::unique_ptr<LazyLoadModelObserver> m_lazyLoadModelObserver;
+#endif
 
     std::unique_ptr<ContentVisibilityDocumentState> m_contentVisibilityDocumentState;
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -408,7 +408,7 @@
 #include "TextRecognitionResult.h"
 #endif
 
-#if ENABLE(ARKIT_INLINE_PREVIEW_MAC)
+#if ENABLE(ARKIT_INLINE_PREVIEW_MAC) || ENABLE(MODEL_ELEMENT)
 #include "HTMLModelElement.h"
 #endif
 
@@ -7963,6 +7963,16 @@ void Internals::disableModelLoadDelaysForTesting()
         return;
 
     document->page()->disableModelLoadDelaysForTesting();
+}
+
+String Internals::modelElementState(HTMLModelElement& element)
+{
+    return element.modelElementStateForTesting();
+}
+
+bool Internals::isModelElementIntersectingViewport(HTMLModelElement& element)
+{
+    return element.isIntersectingViewport();
 }
 #endif
 

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -174,7 +174,7 @@ class MockMediaSessionCoordinator;
 #endif
 #endif
 
-#if ENABLE(ARKIT_INLINE_PREVIEW_MAC)
+#if ENABLE(ARKIT_INLINE_PREVIEW_MAC) || ENABLE(MODEL_ELEMENT)
 class HTMLModelElement;
 #endif
 
@@ -1580,6 +1580,8 @@ public:
 
 #if ENABLE(MODEL_ELEMENT)
     void disableModelLoadDelaysForTesting();
+    String modelElementState(HTMLModelElement&);
+    bool isModelElementIntersectingViewport(HTMLModelElement&);
 #endif
 
 private:

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1454,4 +1454,6 @@ enum ContentsFormat {
 #endif
 
     [Conditional=MODEL_ELEMENT] undefined disableModelLoadDelaysForTesting();
+    [Conditional=MODEL_ELEMENT] DOMString modelElementState(HTMLModelElement element);
+    [Conditional=MODEL_ELEMENT] boolean isModelElementIntersectingViewport(HTMLModelElement element);
 };

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -400,6 +400,11 @@ void ModelProcessModelPlayerProxy::unloadModelTimerFired()
     if (!strongManager)
         return;
 
+    if (m_loader) {
+        m_loader->cancel();
+        m_loader = nullptr;
+    }
+
     RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy::unloadModelTimerFired(): inform manager to unload model id=%" PRIu64, this, m_id.toUInt64());
     strongManager->unloadModelPlayer(m_id);
 }


### PR DESCRIPTION
#### 3391caa9afee4eadf7547dc93143b531eac64e45
<pre>
[Model Element] Implement lazy loading and unloading based on viewport intersection
<a href="https://bugs.webkit.org/show_bug.cgi?id=295640">https://bugs.webkit.org/show_bug.cgi?id=295640</a>
149973010

Reviewed by Ada Chan.

This change implements lazy loading for model elements to improve performance by
only loading models when they are visible in the viewport and unloading them
when they scroll out of view. That helps to reduce memory usage and improve page
load performance for pages with many model elements.

Since WebCore/Sources.txt is changed, missing headers added here and there to fix the build.

Key changes:
- Add LazyLoadModelObserver class that uses IntersectionObserver to track when
  model elements enter/exit the viewport
- Models now only begin loading when they intersect the viewport, not immediately
  when sources are set
- Models are unloaded when they leave the viewport to free memory
- Update visibility logic to consider both page visibility and viewport intersection
- Rename reloadModelTimer to loadModelTimer to better reflect its purpose

* LayoutTests/model-element/model-element-animations-replace-sources.html:
* LayoutTests/model-element/model-element-bounding-box.html:
* LayoutTests/model-element/model-element-contents-layer-updates-with-clipping.html:
* LayoutTests/model-element/model-element-contents-layer-updates.html:
* LayoutTests/model-element/model-element-entity-transform.html:
* LayoutTests/model-element/model-element-environment-map-ready.html:
* LayoutTests/model-element/model-element-lazy-loading-unloading-expected.txt: Added.
* LayoutTests/model-element/model-element-lazy-loading-unloading.html: Added.
* LayoutTests/model-element/model-element-on-hidden-page-with-delays-expected.txt: Added.
* LayoutTests/model-element/model-element-on-hidden-page-with-delays.html: Added.
* LayoutTests/model-element/model-element-ready.html:
* LayoutTests/model-element/model-element-stagemode.html:
* LayoutTests/model-element/resources/model-element-test-utils.js:
(async waitForModelState):
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::~HTMLModelElement):
(WebCore::HTMLModelElement::resume):
(WebCore::HTMLModelElement::visibilityStateChanged):
(WebCore::HTMLModelElement::setSourceURL):
(WebCore::HTMLModelElement::startLoadModelTimer):
(WebCore::HTMLModelElement::loadModelTimerFired):
(WebCore::HTMLModelElement::didFailLoading):
(WebCore::HTMLModelElement::isVisible const):
(WebCore::HTMLModelElement::didUnload):
(WebCore::HTMLModelElement::shouldDeferLoading const):
(WebCore::HTMLModelElement::modelResourceFinished):
(WebCore::HTMLModelElement::stop):
(WebCore::HTMLModelElement::insertedIntoAncestor):
(WebCore::HTMLModelElement::removedFromAncestor):
(WebCore::HTMLModelElement::sourceRequestResource):
(WebCore::HTMLModelElement::viewportIntersectionChanged):
(WebCore::HTMLModelElement::isModelDeferred const):
(WebCore::HTMLModelElement::isModelLoading const):
(WebCore::HTMLModelElement::isModelLoaded const):
(WebCore::HTMLModelElement::isModelUnloading const):
(WebCore::HTMLModelElement::isModelUnloaded const):
(WebCore::HTMLModelElement::modelElementStateForTesting const):
(WebCore::HTMLModelElement::startReloadModelTimer): Deleted.
(WebCore::HTMLModelElement::reloadModelTimerFired): Deleted.
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/Modules/model-element/LazyLoadModelObserver.cpp: Added.
(WebCore::LazyLoadModelObserver::observe):
(WebCore::LazyLoadModelObserver::unobserve):
(WebCore::LazyLoadModelObserver::intersectionObserver):
* Source/WebCore/Modules/model-element/LazyLoadModelObserver.h: Added.
* Source/WebCore/Modules/model-element/ModelPlayerClient.h:
* Source/WebCore/Modules/notifications/NotificationResourcesLoader.cpp:
* Source/WebCore/Modules/permissions/NavigatorPermissions.h:
* Source/WebCore/Modules/permissions/PermissionStatus.cpp:
(WebCore::PermissionStatus::scriptExecutionContext const):
* Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.cpp:
* Source/WebCore/Modules/speech/LocalDOMWindowSpeechSynthesis.cpp:
* Source/WebCore/Modules/webaudio/ConvolverNode.cpp:
* Source/WebCore/Modules/webaudio/IIRFilterNode.cpp:
* Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.cpp:
* Source/WebCore/Modules/webaudio/WaveShaperNode.cpp:
* Source/WebCore/Modules/webdatabase/SQLResultSetRowList.cpp:
* Source/WebCore/Modules/webdriver/NavigatorWebDriver.cpp:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::lazyLoadModelObserver):
* Source/WebCore/dom/Document.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::modelElementState):
(WebCore::Internals::isModelElementIntersectingViewport):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::unloadModelTimerFired):

Canonical link: <a href="https://commits.webkit.org/297264@main">https://commits.webkit.org/297264@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c2162aa2a65743e624d5ad0719d17f7f28b8e1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111078 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30744 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21175 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117109 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61345 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113040 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31425 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39326 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84448 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114025 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25107 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100006 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64894 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/110509 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24451 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18151 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60929 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94486 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18216 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119999 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38127 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28334 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93389 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38503 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96283 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93213 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23756 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38290 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16031 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34108 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38016 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43492 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37680 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41014 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39383 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->