### PR TITLE
Fix static analyzer warnings in WebKit/ folder cookie code

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -63,7 +63,6 @@ WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
 WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm
 WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
 WebProcess/WebPage/ViewGestureGeometryCollector.cpp
-WebProcess/WebPage/WebCookieCache.cpp
 WebProcess/WebPage/WebFoundTextRangeController.cpp
 WebProcess/WebPage/WebFrame.cpp
 WebProcess/WebPage/WebPage.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -9,7 +9,6 @@ UIProcess/API/C/mac/WKPagePrivateMac.mm
 UIProcess/API/Cocoa/WKContentWorld.mm
 UIProcess/API/Cocoa/WKDownload.mm
 UIProcess/API/Cocoa/WKFrameInfo.mm
-UIProcess/API/Cocoa/WKHTTPCookieStore.mm
 UIProcess/API/Cocoa/WKOpenPanelParameters.mm
 UIProcess/API/Cocoa/WKPreferences.mm
 UIProcess/API/Cocoa/WKProcessPool.mm

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -67,7 +67,6 @@ Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm
 Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
 Shared/JavaScriptEvaluationResult.mm
 Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
-Shared/cf/CookieStorageUtilsCF.mm
 Shared/cf/CoreIPCNumber.mm
 Shared/mac/AuxiliaryProcessMac.mm
 Shared/mac/ScrollingAccelerationCurveMac.mm
@@ -78,7 +77,6 @@ UIProcess/API/Cocoa/NSAttributedString.mm
 UIProcess/API/Cocoa/WKContentRuleListStore.mm
 UIProcess/API/Cocoa/WKDownload.mm
 UIProcess/API/Cocoa/WKFrameInfo.mm
-UIProcess/API/Cocoa/WKHTTPCookieStore.mm
 UIProcess/API/Cocoa/WKNSURLAuthenticationChallenge.mm
 UIProcess/API/Cocoa/WKNavigationAction.mm
 UIProcess/API/Cocoa/WKNavigationResponse.mm
@@ -223,7 +221,6 @@ WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm
 WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
 WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
 WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
-WebProcess/WebPage/Cocoa/WebCookieJarCocoa.mm
 WebProcess/WebPage/Cocoa/WebPageCocoa.mm
 WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
 WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm

--- a/Source/WebKit/Shared/cf/CookieStorageUtilsCF.mm
+++ b/Source/WebKit/Shared/cf/CookieStorageUtilsCF.mm
@@ -41,7 +41,7 @@ RetainPtr<CFHTTPCookieStorageRef> cookieStorageFromIdentifyingData(const Vector<
     RetainPtr cookieStorage = adoptCF(CFHTTPCookieStorageCreateFromIdentifyingData(kCFAllocatorDefault, cookieStorageData.get()));
     ASSERT(cookieStorage);
 
-    CFHTTPCookieStorageScheduleWithRunLoop(cookieStorage.get(), [NSURLConnection resourceLoaderRunLoop], kCFRunLoopCommonModes);
+    CFHTTPCookieStorageScheduleWithRunLoop(cookieStorage.get(), RetainPtr { [NSURLConnection resourceLoaderRunLoop] }.get(), kCFRunLoopCommonModes);
 
     return cookieStorage;
 }

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebCookieJarCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebCookieJarCocoa.mm
@@ -97,7 +97,8 @@ void WebCookieJar::setCookiesInPartitionedCookieStorage(const WebCore::Document&
     if (!cookie || ![[cookie name] length] || [cookie isHTTPOnly])
         return;
 
-    [ensurePartitionedCookieStorage() _setCookies:@[cookie.get()] forURL:cookieURL.createNSURL().get() mainDocumentURL:firstPartyURL.createNSURL().get() policyProperties:policyProperties(sameSiteInfo, cookieURL).get()];
+    RetainPtr partitionedCookieStorage = ensurePartitionedCookieStorage();
+    [partitionedCookieStorage _setCookies:@[cookie.get()] forURL:cookieURL.createNSURL().get() mainDocumentURL:firstPartyURL.createNSURL().get() policyProperties:policyProperties(sameSiteInfo, cookieURL).get()];
 }
 
 NSHTTPCookieStorage* WebCookieJar::ensurePartitionedCookieStorage()

--- a/Source/WebKit/WebProcess/WebPage/WebCookieCache.h
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieCache.h
@@ -77,6 +77,8 @@ private:
     WebCookieCache() = default;
 
     WebCore::NetworkStorageSession& inMemoryStorageSession();
+    CheckedRef<WebCore::NetworkStorageSession> checkedInMemoryStorageSession() { return inMemoryStorageSession(); }
+
     void pruneCacheIfNecessary();
     bool cacheMayBeOutOfSync() const;
 


### PR DESCRIPTION
#### fc6b0a004b710bedf5a454f2649ce22aa128e508
<pre>
Fix static analyzer warnings in WebKit/ folder cookie code
<a href="https://bugs.webkit.org/show_bug.cgi?id=295675">https://bugs.webkit.org/show_bug.cgi?id=295675</a>
<a href="https://rdar.apple.com/155477189">rdar://155477189</a>

Reviewed by NOBODY (OOPS!).

* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/Shared/cf/CookieStorageUtilsCF.mm:
(WebKit::cookieStorageFromIdentifyingData):
* Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm:
(WKHTTPCookieStoreObserver::create):
(-[WKHTTPCookieStore _protectedCookieStore]):
(-[WKHTTPCookieStore dealloc]):
(-[WKHTTPCookieStore getAllCookies:]):
(-[WKHTTPCookieStore setCookie:completionHandler:]):
(-[WKHTTPCookieStore setCookies:completionHandler:]):
(-[WKHTTPCookieStore deleteCookie:completionHandler:]):
(-[WKHTTPCookieStore addObserver:]):
(-[WKHTTPCookieStore removeObserver:]):
(-[WKHTTPCookieStore setCookiePolicy:completionHandler:]):
(-[WKHTTPCookieStore getCookiePolicy:]):
(-[WKHTTPCookieStore _getCookiesForURL:completionHandler:]):
(-[WKHTTPCookieStore _setCookieAcceptPolicy:completionHandler:]):
(-[WKHTTPCookieStore _flushCookiesToDiskWithCompletionHandler:]):
(-[WKHTTPCookieStore _setCookies:completionHandler:]):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebCookieJarCocoa.mm:
(WebKit::WebCookieJar::setCookiesInPartitionedCookieStorage):
* Source/WebKit/WebProcess/WebPage/WebCookieCache.cpp:
(WebKit::WebCookieCache::cookiesForDOM):
(WebKit::WebCookieCache::setCookiesFromDOM):
(WebKit::WebCookieCache::didSetCookieFromDOM):
(WebKit::WebCookieCache::cookiesAdded):
(WebKit::WebCookieCache::cookiesDeleted):
(WebKit::WebCookieCache::clearForHost):
* Source/WebKit/WebProcess/WebPage/WebCookieCache.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc6b0a004b710bedf5a454f2649ce22aa128e508

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110842 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30505 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20939 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116871 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61110 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31185 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39091 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84267 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113790 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24913 "Found 60 new test failures: compositing/layer-creation/overlap-animation-container.html fast/dom/window-scroll-scaling.html fast/forms/file/file-input-reset-using-open-panel.html http/tests/app-privacy-report/user-attribution-cors-preflight-redirect.html http/tests/cache-storage/cache-representation.https.html http/tests/cache/disk-cache/redirect-chain-limits.html http/tests/fetch/response-clone-blob.html http/tests/in-app-browser-privacy/non-app-bound-iframe-under-app-bound-domain-is-app-bound.html http/tests/is-logged-in/unavailable-in-insecure-contexts.html http/tests/permissions/permissions-query-shared-worker.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99802 "Found 6 new API test failures: TestWebKitAPI.WKWebsiteDataStore.ReferenceCycle, TestWebKitAPI.WKHTTPCookieStore.WithoutProcessPoolWithoutPrewarming, TestWebKitAPI.WKHTTPCookieStore.WithoutProcessPoolWithPrewarming, TestWebKitAPI.WKHTTPCookieStore.SetCookies, TestWebKitAPI.WKHTTPCookieStore.CookiesSetInAnotherStoreBeforeLoad, TestWebKitAPI.WKWebsiteDataStoreConfiguration.SameCustomPathForDifferentTypes (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64711 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24269 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60668 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94297 "Found 6 new API test failures: TestWebKitAPI.WKWebsiteDataStore.ReferenceCycle, TestWebKitAPI.WKHTTPCookieStore.WithoutProcessPoolWithoutPrewarming, TestWebKitAPI.WKHTTPCookieStore.WithoutProcessPoolWithPrewarming, TestWebKitAPI.WKHTTPCookieStore.SetCookies, TestWebKitAPI.WKHTTPCookieStore.CookiesSetInAnotherStoreBeforeLoad, TestWebKitAPI.WKWebsiteDataStoreConfiguration.SameCustomPathForDifferentTypes (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18006 "Found 60 new test failures: accessibility/mac/replaced-element-text-selection.html compositing/images/truncated-direct-png-image.html compositing/transforms/transformed-replaced-with-shadow-children.html crypto/subtle/rsa-indexeddb-private.html fast/css-grid-layout/grid-simplified-layout-positioned.html fast/dom/window-opener-setter-throws-if-defineownproperty-fails-2.html fast/mediastream/getUserMedia-grant-persistency2.html fast/mediastream/getUserMedia-webaudio.html fast/mediastream/video-background-with-canvas.html http/tests/cache-storage/cache-representation.https.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119665 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37887 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28151 "Found 60 new test failures: crypto/subtle/rsa-indexeddb-private.html fast/dom/window-opener-setter-throws-if-defineownproperty-fails-2.html http/tests/cache-storage/cache-representation.https.html http/tests/cache/disk-cache/redirect-chain-limits.html http/tests/fetch/response-clone-blob.html http/tests/media/pdf-served-as-pdf.html http/tests/navigation/pushstate-updates-referrer.html http/tests/permissions/permission-status-onchange-event-service-worker.html http/tests/privateClickMeasurement/store-private-click-measurement.html http/tests/referrer-policy-iframe/no-referrer/cross-origin-http-UpgradeMixedContent.https.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93226 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38263 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96077 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93051 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38102 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15849 "Found 60 new test failures: crypto/subtle/rsa-indexeddb-private.html css3/calc/block-mask-overlay-image-outset.html fast/dom/window-opener-setter-throws-if-defineownproperty-fails-2.html fast/table/border-collapsing/adjacent-row-groups-multi.html http/tests/cache-storage/cache-representation.https.html http/tests/cache/disk-cache/disk-cache-vary-no-body.html http/tests/fetch/response-clone-blob.html http/tests/media/pdf-served-as-pdf.html http/tests/navigation/pushstate-updates-referrer.html http/tests/permissions/permission-status-onchange-event-service-worker.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33861 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37780 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43250 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37443 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40779 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39148 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->