### PR TITLE
[JSC] Add missing name to async and async generator functions

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/capability_checks/features/texture_formats-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/capability_checks/features/texture_formats-expected.txt
@@ -322,7 +322,7 @@ FAIL :canvas_configuration:format="depth32float-stencil8";canvasType="onscreen";
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format depth32float-stencil8 is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="depth32float-stencil8";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="depth32float-stencil8";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -330,7 +330,7 @@ FAIL :canvas_configuration:format="depth32float-stencil8";canvasType="offscreen"
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format depth32float-stencil8 is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="depth32float-stencil8";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="bc1-rgba-unorm";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -338,7 +338,7 @@ FAIL :canvas_configuration:format="bc1-rgba-unorm";canvasType="onscreen";enable_
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format bc1-rgba-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="bc1-rgba-unorm";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="bc1-rgba-unorm";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -346,7 +346,7 @@ FAIL :canvas_configuration:format="bc1-rgba-unorm";canvasType="offscreen";enable
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format bc1-rgba-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="bc1-rgba-unorm";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="bc1-rgba-unorm-srgb";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -354,7 +354,7 @@ FAIL :canvas_configuration:format="bc1-rgba-unorm-srgb";canvasType="onscreen";en
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format bc1-rgba-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="bc1-rgba-unorm-srgb";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="bc1-rgba-unorm-srgb";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -362,7 +362,7 @@ FAIL :canvas_configuration:format="bc1-rgba-unorm-srgb";canvasType="offscreen";e
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format bc1-rgba-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="bc1-rgba-unorm-srgb";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="bc2-rgba-unorm";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -370,7 +370,7 @@ FAIL :canvas_configuration:format="bc2-rgba-unorm";canvasType="onscreen";enable_
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format bc2-rgba-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="bc2-rgba-unorm";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="bc2-rgba-unorm";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -378,7 +378,7 @@ FAIL :canvas_configuration:format="bc2-rgba-unorm";canvasType="offscreen";enable
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format bc2-rgba-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="bc2-rgba-unorm";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="bc2-rgba-unorm-srgb";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -386,7 +386,7 @@ FAIL :canvas_configuration:format="bc2-rgba-unorm-srgb";canvasType="onscreen";en
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format bc2-rgba-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="bc2-rgba-unorm-srgb";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="bc2-rgba-unorm-srgb";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -394,7 +394,7 @@ FAIL :canvas_configuration:format="bc2-rgba-unorm-srgb";canvasType="offscreen";e
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format bc2-rgba-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="bc2-rgba-unorm-srgb";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="bc3-rgba-unorm";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -402,7 +402,7 @@ FAIL :canvas_configuration:format="bc3-rgba-unorm";canvasType="onscreen";enable_
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format bc3-rgba-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="bc3-rgba-unorm";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="bc3-rgba-unorm";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -410,7 +410,7 @@ FAIL :canvas_configuration:format="bc3-rgba-unorm";canvasType="offscreen";enable
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format bc3-rgba-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="bc3-rgba-unorm";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="bc3-rgba-unorm-srgb";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -418,7 +418,7 @@ FAIL :canvas_configuration:format="bc3-rgba-unorm-srgb";canvasType="onscreen";en
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format bc3-rgba-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="bc3-rgba-unorm-srgb";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="bc3-rgba-unorm-srgb";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -426,7 +426,7 @@ FAIL :canvas_configuration:format="bc3-rgba-unorm-srgb";canvasType="offscreen";e
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format bc3-rgba-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="bc3-rgba-unorm-srgb";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="bc4-r-unorm";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -434,7 +434,7 @@ FAIL :canvas_configuration:format="bc4-r-unorm";canvasType="onscreen";enable_req
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format bc4-r-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="bc4-r-unorm";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="bc4-r-unorm";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -442,7 +442,7 @@ FAIL :canvas_configuration:format="bc4-r-unorm";canvasType="offscreen";enable_re
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format bc4-r-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="bc4-r-unorm";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="bc4-r-snorm";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -450,7 +450,7 @@ FAIL :canvas_configuration:format="bc4-r-snorm";canvasType="onscreen";enable_req
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format bc4-r-snorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="bc4-r-snorm";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="bc4-r-snorm";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -458,7 +458,7 @@ FAIL :canvas_configuration:format="bc4-r-snorm";canvasType="offscreen";enable_re
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format bc4-r-snorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="bc4-r-snorm";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="bc5-rg-unorm";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -466,7 +466,7 @@ FAIL :canvas_configuration:format="bc5-rg-unorm";canvasType="onscreen";enable_re
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format bc5-rg-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="bc5-rg-unorm";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="bc5-rg-unorm";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -474,7 +474,7 @@ FAIL :canvas_configuration:format="bc5-rg-unorm";canvasType="offscreen";enable_r
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format bc5-rg-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="bc5-rg-unorm";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="bc5-rg-snorm";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -482,7 +482,7 @@ FAIL :canvas_configuration:format="bc5-rg-snorm";canvasType="onscreen";enable_re
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format bc5-rg-snorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="bc5-rg-snorm";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="bc5-rg-snorm";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -490,7 +490,7 @@ FAIL :canvas_configuration:format="bc5-rg-snorm";canvasType="offscreen";enable_r
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format bc5-rg-snorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="bc5-rg-snorm";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="bc6h-rgb-ufloat";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -498,7 +498,7 @@ FAIL :canvas_configuration:format="bc6h-rgb-ufloat";canvasType="onscreen";enable
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format bc6h-rgb-ufloat is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="bc6h-rgb-ufloat";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="bc6h-rgb-ufloat";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -506,7 +506,7 @@ FAIL :canvas_configuration:format="bc6h-rgb-ufloat";canvasType="offscreen";enabl
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format bc6h-rgb-ufloat is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="bc6h-rgb-ufloat";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="bc6h-rgb-float";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -514,7 +514,7 @@ FAIL :canvas_configuration:format="bc6h-rgb-float";canvasType="onscreen";enable_
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format bc6h-rgb-float is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="bc6h-rgb-float";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="bc6h-rgb-float";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -522,7 +522,7 @@ FAIL :canvas_configuration:format="bc6h-rgb-float";canvasType="offscreen";enable
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format bc6h-rgb-float is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="bc6h-rgb-float";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="bc7-rgba-unorm";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -530,7 +530,7 @@ FAIL :canvas_configuration:format="bc7-rgba-unorm";canvasType="onscreen";enable_
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format bc7-rgba-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="bc7-rgba-unorm";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="bc7-rgba-unorm";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -538,7 +538,7 @@ FAIL :canvas_configuration:format="bc7-rgba-unorm";canvasType="offscreen";enable
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format bc7-rgba-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="bc7-rgba-unorm";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="bc7-rgba-unorm-srgb";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -546,7 +546,7 @@ FAIL :canvas_configuration:format="bc7-rgba-unorm-srgb";canvasType="onscreen";en
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format bc7-rgba-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="bc7-rgba-unorm-srgb";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="bc7-rgba-unorm-srgb";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -554,7 +554,7 @@ FAIL :canvas_configuration:format="bc7-rgba-unorm-srgb";canvasType="offscreen";e
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format bc7-rgba-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="bc7-rgba-unorm-srgb";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="etc2-rgb8unorm";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -562,7 +562,7 @@ FAIL :canvas_configuration:format="etc2-rgb8unorm";canvasType="onscreen";enable_
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format etc2-rgb8unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="etc2-rgb8unorm";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="etc2-rgb8unorm";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -570,7 +570,7 @@ FAIL :canvas_configuration:format="etc2-rgb8unorm";canvasType="offscreen";enable
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format etc2-rgb8unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="etc2-rgb8unorm";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="etc2-rgb8unorm-srgb";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -578,7 +578,7 @@ FAIL :canvas_configuration:format="etc2-rgb8unorm-srgb";canvasType="onscreen";en
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format etc2-rgb8unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="etc2-rgb8unorm-srgb";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="etc2-rgb8unorm-srgb";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -586,7 +586,7 @@ FAIL :canvas_configuration:format="etc2-rgb8unorm-srgb";canvasType="offscreen";e
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format etc2-rgb8unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="etc2-rgb8unorm-srgb";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="etc2-rgb8a1unorm";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -594,7 +594,7 @@ FAIL :canvas_configuration:format="etc2-rgb8a1unorm";canvasType="onscreen";enabl
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format etc2-rgb8a1unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="etc2-rgb8a1unorm";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="etc2-rgb8a1unorm";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -602,7 +602,7 @@ FAIL :canvas_configuration:format="etc2-rgb8a1unorm";canvasType="offscreen";enab
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format etc2-rgb8a1unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="etc2-rgb8a1unorm";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="etc2-rgb8a1unorm-srgb";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -610,7 +610,7 @@ FAIL :canvas_configuration:format="etc2-rgb8a1unorm-srgb";canvasType="onscreen";
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format etc2-rgb8a1unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="etc2-rgb8a1unorm-srgb";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="etc2-rgb8a1unorm-srgb";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -618,7 +618,7 @@ FAIL :canvas_configuration:format="etc2-rgb8a1unorm-srgb";canvasType="offscreen"
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format etc2-rgb8a1unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="etc2-rgb8a1unorm-srgb";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="etc2-rgba8unorm";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -626,7 +626,7 @@ FAIL :canvas_configuration:format="etc2-rgba8unorm";canvasType="onscreen";enable
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format etc2-rgba8unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="etc2-rgba8unorm";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="etc2-rgba8unorm";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -634,7 +634,7 @@ FAIL :canvas_configuration:format="etc2-rgba8unorm";canvasType="offscreen";enabl
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format etc2-rgba8unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="etc2-rgba8unorm";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="etc2-rgba8unorm-srgb";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -642,7 +642,7 @@ FAIL :canvas_configuration:format="etc2-rgba8unorm-srgb";canvasType="onscreen";e
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format etc2-rgba8unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="etc2-rgba8unorm-srgb";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="etc2-rgba8unorm-srgb";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -650,7 +650,7 @@ FAIL :canvas_configuration:format="etc2-rgba8unorm-srgb";canvasType="offscreen";
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format etc2-rgba8unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="etc2-rgba8unorm-srgb";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="eac-r11unorm";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -658,7 +658,7 @@ FAIL :canvas_configuration:format="eac-r11unorm";canvasType="onscreen";enable_re
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format eac-r11unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="eac-r11unorm";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="eac-r11unorm";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -666,7 +666,7 @@ FAIL :canvas_configuration:format="eac-r11unorm";canvasType="offscreen";enable_r
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format eac-r11unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="eac-r11unorm";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="eac-r11snorm";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -674,7 +674,7 @@ FAIL :canvas_configuration:format="eac-r11snorm";canvasType="onscreen";enable_re
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format eac-r11snorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="eac-r11snorm";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="eac-r11snorm";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -682,7 +682,7 @@ FAIL :canvas_configuration:format="eac-r11snorm";canvasType="offscreen";enable_r
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format eac-r11snorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="eac-r11snorm";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="eac-rg11unorm";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -690,7 +690,7 @@ FAIL :canvas_configuration:format="eac-rg11unorm";canvasType="onscreen";enable_r
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format eac-rg11unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="eac-rg11unorm";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="eac-rg11unorm";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -698,7 +698,7 @@ FAIL :canvas_configuration:format="eac-rg11unorm";canvasType="offscreen";enable_
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format eac-rg11unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="eac-rg11unorm";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="eac-rg11snorm";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -706,7 +706,7 @@ FAIL :canvas_configuration:format="eac-rg11snorm";canvasType="onscreen";enable_r
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format eac-rg11snorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="eac-rg11snorm";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="eac-rg11snorm";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -714,7 +714,7 @@ FAIL :canvas_configuration:format="eac-rg11snorm";canvasType="offscreen";enable_
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format eac-rg11snorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="eac-rg11snorm";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-4x4-unorm";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -722,7 +722,7 @@ FAIL :canvas_configuration:format="astc-4x4-unorm";canvasType="onscreen";enable_
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-4x4-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-4x4-unorm";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-4x4-unorm";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -730,7 +730,7 @@ FAIL :canvas_configuration:format="astc-4x4-unorm";canvasType="offscreen";enable
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-4x4-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-4x4-unorm";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-4x4-unorm-srgb";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -738,7 +738,7 @@ FAIL :canvas_configuration:format="astc-4x4-unorm-srgb";canvasType="onscreen";en
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-4x4-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-4x4-unorm-srgb";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-4x4-unorm-srgb";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -746,7 +746,7 @@ FAIL :canvas_configuration:format="astc-4x4-unorm-srgb";canvasType="offscreen";e
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-4x4-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-4x4-unorm-srgb";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-5x4-unorm";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -754,7 +754,7 @@ FAIL :canvas_configuration:format="astc-5x4-unorm";canvasType="onscreen";enable_
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-5x4-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-5x4-unorm";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-5x4-unorm";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -762,7 +762,7 @@ FAIL :canvas_configuration:format="astc-5x4-unorm";canvasType="offscreen";enable
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-5x4-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-5x4-unorm";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-5x4-unorm-srgb";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -770,7 +770,7 @@ FAIL :canvas_configuration:format="astc-5x4-unorm-srgb";canvasType="onscreen";en
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-5x4-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-5x4-unorm-srgb";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-5x4-unorm-srgb";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -778,7 +778,7 @@ FAIL :canvas_configuration:format="astc-5x4-unorm-srgb";canvasType="offscreen";e
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-5x4-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-5x4-unorm-srgb";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-5x5-unorm";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -786,7 +786,7 @@ FAIL :canvas_configuration:format="astc-5x5-unorm";canvasType="onscreen";enable_
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-5x5-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-5x5-unorm";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-5x5-unorm";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -794,7 +794,7 @@ FAIL :canvas_configuration:format="astc-5x5-unorm";canvasType="offscreen";enable
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-5x5-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-5x5-unorm";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-5x5-unorm-srgb";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -802,7 +802,7 @@ FAIL :canvas_configuration:format="astc-5x5-unorm-srgb";canvasType="onscreen";en
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-5x5-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-5x5-unorm-srgb";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-5x5-unorm-srgb";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -810,7 +810,7 @@ FAIL :canvas_configuration:format="astc-5x5-unorm-srgb";canvasType="offscreen";e
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-5x5-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-5x5-unorm-srgb";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-6x5-unorm";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -818,7 +818,7 @@ FAIL :canvas_configuration:format="astc-6x5-unorm";canvasType="onscreen";enable_
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-6x5-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-6x5-unorm";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-6x5-unorm";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -826,7 +826,7 @@ FAIL :canvas_configuration:format="astc-6x5-unorm";canvasType="offscreen";enable
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-6x5-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-6x5-unorm";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-6x5-unorm-srgb";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -834,7 +834,7 @@ FAIL :canvas_configuration:format="astc-6x5-unorm-srgb";canvasType="onscreen";en
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-6x5-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-6x5-unorm-srgb";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-6x5-unorm-srgb";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -842,7 +842,7 @@ FAIL :canvas_configuration:format="astc-6x5-unorm-srgb";canvasType="offscreen";e
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-6x5-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-6x5-unorm-srgb";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-6x6-unorm";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -850,7 +850,7 @@ FAIL :canvas_configuration:format="astc-6x6-unorm";canvasType="onscreen";enable_
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-6x6-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-6x6-unorm";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-6x6-unorm";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -858,7 +858,7 @@ FAIL :canvas_configuration:format="astc-6x6-unorm";canvasType="offscreen";enable
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-6x6-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-6x6-unorm";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-6x6-unorm-srgb";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -866,7 +866,7 @@ FAIL :canvas_configuration:format="astc-6x6-unorm-srgb";canvasType="onscreen";en
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-6x6-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-6x6-unorm-srgb";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-6x6-unorm-srgb";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -874,7 +874,7 @@ FAIL :canvas_configuration:format="astc-6x6-unorm-srgb";canvasType="offscreen";e
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-6x6-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-6x6-unorm-srgb";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-8x5-unorm";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -882,7 +882,7 @@ FAIL :canvas_configuration:format="astc-8x5-unorm";canvasType="onscreen";enable_
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-8x5-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-8x5-unorm";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-8x5-unorm";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -890,7 +890,7 @@ FAIL :canvas_configuration:format="astc-8x5-unorm";canvasType="offscreen";enable
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-8x5-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-8x5-unorm";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-8x5-unorm-srgb";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -898,7 +898,7 @@ FAIL :canvas_configuration:format="astc-8x5-unorm-srgb";canvasType="onscreen";en
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-8x5-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-8x5-unorm-srgb";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-8x5-unorm-srgb";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -906,7 +906,7 @@ FAIL :canvas_configuration:format="astc-8x5-unorm-srgb";canvasType="offscreen";e
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-8x5-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-8x5-unorm-srgb";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-8x6-unorm";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -914,7 +914,7 @@ FAIL :canvas_configuration:format="astc-8x6-unorm";canvasType="onscreen";enable_
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-8x6-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-8x6-unorm";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-8x6-unorm";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -922,7 +922,7 @@ FAIL :canvas_configuration:format="astc-8x6-unorm";canvasType="offscreen";enable
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-8x6-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-8x6-unorm";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-8x6-unorm-srgb";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -930,7 +930,7 @@ FAIL :canvas_configuration:format="astc-8x6-unorm-srgb";canvasType="onscreen";en
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-8x6-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-8x6-unorm-srgb";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-8x6-unorm-srgb";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -938,7 +938,7 @@ FAIL :canvas_configuration:format="astc-8x6-unorm-srgb";canvasType="offscreen";e
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-8x6-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-8x6-unorm-srgb";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-8x8-unorm";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -946,7 +946,7 @@ FAIL :canvas_configuration:format="astc-8x8-unorm";canvasType="onscreen";enable_
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-8x8-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-8x8-unorm";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-8x8-unorm";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -954,7 +954,7 @@ FAIL :canvas_configuration:format="astc-8x8-unorm";canvasType="offscreen";enable
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-8x8-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-8x8-unorm";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-8x8-unorm-srgb";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -962,7 +962,7 @@ FAIL :canvas_configuration:format="astc-8x8-unorm-srgb";canvasType="onscreen";en
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-8x8-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-8x8-unorm-srgb";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-8x8-unorm-srgb";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -970,7 +970,7 @@ FAIL :canvas_configuration:format="astc-8x8-unorm-srgb";canvasType="offscreen";e
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-8x8-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-8x8-unorm-srgb";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-10x5-unorm";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -978,7 +978,7 @@ FAIL :canvas_configuration:format="astc-10x5-unorm";canvasType="onscreen";enable
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-10x5-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-10x5-unorm";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-10x5-unorm";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -986,7 +986,7 @@ FAIL :canvas_configuration:format="astc-10x5-unorm";canvasType="offscreen";enabl
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-10x5-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-10x5-unorm";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-10x5-unorm-srgb";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -994,7 +994,7 @@ FAIL :canvas_configuration:format="astc-10x5-unorm-srgb";canvasType="onscreen";e
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-10x5-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-10x5-unorm-srgb";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-10x5-unorm-srgb";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -1002,7 +1002,7 @@ FAIL :canvas_configuration:format="astc-10x5-unorm-srgb";canvasType="offscreen";
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-10x5-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-10x5-unorm-srgb";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-10x6-unorm";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -1010,7 +1010,7 @@ FAIL :canvas_configuration:format="astc-10x6-unorm";canvasType="onscreen";enable
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-10x6-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-10x6-unorm";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-10x6-unorm";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -1018,7 +1018,7 @@ FAIL :canvas_configuration:format="astc-10x6-unorm";canvasType="offscreen";enabl
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-10x6-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-10x6-unorm";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-10x6-unorm-srgb";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -1026,7 +1026,7 @@ FAIL :canvas_configuration:format="astc-10x6-unorm-srgb";canvasType="onscreen";e
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-10x6-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-10x6-unorm-srgb";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-10x6-unorm-srgb";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -1034,7 +1034,7 @@ FAIL :canvas_configuration:format="astc-10x6-unorm-srgb";canvasType="offscreen";
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-10x6-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-10x6-unorm-srgb";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-10x8-unorm";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -1042,7 +1042,7 @@ FAIL :canvas_configuration:format="astc-10x8-unorm";canvasType="onscreen";enable
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-10x8-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-10x8-unorm";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-10x8-unorm";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -1050,7 +1050,7 @@ FAIL :canvas_configuration:format="astc-10x8-unorm";canvasType="offscreen";enabl
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-10x8-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-10x8-unorm";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-10x8-unorm-srgb";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -1058,7 +1058,7 @@ FAIL :canvas_configuration:format="astc-10x8-unorm-srgb";canvasType="onscreen";e
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-10x8-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-10x8-unorm-srgb";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-10x8-unorm-srgb";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -1066,7 +1066,7 @@ FAIL :canvas_configuration:format="astc-10x8-unorm-srgb";canvasType="offscreen";
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-10x8-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-10x8-unorm-srgb";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-10x10-unorm";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -1074,7 +1074,7 @@ FAIL :canvas_configuration:format="astc-10x10-unorm";canvasType="onscreen";enabl
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-10x10-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-10x10-unorm";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-10x10-unorm";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -1082,7 +1082,7 @@ FAIL :canvas_configuration:format="astc-10x10-unorm";canvasType="offscreen";enab
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-10x10-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-10x10-unorm";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-10x10-unorm-srgb";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -1090,7 +1090,7 @@ FAIL :canvas_configuration:format="astc-10x10-unorm-srgb";canvasType="onscreen";
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-10x10-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-10x10-unorm-srgb";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-10x10-unorm-srgb";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -1098,7 +1098,7 @@ FAIL :canvas_configuration:format="astc-10x10-unorm-srgb";canvasType="offscreen"
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-10x10-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-10x10-unorm-srgb";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-12x10-unorm";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -1106,7 +1106,7 @@ FAIL :canvas_configuration:format="astc-12x10-unorm";canvasType="onscreen";enabl
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-12x10-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-12x10-unorm";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-12x10-unorm";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -1114,7 +1114,7 @@ FAIL :canvas_configuration:format="astc-12x10-unorm";canvasType="offscreen";enab
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-12x10-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-12x10-unorm";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-12x10-unorm-srgb";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -1122,7 +1122,7 @@ FAIL :canvas_configuration:format="astc-12x10-unorm-srgb";canvasType="onscreen";
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-12x10-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-12x10-unorm-srgb";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-12x10-unorm-srgb";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -1130,7 +1130,7 @@ FAIL :canvas_configuration:format="astc-12x10-unorm-srgb";canvasType="offscreen"
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-12x10-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-12x10-unorm-srgb";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-12x12-unorm";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -1138,7 +1138,7 @@ FAIL :canvas_configuration:format="astc-12x12-unorm";canvasType="onscreen";enabl
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-12x12-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-12x12-unorm";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-12x12-unorm";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -1146,7 +1146,7 @@ FAIL :canvas_configuration:format="astc-12x12-unorm";canvasType="offscreen";enab
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-12x12-unorm is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-12x12-unorm";canvasType="offscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-12x12-unorm-srgb";canvasType="onscreen";enable_required_feature=true assert_unreached:
@@ -1154,7 +1154,7 @@ FAIL :canvas_configuration:format="astc-12x12-unorm-srgb";canvasType="onscreen";
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-12x12-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-12x12-unorm-srgb";canvasType="onscreen";enable_required_feature=false
 FAIL :canvas_configuration:format="astc-12x12-unorm-srgb";canvasType="offscreen";enable_required_feature=true assert_unreached:
