### PR TITLE
Remove unnecessary ObjC object instantiation in JavaScriptEvaluationResult conversion to JSValueRef, take 2

### DIFF
--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
@@ -28,13 +28,223 @@
 
 #include "APIArray.h"
 #include "APIDictionary.h"
+#include "APINumber.h"
 #include "APISerializedScriptValue.h"
+#include "APIString.h"
+#include "WKSharedAPICast.h"
 #include <WebCore/ExceptionDetails.h>
 #include <WebCore/SerializedScriptValue.h>
 
 namespace WebKit {
 
-#if !PLATFORM(COCOA)
+#if PLATFORM(COCOA)
+
+JavaScriptEvaluationResult::JavaScriptEvaluationResult(JSObjectID root, HashMap<JSObjectID, Variant>&& map)
+    : m_map(WTFMove(map))
+    , m_root(root) { }
+
+RefPtr<API::Object> JavaScriptEvaluationResult::toAPI(Variant&& root)
+{
+    return WTF::switchOn(WTFMove(root), [] (NullType) -> RefPtr<API::Object> {
+        return nullptr;
+    }, [] (bool value) -> RefPtr<API::Object> {
+        return API::Boolean::create(value);
+    }, [] (double value) -> RefPtr<API::Object> {
+        return API::Double::create(value);
+    }, [] (String&& value) -> RefPtr<API::Object> {
+        return API::String::create(value);
+    }, [] (Seconds value) -> RefPtr<API::Object> {
+        return API::Double::create(value.seconds());
+    }, [&] (Vector<JSObjectID>&& vector) -> RefPtr<API::Object> {
+        Ref array = API::Array::create();
+        m_arrays.append({ WTFMove(vector), array });
+        return { WTFMove(array) };
+    }, [&] (HashMap<JSObjectID, JSObjectID>&& map) -> RefPtr<API::Object> {
+        Ref dictionary = API::Dictionary::create();
+        m_dictionaries.append({ WTFMove(map), dictionary });
+        return { WTFMove(dictionary) };
+    });
+}
+
+WKRetainPtr<WKTypeRef> JavaScriptEvaluationResult::toWK()
+{
+    for (auto [identifier, variant] : std::exchange(m_map, { }))
+        m_instantiatedObjects.add(identifier, toAPI(WTFMove(variant)));
+    for (auto [vector, array] : std::exchange(m_arrays, { })) {
+        for (auto identifier : vector) {
+            if (RefPtr object = m_instantiatedObjects.get(identifier))
+                Ref { array }->append(object.releaseNonNull());
+        }
+    }
+    for (auto [map, dictionary] : std::exchange(m_dictionaries, { })) {
+        for (auto [keyIdentifier, valueIdentifier] : map) {
+            RefPtr key = dynamicDowncast<API::String>(m_instantiatedObjects.get(keyIdentifier));
+            if (!key)
+                continue;
+            RefPtr value = m_instantiatedObjects.get(valueIdentifier);
+            if (!value)
+                continue;
+            Ref { dictionary }->add(key->string(), WTFMove(value));
+        }
+    }
+    return WebKit::toAPI(std::exchange(m_instantiatedObjects, { }).take(m_root).get());
+}
+
+JSObjectID JavaScriptEvaluationResult::addObjectToMap(JSGlobalContextRef context, JSValueRef object)
+{
+    if (!object) {
+        if (!m_nullObjectID) {
+            m_nullObjectID = JSObjectID::generate();
+            m_map.add(*m_nullObjectID, Variant { NullType::NullPointer });
+        }
+        return *m_nullObjectID;
+    }
+
+    Protected<JSValueRef> value(context, object);
+    auto it = m_jsObjectsInMap.find(value);
+    if (it != m_jsObjectsInMap.end())
+        return it->value;
+
+    auto identifier = JSObjectID::generate();
+    m_jsObjectsInMap.set(WTFMove(value), identifier);
+    m_map.add(identifier, toVariant(context, object));
+    return identifier;
+}
+
+static std::optional<JSValueRef> roundTripThroughSerializedScriptValue(JSGlobalContextRef serializationContext, JSGlobalContextRef deserializationContext, JSValueRef value)
+{
+    if (RefPtr serialized = WebCore::SerializedScriptValue::create(serializationContext, value, nullptr))
+        return serialized->deserialize(deserializationContext, nullptr);
+    return std::nullopt;
+}
+
+std::optional<JavaScriptEvaluationResult> JavaScriptEvaluationResult::extract(JSGlobalContextRef context, JSValueRef value)
+{
+    JSRetainPtr deserializationContext = API::SerializedScriptValue::deserializationContext();
+
+    auto result = roundTripThroughSerializedScriptValue(context, deserializationContext.get(), value);
+    if (!result)
+        return std::nullopt;
+    return { JavaScriptEvaluationResult { deserializationContext.get(), *result } };
+}
+
+// Similar to JSValue's valueToObjectWithoutCopy.
+auto JavaScriptEvaluationResult::toVariant(JSGlobalContextRef context, JSValueRef value) -> Variant
+{
+    if (!JSValueIsObject(context, value)) {
+        if (JSValueIsBoolean(context, value))
+            return JSValueToBoolean(context, value);
+        if (JSValueIsNumber(context, value)) {
+            value = JSValueMakeNumber(context, JSValueToNumber(context, value, 0));
+            return JSValueToNumber(context, value, 0);
+        }
+        if (JSValueIsString(context, value)) {
+            auto* globalObject = ::toJS(context);
+            JSC::JSValue jsValue = ::toJS(globalObject, value);
+            return jsValue.toWTFString(globalObject);
+        }
+        if (JSValueIsNull(context, value))
+            return NullType::NSNull;
+        return NullType::NullPointer;
+    }
+
+    JSObjectRef object = JSValueToObject(context, value, 0);
+
+    if (JSValueIsDate(context, object))
+        return Seconds(JSValueToNumber(context, object, 0) / 1000.0);
+
+    if (JSValueIsArray(context, object)) {
+        SUPPRESS_UNCOUNTED_ARG JSValueRef lengthPropertyName = JSValueMakeString(context, adopt(JSStringCreateWithUTF8CString("length")).get());
+        JSValueRef lengthValue = JSObjectGetPropertyForKey(context, object, lengthPropertyName, nullptr);
+        double lengthDouble = JSValueToNumber(context, lengthValue, nullptr);
+        if (lengthDouble < 0 || lengthDouble > static_cast<double>(std::numeric_limits<size_t>::max()))
+            return NullType::NullPointer;
+
+        size_t length = lengthDouble;
+        Vector<JSObjectID> vector;
+        if (!vector.tryReserveInitialCapacity(length))
+            return NullType::NullPointer;
+
+        for (size_t i = 0; i < length; ++i)
+            vector.append(addObjectToMap(context, JSObjectGetPropertyAtIndex(context, object, i, nullptr)));
+        return WTFMove(vector);
+    }
+
+    JSPropertyNameArrayRef names = JSObjectCopyPropertyNames(context, object);
+    size_t length = JSPropertyNameArrayGetCount(names);
+    HashMap<JSObjectID, JSObjectID> map;
+    for (size_t i = 0; i < length; i++) {
+        JSRetainPtr<JSStringRef> key = JSPropertyNameArrayGetNameAtIndex(names, i);
+        SUPPRESS_UNCOUNTED_ARG map.add(addObjectToMap(context, JSValueMakeString(context, key.get())), addObjectToMap(context, JSObjectGetPropertyForKey(context, object, JSValueMakeString(context, key.get()), nullptr)));
+    }
+    JSPropertyNameArrayRelease(names);
+    return WTFMove(map);
+}
+
+JavaScriptEvaluationResult::JavaScriptEvaluationResult(JSGlobalContextRef context, JSValueRef value)
+    : m_root(addObjectToMap(context, value))
+{
+    m_jsObjectsInMap.clear();
+    m_nullObjectID = std::nullopt;
+}
+
+JSValueRef JavaScriptEvaluationResult::toJS(JSGlobalContextRef context, Variant&& root)
+{
+    return WTF::switchOn(WTFMove(root), [&] (NullType) -> JSValueRef {
+        return JSValueMakeNull(context);
+    }, [&] (bool value) -> JSValueRef {
+        return JSValueMakeBoolean(context, value);
+    }, [&] (double value) -> JSValueRef {
+        return JSValueMakeNumber(context, value);
+    }, [&] (String&& value) -> JSValueRef {
+        auto string = OpaqueJSString::tryCreate(WTFMove(value));
+        return JSValueMakeString(context, string.get());
+    }, [&] (Seconds value) -> JSValueRef {
+        JSValueRef argument = JSValueMakeNumber(context, value.value() * 1000.0);
+        return JSObjectMakeDate(context, 1, &argument, 0);
+    }, [&] (Vector<JSObjectID>&& vector) -> JSValueRef {
+        JSValueRef array = JSObjectMakeArray(context, 0, nullptr, 0);
+        m_jsArrays.append({ WTFMove(vector), Protected<JSValueRef>(context, array) });
+        return array;
+    }, [&] (HashMap<JSObjectID, JSObjectID>&& map) -> JSValueRef {
+        JSObjectRef dictionary = JSObjectMake(context, 0, 0);
+        m_jsDictionaries.append({ WTFMove(map), Protected<JSObjectRef>(context, dictionary) });
+        return dictionary;
+    });
+}
+
+Protected<JSValueRef> JavaScriptEvaluationResult::toJS(JSGlobalContextRef context)
+{
+    for (auto [identifier, variant] : std::exchange(m_map, { }))
+        m_instantiatedJSObjects.add(identifier, Protected<JSValueRef>(context, toJS(context, WTFMove(variant))));
+    for (auto& [vector, array] : std::exchange(m_jsArrays, { })) {
+        JSObjectRef jsArray = JSValueToObject(context, array.get(), 0);
+        for (size_t index = 0; index < vector.size(); ++index) {
+            auto identifier = vector[index];
+            if (Protected<JSValueRef> element = m_instantiatedJSObjects.get(identifier))
+                JSObjectSetPropertyAtIndex(context, jsArray, index, element.get(), 0);
+        }
+    }
+    for (auto& [map, dictionary] : std::exchange(m_jsDictionaries, { })) {
+        for (auto [keyIdentifier, valueIdentifier] : map) {
+            Protected<JSValueRef> key = m_instantiatedJSObjects.get(keyIdentifier);
+            if (!key)
+                continue;
+            ASSERT(JSValueIsString(context, key.get()));
+            SUPPRESS_UNCOUNTED_ARG auto keyString = adopt(JSValueToStringCopy(context, key.get(), nullptr));
+            if (!keyString)
+                continue;
+            Protected<JSValueRef> value = m_instantiatedJSObjects.get(valueIdentifier);
+            if (!value)
+                continue;
+            SUPPRESS_UNCOUNTED_ARG JSObjectSetProperty(context, dictionary.get(), keyString.get(), value.get(), 0, 0);
+        }
+    }
+    return std::exchange(m_instantiatedJSObjects, { }).take(m_root);
+}
+
+#else // PLATFORM(COCOA)
+
 Ref<API::SerializedScriptValue> JavaScriptEvaluationResult::legacySerializedScriptValue() const
 {
     return API::SerializedScriptValue::createFromWireBytes(Vector(wireBytes()));
@@ -45,10 +255,10 @@ WKRetainPtr<WKTypeRef> JavaScriptEvaluationResult::toWK()
     return API::SerializedScriptValue::deserializeWK(legacySerializedScriptValue()->internalRepresentation());
 }
 
-JSValueRef JavaScriptEvaluationResult::toJS(JSGlobalContextRef context)
+Protected<JSValueRef> JavaScriptEvaluationResult::toJS(JSGlobalContextRef context)
 {
     Ref serializedScriptValue = API::SerializedScriptValue::createFromWireBytes(wireBytes());
-    return serializedScriptValue->internalRepresentation().deserialize(context, nullptr);
+    return Protected<JSValueRef>(context, serializedScriptValue->internalRepresentation().deserialize(context, nullptr));
 }
 
 JavaScriptEvaluationResult::JavaScriptEvaluationResult(JSGlobalContextRef context, JSValueRef value)
@@ -61,7 +271,8 @@ std::optional<JavaScriptEvaluationResult> JavaScriptEvaluationResult::extract(JS
 {
     return JavaScriptEvaluationResult { context, value };
 }
-#endif
+
+#endif // PLATFORM(COCOA)
 
 JavaScriptEvaluationResult::JavaScriptEvaluationResult(JavaScriptEvaluationResult&&) = default;
 

--- a/Source/WebKit/Shared/Protected.h
+++ b/Source/WebKit/Shared/Protected.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <JavaScriptCore/JSRetainPtr.h>
+#include <JavaScriptCore/JSValueRef.h>
+
+namespace WebKit {
+
+template<typename T>
+class Protected {
+public:
+    Protected() = default;
+
+    Protected(JSGlobalContextRef context, T value)
+        : m_context(context)
+        , m_value(value)
+    {
+        ASSERT(context);
+        ASSERT(value);
+        protectIfNonNull();
+    }
+
+    Protected(Protected&& other) { moveFrom(WTFMove(other)); }
+
+    Protected(const Protected& other) { copyFrom(other); }
+
+    Protected& operator=(Protected&& other)
+    {
+        moveFrom(WTFMove(other));
+        return *this;
+    }
+
+    Protected& operator=(const Protected& other)
+    {
+        copyFrom(other);
+        return *this;
+    }
+
+    ~Protected() { unprotectIfNonNull(); }
+
+    T get() const { return m_value; }
+
+    explicit operator bool() const { return !!m_value; }
+
+    bool operator==(const Protected& other) const { return m_value == other.m_value; }
+
+    Protected(WTF::HashTableDeletedValueType)
+        : m_value(reinterpret_cast<T>(-1)) { }
+
+    bool isHashTableDeletedValue() const { return m_value == reinterpret_cast<T>(-1); }
+
+private:
+    void moveFrom(Protected&& other)
+    {
+        unprotectIfNonNull();
+        m_context = std::exchange(other.m_context, nullptr);
+        m_value = std::exchange(other.m_value, nullptr);
+    }
+
+    void copyFrom(const Protected& other)
+    {
+        unprotectIfNonNull();
+        m_context = other.m_context;
+        m_value = other.m_value;
+        protectIfNonNull();
+    }
+
+    void protectIfNonNull()
+    {
+        if (m_value)
+            JSValueProtect(m_context.get(), m_value);
+    }
+
+    void unprotectIfNonNull()
+    {
+        if (T value = std::exchange(m_value, nullptr))
+            JSValueUnprotect(m_context.get(), value);
+        m_context = nullptr;
+    }
+
+    JSRetainPtr<JSGlobalContextRef> m_context;
+    T m_value { nullptr };
+};
+
+}
+
+namespace WTF {
+template<typename T> struct HashTraits<WebKit::Protected<T>> : SimpleClassHashTraits<WebKit::Protected<T>> { };
+template<typename T> struct DefaultHash<WebKit::Protected<T>> {
+    static unsigned hash(const WebKit::Protected<T>& key) { return IntHash<uintptr_t>::hash(reinterpret_cast<uintptr_t>(key.get())); }
+    static bool equal(const WebKit::Protected<T>& a, const WebKit::Protected<T>& b) { return a.get() == b.get(); }
+    static constexpr bool safeToCompareToEmptyOrDeleted = true;
+};
+}

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2592,7 +2592,6 @@
 		F4E090952D889D6A00322226 /* WKIdentityDocumentPresentmentDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E090942D889CB800322226 /* WKIdentityDocumentPresentmentDelegate.h */; };
 		F4E090992D88AAC300322226 /* WKIdentityDocumentPresentmentRawRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E090962D88A66F00322226 /* WKIdentityDocumentPresentmentRawRequest.h */; };
 		F4E28A362C923814008120DD /* ScriptTrackingPrivacyFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E28A352C923814008120DD /* ScriptTrackingPrivacyFilter.h */; };
