### PR TITLE
[webkitapipy] Support conditional allowlist entries

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 			buildPhases = (
 				DDE99311278D088800F60D26 /* Product Dependencies */,
 				65FB3F6509D11E9100F49DEB /* Generate Derived Sources */,
+				DD190BB72E1C480200BE3ECA /* Generate <wtf/Platform.h> args */,
 			);
 			dependencies = (
 			);
@@ -12714,6 +12715,33 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if [ -f \"${SCRIPT_INPUT_FILE_0}\" ]\nthen \"${SCRIPT_INPUT_FILE_0}\" \"${BUILT_PRODUCTS_DIR}/JavaScriptCore.framework/JavaScriptCore\" --allowlists \"${SRCROOT}/Configurations/AllowedSPI-legacy.toml\" \"${SRCROOT}/Configurations/AllowedSPI.toml\"\nfi && touch \"${DERIVED_FILES_DIR}/audit-spi.d\"\n";
+		};
+		DD190BB72E1C480200BE3ECA /* Generate <wtf/Platform.h> args */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			dependencyFile = "$(DERIVED_FILES_DIR)/generate-platform-args.d";
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(WTF_BUILD_SCRIPTS_DIR)/generate-platform-args",
+			);
+			name = "Generate <wtf/Platform.h> args";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/platform-enabled-swift-args.arm64.resp",
+				"$(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/platform-enabled-swift-args.arm64_32.resp",
+				"$(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/platform-enabled-swift-args.arm64e.resp",
+				"$(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/platform-enabled-swift-args.armv7k.resp",
+				"$(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/platform-enabled-swift-args.i386.resp",
+				"$(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/platform-enabled-swift-args.x86_64.resp",
+				"$(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/rdar150228472.swift",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [ \"${ACTION}\" = installhdrs ]\nthen touch \"${DERIVED_FILES_DIR}/generate-platform-args.d\"\nelse \"${SCRIPT_INPUT_FILE_0}\"\nfi\n";
 		};
 		DD9C4CC52A05D4FB00D52E2E /* Fix up SDKROOT path in TAPI filelists (install only) */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Source/WTF/Scripts/audit-spi-if-needed.sh
+++ b/Source/WTF/Scripts/audit-spi-if-needed.sh
@@ -30,6 +30,7 @@ if [[ "${WK_AUDIT_SPI}" == YES && -f "${program}" ]]; then
          --depfile "${depfile}" \
          -F "${BUILT_PRODUCTS_DIR}" \
          -L "${BUILT_PRODUCTS_DIR}" \
+         @"${BUILT_PRODUCTS_DIR}/DerivedSources/${PROJECT_NAME}/platform-enabled-swift-args.${arch}.resp" \
          --no-errors \
          $@)
      done

--- a/Source/WTF/Scripts/generate-platform-args
+++ b/Source/WTF/Scripts/generate-platform-args
@@ -8,6 +8,14 @@ import re
 # Preprocesses wtf/Platform.h with clang, extracts macro definitions, and saves
 # the platform flags to a Swift-style response file containing -D arguments.
 
