### PR TITLE
[HDR] Support HDR snapshotting for WKThumbnailView.

### DIFF
--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5850,6 +5850,16 @@ bool Page::requiresUserGestureForVideoPlayback() const
 }
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
+bool Page::drawsHDRContent() const
+{
+    bool drawsHDRContent = false;
+    forEachRenderableDocument([&] (Document& document) {
+        if (document.drawsHDRContent())
+            drawsHDRContent = true;
+    });
+    return drawsHDRContent;
+}
+
 void Page::updateDisplayEDRHeadroom()
 {
     static constexpr float kMinimumRequiredHeadroomForTonemapping = 2.7;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1355,6 +1355,7 @@ public:
     bool requiresUserGestureForVideoPlayback() const;
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
+    WEBCORE_EXPORT bool drawsHDRContent() const;
     Headroom displayEDRHeadroom() const { return m_displayEDRHeadroom; }
     bool hdrLayersRequireTonemapping() const { return m_hdrLayersRequireTonemapping; }
     void updateDisplayEDRHeadroom();

--- a/Source/WebCore/platform/graphics/DestinationColorSpace.h
+++ b/Source/WebCore/platform/graphics/DestinationColorSpace.h
@@ -67,7 +67,7 @@ public:
 
     WEBCORE_EXPORT bool supportsOutput() const;
 
-    bool usesExtendedRange() const;
+    WEBCORE_EXPORT bool usesExtendedRange() const;
     bool usesITUR_2100TF() const;
 
 private:

--- a/Source/WebCore/platform/graphics/ImageTypes.h
+++ b/Source/WebCore/platform/graphics/ImageTypes.h
@@ -116,6 +116,10 @@ struct Headroom {
     constexpr operator float() const { return headroom; }
 
     friend constexpr bool operator==(const Headroom&, const Headroom&) = default;
+    friend constexpr bool operator<(const Headroom& a, const Headroom& b)
+    {
+        return a.headroom < b.headroom;
+    }
 
     static const Headroom FromImage;
     static const Headroom None;
@@ -132,5 +136,15 @@ enum class StrictImageClamping : bool {
     Yes
 };
 #endif
+
+}
+
+namespace IPC {
+
+template<typename AsyncReplyResult> struct AsyncReplyError;
+
+template<> struct AsyncReplyError<WebCore::Headroom> {
+    static WebCore::Headroom create() { return WebCore::Headroom::None; }
+};
 
 }

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.h
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.h
@@ -162,7 +162,7 @@ public:
     // Passed in context is the context through which the contents was drawn.
     WEBCORE_EXPORT RetainPtr<CGImageRef> createImage(CGContextRef);
     // Passed in context is the context through which the contents was drawn.
-    WEBCORE_EXPORT static RetainPtr<CGImageRef> sinkIntoImage(std::unique_ptr<IOSurface>, RetainPtr<CGContextRef>);
+    WEBCORE_EXPORT static RetainPtr<CGImageRef> sinkIntoImage(std::unique_ptr<IOSurface>, RetainPtr<CGContextRef> = nullptr);
 
     WEBCORE_EXPORT static Name nameForRenderingPurpose(RenderingPurpose);
     Name name() const { return m_name; }

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
@@ -431,6 +431,8 @@ RetainPtr<CGImageRef> IOSurface::createImage(CGContextRef context)
 
 RetainPtr<CGImageRef> IOSurface::sinkIntoImage(std::unique_ptr<IOSurface> surface, RetainPtr<CGContextRef> context)
 {
+    if (!context)
+        context = surface->createPlatformContext();
     ASSERT(CGIOSurfaceContextGetSurface(context.get()) == surface->m_surface);
     UNUSED_PARAM(surface);
     return adoptCF(CGIOSurfaceContextCreateImageReference(context.get()));

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1064,6 +1064,7 @@ def headers_for_type(type, for_implementation_file=False):
         'WebCore::GraphicsDropShadow': ['<WebCore/GraphicsStyle.h>'],
         'WebCore::HasAvailableTargets': ['<WebCore/MediaSessionHelperIOS.h>'],
         'WebCore::HasInsecureContent': ['<WebCore/FrameLoaderTypes.h>'],
+        'WebCore::Headroom': ['<WebCore/ImageTypes.h>'],
         'WebCore::HighlightRequestOriginatedInApp': ['<WebCore/AppHighlight.h>'],
         'WebCore::HighlightVisibility': ['<WebCore/HighlightVisibility.h>'],
         'WebCore::InterpolationQuality': ['<WebCore/GraphicsTypes.h>'],

--- a/Source/WebKit/Shared/ImageOptions.h
+++ b/Source/WebKit/Shared/ImageOptions.h
@@ -33,8 +33,8 @@ enum class ImageOption : uint8_t {
     Shareable = 1 << 0,
     // Makes local in process buffer
     Local = 1 << 1,
-    SupportsBackendHandleVariant = 1 << 2,
-    Accelerated = 1 << 3,
+    Accelerated = 1 << 2,
+    AllowHDR = 1 << 3,
 };
 
 using ImageOptions = OptionSet<ImageOption>;
@@ -54,6 +54,7 @@ enum class SnapshotOption : uint16_t {
     TransparentBackground = 1 << 12,
     // Not supported with takeSnapshotLegacy
     Accelerated = 1 << 13,
+    AllowHDR = 1 << 14,
 };
 
 using SnapshotOptions = OptionSet<SnapshotOption>;
@@ -64,6 +65,8 @@ inline ImageOptions snapshotOptionsToImageOptions(SnapshotOptions snapshotOption
         return ImageOption::Shareable;
     if (snapshotOptions.contains(SnapshotOption::Accelerated))
         return ImageOption::Accelerated;
+    if (snapshotOptions.contains(SnapshotOption::AllowHDR))
+        return ImageOption::AllowHDR;
     return { };
 }
 

--- a/Source/WebKit/Shared/ImageOptions.serialization.in
+++ b/Source/WebKit/Shared/ImageOptions.serialization.in
@@ -36,4 +36,5 @@ header: "ImageOptions.h"
     FullContentRect,
     TransparentBackground,
     Accelerated,
+    AllowHDR,
 };

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKThumbnailView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKThumbnailView.mm
@@ -147,7 +147,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         static_cast<int>(obscuredContentInsets.left()),
         static_cast<int>(obscuredContentInsets.top())
     });
