### PR TITLE
Fix more static analyzer warnings in cookie code

### DIFF
--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -114,7 +114,7 @@ void CookieStore::MainThreadBridge::ensureOnMainThread(Function<void(ScriptExecu
         return;
     }
 
-    downcast<WorkerGlobalScope>(*context).protectedThread()->workerLoaderProxy()->postTaskToLoader(WTFMove(task));
+    downcast<WorkerGlobalScope>(*context).protectedThread()->checkedWorkerLoaderProxy()->postTaskToLoader(WTFMove(task));
 }
 
 void CookieStore::MainThreadBridge::ensureOnContextThread(Function<void(CookieStore&)>&& task)

--- a/Source/WebCore/Modules/webaudio/AudioWorkletThread.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletThread.cpp
@@ -56,7 +56,7 @@ void AudioWorkletThread::clearProxies()
     m_messagingProxy = nullptr;
 }
 
-WorkerLoaderProxy* AudioWorkletThread::workerLoaderProxy()
+WorkerLoaderProxy* AudioWorkletThread::workerLoaderProxy() const
 {
     return m_messagingProxy.get();
 }

--- a/Source/WebCore/Modules/webaudio/AudioWorkletThread.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletThread.h
@@ -50,7 +50,7 @@ public:
     void clearProxies() final;
 
     // WorkerOrWorkletThread.
-    WorkerLoaderProxy* workerLoaderProxy() final;
+    WorkerLoaderProxy* workerLoaderProxy() const final;
     WorkerDebuggerProxy* workerDebuggerProxy() const final;
 
     AudioWorkletMessagingProxy* messagingProxy() { return m_messagingProxy.get(); }

--- a/Source/WebCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -15,6 +15,5 @@ platform/ios/WebAVPlayerController.mm
 platform/mac/WebCoreFullScreenPlaceholderView.h
 platform/mac/WebPlaybackControlsManager.h
 platform/network/cf/FormDataStreamCFNet.cpp
-platform/network/cocoa/CookieStorageObserver.mm
 platform/network/cocoa/WebCoreNSURLSession.h
 platform/network/cocoa/WebCoreNSURLSession.mm

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -1,7 +1,6 @@
 Modules/airplay/WebMediaSessionManager.cpp
 Modules/applicationmanifest/ApplicationManifestParser.cpp
 Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
-Modules/cookie-store/CookieStore.cpp
 Modules/credentialmanagement/CredentialsContainer.cpp
 Modules/gamepad/GamepadManager.cpp
 Modules/indexeddb/IDBCursor.cpp

--- a/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -221,7 +221,6 @@ platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
 platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
 platform/network/cf/DNSResolveQueueCFNet.cpp
 platform/network/cf/FormDataStreamCFNet.cpp
-platform/network/cocoa/CookieCocoa.mm
 platform/network/cocoa/CredentialCocoa.mm
 platform/network/cocoa/NetworkStorageSessionCocoa.mm
 platform/network/cocoa/ProtectionSpaceCocoa.mm

--- a/Source/WebCore/platform/Cookie.h
+++ b/Source/WebCore/platform/Cookie.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <wtf/RetainPtr.h>
 #include <wtf/URL.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
@@ -49,6 +50,7 @@ struct Cookie {
 #ifdef __OBJC__
     WEBCORE_EXPORT Cookie(NSHTTPCookie *);
     WEBCORE_EXPORT operator NSHTTPCookie *() const;
+    WEBCORE_EXPORT RetainPtr<NSHTTPCookie> toProtectedNSHTTPCookie() const;
 #elif USE(SOUP)
     explicit Cookie(SoupCookie*);
     SoupCookie* toSoupCookie() const;

--- a/Source/WebCore/platform/network/cocoa/CookieCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/CookieCocoa.mm
@@ -159,20 +159,20 @@ Cookie::operator NSHTTPCookie * _Nullable () const
         [properties setObject:expirationDate.get() forKey:NSHTTPCookieExpires];
     }
 
-    [properties setObject:@(created / 1000.0 - NSTimeIntervalSince1970) forKey:@"Created"];
+    SUPPRESS_UNRETAINED_ARG [properties setObject:@(created / 1000.0 - NSTimeIntervalSince1970) forKey:@"Created"];
 
     RetainPtr portString = portStringFromVector(ports);
     if (portString)
         [properties setObject:portString.get() forKey:NSHTTPCookiePort];
 
     if (secure)