@@ -1162,7 +1162,7 @@ FAIL :canvas_configuration:format="astc-12x12-unorm-srgb";canvasType="offscreen"
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Requested texture format astc-12x12-unorm-srgb is not a valid context format
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :canvas_configuration:format="astc-12x12-unorm-srgb";canvasType="offscreen";enable_required_feature=false
 PASS :canvas_configuration_view_formats:viewFormats=["depth32float-stencil8"];canvasType="onscreen";enable_required_feature=true

--- a/LayoutTests/inspector/canvas/recording-bitmaprenderer-frameCount-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-bitmaprenderer-frameCount-expected.txt
@@ -18,6 +18,6 @@ frames:
         0: transferFromImageBitmap
         1: (anonymous function)
         2: executeFrameFunction
-        3: (anonymous function)
+        3: performActions
       snapshot: <filtered>
 

--- a/LayoutTests/inspector/canvas/recording-bitmaprenderer-full-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-bitmaprenderer-full-expected.txt
@@ -18,7 +18,7 @@ frames:
         0: transferFromImageBitmap
         1: (anonymous function)
         2: executeFrameFunction
-        3: (anonymous function)
+        3: performActions
       snapshot: <filtered>
   1: (duration)
     0: width

--- a/LayoutTests/inspector/canvas/recording-bitmaprenderer-memoryLimit-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-bitmaprenderer-memoryLimit-expected.txt
@@ -18,6 +18,6 @@ frames:
         0: transferFromImageBitmap
         1: (anonymous function)
         2: executeFrameFunction
