### PR TITLE
Address feedback from Darin on 297196@main

### DIFF
--- a/Source/JavaScriptCore/yarr/YarrParser.h
+++ b/Source/JavaScriptCore/yarr/YarrParser.h
@@ -163,8 +163,7 @@ private:
 
         void nextAlternative()
         {
-            m_nestedCaptureGroupNames.last().addAll(m_activeCaptureGroupNames.last());
-            m_activeCaptureGroupNames.last().clear();
+            m_nestedCaptureGroupNames.last().addAll(std::exchange(m_activeCaptureGroupNames.last(), { }));
 
             // For nested parenthesis, we need to seed the new alternative with the already seen
             // named captures from the containing alternative.
@@ -183,10 +182,10 @@ private:
         {
             ASSERT(m_nestedCaptureGroupNames.size() > 1);
             ASSERT(m_activeCaptureGroupNames.size() > 1);
-            m_nestedCaptureGroupNames.last().addAll(m_activeCaptureGroupNames.last());
+            m_nestedCaptureGroupNames.last().addAll(WTFMove(m_activeCaptureGroupNames.last()));
 
             // Add all the names seen in this parenthesis to the containing alternative.
-            m_activeCaptureGroupNames[m_activeCaptureGroupNames.size() - 2].addAll(m_nestedCaptureGroupNames.last());
+            m_activeCaptureGroupNames[m_activeCaptureGroupNames.size() - 2].addAll(WTFMove(m_nestedCaptureGroupNames.last()));
 
             m_nestedCaptureGroupNames.removeLast();
             m_activeCaptureGroupNames.removeLast();

--- a/Source/WTF/wtf/HashSet.h
+++ b/Source/WTF/wtf/HashSet.h
@@ -57,10 +57,26 @@ public:
     using AddResult = typename HashTableType::AddResult;
 
     HashSet() = default;
+
     HashSet(std::initializer_list<ValueArg> initializerList)
     {
-        for (const auto& value : initializerList)
-            add(value);
+        if (!initializerList.size())
+            return;
+
+        reserveInitialCapacity(initializerList.size());
+        for (auto&& value : initializerList)
+            add(std::forward<decltype(value)>(value));
+    }
+
+    template<typename ContainerType>
+    explicit HashSet(ContainerType&& container)
+    {
+        if (!container.size())
+            return;
+
+        reserveInitialCapacity(container.size());
+        for (auto&& value : std::forward<ContainerType>(container))
+            add(std::forward<decltype(value)>(value));
     }
 
     void swap(HashSet&);

--- a/Source/WebCore/contentextensions/CombinedURLFilters.cpp
+++ b/Source/WebCore/contentextensions/CombinedURLFilters.cpp
@@ -252,7 +252,7 @@ static void generateSuffixWithReverseSuffixTree(NFA& nfa, Vector<ActiveSubtree>&
     auto rootAddResult = reverseSuffixTreeRoots.add(hashableActionList, ReverseSuffixTreeVertex());
     if (rootAddResult.isNewEntry) {
         ImmutableCharNFANodeBuilder newNode(nfa);
-        newNode.setActions(actionList);
+        newNode.setActions(WTFMove(actionList));
         rootAddResult.iterator->value.nodeId = newNode.nodeId();
     }
 

--- a/Source/WebCore/contentextensions/ImmutableNFANodeBuilder.h
+++ b/Source/WebCore/contentextensions/ImmutableNFANodeBuilder.h
@@ -140,12 +140,12 @@ public:
     }
 
     template<typename ActionContainer>
-    void setActions(const ActionContainer& actions)
+    void setActions(ActionContainer&& actions)
     {
         ASSERT(!m_finalized);
         ASSERT(m_immutableNFA);
 
-        m_actions.addAll(actions);
+        m_actions.addAll(WTFMove(actions));
     }
 
     ImmutableNFANodeBuilder& operator=(ImmutableNFANodeBuilder&& other)

--- a/Source/WebCore/contentextensions/NFAToDFA.cpp
+++ b/Source/WebCore/contentextensions/NFAToDFA.cpp
@@ -274,8 +274,7 @@ struct DataConverterWithEpsilonClosure {
         NFANodeIndexSet result;
         for (unsigned nodeId : iterable) {
             result.add(nodeId);
-            const UniqueNodeList& nodeClosure = nfaNodeclosures[nodeId];
-            result.addAll(nodeClosure);
+            result.addAll(nfaNodeclosures[nodeId]);
         }
         return result;
     }
@@ -285,10 +284,8 @@ struct DataConverterWithEpsilonClosure {
     {
         for (unsigned nodeId : iterable) {
             auto addResult = destination.add(nodeId);
-            if (addResult.isNewEntry) {
-                const UniqueNodeList& nodeClosure = nfaNodeclosures[nodeId];
-                destination.addAll(nodeClosure);
-            }
+            if (addResult.isNewEntry)
+                destination.addAll(nfaNodeclosures[nodeId]);
         }
     }
 };

--- a/Source/WebCore/contentextensions/Term.h
+++ b/Source/WebCore/contentextensions/Term.h
@@ -81,7 +81,7 @@ public:
 
     void quantify(const AtomQuantifier&);
 
-    ImmutableCharNFANodeBuilder generateGraph(NFA&, ImmutableCharNFANodeBuilder& source, const ActionList& finalActions) const;
+    ImmutableCharNFANodeBuilder generateGraph(NFA&, ImmutableCharNFANodeBuilder& source, ActionList&& finalActions) const;
     void generateGraph(NFA&, ImmutableCharNFANodeBuilder& source, uint32_t destination) const;
 
     bool isEndOfLineAssertion() const;
@@ -380,11 +380,11 @@ inline void Term::quantify(const AtomQuantifier& quantifier)
     m_quantifier = quantifier;
 }
 
-inline ImmutableCharNFANodeBuilder Term::generateGraph(NFA& nfa, ImmutableCharNFANodeBuilder& source, const ActionList& finalActions) const
+inline ImmutableCharNFANodeBuilder Term::generateGraph(NFA& nfa, ImmutableCharNFANodeBuilder& source, ActionList&& finalActions) const
 {
     ImmutableCharNFANodeBuilder newEnd(nfa);
     generateGraph(nfa, source, newEnd.nodeId());
-    newEnd.setActions(finalActions);
+    newEnd.setActions(WTFMove(finalActions));
     return newEnd;
 }
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -304,9 +304,6 @@ static constexpr std::array supportedTypesOESTextureHalfFloat {
     GraphicsContextGL::HALF_FLOAT_OES,
 };
 
-#define ADD_VALUES_TO_SET(set, array) \
-    set.addAll(array)
-
 // Counter for determining which context has the earliest active ordinal number.
 static std::atomic<uint64_t> s_lastActiveOrdinal;
 
@@ -612,9 +609,9 @@ void WebGLRenderingContextBase::initializeContextState()
     m_areOESTextureFloatFormatsAndTypesAdded = false;
     m_areOESTextureHalfFloatFormatsAndTypesAdded = false;
     m_areEXTsRGBFormatsAndTypesAdded = false;
-    ADD_VALUES_TO_SET(m_supportedTexImageSourceInternalFormats, supportedFormatsES2);
-    ADD_VALUES_TO_SET(m_supportedTexImageSourceFormats, supportedFormatsES2);
-    ADD_VALUES_TO_SET(m_supportedTexImageSourceTypes, supportedTypesES2);
+    m_supportedTexImageSourceInternalFormats.addAll(supportedFormatsES2);
+    m_supportedTexImageSourceFormats.addAll(supportedFormatsES2);
+    m_supportedTexImageSourceTypes.addAll(supportedTypesES2);
     m_packReverseRowOrderSupported = enableSupportedExtension("GL_ANGLE_reverse_row_order"_s);
 }
 
