### PR TITLE
REGRESSION (296485@main): Wikipedia can get into a weird state after long pressing on certain video links

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -467,6 +467,7 @@ struct PerWebProcessState {
     WebCore::RectEdges<RetainPtr<WKColorExtensionView>> _fixedColorExtensionViews;
     OptionSet<WebKit::HideScrollPocketReason> _reasonsToHideTopScrollPocket;
     BOOL _needsTopScrollPocketDueToVisibleContentInset;
+    BOOL _shouldUpdateNeedsTopScrollPocketDueToVisibleContentInset;
 #endif
 }
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -1128,6 +1128,10 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
 
         [self _updateScrollViewForTransaction:layerTreeTransaction];
 
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+        [self _updateNeedsTopScrollPocketDueToVisibleContentInset];
+#endif
+
         _perProcessState.viewportMetaTagWidth = layerTreeTransaction.viewportMetaTagWidth();
         _perProcessState.viewportMetaTagWidthWasExplicit = layerTreeTransaction.viewportMetaTagWidthWasExplicit();
         _perProcessState.viewportMetaTagCameFromImageDocument = layerTreeTransaction.viewportMetaTagCameFromImageDocument();
@@ -2405,6 +2409,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)_updateNeedsTopScrollPocketDueToVisibleContentInset
 {
+    if (!std::exchange(_shouldUpdateNeedsTopScrollPocketDueToVisibleContentInset, NO))
+        return;
+
     BOOL value = [&] -> BOOL {
         if ([_scrollView adjustedContentInset].top <= self._computedObscuredInset.top + CGFLOAT_EPSILON)
             return NO;
@@ -2443,7 +2450,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (void)scrollViewDidChangeAdjustedContentInset:(UIScrollView *)scrollView
 {
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
-    [self _updateNeedsTopScrollPocketDueToVisibleContentInset];
+    _shouldUpdateNeedsTopScrollPocketDueToVisibleContentInset = YES;
 #endif
 }
 
@@ -2454,7 +2461,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
         [self _updateFixedColorExtensionViewFrames];
         [self _reinsertTopFixedColorExtensionViewIfNeeded];
-        [self _updateNeedsTopScrollPocketDueToVisibleContentInset];
+        _shouldUpdateNeedsTopScrollPocketDueToVisibleContentInset = YES;
 #endif
     }
 

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
@@ -228,10 +228,12 @@ static UIAxis axesForDelta(WebCore::FloatSize delta)
 
 - (BOOL)_wk_usesHardTopScrollEdgeEffect
 {
+    // Calling this getter may trigger unintended behaviors, since calling -[UIScrollEdgeEffect style]
+    // may cause UIKit to layout subviews during the next update cycle.
     return [self.topEdgeEffect.style isEqual:UIScrollEdgeEffectStyle.hardStyle];
 }
 
-#endif
+#endif // ENABLE(CONTENT_INSET_BACKGROUND_FILL)
 
 @end
 


### PR DESCRIPTION
#### d16baa5d785797e77476004365f8df27832fee70
<pre>
REGRESSION (296485@main): Wikipedia can get into a weird state after long pressing on certain video links
<a href="https://bugs.webkit.org/show_bug.cgi?id=295672">https://bugs.webkit.org/show_bug.cgi?id=295672</a>
<a href="https://rdar.apple.com/154793516">rdar://154793516</a>

Reviewed by Abrar Rahman Protyasha.

After the changes in 296485@main, long-pressing a link to a video that triggers the fullscreen AVKit
player and then dismissing the view controller causes `WKWebView` to get into a state where the
dimensions of its inner `WKScrollView` are much, much larger than intended.

This happens because `UIScrollView.topEdgeEffect.style` is internally backed by `@Observable` state
in UIKit; when anything *reads* this state or changes it, UIKit observation tracking logic is
scheduled on the next update cycle, triggering various workloads (in this bug, `-layoutSubviews`).
This, in turn, may cause views in the view hierarchy (in this case, Safari-owned views) to lay out
subviews based on out-of-date or inconsistent geometry.

To fix this, we refactor this logic to be more judicious when checking `topEdgeEffect.style`, such
that we only invoke this getter during the next layer tree commit (instead of immediately when
scrolling or changing adjusted content insets). This is probably a much safer place, because:

- The rest of the view hierarchy is being updated anyways, and...
- Many other aspects of scroll view geometry are changed underneath this codepath.

As a nice byproduct of this refactoring, we will now avoid thrashing the state of
`_needsTopScrollPocketDueToVisibleContentInset` in cases where the content offset and content inset
are changing at the same time, in such a way that the scroll view is temporarily scrolled beyond the
top extent.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _didCommitLayerTree:]):

Invoke `_updateNeedsTopScrollPocketDueToVisibleContentInset` during the layer tree commit, when the
rest of the scroll view&apos;s geometry is being updated anyways.

(-[WKWebView _updateNeedsTopScrollPocketDueToVisibleContentInset]):

Make this method a no-op unless the new `_shouldUpdateNeedsTopScrollPocketDueToVisibleContentInset`
flag has been set.

(-[WKWebView scrollViewDidChangeAdjustedContentInset:]):
(-[WKWebView scrollViewDidScroll:]):

Instead of directly calling `-_updateNeedsTopScrollPocketDueToVisibleContentInset`, set a new flag
to indicate that we should recompute the state during the next layer tree commit, when the entire
view hierarchy is also being updated at the same time. See above for more details.

* Source/WebKit/UIProcess/ios/UIKitUtilities.mm:
(-[UIScrollView _wk_usesHardTopScrollEdgeEffect]):

Add a comment warning that this method might cause layout issues if invoked at the wrong time. Note
that there is one remaining call site when an element is focused; in my testing, this seems to be
safe, because element focus triggers view layout anyways as input views are reloaded.

Canonical link: <a href="https://commits.webkit.org/297197@main">https://commits.webkit.org/297197@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79678e7bf206b6e3619023885bf3168470b65518

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110841 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30504 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20938 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116870 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/61109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31184 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39090 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84266 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/61109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113789 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24910 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99799 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64710 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24265 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60666 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94294 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18003 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119664 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37886 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28148 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93224 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38262 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96074 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93049 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23717 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38098 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15846 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33860 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37779 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43249 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37440 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40778 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39147 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->