### PR TITLE
[bmalloc] Remove superflous mutex

### DIFF
--- a/Source/bmalloc/bmalloc/TZoneHeapManager.cpp
+++ b/Source/bmalloc/bmalloc/TZoneHeapManager.cpp
@@ -120,25 +120,21 @@ TZoneHeapManager::TZoneHeapManager()
 
 void determineTZoneMallocFallback()
 {
-    static Mutex s_mutex;
-    LockHolder lock(s_mutex);
-    {
-        if (tzoneMallocFallback != TZoneMallocFallback::Undecided)
-            return;
+    if (tzoneMallocFallback != TZoneMallocFallback::Undecided)
+        return;
 
-        if (Environment::get()->isSystemHeapEnabled()) {
-            tzoneMallocFallback = TZoneMallocFallback::ForceDebugMalloc;
-            return;
-        }
-
-        const char* env = getenv("bmalloc_TZoneHeap");
-        if (env && (!strcasecmp(env, "false") || !strcasecmp(env, "no") || !strcmp(env, "0"))) {
-            tzoneMallocFallback = TZoneMallocFallback::ForceDebugMalloc;
-            return;
-        }
-
-        tzoneMallocFallback = TZoneMallocFallback::DoNotFallBack;
+    if (Environment::get()->isSystemHeapEnabled()) {
+        tzoneMallocFallback = TZoneMallocFallback::ForceDebugMalloc;
+        return;
     }
+
+    const char* env = getenv("bmalloc_TZoneHeap");
+    if (env && (!strcasecmp(env, "false") || !strcasecmp(env, "no") || !strcmp(env, "0"))) {
+        tzoneMallocFallback = TZoneMallocFallback::ForceDebugMalloc;
+        return;
+    }
+
+    tzoneMallocFallback = TZoneMallocFallback::DoNotFallBack;
 }
 
 void TZoneHeapManager::requirePerBootSeed()


### PR DESCRIPTION
#### ca4b5344596a2af8358778a26208fc7311426785
<pre>
[bmalloc] Remove superflous mutex
<a href="https://bugs.webkit.org/show_bug.cgi?id=295677">https://bugs.webkit.org/show_bug.cgi?id=295677</a>
<a href="https://rdar.apple.com/155477794">rdar://155477794</a>

Reviewed by Keith Miller and Mark Lam.

This lock is no longer necessary; the rest of TZoneHeapManager&apos;s
initialization is not guarded by a lock, and there&apos;s no reason why
this region in particular needs one.

* Source/bmalloc/bmalloc/TZoneHeapManager.cpp:
(bmalloc::api::determineTZoneMallocFallback):

Canonical link: <a href="https://commits.webkit.org/297205@main">https://commits.webkit.org/297205@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4759efc2ffde0c576ad526f553bfb1afcb3a339

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110848 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30511 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20945 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116877 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61116 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31191 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39097 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84270 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113796 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24912 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99804 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64714 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24267 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17946 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60674 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/103340 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94296 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18007 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119671 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109402 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37893 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28154 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93229 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38269 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96078 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93054 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38099 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15850 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33867 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17889 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37786 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/133677 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37448 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36093 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40785 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39154 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->