### PR TITLE
Boxes in the top layer should use the initial containing block as their static-position rectangle

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-bottom-left-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-bottom-left-ref.html
@@ -1,0 +1,12 @@
+<style>
+  #green {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100px;
+    height: 100px;
+    background: green;
+  }
+</style>
+
+<div id="green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-bottom-right-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-bottom-right-ref.html
@@ -1,0 +1,12 @@
+<style>
+  #green {
+    position: fixed;
+    bottom: 0;
+    right: 0;
+    width: 100px;
+    height: 100px;
+    background: green;
+  }
+</style>
+
+<div id="green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-htb-ltr-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-htb-ltr-expected.html
@@ -1,0 +1,12 @@
+<style>
+  #green {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100px;
+    height: 100px;
+    background: green;
+  }
+</style>
+
+<div id="green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-htb-ltr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-htb-ltr.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+<html class="reftest-wait">
+
+<title>Boxes in the top layer use the initial containing block as their static-position rectangle.</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#staticpos-rect">
+<link rel="match" href="top-layer-box-uses-icb-top-left-ref.html">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<style>
+  :root {
+    writing-mode: horizontal-tb;
+    direction: ltr;
+  }
+
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #reference {
+    width: 100px;
+    height: 100px;
+    background: red;
+  }
+
+  #popover {
+    width: 100px;
+    height: 100px;
+    background: green;
+
+    /* Override popover UA style */
+    border: none;
+    padding: 0;
+
+    inset: auto;
+  }
+</style>
+
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+
+<div id="reference"></div>
+<!-- This green box should fully cover the red box above. -->
+<div id="popover" popover></div>
+
+<script>
+  document.getElementById("popover").showPopover();
+  waitForAtLeastOneFrame().then(takeScreenshot);
+</script>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-htb-rtl-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-htb-rtl-expected.html
@@ -1,0 +1,12 @@
+<style>
+  #green {
+    position: fixed;
+    top: 0;
+    right: 0;
+    width: 100px;
+    height: 100px;
+    background: green;
+  }
+</style>
+
+<div id="green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-htb-rtl.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-htb-rtl.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+<html class="reftest-wait">
+
+<title>Boxes in the top layer use the initial containing block as their static-position rectangle.</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#staticpos-rect">
+<link rel="match" href="top-layer-box-uses-icb-top-right-ref.html">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<style>
+  :root {
+    writing-mode: horizontal-tb;
+    direction: rtl;
+  }
+
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #reference {
+    width: 100px;
+    height: 100px;
+    background: red;
+  }
+
+  #popover {
+    width: 100px;
+    height: 100px;
+    background: green;
+
+    /* Override popover UA style */
+    border: none;
+    padding: 0;
+
+    inset: auto;
+  }
+</style>
+
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+
+<div id="reference"></div>
+<!-- This green box should fully cover the red box above. -->
+<div id="popover" popover></div>
+
+<script>
+  document.getElementById("popover").showPopover();
+  waitForAtLeastOneFrame().then(takeScreenshot);
+</script>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-slr-ltr-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-slr-ltr-expected.html
@@ -1,0 +1,12 @@
+<style>
+  #green {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100px;
+    height: 100px;
+    background: green;
+  }
+</style>
+
+<div id="green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-slr-ltr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-slr-ltr.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+<html class="reftest-wait">
+
+<title>Boxes in the top layer use the initial containing block as their static-position rectangle.</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#staticpos-rect">
+<link rel="match" href="top-layer-box-uses-icb-bottom-left-ref.html">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<style>
+  :root {
+    writing-mode: sideways-lr;
+    direction: ltr;
+  }
+
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #reference {
+    width: 100px;
+    height: 100px;
+    background: red;
+  }
+
+  #popover {
+    width: 100px;
+    height: 100px;
+    background: green;
+
+    /* Override popover UA style */
+    border: none;
+    padding: 0;
+
+    inset: auto;
+  }
+</style>
+
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+
+<div id="reference"></div>
+<!-- This green box should fully cover the red box above. -->
+<div id="popover" popover></div>
+
+<script>
+  document.getElementById("popover").showPopover();
+  waitForAtLeastOneFrame().then(takeScreenshot);
+</script>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-slr-rtl-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-slr-rtl-expected.html
@@ -1,0 +1,12 @@
+<style>
+  #green {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100px;
+    height: 100px;
+    background: green;
+  }
+</style>
+
+<div id="green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-slr-rtl.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-slr-rtl.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+<html class="reftest-wait">
+
+<title>Boxes in the top layer use the initial containing block as their static-position rectangle.</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#staticpos-rect">
+<link rel="match" href="top-layer-box-uses-icb-top-left-ref.html">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<style>
+  :root {
+    writing-mode: sideways-lr;
+    direction: rtl;
+  }
+
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #reference {
+    width: 100px;
+    height: 100px;
+    background: red;
+  }
+
+  #popover {
+    width: 100px;
+    height: 100px;
+    background: green;
+
+    /* Override popover UA style */
+    border: none;
+    padding: 0;
+
+    inset: auto;
+  }
+</style>
+
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+
+<div id="reference"></div>
+<!-- This green box should fully cover the red box above. -->
+<div id="popover" popover></div>
+
+<script>
+  document.getElementById("popover").showPopover();
+  waitForAtLeastOneFrame().then(takeScreenshot);
+</script>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-srl-ltr-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-srl-ltr-expected.html
@@ -1,0 +1,12 @@
+<style>
+  #green {
+    position: fixed;
+    top: 0;
+    right: 0;
+    width: 100px;
+    height: 100px;
+    background: green;
+  }
+</style>
+
+<div id="green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-srl-ltr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-srl-ltr.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+<html class="reftest-wait">
+
+<title>Boxes in the top layer use the initial containing block as their static-position rectangle.</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#staticpos-rect">
+<link rel="match" href="top-layer-box-uses-icb-top-right-ref.html">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<style>
+  :root {
+    writing-mode: sideways-rl;
+    direction: ltr;
+  }
+
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #reference {
+    width: 100px;
+    height: 100px;
+    background: red;
+  }
+
+  #popover {
+    width: 100px;
+    height: 100px;
+    background: green;
+
+    /* Override popover UA style */
+    border: none;
+    padding: 0;
+
+    inset: auto;
+  }
+</style>
+
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+
+<div id="reference"></div>
+<!-- This green box should fully cover the red box above. -->
+<div id="popover" popover></div>
+
+<script>
+  document.getElementById("popover").showPopover();
+  waitForAtLeastOneFrame().then(takeScreenshot);
+</script>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-srl-rtl-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-srl-rtl-expected.html
@@ -1,0 +1,12 @@
+<style>
+  #green {
+    position: fixed;
+    bottom: 0;
+    right: 0;
+    width: 100px;
+    height: 100px;
+    background: green;
+  }
+</style>
+
+<div id="green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-srl-rtl.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-srl-rtl.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+<html class="reftest-wait">
+
+<title>Boxes in the top layer use the initial containing block as their static-position rectangle.</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#staticpos-rect">
+<link rel="match" href="top-layer-box-uses-icb-bottom-right-ref.html">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<style>
+  :root {
+    writing-mode: sideways-rl;
+    direction: rtl;
+  }
+
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #reference {
+    width: 100px;
+    height: 100px;
+    background: red;
+  }
+
+  #popover {
+    width: 100px;
+    height: 100px;
+    background: green;
+
+    /* Override popover UA style */
+    border: none;
+    padding: 0;
+
+    inset: auto;
+  }
+</style>
+
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+
+<div id="reference"></div>
+<!-- This green box should fully cover the red box above. -->
+<div id="popover" popover></div>
+
+<script>
+  document.getElementById("popover").showPopover();
+  waitForAtLeastOneFrame().then(takeScreenshot);
+</script>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-top-left-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-top-left-ref.html
@@ -1,0 +1,12 @@
+<style>
+  #green {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100px;
+    height: 100px;
+    background: green;
+  }
+</style>
+
+<div id="green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-top-right-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-top-right-ref.html
@@ -1,0 +1,12 @@
+<style>
+  #green {
+    position: fixed;
+    top: 0;
+    right: 0;
+    width: 100px;
+    height: 100px;
+    background: green;
+  }
+</style>
+
+<div id="green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-vlr-ltr-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-vlr-ltr-expected.html
@@ -1,0 +1,12 @@
+<style>
+  #green {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100px;
+    height: 100px;
+    background: green;
+  }
+</style>
+
+<div id="green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-vlr-ltr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-vlr-ltr.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+<html class="reftest-wait">
+
+<title>Boxes in the top layer use the initial containing block as their static-position rectangle.</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#staticpos-rect">
+<link rel="match" href="top-layer-box-uses-icb-top-left-ref.html">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<style>
+  :root {
+    writing-mode: vertical-lr;
+    direction: ltr;
+  }
+
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #reference {
+    width: 100px;
+    height: 100px;
+    background: red;
+  }
+
+  #popover {
+    width: 100px;
+    height: 100px;
+    background: green;
+
+    /* Override popover UA style */
+    border: none;
+    padding: 0;
+
+    inset: auto;
+  }
+</style>
+
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+
+<div id="reference"></div>
+<!-- This green box should fully cover the red box above. -->
+<div id="popover" popover></div>
+
+<script>
+  document.getElementById("popover").showPopover();
+  waitForAtLeastOneFrame().then(takeScreenshot);
+</script>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-vlr-rtl-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-vlr-rtl-expected.html
@@ -1,0 +1,12 @@
+<style>
+  #green {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100px;
+    height: 100px;
+    background: green;
+  }
+</style>
+
+<div id="green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-vlr-rtl.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-vlr-rtl.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+<html class="reftest-wait">
+
+<title>Boxes in the top layer use the initial containing block as their static-position rectangle.</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#staticpos-rect">
+<link rel="match" href="top-layer-box-uses-icb-bottom-left-ref.html">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<style>
+  :root {
+    writing-mode: vertical-lr;
+    direction: rtl;
+  }
+
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #reference {
+    width: 100px;
+    height: 100px;
+    background: red;
+  }
+
+  #popover {
+    width: 100px;
+    height: 100px;
+    background: green;
+
+    /* Override popover UA style */
+    border: none;
+    padding: 0;
+
+    inset: auto;
+  }
+</style>
+
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+
+<div id="reference"></div>
+<!-- This green box should fully cover the red box above. -->
+<div id="popover" popover></div>
+
+<script>
+  document.getElementById("popover").showPopover();
+  waitForAtLeastOneFrame().then(takeScreenshot);
+</script>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-vrl-ltr-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-vrl-ltr-expected.html
@@ -1,0 +1,12 @@
+<style>
+  #green {
+    position: fixed;
+    top: 0;
+    right: 0;
+    width: 100px;
+    height: 100px;
+    background: green;
+  }
+</style>
+
+<div id="green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-vrl-ltr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-vrl-ltr.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+<html class="reftest-wait">
+
+<title>Boxes in the top layer use the initial containing block as their static-position rectangle.</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#staticpos-rect">
+<link rel="match" href="top-layer-box-uses-icb-top-right-ref.html">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<style>
+  :root {
+    writing-mode: vertical-rl;
+    direction: ltr;
+  }
+
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #reference {
+    width: 100px;
+    height: 100px;
+    background: red;
+  }
+
+  #popover {
+    width: 100px;
+    height: 100px;
+    background: green;
+
+    /* Override popover UA style */
+    border: none;
+    padding: 0;
+
+    inset: auto;
+  }
+</style>
+
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+
+<div id="reference"></div>
+<!-- This green box should fully cover the red box above. -->
+<div id="popover" popover></div>
+
+<script>
+  document.getElementById("popover").showPopover();
+  waitForAtLeastOneFrame().then(takeScreenshot);
+</script>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-vrl-rtl-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-vrl-rtl-expected.html
@@ -1,0 +1,12 @@
+<style>
+  #green {
+    position: fixed;
+    bottom: 0;
+    right: 0;
+    width: 100px;
+    height: 100px;
+    background: green;
+  }
+</style>
+
+<div id="green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-vrl-rtl.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-vrl-rtl.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+<html class="reftest-wait">
+
+<title>Boxes in the top layer use the initial containing block as their static-position rectangle.</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#staticpos-rect">
+<link rel="match" href="top-layer-box-uses-icb-bottom-right-ref.html">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<style>
+  :root {
+    writing-mode: vertical-rl;
+    direction: rtl;
+  }
+
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #reference {
+    width: 100px;
+    height: 100px;
+    background: red;
+  }
+
+  #popover {
+    width: 100px;
+    height: 100px;
+    background: green;
+
+    /* Override popover UA style */
+    border: none;
+    padding: 0;
+
+    inset: auto;
+  }
+</style>
+
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+
+<div id="reference"></div>
+<!-- This green box should fully cover the red box above. -->
+<div id="popover" popover></div>
+
+<script>
+  document.getElementById("popover").showPopover();
+  waitForAtLeastOneFrame().then(takeScreenshot);
+</script>
+
+</html>

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -1279,24 +1279,37 @@ void RenderBlockFlow::adjustOutOfFlowBlock(RenderBox& child, const MarginInfo& m
 {
     bool isHorizontal = isHorizontalWritingMode();
     bool hasStaticBlockPosition = child.style().hasStaticBlockPosition(isHorizontal);
-    
-    LayoutUnit logicalTop = logicalHeight();
-    updateStaticInlinePositionForChild(child, logicalTop);
 
-    if (!marginInfo.canCollapseWithMarginBefore()) {
-        // Positioned blocks don't collapse margins, so add the margin provided by
-        // the container now. The child's own margin is added later when calculating its logical top.
-        LayoutUnit collapsedBeforePos = marginInfo.positiveMargin();
-        LayoutUnit collapsedBeforeNeg = marginInfo.negativeMargin();
-        logicalTop += collapsedBeforePos - collapsedBeforeNeg;
+    LayoutUnit blockPosition = 0;
+    LayoutUnit inlinePosition = 0;
+
+    // https://drafts.csswg.org/css-position-3/#staticpos-rect
+    // > Boxes in the top layer always use the initial containing block as their static-position rectangle.
+    // In other cases, we compute the static position as usual.
+    if (RefPtr element = child.element(); !(element && element->isInTopLayer())) [[likely]] {
+        blockPosition = logicalHeight();
+        if (!marginInfo.canCollapseWithMarginBefore()) {
+            // Positioned blocks don't collapse margins, so add the margin provided by
+            // the container now. The child's own margin is added later when calculating its logical top.
+            LayoutUnit collapsedBeforePos = marginInfo.positiveMargin();
+            LayoutUnit collapsedBeforeNeg = marginInfo.negativeMargin();
+            blockPosition += collapsedBeforePos - collapsedBeforeNeg;
+        }
+
+        if (child.style().originalDisplay().isInlineType())
+            inlinePosition = staticInlinePositionForOriginalDisplayInline(blockPosition);
+        else
+            inlinePosition = startOffsetForContent();
     }
 
     CheckedPtr childLayer = child.layer();
-    if (childLayer->staticBlockPosition() != logicalTop) {
-        childLayer->setStaticBlockPosition(logicalTop);
+    if (childLayer->staticBlockPosition() != blockPosition) {
+        childLayer->setStaticBlockPosition(blockPosition);
         if (hasStaticBlockPosition)
             child.setChildNeedsLayout(MarkingBehavior::MarkOnlyThis);
     }
+
+    setStaticInlinePositionForChild(child, inlinePosition);
 }
 
 void RenderBlockFlow::determineLogicalLeftPositionForChild(RenderBox& child, ApplyLayoutDeltaMode applyDelta)
@@ -1350,14 +1363,6 @@ void RenderBlockFlow::adjustFloatingBlock(const MarginInfo& marginInfo)
     setLogicalHeight(logicalHeight() + marginOffset);
     positionNewFloats();
     setLogicalHeight(logicalHeight() - marginOffset);
-}
-
-void RenderBlockFlow::updateStaticInlinePositionForChild(RenderBox& child, LayoutUnit logicalTop)
-{
-    if (child.style().originalDisplay().isInlineType())
-        setStaticInlinePositionForChild(child, staticInlinePositionForOriginalDisplayInline(logicalTop));
-    else
-        setStaticInlinePositionForChild(child, startOffsetForContent());
 }
 
 void RenderBlockFlow::setStaticInlinePositionForChild(RenderBox& child, LayoutUnit inlinePosition)

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -256,7 +256,6 @@ public:
     void trimBlockEndChildrenMargins();
 
     void setStaticInlinePositionForChild(RenderBox& child, LayoutUnit inlinePosition);
-    void updateStaticInlinePositionForChild(RenderBox& child, LayoutUnit logicalTop);
 
     LayoutUnit staticInlinePositionForOriginalDisplayInline(LayoutUnit logicalTop);
 


### PR DESCRIPTION
#### b67aa8964b5858168f560d95722d5501800e00d1
<pre>
Boxes in the top layer should use the initial containing block as their static-position rectangle
<a href="https://rdar.apple.com/155495104">rdar://155495104</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=295686">https://bugs.webkit.org/show_bug.cgi?id=295686</a>

Reviewed by Alan Baradlay.

Per resolution [1], boxes in the top layer should use the initial containing block
as their static-position rectangle. Change RenderBlockFlow::adjustOutOfFlowBlock to
set the static block/inline position to 0 if the child is in the top layer.

[1]: <a href="https://github.com/w3c/csswg-drafts/issues/9939">https://github.com/w3c/csswg-drafts/issues/9939</a>

Tests: imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-htb-ltr.html
       imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-htb-rtl.html
       imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-slr-ltr.html
       imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-slr-rtl.html
       imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-srl-ltr.html
       imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-srl-rtl.html
       imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-vlr-ltr.html
       imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-vlr-rtl.html
       imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-vrl-ltr.html
       imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-vrl-rtl.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-bottom-left-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-bottom-right-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-htb-ltr-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-htb-ltr.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-htb-rtl-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-htb-rtl.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-slr-ltr-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-slr-ltr.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-slr-rtl-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-slr-rtl.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-srl-ltr-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-srl-ltr.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-srl-rtl-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-srl-rtl.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-top-left-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-top-right-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-vlr-ltr-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-vlr-ltr.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-vlr-rtl-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-vlr-rtl.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-vrl-ltr-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-vrl-ltr.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-vrl-rtl-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/static-position/top-layer-box-uses-icb-vrl-rtl.html: Added.
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::adjustOutOfFlowBlock):
    - Rename logicalTop to blockPosition for consistency.
    - Set static block/inline position to 0 if child is in the top layer.
(WebCore::RenderBlockFlow::updateStaticInlinePositionForChild): Deleted.
    - Fold this method into RenderBlockFlow::adjustOutOfFlowBlock, since it needs
      to know if child is in the top layer or not, which is already computed there.
* Source/WebCore/rendering/RenderBlockFlow.h:

Canonical link: <a href="https://commits.webkit.org/312908@main">https://commits.webkit.org/312908@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7ab35bb434e16424897dde5f17ad3b6282d5666

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160649 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169552 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115715 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162518 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34223 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34122 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124583 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87970 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163608 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26832 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144303 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105183 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/70b568d5-bf47-4fa6-8cfb-b883aefa917d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25884 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24388 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17272 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135578 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22066 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172031 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18908 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23706 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132858 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33796 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28480 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132863 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36071 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33780 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143861 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95589 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27461 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20676 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33291 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100533 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32790 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33034 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32938 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->