-        3: (anonymous function)
+        3: performActions
       snapshot: <filtered>
 

--- a/LayoutTests/inspector/canvas/recording-offscreen-bitmaprenderer-frameCount-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-offscreen-bitmaprenderer-frameCount-expected.txt
@@ -18,6 +18,6 @@ frames:
         0: transferFromImageBitmap
         1: (anonymous function)
         2: executeFrameFunction
-        3: (anonymous function)
+        3: performActions
       snapshot: <filtered>
 

--- a/LayoutTests/inspector/canvas/recording-offscreen-bitmaprenderer-full-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-offscreen-bitmaprenderer-full-expected.txt
@@ -18,7 +18,7 @@ frames:
         0: transferFromImageBitmap
         1: (anonymous function)
         2: executeFrameFunction
-        3: (anonymous function)
+        3: performActions
       snapshot: <filtered>
   1: (duration)
     0: width

--- a/LayoutTests/inspector/canvas/recording-offscreen-bitmaprenderer-memoryLimit-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-offscreen-bitmaprenderer-memoryLimit-expected.txt
@@ -18,6 +18,6 @@ frames:
         0: transferFromImageBitmap
         1: (anonymous function)
         2: executeFrameFunction
-        3: (anonymous function)
+        3: performActions
       snapshot: <filtered>
 

