### PR TITLE
WIP unexpected offsetForInFlowPosition for static position

### DIFF
--- a/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
@@ -451,8 +451,6 @@ void PositionedLayoutConstraints::computeInlineStaticDistance(const RenderBox& r
             if (!renderBox)
                 continue;
             staticPosition += haveOrthogonalWritingModes ? renderBox->logicalTop() : renderBox->logicalLeft();
-            if (renderBox->isInFlowPositioned())
-                staticPosition += renderBox->isHorizontalWritingMode() ? renderBox->offsetForInFlowPosition().width() : renderBox->offsetForInFlowPosition().height();
         }
         m_insetBefore = Style::InsetEdge::Fixed { staticPosition };
     } else {


### PR DESCRIPTION
#### 0f89597b1e59eda7d7817556c28fe1959477f377
<pre>
WIP unexpected offsetForInFlowPosition for static position
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f89597b1e59eda7d7817556c28fe1959477f377

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110766 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30429 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116795 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61034 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112729 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31109 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39015 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84224 "Found 2 new test failures: fast/block/positioning/fixed-container-with-sticky-parent.html imported/w3c/web-platform-tests/css/css-position/hypothetical-dynamic-change-003.html (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113714 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24854 "Found 1 new test failure: fast/block/positioning/fixed-container-with-sticky-parent.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99752 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64665 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24222 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-position/hypothetical-dynamic-change-003.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17887 "Found 5 new test failures: fast/block/positioning/fixed-container-with-sticky-parent.html fonts/monospace.html fonts/sans-serif.html fonts/serif.html imported/w3c/web-platform-tests/css/css-position/hypothetical-dynamic-change-003.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60588 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94247 "Found 1 new API test failure: TestWebKitAPI.GPUProcess.ExitsUnderMemoryPressureWebAudioCase (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17945 "Found 2 new test failures: fast/block/positioning/fixed-container-with-sticky-parent.html imported/w3c/web-platform-tests/css/css-position/hypothetical-dynamic-change-003.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119585 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37811 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28101 "Found 2 new test failures: fast/block/positioning/fixed-container-with-sticky-parent.html imported/w3c/web-platform-tests/css/css-position/hypothetical-dynamic-change-003.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93185 "Found 2 new test failures: fast/block/positioning/fixed-container-with-sticky-parent.html imported/w3c/web-platform-tests/css/css-position/hypothetical-dynamic-change-003.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38187 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96016 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93009 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38042 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15801 "Found 2 new test failures: fast/block/positioning/fixed-container-with-sticky-parent.html imported/w3c/web-platform-tests/css/css-position/hypothetical-dynamic-change-003.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33785 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37704 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43174 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37365 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40703 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39072 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->