-    WebKit::SnapshotOptions options { WebKit::SnapshotOption::InViewCoordinates, WebKit::SnapshotOption::UseScreenColorSpace, WebKit::SnapshotOption::Accelerated };
+    WebKit::SnapshotOptions options { WebKit::SnapshotOption::InViewCoordinates, WebKit::SnapshotOption::UseScreenColorSpace, WebKit::SnapshotOption::Accelerated, WebKit::SnapshotOption::AllowHDR };
     WebCore::IntSize bitmapSize = snapshotRect.size();
     bitmapSize.scale(_scale * webPageProxy->deviceScaleFactor());
 
@@ -162,35 +162,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     _lastSnapshotScale = _scale;
     _lastSnapshotMaximumSize = _maximumSnapshotSize;
-    webPageProxy->takeSnapshot(snapshotRect, bitmapSize, options, [thumbnailView](std::optional<WebKit::ImageBufferBackendHandle>&& imageHandle) {
-        if (!imageHandle)
+    webPageProxy->takeSnapshot(snapshotRect, bitmapSize, options, [thumbnailView](CGImageRef image) {
+        if (!image)
             return;
-        RetainPtr<id> contents;
-        CGSize size;
-        WTF::switchOn(*imageHandle,
-            [&contents, &size] (WebCore::ShareableBitmap::Handle& handle) {
-                if (auto bitmap = WebCore::ShareableBitmap::create(WTFMove(handle), WebCore::SharedMemory::Protection::ReadOnly)) {
-                    RetainPtr image = bitmap->makeCGImage();
-                    contents = bridge_id_cast(image);
-                    size = CGSizeMake(CGImageGetWidth(image.get()), CGImageGetHeight(image.get()));
-                }
-            }
-#if PLATFORM(COCOA)
-            , [&] (MachSendRight& machSendRight) {
-                if (auto surface = WebCore::IOSurface::createFromSendRight(WTFMove(machSendRight))) {
-                    contents = surface->asLayerContents();
-                    size = CGSizeMake(surface->size().width(), surface->size().height());
-                }
-            }
-#endif
-#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
-            , [&] (WebCore::DynamicContentScalingDisplayList& handle) {
-                ASSERT_NOT_REACHED();
-            }
-#endif
-        );
-        tracePoint(TakeSnapshotEnd, !!contents);
-        [thumbnailView _didTakeSnapshot:contents.get() size:size];
+        tracePoint(TakeSnapshotEnd, !!image);
+        [thumbnailView _didTakeSnapshot:image];
     });
 }
 
@@ -264,15 +240,24 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [self requestSnapshot];
 }
 
