### PR TITLE
[Style] Convert grid-template-areas to use strong style types

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -109,6 +109,7 @@ set(WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/css/values/color-adjust"
     "${WEBCORE_DIR}/css/values/easing"
     "${WEBCORE_DIR}/css/values/filter-effects"
+    "${WEBCORE_DIR}/css/values/grid"
     "${WEBCORE_DIR}/css/values/images"
     "${WEBCORE_DIR}/css/values/motion"
     "${WEBCORE_DIR}/css/values/primitives"

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1024,6 +1024,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     css/values/color-adjust/CSSColorScheme.h
 
+    css/values/grid/CSSGridNamedAreaMap.h
+    css/values/grid/CSSGridTemplateAreas.h
+
     css/values/images/CSSGradient.h
 
     css/values/motion/CSSRayFunction.h
@@ -2775,6 +2778,10 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     style/values/flexbox/StyleFlexBasis.h
 
+    style/values/grid/StyleGridNamedAreaMap.h
+    style/values/grid/StyleGridNamedLinesMap.h
+    style/values/grid/StyleGridOrderedNamedLinesMap.h
+    style/values/grid/StyleGridTemplateAreas.h
     style/values/grid/StyleGridTrackBreadth.h
 
     style/values/images/StyleGradient.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1156,6 +1156,7 @@ css/values/color/CSSKeywordColor.cpp
 css/values/color/CSSLightDarkColor.cpp
 css/values/color/CSSPlatformColorResolutionState.cpp
 css/values/color/CSSResolvedColor.cpp
+css/values/grid/CSSGridNamedAreaMap.cpp
 css/values/images/CSSGradient.cpp
 css/values/motion/CSSRayFunction.cpp
 css/values/primitives/CSSPosition.cpp
@@ -3176,6 +3177,8 @@ style/values/filter-effects/StyleOpacityFunction.cpp
 style/values/filter-effects/StyleSaturateFunction.cpp
 style/values/filter-effects/StyleSepiaFunction.cpp
 style/values/flexbox/StyleFlexBasis.cpp
+style/values/grid/StyleGridNamedLinesMap.cpp
+style/values/grid/StyleGridTemplateAreas.cpp
 style/values/images/StyleGradient.cpp
 style/values/masking/StyleClipPath.cpp
 style/values/motion/StyleOffsetAnchor.cpp

--- a/Source/WebCore/css/CSSGridTemplateAreasValue.cpp
+++ b/Source/WebCore/css/CSSGridTemplateAreasValue.cpp
@@ -32,7 +32,6 @@
 #include "config.h"
 #include "CSSGridTemplateAreasValue.h"
 
-#include "GridArea.h"
 #include <wtf/FixedVector.h>
 #include <wtf/HashSet.h>
 #include <wtf/text/StringBuilder.h>
@@ -40,41 +39,33 @@
 
 namespace WebCore {
 
-CSSGridTemplateAreasValue::CSSGridTemplateAreasValue(NamedGridAreaMap map, size_t rowCount, size_t columnCount)
+CSSGridTemplateAreasValue::CSSGridTemplateAreasValue(CSS::GridTemplateAreas&& areas)
     : CSSValue(ClassType::GridTemplateAreas)
-    , m_map(WTFMove(map))
-    , m_rowCount(rowCount)
-    , m_columnCount(columnCount)
+    , m_areas(WTFMove(areas))
 {
-    ASSERT(m_rowCount);
-    ASSERT(m_columnCount);
+    ASSERT(m_areas.map.rowCount);
+    ASSERT(m_areas.map.columnCount);
 }
 
-Ref<CSSGridTemplateAreasValue> CSSGridTemplateAreasValue::create(NamedGridAreaMap map, size_t rowCount, size_t columnCount)
+CSSGridTemplateAreasValue::CSSGridTemplateAreasValue(const CSS::GridTemplateAreas& areas)
+    : CSSGridTemplateAreasValue { CSS::GridTemplateAreas { areas } }
 {
-    return adoptRef(*new CSSGridTemplateAreasValue(WTFMove(map), rowCount, columnCount));
 }
 
-static String stringForPosition(const NamedGridAreaMap& gridAreaMap, size_t row, size_t column)
+Ref<CSSGridTemplateAreasValue> CSSGridTemplateAreasValue::create(CSS::GridTemplateAreas&& areas)
 {
-    HashSet<String> candidates;
-    for (auto& it : gridAreaMap.map) {
-        auto& area = it.value;
-        if (row >= area.rows.startLine() && row < area.rows.endLine())
-            candidates.add(it.key);
-    }
-    for (auto& it : gridAreaMap.map) {
-        auto& area = it.value;
-        if (column >= area.columns.startLine() && column < area.columns.endLine() && candidates.contains(it.key))
-            return it.key;
-    }
-    return "."_s;
+    return adoptRef(*new CSSGridTemplateAreasValue(WTFMove(areas)));
+}
+
+Ref<CSSGridTemplateAreasValue> CSSGridTemplateAreasValue::create(const CSS::GridTemplateAreas& areas)
+{
+    return adoptRef(*new CSSGridTemplateAreasValue(areas));
 }
 
 String CSSGridTemplateAreasValue::stringForRow(size_t row) const
 {
-    FixedVector<String> columns(m_columnCount);
-    for (auto& it : m_map.map) {
+    FixedVector<String> columns(m_areas.map.columnCount);
+    for (auto& it : m_areas.map.map) {
         auto& area = it.value;
         if (row >= area.rows.startLine() && row < area.rows.endLine()) {
             for (unsigned i = area.columns.startLine(); i < area.columns.endLine(); i++)
@@ -95,26 +86,14 @@ String CSSGridTemplateAreasValue::stringForRow(size_t row) const
     return builder.toString();
 }
 
-String CSSGridTemplateAreasValue::customCSSText(const CSS::SerializationContext&) const
+String CSSGridTemplateAreasValue::customCSSText(const CSS::SerializationContext& context) const
 {
-    StringBuilder builder;
-    for (size_t row = 0; row < m_rowCount; ++row) {
-        builder.append('"');
-        for (size_t column = 0; column < m_columnCount; ++column) {
-            builder.append(stringForPosition(m_map, row, column));
-            if (column != m_columnCount - 1)
-                builder.append(' ');
-        }
-        builder.append('"');
-        if (row != m_rowCount - 1)
-            builder.append(' ');
-    }
-    return builder.toString();
+    return CSS::serializationForCSS(context, m_areas);
 }
 
 bool CSSGridTemplateAreasValue::equals(const CSSGridTemplateAreasValue& other) const
 {
-    return m_map.map == other.m_map.map && m_rowCount == other.m_rowCount && m_columnCount == other.m_columnCount;
+    return m_areas == other.m_areas;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSGridTemplateAreasValue.h
+++ b/Source/WebCore/css/CSSGridTemplateAreasValue.h
@@ -31,31 +31,28 @@
 
 #pragma once
 
+#include "CSSGridTemplateAreas.h"
 #include "CSSValue.h"
-#include "GridArea.h"
 
 namespace WebCore {
 
 class CSSGridTemplateAreasValue final : public CSSValue {
 public:
-    static Ref<CSSGridTemplateAreasValue> create(NamedGridAreaMap, size_t rowCount, size_t columnCount);
+    static Ref<CSSGridTemplateAreasValue> create(CSS::GridTemplateAreas&&);
+    static Ref<CSSGridTemplateAreasValue> create(const CSS::GridTemplateAreas&);
+
+    const CSS::GridTemplateAreas& areas() const { return m_areas; }
 
     String customCSSText(const CSS::SerializationContext&) const;
-
-    const NamedGridAreaMap& gridAreaMap() const { return m_map; }
-    size_t rowCount() const { return m_rowCount; }
-    size_t columnCount() const { return m_columnCount; }
-
     bool equals(const CSSGridTemplateAreasValue&) const;
 
     String stringForRow(size_t row) const;
 
 private:
-    CSSGridTemplateAreasValue(NamedGridAreaMap, size_t rowCount, size_t columnCount);
+    explicit CSSGridTemplateAreasValue(CSS::GridTemplateAreas&&);
+    explicit CSSGridTemplateAreasValue(const CSS::GridTemplateAreas&);
 
-    NamedGridAreaMap m_map;
-    size_t m_rowCount;
-    size_t m_columnCount;
+    CSS::GridTemplateAreas m_areas;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -10132,10 +10132,7 @@
             "animation-type": "discrete",
             "initial": "none",
             "codegen-properties": {
-                "animation-wrapper": "GridTemplateAreasWrapper",
-                "animation-wrapper-requires-override-parameters": [],
-                "style-builder-custom": "All",
-                "style-extractor-custom": true,
+                "style-converter": "StyleType<GridTemplateAreas>",
                 "parser-function": "consumeGridTemplateAreas",
                 "parser-grammar-unused": "none | <string>+",
                 "parser-grammar-unused-reason": "Needs support for nested grammars in <string> values."

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.h
@@ -33,11 +33,10 @@ class CSSGridLineNamesValue;
 class CSSParserTokenRange;
 class CSSValue;
 
-struct NamedGridAreaMap;
-
 enum CSSValueID : uint16_t;
 
 namespace CSS {
+struct GridNamedAreaMap;
 struct PropertyParserState;
 }
 
@@ -49,7 +48,7 @@ enum class AllowEmpty : bool { No, Yes };
 enum TrackListType : uint8_t { GridTemplate, GridTemplateNoRepeat, GridAuto };
 
 bool isGridBreadthIdent(CSSValueID);
-bool parseGridTemplateAreasRow(StringView gridRowNames, NamedGridAreaMap&, size_t rowCount, size_t& columnCount);
+bool parseGridTemplateAreasRow(StringView gridRowNames, CSS::GridNamedAreaMap&);
 RefPtr<CSSGridLineNamesValue> consumeGridLineNames(CSSParserTokenRange&, CSS::PropertyParserState&, AllowEmpty = AllowEmpty::No);
 RefPtr<CSSValue> consumeGridLine(CSSParserTokenRange&, CSS::PropertyParserState&);
 RefPtr<CSSValue> consumeGridTrackSize(CSSParserTokenRange&, CSS::PropertyParserState&);

--- a/Source/WebCore/css/parser/CSSPropertyParserCustom.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserCustom.h
@@ -1417,9 +1417,7 @@ inline bool PropertyParserCustom::consumeGridTemplateShorthand(CSSParserTokenRan
 
     range = rangeCopy;
 
-    NamedGridAreaMap gridAreaMap;
-    size_t rowCount = 0;
-    size_t columnCount = 0;
+    CSS::GridNamedAreaMap gridAreaMap;
     CSSValueListBuilder templateRows;
 
     // Persists between loop iterations so we can use the same value for
@@ -1441,9 +1439,8 @@ inline bool PropertyParserCustom::consumeGridTemplateShorthand(CSSParserTokenRan
         }
 
         // Handle a template-area's row.
-        if (range.peek().type() != StringToken || !parseGridTemplateAreasRow(range.consumeIncludingWhitespace().value(), gridAreaMap, rowCount, columnCount))
+        if (range.peek().type() != StringToken || !parseGridTemplateAreasRow(range.consumeIncludingWhitespace().value(), gridAreaMap))
             return false;
-        ++rowCount;
 
         // Handle template-rows's track-size.
         if (RefPtr value = consumeGridTrackSize(range, state))
@@ -1469,7 +1466,7 @@ inline bool PropertyParserCustom::consumeGridTemplateShorthand(CSSParserTokenRan
     }
     result.addPropertyForCurrentShorthand(state, CSSPropertyGridTemplateRows, CSSValueList::createSpaceSeparated(WTFMove(templateRows)));
     result.addPropertyForCurrentShorthand(state, CSSPropertyGridTemplateColumns, columnsValue.releaseNonNull());
-    result.addPropertyForCurrentShorthand(state, CSSPropertyGridTemplateAreas, CSSGridTemplateAreasValue::create(gridAreaMap, rowCount, columnCount));
+    result.addPropertyForCurrentShorthand(state, CSSPropertyGridTemplateAreas, CSSGridTemplateAreasValue::create({ WTFMove(gridAreaMap) }));
     return true;
 }
 

--- a/Source/WebCore/css/values/grid/CSSGridNamedAreaMap.cpp
+++ b/Source/WebCore/css/values/grid/CSSGridNamedAreaMap.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSGridNamedAreaMap.h"
+
+#include "CSSSerializationContext.h"
+#include <wtf/text/StringBuilder.h>
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+namespace CSS {
+
+static void serializeGridNamedAreaMapPosition(StringBuilder& builder, const GridNamedAreaMap::Map& map, size_t row, size_t column)
+{
+    HashSet<String> candidates;
+    for (auto& [name, area] : map) {
+        if (row >= area.rows.startLine() && row < area.rows.endLine())
+            candidates.add(name);
+    }
+    for (auto& [name, area] : map) {
+        if (column >= area.columns.startLine() && column < area.columns.endLine() && candidates.contains(name)) {
+            builder.append(name);
+            return;
+        }
+    }
+    builder.append('.');
+}
+
+void Serialize<GridNamedAreaMap>::operator()(StringBuilder& builder, const CSS::SerializationContext&, const GridNamedAreaMap& value)
+{
+    for (size_t row = 0; row < value.rowCount; ++row) {
+        builder.append('"');
+        for (size_t column = 0; column < value.columnCount; ++column) {
+            serializeGridNamedAreaMapPosition(builder, value.map, row, column);
+            if (column != value.columnCount - 1)
+                builder.append(' ');
+        }
+        builder.append('"');
+        if (row != value.rowCount - 1)
+            builder.append(' ');
+    }
+}
+
+TextStream& operator<<(TextStream& ts, const GridNamedAreaMap& value)
+{
+    return ts << serializationForCSS(defaultSerializationContext(), value);
+}
+
+} // namespace CSS
+} // namespace WebCore

--- a/Source/WebCore/css/values/grid/CSSGridNamedAreaMap.h
+++ b/Source/WebCore/css/values/grid/CSSGridNamedAreaMap.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSValueTypes.h"
+#include "GridArea.h"
+#include <wtf/HashMap.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+namespace CSS {
+
+// Parsed representation of the `<string>+` of <'grid-template-areas'>.
+struct GridNamedAreaMap {
+    using Map = HashMap<String, GridArea>;
+
+    Map map;
+    size_t rowCount { 0 };
+    size_t columnCount { 0 };
+
+    bool operator==(const GridNamedAreaMap&) const = default;
+};
+
+template<> struct Serialize<GridNamedAreaMap> { void operator()(StringBuilder&, const CSS::SerializationContext&, const GridNamedAreaMap&); };
+
+WTF::TextStream& operator<<(WTF::TextStream&, const GridNamedAreaMap&);
+
+} // namespace CSS
+} // namespace WebCore

--- a/Source/WebCore/css/values/grid/CSSGridTemplateAreas.h
+++ b/Source/WebCore/css/values/grid/CSSGridTemplateAreas.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSGridNamedAreaMap.h"
+#include "CSSValueTypes.h"
+
+namespace WebCore {
+namespace CSS {
+
+// <'grid-template-areas'> = none | <string>+
+// https://drafts.csswg.org/css-grid/#propdef-grid-template-areas
+struct GridTemplateAreas {
+    GridNamedAreaMap map;
+
+    GridTemplateAreas(CSS::Keyword::None)
+        : map { }
+    {
+    }
+
+    GridTemplateAreas(const GridNamedAreaMap& map)
+        : map { map }
+    {
+    }
+
+    GridTemplateAreas(GridNamedAreaMap&& map)
+        : map { WTFMove(map) }
+    {
+    }
+
+    bool isNone() const { return !map.rowCount; }
+
+    template<typename... F> decltype(auto) switchOn(F&&... f) const
+    {
+        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
+
+        if (isNone())
+            return visitor(CSS::Keyword::None { });
+        return visitor(map);
+    }
+
+    bool operator==(const GridTemplateAreas&) const = default;
+};
+
+} // namespace CSS
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::CSS::GridTemplateAreas);

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -1473,12 +1473,12 @@ static Vector<String> authoredGridTrackSizes(Node* node, GridTrackSizingDirectio
     return trackSizes;
 }
 
-static OrderedNamedGridLinesMap gridLineNames(const RenderStyle* renderStyle, GridTrackSizingDirection direction, unsigned expectedLineCount)
+static Style::GridOrderedNamedLinesMap gridLineNames(const RenderStyle* renderStyle, GridTrackSizingDirection direction, unsigned expectedLineCount)
 {
     if (!renderStyle)
         return { };
     
-    OrderedNamedGridLinesMap combinedGridLineNames;
+    Style::GridOrderedNamedLinesMap combinedGridLineNames;
     auto appendLineNames = [&](unsigned index, const Vector<String>& newNames) {
         if (auto result = combinedGridLineNames.map.add(index, newNames); !result.isNewEntry)
             result.iterator->value.appendVector(newNames);
@@ -1498,7 +1498,7 @@ static OrderedNamedGridLinesMap gridLineNames(const RenderStyle* renderStyle, Gr
         ++autoRepeatIndex;
     }
 
-    auto implicitGridLineNames = direction == GridTrackSizingDirection::ForColumns ? renderStyle->implicitNamedGridColumnLines() : renderStyle->implicitNamedGridRowLines();
+    auto& implicitGridLineNames = direction == GridTrackSizingDirection::ForColumns ? renderStyle->gridTemplateAreas().implicitNamedGridColumnLines : renderStyle->gridTemplateAreas().implicitNamedGridRowLines;
     for (auto& [name, indexes] : implicitGridLineNames.map) {
         for (auto i : indexes)
             appendLineNames(i, {name});
@@ -1833,10 +1833,7 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
     }
 
     if (gridOverlay.config.showAreaNames && !renderGrid.isMasonry()) {
-        for (auto& gridArea : node->renderStyle()->namedGridArea().map) {
-            auto& name = gridArea.key;
-            auto& area = gridArea.value;
-
+        for (auto& [name, area] : node->renderStyle()->gridTemplateAreas().map.map) {
             // Named grid areas will always be rectangular per the CSS Grid specification.
             auto columnStartLine = columnLineAt(columnPositions[area.columns.startLine()]);
             auto columnEndLine = columnLineAt(columnPositions[area.columns.endLine() - 1] + columnWidths[area.columns.endLine() - 1]);

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -195,8 +195,8 @@ bool RenderGrid::explicitGridDidResize(const RenderStyle& oldStyle) const
 {
     return oldStyle.gridColumnTrackSizes().size() != style().gridColumnTrackSizes().size()
         || oldStyle.gridRowTrackSizes().size() != style().gridRowTrackSizes().size()
-        || oldStyle.namedGridAreaColumnCount() != style().namedGridAreaColumnCount()
-        || oldStyle.namedGridAreaRowCount() != style().namedGridAreaRowCount()
+        || oldStyle.gridTemplateAreas().map.columnCount != style().gridTemplateAreas().map.columnCount
+        || oldStyle.gridTemplateAreas().map.rowCount != style().gridTemplateAreas().map.rowCount
         || oldStyle.gridAutoRepeatColumns().size() != style().gridAutoRepeatColumns().size()
         || oldStyle.gridAutoRepeatRows().size() != style().gridAutoRepeatRows().size();
 }
@@ -209,8 +209,8 @@ bool RenderGrid::namedGridLinesDefinitionDidChange(const RenderStyle& oldStyle) 
 
 bool RenderGrid::implicitGridLinesDefinitionDidChange(const RenderStyle& oldStyle) const
 {
-    return oldStyle.implicitNamedGridRowLines().map != style().implicitNamedGridRowLines().map
-        || oldStyle.implicitNamedGridColumnLines().map != style().implicitNamedGridColumnLines().map;
+    return oldStyle.gridTemplateAreas().implicitNamedGridRowLines != style().gridTemplateAreas().implicitNamedGridRowLines
+        || oldStyle.gridTemplateAreas().implicitNamedGridColumnLines != style().gridTemplateAreas().implicitNamedGridColumnLines;
 }
 
 // This method optimizes the gutters computation by skipping the available size

--- a/Source/WebCore/rendering/style/GridArea.h
+++ b/Source/WebCore/rendering/style/GridArea.h
@@ -31,11 +31,8 @@
 
 #pragma once
 
-#include "GridPosition.h"
 #include "GridSpan.h"
-#include <wtf/HashMap.h>
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
@@ -43,7 +40,7 @@ namespace WebCore {
 class GridArea {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(GridArea);
 public:
-    // HashMap requires a default constuctor.
+    // HashMap requires a default constructor.
     GridArea()
         : columns(GridSpan::indefiniteGridSpan())
         , rows(GridSpan::indefiniteGridSpan())
@@ -56,19 +53,10 @@ public:
     {
     }
 
-    bool operator==(const GridArea& o) const
-    {
-        return columns == o.columns && rows == o.rows;
-    }
+    bool operator==(const GridArea&) const = default;
 
     GridSpan columns;
     GridSpan rows;
-};
-
-struct NamedGridAreaMap {
-    HashMap<String, GridArea> map;
-
-    friend bool operator==(const NamedGridAreaMap&, const NamedGridAreaMap&) = default;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/GridPositionsResolver.cpp
+++ b/Source/WebCore/rendering/style/GridPositionsResolver.cpp
@@ -80,7 +80,7 @@ static inline GridPositionSide transposedSide(GridPositionSide side)
 
 static std::optional<int> clampedImplicitLineForArea(const RenderStyle& style, const String& name, int min, int max, bool isRowAxis, bool isStartSide)
 {
-    auto& areas = style.namedGridArea().map;
+    auto& areas = style.gridTemplateAreas().map.map;
     auto gridAreaIt = areas.find(name);
     if (gridAreaIt != areas.end()) {
         const GridArea& gridArea = gridAreaIt->value;
@@ -103,7 +103,7 @@ NamedLineCollectionBase::NamedLineCollectionBase(const RenderGrid& initialGrid, 
 
     auto& gridLineNames = (isRowAxis ? gridContainerStyle->namedGridColumnLines() : gridContainerStyle->namedGridRowLines()).map;
     auto& autoRepeatGridLineNames = (isRowAxis ? gridContainerStyle->autoRepeatNamedGridColumnLines() : gridContainerStyle->autoRepeatNamedGridRowLines()).map;
-    auto& implicitGridLineNames = (isRowAxis ? gridContainerStyle->implicitNamedGridColumnLines() : gridContainerStyle->implicitNamedGridRowLines()).map;
+    auto& implicitGridLineNames = (isRowAxis ? gridContainerStyle->gridTemplateAreas().implicitNamedGridColumnLines : gridContainerStyle->gridTemplateAreas().implicitNamedGridRowLines).map;
 
     auto linesIterator = gridLineNames.find(lineName);
     m_namedLinesIndices = linesIterator == gridLineNames.end() ? nullptr : &linesIterator->value;
@@ -401,7 +401,7 @@ unsigned GridPositionsResolver::explicitGridColumnCount(const RenderGrid& gridCo
         GridTrackSizingDirection direction = GridLayoutFunctions::flowAwareDirectionForGridItem(parent, gridContainer, GridTrackSizingDirection::ForColumns);
         return parent.gridSpanForGridItem(gridContainer, direction).integerSpan();
     }
-    return std::min<unsigned>(std::max(gridContainer.style().gridColumnTrackSizes().size() + gridContainer.autoRepeatCountForDirection(GridTrackSizingDirection::ForColumns), gridContainer.style().namedGridAreaColumnCount()), GridPosition::max());
+    return std::min<unsigned>(std::max(gridContainer.style().gridColumnTrackSizes().size() + gridContainer.autoRepeatCountForDirection(GridTrackSizingDirection::ForColumns), gridContainer.style().gridTemplateAreas().map.columnCount), GridPosition::max());
 }
 
 unsigned GridPositionsResolver::explicitGridRowCount(const RenderGrid& gridContainer)
@@ -411,7 +411,7 @@ unsigned GridPositionsResolver::explicitGridRowCount(const RenderGrid& gridConta
         GridTrackSizingDirection direction = GridLayoutFunctions::flowAwareDirectionForGridItem(parent, gridContainer, GridTrackSizingDirection::ForRows);
         return parent.gridSpanForGridItem(gridContainer, direction).integerSpan();
     }
-    return std::min<unsigned>(std::max(gridContainer.style().gridRowTrackSizes().size() + gridContainer.autoRepeatCountForDirection(GridTrackSizingDirection::ForRows), gridContainer.style().namedGridAreaRowCount()), GridPosition::max());
+    return std::min<unsigned>(std::max(gridContainer.style().gridRowTrackSizes().size() + gridContainer.autoRepeatCountForDirection(GridTrackSizingDirection::ForRows), gridContainer.style().gridTemplateAreas().map.rowCount), GridPosition::max());
 }
 
 static unsigned lookAheadForNamedGridLine(int start, unsigned numberOfLines, NamedLineCollection& linesCollection)

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -252,9 +252,6 @@ struct Length;
 struct LengthPoint;
 struct LengthSize;
 struct ListStyleType;
-struct NamedGridAreaMap;
-struct NamedGridLinesMap;
-struct OrderedNamedGridLinesMap;
 struct SingleTimelineRange;
 
 struct ScrollSnapAlign;
@@ -296,6 +293,9 @@ struct CornerShapeValue;
 struct DynamicRangeLimit;
 struct FlexBasis;
 struct GapGutter;
+struct GridNamedLinesMap;
+struct GridOrderedNamedLinesMap;
+struct GridTemplateAreas;
 struct InsetEdge;
 struct MarginEdge;
 struct MaximumSize;
@@ -893,19 +893,15 @@ public:
     inline unsigned gridAutoRepeatRowsInsertionPoint() const;
     inline AutoRepeatType gridAutoRepeatColumnsType() const;
     inline AutoRepeatType gridAutoRepeatRowsType() const;
-    inline const NamedGridLinesMap& namedGridColumnLines() const;
-    inline const NamedGridLinesMap& namedGridRowLines() const;
-    inline const OrderedNamedGridLinesMap& orderedNamedGridColumnLines() const;
-    inline const OrderedNamedGridLinesMap& orderedNamedGridRowLines() const;
-    inline const NamedGridLinesMap& autoRepeatNamedGridColumnLines() const;
-    inline const NamedGridLinesMap& autoRepeatNamedGridRowLines() const;
-    inline const OrderedNamedGridLinesMap& autoRepeatOrderedNamedGridColumnLines() const;
-    inline const OrderedNamedGridLinesMap& autoRepeatOrderedNamedGridRowLines() const;
-    inline const NamedGridLinesMap& implicitNamedGridColumnLines() const;
-    inline const NamedGridLinesMap& implicitNamedGridRowLines() const;
-    inline const NamedGridAreaMap& namedGridArea() const;
-    inline size_t namedGridAreaRowCount() const;
-    inline size_t namedGridAreaColumnCount() const;
+    inline const Style::GridNamedLinesMap& namedGridColumnLines() const;
+    inline const Style::GridNamedLinesMap& namedGridRowLines() const;
+    inline const Style::GridOrderedNamedLinesMap& orderedNamedGridColumnLines() const;
+    inline const Style::GridOrderedNamedLinesMap& orderedNamedGridRowLines() const;
+    inline const Style::GridNamedLinesMap& autoRepeatNamedGridColumnLines() const;
+    inline const Style::GridNamedLinesMap& autoRepeatNamedGridRowLines() const;
+    inline const Style::GridOrderedNamedLinesMap& autoRepeatOrderedNamedGridColumnLines() const;
+    inline const Style::GridOrderedNamedLinesMap& autoRepeatOrderedNamedGridRowLines() const;
+    inline const Style::GridTemplateAreas& gridTemplateAreas() const;
     inline GridAutoFlow gridAutoFlow() const;
     inline bool gridSubgridRows() const;
     inline bool gridSubgridColumns() const;
@@ -1559,11 +1555,7 @@ public:
     inline void setGridRowList(const GridTrackList&);
     inline void setGridAutoColumns(Vector<GridTrackSize>&&);
     inline void setGridAutoRows(Vector<GridTrackSize>&&);
-    inline void setImplicitNamedGridColumnLines(const NamedGridLinesMap&);
-    inline void setImplicitNamedGridRowLines(const NamedGridLinesMap&);
-    inline void setNamedGridArea(const NamedGridAreaMap&);
-    inline void setNamedGridAreaRowCount(size_t);
-    inline void setNamedGridAreaColumnCount(size_t);
+    inline void setGridTemplateAreas(Style::GridTemplateAreas&&);
     inline void setGridAutoFlow(GridAutoFlow);
     inline void setGridItemColumnStart(const GridPosition&);
     inline void setGridItemColumnEnd(const GridPosition&);
@@ -2197,14 +2189,12 @@ public:
     static inline Vector<GridTrackSize> initialGridAutoColumns();
     static inline Vector<GridTrackSize> initialGridAutoRows();
 
-    static NamedGridAreaMap initialNamedGridArea();
-    static size_t initialNamedGridAreaCount() { return 0; }
+    static Style::GridTemplateAreas initialGridTemplateAreas();
 
-    static NamedGridLinesMap initialNamedGridColumnLines();
-    static NamedGridLinesMap initialNamedGridRowLines();
-
-    static OrderedNamedGridLinesMap initialOrderedNamedGridColumnLines();
-    static OrderedNamedGridLinesMap initialOrderedNamedGridRowLines();
+    static Style::GridNamedLinesMap initialNamedGridColumnLines();
+    static Style::GridNamedLinesMap initialNamedGridRowLines();
+    static Style::GridOrderedNamedLinesMap initialOrderedNamedGridColumnLines();
+    static Style::GridOrderedNamedLinesMap initialOrderedNamedGridRowLines();
 
     static inline GridPosition initialGridItemColumnStart();
     static inline GridPosition initialGridItemColumnEnd();

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -95,10 +95,10 @@ inline Style::Number<CSS::Nonnegative> RenderStyle::aspectRatioHeight() const { 
 inline Style::Number<CSS::Nonnegative> RenderStyle::aspectRatioLogicalHeight() const { return writingMode().isHorizontal() ? aspectRatioHeight() : aspectRatioWidth(); }
 inline Style::Number<CSS::Nonnegative> RenderStyle::aspectRatioLogicalWidth() const { return writingMode().isHorizontal() ? aspectRatioWidth() : aspectRatioHeight(); }
 inline Style::Number<CSS::Nonnegative> RenderStyle::aspectRatioWidth() const { return aspectRatio().width(); }
-inline const NamedGridLinesMap& RenderStyle::autoRepeatNamedGridColumnLines() const { return m_nonInheritedData->rareData->grid->autoRepeatNamedGridColumnLines(); }
-inline const NamedGridLinesMap& RenderStyle::autoRepeatNamedGridRowLines() const { return m_nonInheritedData->rareData->grid->autoRepeatNamedGridRowLines(); }
-inline const OrderedNamedGridLinesMap& RenderStyle::autoRepeatOrderedNamedGridColumnLines() const { return m_nonInheritedData->rareData->grid->autoRepeatOrderedNamedGridColumnLines(); }
-inline const OrderedNamedGridLinesMap& RenderStyle::autoRepeatOrderedNamedGridRowLines() const { return m_nonInheritedData->rareData->grid->autoRepeatOrderedNamedGridRowLines(); }
+inline const Style::GridNamedLinesMap& RenderStyle::autoRepeatNamedGridColumnLines() const { return m_nonInheritedData->rareData->grid->autoRepeatNamedGridColumnLines(); }
+inline const Style::GridNamedLinesMap& RenderStyle::autoRepeatNamedGridRowLines() const { return m_nonInheritedData->rareData->grid->autoRepeatNamedGridRowLines(); }
+inline const Style::GridOrderedNamedLinesMap& RenderStyle::autoRepeatOrderedNamedGridColumnLines() const { return m_nonInheritedData->rareData->grid->autoRepeatOrderedNamedGridColumnLines(); }
+inline const Style::GridOrderedNamedLinesMap& RenderStyle::autoRepeatOrderedNamedGridRowLines() const { return m_nonInheritedData->rareData->grid->autoRepeatOrderedNamedGridRowLines(); }
 inline bool RenderStyle::autoWrap() const { return textWrapMode() != TextWrapMode::NoWrap; }
 inline BackfaceVisibility RenderStyle::backfaceVisibility() const { return static_cast<BackfaceVisibility>(m_nonInheritedData->rareData->backfaceVisibility); }
 inline FillAttachment RenderStyle::backgroundAttachment() const { return backgroundLayers().attachment(); }
@@ -257,6 +257,7 @@ inline const Vector<GridTrackSize>& RenderStyle::gridRowTrackSizes() const { ret
 inline const Vector<GridTrackSize>& RenderStyle::gridTrackSizes(GridTrackSizingDirection direction) const { return direction == GridTrackSizingDirection::ForRows ? m_nonInheritedData->rareData->grid->gridRowTrackSizes() : m_nonInheritedData->rareData->grid->gridColumnTrackSizes(); }
 inline bool RenderStyle::gridSubgridColumns() const { return m_nonInheritedData->rareData->grid->subgridColumns(); }
 inline bool RenderStyle::gridSubgridRows() const { return m_nonInheritedData->rareData->grid->subgridRows(); }
+inline const Style::GridTemplateAreas& RenderStyle::gridTemplateAreas() const { return m_nonInheritedData->rareData->grid->gridTemplateAreas; }
 inline OptionSet<HangingPunctuation> RenderStyle::hangingPunctuation() const { return OptionSet<HangingPunctuation>::fromRaw(m_rareInheritedData->hangingPunctuation); }
 inline bool RenderStyle::hasAnimations() const { return animations() && animations()->size(); }
 inline bool RenderStyle::hasAnimationsOrTransitions() const { return hasAnimations() || hasTransitions(); }
@@ -345,8 +346,6 @@ inline const AtomString& RenderStyle::hyphenationString() const { return m_rareI
 inline Hyphens RenderStyle::hyphens() const { return static_cast<Hyphens>(m_rareInheritedData->hyphens); }
 inline ImageOrientation RenderStyle::imageOrientation() const { return static_cast<ImageOrientation::Orientation>(m_rareInheritedData->imageOrientation); }
 inline ImageRendering RenderStyle::imageRendering() const { return static_cast<ImageRendering>(m_rareInheritedData->imageRendering); }
-inline const NamedGridLinesMap& RenderStyle::implicitNamedGridColumnLines() const { return m_nonInheritedData->rareData->grid->implicitNamedGridColumnLines; }
-inline const NamedGridLinesMap& RenderStyle::implicitNamedGridRowLines() const { return m_nonInheritedData->rareData->grid->implicitNamedGridRowLines; }
 constexpr auto RenderStyle::individualTransformOperations() -> OptionSet<TransformOperationOption> { return { TransformOperationOption::Translate, TransformOperationOption::Rotate, TransformOperationOption::Scale, TransformOperationOption::Offset }; }
 inline const Style::CustomPropertyData& RenderStyle::inheritedCustomProperties() const { return m_rareInheritedData->customProperties.get(); }
 inline Style::AnchorNames RenderStyle::initialAnchorNames() { return CSS::Keyword::None { }; }
@@ -419,6 +418,7 @@ inline GridPosition RenderStyle::initialGridItemRowStart() { return { }; }
 inline GridTrackList RenderStyle::initialGridColumnList() { return { }; }
 inline GridTrackList RenderStyle::initialGridRowList() { return { }; }
 inline Vector<GridTrackSize> RenderStyle::initialGridRowTrackSizes() { return { }; }
+inline Style::GridTemplateAreas RenderStyle::initialGridTemplateAreas() { return CSS::Keyword::None { }; }
 constexpr OptionSet<HangingPunctuation> RenderStyle::initialHangingPunctuation() { return { }; }
 inline const AtomString& RenderStyle::initialHyphenationString() { return nullAtom(); }
 constexpr Hyphens RenderStyle::initialHyphens() { return Hyphens::Manual; }
@@ -450,9 +450,8 @@ constexpr MathStyle RenderStyle::initialMathStyle() { return MathStyle::Normal; 
 inline Style::MaximumSize RenderStyle::initialMaxSize() { return CSS::Keyword::None { }; }
 inline Style::MinimumSize RenderStyle::initialMinSize() { return CSS::Keyword::Auto { }; }
 constexpr NBSPMode RenderStyle::initialNBSPMode() { return NBSPMode::Normal; }
-inline NamedGridAreaMap RenderStyle::initialNamedGridArea() { return { }; }
-inline NamedGridLinesMap RenderStyle::initialNamedGridColumnLines() { return { }; }
-inline NamedGridLinesMap RenderStyle::initialNamedGridRowLines() { return { }; }
+inline Style::GridNamedLinesMap RenderStyle::initialNamedGridColumnLines() { return { }; }
+inline Style::GridNamedLinesMap RenderStyle::initialNamedGridRowLines() { return { }; }
 constexpr ObjectFit RenderStyle::initialObjectFit() { return ObjectFit::Fill; }
 inline LengthPoint RenderStyle::initialObjectPosition() { return { { 50.0f, LengthType::Percent }, { 50.0f, LengthType::Percent } }; }
 inline Style::OffsetAnchor RenderStyle::initialOffsetAnchor() { return CSS::Keyword::Auto { }; }
@@ -460,8 +459,8 @@ inline Style::OffsetDistance RenderStyle::initialOffsetDistance() { return 0_css
 inline Style::OffsetPath RenderStyle::initialOffsetPath() { return CSS::Keyword::None { }; }
 inline Style::OffsetPosition RenderStyle::initialOffsetPosition() { return CSS::Keyword::Normal { }; }
 constexpr Style::OffsetRotate RenderStyle::initialOffsetRotate() { return CSS::Keyword::Auto { }; }
-inline OrderedNamedGridLinesMap RenderStyle::initialOrderedNamedGridColumnLines() { return { }; }
-inline OrderedNamedGridLinesMap RenderStyle::initialOrderedNamedGridRowLines() { return { }; }
+inline Style::GridOrderedNamedLinesMap RenderStyle::initialOrderedNamedGridColumnLines() { return { }; }
+inline Style::GridOrderedNamedLinesMap RenderStyle::initialOrderedNamedGridRowLines() { return { }; }
 constexpr OverflowAnchor RenderStyle::initialOverflowAnchor() { return OverflowAnchor::Auto; }
 inline OverflowContinue RenderStyle::initialOverflowContinue() { return OverflowContinue::Auto; }
 constexpr OutlineStyle RenderStyle::initialOutlineStyle() { return OutlineStyle::None; }
@@ -660,11 +659,8 @@ inline size_t RenderStyle::maxLines() const { return m_nonInheritedData->rareDat
 inline const Style::MaximumSize& RenderStyle::maxWidth() const { return m_nonInheritedData->boxData->maxWidth(); }
 inline const Style::MinimumSize& RenderStyle::minHeight() const { return m_nonInheritedData->boxData->minHeight(); }
 inline const Style::MinimumSize& RenderStyle::minWidth() const { return m_nonInheritedData->boxData->minWidth(); }
-inline const NamedGridAreaMap& RenderStyle::namedGridArea() const { return m_nonInheritedData->rareData->grid->namedGridArea; }
-inline size_t RenderStyle::namedGridAreaColumnCount() const { return m_nonInheritedData->rareData->grid->namedGridAreaColumnCount; }
-inline size_t RenderStyle::namedGridAreaRowCount() const { return m_nonInheritedData->rareData->grid->namedGridAreaRowCount; }
-inline const NamedGridLinesMap& RenderStyle::namedGridColumnLines() const { return m_nonInheritedData->rareData->grid->namedGridColumnLines(); }
-inline const NamedGridLinesMap& RenderStyle::namedGridRowLines() const { return m_nonInheritedData->rareData->grid->namedGridRowLines(); }
+inline const Style::GridNamedLinesMap& RenderStyle::namedGridColumnLines() const { return m_nonInheritedData->rareData->grid->namedGridColumnLines(); }
+inline const Style::GridNamedLinesMap& RenderStyle::namedGridRowLines() const { return m_nonInheritedData->rareData->grid->namedGridRowLines(); }
 inline NBSPMode RenderStyle::nbspMode() const { return static_cast<NBSPMode>(m_rareInheritedData->nbspMode); }
 inline const Style::CustomPropertyData& RenderStyle::nonInheritedCustomProperties() const { return m_nonInheritedData->rareData->customProperties.get(); }
 inline ObjectFit RenderStyle::objectFit() const { return static_cast<ObjectFit>(m_nonInheritedData->miscData->objectFit); }
@@ -677,8 +673,8 @@ inline const Style::OffsetRotate& RenderStyle::offsetRotate() const { return m_n
 inline Length RenderStyle::oneLength() { return { 1, LengthType::Fixed }; }
 inline float RenderStyle::opacity() const { return m_nonInheritedData->miscData->opacity; }
 inline int RenderStyle::order() const { return m_nonInheritedData->miscData->order; }
-inline const OrderedNamedGridLinesMap& RenderStyle::orderedNamedGridColumnLines() const { return m_nonInheritedData->rareData->grid->orderedNamedGridColumnLines(); }
-inline const OrderedNamedGridLinesMap& RenderStyle::orderedNamedGridRowLines() const { return m_nonInheritedData->rareData->grid->orderedNamedGridRowLines(); }
+inline const Style::GridOrderedNamedLinesMap& RenderStyle::orderedNamedGridColumnLines() const { return m_nonInheritedData->rareData->grid->orderedNamedGridColumnLines(); }
+inline const Style::GridOrderedNamedLinesMap& RenderStyle::orderedNamedGridRowLines() const { return m_nonInheritedData->rareData->grid->orderedNamedGridRowLines(); }
 inline unsigned short RenderStyle::orphans() const { return m_rareInheritedData->orphans; }
 inline const OutlineValue& RenderStyle::outline() const { return m_nonInheritedData->backgroundData->outline; }
 inline const Style::Color& RenderStyle::outlineColor() const { return outline().color(); }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -165,6 +165,7 @@ inline void RenderStyle::setGridItemColumnEnd(const GridPosition& columnEndPosit
 inline void RenderStyle::setGridItemColumnStart(const GridPosition& columnStartPosition) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, gridItem, gridColumnStart, columnStartPosition); }
 inline void RenderStyle::setGridItemRowEnd(const GridPosition& rowEndPosition) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, gridItem, gridRowEnd, rowEndPosition); }
 inline void RenderStyle::setGridItemRowStart(const GridPosition& rowStartPosition) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, gridItem, gridRowStart, rowStartPosition); }
+inline void RenderStyle::setGridTemplateAreas(Style::GridTemplateAreas&& areas) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, grid, gridTemplateAreas, WTFMove(areas)); }
 inline void RenderStyle::setHangingPunctuation(OptionSet<HangingPunctuation> punctuation) { SET(m_rareInheritedData, hangingPunctuation, punctuation.toRaw()); }
 inline void RenderStyle::setHasAutoAccentColor() { SET_PAIR(m_rareInheritedData, hasAutoAccentColor, true, accentColor, Style::Color::currentColor()); }
 inline void RenderStyle::setHasAutoCaretColor() { SET_PAIR(m_rareInheritedData, hasAutoCaretColor, true, caretColor, Style::Color::currentColor()); }
@@ -197,8 +198,6 @@ inline void RenderStyle::setHyphenationString(const AtomString& h) { SET(m_rareI
 inline void RenderStyle::setHyphens(Hyphens hyphens) { SET(m_rareInheritedData, hyphens, static_cast<unsigned>(hyphens)); }
 inline void RenderStyle::setImageOrientation(ImageOrientation value) { SET(m_rareInheritedData, imageOrientation, static_cast<unsigned>(value)); }
 inline void RenderStyle::setImageRendering(ImageRendering value) { SET(m_rareInheritedData, imageRendering, static_cast<unsigned>(value)); }
-inline void RenderStyle::setImplicitNamedGridColumnLines(const NamedGridLinesMap& namedGridColumnLines) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, grid, implicitNamedGridColumnLines, namedGridColumnLines); }
-inline void RenderStyle::setImplicitNamedGridRowLines(const NamedGridLinesMap& namedGridRowLines) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, grid, implicitNamedGridRowLines, namedGridRowLines); }
 inline void RenderStyle::setInsetBox(Style::InsetBox&& box) { SET_NESTED(m_nonInheritedData, surroundData, inset, WTFMove(box)); }
 inline void RenderStyle::setInitialLetter(const IntSize& size) { SET_NESTED(m_nonInheritedData, rareData, initialLetter, size); }
 inline void RenderStyle::setInputSecurity(InputSecurity security) { SET_NESTED(m_nonInheritedData, rareData, inputSecurity, static_cast<unsigned>(security)); }
@@ -240,9 +239,6 @@ inline void RenderStyle::setMaxWidth(Style::MaximumSize&& length) { SET_NESTED(m
 inline void RenderStyle::setMinHeight(Style::MinimumSize&& length) { SET_NESTED(m_nonInheritedData, boxData, m_minHeight, WTFMove(length)); }
 inline void RenderStyle::setMinWidth(Style::MinimumSize&& length) { SET_NESTED(m_nonInheritedData, boxData, m_minWidth, WTFMove(length)); }
 inline void RenderStyle::setNBSPMode(NBSPMode mode) { SET(m_rareInheritedData, nbspMode, static_cast<unsigned>(mode)); }
-inline void RenderStyle::setNamedGridArea(const NamedGridAreaMap& map) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, grid, namedGridArea, map); }
-inline void RenderStyle::setNamedGridAreaColumnCount(size_t columnCount) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, grid, namedGridAreaColumnCount, columnCount); }
-inline void RenderStyle::setNamedGridAreaRowCount(size_t rowCount) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, grid, namedGridAreaRowCount, rowCount); }
 inline void RenderStyle::setObjectFit(ObjectFit fit) { SET_NESTED(m_nonInheritedData, miscData, objectFit, static_cast<unsigned>(fit)); }
 inline void RenderStyle::setObjectPosition(LengthPoint position) { SET_NESTED(m_nonInheritedData, miscData, objectPosition, WTFMove(position)); }
 inline void RenderStyle::setOffsetAnchor(Style::OffsetAnchor&& anchor) { SET_NESTED(m_nonInheritedData, rareData, offsetAnchor, WTFMove(anchor)); }

--- a/Source/WebCore/rendering/style/StyleGridData.cpp
+++ b/Source/WebCore/rendering/style/StyleGridData.cpp
@@ -34,14 +34,10 @@ namespace WebCore {
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleGridData);
 
 StyleGridData::StyleGridData()
-    : implicitNamedGridColumnLines(RenderStyle::initialNamedGridColumnLines())
-    , implicitNamedGridRowLines(RenderStyle::initialNamedGridRowLines())
-    , gridAutoFlow(RenderStyle::initialGridAutoFlow())
+    : gridAutoFlow(RenderStyle::initialGridAutoFlow())
     , gridAutoRows(RenderStyle::initialGridAutoRows())
     , gridAutoColumns(RenderStyle::initialGridAutoColumns())
-    , namedGridArea(RenderStyle::initialNamedGridArea())
-    , namedGridAreaRowCount(RenderStyle::initialNamedGridAreaCount())
-    , namedGridAreaColumnCount(RenderStyle::initialNamedGridAreaCount())
+    , gridTemplateAreas(RenderStyle::initialGridTemplateAreas())
     , m_gridColumnTrackSizes(RenderStyle::initialGridColumnTrackSizes())
     , m_gridRowTrackSizes(RenderStyle::initialGridRowTrackSizes())
     , m_namedGridColumnLines(RenderStyle::initialNamedGridColumnLines())
@@ -67,14 +63,10 @@ StyleGridData::StyleGridData()
 
 inline StyleGridData::StyleGridData(const StyleGridData& o)
     : RefCounted<StyleGridData>()
-    , implicitNamedGridColumnLines(o.implicitNamedGridColumnLines)
-    , implicitNamedGridRowLines(o.implicitNamedGridRowLines)
     , gridAutoFlow(o.gridAutoFlow)
     , gridAutoRows(o.gridAutoRows)
     , gridAutoColumns(o.gridAutoColumns)
-    , namedGridArea(o.namedGridArea)
-    , namedGridAreaRowCount(o.namedGridAreaRowCount)
-    , namedGridAreaColumnCount(o.namedGridAreaColumnCount)
+    , gridTemplateAreas(o.gridTemplateAreas)
     , m_columns(o.m_columns)
     , m_rows(o.m_rows)
     , m_gridColumnTrackSizes(o.m_gridColumnTrackSizes)
@@ -104,14 +96,10 @@ bool StyleGridData::operator==(const StyleGridData& o) const
 {
     return m_columns == o.m_columns
         && m_rows == o.m_rows
-        && implicitNamedGridColumnLines == o.implicitNamedGridColumnLines
-        && implicitNamedGridRowLines == o.implicitNamedGridRowLines
         && gridAutoFlow == o.gridAutoFlow
         && gridAutoRows == o.gridAutoRows
         && gridAutoColumns == o.gridAutoColumns
-        && namedGridArea == o.namedGridArea
-        && namedGridAreaRowCount == o.namedGridAreaRowCount
-        && namedGridAreaColumnCount == o.namedGridAreaColumnCount
+        && gridTemplateAreas == o.gridTemplateAreas
         && m_masonryRows == o.m_masonryRows
         && m_masonryColumns == o.m_masonryColumns;
 }
@@ -128,7 +116,7 @@ void StyleGridData::setColumns(const GridTrackList& list)
     computeCachedTrackData(m_columns, m_gridColumnTrackSizes, m_namedGridColumnLines, m_orderedNamedGridColumnLines, m_gridAutoRepeatColumns, m_autoRepeatNamedGridColumnLines, m_autoRepeatOrderedNamedGridColumnLines, m_autoRepeatColumnsInsertionPoint, m_autoRepeatColumnsType, m_subgridColumns, m_masonryColumns);
 }
 
-static void createGridLineNamesList(const Vector<String>& names, unsigned currentNamedGridLine, NamedGridLinesMap& namedGridLines, OrderedNamedGridLinesMap& orderedNamedGridLines)
+static void createGridLineNamesList(const Vector<String>& names, unsigned currentNamedGridLine, Style::GridNamedLinesMap& namedGridLines, Style::GridOrderedNamedLinesMap& orderedNamedGridLines)
 {
     auto orderedResult = orderedNamedGridLines.map.add(currentNamedGridLine, Vector<String>());
 
@@ -140,7 +128,7 @@ static void createGridLineNamesList(const Vector<String>& names, unsigned curren
     }
 }
 
-void StyleGridData::computeCachedTrackData(const GridTrackList& list, Vector<GridTrackSize>& sizes, NamedGridLinesMap& namedLines, OrderedNamedGridLinesMap& orderedNamedLines, Vector<GridTrackSize>& autoRepeatSizes, NamedGridLinesMap& autoRepeatNamedLines, OrderedNamedGridLinesMap& autoRepeatOrderedNamedLines, unsigned& autoRepeatInsertionPoint, AutoRepeatType& autoRepeatType, bool& subgrid, bool& masonry)
+void StyleGridData::computeCachedTrackData(const GridTrackList& list, Vector<GridTrackSize>& sizes, Style::GridNamedLinesMap& namedLines, Style::GridOrderedNamedLinesMap& orderedNamedLines, Vector<GridTrackSize>& autoRepeatSizes, Style::GridNamedLinesMap& autoRepeatNamedLines, Style::GridOrderedNamedLinesMap& autoRepeatOrderedNamedLines, unsigned& autoRepeatInsertionPoint, AutoRepeatType& autoRepeatType, bool& subgrid, bool& masonry)
 {
     sizes.clear();
     namedLines.map.clear();
@@ -242,11 +230,6 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, const GridTrackEntry& entry)
 
     WTF::visit(visitor, entry);
     return ts;
-}
-
-WTF::TextStream& operator<<(WTF::TextStream& ts, const NamedGridLinesMap& namedGridLinesMap)
-{
-    return ts << namedGridLinesMap.map;
 }
 
 Ref<StyleGridData> StyleGridData::copy() const

--- a/Source/WebCore/rendering/style/StyleGridData.h
+++ b/Source/WebCore/rendering/style/StyleGridData.h
@@ -29,6 +29,9 @@
 #include "GridTrackSize.h"
 #include "RenderStyleConstants.h"
 #include "StyleContentAlignmentData.h"
+#include "StyleGridNamedLinesMap.h"
+#include "StyleGridOrderedNamedLinesMap.h"
+#include "StyleGridTemplateAreas.h"
 #include <wtf/FixedVector.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
@@ -37,16 +40,6 @@
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
-
-struct NamedGridLinesMap {
-    HashMap<String, Vector<unsigned>> map;
-
-    friend bool operator==(const NamedGridLinesMap&, const NamedGridLinesMap&) = default;
-};
-
-struct OrderedNamedGridLinesMap {
-    HashMap<unsigned, Vector<String>, IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> map;
-};
 
 typedef Variant<GridTrackSize, Vector<String>> RepeatEntry;
 typedef Vector<RepeatEntry> RepeatTrackList;
@@ -82,7 +75,6 @@ inline WTF::TextStream& operator<<(WTF::TextStream& stream, const GridTrackList&
 
 WTF::TextStream& operator<<(WTF::TextStream&, const RepeatEntry&);
 WTF::TextStream& operator<<(WTF::TextStream&, const GridTrackEntry&);
-WTF::TextStream& operator<<(WTF::TextStream&, const NamedGridLinesMap&);
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleGridData);
 class StyleGridData : public RefCounted<StyleGridData> {
@@ -103,16 +95,16 @@ public:
     const Vector<GridTrackSize>& gridColumnTrackSizes() const { return m_gridColumnTrackSizes; }
     const Vector<GridTrackSize>& gridRowTrackSizes() const { return m_gridRowTrackSizes; }
 
-    const NamedGridLinesMap& namedGridColumnLines() const { return m_namedGridColumnLines; };
-    const NamedGridLinesMap& namedGridRowLines() const { return m_namedGridRowLines; };
+    const Style::GridNamedLinesMap& namedGridColumnLines() const { return m_namedGridColumnLines; };
+    const Style::GridNamedLinesMap& namedGridRowLines() const { return m_namedGridRowLines; };
 
-    const OrderedNamedGridLinesMap& orderedNamedGridColumnLines() const { return m_orderedNamedGridColumnLines; }
-    const OrderedNamedGridLinesMap& orderedNamedGridRowLines() const { return m_orderedNamedGridRowLines; }
+    const Style::GridOrderedNamedLinesMap& orderedNamedGridColumnLines() const { return m_orderedNamedGridColumnLines; }
+    const Style::GridOrderedNamedLinesMap& orderedNamedGridRowLines() const { return m_orderedNamedGridRowLines; }
 
-    const NamedGridLinesMap& autoRepeatNamedGridColumnLines() const { return m_autoRepeatNamedGridColumnLines; }
-    const NamedGridLinesMap& autoRepeatNamedGridRowLines() const { return m_autoRepeatNamedGridRowLines; }
-    const OrderedNamedGridLinesMap& autoRepeatOrderedNamedGridColumnLines() const { return m_autoRepeatOrderedNamedGridColumnLines; }
-    const OrderedNamedGridLinesMap& autoRepeatOrderedNamedGridRowLines() const { return m_autoRepeatOrderedNamedGridRowLines; }
+    const Style::GridNamedLinesMap& autoRepeatNamedGridColumnLines() const { return m_autoRepeatNamedGridColumnLines; }
+    const Style::GridNamedLinesMap& autoRepeatNamedGridRowLines() const { return m_autoRepeatNamedGridRowLines; }
+    const Style::GridOrderedNamedLinesMap& autoRepeatOrderedNamedGridColumnLines() const { return m_autoRepeatOrderedNamedGridColumnLines; }
+    const Style::GridOrderedNamedLinesMap& autoRepeatOrderedNamedGridRowLines() const { return m_autoRepeatOrderedNamedGridRowLines; }
 
     const Vector<GridTrackSize>& gridAutoRepeatColumns() const { return m_gridAutoRepeatColumns; }
     const Vector<GridTrackSize>& gridAutoRepeatRows() const { return m_gridAutoRepeatRows; }
@@ -132,22 +124,15 @@ public:
     const GridTrackList& columns() const { return m_columns; }
     const GridTrackList& rows() const { return m_rows; }
 
-    NamedGridLinesMap implicitNamedGridColumnLines;
-    NamedGridLinesMap implicitNamedGridRowLines;
-
     unsigned gridAutoFlow : GridAutoFlowBits;
 
     Vector<GridTrackSize> gridAutoRows;
     Vector<GridTrackSize> gridAutoColumns;
 
-    NamedGridAreaMap namedGridArea;
-    // Because namedGridArea doesn't store the unnamed grid areas, we need to keep track
-    // of the explicit grid size defined by both named and unnamed grid areas.
-    unsigned namedGridAreaRowCount;
-    unsigned namedGridAreaColumnCount;
+    Style::GridTemplateAreas gridTemplateAreas;
 
 private:
-    void computeCachedTrackData(const GridTrackList&, Vector<GridTrackSize>& sizes, NamedGridLinesMap& namedLines, OrderedNamedGridLinesMap& orderedNamedLines, Vector<GridTrackSize>& autoRepeatSizes, NamedGridLinesMap& autoRepeatNamedLines, OrderedNamedGridLinesMap& autoRepeatOrderedNamedLines, unsigned& autoRepeatInsertionPoint, AutoRepeatType&, bool& subgrid, bool& masonry);
+    void computeCachedTrackData(const GridTrackList&, Vector<GridTrackSize>& sizes, Style::GridNamedLinesMap&, Style::GridOrderedNamedLinesMap&, Vector<GridTrackSize>& autoRepeatSizes, Style::GridNamedLinesMap& autoRepeatNamedLines, Style::GridOrderedNamedLinesMap& autoRepeatOrderedNamedLines, unsigned& autoRepeatInsertionPoint, AutoRepeatType&, bool& subgrid, bool& masonry);
 
     GridTrackList m_columns;
     GridTrackList m_rows;
@@ -156,16 +141,15 @@ private:
     Vector<GridTrackSize> m_gridColumnTrackSizes;
     Vector<GridTrackSize> m_gridRowTrackSizes;
 
-    NamedGridLinesMap m_namedGridColumnLines;
-    NamedGridLinesMap m_namedGridRowLines;
+    Style::GridNamedLinesMap m_namedGridColumnLines;
+    Style::GridNamedLinesMap m_namedGridRowLines;
+    Style::GridOrderedNamedLinesMap m_orderedNamedGridColumnLines;
+    Style::GridOrderedNamedLinesMap m_orderedNamedGridRowLines;
 
-    OrderedNamedGridLinesMap m_orderedNamedGridColumnLines;
-    OrderedNamedGridLinesMap m_orderedNamedGridRowLines;
-
-    NamedGridLinesMap m_autoRepeatNamedGridColumnLines;
-    NamedGridLinesMap m_autoRepeatNamedGridRowLines;
-    OrderedNamedGridLinesMap m_autoRepeatOrderedNamedGridColumnLines;
-    OrderedNamedGridLinesMap m_autoRepeatOrderedNamedGridRowLines;
+    Style::GridNamedLinesMap m_autoRepeatNamedGridColumnLines;
+    Style::GridNamedLinesMap m_autoRepeatNamedGridRowLines;
+    Style::GridOrderedNamedLinesMap m_autoRepeatOrderedNamedGridColumnLines;
+    Style::GridOrderedNamedLinesMap m_autoRepeatOrderedNamedGridRowLines;
 
     Vector<GridTrackSize> m_gridAutoRepeatColumns;
     Vector<GridTrackSize> m_gridAutoRepeatRows;

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -266,7 +266,6 @@ private:
     static GridTrackSize createGridTrackSize(BuilderState&, const CSSValue&);
     static std::optional<GridTrackList> createGridTrackList(BuilderState&, const CSSValue&);
     static GridPosition createGridPosition(BuilderState&, const CSSValue&);
-    static NamedGridLinesMap createImplicitNamedGridLinesFromGridArea(BuilderState&, const NamedGridAreaMap&, GridTrackSizingDirection);
 
     static CSSToLengthConversionData cssToLengthConversionDataWithTextZoomFactor(BuilderState&);
 };
@@ -1205,27 +1204,6 @@ inline GridPosition BuilderConverter::createGridPosition(BuilderState& builderSt
     return position;
 }
 
-inline NamedGridLinesMap BuilderConverter::createImplicitNamedGridLinesFromGridArea(BuilderState&, const NamedGridAreaMap& namedGridAreas, GridTrackSizingDirection direction)
-{
-    NamedGridLinesMap namedGridLines;
-
-    for (auto& area : namedGridAreas.map) {
-        GridSpan areaSpan = direction == GridTrackSizingDirection::ForRows ? area.value.rows : area.value.columns;
-        {
-            auto& startVector = namedGridLines.map.add(makeString(area.key, "-start"_s), Vector<unsigned>()).iterator->value;
-            startVector.append(areaSpan.startLine());
-            std::ranges::sort(startVector);
-        }
-        {
-            auto& endVector = namedGridLines.map.add(makeString(area.key, "-end"_s), Vector<unsigned>()).iterator->value;
-            endVector.append(areaSpan.endLine());
-            std::ranges::sort(endVector);
-        }
-    }
-    // FIXME: For acceptable performance, should sort once at the end, not as we add each item, or at least insert in sorted order instead of using std::sort each time.
-
-    return namedGridLines;
-}
 
 inline Vector<GridTrackSize> BuilderConverter::convertGridTrackSizeList(BuilderState& builderState, const CSSValue& value)
 {

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -36,7 +36,6 @@
 #include "CSSCursorImageValue.h"
 #include "CSSFontValue.h"
 #include "CSSGradientValue.h"
-#include "CSSGridTemplateAreasValue.h"
 #include "CSSPropertyParserConsumer+Font.h"
 #include "CSSRatioValue.h"
 #include "CSSRectValue.h"
@@ -104,6 +103,7 @@ inline FlexBasis forwardInheritedValue(const FlexBasis& value) { auto copy = val
 inline DynamicRangeLimit forwardInheritedValue(const DynamicRangeLimit& value) { auto copy = value; return copy; }
 inline ClipPath forwardInheritedValue(const ClipPath& value) { auto copy = value; return copy; }
 inline CornerShapeValue forwardInheritedValue(const CornerShapeValue& value) { auto copy = value; return copy; }
+inline GridTemplateAreas forwardInheritedValue(const GridTemplateAreas& value) { auto copy = value; return copy; }
 inline OffsetAnchor forwardInheritedValue(const OffsetAnchor& value) { auto copy = value; return copy; }
 inline OffsetDistance forwardInheritedValue(const OffsetDistance& value) { auto copy = value; return copy; }
 inline OffsetPath forwardInheritedValue(const OffsetPath& value) { auto copy = value; return copy; }
@@ -156,7 +156,6 @@ public:
     DECLARE_PROPERTY_CUSTOM_HANDLERS(FontVariantLigatures);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(FontVariantNumeric);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(FontVariantEastAsian);
-    DECLARE_PROPERTY_CUSTOM_HANDLERS(GridTemplateAreas);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(LetterSpacing);
 #if ENABLE(TEXT_AUTOSIZING)
     DECLARE_PROPERTY_CUSTOM_HANDLERS(LineHeight);
@@ -1439,47 +1438,6 @@ inline void BuilderCustom::applyValueFontSize(BuilderState& builderState, CSSVal
 inline void BuilderCustom::applyValueFontSizeAdjust(BuilderState& builderState, CSSValue& value)
 {
     builderState.setFontDescriptionFontSizeAdjust(BuilderConverter::convertFontSizeAdjust(builderState, value));
-}
-
-inline void BuilderCustom::applyInitialGridTemplateAreas(BuilderState& builderState)
-{
-    builderState.style().setImplicitNamedGridColumnLines(RenderStyle::initialNamedGridColumnLines());
-    builderState.style().setImplicitNamedGridRowLines(RenderStyle::initialNamedGridRowLines());
-
-    builderState.style().setNamedGridArea(RenderStyle::initialNamedGridArea());
-    builderState.style().setNamedGridAreaRowCount(RenderStyle::initialNamedGridAreaCount());
-    builderState.style().setNamedGridAreaColumnCount(RenderStyle::initialNamedGridAreaCount());
-}
-
-inline void BuilderCustom::applyInheritGridTemplateAreas(BuilderState& builderState)
-{
-    builderState.style().setImplicitNamedGridColumnLines(builderState.parentStyle().implicitNamedGridColumnLines());
-    builderState.style().setImplicitNamedGridRowLines(builderState.parentStyle().implicitNamedGridRowLines());
-
-    builderState.style().setNamedGridArea(builderState.parentStyle().namedGridArea());
-    builderState.style().setNamedGridAreaRowCount(builderState.parentStyle().namedGridAreaRowCount());
-    builderState.style().setNamedGridAreaColumnCount(builderState.parentStyle().namedGridAreaColumnCount());
-}
-
-inline void BuilderCustom::applyValueGridTemplateAreas(BuilderState& builderState, CSSValue& value)
-{
-    if (value.valueID() == CSSValueNone) {
-        applyInitialGridTemplateAreas(builderState);
-        return;
-    }
-
-    auto gridTemplateAreasValue = requiredDowncast<CSSGridTemplateAreasValue>(builderState, value);
-    if (!gridTemplateAreasValue)
-        return;
-
-    const NamedGridAreaMap& newNamedGridAreas = gridTemplateAreasValue->gridAreaMap();
-
-    builderState.style().setImplicitNamedGridColumnLines(BuilderConverter::createImplicitNamedGridLinesFromGridArea(builderState, newNamedGridAreas, GridTrackSizingDirection::ForColumns));
-    builderState.style().setImplicitNamedGridRowLines(BuilderConverter::createImplicitNamedGridLinesFromGridArea(builderState, newNamedGridAreas, GridTrackSizingDirection::ForRows));
-
-    builderState.style().setNamedGridArea(gridTemplateAreasValue->gridAreaMap());
-    builderState.style().setNamedGridAreaRowCount(gridTemplateAreasValue->rowCount());
-    builderState.style().setNamedGridAreaColumnCount(gridTemplateAreasValue->columnCount());
 }
 
 inline void BuilderCustom::applyValueStrokeWidth(BuilderState& builderState, CSSValue& value)

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -96,7 +96,6 @@ public:
     static Ref<CSSValue> extractScale(ExtractorState&);
     static Ref<CSSValue> extractRotate(ExtractorState&);
     static Ref<CSSValue> extractGridAutoFlow(ExtractorState&);
-    static Ref<CSSValue> extractGridTemplateAreas(ExtractorState&);
     static Ref<CSSValue> extractGridTemplateColumns(ExtractorState&);
     static Ref<CSSValue> extractGridTemplateRows(ExtractorState&);
 
@@ -199,7 +198,6 @@ public:
     static void extractScaleSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractRotateSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractGridAutoFlowSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
-    static void extractGridTemplateAreasSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractGridTemplateColumnsSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractGridTemplateRowsSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
 
@@ -2254,35 +2252,6 @@ inline void ExtractorCustom::extractGridAutoFlowSerialization(ExtractorState& st
             builder.append(' ');
         CSS::serializationForCSS(builder, context, CSS::Keyword::Dense { });
     }
-}
-
-inline Ref<CSSValue> ExtractorCustom::extractGridTemplateAreas(ExtractorState& state)
-{
-    if (!state.style.namedGridAreaRowCount()) {
-        ASSERT(!state.style.namedGridAreaColumnCount());
-        return CSSPrimitiveValue::create(CSSValueNone);
-    }
-    return CSSGridTemplateAreasValue::create(
-        state.style.namedGridArea(),
-        state.style.namedGridAreaRowCount(),
-        state.style.namedGridAreaColumnCount()
-    );
-}
-
-inline void ExtractorCustom::extractGridTemplateAreasSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
-{
-    if (!state.style.namedGridAreaRowCount()) {
-        ASSERT(!state.style.namedGridAreaColumnCount());
-        CSS::serializationForCSS(builder, context, CSS::Keyword::None { });
-        return;
-    }
-
-    // FIXME: Do this more efficiently without creating and destroying a CSSValue object.
-    builder.append(CSSGridTemplateAreasValue::create(
-        state.style.namedGridArea(),
-        state.style.namedGridAreaRowCount(),
-        state.style.namedGridAreaColumnCount()
-    )->cssText(context));
 }
 
 inline Ref<CSSValue> ExtractorCustom::extractGridTemplateColumns(ExtractorState& state)

--- a/Source/WebCore/style/StyleInterpolationWrappers.h
+++ b/Source/WebCore/style/StyleInterpolationWrappers.h
@@ -1720,49 +1720,6 @@ public:
 #endif
 };
 
-class GridTemplateAreasWrapper final : public WrapperBase {
-    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Animation);
-public:
-    GridTemplateAreasWrapper()
-        : WrapperBase(CSSPropertyGridTemplateAreas)
-    {
-    }
-
-    bool equals(const RenderStyle& a, const RenderStyle& b) const final
-    {
-        return a.implicitNamedGridColumnLines().map == b.implicitNamedGridColumnLines().map
-            && a.implicitNamedGridRowLines().map == b.implicitNamedGridRowLines().map
-            && a.namedGridArea().map == b.namedGridArea().map
-            && a.namedGridAreaRowCount() == b.namedGridAreaRowCount()
-            && a.namedGridAreaColumnCount() == b.namedGridAreaColumnCount();
-    }
-
-    bool canInterpolate(const RenderStyle&, const RenderStyle&, CompositeOperation) const final
-    {
-        return false;
-    }
-
-    void interpolate(RenderStyle& destination, const RenderStyle& from, const RenderStyle& to, const Context& context) const final
-    {
-        ASSERT(context.isDiscrete);
-        ASSERT(!context.progress || context.progress == 1);
-
-        auto& source = context.progress ? to : from;
-        destination.setImplicitNamedGridColumnLines(source.implicitNamedGridColumnLines());
-        destination.setImplicitNamedGridRowLines(source.implicitNamedGridRowLines());
-        destination.setNamedGridArea(source.namedGridArea());
-        destination.setNamedGridAreaRowCount(source.namedGridAreaRowCount());
-        destination.setNamedGridAreaColumnCount(source.namedGridAreaColumnCount());
-    }
-
-#if !LOG_DISABLED
-    void log(const RenderStyle&, const RenderStyle&, const RenderStyle&, double progress) const final
-    {
-        LOG_WITH_STREAM(Animations, stream << " blending " << property() << " at " << TextStream::FormatNumberRespectingIntegers(progress) << ".");
-    }
-#endif
-};
-
 class QuotesWrapper final : public WrapperBase {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Animation);
 public:

--- a/Source/WebCore/style/StyleOrderedNamedLinesCollector.h
+++ b/Source/WebCore/style/StyleOrderedNamedLinesCollector.h
@@ -59,8 +59,8 @@ protected:
     enum class NamedLinesType : bool { NamedLines, AutoRepeatNamedLines };
     void appendLines(Vector<String>&, unsigned index, NamedLinesType) const;
 
-    const OrderedNamedGridLinesMap& m_orderedNamedGridLines;
-    const OrderedNamedGridLinesMap& m_orderedNamedAutoRepeatGridLines;
+    const GridOrderedNamedLinesMap& m_orderedNamedGridLines;
+    const GridOrderedNamedLinesMap& m_orderedNamedAutoRepeatGridLines;
 };
 
 class OrderedNamedLinesCollectorInGridLayout : public OrderedNamedLinesCollector {

--- a/Source/WebCore/style/values/grid/StyleGridNamedAreaMap.h
+++ b/Source/WebCore/style/values/grid/StyleGridNamedAreaMap.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSGridNamedAreaMap.h"
+
+namespace WebCore {
+namespace Style {
+
+using GridNamedAreaMap = CSS::GridNamedAreaMap;
+template<> inline constexpr bool TreatAsNonConverting<GridNamedAreaMap> = true;
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/grid/StyleGridNamedLinesMap.cpp
+++ b/Source/WebCore/style/values/grid/StyleGridNamedLinesMap.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleGridNamedLinesMap.h"
+
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+namespace Style {
+
+TextStream& operator<<(TextStream& ts, const GridNamedLinesMap& value)
+{
+    return ts << value.map;
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/grid/StyleGridNamedLinesMap.h
+++ b/Source/WebCore/style/values/grid/StyleGridNamedLinesMap.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/HashMap.h>
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+namespace Style {
+
+struct GridNamedLinesMap {
+    HashMap<String, Vector<unsigned>> map;
+
+    bool operator==(const GridNamedLinesMap&) const = default;
+};
+
+WTF::TextStream& operator<<(WTF::TextStream&, const GridNamedLinesMap&);
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/grid/StyleGridOrderedNamedLinesMap.h
+++ b/Source/WebCore/style/values/grid/StyleGridOrderedNamedLinesMap.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/HashMap.h>
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+namespace Style {
+
+struct GridOrderedNamedLinesMap {
+    HashMap<unsigned, Vector<String>, IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> map;
+
+    bool operator==(const GridOrderedNamedLinesMap&) const = default;
+};
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/grid/StyleGridTemplateAreas.cpp
+++ b/Source/WebCore/style/values/grid/StyleGridTemplateAreas.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleGridTemplateAreas.h"
+
+#include "CSSGridTemplateAreasValue.h"
+#include "GridPositionsResolver.h"
+#include "StyleBuilderChecking.h"
+#include "StylePrimitiveNumericTypes+Blending.h"
+#include <algorithm>
+
+namespace WebCore {
+namespace Style {
+
+static GridNamedLinesMap initializeImplicitNamedGridLines(const GridNamedAreaMap& namedGridAreas, GridTrackSizingDirection direction)
+{
+    GridNamedLinesMap namedGridLines;
+
+    for (auto& area : namedGridAreas.map) {
+        auto areaSpan = direction == GridTrackSizingDirection::ForRows ? area.value.rows : area.value.columns;
+        {
+            auto& startVector = namedGridLines.map.add(makeString(area.key, "-start"_s), Vector<unsigned>()).iterator->value;
+            startVector.append(areaSpan.startLine());
+            std::ranges::sort(startVector);
+        }
+        {
+            auto& endVector = namedGridLines.map.add(makeString(area.key, "-end"_s), Vector<unsigned>()).iterator->value;
+            endVector.append(areaSpan.endLine());
+            std::ranges::sort(endVector);
+        }
+    }
+
+    // FIXME: For acceptable performance, should sort once at the end, not as we add each item, or at least insert in sorted order instead of using std::sort each time.
+
+    return namedGridLines;
+}
+
+GridTemplateAreas::GridTemplateAreas(GridNamedAreaMap&& map)
+    : map { WTFMove(map) }
+    , implicitNamedGridColumnLines { initializeImplicitNamedGridLines(map, GridTrackSizingDirection::ForColumns) }
+    , implicitNamedGridRowLines { initializeImplicitNamedGridLines(map, GridTrackSizingDirection::ForRows) }
+{
+}
+
+GridTemplateAreas::GridTemplateAreas(const GridNamedAreaMap& map)
+    : map { map }
+    , implicitNamedGridColumnLines { initializeImplicitNamedGridLines(map, GridTrackSizingDirection::ForColumns) }
+    , implicitNamedGridRowLines { initializeImplicitNamedGridLines(map, GridTrackSizingDirection::ForRows) }
+{
+}
+
+// MARK: - Conversion
+
+auto CSSValueConversion<GridTemplateAreas>::operator()(BuilderState& state, const CSSValue& value) -> GridTemplateAreas
+{
+    if (isValueID(value, CSSValueNone))
+        return CSS::Keyword::None { };
+
+    RefPtr gridTemplateAreasValue = requiredDowncast<CSSGridTemplateAreasValue>(state, value);
+    if (!gridTemplateAreasValue)
+        return CSS::Keyword::None { };
+
+    return GridTemplateAreas { gridTemplateAreasValue->areas().map };
+}
+
+auto CSSValueCreation<GridTemplateAreas>::operator()(CSSValuePool& pool, const RenderStyle& style, const GridTemplateAreas& value) -> Ref<CSSValue>
+{
+    return WTF::switchOn(value,
+        [&](const CSS::Keyword::None& keyword) -> Ref<CSSValue> {
+            return createCSSValue(pool, style, keyword);
+        },
+        [&](const GridNamedAreaMap& map) -> Ref<CSSValue> {
+            return CSSGridTemplateAreasValue::create(CSS::GridTemplateAreas { map });
+        }
+    );
+}
+
+// MARK: - Serialization
+
+void Serialize<GridTemplateAreas>::operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const GridTemplateAreas& value)
+{
+    WTF::switchOn(value,
+        [&](const CSS::Keyword::None& keyword) {
+            serializationForCSS(builder, context, style, keyword);
+        },
+        [&](const GridNamedAreaMap& map) {
+            serializationForCSS(builder, context, style, map);
+        }
+    );
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/grid/StyleGridTemplateAreas.h
+++ b/Source/WebCore/style/values/grid/StyleGridTemplateAreas.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSGridTemplateAreas.h"
+#include "StyleGridNamedAreaMap.h"
+#include "StyleGridNamedLinesMap.h"
+
+namespace WebCore {
+namespace Style {
+
+// <'grid-template-areas'> = none | <string>+
+// https://drafts.csswg.org/css-grid/#propdef-grid-template-areas
+struct GridTemplateAreas {
+    GridNamedAreaMap map { };
+    GridNamedLinesMap implicitNamedGridColumnLines { };
+    GridNamedLinesMap implicitNamedGridRowLines { };
+
+    GridTemplateAreas(CSS::Keyword::None) { }
+    GridTemplateAreas(GridNamedAreaMap&&);
+    GridTemplateAreas(const GridNamedAreaMap&);
+
+    bool isNone() const { return !map.rowCount; }
+
+    template<typename... F> decltype(auto) switchOn(F&&... f) const
+    {
+        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
+
+        if (isNone())
+            return visitor(CSS::Keyword::None { });
+        return visitor(map);
+    }
+
+    bool operator==(const GridTemplateAreas& other) const
+    {
+        // It is only necessary to compare the `map` member, as the `implicit*` members
+        // are purely cached derived values based on the value of `map`.
+        return map == other.map;
+    }
+};
+
+// MARK: - Conversion
+
+template<> struct CSSValueConversion<GridTemplateAreas> { auto operator()(BuilderState&, const CSSValue&) -> GridTemplateAreas; };
+template<> struct CSSValueCreation<GridTemplateAreas> { auto operator()(CSSValuePool&, const RenderStyle&, const GridTemplateAreas&) -> Ref<CSSValue>; };
+
+// MARK: - Serialization
+
+template<> struct Serialize<GridTemplateAreas> { void operator()(StringBuilder&, const CSS::SerializationContext&, const RenderStyle&, const GridTemplateAreas&); };
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::GridTemplateAreas);


### PR DESCRIPTION
#### 2d2562d50a84003b593458a656b99c4c3969942f
<pre>
[Style] Convert grid-template-areas to use strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=295714">https://bugs.webkit.org/show_bug.cgi?id=295714</a>

Reviewed by Darin Adler.

Bundles up the values for the `grid-template-areas` property into a new
`Style::GridTemplateAreas` type.

Also modernizes the CSS side a, bundling up the map and row/column count
values into a struct.

* Source/WebCore/Headers.cmake:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSGridTemplateAreasValue.cpp:
* Source/WebCore/css/CSSGridTemplateAreasValue.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.h:
* Source/WebCore/css/parser/CSSPropertyParserCustom.h:
* Source/WebCore/css/values/grid/CSSGridNamedAreaMap.cpp: Added.
* Source/WebCore/css/values/grid/CSSGridNamedAreaMap.h: Added.
* Source/WebCore/css/values/grid/CSSGridTemplateAreas.cpp: Added.
* Source/WebCore/css/values/grid/CSSGridTemplateAreas.h: Added.
* Source/WebCore/inspector/InspectorOverlay.cpp:
* Source/WebCore/rendering/RenderGrid.cpp:
* Source/WebCore/rendering/style/GridArea.h:
* Source/WebCore/rendering/style/GridPositionsResolver.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:
* Source/WebCore/rendering/style/StyleGridData.cpp:
* Source/WebCore/rendering/style/StyleGridData.h:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleBuilderCustom.h:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/StyleInterpolationWrappers.h:
* Source/WebCore/style/StyleOrderedNamedLinesCollector.h:
* Source/WebCore/style/values/grid/StyleGridNamedLinesMap.cpp: Added.
* Source/WebCore/style/values/grid/StyleGridNamedLinesMap.h: Added.
* Source/WebCore/style/values/grid/StyleGridOrderedNamedLinesMap.h: Added.
* Source/WebCore/style/values/grid/StyleGridTemplateAreas.cpp: Added.
* Source/WebCore/style/values/grid/StyleGridTemplateAreas.h: Added.

Canonical link: <a href="https://commits.webkit.org/297304@main">https://commits.webkit.org/297304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/549b53f86b2ea490c7144db2f8821eaa3f502115

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111212 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21392 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117243 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61480 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113174 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39460 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84533 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114159 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25205 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100172 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64979 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24547 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18313 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61063 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94583 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18381 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120305 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38261 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28430 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93463 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38637 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96448 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93288 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23781 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38380 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16188 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34246 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38150 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43627 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37815 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41148 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39517 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->