--- a/LayoutTests/inspector/console/message-stack-trace-expected.txt
+++ b/LayoutTests/inspector/console/message-stack-trace-expected.txt
@@ -60,5 +60,5 @@ ASYNC CALL STACK:
 
 -- Running test case: Console.StackTrace.UnhandledPromiseRejection.Module
 CALL STACK:
-0: [F] (anonymous function)
+0: [F] wrapper
 

--- a/Source/JavaScriptCore/parser/ASTBuilder.h
+++ b/Source/JavaScriptCore/parser/ASTBuilder.h
@@ -444,15 +444,20 @@ public:
         return result;
     }
 
-    ExpressionNode* createAsyncFunctionBody(const JSTokenLocation& location, const ParserFunctionInfo<ASTBuilder>& functionInfo, SourceParseMode parseMode)
+    ExpressionNode* createAsyncFunctionBody(const JSTokenLocation& location, const ParserFunctionInfo<ASTBuilder>& functionInfo, SourceParseMode parseMode, const Identifier& name)
     {
         if (parseMode == SourceParseMode::AsyncArrowFunctionBodyMode) {
             SourceCode source = m_sourceCode->subExpression(functionInfo.startOffset, functionInfo.body->isArrowFunctionBodyExpression() ? functionInfo.endOffset - 1 : functionInfo.endOffset, functionInfo.startLine, functionInfo.parametersStartColumn);
             FuncExprNode* result = new (m_parserArena) FuncExprNode(location, *functionInfo.name, functionInfo.body, source);
+            if (!name.isNull())
+                result->metadata()->setEcmaName(name);
             functionInfo.body->setLoc(functionInfo.startLine, functionInfo.endLine, location.startOffset, location.lineStartOffset);
             return result;
         }
-        return createFunctionExpr(location, functionInfo);
+        FuncExprNode* result =  static_cast<FuncExprNode*>(createFunctionExpr(location, functionInfo));
+        if (!name.isNull())
+            result->metadata()->setEcmaName(name);
+        return result;
     }
 
     ExpressionNode* createMethodDefinition(const JSTokenLocation& location, const ParserFunctionInfo<ASTBuilder>& functionInfo)

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -269,7 +269,7 @@ Expected<typename Parser<LexerType>::ParseInnerResult, String> Parser<LexerType>
     // The only way we can error this early is if we reparse a function and we run out of stack space.
     if (!hasError()) {
         if (isAsyncFunctionWrapperParseMode(parseMode))
-            sourceElements = parseAsyncFunctionSourceElements(context, isArrowFunctionBodyExpression, CheckForStrictMode);
+            sourceElements = parseAsyncFunctionSourceElements(context, calleeName, isArrowFunctionBodyExpression, CheckForStrictMode);
         else if (isArrowFunctionBodyExpression)
             sourceElements = parseArrowFunctionSingleExpressionBodySourceElements(context);
         else if (isModuleParseMode(parseMode))
@@ -277,7 +277,7 @@ Expected<typename Parser<LexerType>::ParseInnerResult, String> Parser<LexerType>
         else if (isGeneratorWrapperParseMode(parseMode))
             sourceElements = parseGeneratorFunctionSourceElements(context, calleeName, CheckForStrictMode);
         else if (isAsyncGeneratorWrapperParseMode(parseMode))
-            sourceElements = parseAsyncGeneratorFunctionSourceElements(context, isArrowFunctionBodyExpression, CheckForStrictMode);
+            sourceElements = parseAsyncGeneratorFunctionSourceElements(context, calleeName, isArrowFunctionBodyExpression, CheckForStrictMode);
         else if (parsingContext == ParsingContext::FunctionConstructor)
             sourceElements = parseSingleFunction(context, functionConstructorParametersEndPosition);
         else if (parseMode == SourceParseMode::ClassFieldInitializerMode) {
@@ -564,7 +564,7 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseGenerato
 }
 
 template <typename LexerType>
-template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseAsyncFunctionSourceElements(TreeBuilder& context, bool isArrowFunctionBodyExpression, SourceElementsMode mode)
+template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseAsyncFunctionSourceElements(TreeBuilder& context, const Identifier& calleeName, bool isArrowFunctionBodyExpression, SourceElementsMode mode)
 {
     ASSERT(isAsyncFunctionOrAsyncGeneratorWrapperParseMode(sourceParseMode()));
     auto sourceElements = context.createSourceElements();
@@ -610,7 +610,7 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseAsyncFun
     info.endOffset = isArrowFunctionBodyExpression ? tokenLocation().endOffset : m_token.m_data.offset;
     info.parametersStartColumn = startColumn;
 
-    auto functionExpr = context.createAsyncFunctionBody(startLocation, info, parseMode);
+    auto functionExpr = context.createAsyncFunctionBody(startLocation, info, parseMode, calleeName);
     auto statement = context.createExprStatement(startLocation, functionExpr, start, m_lastTokenEndPosition.line);
     context.appendStatement(sourceElements, statement);
 
@@ -618,7 +618,7 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseAsyncFun
 }
 
 template <typename LexerType>
-template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseAsyncGeneratorFunctionSourceElements(TreeBuilder& context, bool isArrowFunctionBodyExpression, SourceElementsMode mode)
+template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseAsyncGeneratorFunctionSourceElements(TreeBuilder& context, const Identifier& calleeName, bool isArrowFunctionBodyExpression, SourceElementsMode mode)
 {
     ASSERT(isAsyncGeneratorWrapperParseMode(sourceParseMode()));
     auto sourceElements = context.createSourceElements();
@@ -664,7 +664,7 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseAsyncGen
     info.endOffset = isArrowFunctionBodyExpression ? tokenLocation().endOffset : m_token.m_data.offset;
     info.parametersStartColumn = startColumn;
 
-    auto functionExpr = context.createAsyncFunctionBody(startLocation, info, parseMode);
+    auto functionExpr = context.createAsyncFunctionBody(startLocation, info, parseMode, calleeName);
     auto statement = context.createExprStatement(startLocation, functionExpr, start, m_lastTokenEndPosition.line);
     context.appendStatement(sourceElements, statement);
         

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -1788,8 +1788,8 @@ private:
 
     template <class TreeBuilder> TreeSourceElements parseSourceElements(TreeBuilder&, SourceElementsMode);
     template <class TreeBuilder> TreeSourceElements parseGeneratorFunctionSourceElements(TreeBuilder&, const Identifier& name, SourceElementsMode);
-    template <class TreeBuilder> TreeSourceElements parseAsyncFunctionSourceElements(TreeBuilder&, bool isArrowFunctionBodyExpression, SourceElementsMode);
-    template <class TreeBuilder> TreeSourceElements parseAsyncGeneratorFunctionSourceElements(TreeBuilder&, bool isArrowFunctionBodyExpression, SourceElementsMode);
+    template <class TreeBuilder> TreeSourceElements parseAsyncFunctionSourceElements(TreeBuilder&, const Identifier& calleeName, bool isArrowFunctionBodyExpression, SourceElementsMode);
+    template <class TreeBuilder> TreeSourceElements parseAsyncGeneratorFunctionSourceElements(TreeBuilder&, const Identifier& calleeName, bool isArrowFunctionBodyExpression, SourceElementsMode);
     template <class TreeBuilder> TreeSourceElements parseSingleFunction(TreeBuilder&, std::optional<int> functionConstructorParametersEndPosition);
     template <class TreeBuilder> TreeSourceElements parseClassFieldInitializerSourceElements(TreeBuilder&, const FixedVector<UnlinkedFunctionExecutable::ClassElementDefinition>&);
     template <class TreeBuilder> TreeStatement parseStatementListItem(TreeBuilder&, const Identifier*& directive, unsigned* directiveLiteralLength);


### PR DESCRIPTION
#### 3f41339e65ab6b981d9d16b2e276badbc154989b
<pre>
[JSC] Add missing name to async and async generator functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=295731">https://bugs.webkit.org/show_bug.cgi?id=295731</a>

Reviewed by Devin Rousso.

This patch adds missing name to async and async generator functions.
We already do the same thing in parseGeneratorFunctionSourceElements.

While this patch doesn&apos;t have much meaning by itself, it will be necessary
when implementing features like async stack traces in the future.

This change is adapted from Bun&apos;s WebKit fork:
<a href="https://github.com/oven-sh/WebKit/commit/2fda64ba3e27d0c029e823f6fedd38fa645c028b">https://github.com/oven-sh/WebKit/commit/2fda64ba3e27d0c029e823f6fedd38fa645c028b</a>

* LayoutTests/http/tests/webgpu/webgpu/api/validation/capability_checks/features/texture_formats-expected.txt:
* LayoutTests/inspector/canvas/recording-bitmaprenderer-frameCount-expected.txt:
* LayoutTests/inspector/canvas/recording-bitmaprenderer-full-expected.txt:
* LayoutTests/inspector/canvas/recording-bitmaprenderer-memoryLimit-expected.txt:
* LayoutTests/inspector/canvas/recording-offscreen-bitmaprenderer-frameCount-expected.txt:
* LayoutTests/inspector/canvas/recording-offscreen-bitmaprenderer-full-expected.txt:
* LayoutTests/inspector/canvas/recording-offscreen-bitmaprenderer-memoryLimit-expected.txt:
* LayoutTests/inspector/console/message-stack-trace-expected.txt:
* Source/JavaScriptCore/parser/ASTBuilder.h:
(JSC::ASTBuilder::createAsyncFunctionBody):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseInner):
(JSC::Parser&lt;LexerType&gt;::parseAsyncFunctionSourceElements):
(JSC::Parser&lt;LexerType&gt;::parseAsyncGeneratorFunctionSourceElements):
* Source/JavaScriptCore/parser/Parser.h:

Canonical link: <a href="https://commits.webkit.org/297342@main">https://commits.webkit.org/297342@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/513b20960d1cf27bb79100387d0b3caefef72767

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31007 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21472 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117373 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61609 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39589 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84625 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114288 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25303 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100236 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65073 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24646 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18375 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61193 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/103834 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94687 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18442 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120546 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109895 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38390 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28526 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93552 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38766 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96509 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93376 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23802 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38476 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16247 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34400 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38279 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43756 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/134170 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37944 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36170 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41277 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39646 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->