-- (void)_didTakeSnapshot:(id)image size:(CGSize)size
+- (void)_didTakeSnapshot:(CGImageRef)image
 {
     [self willChangeValueForKey:@"snapshotSize"];
 
-    _snapshotSize = size;
+    _snapshotSize = CGSizeMake(CGImageGetWidth(image), CGImageGetHeight(image));
     _waitingForSnapshot = NO;
     self.layer.sublayers = @[];
     self.layer.contentsGravity = kCAGravityResizeAspectFill;
-    self.layer.contents = image;
+    self.layer.contents = (__bridge id)image;
+#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
+    if (CGImageGetContentHeadroom(image) > 1) {
+        self.layer.toneMapMode = CAToneMapModeIfSupported;
+        self.layer.preferredDynamicRange = CADynamicRangeHigh;
+    } else {
+        self.layer.toneMapMode = CAToneMapModeAutomatic;
+        self.layer.preferredDynamicRange = CADynamicRangeAutomatic;
+    }
+#endif
 
     // If we got a scale change while snapshotting, we'll take another snapshot once the first one returns.
     if (_snapshotWasDeferred) {

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -4793,8 +4793,7 @@ static bool isLockdownModeWarningNeeded()
         CATransform3D transform = CATransform3DMakeScale(imageScaleInViewCoordinates, imageScaleInViewCoordinates, 1);
         transform = CATransform3DTranslate(transform, -rectInViewCoordinates.origin.x, -rectInViewCoordinates.origin.y, 0);
         CARenderServerRenderDisplayLayerWithTransformAndTimeOffset(MACH_PORT_NULL, (CFStringRef)displayName, self.layer.context.contextId, reinterpret_cast<uint64_t>(self.layer), surface->surface(), 0, 0, &transform, 0);
-        auto context = surface->createPlatformContext();
-        completionHandler(WebCore::IOSurface::sinkIntoImage(WTFMove(surface), WTFMove(context)).get());
+        completionHandler(WebCore::IOSurface::sinkIntoImage(WTFMove(surface)).get());
         return;
     }
 #endif
@@ -4818,16 +4817,8 @@ static bool isLockdownModeWarningNeeded()
         return;
     }
 
