### PR TITLE
Make anchor-scope scope anchor lookups, not just anchor names

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7709,7 +7709,6 @@ webkit.org/b/282024 fast/text/text-box-edge-with-margin-padding-border-simple.ht
 # general failures
 webkit.org/b/289743 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-007.html [ ImageOnlyFailure ]
 webkit.org/b/289743 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-008.html [ ImageOnlyFailure ]
-webkit.org/b/289743 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scope-scroll.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-chained-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-chained-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-chained-003.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scope-shadow-all-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scope-shadow-all-expected.txt
@@ -1,3 +1,3 @@
 
-PASS anchor-scope:all is tree-scoped
+FAIL anchor-scope:all is tree-scoped assert_equals: expected "10px" but got "1px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scope-shadow-names-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scope-shadow-names-expected.txt
@@ -1,7 +1,7 @@
 
-PASS anchor-scope matches tree-scoped names
-PASS anchor-scope in shadow does not affect slotted-in element
-PASS anchor-scope in ::slotted() rule does not affect anchoring outside
-PASS anchor-scope in shadow does not affected slotted-in element (:host)
-FAIL anchor-scope in ::part() affects slotted-in element assert_equals: expected "1px" but got "10px"
+FAIL anchor-scope matches tree-scoped names assert_equals: expected "10px" but got "1px"
+FAIL anchor-scope in shadow does not affect slotted-in element assert_equals: expected "10px" but got "1px"
+FAIL anchor-scope in ::slotted() rule does not affect anchoring outside assert_equals: expected "10px" but got "1px"
+FAIL anchor-scope in shadow does not affected slotted-in element (:host) assert_equals: expected "10px" but got "1px"
+PASS anchor-scope in ::part() affects slotted-in element
 


### PR DESCRIPTION
#### 448f87edcfe9b6186a2c59e5e47e5976fcef57bc
<pre>
Make anchor-scope scope anchor lookups, not just anchor names
<a href="https://bugs.webkit.org/show_bug.cgi?id=295005">https://bugs.webkit.org/show_bug.cgi?id=295005</a>
<a href="https://rdar.apple.com/154350392">rdar://154350392</a>

Reviewed by Tim Nguyen.

anchor-scope is supposed to constrain not only the anchor name from escaping
(and being visible outside the scope), but also the anchor lookup from escaping
(and finding things outside the scope).

* LayoutTests/TestExpectations:
Passing test, yay!

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scope-shadow-all-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scope-shadow-names-expected.txt:
We don&apos;t actually do tree-scoped lookups for anchor-scope, so these results
are incidental. Rebaseline them.

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::anchorScopeForAnchorName):
Update logic.

Canonical link: <a href="https://commits.webkit.org/297242@main">https://commits.webkit.org/297242@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56522f6a649dd495412cb5b9b73053665fe547d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30678 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21109 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117042 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61279 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112974 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31359 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39260 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84397 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113959 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25049 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99944 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64843 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24396 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18086 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60855 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94433 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18152 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119870 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38061 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28282 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93344 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38437 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96219 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93168 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23743 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38240 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15971 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34042 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37950 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43421 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37614 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40948 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39317 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->