-        [properties setObject:@YES forKey:NSHTTPCookieSecure];
+        SUPPRESS_UNRETAINED_ARG [properties setObject:@YES forKey:NSHTTPCookieSecure];
 
     if (session)
-        [properties setObject:@YES forKey:NSHTTPCookieDiscard];
+        SUPPRESS_UNRETAINED_ARG [properties setObject:@YES forKey:NSHTTPCookieDiscard];
     
     if (httpOnly)
-        [properties setObject:@YES forKey:@"HttpOnly"];
+        SUPPRESS_UNRETAINED_ARG [properties setObject:@YES forKey:@"HttpOnly"];
 
     if (RetainPtr sameSitePolicy = nsSameSitePolicy(sameSite))
         [properties setObject:sameSitePolicy.get() forKey:@"SameSite"];
@@ -189,14 +189,19 @@ bool Cookie::operator==(const Cookie& other) const
     bool otherNull = other.isNull();
     if (thisNull || otherNull)
         return thisNull == otherNull;
-    return [static_cast<NSHTTPCookie *>(*this) isEqual:other];
+    return [toProtectedNSHTTPCookie() isEqual:other.toProtectedNSHTTPCookie().get()];
 }
     
 unsigned Cookie::hash() const
 {
     ASSERT(!name.isHashTableDeletedValue());
     ASSERT(!isNull());
-    return static_cast<NSHTTPCookie *>(*this).hash;
+    return toProtectedNSHTTPCookie().get().hash;
+}
+
+RetainPtr<NSHTTPCookie> Cookie::toProtectedNSHTTPCookie() const
+{
+    return static_cast<NSHTTPCookie *>(*this);
 }
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebCore/platform/network/cocoa/CookieStorageObserver.mm
+++ b/Source/WebCore/platform/network/cocoa/CookieStorageObserver.mm
@@ -33,7 +33,7 @@
 
 @interface WebNSHTTPCookieStorageDummyForInternalAccess : NSObject {
 @public
-    NSHTTPCookieStorageInternal *_internal;
+    RetainPtr<NSHTTPCookieStorageInternal> _internal;
 }
 @end
 

--- a/Source/WebCore/workers/WorkerOrWorkletThread.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletThread.cpp
@@ -28,6 +28,7 @@
 
 #include "ThreadGlobalData.h"
 #include "WorkerEventLoop.h"
+#include "WorkerLoaderProxy.h"
 #include "WorkerOrWorkletGlobalScope.h"
 #include "WorkerOrWorkletScriptController.h"
 
