### PR TITLE
Add Type Summary for StyleSelfAlignmentData.

### DIFF
--- a/Tools/lldb/lldb_webkit.py
+++ b/Tools/lldb/lldb_webkit.py
@@ -113,6 +113,8 @@ def __lldb_init_module(debugger, dict):
 
     debugger.HandleCommand('type summary add -F lldb_webkit.WebCoreLength_SummaryProvider WebCore::Length')
 
+    debugger.HandleCommand('type summary add -F lldb_webkit.WebCoreStyleSelfAlignmentData_SummaryProvider WebCore::StyleSelfAlignmentData')
+
     debugger.HandleCommand('type summary add -F lldb_webkit.WebCoreSecurityOrigin_SummaryProvider WebCore::SecurityOrigin')
     debugger.HandleCommand('type summary add -F lldb_webkit.WebCoreFrame_SummaryProvider WebCore::Frame')
 
@@ -302,6 +304,11 @@ def WebCoreLength_SummaryProvider(valobj, dict):
 def WebCoreSecurityOrigin_SummaryProvider(valobj, dict):
     provider = WebCoreSecurityOriginProvider(valobj, dict)
     return '{ %s, domain = %s, hasUniversalAccess = %d }' % (provider.to_string(), provider.domain(), provider.has_universal_access())
+
+
+def WebCoreStyleSelfAlignmentData_SummaryProvider(valobj, dict):
+    provider = WebCoreStyleSelfAlignmentDataProvider(valobj, dict)
+    return "{ %s, %s, %s }" % (provider.get_item_position(), provider.get_item_position_type(), provider.get_overflow_alignment())
 
 
 def WebCoreFrame_SummaryProvider(valobj, dict):
@@ -863,6 +870,24 @@ class WebCoreLengthProvider:
 
         return self.valobj.GetChildMemberWithName('m_intValue').GetValueAsSigned()
 
+
+class WebCoreStyleSelfAlignmentDataProvider:
+    "Print a WebCore::StyleSelfAlignmentData"
+
+    def __init__(self, valobj, dict):
+        self.valobj = valobj
+
+    def get_item_position(self):
+        item_position = self.valobj.GetChildMemberWithName("m_position").GetValueAsUnsigned()
+        return self.valobj.CreateValueFromExpression("itemPosition", f"(WebCore::ItemPosition){item_position}")
+
+    def get_item_position_type(self):
+        item_position_type = self.valobj.GetChildMemberWithName("m_positionType").GetValueAsUnsigned()
+        return self.valobj.CreateValueFromExpression("positionType", f"(WebCore::ItemPositionType){item_position_type}")
+
+    def get_overflow_alignment(self):
+        overflow_alignment = self.valobj.GetChildMemberWithName("m_overflow").GetValueAsUnsigned()
+        return self.valobj.CreateValueFromExpression("overflow", f"(WebCore::OverflowAlignment){overflow_alignment}")
 
 
 class WTFURLProvider:


### PR DESCRIPTION
#### 1c2b2a6430106ca28671be1e364481b9c7be1fa5
<pre>
Add Type Summary for StyleSelfAlignmentData.
<a href="https://bugs.webkit.org/show_bug.cgi?id=295650">https://bugs.webkit.org/show_bug.cgi?id=295650</a>
<a href="https://rdar.apple.com/problem/155454737">rdar://problem/155454737</a>

Reviewed by Ryan Reno.

StyleSelfAlignmentData has bitfields used to represent ItemPosition,
ItemPositionType, and OverflowAlignment which are all enums. Printing
this class in lldb right now is not super helpful and you would need to
call the respective functions, which return the enum, to get any useful
information easily. We can add a type summary for this that does the
same thing so that it makes debugging a bit easier.

Canonical link: <a href="https://commits.webkit.org/297184@main">https://commits.webkit.org/297184@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bbb5590515c1777f7e1b8e0be8a02a03fd468cdf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110784 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30447 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20879 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116813 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/61052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112747 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31127 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39033 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/84236 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/61052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113732 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24864 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/99763 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64677 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/24231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17899 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/60607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94257 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17959 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119603 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37829 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28113 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/93196 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38205 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96030 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93020 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23711 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38058 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/15811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/33803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37722 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37383 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40721 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/39090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->