### PR TITLE
Unnecessary calls to hasAvailableFrameCallback

### DIFF
--- a/LayoutTests/media/media-source/media-source-rvfc-paused-offscreen.html
+++ b/LayoutTests/media/media-source/media-source-rvfc-paused-offscreen.html
@@ -1,7 +1,7 @@
 <html>
 <head>
 <title>requestVideoFrameCallback with paused MSE while offscreen</title>
-<script src="../resources/testharness.js"></script>
+<script src="../../resources/testharness.js"></script>
 <script src="../video-test.js"></script>
 <script src="../utilities.js"></script>
 <script>

--- a/LayoutTests/media/media-source/media-source-rvfc-paused.html
+++ b/LayoutTests/media/media-source/media-source-rvfc-paused.html
@@ -1,7 +1,7 @@
 <html>
 <head>
 <title>requestVideoFrameCallback with paused MSE</title>
-<script src="../resources/testharness.js"></script>
+<script src="../../resources/testharness.js"></script>
 <script src="../video-test.js"></script>
 <script src="../utilities.js"></script>
 <script>

--- a/LayoutTests/media/media-source/media-source-rvfc-playing-offscreen.html
+++ b/LayoutTests/media/media-source/media-source-rvfc-playing-offscreen.html
@@ -1,7 +1,7 @@
 <html>
 <head>
 <title>requestVideoFrameCallback with playing MSE in offscreen video element</title>
-<script src="../resources/testharness.js"></script>
+<script src="../../resources/testharness.js"></script>
 <script src="../video-test.js"></script>
 <script src="../utilities.js"></script>
 <script>

--- a/LayoutTests/media/media-source/media-source-rvfc-playing.html
+++ b/LayoutTests/media/media-source/media-source-rvfc-playing.html
@@ -1,7 +1,7 @@
 <html>
 <head>
 <title>requestVideoFrameCallback with playing MSE</title>
-<script src="../resources/testharness.js"></script>
+<script src="../../resources/testharness.js"></script>
 <script src="../video-test.js"></script>
 <script src="../utilities.js"></script>
 <script>

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -318,6 +318,7 @@ private:
     bool playAtHostTime(const MonotonicTime&) final;
     bool pauseAtHostTime(const MonotonicTime&) final;
 
+    void setVideoFrameMetadataGatheringCallbackIfNeeded(VideoMediaSampleRenderer&);
     void startVideoFrameMetadataGathering() final;
     void stopVideoFrameMetadataGathering() final;
     std::optional<VideoFrameMetadata> videoFrameMetadata() final { return std::exchange(m_videoFrameMetadata, { }); }

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -256,6 +256,7 @@ private:
     void setVideoRenderer(WebSampleBufferVideoRendering *);
     void stageVideoRenderer(WebSampleBufferVideoRendering *);
 
+    void setVideoFrameMetadataGatheringCallbackIfNeeded(VideoMediaSampleRenderer&);
     void startVideoFrameMetadataGathering() final;
     void stopVideoFrameMetadataGathering() final;
     std::optional<VideoFrameMetadata> videoFrameMetadata() final { return std::exchange(m_videoFrameMetadata, { }); }

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
@@ -75,6 +75,7 @@ public:
     void enqueueSample(const MediaSample&, const MediaTime&);
     void stopRequestingMediaData();
 
+    void notifyFirstFrameAvailable(Function<void(const MediaTime&, double)>&&);
     void notifyWhenHasAvailableVideoFrame(Function<void(const MediaTime&, double)>&&);
     void notifyWhenDecodingErrorOccurred(Function<void(OSStatus)>&&);
     void notifyWhenVideoRendererRequiresFlushToResumeDecoding(Function<void()>&&);
@@ -180,6 +181,7 @@ private:
     std::optional<CMTime> m_lastDisplayedSample WTF_GUARDED_BY_CAPABILITY(dispatcher().get());
     std::optional<CMTime> m_nextScheduledPurge WTF_GUARDED_BY_CAPABILITY(dispatcher().get());
 
+    bool m_notifiedFirstFrameAvailable WTF_GUARDED_BY_CAPABILITY(dispatcher().get()) { false };
     bool m_waitingForMoreMediaData WTF_GUARDED_BY_CAPABILITY(dispatcher().get()) { false };
     Function<void()> m_readyForMoreMediaDataFunction WTF_GUARDED_BY_CAPABILITY(mainThread);
     Preferences m_preferences;
@@ -200,7 +202,9 @@ private:
     // Protected samples
     bool m_wasProtected { false };
 
+    Function<void(const MediaTime&, double)> m_hasFirstFrameAvailableCallback WTF_GUARDED_BY_CAPABILITY(mainThread);
     Function<void(const MediaTime&, double)> m_hasAvailableFrameCallback WTF_GUARDED_BY_CAPABILITY(mainThread);
+    std::atomic<bool> m_notifyWhenHasAvailableVideoFrame { false };
     Function<void(OSStatus)> m_errorOccurredFunction WTF_GUARDED_BY_CAPABILITY(mainThread);
     Function<void()> m_rendererNeedsFlushFunction WTF_GUARDED_BY_CAPABILITY(mainThread);
     ProcessIdentity m_resourceOwner;


### PR DESCRIPTION
#### d392a868cc16eb889541f2c9716f5bee99db44db
<pre>
Unnecessary calls to hasAvailableFrameCallback
<a href="https://bugs.webkit.org/show_bug.cgi?id=295704">https://bugs.webkit.org/show_bug.cgi?id=295704</a>
<a href="https://rdar.apple.com/155519872">rdar://155519872</a>

Reviewed by Youenn Fablet.

hasAvailableFrameCallback was called whenever we render a frame on screen with no exception.

This callback is used for two purposes:
1- Let the MediaPlayerPrivate knows that the first frame has been decoded and rendered
2- When gathering frame metadata due to a call to requestVideoFrameCallback

1- is only required once after a flush
2- is only required if the JS has used requestVideoFrameCallback API.

We optimise the code to only call hasAvailableFrameCallback when needed only
by creating two callbacks that can be set, the first to be notified when the
first frame has been queued for rendering, and the second to be notified
after every single frame being rendered.

No change in observable behaviour, covered by existing tests.

* LayoutTests/media/media-source/media-source-rvfc-paused-offscreen.html: Fix incorrect include path.
* LayoutTests/media/media-source/media-source-rvfc-paused.html: ditto
* LayoutTests/media/media-source/media-source-rvfc-playing-offscreen.html: ditto
* LayoutTests/media/media-source/media-source-rvfc-playing.html: ditto

Canonical link: <a href="https://commits.webkit.org/297330@main">https://commits.webkit.org/297330@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f89ac8993d2236c4fa905e4885bef8684cf6923

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31072 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117438 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61674 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113368 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31753 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39654 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84668 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114353 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25349 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100284 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65115 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24694 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18421 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61258 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94735 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18487 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120644 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38455 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28575 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93592 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38831 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96554 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93416 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23798 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38523 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16294 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34483 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38344 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43821 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38009 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41342 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39711 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->