### PR TITLE
Introduce SupplementBase as a way to downcast Supplement<T>

### DIFF
--- a/Source/WebCore/Modules/cookie-consent/NavigatorCookieConsent.cpp
+++ b/Source/WebCore/Modules/cookie-consent/NavigatorCookieConsent.cpp
@@ -73,7 +73,7 @@ void NavigatorCookieConsent::requestCookieConsent(RequestCookieConsentOptions&& 
 
 NavigatorCookieConsent& NavigatorCookieConsent::from(Navigator& navigator)
 {
-    if (auto supplement = static_cast<NavigatorCookieConsent*>(Supplement<Navigator>::from(&navigator, supplementName())))
+    if (auto supplement = downcast<NavigatorCookieConsent>(Supplement<Navigator>::from(&navigator, supplementName())))
         return *supplement;
 
     auto newSupplement = makeUnique<NavigatorCookieConsent>(navigator);

--- a/Source/WebCore/Modules/cookie-consent/NavigatorCookieConsent.h
+++ b/Source/WebCore/Modules/cookie-consent/NavigatorCookieConsent.h
@@ -51,6 +51,7 @@ public:
 private:
     static NavigatorCookieConsent& from(Navigator&);
     static ASCIILiteral supplementName() { return "NavigatorCookieConsent"_s; }
+    bool isNavigatorCookieConsent() const final { return true; }
 
     void requestCookieConsent(RequestCookieConsentOptions&&, Ref<DeferredPromise>&&);
 
@@ -58,3 +59,7 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::NavigatorCookieConsent)
+    static bool isType(const WebCore::SupplementBase& supplement) { return supplement.isNavigatorCookieConsent(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -9,7 +9,6 @@ Modules/audiosession/NavigatorAudioSession.cpp
 Modules/beacon/NavigatorBeacon.cpp
 Modules/cache/WindowOrWorkerGlobalScopeCaches.cpp
 Modules/contact-picker/NavigatorContacts.cpp
-Modules/cookie-consent/NavigatorCookieConsent.cpp
 Modules/credentialmanagement/NavigatorCredentials.cpp
 Modules/encryptedmedia/MediaKeySystemController.cpp
 Modules/gamepad/NavigatorGamepad.cpp

--- a/Source/WebCore/platform/Supplementable.h
+++ b/Source/WebCore/platform/Supplementable.h
@@ -72,13 +72,23 @@ namespace WebCore {
 //         return reinterpret_cast<MyClass*>(Supplement<MySupplementable>::from(host, supplementName()));
 //     }
 
+class SupplementBase {
+public:
+    virtual ~SupplementBase() = default;
+
+    // To allow a downcast from Supplement<Foo> to a subclass Bar, we require
+    // a TypeCastTraits specialization. The isBar() function needed for this
+    // specialization can be implemented here and overridden in the base class.
+
+    virtual bool isNavigatorCookieConsent() const { return false; }
+};
+
 template<typename T>
 class Supplementable;
 
 template<typename T>
-class Supplement {
+class Supplement : public SupplementBase {
 public:
-    virtual ~Supplement() = default;
 #if ASSERT_ENABLED || ENABLE(SECURITY_ASSERTIONS)
     virtual bool isRefCountedWrapper() const { return false; }
 #endif


### PR DESCRIPTION
#### 3185431fb4843cf1912dbd122ae8d61ac6f35d2b
<pre>
Introduce SupplementBase as a way to downcast Supplement&lt;T&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=295721">https://bugs.webkit.org/show_bug.cgi?id=295721</a>
<a href="https://rdar.apple.com/155542045">rdar://155542045</a>

Reviewed by Chris Dumez.

For the sake of safety, we often prefer to use downcast in place of
static_cast (the static analyzer catches cases where we should).

In order to use downcast, we may require a TypeCastsTraits specialization
which has an isType() function. This function takes in an argument with
the type of the base class and calls a function that returns true if the
instance is of the derived class and false if it&apos;s not.

Consider the case where class Bar inherits from Supplement&lt;Foo&gt; and we
want to downcast from Supplement&lt;Foo&gt; to Bar. Normally, Supplement&lt;Foo&gt;
would have a virtual function isBar() that returns false, and Bar would
override this function to return true. The isType() function in the
TypeCastsTraits specialization would call isBar() to determine if an
instance of Supplement&lt;Foo&gt; is also an instance of Bar.

But Supplement&lt;Foo&gt; is a class generated by the Supplement&lt;T&gt; template.
We cannot declare and implement the virtual function isBar() in the
template because class templates cannot contain virtual functions.

We fix this by creating a concrete base class SupplementBase that the
template Supplement&lt;T&gt; inherits from. Virtual functions like isBar() can be
declared + implemented here.

This patch adds this class and uses it to fix the static analysis warning
in NavigatorCookieConsent.cpp.

(Thank you to Wenson for helping come up with the idea).

* Source/WebCore/Modules/cookie-consent/NavigatorCookieConsent.cpp:
(WebCore::NavigatorCookieConsent::from):
* Source/WebCore/Modules/cookie-consent/NavigatorCookieConsent.h:
(isType):
* Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebCore/platform/Supplementable.h:
(WebCore::SupplementBase::isNavigatorCookieConsent const):

Canonical link: <a href="https://commits.webkit.org/297255@main">https://commits.webkit.org/297255@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f57e4ac9a290e4143ce8733daeb55024d0fc71bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30715 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21146 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117079 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61316 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113011 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31396 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39297 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84429 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113996 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25081 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99980 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64875 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24434 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18123 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60906 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94462 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18188 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119964 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38098 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28311 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93381 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38474 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96255 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93205 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23753 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38265 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16006 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34079 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37987 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43463 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37651 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40985 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39354 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->