### PR TITLE
[SiteIsolation] Implement basic "descendant frames" focus advancing across site isolated frames

### DIFF
--- a/Source/WebCore/page/FocusController.h
+++ b/Source/WebCore/page/FocusController.h
@@ -95,13 +95,20 @@ public:
 
     WEBCORE_EXPORT bool relinquishFocusToChrome(FocusDirection);
 
+    WEBCORE_EXPORT FocusableElementSearchResult findAndFocusElementStartingWithLocalFrame(FocusDirection, const FocusEventData&, LocalFrame&);
+
 private:
     void setActiveInternal(bool);
     void setFocusedInternal(bool);
     void setIsVisibleAndActiveInternal(bool);
 
+    enum class InitialFocus : bool { No, Yes };
+    enum class ContinuingRemoteSearch : bool { No, Yes };
+
     bool advanceFocusDirectionally(FocusDirection, const FocusEventData&);
-    bool advanceFocusInDocumentOrder(FocusDirection, const FocusEventData&, bool initialFocus);
+    bool advanceFocusInDocumentOrder(FocusDirection, const FocusEventData&, InitialFocus);
+
+    FocusableElementSearchResult findAndFocusElementInDocumentOrderStartingWithFrame(Ref<LocalFrame>, RefPtr<Node> scopeNode, RefPtr<Node> startingNode, FocusDirection, const FocusEventData&, InitialFocus, ContinuingRemoteSearch);
 
     FocusableElementSearchResult findFocusableElementAcrossFocusScope(FocusDirection, const FocusNavigationScope& startScope, Node* start, const FocusEventData&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1538,10 +1538,21 @@ std::optional<ResourceResponse> WebFrame::resourceResponseForURL(const URL& url)
     return std::nullopt;
 }
 
-void WebFrame::findFocusableElementDescendingIntoRemoteFrame(WebCore::FocusDirection, const WebCore::FocusEventData&, CompletionHandler<void(WebCore::FoundElementInRemoteFrame)>&& completionHandler)
+void WebFrame::findFocusableElementDescendingIntoRemoteFrame(WebCore::FocusDirection direction, const WebCore::FocusEventData& focusEventData, CompletionHandler<void(WebCore::FoundElementInRemoteFrame)>&& completionHandler)
 {
-    // FIXME: Implement
-    completionHandler(WebCore::FoundElementInRemoteFrame::No);
+    auto foundElementInRemoteFrame = WebCore::FoundElementInRemoteFrame::No;
+
+    if (m_coreFrame) {
+        if (RefPtr localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get())) {
+            if (RefPtr page = localFrame->page()) {
+                auto result = page->focusController().findAndFocusElementStartingWithLocalFrame(direction, focusEventData, *localFrame);
+                if (result.element)
+                    foundElementInRemoteFrame = WebCore::FoundElementInRemoteFrame::Yes;
+            }
+        }
+    }
+
+    completionHandler(foundElementInRemoteFrame);
 }
 
 } // namespace WebKit

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -3597,12 +3597,12 @@ TEST(SiteIsolation, ThemeColor)
     [webView.get() removeObserver:observer.get() forKeyPath:@"underPageBackgroundColor"];
 }
 
-static WebViewAndDelegates makeWebViewAndDelegates(HTTPServer& server)
+static WebViewAndDelegates makeWebViewAndDelegates(HTTPServer& server, bool enable = true)
 {
     RetainPtr messageHandler = adoptNS([TestMessageHandler new]);
     RetainPtr configuration = server.httpsProxyConfiguration();
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
-    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration.get());
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration.get(), CGRectZero, enable);
     RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     [webView setUIDelegate:uiDelegate.get()];
     return {
@@ -4993,5 +4993,124 @@ TEST(SiteIsolation, UserScript)
     [[webView configuration].userContentController _addUserScriptImmediately:script.get()];
     EXPECT_WK_STREQ([webView _test_waitForAlert], "script ran in iframe");
 }
