### PR TITLE
[Safer CPP] Address issues in CSSFontSelector and CSSFontStyleRangeValue

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -42,7 +42,6 @@ bindings/js/WindowProxy.h
 bridge/objc/objc_runtime.h
 crypto/cocoa/CryptoAlgorithmEd25519Cocoa.cpp
 crypto/cocoa/CryptoKeyOKPCocoa.cpp
-css/CSSFontSelector.h
 css/CSSImageValue.cpp
 css/CSSStyleProperties.h
 css/CSSToLengthConversionData.h

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -10,7 +10,6 @@ Modules/webdatabase/SQLTransactionBackend.h
 accessibility/AXSearchManager.h
 bindings/js/JSEventTargetCustom.h
 bindings/js/JSLazyEventListener.cpp
-css/CSSFontSelector.h
 css/CSSPrimitiveValue.h
 css/CSSRule.h
 css/CSSRuleList.h

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -70,7 +70,6 @@ bindings/js/JSXMLHttpRequestCustom.cpp
 bindings/js/ScheduledAction.cpp
 bindings/js/ScriptModuleLoader.cpp
 contentextensions/ContentExtensionsBackend.cpp
-css/CSSFontSelector.cpp
 css/CSSStyleSheet.cpp
 css/FontFaceSet.cpp
 css/MediaQueryMatcher.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -295,9 +295,6 @@ css/CSSCounterValue.h
 css/CSSCursorImageValue.cpp
 css/CSSFontFace.cpp
 css/CSSFontFaceRule.cpp
-css/CSSFontSelector.cpp
-css/CSSFontStyleRangeValue.cpp
-css/CSSFontStyleRangeValue.h
 css/CSSFontValue.cpp
 css/CSSGridLineValue.cpp
 css/CSSGroupingRule.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -123,7 +123,6 @@ css/CSSCounterStyleDescriptors.cpp
 css/CSSFontFace.cpp
 css/CSSFontFaceSet.cpp
 css/CSSFontFaceSource.cpp
-css/CSSFontSelector.cpp
 css/CSSGroupingRule.cpp
 css/CSSImageSetValue.cpp
 css/CSSImageValue.cpp

--- a/Source/WebCore/css/CSSFontSelector.h
+++ b/Source/WebCore/css/CSSFontSelector.h
@@ -32,6 +32,7 @@
 #include "Font.h"
 #include "FontSelector.h"
 #include "ScriptExecutionContext.h"
+#include "StyleRule.h"
 #include "Timer.h"
 #include "WebKitFontFamilyNames.h"
 #include <memory>
@@ -47,9 +48,6 @@ class CSSSegmentedFontFace;
 class CSSValueList;
 class CachedFont;
 class ScriptExecutionContext;
-class StyleRuleFontFace;
-class StyleRuleFontFeatureValues;
-class StyleRuleFontPaletteValues;
 
 class CSSFontSelector final : public FontSelector, public CSSFontFaceClient, public ActiveDOMObject {
 public:
@@ -124,7 +122,7 @@ private:
     void fontModified();
 
     struct PendingFontFaceRule {
-        StyleRuleFontFace& styleRuleFontFace;
+        const Ref<StyleRuleFontFace> styleRuleFontFace;
         bool isInitiatingElementInUserAgentShadowTree;
     };
     Vector<PendingFontFaceRule> m_stagingArea;

--- a/Source/WebCore/css/CSSFontStyleRangeValue.cpp
+++ b/Source/WebCore/css/CSSFontStyleRangeValue.cpp
@@ -32,6 +32,8 @@ namespace WebCore {
 
 String CSSFontStyleRangeValue::customCSSText(const CSS::SerializationContext& context) const
 {
+    RefPtr obliqueValues = this->obliqueValues;
+    Ref fontStyleValue = this->fontStyleValue;
     if (!obliqueValues)
         return fontStyleValue->cssText(context);
 

--- a/Source/WebCore/css/CSSFontStyleRangeValue.h
+++ b/Source/WebCore/css/CSSFontStyleRangeValue.h
@@ -50,7 +50,7 @@ public:
     {
         if (func(fontStyleValue.get()) == IterationStatus::Done)
             return IterationStatus::Done;
-        if (obliqueValues) {
+        if (RefPtr obliqueValues = this->obliqueValues) {
             if (func(*obliqueValues) == IterationStatus::Done)
                 return IterationStatus::Done;
         }


### PR DESCRIPTION
#### 642dd9043e5d7ced8a8fe77de6c3445650b14316
<pre>
[Safer CPP] Address issues in CSSFontSelector and CSSFontStyleRangeValue
<a href="https://bugs.webkit.org/show_bug.cgi?id=295682">https://bugs.webkit.org/show_bug.cgi?id=295682</a>
<a href="https://rdar.apple.com/155481948">rdar://155481948</a>

Reviewed by Ryosuke Niwa.

Address Safer CPP issues in CSSFontSelector and CSSFontStyleRangeValue.

* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/css/CSSFontSelector.cpp:
(WebCore::CSSFontSelector::~CSSFontSelector):
(WebCore::CSSFontSelector::fontFaceSet):
(WebCore::CSSFontSelector::buildStarted):
(WebCore::CSSFontSelector::buildCompleted):
(WebCore::CSSFontSelector::addFontFaceRule):
(WebCore::CSSFontSelector::addFontFeatureValuesRule):
(WebCore::CSSFontSelector::resolveGenericFamily):
(WebCore::CSSFontSelector::fontRangesForFamily):
(WebCore::CSSFontSelector::fallbackFontCount):
(WebCore::CSSFontSelector::fallbackFontAt):
(WebCore::CSSFontSelector::isSimpleFontSelectorForDescription const):
* Source/WebCore/css/CSSFontSelector.h:
* Source/WebCore/css/CSSFontStyleRangeValue.cpp:
(WebCore::CSSFontStyleRangeValue::customCSSText const):
* Source/WebCore/css/CSSFontStyleRangeValue.h:

Canonical link: <a href="https://commits.webkit.org/297356@main">https://commits.webkit.org/297356@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fdf61863ef5a9ee577b3ac4aca7abb387f6b3dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111466 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31132 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21597 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117498 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61734 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113428 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31813 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39714 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84715 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/35522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114413 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25401 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100343 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65163 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24749 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18478 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61320 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94787 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18544 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120721 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38515 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28623 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93637 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38891 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96611 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93463 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23813 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38573 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16351 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34552 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38404 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43881 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38069 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41402 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39771 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->