### PR TITLE
[libpas] Improve parsing of Probabilistic Guard Malloc activation state

### DIFF
--- a/Source/JavaScriptCore/API/PASReportCrashPrivate.cpp
+++ b/Source/JavaScriptCore/API/PASReportCrashPrivate.cpp
@@ -42,15 +42,6 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 using namespace JSC;
 
 #ifdef __APPLE__
-kern_return_t PASPGMEnabledOnProcess()
-{
-#if !USE(SYSTEM_MALLOC)
-#if BENABLE(LIBPAS)
-    return pas_probabilistic_guard_malloc_enabled_on_process() ? KERN_SUCCESS : KERN_FAILURE;
-#endif /* BENABLE(LIBPAS) */
-#endif /* !USE(SYSTEM_MALLOC) */
-    return KERN_FAILURE;
-}
 
 kern_return_t PASReportCrashExtractResults(vm_address_t fault_address, mach_vm_address_t pas_dead_root, unsigned version, task_t task, pas_report_crash_pgm_report *report, crash_reporter_memory_reader_t crm_reader)
 {

--- a/Source/JavaScriptCore/API/PASReportCrashPrivate.h
+++ b/Source/JavaScriptCore/API/PASReportCrashPrivate.h
@@ -34,7 +34,6 @@
 extern "C" {
 #endif
 
-JS_EXPORT kern_return_t PASPGMEnabledOnProcess(void);
 JS_EXPORT kern_return_t PASReportCrashExtractResults(vm_address_t fault_address, mach_vm_address_t pas_dead_root, unsigned version, task_t task, pas_report_crash_pgm_report *report, crash_reporter_memory_reader_t crm_reader);
 
 #ifdef __cplusplus

--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
@@ -32,13 +32,10 @@
 
 #include "iso_heap_config.h"
 #include "pas_heap.h"
-#include "pas_large_heap.h"
 #include "pas_large_utility_free_heap.h"
-#include "pas_ptr_hash_map.h"
 #include "pas_random.h"
 #include "pas_utility_heap.h"
 #include "pas_utility_heap_support.h"
-#include "pas_utils.h"
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -74,7 +71,7 @@ bool pas_probabilistic_guard_malloc_is_initialized = false;
  * Flag to indicate if PGM has enabled at all for this process,
  * even if it been subsequently disabled, or no guarded allocations have been made
 */
-static bool pas_probabilistic_guard_malloc_has_been_used = false;
+bool pas_probabilistic_guard_malloc_has_been_used = false;
 
 /*
  * the hash map is used to keep track of all pgm allocations
@@ -333,7 +330,6 @@ void pas_probabilistic_guard_malloc_deallocate(void* mem)
         pas_probabilistic_guard_malloc_debug_info((void*)key, value, "Deallocating Memory");
 
     pas_probabilistic_guard_malloc_can_use = true;
-    pas_probabilistic_guard_malloc_has_been_used = true;
 }
 
 bool pas_probabilistic_guard_malloc_check_exists(uintptr_t mem)
@@ -391,14 +387,6 @@ pas_ptr_hash_map_entry* pas_probabilistic_guard_malloc_get_metadata_array(void)
     return pgm_metadata_vector;
 }
 
-/*
- * Function to be called to check if PGM has been enabled on this process at any point,
- * regardless of if it has since been disabled, or if any guarded allocations were made.
-*/
-bool pas_probabilistic_guard_malloc_enabled_on_process(void)
-{
-    return pas_probabilistic_guard_malloc_has_been_used;
-}
 
 /*
  * During heap creation we want to check whether we should enable PGM.
@@ -425,6 +413,7 @@ void pas_probabilistic_guard_malloc_initialize_pgm(void)
     if (!pas_probabilistic_guard_malloc_is_initialized) {
         pas_probabilistic_guard_malloc_is_initialized = true;
         pas_probabilistic_guard_malloc_can_use = false;
+        pas_probabilistic_guard_malloc_has_been_used = true;
     }
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h
@@ -94,6 +94,12 @@ struct pas_pgm_storage {
     pas_large_heap* large_heap;
 };
 
+/* 
+ * Flag to indicate if PGM was ever enabled for this process,
+ * even if it been subsequently disabled, or no guarded allocations have been made.
+*/
+extern bool pas_probabilistic_guard_malloc_has_been_used;
+
 /* max amount of free memory that can be wasted (1MB) */
 #define PAS_PGM_MAX_WASTED_MEMORY (1024 * 1024)
 

--- a/Source/bmalloc/libpas/src/libpas/pas_report_crash.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_report_crash.c
@@ -93,6 +93,13 @@ kern_return_t pas_report_crash_extract_pgm_failure(vm_address_t fault_address, m
     if (kr != KERN_SUCCESS)
         return KERN_FAILURE;
 
+    kr = reader(task, (vm_address_t)read_pas_dead_root->probabilistic_guard_malloc_has_been_used, sizeof(report->pgm_has_been_used), (void**)&report->pgm_has_been_used);
+    if (kr != KERN_SUCCESS)
+        return KERN_FAILURE;
+
+    if (!report->pgm_has_been_used)
+        return KERN_FAILURE;
+
     kr = reader(task, (vm_address_t)read_pas_dead_root->pas_pgm_hash_map_instance, sizeof(pas_ptr_hash_map), (void**)&hash_map);
     if (kr != KERN_SUCCESS)
         return KERN_FAILURE;

--- a/Source/bmalloc/libpas/src/libpas/pas_report_crash_pgm_report.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_report_crash_pgm_report.h
@@ -47,7 +47,7 @@ extern "C" {
 typedef void *(*crash_reporter_memory_reader_t)(task_t task, vm_address_t address, size_t size);
 
 /* Crash Report Version number. This must be in sync between ReportCrash and libpas to generate a report. */
-const unsigned pas_crash_report_version = 3;
+const unsigned pas_crash_report_version = 4;
 
 /* Report sent back to the ReportCrash process. */
 typedef struct pas_report_crash_pgm_report pas_report_crash_pgm_report;
@@ -59,6 +59,7 @@ struct pas_report_crash_pgm_report {
     size_t allocation_size;
     pas_backtrace_metadata* alloc_backtrace;
     pas_backtrace_metadata* dealloc_backtrace;
+    bool pgm_has_been_used;
 };
 #endif /* __APPLE__ */
 

--- a/Source/bmalloc/libpas/src/libpas/pas_root.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_root.c
@@ -127,6 +127,8 @@ void pas_root_construct(pas_root* root)
     root->tiny_large_map_second_level_hashtable_in_flux_stash_instance =
         &pas_tiny_large_map_second_level_hashtable_in_flux_stash_instance;
 
+    root->probabilistic_guard_malloc_has_been_used = &pas_probabilistic_guard_malloc_has_been_used;
+
     root->pas_pgm_hash_map_instance = &pas_pgm_hash_map;
     root->pas_pgm_hash_map_instance_in_flux_stash = &pas_pgm_hash_map_in_flux_stash;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_root.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_root.h
@@ -101,6 +101,7 @@ struct pas_root {
     size_t num_baseline_allocators;
     pas_ptr_hash_map* pas_pgm_hash_map_instance;
     pas_ptr_hash_map_in_flux_stash* pas_pgm_hash_map_instance_in_flux_stash;
+    bool* probabilistic_guard_malloc_has_been_used;
 };
 
 #define PAS_ROOT_MAGIC 0xbeeeeeeeefllu
@@ -146,4 +147,3 @@ PAS_API kern_return_t pas_root_visit_conservative_candidate_pointers_in_address_
 PAS_END_EXTERN_C;
 
 #endif /* PAS_ROOT_H */
-


### PR DESCRIPTION
#### 262891bb0d263134adb58951a89f337996435804
<pre>
[libpas] Improve parsing of Probabilistic Guard Malloc activation state
<a href="https://bugs.webkit.org/show_bug.cgi?id=295649">https://bugs.webkit.org/show_bug.cgi?id=295649</a>
<a href="https://rdar.apple.com/155454591">rdar://155454591</a>

Reviewed by Dan Hecht.

Fix a variety of issues on the WebKit side related to reading the PGM activation state.
We need to add this flag into the pas root so we can subsequently read it from the dead process.

* Source/JavaScriptCore/API/PASReportCrashPrivate.cpp:
(PASPGMEnabledOnProcess): Deleted.
* Source/JavaScriptCore/API/PASReportCrashPrivate.h:
* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c:
(pas_probabilistic_guard_malloc_deallocate):
(pas_probabilistic_guard_malloc_initialize_pgm):
(pas_probabilistic_guard_malloc_enabled_on_process): Deleted.
* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h:
* Source/bmalloc/libpas/src/libpas/pas_report_crash.c:
(pas_report_crash_extract_pgm_failure):
* Source/bmalloc/libpas/src/libpas/pas_report_crash_pgm_report.h:
* Source/bmalloc/libpas/src/libpas/pas_root.c:
(pas_root_construct):
* Source/bmalloc/libpas/src/libpas/pas_root.h:

Canonical link: <a href="https://commits.webkit.org/298400@main">https://commits.webkit.org/298400@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5afeac2a88475725cf659205515b225b752d9ddd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115402 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35096 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25598 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121491 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65980 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/45af06b4-e788-4844-894d-ce0b54243496) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35755 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43667 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87685 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e00564ff-5ab8-4524-b65b-4e60416f3961) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118350 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28518 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103591 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68077 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27676 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21713 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65148 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/107610 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97907 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21826 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124656 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/113941 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42341 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31720 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96467 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42709 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99779 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96253 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24488 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41481 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19337 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38251 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42222 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47777 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/139046 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile JSC; Compiled JSC (cancelled)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41725 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/139046 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile JSC; Compiled JSC (cancelled)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45053 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43444 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->