+
+static auto advanceFocusAcrossFramesMainFrame = R"FOCUSRESOURCE(
+<script>
+
+function sendResult(msg) {
+    window.webkit.messageHandlers.testHandler.postMessage(msg);
+}
+
+function postResult(event) {
+    sendResult(event.data)
+}
+
+addEventListener('message', postResult, false);
+
+</script>
+<div id="div1" tabindex="1">Main 1</div><br>
+<div id="div2" tabindex="2">Main 2</div><br>
+<iframe id="iframe1" src="https://webkit.org/iframe"></iframe><br>
+<script>
+document.body.addEventListener("focus", (event) => {
+    sendResult('main - focus body', '*');
+});
+document.getElementById("div1").addEventListener("focus", (event) => {
+    sendResult('main - focus div1', '*');
+});
+document.getElementById("div2").addEventListener("focus", (event) => {
+    sendResult('main - focus div2', '*');
+});
+document.getElementById("iframe1").addEventListener("focus", (event) => {
+    sendResult('main - focus iframe element', '*');
+});
+</script>
+)FOCUSRESOURCE"_s;
+
+static auto advanceFocusAcrossFramesChildFrame = R"FOCUSRESOURCE(
+<div id="div1" tabindex="1">Child 1</div><br>
+<div id="div2" tabindex="2">Child 2</div><br>
+<div id="log">Initial logging</div>
+<script>
+document.body.addEventListener("focus", (event) => {
+    parent.postMessage('iframe - focus body', '*');
+});
+document.getElementById("div1").addEventListener("focus", (event) => {
+    parent.postMessage('iframe - focus div1', '*');
+});
+document.getElementById("div2").addEventListener("focus", (event) => {
+    parent.postMessage('iframe - focus div2', '*');
+});
+</script>
+)FOCUSRESOURCE"_s;
+
+// FIXME: To enable, need `typeCharacter:` support for TestWKWebView on iOS
+#if PLATFORM(MAC)
+TEST(SiteIsolation, AdvanceFocusAcrossFrames)
+{
+    HTTPServer server({
+        { "/example"_s, { advanceFocusAcrossFramesMainFrame } },
+        { "/iframe"_s, { advanceFocusAcrossFramesChildFrame } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webViewAndDelegates = makeWebViewAndDelegates(server);
+    auto webView = WTFMove(webViewAndDelegates.webView);
+    auto messageHandler = WTFMove(webViewAndDelegates.messageHandler);
+    auto navigationDelegate = WTFMove(webViewAndDelegates.navigationDelegate);
+    auto uiDelegate = WTFMove(webViewAndDelegates.uiDelegate);
+
+    __block RetainPtr<NSString> mostRecentMessage;
+    __block bool messageReceived = false;
+    [messageHandler setDidReceiveScriptMessage:^(NSString *message) {
+        mostRecentMessage = message;
+        messageReceived = true;
+    }];
+
+    uiDelegate.get().takeFocus = ^(WKWebView *, _WKFocusDirection) {
+        mostRecentMessage = @"Chrome focus taken";
+        messageReceived = true;
+    };
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    NSArray *expectedMessages = @[
+        @"main - focus div1",
+        @"main - focus div1",
+        @"main - focus div2",
+        @"iframe - focus div1",
+        @"iframe - focus div2",
+        @"Chrome focus taken"
+    ];
+    size_t currentExpected = 0;
+
+    [webView typeCharacter:'\t'];
+    Util::run(&messageReceived);
+    EXPECT_TRUE([mostRecentMessage isEqualToString:expectedMessages[currentExpected++]]);
+    messageReceived = false;
+    Util::run(&messageReceived);
+    EXPECT_TRUE([mostRecentMessage isEqualToString:expectedMessages[currentExpected++]]);
+
+    messageReceived = false;
+    [webView typeCharacter:'\t'];
+    Util::run(&messageReceived);
+    EXPECT_TRUE([mostRecentMessage isEqualToString:expectedMessages[currentExpected++]]);
+
+    messageReceived = false;
+    [webView typeCharacter:'\t'];
+    Util::run(&messageReceived);
+    EXPECT_TRUE([mostRecentMessage isEqualToString:expectedMessages[currentExpected++]]);
+
+    messageReceived = false;
+    [webView typeCharacter:'\t'];
+    Util::run(&messageReceived);
+    EXPECT_TRUE([mostRecentMessage isEqualToString:expectedMessages[currentExpected++]]);
+
+    messageReceived = false;
+    [webView typeCharacter:'\t'];
+    Util::run(&messageReceived);
+    EXPECT_TRUE([mostRecentMessage isEqualToString:expectedMessages[currentExpected++]]);
+}
+#endif // PLATFORM(MAC)
 
 }

--- a/Tools/TestWebKitAPI/cocoa/TestUIDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestUIDelegate.h
@@ -43,6 +43,7 @@
 @property (nonatomic, copy) void (^saveDataToFile)(WKWebView *, NSData *, NSString *, NSString *, NSURL *);
 @property (nonatomic, copy) void (^focusWebView)(WKWebView *);
 @property (nonatomic, copy) void (^unfocusWebView)(WKWebView *);
+@property (nonatomic, copy) void (^takeFocus)(WKWebView *, _WKFocusDirection);
 @property (nonatomic, copy) void (^webViewDidClose)(WKWebView *);
 @property (nonatomic, copy) void (^webViewDidAdjustVisibilityWithSelectors)(WKWebView *, NSArray<NSString *> *);
 @property (nonatomic, copy) void (^runOpenPanelWithParameters)(WKWebView *, WKOpenPanelParameters *, WKFrameInfo *, void (^)(NSArray<NSURL *> *));

--- a/Tools/TestWebKitAPI/cocoa/TestUIDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestUIDelegate.mm
@@ -106,6 +106,12 @@
         _runOpenPanelWithParameters(webView, parameters, frame, completionHandler);
 }
 
+- (void)_webView:(WKWebView *)webView takeFocus:(_WKFocusDirection)direction
+{
+    if (_takeFocus)
+        _takeFocus(webView, direction);
+}
+
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
 
 - (NSColor *)_webView:(WKWebView *)webView adjustedColorForTopContentInsetColor:(NSColor *)proposedColor

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -183,6 +183,7 @@ class Color;
 - (std::optional<CGPoint>)getElementMidpoint:(NSString *)selector;
 - (Vector<WebCore::Color>)sampleColors;
 - (Vector<WebCore::Color>)sampleColorsWithInterval:(unsigned)interval;
+- (RetainPtr<_WKFrameTreeNode>)frameTree;
 @end
 
 #if PLATFORM(IOS_FAMILY)

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -1262,6 +1262,20 @@ static UIWindowScene *windowScene()
     return samples;
 }
 
