### PR TITLE
Web locks is not released after page navigated / refreshed

### DIFF
--- a/LayoutTests/http/wpt/web-locks/back-forward-cache-suspend-test.https-expected.txt
+++ b/LayoutTests/http/wpt/web-locks/back-forward-cache-suspend-test.https-expected.txt
@@ -1,0 +1,19 @@
+CONSOLE MESSAGE: TEST: Starting WebLocks suspend test
+CONSOLE MESSAGE: TEST: pageshow event, persisted:
+CONSOLE MESSAGE: TEST: Lock granted, lock object:
+CONSOLE MESSAGE: TEST: Lock promise created, waiting for suspend...
+CONSOLE MESSAGE: TEST: Checking initial lock state...
+CONSOLE MESSAGE: TEST: Initial query - held:
+CONSOLE MESSAGE: TEST: Lock details:
+CONSOLE MESSAGE: TEST: About to navigate to trigger BFCache...
+CONSOLE MESSAGE: TEST: Navigation initiated
+CONSOLE MESSAGE: TEST: pagehide event, persisted:
+CONSOLE MESSAGE: TEST: Page entering BFCache
+CONSOLE MESSAGE: TEST: pageshow event, persisted:
+CONSOLE MESSAGE: TEST: Page restored from BFCache
+CONSOLE MESSAGE: TEST: Lock promise rejected, reason:
+CONSOLE MESSAGE: TEST: Query after pageshow - held:
+CONSOLE MESSAGE: TEST: Test completed successfully
+
+PASS WebLocks are properly released when page is suspended for back/forward cache
+

