### PR TITLE
REGRESSION (296274@main): 14X media layout tests are encountering CONSOLE MESSAGE: A capture MediaStreamTrack was destroyed without having been stopped explicitly

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -537,6 +537,7 @@ imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allow
 imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-self.https.sub.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-some.https.sub.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-disallowed-for-all.https.sub.html [ DumpJSConsoleLogInStdErr ]
+imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-timing.https.sub.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/html/anonymous-iframe/embedding.tentative.https.window.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/failure-check-sequence.https.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/redirect-to-data.html [ DumpJSConsoleLogInStdErr ]
@@ -1344,6 +1345,7 @@ imported/w3c/web-platform-tests/event-timing/interactionid-keyboard-event-simula
 imported/w3c/web-platform-tests/event-timing/interactionid-keyboard-event-simulated-click-button-space.html [ Skip ]
 
 imported/w3c/web-platform-tests/mediacapture-streams/MediaStream-default-feature-policy.https.html [ DumpJSConsoleLogInStdErr ]
+imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-applyConstraints.https.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-MediaElement-disabled-video-is-black.https.html [ Pass Failure ]
 imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-enumerateDevices-per-origin-ids.sub.https.html [ Skip ]
 

--- a/LayoutTests/fast/mediastream/MediaDevices-getUserMedia.html
+++ b/LayoutTests/fast/mediastream/MediaDevices-getUserMedia.html
@@ -61,6 +61,8 @@
                 shouldBeEqualToString("stream.getVideoTracks()[0].getSettings().facingMode", "user");
                 shouldBe("stream.getAudioTracks().length", "0");
 