+- (RetainPtr<_WKFrameTreeNode>)frameTree
+{
+    __block RetainPtr<_WKFrameTreeNode> result;
+    __block bool isDone = false;
+
+    [self _frames:^(_WKFrameTreeNode *tree) {
+        result = tree;
+        isDone = true;
+    }];
+    TestWebKitAPI::Util::run(&isDone);
+
+    return result;
+}
+
 #if PLATFORM(IOS_FAMILY)
 
 - (NSString *)textForSpeakSelection


### PR DESCRIPTION
#### 8b2d5e03d8b976c2712356a30fdda4d32132b123
<pre>
[SiteIsolation] Implement basic &quot;descendant frames&quot; focus advancing across site isolated frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=295684">https://bugs.webkit.org/show_bug.cgi?id=295684</a>
&lt;<a href="https://rdar.apple.com/problem/155493711">rdar://problem/155493711</a>&gt;

Reviewed by Alex Christensen.

This implements advancing focus across descendant isolated frames.
e.g.

A
|
-&gt;B
  |
  -&gt;C

Where B and C are different origins from A, and therefore in other processes, focus advancing will
cross process boundaries and finally relinquish to the browser chrome at the end, all before starting
over again up at A.

Known to still not work is sibling isolated frames.
e.g.

  A
  |
&lt;-.-&gt;
|   |
B   C

In this arrangement, advancing focus will move from A to B, then relinquish to the browser chrome
instead of continuing in C.

Making that work is the next step after this patch.

* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::findAndFocusElementStartingWithLocalFrame):
(WebCore::FocusController::findFocusableElementDescendingIntoSubframes):
(WebCore::FocusController::advanceFocusInDocumentOrder):
(WebCore::FocusController::findFocusableElementAcrossFocusScope):
* Source/WebCore/page/FocusController.h:

* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::findFocusableElementDescendingIntoRemoteFrame):

* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::makeWebViewAndDelegates):
(TestWebKitAPI::(SiteIsolation, AdvanceFocusAcrossFrames)):

* Tools/TestWebKitAPI/cocoa/TestUIDelegate.h:
* Tools/TestWebKitAPI/cocoa/TestUIDelegate.mm:
(-[TestUIDelegate _webView:takeFocus:]):

Synchronous access to the frame tree was useful in an earlier iteration of this test, and seems
like it is generally useful to TestWebKitAPI clients, so I&apos;m leaving it in.
* Tools/TestWebKitAPI/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[TestWKWebView frameTree]):

Canonical link: <a href="https://commits.webkit.org/297419@main">https://commits.webkit.org/297419@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5f0e43712d896291709f9651e468ca3120a351a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111722 "10 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31388 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21863 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117754 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/61980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113684 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32076 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39973 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84887 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/61980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114669 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25610 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100555 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65325 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/24945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18687 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61586 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94997 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18759 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121005 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38768 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/28821 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/93778 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39148 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96810 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93600 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23861 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38751 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/16543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34798 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38662 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44153 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38316 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41644 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40023 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->