-		F4E44EB72DCD33E800A304C4 /* ISO18013MobileDocumentRequest+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E44EB62DCD33E800A304C4 /* ISO18013MobileDocumentRequest+Extras.swift */; };
 		F4E44EB72DCD33E800A304C4 /* WKIdentityDocumentPresentmentMobileDocumentRequest+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E44EB62DCD33E800A304C4 /* WKIdentityDocumentPresentmentMobileDocumentRequest+Extras.swift */; };
 		F4E727232A547F0400CE34FD /* WKTouchEventsGestureRecognizerTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E727222A547E2100CE34FD /* WKTouchEventsGestureRecognizerTypes.h */; };
 		F4EB4AFD269CD7F300D297AE /* OSStateSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = F4EB4AFC269CD23600D297AE /* OSStateSPI.h */; };
@@ -8013,7 +8012,7 @@
 		CD8252DA25D4915400862FD8 /* RemoteRemoteCommandListenerProxyMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteRemoteCommandListenerProxyMessageReceiver.cpp; sourceTree = "<group>"; };
 		CD8252E025D4918400862FD8 /* RemoteRemoteCommandListenerMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteRemoteCommandListenerMessageReceiver.cpp; sourceTree = "<group>"; };
 		CD8252E125D4918500862FD8 /* RemoteRemoteCommandListenerMessages.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteRemoteCommandListenerMessages.h; sourceTree = "<group>"; };
-		CD95493526159004008372D9 /* .dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = .dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		CD95493526159004008372D9 /* libWebKitSwift.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libWebKitSwift.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD9A649F27C8972C003827C0 /* UIProcessLogInitialization.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UIProcessLogInitialization.h; sourceTree = "<group>"; };
 		CD9A64A027C8972C003827C0 /* UIProcessLogInitialization.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UIProcessLogInitialization.cpp; sourceTree = "<group>"; };
 		CD9A64A127C89742003827C0 /* UIProcessLogInitializationCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = UIProcessLogInitializationCocoa.mm; sourceTree = "<group>"; };
@@ -8667,6 +8666,7 @@
 		FA580B382DA64B5F005E4965 /* UnifiedSource178.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource178.cpp; sourceTree = "<group>"; };
 		FA580B392DA64B5F005E4965 /* UnifiedSource179.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource179.cpp; sourceTree = "<group>"; };
 		FA580B3A2DA64B5F005E4965 /* UnifiedSource180.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource180.cpp; sourceTree = "<group>"; };
+		FA58F47C2E1F318A0098E1C8 /* Protected.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Protected.h; sourceTree = "<group>"; };
 		FA5C22422DC5710500B13EF3 /* RemoteWebTouchEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteWebTouchEvent.h; sourceTree = "<group>"; };
 		FA5C22432DC5719D00B13EF3 /* RemoteWebTouchEvent.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteWebTouchEvent.serialization.in; sourceTree = "<group>"; };
 		FA6342192D9D98D300A6BECE /* WebFrame.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebFrame.messages.in; sourceTree = "<group>"; };
@@ -8898,7 +8898,7 @@
 				BC3DE46615A91763008D26FC /* com.apple.WebKit.WebContent.xpc */,
 				5CE4B62029CF877F0038F565 /* GPUExtension.appex */,
 				7B9FC59D28A28F88007570E7 /* libWebKitPlatform.a */,
