### PR TITLE
[JSC] Use more `enum class` for Safer C++

### DIFF
--- a/Source/JavaScriptCore/API/OpaqueJSString.cpp
+++ b/Source/JavaScriptCore/API/OpaqueJSString.cpp
@@ -73,7 +73,7 @@ Identifier OpaqueJSString::identifier(VM* vm) const
     if (m_string.isNull())
         return Identifier();
     if (m_string.isEmpty())
-        return Identifier(Identifier::EmptyIdentifier);
+        return Identifier(Identifier::EmptyIdentifierFlag::EmptyIdentifier);
     if (m_string.is8Bit())
         return Identifier::fromString(*vm, m_string.span8());
     return Identifier::fromString(*vm, m_string.span16());

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
@@ -61,15 +61,15 @@ static bool tryAllocate(VM* vm, const Func& allocate)
     bool success = false;
     for (unsigned i = 0; i < numTries && !success; ++i) {
         switch (allocate()) {
-        case BufferMemoryResult::Success:
+        case BufferMemoryResult::Kind::Success:
             success = true;
             break;
-        case BufferMemoryResult::SuccessAndNotifyMemoryPressure:
+        case BufferMemoryResult::Kind::SuccessAndNotifyMemoryPressure:
             if (vm)
                 vm->heap.collectAsync(CollectionScope::Full);
             success = true;
             break;
-        case BufferMemoryResult::SyncTryToReclaimMemory:
+        case BufferMemoryResult::Kind::SyncTryToReclaimMemory:
             if (i + 1 == numTries)
                 break;
             if (vm)

--- a/Source/JavaScriptCore/runtime/BufferMemoryHandle.h
+++ b/Source/JavaScriptCore/runtime/BufferMemoryHandle.h
@@ -60,7 +60,7 @@ enum class GrowFailReason : uint8_t {
 };
 
 struct BufferMemoryResult {
-    enum Kind {
+    enum class Kind {
         Success,
         SuccessAndNotifyMemoryPressure,
         SyncTryToReclaimMemory

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.cpp
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(CommonIdentifiers);
 
 CommonIdentifiers::CommonIdentifiers(VM& vm)
     : nullIdentifier()
-    , emptyIdentifier(Identifier::EmptyIdentifier)
+    , emptyIdentifier(Identifier::EmptyIdentifierFlag::EmptyIdentifier)
     , underscoreProto(Identifier::fromString(vm, "__proto__"_s))
     , useStrictIdentifier(Identifier::fromString(vm, "use strict"_s))
     , timesIdentifier(Identifier::fromString(vm, "*"_s))

--- a/Source/JavaScriptCore/runtime/ConsoleClient.cpp
+++ b/Source/JavaScriptCore/runtime/ConsoleClient.cpp
@@ -250,7 +250,7 @@ void ConsoleClient::printConsoleMessageWithArguments(MessageSource source, Messa
 
 void ConsoleClient::internalMessageWithTypeAndLevel(MessageType type, MessageLevel level, JSC::JSGlobalObject* globalObject, Ref<ScriptArguments>&& arguments, ArgumentRequirement argumentRequirement)
 {
-    if (argumentRequirement == ArgumentRequired && !arguments->argumentCount())
+    if (argumentRequirement == ArgumentRequirement::Yes && !arguments->argumentCount())
         return;
 
     messageWithTypeAndLevel(type, level, globalObject, WTFMove(arguments));
@@ -258,52 +258,52 @@ void ConsoleClient::internalMessageWithTypeAndLevel(MessageType type, MessageLev
 
 void ConsoleClient::logWithLevel(JSGlobalObject* globalObject, Ref<ScriptArguments>&& arguments, MessageLevel level)
 {
-    internalMessageWithTypeAndLevel(MessageType::Log, level, globalObject, WTFMove(arguments), ArgumentRequired);
+    internalMessageWithTypeAndLevel(MessageType::Log, level, globalObject, WTFMove(arguments), ArgumentRequirement::Yes);
 }
 
 void ConsoleClient::clear(JSGlobalObject* globalObject)
 {
-    internalMessageWithTypeAndLevel(MessageType::Clear, MessageLevel::Log, globalObject, ScriptArguments::create(globalObject, { }), ArgumentNotRequired);
+    internalMessageWithTypeAndLevel(MessageType::Clear, MessageLevel::Log, globalObject, ScriptArguments::create(globalObject, { }), ArgumentRequirement::No);
 }
 
 void ConsoleClient::dir(JSGlobalObject* globalObject, Ref<ScriptArguments>&& arguments)
 {
-    internalMessageWithTypeAndLevel(MessageType::Dir, MessageLevel::Log, globalObject, WTFMove(arguments), ArgumentRequired);
+    internalMessageWithTypeAndLevel(MessageType::Dir, MessageLevel::Log, globalObject, WTFMove(arguments), ArgumentRequirement::Yes);
 }
 
 void ConsoleClient::dirXML(JSGlobalObject* globalObject, Ref<ScriptArguments>&& arguments)
 {
-    internalMessageWithTypeAndLevel(MessageType::DirXML, MessageLevel::Log, globalObject, WTFMove(arguments), ArgumentRequired);
+    internalMessageWithTypeAndLevel(MessageType::DirXML, MessageLevel::Log, globalObject, WTFMove(arguments), ArgumentRequirement::Yes);
 }
 
 void ConsoleClient::table(JSGlobalObject* globalObject, Ref<ScriptArguments>&& arguments)
 {
-    internalMessageWithTypeAndLevel(MessageType::Table, MessageLevel::Log, globalObject, WTFMove(arguments), ArgumentRequired);
+    internalMessageWithTypeAndLevel(MessageType::Table, MessageLevel::Log, globalObject, WTFMove(arguments), ArgumentRequirement::Yes);
 }
 
 void ConsoleClient::trace(JSGlobalObject* globalObject, Ref<ScriptArguments>&& arguments)
 {
-    internalMessageWithTypeAndLevel(MessageType::Trace, MessageLevel::Log, globalObject, WTFMove(arguments), ArgumentNotRequired);
+    internalMessageWithTypeAndLevel(MessageType::Trace, MessageLevel::Log, globalObject, WTFMove(arguments), ArgumentRequirement::No);
 }
 
 void ConsoleClient::assertion(JSGlobalObject* globalObject, Ref<ScriptArguments>&& arguments)
 {
-    internalMessageWithTypeAndLevel(MessageType::Assert, MessageLevel::Error, globalObject, WTFMove(arguments), ArgumentNotRequired);
+    internalMessageWithTypeAndLevel(MessageType::Assert, MessageLevel::Error, globalObject, WTFMove(arguments), ArgumentRequirement::No);
 }
 
 void ConsoleClient::group(JSGlobalObject* globalObject, Ref<ScriptArguments>&& arguments)
 {
-    internalMessageWithTypeAndLevel(MessageType::StartGroup, MessageLevel::Log, globalObject, WTFMove(arguments), ArgumentNotRequired);
+    internalMessageWithTypeAndLevel(MessageType::StartGroup, MessageLevel::Log, globalObject, WTFMove(arguments), ArgumentRequirement::No);
 }
 
 void ConsoleClient::groupCollapsed(JSGlobalObject* globalObject, Ref<ScriptArguments>&& arguments)
 {
-    internalMessageWithTypeAndLevel(MessageType::StartGroupCollapsed, MessageLevel::Log, globalObject, WTFMove(arguments), ArgumentNotRequired);
+    internalMessageWithTypeAndLevel(MessageType::StartGroupCollapsed, MessageLevel::Log, globalObject, WTFMove(arguments), ArgumentRequirement::No);
 }
 
 void ConsoleClient::groupEnd(JSGlobalObject* globalObject, Ref<ScriptArguments>&& arguments)
 {
-    internalMessageWithTypeAndLevel(MessageType::EndGroup, MessageLevel::Log, globalObject, WTFMove(arguments), ArgumentNotRequired);
+    internalMessageWithTypeAndLevel(MessageType::EndGroup, MessageLevel::Log, globalObject, WTFMove(arguments), ArgumentRequirement::No);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/ConsoleClient.h
+++ b/Source/JavaScriptCore/runtime/ConsoleClient.h
@@ -80,7 +80,7 @@ public:
     virtual void screenshot(JSGlobalObject*, Ref<Inspector::ScriptArguments>&&) = 0;
 
 private:
-    enum ArgumentRequirement { ArgumentRequired, ArgumentNotRequired };
+    enum class ArgumentRequirement { No, Yes };
     void internalMessageWithTypeAndLevel(MessageType, MessageLevel, JSC::JSGlobalObject*, Ref<Inspector::ScriptArguments>&&, ArgumentRequirement);
 };
 

--- a/Source/JavaScriptCore/runtime/ConstantMode.cpp
+++ b/Source/JavaScriptCore/runtime/ConstantMode.cpp
@@ -33,10 +33,10 @@ using namespace JSC;
 void printInternal(PrintStream& out, ConstantMode mode)
 {
     switch (mode) {
-    case IsConstant:
+    case ConstantMode::IsConstant:
         out.print("Constant");
         return;
-    case IsVariable:
+    case ConstantMode::IsVariable:
         out.print("Variable");
         return;
     }

--- a/Source/JavaScriptCore/runtime/ConstantMode.h
+++ b/Source/JavaScriptCore/runtime/ConstantMode.h
@@ -29,11 +29,11 @@
 
 namespace JSC {
 
-enum ConstantMode { IsConstant, IsVariable };
+enum class ConstantMode { IsConstant, IsVariable };
 
 inline ConstantMode modeForIsConstant(bool isConstant)
 {
-    return isConstant ? IsConstant : IsVariable;
+    return isConstant ? ConstantMode::IsConstant : ConstantMode::IsVariable;
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/DateConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/DateConstructor.cpp
@@ -153,7 +153,7 @@ JSC_DEFINE_HOST_FUNCTION(callDate, (JSGlobalObject* globalObject, CallFrame*))
     VM& vm = globalObject->vm();
     GregorianDateTime ts;
     vm.dateCache.msToGregorianDateTime(WallTime::now().secondsSinceEpoch().milliseconds(), TimeType::LocalTime, ts);
-    return JSValue::encode(jsNontrivialString(vm, formatDateTime(ts, DateTimeFormatDateAndTime, false, vm.dateCache)));
+    return JSValue::encode(jsNontrivialString(vm, formatDateTime(ts, DateTimeFormat::DateAndTime, false, vm.dateCache)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(dateParse, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/DateConversion.cpp
+++ b/Source/JavaScriptCore/runtime/DateConversion.cpp
@@ -59,8 +59,8 @@ void appendNumber<2>(StringBuilder& builder, int value)
 
 String formatDateTime(const GregorianDateTime& t, DateTimeFormat format, bool asUTCVariant, DateCache& dateCache)
 {
-    bool appendDate = format & DateTimeFormatDate;
-    bool appendTime = format & DateTimeFormatTime;
+    bool appendDate = static_cast<int>(format) & static_cast<int>(DateTimeFormat::Date);
+    bool appendTime = static_cast<int>(format) & static_cast<int>(DateTimeFormat::Time);
 
     StringBuilder builder;
 

--- a/Source/JavaScriptCore/runtime/DateConversion.h
+++ b/Source/JavaScriptCore/runtime/DateConversion.h
@@ -31,10 +31,10 @@ namespace JSC {
 
 class DateCache;
 
-enum DateTimeFormat {
-    DateTimeFormatDate = 1,
-    DateTimeFormatTime = 2,
-    DateTimeFormatDateAndTime = DateTimeFormatDate | DateTimeFormatTime
+enum class DateTimeFormat {
+    Date = 1,
+    Time = 2,
+    DateAndTime = Date | Time
 };
 
 JS_EXPORT_PRIVATE WTF::String formatDateTime(const GregorianDateTime&, DateTimeFormat, bool asUTCVariant, DateCache&);

--- a/Source/JavaScriptCore/runtime/DatePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/DatePrototype.cpp
@@ -305,13 +305,13 @@ void DatePrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
 JSC_DEFINE_HOST_FUNCTION(dateProtoFuncToString, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     const bool asUTCVariant = false;
-    return formateDateInstance(globalObject, callFrame, DateTimeFormatDateAndTime, asUTCVariant);
+    return formateDateInstance(globalObject, callFrame, DateTimeFormat::DateAndTime, asUTCVariant);
 }
 
 JSC_DEFINE_HOST_FUNCTION(dateProtoFuncToUTCString, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     const bool asUTCVariant = true;
-    return formateDateInstance(globalObject, callFrame, DateTimeFormatDateAndTime, asUTCVariant);
+    return formateDateInstance(globalObject, callFrame, DateTimeFormat::DateAndTime, asUTCVariant);
 }
 
 JSC_DEFINE_HOST_FUNCTION(dateProtoFuncToISOString, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -359,13 +359,13 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncToISOString, (JSGlobalObject* globalObject
 JSC_DEFINE_HOST_FUNCTION(dateProtoFuncToDateString, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     const bool asUTCVariant = false;
-    return formateDateInstance(globalObject, callFrame, DateTimeFormatDate, asUTCVariant);
+    return formateDateInstance(globalObject, callFrame, DateTimeFormat::Date, asUTCVariant);
 }
 
 JSC_DEFINE_HOST_FUNCTION(dateProtoFuncToTimeString, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     const bool asUTCVariant = false;
-    return formateDateInstance(globalObject, callFrame, DateTimeFormatTime, asUTCVariant);
+    return formateDateInstance(globalObject, callFrame, DateTimeFormat::Time, asUTCVariant);
 }
 
 JSC_DEFINE_HOST_FUNCTION(dateProtoFuncToPrimitiveSymbol, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/DeletePropertySlot.h
+++ b/Source/JavaScriptCore/runtime/DeletePropertySlot.h
@@ -32,35 +32,35 @@ namespace JSC {
     
 class DeletePropertySlot {
 public:
-    enum Type : uint8_t { Uncacheable, DeleteHit, ConfigurableDeleteMiss, Nonconfigurable };
+    enum class Type : uint8_t { Uncacheable, DeleteHit, ConfigurableDeleteMiss, Nonconfigurable };
 
     DeletePropertySlot()
         : m_offset(invalidOffset)
         , m_cacheability(CachingAllowed)
-        , m_type(Uncacheable)
+        , m_type(Type::Uncacheable)
     {
     }
 
     void setConfigurableMiss()
     {
-        m_type = ConfigurableDeleteMiss;
+        m_type = Type::ConfigurableDeleteMiss;
     }
 
     void setNonconfigurable()
     {
-        m_type = Nonconfigurable;
+        m_type = Type::Nonconfigurable;
     }
 
     void setHit(PropertyOffset offset)
     {
-        m_type = DeleteHit;
+        m_type = Type::DeleteHit;
         m_offset = offset;
     }
 
-    bool isCacheableDelete() const { return isCacheable() && m_type != Uncacheable; }
-    bool isDeleteHit() const { return m_type == DeleteHit; }
-    bool isConfigurableDeleteMiss() const { return m_type == ConfigurableDeleteMiss; }
-    bool isNonconfigurable() const { return m_type == Nonconfigurable; }
+    bool isCacheableDelete() const { return isCacheable() && m_type != Type::Uncacheable; }
+    bool isDeleteHit() const { return m_type == Type::DeleteHit; }
+    bool isConfigurableDeleteMiss() const { return m_type == Type::ConfigurableDeleteMiss; }
+    bool isNonconfigurable() const { return m_type == Type::Nonconfigurable; }
 
     PropertyOffset cachedOffset() const
     {

--- a/Source/JavaScriptCore/runtime/ErrorInstance.cpp
+++ b/Source/JavaScriptCore/runtime/ErrorInstance.cpp
@@ -88,7 +88,7 @@ String appendSourceToErrorMessage(CodeBlock* codeBlock, BytecodeIndex bytecodeIn
         return message;
     
     if (expressionStart < expressionStop)
-        return appender(message, codeBlock->source().provider()->getRange(expressionStart, expressionStop), type, ErrorInstance::FoundExactSource);
+        return appender(message, codeBlock->source().provider()->getRange(expressionStart, expressionStop), type, ErrorInstance::SourceTextWhereErrorOccurred::FoundExactSource);
 
     // No range information, so give a few characters of context.
     int dataLength = sourceString.length();
@@ -104,7 +104,7 @@ String appendSourceToErrorMessage(CodeBlock* codeBlock, BytecodeIndex bytecodeIn
         stop++;
     while (stop > expressionStart && isStrWhiteSpace(sourceString[stop - 1]))
         stop--;
-    return appender(message, codeBlock->source().provider()->getRange(start, stop), type, ErrorInstance::FoundApproximateSource);
+    return appender(message, codeBlock->source().provider()->getRange(start, stop), type, ErrorInstance::SourceTextWhereErrorOccurred::FoundApproximateSource);
 }
 
 void ErrorInstance::finishCreation(VM& vm, const String& message, JSValue cause, SourceAppender appender, RuntimeType type, bool useCurrentFrame, JSCell* subclassCaller)

--- a/Source/JavaScriptCore/runtime/ErrorInstance.h
+++ b/Source/JavaScriptCore/runtime/ErrorInstance.h
@@ -47,7 +47,7 @@ public:
         return vm.errorInstanceSpace<mode>();
     }
 
-    enum SourceTextWhereErrorOccurred { FoundExactSource, FoundApproximateSource };
+    enum class SourceTextWhereErrorOccurred { FoundExactSource, FoundApproximateSource };
     typedef String (*SourceAppender) (const String& originalMessage, StringView sourceText, RuntimeType, SourceTextWhereErrorOccurred);
 
     DECLARE_EXPORT_INFO;

--- a/Source/JavaScriptCore/runtime/Exception.h
+++ b/Source/JavaScriptCore/runtime/Exception.h
@@ -43,11 +43,11 @@ public:
         return &vm.exceptionSpace();
     }
 
-    enum StackCaptureAction {
+    enum class StackCaptureAction {
         CaptureStack,
         DoNotCaptureStack
     };
-    JS_EXPORT_PRIVATE static Exception* create(VM&, JSValue thrownValue, StackCaptureAction = CaptureStack);
+    JS_EXPORT_PRIVATE static Exception* create(VM&, JSValue thrownValue, StackCaptureAction = StackCaptureAction::CaptureStack);
 
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue prototype);
 

--- a/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
+++ b/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
@@ -94,10 +94,10 @@ static String defaultApproximateSourceError(const String& originalMessage, Strin
 
 String defaultSourceAppender(const String& originalMessage, StringView sourceText, RuntimeType, ErrorInstance::SourceTextWhereErrorOccurred occurrence)
 {
-    if (occurrence == ErrorInstance::FoundApproximateSource)
+    if (occurrence == ErrorInstance::SourceTextWhereErrorOccurred::FoundApproximateSource)
         return defaultApproximateSourceError(originalMessage, sourceText);
 
-    ASSERT(occurrence == ErrorInstance::FoundExactSource);
+    ASSERT(occurrence == ErrorInstance::SourceTextWhereErrorOccurred::FoundExactSource);
     return makeString(clampErrorMessage(originalMessage), " (evaluating '"_s, sourceText, "')"_s);
 }
 
@@ -163,10 +163,10 @@ String notAFunctionSourceAppender(const String& originalMessage, StringView sour
 {
     ASSERT(type != TypeFunction);
 
-    if (occurrence == ErrorInstance::FoundApproximateSource)
+    if (occurrence == ErrorInstance::SourceTextWhereErrorOccurred::FoundApproximateSource)
         return defaultApproximateSourceError(originalMessage, sourceText);
 
-    ASSERT(occurrence == ErrorInstance::FoundExactSource);
+    ASSERT(occurrence == ErrorInstance::SourceTextWhereErrorOccurred::FoundExactSource);
     auto notAFunctionIndex = originalMessage.reverseFind("is not a function"_s);
     RELEASE_ASSERT(notAFunctionIndex != notFound);
     auto displayValue = StringView { originalMessage }.left(notAFunctionIndex - 1);
@@ -195,10 +195,10 @@ static String invalidParameterInSourceAppender(const String& originalMessage, St
 {
     ASSERT_UNUSED(type, type != TypeObject);
 
-    if (occurrence == ErrorInstance::FoundApproximateSource)
+    if (occurrence == ErrorInstance::SourceTextWhereErrorOccurred::FoundApproximateSource)
         return defaultApproximateSourceError(originalMessage, sourceText);
 
-    ASSERT(occurrence == ErrorInstance::FoundExactSource);
+    ASSERT(occurrence == ErrorInstance::SourceTextWhereErrorOccurred::FoundExactSource);
     auto inIndex = sourceText.reverseFind("in"_s);
     if (inIndex == notFound) {
         // This should basically never happen, since JS code must use the literal
@@ -216,10 +216,10 @@ static String invalidParameterInSourceAppender(const String& originalMessage, St
 
 inline String invalidParameterInstanceofSourceAppender(const String& content, const String& originalMessage, StringView sourceText, RuntimeType, ErrorInstance::SourceTextWhereErrorOccurred occurrence)
 {
-    if (occurrence == ErrorInstance::FoundApproximateSource)
+    if (occurrence == ErrorInstance::SourceTextWhereErrorOccurred::FoundApproximateSource)
         return defaultApproximateSourceError(originalMessage, sourceText);
 
-    ASSERT(occurrence == ErrorInstance::FoundExactSource);
+    ASSERT(occurrence == ErrorInstance::SourceTextWhereErrorOccurred::FoundExactSource);
     auto instanceofIndex = sourceText.reverseFind("instanceof"_s);
     // This can happen when Symbol.hasInstance function is directly called.
     if (instanceofIndex == notFound)
@@ -245,7 +245,7 @@ static String invalidParameterInstanceofhasInstanceValueNotFunctionSourceAppende
 
 static String invalidPrototypeSourceAppender(const String& originalMessage, StringView sourceText, RuntimeType, ErrorInstance::SourceTextWhereErrorOccurred occurrence)
 {
-    if (occurrence == ErrorInstance::FoundApproximateSource)
+    if (occurrence == ErrorInstance::SourceTextWhereErrorOccurred::FoundApproximateSource)
         return defaultApproximateSourceError(originalMessage, sourceText);
 
     auto extendsIndex = sourceText.reverseFind("extends"_s);

--- a/Source/JavaScriptCore/runtime/ExecutableBase.h
+++ b/Source/JavaScriptCore/runtime/ExecutableBase.h
@@ -44,7 +44,7 @@ class LLIntOffsetsExtractor;
 class ModuleProgramCodeBlock;
 class ProgramCodeBlock;
 
-enum CompilationKind { FirstCompilation, OptimizingCompilation };
+enum class CompilationKind { FirstCompilation, OptimizingCompilation };
 
 inline bool isCall(CodeSpecializationKind kind)
 {

--- a/Source/JavaScriptCore/runtime/Identifier.h
+++ b/Source/JavaScriptCore/runtime/Identifier.h
@@ -88,7 +88,7 @@ class Identifier {
     friend class Structure;
 public:
     Identifier() = default;
-    enum EmptyIdentifierFlag { EmptyIdentifier };
+    enum class EmptyIdentifierFlag { EmptyIdentifier };
     Identifier(EmptyIdentifierFlag) : m_string(StringImpl::empty()) { ASSERT(m_string.impl()->isAtom()); }
 
     const AtomString& string() const { return m_string; }

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -640,7 +640,7 @@ Exception* VM::ensureTerminationException()
 {
     if (!m_terminationException) {
         JSString* terminationError = jsNontrivialString(*this, terminationErrorString);
-        m_terminationException = Exception::create(*this, terminationError, Exception::DoNotCaptureStack);
+        m_terminationException = Exception::create(*this, terminationError, Exception::StackCaptureAction::DoNotCaptureStack);
     }
     return m_terminationException;
 }

--- a/Source/JavaScriptCore/wasm/WasmMemory.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMemory.cpp
@@ -74,14 +74,14 @@ static bool tryAllocate(VM& vm, const Func& allocate)
     bool done = false;
     for (unsigned i = 0; i < numTries && !done; ++i) {
         switch (allocate()) {
-        case BufferMemoryResult::Success:
+        case BufferMemoryResult::Kind::Success:
             done = true;
             break;
-        case BufferMemoryResult::SuccessAndNotifyMemoryPressure:
+        case BufferMemoryResult::Kind::SuccessAndNotifyMemoryPressure:
             vm.heap.collectAsync(CollectionScope::Full);
             done = true;
             break;
-        case BufferMemoryResult::SyncTryToReclaimMemory:
+        case BufferMemoryResult::Kind::SyncTryToReclaimMemory:
             if (i + 1 == numTries)
                 break;
             vm.heap.collectSync(CollectionScope::Full);

--- a/Source/WebCore/bindings/js/JSDOMExceptionHandling.cpp
+++ b/Source/WebCore/bindings/js/JSDOMExceptionHandling.cpp
@@ -47,7 +47,7 @@ void reportException(JSGlobalObject* lexicalGlobalObject, JSValue exceptionValue
     if (!exception) {
         exception = vm.lastException();
         if (!exception)
-            exception = JSC::Exception::create(lexicalGlobalObject->vm(), exceptionValue, JSC::Exception::DoNotCaptureStack);
+            exception = JSC::Exception::create(lexicalGlobalObject->vm(), exceptionValue, JSC::Exception::StackCaptureAction::DoNotCaptureStack);
     }
 
     reportException(lexicalGlobalObject, exception, cachedScript, fromModule);


### PR DESCRIPTION
#### e3cf8388bf12f51e3a7a7fafb6e4f3e3c419691a
<pre>
[JSC] Use more `enum class` for Safer C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=295733">https://bugs.webkit.org/show_bug.cgi?id=295733</a>

Reviewed by Darin Adler and Sosuke Suzuki.

This is a refactoring-only patch with no behavior changes.
Use `enum class` for `Kind`, `ArgumentRequirement`, `ConstantMode`, `DateTimeFormat`, `Type`, `SourceTextWhereErrorOccurred`,
`StackCaptureAction`, `CompilationKind`, `EmptyIdentifierFlag` for Safer C++ [1].

[1]: <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#use-enum-classes-instead-of-old-style-enumerations">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#use-enum-classes-instead-of-old-style-enumerations</a>

* Source/JavaScriptCore/API/OpaqueJSString.cpp:
(OpaqueJSString::identifier const):
* Source/JavaScriptCore/runtime/ArrayBuffer.cpp:
(JSC::tryAllocate):
* Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp:
(JSC::BufferMemoryManager::tryAllocateFastMemory):
(JSC::BufferMemoryManager::tryAllocateGrowableBoundsCheckingMemory):
(JSC::BufferMemoryManager::tryAllocatePhysicalBytes):
* Source/JavaScriptCore/runtime/BufferMemoryHandle.h:
* Source/JavaScriptCore/runtime/CommonIdentifiers.cpp:
(JSC::CommonIdentifiers::CommonIdentifiers):
* Source/JavaScriptCore/runtime/ConsoleClient.cpp:
(JSC::ConsoleClient::internalMessageWithTypeAndLevel):
(JSC::ConsoleClient::logWithLevel):
(JSC::ConsoleClient::clear):
(JSC::ConsoleClient::dir):
(JSC::ConsoleClient::dirXML):
(JSC::ConsoleClient::table):
(JSC::ConsoleClient::trace):
(JSC::ConsoleClient::assertion):
(JSC::ConsoleClient::group):
(JSC::ConsoleClient::groupCollapsed):
(JSC::ConsoleClient::groupEnd):
* Source/JavaScriptCore/runtime/ConsoleClient.h:
(): Deleted.
* Source/JavaScriptCore/runtime/ConstantMode.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/runtime/ConstantMode.h:
(JSC::modeForIsConstant):
(): Deleted.
* Source/JavaScriptCore/runtime/DateConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/DateConversion.cpp:
(JSC::formatDateTime):
* Source/JavaScriptCore/runtime/DateConversion.h:
(): Deleted.
* Source/JavaScriptCore/runtime/DatePrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/DeletePropertySlot.h:
(JSC::DeletePropertySlot::DeletePropertySlot):
(JSC::DeletePropertySlot::setConfigurableMiss):
(JSC::DeletePropertySlot::setNonconfigurable):
(JSC::DeletePropertySlot::setHit):
(JSC::DeletePropertySlot::isCacheableDelete const):
(JSC::DeletePropertySlot::isDeleteHit const):
(JSC::DeletePropertySlot::isConfigurableDeleteMiss const):
(JSC::DeletePropertySlot::isNonconfigurable const):
(): Deleted.
* Source/JavaScriptCore/runtime/ErrorInstance.cpp:
(JSC::appendSourceToErrorMessage):
* Source/JavaScriptCore/runtime/ErrorInstance.h:
* Source/JavaScriptCore/runtime/Exception.h:
* Source/JavaScriptCore/runtime/ExceptionHelpers.cpp:
(JSC::defaultSourceAppender):
(JSC::notAFunctionSourceAppender):
(JSC::invalidParameterInSourceAppender):
(JSC::invalidParameterInstanceofSourceAppender):
(JSC::invalidPrototypeSourceAppender):
* Source/JavaScriptCore/runtime/ExecutableBase.h:
(): Deleted.
* Source/JavaScriptCore/runtime/Identifier.h:
(): Deleted.
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::ensureTerminationException):
* Source/JavaScriptCore/wasm/WasmMemory.cpp:
* Source/WebCore/bindings/js/JSDOMExceptionHandling.cpp:
(WebCore::reportException):

Canonical link: <a href="https://commits.webkit.org/302621@main">https://commits.webkit.org/302621@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7acd58fd2f5f40fffd07135362e842a8f7d7c41

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129616 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1873 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40455 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/137003 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/81063 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131487 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1806 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1749 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98739 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66588 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132563 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1406 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/116099 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79403 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1324 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/34230 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80276 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/121608 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109798 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34728 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139482 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/128068 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1663 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1586 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107260 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1705 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112440 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/107106 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27287 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1362 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30952 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/54415 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1734 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/65097 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/161082 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1554 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40176 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1588 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1656 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->