@@ -361,6 +362,11 @@ void WorkerOrWorkletThread::removeChildThread(WorkerOrWorkletThread& childThread
     m_childThreads.remove(childThread);
     if (m_childThreads.isEmptyIgnoringNullReferences() && m_runWhenLastChildThreadIsGone)
         std::exchange(m_runWhenLastChildThreadIsGone, nullptr)();
+}
+
+CheckedPtr<WorkerLoaderProxy> WorkerOrWorkletThread::checkedWorkerLoaderProxy() const
+{
+    return workerLoaderProxy();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerOrWorkletThread.h
+++ b/Source/WebCore/workers/WorkerOrWorkletThread.h
@@ -58,7 +58,8 @@ public:
     virtual void clearProxies() = 0;
 
     virtual WorkerDebuggerProxy* workerDebuggerProxy() const = 0;
-    virtual WorkerLoaderProxy* workerLoaderProxy() = 0;
+    virtual WorkerLoaderProxy* workerLoaderProxy() const = 0;
+    virtual CheckedPtr<WorkerLoaderProxy> checkedWorkerLoaderProxy() const;
 
     WorkerOrWorkletGlobalScope* globalScope() const { return m_globalScope.get(); }
     WorkerRunLoop& runLoop() { return m_runLoop; }

--- a/Source/WebCore/workers/WorkerThread.h
+++ b/Source/WebCore/workers/WorkerThread.h
@@ -100,7 +100,7 @@ public:
 
     WorkerBadgeProxy* workerBadgeProxy() const { return m_workerBadgeProxy.get(); }
     WorkerDebuggerProxy* workerDebuggerProxy() const final { return m_workerDebuggerProxy.get(); }
-    WorkerLoaderProxy* workerLoaderProxy() final { return m_workerLoaderProxy.get(); }
+    WorkerLoaderProxy* workerLoaderProxy() const final { return m_workerLoaderProxy.get(); }
     WorkerReportingProxy* workerReportingProxy() const { return m_workerReportingProxy.get(); }
 
     // Number of active worker threads.

--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -61,7 +61,6 @@ WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
 WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm
 WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
 WebProcess/WebPage/ViewGestureGeometryCollector.cpp
-WebProcess/WebPage/WebCookieCache.cpp
 WebProcess/WebPage/WebFoundTextRangeController.cpp
 WebProcess/WebPage/WebFrame.cpp
 WebProcess/WebPage/WebPage.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -7,7 +7,6 @@ UIProcess/API/C/mac/WKPagePrivateMac.mm
 UIProcess/API/Cocoa/WKContentWorld.mm
 UIProcess/API/Cocoa/WKDownload.mm
 UIProcess/API/Cocoa/WKFrameInfo.mm
-UIProcess/API/Cocoa/WKHTTPCookieStore.mm
 UIProcess/API/Cocoa/WKOpenPanelParameters.mm
 UIProcess/API/Cocoa/WKPreferences.mm
 UIProcess/API/Cocoa/WKProcessPool.mm

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -67,7 +67,6 @@ Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm
 Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
 Shared/JavaScriptEvaluationResult.mm
 Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
-Shared/cf/CookieStorageUtilsCF.mm
 Shared/cf/CoreIPCNumber.mm
 Shared/mac/AuxiliaryProcessMac.mm
 Shared/mac/ScrollingAccelerationCurveMac.mm
@@ -78,7 +77,6 @@ UIProcess/API/Cocoa/NSAttributedString.mm
 UIProcess/API/Cocoa/WKContentRuleListStore.mm
 UIProcess/API/Cocoa/WKDownload.mm
 UIProcess/API/Cocoa/WKFrameInfo.mm
-UIProcess/API/Cocoa/WKHTTPCookieStore.mm
 UIProcess/API/Cocoa/WKNSURLAuthenticationChallenge.mm
 UIProcess/API/Cocoa/WKNavigationAction.mm
 UIProcess/API/Cocoa/WKNavigationResponse.mm
@@ -223,7 +221,6 @@ WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm
 WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
 WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
 WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
-WebProcess/WebPage/Cocoa/WebCookieJarCocoa.mm
 WebProcess/WebPage/Cocoa/WebPageCocoa.mm
 WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
 WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm

--- a/Source/WebKit/Shared/cf/CookieStorageUtilsCF.mm
+++ b/Source/WebKit/Shared/cf/CookieStorageUtilsCF.mm
@@ -41,7 +41,7 @@ RetainPtr<CFHTTPCookieStorageRef> cookieStorageFromIdentifyingData(const Vector<
     RetainPtr cookieStorage = adoptCF(CFHTTPCookieStorageCreateFromIdentifyingData(kCFAllocatorDefault, cookieStorageData.get()));
     ASSERT(cookieStorage);
 
-    CFHTTPCookieStorageScheduleWithRunLoop(cookieStorage.get(), [NSURLConnection resourceLoaderRunLoop], kCFRunLoopCommonModes);
+    CFHTTPCookieStorageScheduleWithRunLoop(cookieStorage.get(), RetainPtr { [NSURLConnection resourceLoaderRunLoop] }.get(), kCFRunLoopCommonModes);
 
     return cookieStorage;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm
@@ -49,9 +49,9 @@ static NSArray<NSHTTPCookie *> *coreCookiesToNSCookies(const Vector<WebCore::Coo
 class WKHTTPCookieStoreObserver : public API::HTTPCookieStoreObserver {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(WKHTTPCookieStoreObserver);
 public:
-    static RefPtr<WKHTTPCookieStoreObserver> create(id<WKHTTPCookieStoreObserver> observer)
+    static Ref<WKHTTPCookieStoreObserver> create(id<WKHTTPCookieStoreObserver> observer)
     {
-        return adoptRef(new WKHTTPCookieStoreObserver(observer));
+        return adoptRef(*new WKHTTPCookieStoreObserver(observer));
     }
 
 private:
@@ -62,8 +62,9 @@ private:
 
     void cookiesDidChange(API::HTTPCookieStore& cookieStore) final
     {
-        if ([m_observer respondsToSelector:@selector(cookiesDidChangeInCookieStore:)])
-            [m_observer cookiesDidChangeInCookieStore:wrapper(cookieStore)];
+        RetainPtr observer = m_observer.get();
+        if ([observer respondsToSelector:@selector(cookiesDidChangeInCookieStore:)])
+            [observer cookiesDidChangeInCookieStore:(RetainPtr { wrapper(cookieStore) }.get())];
     }
 
     WeakObjCPtr<id<WKHTTPCookieStoreObserver>> m_observer;
@@ -71,6 +72,11 @@ private:
 
 @implementation WKHTTPCookieStore {
     HashMap<CFTypeRef, RefPtr<WKHTTPCookieStoreObserver>> _observers;
+}
+
+- (Ref<API::HTTPCookieStore>)_protectedCookieStore
+{
+    return *_cookieStore;
 }
 
 WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
@@ -81,16 +87,16 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
         return;
 
     for (RefPtr observer : _observers.values())
-        _cookieStore->unregisterObserver(*observer);
+        self._protectedCookieStore->unregisterObserver(*observer);
 
-    _cookieStore->API::HTTPCookieStore::~HTTPCookieStore();
+    SUPPRESS_UNCOUNTED_ARG _cookieStore->API::HTTPCookieStore::~HTTPCookieStore();
 
     [super dealloc];
 }
 
 - (void)getAllCookies:(void (^)(NSArray<NSHTTPCookie *> *))completionHandler
 {
-    _cookieStore->cookies([handler = adoptNS([completionHandler copy])](const Vector<WebCore::Cookie>& cookies) {
+    self._protectedCookieStore->cookies([handler = adoptNS([completionHandler copy])](const Vector<WebCore::Cookie>& cookies) {
         auto rawHandler = (void (^)(NSArray<NSHTTPCookie *> *))handler.get();
         rawHandler(coreCookiesToNSCookies(cookies));
     });
@@ -98,7 +104,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (void)setCookie:(NSHTTPCookie *)cookie completionHandler:(void (^)(void))completionHandler
 {
-    _cookieStore->setCookies({ cookie }, [handler = adoptNS([completionHandler copy])]() {
+    self._protectedCookieStore->setCookies({ cookie }, [handler = adoptNS([completionHandler copy])]() {
         auto rawHandler = (void (^)())handler.get();
         if (rawHandler)
             rawHandler();
@@ -116,14 +122,14 @@ static std::optional<WebCore::Cookie> makeVectorElement(const WebCore::Cookie*, 
 
 - (void)setCookies:(NSArray<NSHTTPCookie *> *)cookies completionHandler:(void (^)(void))completionHandler
 {
-    _cookieStore->setCookies(makeVector<WebCore::Cookie>(cookies), [completionHandler = makeBlockPtr(completionHandler)]() {
+    self._protectedCookieStore->setCookies(makeVector<WebCore::Cookie>(cookies), [completionHandler = makeBlockPtr(completionHandler)]() {
         completionHandler();
     });
 }
 
 - (void)deleteCookie:(NSHTTPCookie *)cookie completionHandler:(void (^)(void))completionHandler
 {
-    _cookieStore->deleteCookie(cookie, [handler = adoptNS([completionHandler copy])]() {
+    self._protectedCookieStore->deleteCookie(cookie, [handler = adoptNS([completionHandler copy])]() {
         auto rawHandler = (void (^)())handler.get();
         if (rawHandler)
             rawHandler();
@@ -137,7 +143,7 @@ static std::optional<WebCore::Cookie> makeVectorElement(const WebCore::Cookie*, 
         return;
 
     result.iterator->value = WKHTTPCookieStoreObserver::create(observer);
-    _cookieStore->registerObserver(*result.iterator->value);
+    self._protectedCookieStore->registerObserver(Ref { *result.iterator->value }.get());
 }
 
 - (void)removeObserver:(id<WKHTTPCookieStoreObserver>)observer
@@ -146,7 +152,7 @@ static std::optional<WebCore::Cookie> makeVectorElement(const WebCore::Cookie*, 
     if (!result)
         return;
 
-    _cookieStore->unregisterObserver(*result);
+    self._protectedCookieStore->unregisterObserver(*result);
 }
 
 static WebCore::HTTPCookieAcceptPolicy toHTTPCookieAcceptPolicy(WKCookiePolicy wkCookiePolicy)
@@ -175,7 +181,7 @@ static WKCookiePolicy toWKCookiePolicy(WebCore::HTTPCookieAcceptPolicy policy)
 
 - (void)setCookiePolicy:(WKCookiePolicy)policy completionHandler:(void (^)(void))completionHandler
 {
-    _cookieStore->setHTTPCookieAcceptPolicy(toHTTPCookieAcceptPolicy(policy), [completionHandler = makeBlockPtr(completionHandler)] {
+    self._protectedCookieStore->setHTTPCookieAcceptPolicy(toHTTPCookieAcceptPolicy(policy), [completionHandler = makeBlockPtr(completionHandler)] {
         if (completionHandler)
             completionHandler.get()();
     });
@@ -183,7 +189,7 @@ static WKCookiePolicy toWKCookiePolicy(WebCore::HTTPCookieAcceptPolicy policy)
 
 - (void)getCookiePolicy:(void (^)(WKCookiePolicy))completionHandler
 {
-    _cookieStore->getHTTPCookieAcceptPolicy([completionHandler = makeBlockPtr(completionHandler)] (WebCore::HTTPCookieAcceptPolicy policy) {
+    self._protectedCookieStore->getHTTPCookieAcceptPolicy([completionHandler = makeBlockPtr(completionHandler)] (WebCore::HTTPCookieAcceptPolicy policy) {
         completionHandler(toWKCookiePolicy(policy));
     });
 }
@@ -201,21 +207,21 @@ static WKCookiePolicy toWKCookiePolicy(WebCore::HTTPCookieAcceptPolicy policy)
 
 - (void)_getCookiesForURL:(NSURL *)url completionHandler:(void (^)(NSArray<NSHTTPCookie *> *))completionHandler
 {
-    _cookieStore->cookiesForURL(url, [handler = makeBlockPtr(completionHandler)] (const Vector<WebCore::Cookie>& cookies) {
+    self._protectedCookieStore->cookiesForURL(url, [handler = makeBlockPtr(completionHandler)] (const Vector<WebCore::Cookie>& cookies) {
         handler.get()(coreCookiesToNSCookies(cookies));
     });
 }
 
 - (void)_setCookieAcceptPolicy:(NSHTTPCookieAcceptPolicy)policy completionHandler:(void (^)())completionHandler
 {
-    _cookieStore->setHTTPCookieAcceptPolicy(WebCore::toHTTPCookieAcceptPolicy(policy), [completionHandler = makeBlockPtr(completionHandler)] {
+    self._protectedCookieStore->setHTTPCookieAcceptPolicy(WebCore::toHTTPCookieAcceptPolicy(policy), [completionHandler = makeBlockPtr(completionHandler)] {
         completionHandler.get()();
     });
 }
 
 - (void)_flushCookiesToDiskWithCompletionHandler:(void(^)(void))completionHandler
 {
-    _cookieStore->flushCookies([completionHandler = makeBlockPtr(completionHandler)]() {
+    self._protectedCookieStore->flushCookies([completionHandler = makeBlockPtr(completionHandler)]() {
         completionHandler();
     });
 }
@@ -224,7 +230,7 @@ static WKCookiePolicy toWKCookiePolicy(WebCore::HTTPCookieAcceptPolicy policy)
 
 - (void)_setCookies:(NSArray<NSHTTPCookie *> *)cookies completionHandler:(void (^)(void))completionHandler
 {
-    _cookieStore->setCookies(makeVector<WebCore::Cookie>(cookies), [completionHandler = makeBlockPtr(completionHandler)]() {
+    self._protectedCookieStore->setCookies(makeVector<WebCore::Cookie>(cookies), [completionHandler = makeBlockPtr(completionHandler)]() {
         completionHandler();
     });
 }

--- a/Source/WebKit/WebProcess/WebPage/WebCookieCache.h
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieCache.h
@@ -77,6 +77,8 @@ private:
     WebCookieCache() = default;
 
     WebCore::NetworkStorageSession& inMemoryStorageSession();
+    CheckedRef<WebCore::NetworkStorageSession> checkedInMemoryStorageSession() { return inMemoryStorageSession(); }
+
     void pruneCacheIfNecessary();
     bool cacheMayBeOutOfSync() const;
 

--- a/Source/WebKit/WebProcess/WebPage/WebCookieJar.h
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieJar.h
@@ -97,7 +97,7 @@ private:
     HashMap<String, WeakHashSet<WebCore::CookieChangeListener>> m_changeListeners;
 
 #if PLATFORM(COCOA)
-    RetainPtr<NSHTTPCookieStorage> m_partitionedStorageForDOMCookies;
+    const RetainPtr<NSHTTPCookieStorage> m_partitionedStorageForDOMCookies;
 #endif
 };
 


### PR DESCRIPTION
#### 178858db52533be28686fc5e90aa465d9cb78656
<pre>
Fix more static analyzer warnings in cookie code
<a href="https://bugs.webkit.org/show_bug.cgi?id=295675">https://bugs.webkit.org/show_bug.cgi?id=295675</a>
<a href="https://rdar.apple.com/155477189">rdar://155477189</a>

Reviewed by Chris Dumez.

* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::MainThreadBridge::ensureOnMainThread):
* Source/WebCore/Modules/webaudio/AudioWorkletThread.cpp:
(WebCore::AudioWorkletThread::workerLoaderProxy const):
(WebCore::AudioWorkletThread::workerLoaderProxy): Deleted.
* Source/WebCore/Modules/webaudio/AudioWorkletThread.h:
* Source/WebCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebCore/platform/Cookie.h:
* Source/WebCore/platform/network/cocoa/CookieCocoa.mm:
(WebCore::Cookie::operator NSHTTPCookie * _Nullable  const):
(WebCore::Cookie::operator== const):
(WebCore::Cookie::hash const):
(WebCore::Cookie::toProtectedNSHTTPCookie const):
* Source/WebCore/platform/network/cocoa/CookieStorageObserver.mm:
* Source/WebCore/workers/WorkerOrWorkletThread.cpp:
(WebCore::WorkerOrWorkletThread::checkedWorkerLoaderProxy const):
* Source/WebCore/workers/WorkerOrWorkletThread.h:
* Source/WebCore/workers/WorkerThread.h:
* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/Shared/cf/CookieStorageUtilsCF.mm:
(WebKit::cookieStorageFromIdentifyingData):
* Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm:
(WKHTTPCookieStoreObserver::create):
(-[WKHTTPCookieStore _protectedCookieStore]):
(-[WKHTTPCookieStore dealloc]):
(-[WKHTTPCookieStore getAllCookies:]):
(-[WKHTTPCookieStore setCookie:completionHandler:]):
(-[WKHTTPCookieStore setCookies:completionHandler:]):
(-[WKHTTPCookieStore deleteCookie:completionHandler:]):
(-[WKHTTPCookieStore addObserver:]):
(-[WKHTTPCookieStore removeObserver:]):
(-[WKHTTPCookieStore setCookiePolicy:completionHandler:]):
(-[WKHTTPCookieStore getCookiePolicy:]):
(-[WKHTTPCookieStore _getCookiesForURL:completionHandler:]):
(-[WKHTTPCookieStore _setCookieAcceptPolicy:completionHandler:]):
(-[WKHTTPCookieStore _flushCookiesToDiskWithCompletionHandler:]):
(-[WKHTTPCookieStore _setCookies:completionHandler:]):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebCookieJarCocoa.mm:
(WebKit::WebCookieJar::cookiesInPartitionedCookieStorage const):
(WebKit::WebCookieJar::setCookiesInPartitionedCookieStorage):
(WebKit::WebCookieJar::ensurePartitionedCookieStorage):
* Source/WebKit/WebProcess/WebPage/WebCookieCache.cpp:
(WebKit::WebCookieCache::cookiesForDOM):
(WebKit::WebCookieCache::setCookiesFromDOM):
(WebKit::WebCookieCache::didSetCookieFromDOM):
(WebKit::WebCookieCache::cookiesAdded):
(WebKit::WebCookieCache::cookiesDeleted):
(WebKit::WebCookieCache::clearForHost):
* Source/WebKit/WebProcess/WebPage/WebCookieCache.h:
* Source/WebKit/WebProcess/WebPage/WebCookieJar.h:

Canonical link: <a href="https://commits.webkit.org/297232@main">https://commits.webkit.org/297232@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b608388784d1078e491ed4915353d2d3dfcae70

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30596 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21031 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116964 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61201 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112896 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31276 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39182 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84347 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113881 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24992 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99884 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64791 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24342 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18026 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60776 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94391 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18086 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119775 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37978 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28226 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93306 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38354 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96156 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93130 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23737 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38180 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15921 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33964 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37871 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43342 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37534 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40870 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39239 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->