### PR TITLE
AX: Wrong text is selected via -[accessibilitySetValue:(id) forAttribute:NSAccessibilitySelectedTextMarkerRangeAttribute] when the given range points to text after a soft linebreak

### DIFF
--- a/LayoutTests/accessibility/mac/select-text-with-soft-linebreaks-expected.txt
+++ b/LayoutTests/accessibility/mac/select-text-with-soft-linebreaks-expected.txt
@@ -1,0 +1,8 @@
+This test ensures setting text selection round-trips correctly for text that has soft linebreaks and collapsed whitespace.
+
+PASS: window.getSelection().toString() === 'Jupiter'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+The planets, ordered from \tclosest to farther from the Sun, is Mercury, \nVenus, Earth, Mars, Jupiter, Saturn, Uranus, and Neptune.

--- a/LayoutTests/accessibility/mac/select-text-with-soft-linebreaks.html
+++ b/LayoutTests/accessibility/mac/select-text-with-soft-linebreaks.html
@@ -1,0 +1,48 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div style="width: 200px;">
+    <!-- Note that these additional spaces, \n, tab characters are intentional to add whitespace that gets collapsed. -->
+    <p id="paragraph" role="group">The planets,   ordered from \tclosest to farther from the Sun, is  Mercury, \nVenus, Earth, Mars,     Jupiter, Saturn, Uranus, and Neptune.</p>
+</div>
+    
+<script>
+var output = "This test ensures setting text selection round-trips correctly for text that has soft linebreaks and collapsed whitespace.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    let range = document.createRange();
+    range.setStart(document.getElementById("paragraph").firstChild, 101);
+    range.setEnd(document.getElementById("paragraph").firstChild, 109);
+    window.getSelection().addRange(range);
+
+    var selectedMarkerRange;
+    var paragraph = accessibilityController.accessibleElementById("paragraph");
+    setTimeout(async function() {
+        await waitFor(() => {
+            selectedMarkerRange = paragraph.selectedTextMarkerRange();
+            return paragraph.stringForTextMarkerRange(selectedMarkerRange) === "Jupiter";
+        });
+
+        // Re-set the selected text marker range with the range we already have, which should result in Jupiter remaining the selected text.
+        paragraph.setSelectedTextMarkerRange(selectedMarkerRange);
+        // If our implementation behaves incorrectly, this will result in some text that isn't "Jupiter" being selected,
+        // meaning our round-trip of selected text marker ranges is not right. Wait some time to allow the bug to happen
+        // in case our implementation is wrong.
+        await sleep(100);
+        output += await expectAsync("window.getSelection().toString()", "'Jupiter'");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AXTextRun.cpp
+++ b/Source/WebCore/accessibility/AXTextRun.cpp
@@ -29,16 +29,6 @@
 
 #if ENABLE(AX_THREAD_TEXT_APIS)
 
-#define TEXT_RUN_ASSERT_AND_LOG(assertion, methodName) do { \
-    if (!(assertion)) { \
-        RELEASE_LOG(Accessibility, "[AX Thread Text Run] hit assertion in %" PUBLIC_LOG_STRING, methodName); \
-        ASSERT(assertion); \
-    } \
-} while (0)
-#define TEXT_RUN_ASSERT_NOT_REACHED_AND_LOG(methodName) do { \
-    TEXT_RUN_ASSERT_AND_LOG(false, methodName); \
-} while (0)
-
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
@@ -97,7 +87,7 @@ unsigned AXTextRuns::domOffset(unsigned renderedTextOffset) const
     for (size_t i = 0; i < size(); i++) {
         const auto& domOffsets = at(i).domOffsets();
         for (const auto& domOffsetPair : domOffsets) {
-            TEXT_RUN_ASSERT_AND_LOG(domOffsetPair[0] >= previousEndDomOffset, "domOffset");
+            ASSERT(domOffsetPair[0] >= previousEndDomOffset);
             if (domOffsetPair[0] < previousEndDomOffset)
                 return renderedTextOffset;
             // domOffsetPair[0] represents the start DOM offset of this run. Subtracting it
@@ -125,7 +115,7 @@ unsigned AXTextRuns::domOffset(unsigned renderedTextOffset) const
     }
     // We were provided with a rendered-text offset that didn't actually fit into our
     // runs. This should never happen.
-    TEXT_RUN_ASSERT_NOT_REACHED_AND_LOG("renderedTextOffset");
+    ASSERT_NOT_REACHED();
     return renderedTextOffset;
 }
 