-				CD95493526159004008372D9 /* .dylib */,
+				CD95493526159004008372D9 /* libWebKitSwift.dylib */,
 				5CE4B61329CF87680038F565 /* NetworkingExtension.appex */,
 				5C139DAC29DB82E500D5117B /* WebContentCaptivePortalExtension.appex */,
 				5CA5A2CA29CBBA1B000F1046 /* WebContentExtension.appex */,
@@ -9760,6 +9760,7 @@
 				3D3C76402B6B1E280013828A /* ProcessQualified.serialization.in */,
 				0FEC6E05280915CF008082AC /* ProcessTerminationReason.cpp */,
 				463FD4811EB94EAD00A2982C /* ProcessTerminationReason.h */,
+				FA58F47C2E1F318A0098E1C8 /* Protected.h */,
 				1ADC268D29E89FAF005990CA /* ProvisionalFrameCreationParameters.h */,
 				1ADC269329E8AD96005990CA /* ProvisionalFrameCreationParameters.serialization.in */,
 				517B5F94275EBA62002DC22D /* PushMessageForTesting.h */,
@@ -19041,7 +19042,7 @@
 			);
 			name = WebKitSwift;
 			productName = WebKitSwift;
-			productReference = CD95493526159004008372D9 /* .dylib */;
+			productReference = CD95493526159004008372D9 /* libWebKitSwift.dylib */;
 			productType = "com.apple.product-type.library.dynamic";
 		};
 /* End PBXNativeTarget section */
