### PR TITLE
Fix conditional check for reaching maximum DOM tree depth

### DIFF
--- a/LayoutTests/fast/parser/block-nesting-cap-expected.txt
+++ b/LayoutTests/fast/parser/block-nesting-cap-expected.txt
@@ -3,9 +3,9 @@ Test that the HTML parser does not allow the nesting depth of elements to exceed
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS d512.parentNode === d510 is true
-PASS d511.parentNode === d510 is true
-PASS d512.previousSibling === d511 is true
+PASS d511.parentNode === d509 is true
+PASS d510.parentNode === d509 is true
+PASS d511.previousSibling === d510 is true
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/parser/block-nesting-cap.html
+++ b/LayoutTests/fast/parser/block-nesting-cap.html
@@ -7,7 +7,7 @@
 <script>
 description('Test that the HTML parser does not allow the nesting depth of elements to exceed 512.');
 
-var depth = 514;
+var depth = 512;
 var markup = "";
 var i;
 for (i = 0; i < depth; ++i)
@@ -15,13 +15,13 @@ for (i = 0; i < depth; ++i)
 var doc = document.implementation.createHTMLDocument();
 doc.body.innerHTML = markup;
 
+var d509 = doc.getElementById("d509");
 var d510 = doc.getElementById("d510");
 var d511 = doc.getElementById("d511");
-var d512 = doc.getElementById("d512");
 
-shouldBe("d512.parentNode === d510", "true");
-shouldBe("d511.parentNode === d510", "true");
-shouldBe("d512.previousSibling === d511", "true");
+shouldBe("d511.parentNode === d509", "true");
+shouldBe("d510.parentNode === d509", "true");
+shouldBe("d511.previousSibling === d510", "true");
 </script>
 <script src="../../resources/js-test-post.js"></script>
 </body>

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -236,7 +236,7 @@ void HTMLConstructionSite::attachLater(Ref<ContainerNode>&& parent, Ref<Node>&& 
     task.selfClosing = selfClosing;
 
     // Add as a sibling of the parent if we have reached the maximum depth allowed.
-    if (m_openElements.stackDepth() > m_maximumDOMTreeDepth && task.parent->parentNode())
+    if (m_openElements.stackDepth() >= m_maximumDOMTreeDepth && task.parent->parentNode())
         task.parent = task.parent->parentNode();
 
     ASSERT(task.parent);


### PR DESCRIPTION
#### 6b7c4e637f2f8da9c37bd060f73b7335b59cbb6c
<pre>
Fix conditional check for reaching maximum DOM tree depth
<a href="https://bugs.webkit.org/show_bug.cgi?id=295696">https://bugs.webkit.org/show_bug.cgi?id=295696</a>
<a href="https://rdar.apple.com/155538446">rdar://155538446</a>

Reviewed by Ryosuke Niwa.

Now we start adding as siblings right when we hit the max depth rather than waiting to go over the max.
&gt;= is used to be robust and avoid off-by-one surprises.
Updated test to correctly check for sibling behavior exactly at max depth rather than max depth + 1.

* LayoutTests/fast/parser/block-nesting-cap-expected.txt:
* LayoutTests/fast/parser/block-nesting-cap.html:
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::HTMLConstructionSite::attachLater):

Canonical link: <a href="https://commits.webkit.org/297241@main">https://commits.webkit.org/297241@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/957cf5c0857f119c5fea9386a829e59766745737

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111021 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21118 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117051 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/61288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112983 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31368 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39269 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84403 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/61288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25057 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99948 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64849 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24408 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18090 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60864 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94440 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18156 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119879 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38070 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28288 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93349 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38446 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96223 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93173 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23741 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38243 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15975 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/34051 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37959 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43435 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37623 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40957 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39326 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->