### PR TITLE
Qualify use of WebCore::SecurityOriginData to fix build error

### DIFF
--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -793,7 +793,7 @@ private:
         ScreenTimeWebsiteDataSupport::getScreenTimeURLs(configuration().identifier(), { [callbackAggregator](HashSet<URL> urls) {
             WebsiteData websiteData;
             websiteData.entries = WTF::map(urls, [](auto& url) {
-                return WebsiteData::Entry { SecurityOriginData::fromURL(url), WebsiteDataType::ScreenTime, 0 };
+                return WebsiteData::Entry { WebCore::SecurityOriginData::fromURL(url), WebsiteDataType::ScreenTime, 0 };
             });
             callbackAggregator->addWebsiteData(WTFMove(websiteData));
         } });


### PR DESCRIPTION
#### 6a26a4c9c0e18c9ae787b5f30e2967941f08fe74
<pre>
Qualify use of WebCore::SecurityOriginData to fix build error
<a href="https://bugs.webkit.org/show_bug.cgi?id=295715">https://bugs.webkit.org/show_bug.cgi?id=295715</a>
<a href="https://rdar.apple.com/155551248">rdar://155551248</a>

Reviewed by NOBODY (OOPS!).

Properly qualify a use of WebCore::SecurityOriginData to fix a build error that comes up with changes to unified source ordering.

* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::fetchDataAndApply):
</pre>