@@ -21105,7 +21106,6 @@
 				0735F31E2D3760BC0003D029 /* IntelligenceTextEffectChunk.swift in Sources */,
 				0735F31C2D3760AA0003D029 /* IntelligenceTextEffectViewManager.swift in Sources */,
 				E838FCB02DE90BF800703353 /* ISO18013MobileDocumentRequest+Extras.swift in Sources */,
-				A1098E6D2BB6436400449EE0 /* LinearMediaKitExtras.swift in Sources */,
 				A14F9B772B68CA6C00AD9C56 /* LinearMediaPlayer.swift in Sources */,
 				A14F9B642B686DD300AD9C56 /* LinearMediaTypes.swift in Sources */,
 				0785E8002CBCDFFD00F68126 /* PlatformIntelligenceTextEffectView.swift in Sources */,

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
@@ -312,7 +312,7 @@ private:
         WebProcess::singleton().protectedParentProcessConnection()->sendWithAsyncReply(Messages::WebUserContentControllerProxy::DidPostMessage(webPage->webPageProxyIdentifier(), webFrame->info(), m_identifier, *message), [completionHandler = WTFMove(completionHandler), context](Expected<WebKit::JavaScriptEvaluationResult, String>&& result) {
             if (!result)
                 return completionHandler(JSC::jsUndefined(), result.error());
-            completionHandler(toJS(toJS(context.get()), result->toJS(context.get())), { });
+            completionHandler(toJS(toJS(context.get()), result->toJS(context.get()).get()), { });
         }, m_controller->identifier());
     }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4440,7 +4440,7 @@ void WebPage::runJavaScript(WebFrame* frame, RunJavaScriptParameters&& parameter
         HashMap<String, Function<JSC::JSValue(JSC::JSGlobalObject&)>> map;
         for (auto&& [key, result] : WTFMove(*vector)) {
             map.set(key, [result = WTFMove(result)] (JSC::JSGlobalObject& globalObject) mutable -> JSC::JSValue {
-                return toJS(&globalObject, result.toJS(JSContextGetGlobalContext(toRef(&globalObject))));
+                return toJS(&globalObject, result.toJS(JSContextGetGlobalContext(toRef(&globalObject))).get());
             });
         }
         return { WTFMove(map) };


### PR DESCRIPTION
#### fa18a5546964a3984cc140b687525847bd15523a
<pre>
Remove unnecessary ObjC object instantiation in JavaScriptEvaluationResult conversion to JSValueRef, take 2
<a href="https://rdar.apple.com/155474131">rdar://155474131</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=295671">https://bugs.webkit.org/show_bug.cgi?id=295671</a>

Reviewed by Richard Robinson.

297138@main was reverted because the call to value.asCell() was not protected by a call to value.isCell().
It was also incompletely protecting the JSCells, leaving the values of m_instantiatedJSObjects, m_jsDictionaries,
and m_jsArrays as unsafe pointer types.

This does the same thing, but instead of using String&lt;JSCell&gt; we use Protected&lt;JSValueRef&gt; and Protected&lt;JSObjectRef&gt;.

* Source/WebKit/Shared/JavaScriptEvaluationResult.cpp:
(WebKit::JavaScriptEvaluationResult::JavaScriptEvaluationResult):
(WebKit::JavaScriptEvaluationResult::toAPI):
(WebKit::JavaScriptEvaluationResult::toWK):
(WebKit::JavaScriptEvaluationResult::addObjectToMap):
(WebKit::roundTripThroughSerializedScriptValue):
(WebKit::JavaScriptEvaluationResult::extract):
(WebKit::JavaScriptEvaluationResult::toVariant):
(WebKit::JavaScriptEvaluationResult::toJS):
* Source/WebKit/Shared/JavaScriptEvaluationResult.h:
* Source/WebKit/Shared/JavaScriptEvaluationResult.mm:
(WebKit::JavaScriptEvaluationResult::toVariant):
(WebKit::JavaScriptEvaluationResult::addObjectToMap):
(WebKit::JavaScriptEvaluationResult::toAPI): Deleted.
(WebKit::JavaScriptEvaluationResult::toWK): Deleted.
(WebKit::roundTripThroughSerializedScriptValue): Deleted.
(WebKit::JavaScriptEvaluationResult::jsValueToVariant): Deleted.
(WebKit::JavaScriptEvaluationResult::toJS): Deleted.
* Source/WebKit/Shared/Protected.h: Added.
(WebKit::Protected::Protected):
(WebKit::Protected::operator=):
(WebKit::Protected::~Protected):
(WebKit::Protected::get const):
(WebKit::Protected::operator bool const):
(WebKit::Protected::operator== const):
(WebKit::Protected::isHashTableDeletedValue const):
(WTF::DefaultHash&lt;WebKit::Protected&lt;T&gt;&gt;::hash):
(WTF::DefaultHash&lt;WebKit::Protected&lt;T&gt;&gt;::equal):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::runJavaScript):

Canonical link: <a href="https://commits.webkit.org/297201@main">https://commits.webkit.org/297201@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24b07860ba2345a46aced26d98986583abf611c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20973 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116905 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61143 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31218 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39124 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84300 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113823 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24936 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99829 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64736 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60703 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94321 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18033 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119707 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37920 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28176 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93251 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38296 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96103 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93076 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38125 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15870 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33895 "Built successfully") | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/17887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37813 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43284 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37476 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40812 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39181 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->