--- a/LayoutTests/http/wpt/web-locks/back-forward-cache-suspend-test.https.html
+++ b/LayoutTests/http/wpt/web-locks/back-forward-cache-suspend-test.https.html
@@ -1,0 +1,112 @@
+<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebLocks Back/Forward Cache Suspend Test</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+'use strict';
+
+// Test that WebLocks are properly released when page is suspended for back/forward cache
+async_test(t => {
+    let lockReleased = false;
+    let promiseRejected = false;
+    let pageHidden = false;
+    let pageShown = false;
+    
+    console.log('TEST: Starting WebLocks suspend test');
+    
+    // Listen for page cache events
+    window.addEventListener('pagehide', function(event) {
+        console.log('TEST: pagehide event, persisted:', event.persisted);
+        if (event.persisted) {
+            pageHidden = true;
+            console.log('TEST: Page entering BFCache');
+        }
+    });
+    
+    window.addEventListener('pageshow', function(event) {
+        console.log('TEST: pageshow event, persisted:', event.persisted);
+        if (event.persisted) {
+            pageShown = true;
+            console.log('TEST: Page restored from BFCache');
+            
+            // Check if lock was released while in cache
+            setTimeout(() => {
+                navigator.locks.query().then(snapshot => {
+                    console.log('TEST: Query after pageshow - held:', snapshot.held.length, 'pending:', snapshot.pending.length);
+                    t.step(() => {
+                        assert_true(pageHidden, 'Page should have been hidden');
+                        assert_true(pageShown, 'Page should have been shown');
+                        assert_equals(snapshot.held.length, 0, 'Lock should be released after BFCache');
+                        assert_equals(snapshot.pending.length, 0, 'No pending locks should remain');
+                        assert_true(promiseRejected, 'Lock promise should have been rejected');
+                        assert_true(lockReleased, 'Lock should have been released');
+                    });
+                    console.log('TEST: Test completed successfully');
+                    t.done();
+                });
+            }, 100);
+        }
+    });
+    
+    // Request a lock that should be released when page is suspended
+    const lockPromise = navigator.locks.request('suspend-test-lock', async (lock) => {
+        console.log('TEST: Lock granted, lock object:', lock);
+        // Return a promise that never resolves normally
+        // It should be rejected when suspend() is called
+        return new Promise((resolve, reject) => {
+            console.log('TEST: Lock promise created, waiting for suspend...');
+            // This promise will be rejected by suspend() implementation
+        });
+    });
+    
+    lockPromise.catch(reason => {
+        console.log('TEST: Lock promise rejected, reason:', reason);
+        promiseRejected = true;
+        lockReleased = true;
+    });
+    
+    // Wait for the lock to be acquired, then navigate to trigger suspend
+    window.addEventListener('load', function() {
+        setTimeout(() => {
+            console.log('TEST: Checking initial lock state...');
+            navigator.locks.query().then(snapshot => {
+                console.log('TEST: Initial query - held:', snapshot.held.length, 'pending:', snapshot.pending.length);
+                if (snapshot.held.length > 0) {
+                    console.log('TEST: Lock details:', snapshot.held[0]);
+                }
+                
+                t.step(() => {
+                    assert_equals(snapshot.held.length, 1, 'Lock should be held initially');
+                    assert_equals(snapshot.held[0].name, 'suspend-test-lock', 'Correct lock name');
+                });
+                
+                console.log('TEST: About to navigate to trigger BFCache...');
+                // Navigate to a helper page that will navigate back
+                window.location.href = 'resources/bfcache-helper.html';
+                console.log('TEST: Navigation initiated');
+            });
+        }, 100);
+    });
+    
+    // Timeout if suspend doesn't work
+    setTimeout(() => {
+        if (!lockReleased && !pageShown) {
+            console.log('TEST: Timeout - lock was not released, pageHidden:', pageHidden, 'pageShown:', pageShown);
+            t.step(() => {
+                assert_unreached('Lock should have been released due to suspend');
+            });
+            t.done();
+        }
+    }, 10000);
+    
+}, 'WebLocks are properly released when page is suspended for back/forward cache');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/web-locks/resources/bfcache-helper.html
+++ b/LayoutTests/http/wpt/web-locks/resources/bfcache-helper.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>BFCache Helper</title>
+</head>
+<body>
+<p>BFCache Helper Page</p>
+<script>
+window.addEventListener("load", function() {
+    setTimeout(function() {
+        history.back();
+    }, 100);
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/web-locks/WebLockManager.h
+++ b/Source/WebCore/Modules/web-locks/WebLockManager.h
@@ -74,6 +74,7 @@ private:
     // ActiveDOMObject.
     void stop() final;
     bool virtualHasPendingActivity() const final;
+    void suspend(ReasonForSuspension) final;
 
     class MainThreadBridge;
     RefPtr<MainThreadBridge> m_mainThreadBridge;


### PR DESCRIPTION
#### 278f1e3a76d982a661d3cc6ea4443c1279203d9c
<pre>
Web locks is not released after page navigated / refreshed
<a href="https://bugs.webkit.org/show_bug.cgi?id=283528">https://bugs.webkit.org/show_bug.cgi?id=283528</a>
<a href="https://rdar.apple.com/140399284">rdar://140399284</a>

Reviewed by Chris Dumez.

When a page holding WebLocks enters the Back/Forward Cache (BFCache), the locks were not being released properly.
This caused locks remain held while page is in BFCache. The WebLockManager and its locks stay alive in the
suspended page

The core issue is that pages in BFCache maintain their JavaScript context and objects (including WebLockManager),
but should release shared resources like locks to avoid blocking other pages.

To solve this, override `WebLockManager::suspend()` to release locks when pages enter BFCache. Also reject all
promise before clearing from the lock manager.

Added LayoutTest to verify BFCache-specific behavior.

* LayoutTests/http/wpt/web-locks/back-forward-cache-suspend-test.https-expected.txt: Added.
* LayoutTests/http/wpt/web-locks/back-forward-cache-suspend-test.https.html: Added.
* LayoutTests/http/wpt/web-locks/resources/bfcache-helper.html: Added.
* Source/WebCore/Modules/web-locks/WebLockManager.cpp:
(WebCore::WebLockManager::clientIsGoingAway):
(WebCore::WebLockManager::suspend):
* Source/WebCore/Modules/web-locks/WebLockManager.h:

Canonical link: <a href="https://commits.webkit.org/297294@main">https://commits.webkit.org/297294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84084036cfcf81ffc2ba1adf5f6b7368b12ab77c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111183 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30849 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21312 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117214 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61451 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113145 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31530 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39431 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84514 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114130 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25187 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100117 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64960 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24529 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/18258 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61034 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94565 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18325 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120270 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38232 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28409 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93453 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38608 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96392 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93278 "Found 2 new API test failures: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23773 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38364 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16135 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34217 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38121 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43598 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37786 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41119 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39488 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->