+                stream.getTracks().forEach(t => t.stop());
+
                 audioConstraints = {
                     sampleRate: {
                         min: .6,
@@ -82,6 +84,8 @@
                 shouldBe("stream.getAudioTracks().length", "0");
                 shouldBe("stream.getVideoTracks().length", "1");
 
+                stream.getTracks().forEach(t => t.stop());
+
                 videoConstraints = {
                     facingMode: {
                         exact: ['user']
@@ -97,6 +101,8 @@
 
                 shouldBe("stream.getAudioTracks().length", "1");
                 shouldBe("stream.getVideoTracks().length", "0");
+
+                stream.getTracks().forEach(t => t.stop());
 
                 videoConstraints = {
                     width: {
@@ -119,6 +125,8 @@
                 shouldBe("stream.getAudioTracks().length", "1");
                 shouldBe("stream.getVideoTracks().length", "1");
 
+                stream.getTracks().forEach(t => t.stop());
+
                 audioConstraints = {
                     sampleRate: {
                         min: 44100,
@@ -138,6 +146,8 @@
                 shouldBe("stream.getAudioTracks().length", "1");
                 shouldBe("stream.getVideoTracks().length", "1");
 
+                stream.getTracks().forEach(t => t.stop());
+
                 debug("");
                 shouldNotThrow("navigator.mediaDevices.getUserMedia({audio:{}, video:{}}).then(gotStream4);");
             }
@@ -148,6 +158,8 @@
                 shouldBe("stream.getAudioTracks().length", "0");
                 shouldBe("stream.getVideoTracks().length", "1");
 
+                stream.getTracks().forEach(t => t.stop());
+
                 debug("");
                 shouldNotThrow("navigator.mediaDevices.getUserMedia({audio:true, video:true}).then(gotStream3);");
             }
@@ -157,6 +169,8 @@
                 testPassed("Stream 1 generated.");
                 shouldBe("stream.getAudioTracks().length", "1");
                 shouldBe("stream.getVideoTracks().length", "0");
+
+                stream.getTracks().forEach(t => t.stop());
 
                 debug("");
                 shouldNotThrow("navigator.mediaDevices.getUserMedia({video:true}).then(gotStream2);")

--- a/LayoutTests/fast/mediastream/captureInGPUProcess.html
+++ b/LayoutTests/fast/mediastream/captureInGPUProcess.html
@@ -13,11 +13,13 @@
 promise_test(async (test) => {
     video.srcObject = await navigator.mediaDevices.getUserMedia({ audio: true });
     await video.play();
+    video.srcObject.getTracks().forEach(t => t.stop());
 }, "Play audio captured in GPU process");
 
 promise_test(async (test) => {
     video.srcObject = await navigator.mediaDevices.getUserMedia({ video: true });
     await video.play();
+    video.srcObject.getTracks().forEach(t => t.stop());
 }, "Play video captured in GPU process");
         </script>
     </body>

--- a/LayoutTests/fast/mediastream/get-user-media-device-id.html
+++ b/LayoutTests/fast/mediastream/get-user-media-device-id.html
@@ -22,6 +22,7 @@
 
         return navigator.mediaDevices.getUserMedia({ audio:true, video:true })
             .then((stream) => {
+                stream.getTracks().forEach(t => t.stop());
                 return navigator.mediaDevices.enumerateDevices();
             }).then(devices => {
                 devices.forEach((device) => {
@@ -43,6 +44,7 @@
         var audioTrack, videoTrack;
         return navigator.mediaDevices.getUserMedia(constraints)
             .then((stream) => {
+                stream.getTracks().forEach(t => t.stop());
                 assert_equals(stream.getAudioTracks().length, 1, "correct number of audio tracks");
                 assert_equals(stream.getVideoTracks().length, 1, "correct number of audio tracks");
 
@@ -64,6 +66,7 @@
     
         return navigator.mediaDevices.getUserMedia(constraints)
             .then((stream) => {
+                stream.getTracks().forEach(t => t.stop());
                 assert_equals(stream.getAudioTracks().length, 1, "correct number of audio tracks");
                 assert_equals(stream.getVideoTracks().length, 1, "correct number of video tracks");
             })
@@ -71,24 +74,30 @@
     }, "Pass device IDs as optional constraints");
 
     promise_test(async (test) => {
-        await navigator.mediaDevices.getUserMedia({ audio: {deviceId: {exact: ""}}});
-        await navigator.mediaDevices.getUserMedia({ video: {deviceId: {exact: [""]}}});
-        await navigator.mediaDevices.getUserMedia({ audio: {deviceId: {exact: undefined}}});
+        let stream = await navigator.mediaDevices.getUserMedia({ audio: {deviceId: {exact: ""}}});
+        stream.getTracks().forEach(t => t.stop());
+        stream = await navigator.mediaDevices.getUserMedia({ video: {deviceId: {exact: [""]}}});
+        stream.getTracks().forEach(t => t.stop());
+        stream = await navigator.mediaDevices.getUserMedia({ audio: {deviceId: {exact: undefined}}});
+        stream.getTracks().forEach(t => t.stop());
 
         await navigator.mediaDevices.getUserMedia({ audio: {deviceId: {exact: null}}}).then(assert_unreached, () => { });
         await navigator.mediaDevices.getUserMedia({ audio: {deviceId: {exact: "test"}}}).then(assert_unreached, () => { });
     }, "Exact device IDs with special values: empty string, null, undefined");
 
     promise_test(async (test) => {
-        await navigator.mediaDevices.getUserMedia({video: true});
+        const stream = await navigator.mediaDevices.getUserMedia({video: true});
+        stream.getTracks().forEach(t => t.stop());
         const devices  = await navigator.mediaDevices.enumerateDevices();
         for (let device of devices) {
             if (device.kind === "audioinput") {
                 const stream = await navigator.mediaDevices.getUserMedia({audio: {deviceId: device.deviceId}});
                 assert_equals(stream.getAudioTracks()[0].getSettings().deviceId, device.deviceId, "Matching audio device id");
+                stream.getTracks().forEach(t => t.stop());
             } else if (device.kind === "videoinput") {
                 const stream = await navigator.mediaDevices.getUserMedia({video: {deviceId: device.deviceId}});
                 assert_equals(stream.getVideoTracks()[0].getSettings().deviceId, device.deviceId, "Matching video device id");
+                stream.getTracks().forEach(t => t.stop());
             }
         }
     }, "Ideal deviceId constraints");

--- a/LayoutTests/fast/mediastream/getUserMedia-default.html
+++ b/LayoutTests/fast/mediastream/getUserMedia-default.html
@@ -18,12 +18,14 @@ promise_test((test) => {
         assert_equals(settings.frameRate, 30, "frame rate");
         assert_equals(settings.width, settings.height == 640 ? 480 : 640, "frame width");
         assert_equals(settings.height, settings.width = 640 ? 480 : 640, "frame height");
+        stream.getTracks().forEach(t => t.stop());
     });
 }, "Checking default video tracks settings");
 
 promise_test((test) => {
     return navigator.mediaDevices.getUserMedia({ audio: true, video: false }).then((stream) => {
         assert_equals(stream.getVideoTracks().length, 0);
+        stream.getTracks().forEach(t => t.stop());
     });
 }, "Checking only audio capture");
 
@@ -32,6 +34,7 @@ promise_test((test) => {
         let settings = stream.getVideoTracks()[0].getSettings();
         assert_equals(settings.frameRate, 30, "frame rate");
         assert_equals(settings.height, 240, "frame height");
+        stream.getTracks().forEach(t => t.stop());
     });
 }, "Checking default video tracks settings except width and height");
 
@@ -40,6 +43,7 @@ promise_test((test) => {
         let settings = stream.getVideoTracks()[0].getSettings();
         assert_equals(settings.frameRate, 30, "frame rate");
         assert_equals(settings.height, 240, "frame height");
+        stream.getTracks().forEach(t => t.stop());
     });
 }, "Checking default video tracks settings except height");
 
@@ -49,6 +53,7 @@ promise_test((test) => {
         assert_equals(settings.frameRate, 60, "frame rate");
         assert_equals(settings.width, settings.height == 640 ? 480 : 640, "frame width");
         assert_equals(settings.height, settings.width = 640 ? 480 : 640, "frame height");
+        stream.getTracks().forEach(t => t.stop());
     });
 }, "Checking default video tracks settings except frameRate");
         </script>

--- a/LayoutTests/fast/mediastream/getUserMedia-deny-persistency.html
+++ b/LayoutTests/fast/mediastream/getUserMedia-deny-persistency.html
@@ -19,7 +19,8 @@ promise_test((test) => {
         });
     }).then(() => {
         return navigator.mediaDevices.getUserMedia({audio:true, video:false});
-    }).then(() => {
+    }).then(stream => {
+        stream.getTracks().forEach(t => t.stop());
         return navigator.mediaDevices.getUserMedia({audio:false, video:true}).then(assert_unreached, (e) => {
             assert_equals(e.name, "NotAllowedError");
         });

--- a/LayoutTests/fast/mediastream/getUserMedia-deny-persistency3.html
+++ b/LayoutTests/fast/mediastream/getUserMedia-deny-persistency3.html
@@ -14,10 +14,12 @@ promise_test(async (test) => {
     });
     if (window.testRunner)
         testRunner.setUserMediaPermission(true);
-    await navigator.mediaDevices.getUserMedia({audio:true});
+    let stream = await navigator.mediaDevices.getUserMedia({audio:true});
+    stream.getTracks().forEach(t => t.stop());
     if (window.testRunner)
         testRunner.setUserMediaPermission(false);
-    await navigator.mediaDevices.getUserMedia({audio:true});
+    stream = await navigator.mediaDevices.getUserMedia({audio:true});
+    stream.getTracks().forEach(t => t.stop());
 
     await navigator.mediaDevices.getUserMedia({video:true}).then(assert_unreached, (e) => {
         assert_equals(e.name, "NotAllowedError");

--- a/LayoutTests/fast/mediastream/getUserMedia-grant-persistency.html
+++ b/LayoutTests/fast/mediastream/getUserMedia-grant-persistency.html
@@ -10,17 +10,22 @@ promise_test((test) => {
     if (window.testRunner)
         testRunner.setUserMediaPermission(true);
     return navigator.mediaDevices.getUserMedia({audio:false, video:true}).then((stream) => {
+        stream.getTracks().forEach(t => t.stop());
         if (window.testRunner)
             testRunner.setUserMediaPermission(false);
         return navigator.mediaDevices.getUserMedia({audio:false, video:true});
-    }).then(() => {
+    }).then(stream => {
+        stream.getTracks().forEach(t => t.stop());
         if (window.testRunner)
             testRunner.setUserMediaPermission(true);
         return navigator.mediaDevices.getUserMedia({audio:true, video:false});
-    }).then(() => {
+    }).then(stream => {
+        stream.getTracks().forEach(t => t.stop());
         if (window.testRunner)
             testRunner.setUserMediaPermission(false);
         return navigator.mediaDevices.getUserMedia({audio:true, video:true});
+    }).then(stream => {
+        stream.getTracks().forEach(t => t.stop());
     });
 }, "Testing same page getUserMedia grant persistency");
         </script>

--- a/LayoutTests/fast/mediastream/mediastreamtrack-clone-muted.html
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-clone-muted.html
@@ -34,6 +34,9 @@ promise_test(async (t) => {
     video.srcObject = new MediaStream([cloneTrack]);
     await video.play();
     video.srcObject = null;
+
+    track.stop();
+    cloneTrack.stop();
 }, "Video clone during interruption");
 
 promise_test(async (t) => {
@@ -62,6 +65,9 @@ promise_test(async (t) => {
     video.srcObject = new MediaStream([cloneTrack]);
     await video.play();
     video.srcObject = null;
+
+    track.stop();
+    cloneTrack.stop();
 }, "Video clone during muting");
 
 promise_test(async (t) => {
@@ -91,6 +97,9 @@ promise_test(async (t) => {
     video.srcObject = new MediaStream([cloneTrack]);
     await video.play();
     video.srcObject = null;
+
+    track.stop();
+    cloneTrack.stop();
 }, "Audio clone during interruption");
 
 promise_test(async (t) => {
@@ -119,6 +128,9 @@ promise_test(async (t) => {
     video.srcObject = new MediaStream([cloneTrack]);
     await video.play();
     video.srcObject = null;
+
+    track.stop();
+    cloneTrack.stop();
 }, "Audio clone during muting");
 
     </script>

--- a/LayoutTests/fast/mediastream/overconstrainederror-constraint.html
+++ b/LayoutTests/fast/mediastream/overconstrainederror-constraint.html
@@ -21,7 +21,9 @@ promise_test(async () => {
 }, "Before grant");
 
 promise_test(async(test) => {
-    await navigator.mediaDevices.getUserMedia({audio: true});
+    const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+    stream.getTracks().forEach(t => t.stop());
+
     return navigator.mediaDevices.getUserMedia({audio: {deviceId: {exact:"none"}}}).then(
         () => assert_not_reached("gum should fail"),
         (e) => {

--- a/LayoutTests/fast/mediastream/play-newly-added-audio-track.html
+++ b/LayoutTests/fast/mediastream/play-newly-added-audio-track.html
@@ -19,6 +19,9 @@ promise_test(async () => {
     let stream2 = await navigator.mediaDevices.getUserMedia({ audio : true });
     video.srcObject.addTrack(stream2.getAudioTracks()[0]);
     await new Promise(resolve => setTimeout(resolve, 50));
+
+    stream.getTracks().forEach(t => t.stop());
+    stream2.getTracks().forEach(t => t.stop());
 }, "Add an audio track while playing video");
 
 promise_test(async () => {
@@ -34,6 +37,8 @@ promise_test(async () => {
 
     video.srcObject.addTrack(stream.getAudioTracks()[0]);
     await new Promise(resolve => setTimeout(resolve, 50));
+
+    stream.getTracks().forEach(t => t.stop());
 }, "Add an audio track while playing audio");
         </script>
     </head>

--- a/LayoutTests/fast/mediastream/stream-switch.html
+++ b/LayoutTests/fast/mediastream/stream-switch.html
@@ -20,6 +20,7 @@ promise_test(async() => {
         await localVideo.play();
         await waitForVideoFrame(localVideo);
     }
+    stream.getTracks().forEach(t => t.stop());
 }, "Check switching between playing with and without stream");
 
 promise_test(async() => {
@@ -39,6 +40,7 @@ promise_test(async() => {
         stream.addTrack(audioTrack);
         once(stream, 'onaddtrack');
     }
+    stream.getTracks().forEach(t => t.stop());
 }, "Check adding and removing a track to a stream");
 </script>
 </body>

--- a/LayoutTests/http/tests/webrtc/audioSessionInFrames.html
+++ b/LayoutTests/http/tests/webrtc/audioSessionInFrames.html
@@ -15,7 +15,8 @@ function with_iframe(url, allow) {
 
 promise_test(async () => {
     navigator.audioSession.type = "play-and-record";
-    await navigator.mediaDevices.getUserMedia({ audio: true });
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    stream.getTracks().forEach(t => t.stop());
 
     const frame1 = await with_iframe("http://localhost:8080/webrtc/resources/audioSessionFrame.html", "microphone:'none'");
     const result1 = await new Promise(resolve => window.onmessage = (event) => resolve(event.data));

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7937,20 +7937,6 @@ webkit.org/b/295557 fast/dom/Range/scale-page-bounding-client-rect.html [ Pass F
 
 webkit.org/b/295559 [ Release ] media/video-unmuted-after-play-holds-sleep-assertion.html [ Pass Failure ]
 
-# webkit.org/b/295597 REGRESSION (296274@main): 14X media layout tests are encountering CONSOLE MESSAGE: A capture MediaStreamTrack was destroyed without having been stopped explicitly
-[ Debug ] fast/mediastream/getUserMedia-deny-persistency3.html [ Pass Failure ]
-[ Debug ] fast/mediastream/overconstrainederror-constraint.html [ Pass Failure ]
-fast/mediastream/play-newly-added-audio-track.html [ Pass Failure ]
-imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-timing.https.sub.html [ Pass Failure ]
-[ Release ] fast/mediastream/get-user-media-device-id.html [ Pass Failure ]
-[ Release ] fast/mediastream/stream-switch.html [ Pass Failure ]
-fast/mediastream/captureInGPUProcess.html [ Pass Failure ]
-fast/mediastream/getUserMedia-default.html [ Pass Failure ]
-[ Release ] fast/mediastream/mediastreamtrack-clone-muted.html [ Pass Failure ]
-imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-applyConstraints.https.html [ Pass Failure ]
-fast/mediastream/MediaDevices-getUserMedia.html [ Pass Failure ]
-http/tests/webrtc/audioSessionInFrames.html [ Pass Failure ]
-
 webkit.org/b/295604 http/tests/blink/sendbeacon/beacon-cookie.html [ Pass Failure ]
 
 # rdar://148125924 (REGRESSION(291405@Main?): [ OS 26 ] apple-visual-effects/apple-visual-effect-parsing.html is a constant text failure)

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2205,22 +2205,6 @@ webkit.org/b/295441 [ Release ] fast/scrolling/mac/scrollbars/scrollbar-width-dy
 
 webkit.org/b/295527 fast/animation/css-animation-resuming-when-visible-with-style-change2.html [ Pass Failure ]
 
-webkit.org/b/295563 [ Release x86_64 ] fast/webgpu/accelerated-image-conversion-failure.html [ Pass Failure ]
-
-# webkit.org/b/295597 REGRESSION (296274@main): 14X media layout tests are encountering CONSOLE MESSAGE: A capture MediaStreamTrack was destroyed without having been stopped explicitly
-[ Release ] fast/mediastream/getUserMedia-deny-persistency.html [ Pass Failure ]
-[ Release ] fast/mediastream/getUserMedia-deny-persistency3.html [ Pass Failure ]
-[ Release ] fast/mediastream/getUserMedia-grant-persistency.html [ Pass Failure ]
-[ Release ] fast/mediastream/overconstrainederror-constraint.html [ Pass Failure ]
-fast/mediastream/play-newly-added-audio-track.html [ Pass Failure ]
-imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-timing.https.sub.html [ Pass Failure ]
-fast/mediastream/get-user-media-device-id.html [ Pass Failure ]
-[ Release ] fast/mediastream/captureInGPUProcess.html [ Pass Failure ]
-fast/mediastream/getUserMedia-default.html [ Pass Failure ]
-imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-applyConstraints.https.html [ Pass Failure ]
-fast/mediastream/MediaDevices-getUserMedia.html [ Pass Failure ]
-http/tests/webrtc/audioSessionInFrames.html [ Pass Failure ]
-
 webkit.org/b/295738 [ arm64 ] http/tests/images/gif-progressive-load.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/295743 [ Debug ] media/video-display-aspect-ratio.html [ Pass Failure ]


### PR DESCRIPTION
#### fe8fd40757a0c3b898e1d665538b8a66dc066d46
<pre>
REGRESSION (296274@main): 14X media layout tests are encountering CONSOLE MESSAGE: A capture MediaStreamTrack was destroyed without having been stopped explicitly
<a href="https://rdar.apple.com/155363544">rdar://155363544</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=295597">https://bugs.webkit.org/show_bug.cgi?id=295597</a>

Reviewed by Eric Carlson.

Explictly stop tracks where possible and otherwise use DumpJSConsoleLogInStderr for WPT tests.

* LayoutTests/TestExpectations:
* LayoutTests/fast/mediastream/MediaDevices-getUserMedia.html:
* LayoutTests/fast/mediastream/captureInGPUProcess.html:
* LayoutTests/fast/mediastream/get-user-media-device-id.html:
* LayoutTests/fast/mediastream/getUserMedia-default.html:
* LayoutTests/fast/mediastream/getUserMedia-deny-persistency.html:
* LayoutTests/fast/mediastream/getUserMedia-deny-persistency3.html:
* LayoutTests/fast/mediastream/getUserMedia-grant-persistency.html:
* LayoutTests/fast/mediastream/mediastreamtrack-clone-muted.html:
* LayoutTests/fast/mediastream/overconstrainederror-constraint.html:
* LayoutTests/fast/mediastream/play-newly-added-audio-track.html:
* LayoutTests/fast/mediastream/stream-switch.html:
* LayoutTests/http/tests/webrtc/audioSessionInFrames.html:

Canonical link: <a href="https://commits.webkit.org/297265@main">https://commits.webkit.org/297265@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4e4879f5f8ef9604f8af40ca7b1f71dfadd5c8e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111112 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30778 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21209 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117143 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61380 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31459 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39360 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84471 "Found 1 new test failure: fast/mediastream/stream-switch.html (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114059 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25137 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100036 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64917 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24481 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18180 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60963 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94517 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18244 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120077 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38161 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28361 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93412 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38537 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96311 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93236 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23757 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38320 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16059 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34144 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38050 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37714 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41048 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39417 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->