+# For build settings which may be undefined, behave like a shell and implicitly
+# fall back to the empty string.
+os.environ.setdefault('FRAMEWORK_SEARCH_PATHS', '')
+os.environ.setdefault('HEADER_SEARCH_PATHS', '')
+os.environ.setdefault('SYSTEM_FRAMEWORK_SEARCH_PATHS', '')
+os.environ.setdefault('SYSTEM_HEADER_SEARCH_PATHS', '')
+os.environ.setdefault('GCC_PREPROCESSOR_DEFINITIONS', '')
+
 framework_search_paths = shlex.split(
     '{BUILT_PRODUCTS_DIR} {FRAMEWORK_SEARCH_PATHS}'.format_map(os.environ))
 header_search_paths = shlex.split(

--- a/Source/WebKit/Configurations/AllowedSPI-legacy.toml
+++ b/Source/WebKit/Configurations/AllowedSPI-legacy.toml
@@ -133,12 +133,6 @@ classes = [
     "NSURLError",
     "OSLaunchdJob",
     "PDFHostViewController",
-
-    # FIXME: Public SDK builds bind to the former class instead of the
-    # latter. Needs to be cleaned up in rdar://102246762.
-    "PUActivityProgressController",
-    "PXActivityProgressController",
-
     "RBSAssertion",
     "RBSDomainAttribute",
     "RBSProcessHandle",
@@ -1034,4 +1028,14 @@ symbols = [
     "__kCFURLConnectionPropertyShouldSniff",
     "_kAXSEnhanceTextLegibilityChangedNotification",
     "_kGSEventHardwareKeyboardAvailabilityChangedNotification",
-    ]
+]
+
+# FIXME: Public SDK builds bind to the former class instead of the
+# latter. Needs to be cleaned up in rdar://102246762.
+[photos-public-sdk.legacy]
+class = "PUActivityProgressController"
+requires = ["!USE_APPLE_INTERNAL_SDK"]
+
+[photos-internal-sdk.legacy]
+class = "PXActivityProgressController"
+requires = ["USE_APPLE_INTERNAL_SDK"]

--- a/Source/WebKitLegacy/WebKitLegacy.xcodeproj/project.pbxproj
+++ b/Source/WebKitLegacy/WebKitLegacy.xcodeproj/project.pbxproj
@@ -3068,6 +3068,7 @@
 			buildConfigurationList = 149C282D08902B0F008A9EFC /* Build configuration list for PBXNativeTarget "WebKitLegacy" */;
 			buildPhases = (
 				7C02321B251B9A8A00BA7BB6 /* Generate Preferences */,
+				DD7181192E20286B00A096B7 /* Generate <wtf/Platform.h> args */,
 				9398100D0824BF01008DF038 /* Headers */,
 				DD7AF5CF298C51C90059E87E /* Migrate WebCore Headers and Generate Export List */,
 				939810B20824BF01008DF038 /* Resources */,
@@ -3347,6 +3348,33 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "rm -vf \"${OBJROOT}/EagerLinkingTBDs/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}/${CONTENTS_FOLDER_PATH}/${EXECUTABLE_PREFIX}${PRODUCT_NAME}${EXECUTABLE_VARIANT_SUFFIX}.tbd\" &&\ntouch \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+		};
+		DD7181192E20286B00A096B7 /* Generate <wtf/Platform.h> args */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			dependencyFile = "$(DERIVED_FILES_DIR)/generate-platform-args.d";
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(WTF_BUILD_SCRIPTS_DIR)/generate-platform-args",
+			);
+			name = "Generate <wtf/Platform.h> args";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKitLegacy/platform-enabled-swift-args.arm64.resp",
+				"$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKitLegacy/platform-enabled-swift-args.arm64_32.resp",
+				"$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKitLegacy/platform-enabled-swift-args.arm64e.resp",
+				"$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKitLegacy/platform-enabled-swift-args.armv7k.resp",
+				"$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKitLegacy/platform-enabled-swift-args.i386.resp",
+				"$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKitLegacy/platform-enabled-swift-args.x86_64.resp",
+				"$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKitLegacy/rdar150228472.swift",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [ \"${ACTION}\" = installhdrs ]\nthen touch \"${DERIVED_FILES_DIR}/generate-platform-args.d\"\nelse \"${SCRIPT_INPUT_FILE_0}\"\nfi\n\n\n";
 		};
 		DD7AF5CF298C51C90059E87E /* Migrate WebCore Headers and Generate Export List */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
#### 2bb7daae7de66f47266282387a2a6ff60ee62b25
<pre>
[webkitapipy] Support conditional allowlist entries
<a href="https://bugs.webkit.org/show_bug.cgi?id=295681">https://bugs.webkit.org/show_bug.cgi?id=295681</a>

Reviewed by Sam Sneddon.

Some allowed SPI are only used in specific build configurations. Since
audit-spi checks allowlists for exhaustiveness, we need a way to only
allow SPI based on specific build-time conditions.

Building off of the &lt;wtf/Platform.h&gt; flags generator added earlier this
year, teach audit-spi to ingest `-D` compilation condition flags, the
same way swift and clang do. Have it read the response file of platform
flags the same way that swift does.

Support an optional &quot;requires&quot; list in allowlist entries. For example,
the following SPI is only called in WebAuthn code, so we could write:

    [passkeys.equivalent-api]
    symbols = [&quot;_kSecAttrAlias&quot;]
    requires = [&quot;ENABLE_WEB_AUTHN&quot;]

If we supported building for iOS without ENABLE_WEB_AUTHN, this
`requires` list would make it possible to SPI-check both configurations.

Requirements can be a conjunction of multiple conditions. A requirement
can check for the absence of a condition by prefixing it with &quot;!&quot;. For
example:

    requires = [&quot;ENABLE_FOO&quot;, &quot;!ENABLE_BAR&quot;]

This matches under the same conditions that
`ENABLE(FOO) &amp;&amp; !ENABLE(BAR)` would in the C preprocessor.

--

Since allowlist matching is done inside the SDKDB cache, the
implementation works by expressing conditions to the sqlite database. A
`condition_chain` table represents requirements lists as boolean
variables in a graph data structure. Like other aspects of allowlists,
these are persisted and only update when an allowlist changes.

At runtime, audit-spi processes `-D` arguments and fills in an ephemeral
table of active conditions. In SDKDB.audit(), it traverses all edges in
condition_chain to find active &quot;chains&quot; of variables, where every
variable in the chain is satisfied. An allowlist entry is only matched
if it is associated with an active chain, or has no chain.

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj: Run
  `generate-platform-args` in JSC&apos;s derived sources target, just like
  other projects do. This is the first time it&apos;s used from JSC, since
  JSC has no swift code.
* Source/WTF/Scripts/audit-spi-if-needed.sh: Pass in the generated
  response file to audit-spi.
* Source/WTF/Scripts/generate-platform-args: Tweak to work in JSC&apos;s
  build, where some build settings are undefined because they are not
  customized.
* Source/WebKit/Configurations/AllowedSPI-legacy.toml: There is one
  allowed class name that changes based on whether we are building for
  internal or open source. Use requirements to catch it.
* Source/WebKitLegacy/WebKitLegacy.xcodeproj/project.pbxproj: Run
  `generate-platform-args`, same as JSC change.

* Tools/Scripts/libraries/webkitapipy/webkitapipy/allow.py:
(AllowedSPI):
(AllowList.from_dict):
* Tools/Scripts/libraries/webkitapipy/webkitapipy/allow_unittest.py:
(TestAllowList.test_no_repetition_requires):
* Tools/Scripts/libraries/webkitapipy/webkitapipy/program.py:
(get_parser): Support reading arguments from compiler-style response
  files.
* Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb.py:
(SDKDB._initialize_db):
(SDKDB._initialize_temporary_schema):
(SDKDB.InsertionKind):
(SDKDB.InsertionKind.statement):
(SDKDB._add_allowlist):
(SDKDB):
(SDKDB.add_defines):
(SDKDB.audit):
(SDKDB._add_objc_interface):
(SDKDB._add_symbol):
(SDKDB._add_objc_class):
(SDKDB._add_objc_selector):
(SDKDB.InsertionKind.table_name): Deleted.
* Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb_unittest.py:
(TestSDKDB.test_audit_allowed_conditional):
(TestSDKDB):
(TestSDKDB.test_audit_missing_name_conditional):
(TestSDKDB.test_audit_missing_name_negated_conditional):
(TestSDKDB.test_audit_allowed_negated_conditional):
(TestSDKDB.test_audit_allowed_multiple_conditions):
(TestSDKDB.test_audit_missing_name_multiple_conditions):
(TestSDKDB.test_audit_missing_name_multiple_conditions_negation):

Canonical link: <a href="https://commits.webkit.org/297295@main">https://commits.webkit.org/297295@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73814b5424152106d2c1ecf1ff831bcaf4e31075

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111216 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21328 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117247 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/61484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113178 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31563 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39464 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84535 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/61484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114163 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25209 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100127 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64981 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/110649 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24551 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/18268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61067 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/103707 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94587 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18335 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120315 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109769 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38265 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28433 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/93462 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38641 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96402 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93287 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23774 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38382 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/16145 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/34250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38154 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43631 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/134045 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37819 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36149 "Found 2 new JSC stress test failures: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js.default, wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41152 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39521 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->