### PR TITLE
[GStreamer][WebRTC] Applying RTP packetizer encoding parameters leads to flaky warnings in rtpfunnel

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.cpp
@@ -304,25 +304,7 @@ void GStreamerRTPPacketizer::stopUpdatingStats()
 void GStreamerRTPPacketizer::applyEncodingParameters(const GstStructure* encodingParameters) const
 {
     ASSERT(encodingParameters);
-
     configure(encodingParameters);
-
-    auto isActive = gstStructureGet<bool>(encodingParameters, "active"_s).value_or(true);
-    GST_DEBUG_OBJECT(m_bin.get(), "Packetizer is active: %s", boolForPrinting(isActive));
-    g_object_set(m_valve.get(), "drop", !isActive, nullptr);
-    if (isActive)
-        return;
-
-    auto srcPad = adoptGRef(gst_element_get_static_pad(m_bin.get(), "src"));
-    if (!srcPad)
-        return;
-
-    auto peer = adoptGRef(gst_pad_get_peer(srcPad.get()));
-    if (!peer)
-        return;
-
-    gst_pad_send_event(peer.get(), gst_event_new_flush_start());
-    gst_pad_send_event(peer.get(), gst_event_new_flush_stop(FALSE));
 }
 
 void GStreamerRTPPacketizer::reconfigure(GUniquePtr<GstStructure>&& encodingParameters)


### PR DESCRIPTION
#### 30233b64c4ade0c63efae04688674b38ccddce00
<pre>
[GStreamer][WebRTC] Applying RTP packetizer encoding parameters leads to flaky warnings in rtpfunnel
<a href="https://bugs.webkit.org/show_bug.cgi?id=295706">https://bugs.webkit.org/show_bug.cgi?id=295706</a>

Reviewed by Xabier Rodriguez-Calvar.

Pushing flush events out of the blue wasn&apos;t a good idea, leading to situations where the connected
rtpfunnel sink pad receives a buffer just after the sticky events were removed. Let&apos;s try without
flush for now and re-visit this later if needed.

* Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.cpp:
(WebCore::GStreamerRTPPacketizer::applyEncodingParameters const):

Canonical link: <a href="https://commits.webkit.org/297253@main">https://commits.webkit.org/297253@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9fc6fbaa0b20a0b4d086649c5821a2e568fa2ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110909 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30572 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21007 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116954 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61177 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112872 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31252 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39158 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84339 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113857 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24969 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99863 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64783 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24321 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18005 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60737 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94356 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18066 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119741 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37954 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28206 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93284 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38330 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96136 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93109 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23750 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38159 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15901 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33940 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37847 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43318 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37510 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40846 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39215 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->