-    _page->takeSnapshotLegacy(WebCore::enclosingIntRect(snapshotRectInContentCoordinates), WebCore::expandedIntSize(WebCore::FloatSize(imageSize)), WebKit::SnapshotOption::ExcludeDeviceScaleFactor, [completionHandler = makeBlockPtr(completionHandler)](std::optional<WebCore::ShareableBitmap::Handle>&& imageHandle) {
-        if (!imageHandle)
-            return completionHandler(nil);
-
-        auto bitmap = WebCore::ShareableBitmap::create(WTFMove(*imageHandle), WebCore::SharedMemory::Protection::ReadOnly);
-
-        if (!bitmap)
-            return completionHandler(nil);
-
-        completionHandler(bitmap->makeCGImage().get());
+    _page->takeSnapshot(WebCore::enclosingIntRect(snapshotRectInContentCoordinates), WebCore::expandedIntSize(WebCore::FloatSize(imageSize)), WebKit::SnapshotOption::ExcludeDeviceScaleFactor, [completionHandler = makeBlockPtr(completionHandler)](CGImageRef image) {
+        completionHandler(image);
     });
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1951,8 +1951,10 @@ public:
     void serializeAndWrapCryptoKey(IPC::Connection&, WebCore::CryptoKeyData&&, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
     void unwrapCryptoKey(WebCore::WrappedCryptoKey&&, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
 
-    void takeSnapshotLegacy(WebCore::IntRect, WebCore::IntSize bitmapSize, SnapshotOptions, CompletionHandler<void(std::optional<WebCore::ShareableBitmapHandle>&&)>&&);
-    void takeSnapshot(WebCore::IntRect, WebCore::IntSize bitmapSize, SnapshotOptions, CompletionHandler<void(std::optional<ImageBufferBackendHandle>&&)>&&);
+    void takeSnapshotLegacy(const WebCore::IntRect&, const WebCore::IntSize& bitmapSize, SnapshotOptions, CompletionHandler<void(std::optional<WebCore::ShareableBitmapHandle>&&)>&&);
+#if PLATFORM(COCOA)
+    void takeSnapshot(const WebCore::IntRect&, const WebCore::IntSize& bitmapSize, SnapshotOptions, CompletionHandler<void(CGImageRef)>&&);
+#endif
 
     void navigationGestureDidBegin();
     void navigationGestureWillEnd(bool willNavigate, WebBackForwardListItem&);

--- a/Source/WebKit/UIProcess/mac/WKTextAnimationManagerMac.mm
+++ b/Source/WebKit/UIProcess/mac/WKTextAnimationManagerMac.mm
@@ -264,15 +264,13 @@
     WebCore::IntSize bitmapSize(rect.size.width, rect.size.height);
     bitmapSize.scale(deviceScale, deviceScale);
 
-    _webView->page().takeSnapshotLegacy(WebCore::IntRect(rect), bitmapSize, WebKit::SnapshotOption::Shareable, [rect, completionHandler = makeBlockPtr(completionHandler)](std::optional<WebCore::ShareableBitmap::Handle>&& imageHandle) {
-        if (!imageHandle) {
+    _webView->page().takeSnapshot(WebCore::IntRect(rect), bitmapSize, WebKit::SnapshotOption::Shareable, [rect, completionHandler = makeBlockPtr(completionHandler)](CGImageRef image) {
+        if (!image) {
             completionHandler(nil);
             return;
         }
 
-        auto bitmap = WebCore::ShareableBitmap::create(WTFMove(*imageHandle), WebCore::SharedMemory::Protection::ReadOnly);
-        RetainPtr<CGImageRef> cgImage = bitmap ? bitmap->makeCGImage() : nullptr;
-        RetainPtr textPreview = adoptNS([PAL::alloc_WTTextPreviewInstance() initWithSnapshotImage:cgImage.get() presentationFrame:rect]);
+        RetainPtr textPreview = adoptNS([PAL::alloc_WTTextPreviewInstance() initWithSnapshotImage:image presentationFrame:rect]);
         completionHandler(textPreview.get());
     });
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2252,7 +2252,7 @@ private:
     void runJavaScriptInFrameInScriptWorld(RunJavaScriptParameters&&, std::optional<WebCore::FrameIdentifier>, const ContentWorldData&, bool, CompletionHandler<void(Expected<JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>)>&&);
     void getAccessibilityTreeData(CompletionHandler<void(const std::optional<IPC::SharedBufferReference>&)>&&);
     void updateRenderingWithForcedRepaint(CompletionHandler<void()>&&);
-    void takeSnapshot(WebCore::IntRect snapshotRect, WebCore::IntSize bitmapSize, SnapshotOptions, bool, CompletionHandler<void(std::optional<ImageBufferBackendHandle>&&)>&&);
+    void takeSnapshot(WebCore::IntRect snapshotRect, WebCore::IntSize bitmapSize, SnapshotOptions, CompletionHandler<void(std::optional<ImageBufferBackendHandle>&&, WebCore::Headroom)>&&);
 
     void preferencesDidChange(const WebPreferencesStore&, std::optional<uint64_t> sharedPreferencesVersion);
     void preferencesDidChangeDuringDOMPrintOperation(const WebPreferencesStore& store, std::optional<uint64_t> sharedPreferencesVersion) { preferencesDidChange(store, sharedPreferencesVersion); }
@@ -2465,7 +2465,7 @@ private:
 
     void setIsSuspended(bool, CompletionHandler<void(std::optional<bool>)>&&);
 
-    RefPtr<WebImage> snapshotAtSize(const WebCore::IntRect&, const WebCore::IntSize& bitmapSize, SnapshotOptions, WebCore::LocalFrame&, WebCore::LocalFrameView&, ImageOptions = { });
+    RefPtr<WebImage> snapshotAtSize(const WebCore::IntRect&, const WebCore::IntSize& bitmapSize, SnapshotOptions, WebCore::LocalFrame&, WebCore::LocalFrameView&);
     RefPtr<WebImage> snapshotNode(WebCore::Node&, SnapshotOptions, unsigned maximumPixelCount = std::numeric_limits<unsigned>::max());
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -583,7 +583,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
 
     GetSamplingProfilerOutput() -> (String string)
     
-    TakeSnapshot(WebCore::IntRect snapshotRect, WebCore::IntSize bitmapSize, OptionSet<WebKit::SnapshotOption> options, bool sharedBitmapOnly) -> (std::optional<WebKit::ImageBufferBackendHandle> image)
+    TakeSnapshot(WebCore::IntRect snapshotRect, WebCore::IntSize bitmapSize, OptionSet<WebKit::SnapshotOption> options) -> (std::optional<WebKit::ImageBufferBackendHandle> image, struct WebCore::Headroom headroom)
 #if PLATFORM(MAC)
     PerformImmediateActionHitTestAtLocation(WebCore::FrameIdentifier frameID, WebCore::FloatPoint location)
     ImmediateActionDidUpdate()


### PR DESCRIPTION
#### 1f8b191c3bd65655a5a8d67e025c69b701f7dbb1
<pre>
[HDR] Support HDR snapshotting for WKThumbnailView.
<a href="https://bugs.webkit.org/show_bug.cgi?id=283316">https://bugs.webkit.org/show_bug.cgi?id=283316</a>
&lt;<a href="https://rdar.apple.com/140144773">rdar://140144773</a>&gt;

Reviewed by Simon Fraser.

Converts WebPageProxy::takeSnapshot to return a CGImage, and moves the
complexity of unpacking an ImageBufferBackendHandle from WKThumbailView into
WebPageProxy. Moves all consumers of takeSnapshotLegacy to the new version,
since they all just wanted a CGImage already.

Add SnapshotOption::AllowHDR which makes takeSnapshot potentially return a
RGBA16F surface (with extended range color space) if the web page includes HDR
content. Returns the painted headroom of the content back to WebPageProxy, and
stores this on the output CGImage from takeSnapshot.

Opt-in to HDR snapshots for WKThumbnailView, and configure the CALayer with the
headroom and tonemap requests if we get an HDR result.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::drawsHDRContent const):
* Source/WebCore/page/Page.h:
* Source/WebCore/platform/graphics/DestinationColorSpace.h:
* Source/WebCore/platform/graphics/ImageTypes.h:
(WebCore::Headroom::operator&lt;):
(IPC::AsyncReplyError&lt;WebCore::Headroom&gt;::create):
* Source/WebCore/platform/graphics/cocoa/IOSurface.h:
* Source/WebCore/platform/graphics/cocoa/IOSurface.mm:
(WebCore::IOSurface::sinkIntoImage):
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/ImageOptions.h:
(WebKit::snapshotOptionsToImageOptions):
* Source/WebKit/Shared/ImageOptions.serialization.in:
* Source/WebKit/Shared/WebImage.cpp:
(WebKit::WebImage::create):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView takeSnapshotWithConfiguration:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKThumbnailView.mm:
(-[_WKThumbnailView requestSnapshot]):
(-[_WKThumbnailView _didTakeSnapshot:]):
(-[_WKThumbnailView _didTakeSnapshot:size:]): Deleted.
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _snapshotRectAfterScreenUpdates:rectInViewCoordinates:intoImageOfWidth:completionHandler:]):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::takeSnapshotLegacy):
(WebKit::WebPageProxy::takeSnapshot):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/mac/WKTextAnimationManagerMac.mm:
(-[WKTextAnimationManager textPreviewForRect:completion:]):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::takeSnapshot):
(WebKit::snapshotColorSpace):
(WebKit::WebPage::snapshotAtSize):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/297373@main">https://commits.webkit.org/297373@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bcd49b30c20d2ba37d0abdf6c5a89b201dc7d905

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111555 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31222 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21686 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117590 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/61826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113517 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39803 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84766 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/61826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114502 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25461 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100412 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65207 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/110988 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24814 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18550 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61418 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/94857 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18617 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/120841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38608 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28686 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/120841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38985 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96674 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/120841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23828 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38626 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16416 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/34644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38497 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43970 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/38160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41496 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39862 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->