### PR TITLE
[WPE][GTK] Improve error message when auxiliary process crashes immediately

### DIFF
--- a/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
+++ b/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
@@ -665,7 +665,7 @@ pid_t readPIDFromPeer(int socket)
         g_error("readPIDFromPeer: Failed to read pid from PID socket: %s", g_strerror(errno));
 
     if (message.msg_controllen <= 0)
-        g_error("readPIDFromPeer: Unexpected short read from PID socket");
+        g_error("readPIDFromPeer: Unexpected short read from PID socket. (This usually means the auxiliary process crashed immediately. Investigate that instead!)");
 
     for (cmsghdr* header = CMSG_FIRSTHDR(&message); header; header = CMSG_NXTHDR(&message, header)) {
         const unsigned payloadLength = header->cmsg_len - CMSG_LEN(0);


### PR DESCRIPTION
#### bb172d4ed0ff4c7858a5490fcef8ade3e8303f56
<pre>
[WPE][GTK] Improve error message when auxiliary process crashes immediately
<a href="https://bugs.webkit.org/show_bug.cgi?id=295666">https://bugs.webkit.org/show_bug.cgi?id=295666</a>

Reviewed by Patrick Griffis.

* Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp:
(IPC::readPIDFromPeer):

Canonical link: <a href="https://commits.webkit.org/297746@main">https://commits.webkit.org/297746@main</a>
</pre>