@@ -3908,18 +3905,18 @@ bool WebGLRenderingContextBase::validateTexFuncParameters(TexImageFunctionID fun
 void WebGLRenderingContextBase::addExtensionSupportedFormatsAndTypes()
 {
     if (!m_areOESTextureFloatFormatsAndTypesAdded && m_oesTextureFloat) {
-        ADD_VALUES_TO_SET(m_supportedTexImageSourceTypes, supportedTypesOESTextureFloat);
+        m_supportedTexImageSourceTypes.addAll(supportedTypesOESTextureFloat);
         m_areOESTextureFloatFormatsAndTypesAdded = true;
     }
 
     if (!m_areOESTextureHalfFloatFormatsAndTypesAdded && m_oesTextureHalfFloat) {
-        ADD_VALUES_TO_SET(m_supportedTexImageSourceTypes, supportedTypesOESTextureHalfFloat);
+        m_supportedTexImageSourceTypes.addAll(supportedTypesOESTextureHalfFloat);
         m_areOESTextureHalfFloatFormatsAndTypesAdded = true;
     }
 
     if (!m_areEXTsRGBFormatsAndTypesAdded && m_extsRGB) {
-        ADD_VALUES_TO_SET(m_supportedTexImageSourceInternalFormats, supportedInternalFormatsEXTsRGB);
-        ADD_VALUES_TO_SET(m_supportedTexImageSourceFormats, supportedFormatsEXTsRGB);
+        m_supportedTexImageSourceInternalFormats.addAll(supportedInternalFormatsEXTsRGB);
+        m_supportedTexImageSourceFormats.addAll(supportedFormatsEXTsRGB);
         m_areEXTsRGBFormatsAndTypesAdded = true;
     }
 }
@@ -3934,9 +3931,9 @@ bool WebGLRenderingContextBase::validateTexImageSourceFormatAndType(TexImageFunc
     auto functionName = texImageFunctionName(functionID);
     auto functionType = texImageFunctionType(functionID);
     if (!m_areWebGL2TexImageSourceFormatsAndTypesAdded && isWebGL2()) {
-        ADD_VALUES_TO_SET(m_supportedTexImageSourceInternalFormats, supportedInternalFormatsTexImageSourceES3);
-        ADD_VALUES_TO_SET(m_supportedTexImageSourceFormats, supportedFormatsTexImageSourceES3);
-        ADD_VALUES_TO_SET(m_supportedTexImageSourceTypes, supportedTypesTexImageSourceES3);
+        m_supportedTexImageSourceInternalFormats.addAll(supportedInternalFormatsTexImageSourceES3);
+        m_supportedTexImageSourceFormats.addAll(supportedFormatsTexImageSourceES3);
+        m_supportedTexImageSourceTypes.addAll(supportedTypesTexImageSourceES3);
         m_areWebGL2TexImageSourceFormatsAndTypesAdded = true;
     }
 

--- a/Source/WebCore/page/ElementTargetingController.cpp
+++ b/Source/WebCore/page/ElementTargetingController.cpp
@@ -905,8 +905,7 @@ Vector<ElementIdentifier> ElementTargetingController::topologicallySortElements(
     HashSet<ElementIdentifier> processingIDs;
     HashSet<ElementIdentifier> unprocessedIDs;
 
-    const auto elementIDs = elementIDToOccludedElementIDs.keys();
-    unprocessedIDs.addAll(elementIDs);
+    unprocessedIDs.addAll(elementIDToOccludedElementIDs.keys());
 
     while (!unprocessedIDs.isEmpty() || !processingIDs.isEmpty()) {
         if (unprocessedIDs.isEmpty()) {

--- a/Source/WebCore/platform/graphics/cg/UTIRegistry.mm
+++ b/Source/WebCore/platform/graphics/cg/UTIRegistry.mm
@@ -151,8 +151,7 @@ void setAdditionalSupportedImageTypes(const Vector<String>& imageTypes)
     MIMETypeRegistry::additionalSupportedImageMIMETypes().clear();
     for (const auto& imageType : imageTypes) {
         additionalSupportedImageTypes().add(imageType);
-        auto mimeTypes = RequiredMIMETypesFromUTI(imageType);
-        MIMETypeRegistry::additionalSupportedImageMIMETypes().addAll(WTFMove(mimeTypes));
+        MIMETypeRegistry::additionalSupportedImageMIMETypes().addAll(RequiredMIMETypesFromUTI(imageType));
     }
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -16438,10 +16438,7 @@ void WebPageProxy::adjustVisibilityForTargetedElements(const Vector<Ref<API::Tar
         return {
             { info->elementIdentifier(), info->documentIdentifier() },
             info->selectors().map([](auto& selectors) {
-                HashSet<String> result;
-                result.reserveInitialCapacity(selectors.size());
-                result.addAll(selectors);
-                return result;
+                return HashSet<String>(selectors);
             })
         };
     })), WTFMove(completion));


### PR DESCRIPTION
#### 3c42d2ab599c136e01d589f8ff3da55cb454b9a6
<pre>
Address feedback from Darin on 297196@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=295688">https://bugs.webkit.org/show_bug.cgi?id=295688</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/yarr/YarrParser.h:
(JSC::Yarr::Parser::NamedCaptureGroups::nextAlternative):
(JSC::Yarr::Parser::NamedCaptureGroups::popParenthesis):
* Source/WTF/wtf/HashSet.h:
* Source/WebCore/contentextensions/CombinedURLFilters.cpp:
(WebCore::ContentExtensions::generateSuffixWithReverseSuffixTree):
* Source/WebCore/contentextensions/ImmutableNFANodeBuilder.h:
(WebCore::ContentExtensions::ImmutableNFANodeBuilder::setActions):
* Source/WebCore/contentextensions/NFAToDFA.cpp:
(WebCore::ContentExtensions::DataConverterWithEpsilonClosure::convert):
(WebCore::ContentExtensions::DataConverterWithEpsilonClosure::extend):
* Source/WebCore/contentextensions/Term.h:
(WebCore::ContentExtensions::Term::generateGraph const):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::initializeContextState):
(WebCore::WebGLRenderingContextBase::addExtensionSupportedFormatsAndTypes):
(WebCore::WebGLRenderingContextBase::validateTexImageSourceFormatAndType):
* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::ElementTargetingController::topologicallySortElements):
* Source/WebCore/platform/graphics/cg/UTIRegistry.mm:
(WebCore::setAdditionalSupportedImageTypes):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::adjustVisibilityForTargetedElements):

Canonical link: <a href="https://commits.webkit.org/297224@main">https://commits.webkit.org/297224@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0d924901798413994d5e5ecf999475e457d970e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110943 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30606 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21041 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116974 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61211 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112906 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31286 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39192 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84354 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24999 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99891 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64798 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24357 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18033 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60773 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/103435 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94392 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18093 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/rotated-cat-off-top-edge.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119779 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109497 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37988 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28240 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93312 "Found 2 new test failures: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38364 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96163 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93136 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23728 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38187 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15928 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33974 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37881 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43352 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/133773 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37544 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36103 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40880 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39249 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->