### PR TITLE
Add another test for the WebView API after 295442 and 297156.

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ClipboardTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ClipboardTests.mm
@@ -210,7 +210,7 @@ TEST(ClipboardTests, ConvertTIFFToPNGWhenPasting)
     EXPECT_TRUE([[webView stringByEvaluatingJavaScript:@"clipboardData[0]['image/png'].src"] containsString:@"blob:"]);
 }
 
-TEST(ClipboardTests, EphemeralSessionClipboardHasExpiration)
+TEST(ClipboardTests, EphemeralSessionClipboardHasExpirationJavaScript)
 {
     RetainPtr webView = createEphemeralWebViewForClipboardTests();
 
@@ -225,6 +225,26 @@ TEST(ClipboardTests, EphemeralSessionClipboardHasExpiration)
     };
 
     EXPECT_TRUE([webView stringByEvaluatingJavaScript:@"document.execCommand(\"selectAll\", true); document.execCommand(\"copy\");"]);
+
+    EXPECT_TRUE(pasteboardHaveExpirationDate);
+}
+
+TEST(ClipboardTests, EphemeralSessionClipboardHasExpirationWebView)
+{
+    RetainPtr webView = createEphemeralWebViewForClipboardTests();
+
+    __block bool pasteboardHaveExpirationDate = false;
+    auto setExpirationDateSwizzler = InstanceMethodSwizzler {
+        NSPasteboard.class,
+        @selector(_setExpirationDate:),
+        imp_implementationWithBlock(^{
+            pasteboardHaveExpirationDate = true;
+            return YES;
+        })
+    };
+
+    [webView selectAll:nil];
+    [webView _synchronouslyExecuteEditCommand:@"Copy" argument:nil];
 
     EXPECT_TRUE(pasteboardHaveExpirationDate);
 }


### PR DESCRIPTION
#### b3a351e560ea0aab4f44f9ebe809491bb0114beb
<pre>
Add another test for the WebView API after 295442 and 297156.
<a href="https://bugs.webkit.org/show_bug.cgi?id=295680">https://bugs.webkit.org/show_bug.cgi?id=295680</a>
<a href="https://rdar.apple.com/155479808">rdar://155479808</a>

Reviewed by Wenson Hsieh.

Adding another test to ensure that we&apos;re exercising all
clipboard paths.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/ClipboardTests.mm:
(TEST(ClipboardTests, EphemeralSessionClipboardHasExpirationJavaScript)):
(TEST(ClipboardTests, EphemeralSessionClipboardHasExpirationWebView)):
(TEST(ClipboardTests, EphemeralSessionClipboardHasExpiration)): Deleted.

Canonical link: <a href="https://commits.webkit.org/297487@main">https://commits.webkit.org/297487@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa966c7f7df38a4475a018efac1cafe1f361568f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110867 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30530 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20965 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116897 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61135 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112830 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31210 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39116 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84286 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113815 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24929 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99824 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64730 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24285 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17966 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60695 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94314 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18028 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119699 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37912 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28169 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93243 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38288 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96098 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93068 "Found 2 new API test failures: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23925 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38119 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15868 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33886 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37805 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37468 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40804 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39173 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->