### PR TITLE
Adopt more smart pointers in NetworkStorageManager, SQLiteStorageArea

### DIFF
--- a/Source/WebCore/platform/sql/SQLiteStatementAutoResetScope.cpp
+++ b/Source/WebCore/platform/sql/SQLiteStatementAutoResetScope.cpp
@@ -39,6 +39,11 @@ SQLiteStatementAutoResetScope::SQLiteStatementAutoResetScope(SQLiteStatement *st
 {
 }
 
+CheckedPtr<SQLiteStatement> SQLiteStatementAutoResetScope::checkedGet()
+{
+    return m_statement;
+}
+
 SQLiteStatementAutoResetScope::SQLiteStatementAutoResetScope(SQLiteStatementAutoResetScope&&) = default;
 SQLiteStatementAutoResetScope& SQLiteStatementAutoResetScope::operator=(SQLiteStatementAutoResetScope&&) = default;
 

--- a/Source/WebCore/platform/sql/SQLiteStatementAutoResetScope.h
+++ b/Source/WebCore/platform/sql/SQLiteStatementAutoResetScope.h
@@ -46,6 +46,7 @@ public:
 
     SQLiteStatement* get() { return m_statement.get(); }
     SQLiteStatement* operator->() { return m_statement.get(); }
+    WEBCORE_EXPORT CheckedPtr<SQLiteStatement> checkedGet();
 
 private:
     CheckedPtr<SQLiteStatement> m_statement;

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -771,7 +771,7 @@ void NetworkStorageManager::estimate(const WebCore::ClientOrigin& origin, Comple
 {
     assertIsCurrent(workQueue());
 
-    completionHandler(originStorageManager(origin).estimate());
+    completionHandler(checkedOriginStorageManager(origin)->estimate());
 }
 
 void NetworkStorageManager::resetStoragePersistedState(CompletionHandler<void()>&& completionHandler)
@@ -840,7 +840,7 @@ void NetworkStorageManager::fetchSessionStorageForWebPage(WebPageProxyIdentifier
         StorageNamespaceIdentifier storageNameSpaceIdentifier { pageIdentifier.toUInt64() };
 
         for (auto& [origin, originStorageManager] : m_originStorageManagers) {
-            auto* sessionStorageManager = originStorageManager->existingSessionStorageManager();
+            auto* sessionStorageManager = CheckedRef { *originStorageManager }->existingSessionStorageManager();
             if (!sessionStorageManager)
                 continue;
 
@@ -1480,7 +1480,7 @@ void NetworkStorageManager::setOriginQuotaRatioEnabledForTesting(bool enabled, C
         if (m_originQuotaRatioEnabled != enabled) {
             m_originQuotaRatioEnabled = enabled;
             for (auto& [origin, manager] : m_originStorageManagers)
-                manager->protectedQuotaManager()->updateParametersForTesting(originQuotaManagerParameters(origin));
+                CheckedRef { *manager }->protectedQuotaManager()->updateParametersForTesting(originQuotaManagerParameters(origin));
         }
 
         RunLoop::protectedMain()->dispatch(WTFMove(completionHandler));
@@ -1616,17 +1616,19 @@ void NetworkStorageManager::cancelConnectToStorageArea(IPC::Connection& connecti
         return;
 
     auto connectionIdentifier = connection.uniqueID();
+    auto originStorageManager = CheckedRef { *(iterator->value) };
     switch (type) {
     case WebCore::StorageType::Local:
-        if (auto localStorageManager = iterator->value->existingLocalStorageManager())
+        if (auto localStorageManager = originStorageManager->existingLocalStorageManager())
             localStorageManager->cancelConnectToLocalStorageArea(connectionIdentifier);
         break;
     case WebCore::StorageType::TransientLocal:
-        if (auto localStorageManager = iterator->value->existingLocalStorageManager())
+        if (auto localStorageManager = originStorageManager->existingLocalStorageManager())
             localStorageManager->cancelConnectToTransientLocalStorageArea(connectionIdentifier);
+
         break;
     case WebCore::StorageType::Session:
-        if (auto sessionStorageManager = iterator->value->existingSessionStorageManager()) {
+        if (auto sessionStorageManager = originStorageManager->existingSessionStorageManager()) {
             if (!namespaceIdentifier)
                 return;
             sessionStorageManager->cancelConnectToSessionStorageArea(connectionIdentifier, *namespaceIdentifier);
@@ -1996,7 +1998,7 @@ void NetworkStorageManager::lockCacheStorage(IPC::Connection& connection, const 
 
 void NetworkStorageManager::unlockCacheStorage(IPC::Connection& connection, const WebCore::ClientOrigin& origin)
 {
-    if (RefPtr cacheStorageManager = originStorageManager(origin).existingCacheStorageManager())
+    if (RefPtr cacheStorageManager = checkedOriginStorageManager(origin)->existingCacheStorageManager())
         cacheStorageManager->unlockStorage(connection.uniqueID());
 }
 
@@ -2036,7 +2038,7 @@ void NetworkStorageManager::cacheStorageClearMemoryRepresentation(const WebCore:
 
     auto iterator = m_originStorageManagers.find(origin);
     if (iterator != m_originStorageManagers.end())
-        iterator->value->closeCacheStorageManager();
+        CheckedRef { *(iterator->value) }->closeCacheStorageManager();
 
     callback();
 }

--- a/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp
+++ b/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp
@@ -119,7 +119,7 @@ bool SQLiteStorageArea::isEmpty()
     if (!m_database)
         return true;
 
-    auto statement = cachedStatement(StatementType::CountItems);
+    CheckedPtr statement = cachedStatement(StatementType::CountItems).checkedGet();
     if (!statement || statement->step() != SQLITE_ROW) {
         RELEASE_LOG_ERROR(Storage, "SQLiteStorageArea::isEmpty failed on executing statement (%d) - %" PUBLIC_LOG_STRING, m_database->lastError(), m_database->lastErrorMsg());
         return true;
@@ -142,20 +142,21 @@ bool SQLiteStorageArea::createTableIfNecessary()
     if (!m_database)
         return false;
 
-    String statement = m_database->tableSQL("ItemTable"_s);
+    CheckedRef database = *m_database;
+    String statement = database->tableSQL("ItemTable"_s);
     if (statement == createItemTableStatement || statement == createItemTableStatementAlternative)
         return true;
 
     // Table exists but statement is wrong; drop it.
     if (!statement.isEmpty()) {
-        if (!m_database->executeCommand("DROP TABLE ItemTable"_s)) {
+        if (!database->executeCommand("DROP TABLE ItemTable"_s)) {
             RELEASE_LOG_ERROR(Storage, "SQLiteStorageArea::createTableIfNecessary failed to drop existing item table (%d) - %" PUBLIC_LOG_STRING, m_database->lastError(), m_database->lastErrorMsg());
             return false;
         }
     }
 
     // Table does not exist.
-    if (!m_database->executeCommand(createItemTableStatement)) {
+    if (!database->executeCommand(createItemTableStatement)) {
         RELEASE_LOG_ERROR(Storage, "SQLiteStorageArea::createTableIfNecessary failed to create item table (%d) - %" PUBLIC_LOG_STRING, m_database->lastError(), m_database->lastErrorMsg());
         return false;
     }
@@ -165,7 +166,10 @@ bool SQLiteStorageArea::createTableIfNecessary()
 
 bool SQLiteStorageArea::prepareDatabase(ShouldCreateIfNotExists shouldCreateIfNotExists)
 {
-    if (m_database && m_database->isOpen())
+    if (!m_database)
+        return false;
+
+    if (checkedDatabase()->isOpen())
         return true;
 
     m_database = nullptr;
@@ -174,15 +178,16 @@ bool SQLiteStorageArea::prepareDatabase(ShouldCreateIfNotExists shouldCreateIfNo
         return true;
 
     m_database = makeUnique<WebCore::SQLiteDatabase>();
+    CheckedRef resultDatabase = *m_database;
     FileSystem::makeAllDirectories(FileSystem::parentPath(m_path));
-    auto openResult  = m_database->open(m_path, WebCore::SQLiteDatabase::OpenMode::ReadWriteCreate, WebCore::SQLiteDatabase::OpenOptions::CanSuspendWhileLocked);
-    if (!openResult && handleDatabaseErrorIfNeeded(m_database->lastError()) == IsDatabaseDeleted::Yes) {
+    auto openResult  = resultDatabase->open(m_path, WebCore::SQLiteDatabase::OpenMode::ReadWriteCreate, WebCore::SQLiteDatabase::OpenOptions::CanSuspendWhileLocked);
+    if (!openResult && handleDatabaseErrorIfNeeded(resultDatabase->lastError()) == IsDatabaseDeleted::Yes) {
         databaseExists = false;
         if (shouldCreateIfNotExists == ShouldCreateIfNotExists::No)
             return true;
 
         m_database = makeUnique<WebCore::SQLiteDatabase>();
-        openResult = m_database->open(m_path);
+        openResult = checkedDatabase()->open(m_path);
     }
 
     if (!openResult) {
@@ -193,7 +198,7 @@ bool SQLiteStorageArea::prepareDatabase(ShouldCreateIfNotExists shouldCreateIfNo
 
     // Since a WorkQueue isn't bound to a specific thread, we need to disable threading check.
     // We will never access the database from different threads simultaneously.
-    m_database->disableThreadingChecks();
+    checkedDatabase()->disableThreadingChecks();
 
     if (!createTableIfNecessary()) {
         m_database = nullptr;
@@ -213,7 +218,7 @@ void SQLiteStorageArea::startTransactionIfNecessary()
     ASSERT(m_database);
 
     if (!m_transaction || m_transaction->wasRolledBackBySqlite())
-        m_transaction = makeUnique<WebCore::SQLiteTransaction>(*m_database);
+        m_transaction = makeUnique<WebCore::SQLiteTransaction>(*checkedDatabase());
 
     if (m_transaction->inProgress())
         return;
@@ -232,11 +237,16 @@ WebCore::SQLiteStatementAutoResetScope SQLiteStorageArea::cachedStatement(Statem
 
     auto index = static_cast<uint8_t>(type);
     if (!m_cachedStatements[index]) {
-        if (auto result = m_database->prepareHeapStatement(statementString(type)))
+        if (auto result = checkedDatabase()->prepareHeapStatement(statementString(type)))
             m_cachedStatements[index] = result.value().moveToUniquePtr();
     }
 
     return WebCore::SQLiteStatementAutoResetScope { m_cachedStatements[index].get() };
+}
+
+CheckedPtr<WebCore::SQLiteDatabase> SQLiteStorageArea::checkedDatabase() const
+{
+    return m_database.get();
 }
 
 Expected<String, StorageError> SQLiteStorageArea::getItem(const String& key)
@@ -266,7 +276,7 @@ Expected<String, StorageError> SQLiteStorageArea::getItemFromDatabase(const Stri
     int result = SQLITE_OK;
     // Ensure that statement goes out of scope before handleDatabaseErrorIfNeeded(). Otherwise, we may get a CheckedPtr verification failure.
     {
-        auto statement = cachedStatement(StatementType::GetItem);
+        CheckedPtr statement = cachedStatement(StatementType::GetItem).checkedGet();
         if (!statement || statement->bindText(1, key)) {
             RELEASE_LOG_ERROR(Storage, "SQLiteStorageArea::getItemFromDatabase failed on creating statement (%d) - %" PUBLIC_LOG_STRING, m_database->lastError(), m_database->lastErrorMsg());
             return makeUnexpected(StorageError::Database);
@@ -327,7 +337,7 @@ HashMap<String, String> SQLiteStorageArea::allItems()
     int result = SQLITE_OK;
     // Ensure that statement goes out of scope before handleDatabaseErrorIfNeeded(). Otherwise, we may get a CheckedPtr verification failure.
     {
-        auto statement = cachedStatement(StatementType::GetAllItems);
+        CheckedPtr statement = cachedStatement(StatementType::GetAllItems).checkedGet();
         if (!statement) {
             RELEASE_LOG_ERROR(Storage, "SQLiteStorageArea::allItems failed on creating statement (%d) - %" PUBLIC_LOG_STRING, m_database->lastError(), m_database->lastErrorMsg());
             return { };
@@ -379,7 +389,7 @@ Expected<void, StorageError> SQLiteStorageArea::setItem(std::optional<IPC::Conne
     int result = SQLITE_OK;
     // Ensure that statement goes out of scope before handleDatabaseErrorIfNeeded(). Otherwise, we may get a CheckedPtr verification failure.
     {
-        auto statement = cachedStatement(StatementType::SetItem);
+        CheckedPtr statement = cachedStatement(StatementType::SetItem).checkedGet();
         if (!statement || statement->bindText(1, key) || statement->bindBlob(2, value)) {
             RELEASE_LOG_ERROR(Storage, "SQLiteStorageArea::setItem failed on creating statement (%d) - %" PUBLIC_LOG_STRING, m_database->lastError(), m_database->lastErrorMsg());
             return makeUnexpected(StorageError::Database);
@@ -421,7 +431,7 @@ Expected<void, StorageError> SQLiteStorageArea::removeItem(IPC::Connection::Uniq
     int result = SQLITE_OK;
     // Ensure that statement goes out of scope before handleDatabaseErrorIfNeeded(). Otherwise, we may get a CheckedPtr verification failure.
     {
-        auto statement = cachedStatement(StatementType::DeleteItem);
+        CheckedPtr statement = cachedStatement(StatementType::DeleteItem).checkedGet();
         if (!statement || statement->bindText(1, key)) {
             RELEASE_LOG_ERROR(Storage, "SQLiteStorageArea::removeItem failed on creating statement (%d) - %" PUBLIC_LOG_STRING, m_database->lastError(), m_database->lastErrorMsg());
             return makeUnexpected(StorageError::Database);
@@ -466,7 +476,7 @@ Expected<void, StorageError> SQLiteStorageArea::clear(IPC::Connection::UniqueID 
     int result = SQLITE_OK;
     // Ensure that statement goes out of scope before handleDatabaseErrorIfNeeded(). Otherwise, we may get a CheckedPtr verification failure.
     {
-        auto statement = cachedStatement(StatementType::DeleteAllItems);
+        CheckedPtr statement = cachedStatement(StatementType::DeleteAllItems).checkedGet();
         if (!statement) {
             RELEASE_LOG_ERROR(Storage, "SQLiteStorageArea::clear failed on creating statement (%d) - %" PUBLIC_LOG_STRING, m_database->lastError(), m_database->lastErrorMsg());
             return makeUnexpected(StorageError::Database);
@@ -482,7 +492,7 @@ Expected<void, StorageError> SQLiteStorageArea::clear(IPC::Connection::UniqueID 
         return makeUnexpected(StorageError::Database);
     }
 
-    if (m_database->lastChanges() <= 0)
+    if (checkedDatabase()->lastChanges() <= 0)
         return makeUnexpected(StorageError::ItemNotFound);
 
     dispatchEvents(connection, storageAreaImplID, String(), String(), String(), urlString);
@@ -500,8 +510,12 @@ void SQLiteStorageArea::handleLowMemoryWarning()
 {
     ASSERT(!isMainRunLoop());
 
-    if (m_database && m_database->isOpen())
-        m_database->releaseMemory();
+    if (!m_database)
+        return;
+
+    CheckedRef database = *m_database;
+    if (database->isOpen())
+        database->releaseMemory();
 }
 
 SQLiteStorageArea::IsDatabaseDeleted SQLiteStorageArea::handleDatabaseErrorIfNeeded(int databaseError)

--- a/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.h
+++ b/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.h
@@ -79,6 +79,7 @@ private:
     };
     ASCIILiteral statementString(StatementType) const;
     WebCore::SQLiteStatementAutoResetScope cachedStatement(StatementType);
+    CheckedPtr<WebCore::SQLiteDatabase> checkedDatabase() const;
     Expected<String, StorageError> getItem(const String& key);
     Expected<String, StorageError> getItemFromDatabase(const String& key);
     enum class IsDatabaseDeleted : bool { No, Yes };

--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -5,8 +5,6 @@ NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp
 NetworkProcess/cache/AsyncRevalidation.cpp
 NetworkProcess/cocoa/WKURLSessionTaskDelegate.mm
 NetworkProcess/cocoa/WebSocketTaskCocoa.mm
-NetworkProcess/storage/NetworkStorageManager.cpp
-NetworkProcess/storage/SQLiteStorageArea.cpp
 Platform/IPC/ArgumentCoders.h
 Platform/IPC/Connection.cpp
 Platform/cocoa/_WKWebViewTextInputNotifications.mm


### PR DESCRIPTION
#### 42e257ea3a479fec9deae5f1ed138099a19bf656
<pre>
Adopt more smart pointers in NetworkStorageManager, SQLiteStorageArea
<a href="https://bugs.webkit.org/show_bug.cgi?id=295612">https://bugs.webkit.org/show_bug.cgi?id=295612</a>
<a href="https://rdar.apple.com/155384272">rdar://155384272</a>

Reviewed by NOBODY (OOPS!).

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

* Source/WebCore/platform/sql/SQLiteStatementAutoResetScope.cpp:
(WebCore::SQLiteStatementAutoResetScope::checkedGet):
* Source/WebCore/platform/sql/SQLiteStatementAutoResetScope.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::estimate):
(WebKit::NetworkStorageManager::fetchSessionStorageForWebPage):
(WebKit::NetworkStorageManager::setOriginQuotaRatioEnabledForTesting):
(WebKit::NetworkStorageManager::cancelConnectToStorageArea):
(WebKit::NetworkStorageManager::unlockCacheStorage):
(WebKit::NetworkStorageManager::cacheStorageClearMemoryRepresentation):
* Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp:
(WebKit::SQLiteStorageArea::isEmpty):
(WebKit::SQLiteStorageArea::createTableIfNecessary):
(WebKit::SQLiteStorageArea::prepareDatabase):
(WebKit::SQLiteStorageArea::startTransactionIfNecessary):
(WebKit::SQLiteStorageArea::cachedStatement):
(WebKit::SQLiteStorageArea::checkedDatabase const):
(WebKit::SQLiteStorageArea::getItemFromDatabase):
(WebKit::SQLiteStorageArea::allItems):
(WebKit::SQLiteStorageArea::setItem):
(WebKit::SQLiteStorageArea::removeItem):
(WebKit::SQLiteStorageArea::clear):
(WebKit::SQLiteStorageArea::handleLowMemoryWarning):
* Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.h:
* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42e257ea3a479fec9deae5f1ed138099a19bf656

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110809 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/30472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/20905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/116838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/61077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/112772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/31152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/39058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/116838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/61077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/113757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/31152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/20905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/116838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/31152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/20905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/60633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/31152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/20905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/119628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/37854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/39058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/119628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/38230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/20905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/119628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/20905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/33828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/37747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/43217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/37408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/40746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/39115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->