@@ -166,7 +156,7 @@ FloatRect AXTextRuns::localRect(unsigned start, unsigned end, FontOrientation or
             unsigned measuredWidthInDirection = 0;
             if (i == runIndexOfSmallerOffset) {
                 unsigned offsetOfFirstCharacterInRun = !i ? 0 : runLengthSumTo(i - 1);
-                TEXT_RUN_ASSERT_AND_LOG(smallerOffset >= offsetOfFirstCharacterInRun, "localRect (1)");
+                ASSERT(smallerOffset >= offsetOfFirstCharacterInRun);
                 if (smallerOffset < offsetOfFirstCharacterInRun)
                     smallerOffset = offsetOfFirstCharacterInRun;
                 // Measure the characters in this run (accomplished by smallerOffset - offsetOfFirstCharacterInRun)
@@ -203,7 +193,7 @@ FloatRect AXTextRuns::localRect(unsigned start, unsigned end, FontOrientation or
             } else if (i == runIndexOfLargerOffset) {
                 // We're measuring the end of the range, so measure from the first character in the run up to largerOffset.
                 unsigned offsetOfFirstCharacterInRun = !i ? 0 : runLengthSumTo(i - 1);
-                TEXT_RUN_ASSERT_AND_LOG(largerOffset >= offsetOfFirstCharacterInRun, "localRect (3)");
+                ASSERT(largerOffset >= offsetOfFirstCharacterInRun);
                 if (largerOffset < offsetOfFirstCharacterInRun)
                     largerOffset = offsetOfFirstCharacterInRun;
 

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1612,6 +1612,10 @@ AXTextRuns AccessibilityRenderObject::textRuns()
                 lineString.append(' ');
                 ++endIndex;
                 characterWidths.append(0);
+                // We also need to account for this in the DOM offset itself, as otherwise we'll
+                // compute the wrong value when going from rendered-text offset to DOM offset
+                // (e.g. via AXTextRuns::domOffset()).
+                textRunDomOffsets.last()[1] += 1;
             }
             runs.append({ currentLineIndex, startIndex, endIndex, { std::exchange(textRunDomOffsets, { }) }, std::exchange(characterWidths, { }), lineHeight, distanceFromBoundsInDirection });
 


### PR DESCRIPTION
#### e5d0a9b08af9a2e4dd709cb5fbf7c33d72595f43
<pre>
AX: Wrong text is selected via -[accessibilitySetValue:(id) forAttribute:NSAccessibilitySelectedTextMarkerRangeAttribute] when the given range points to text after a soft linebreak
<a href="https://bugs.webkit.org/show_bug.cgi?id=295668">https://bugs.webkit.org/show_bug.cgi?id=295668</a>
<a href="https://rdar.apple.com/155472811">rdar://155472811</a>

Reviewed by Joshua Hoffman.

When ATs set text via -[accessibilitySetValue:(id) forAttribute:NSAccessibilitySelectedTextMarkerRangeAttribute] using
an AXTextMarkerRange, and said range pointed to text after soft linebreaks, we would ask the main-thread to select the
wrong text. Specifically, the text selection would be shifted `1 times number-of-soft-linebreaks-preceeding-text-position`
characters forward (not expanding the selected range, just shifting).

This happened because AccessibilityRenderObject::textRuns() adds in an &quot;artificial&quot; space when whitespace is trimmed at
soft linebreak points. This is necessary, but we need to make sure the AXTextRun::domOffsets we cache also account for
this, so conversion from rendered-text-offsets to DOM offsets is correct.

Test accessibility/mac/select-text-with-soft-linebreaks.html added.

This commit also removes TEXT_RUN_ASSERT_AND_LOG, which RELEASE_LOGS, something we don&apos;t want to do for this feature anymore.

* LayoutTests/accessibility/mac/select-text-with-soft-linebreaks-expected.txt: Added.
* LayoutTests/accessibility/mac/select-text-with-soft-linebreaks.html: Added.
* Source/WebCore/accessibility/AXTextRun.cpp:
(WebCore::AXTextRuns::domOffset const):
(WebCore::AXTextRuns::localRect const):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::textRuns):

Canonical link: <a href="https://commits.webkit.org/297215@main">https://commits.webkit.org/297215@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1982b58a92de73984d845f99754e2108849aa32a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110831 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30494 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20928 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116860 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61099 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112794 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31174 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39080 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84260 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113779 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24900 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64704 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24258 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17930 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60656 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94285 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17991 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119654 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37876 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93220 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38252 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96062 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93045 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23724 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38087 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33850 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37769 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43239 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37430 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40768 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39137 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->