### PR TITLE
Build-Fix to allow deprecation warnings for mainScreen

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
@@ -461,7 +461,10 @@ static void* kvoContext = &kvoContext;
         [_popupWebView _clearOverrideLayoutParameters];
 
         if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone) {
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+            // FIXME: <rdar://155548417> ([ Build-Failure ] [ iOS26+ ] error: 'mainScreen' is deprecated: first deprecated in iOS 26.0)
             CGFloat widthOfDeviceInPortrait = CGRectGetWidth(UIScreen.mainScreen._referenceBounds);
+ALLOW_DEPRECATED_DECLARATIONS_END
 
             CGSize contentSize = self.preferredContentSize;
             contentSize.width = std::max(contentSize.width, widthOfDeviceInPortrait);

--- a/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm
+++ b/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm
@@ -244,7 +244,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)loadView
 {
     RELEASE_LOG(XR, "%s", __FUNCTION__);
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    // FIXME: <rdar://155548417> ([ Build-Failure ] [ iOS26+ ] error: 'mainScreen' is deprecated: first deprecated in iOS 26.0)
     RetainPtr view = adoptNS([[UIView alloc] initWithFrame:UIScreen.mainScreen.bounds]);
+ALLOW_DEPRECATED_DECLARATIONS_END
 
     _touchGestureRecognizer = adoptNS([[_WKTransientGestureRecognizer alloc] initWithSession:self]);
     [_touchGestureRecognizer setDelegate:self];

--- a/Source/WebKit/UIProcess/ios/WKUSDPreviewView.mm
+++ b/Source/WebKit/UIProcess/ios/WKUSDPreviewView.mm
@@ -106,7 +106,10 @@ static RetainPtr<NSString> getUTIForUSDMIMEType(const String& mimeType)
     [self addSubview:_thumbnailView.get()];
     [self _layoutThumbnailView];
 
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    // FIXME: <rdar://155548417> ([ Build-Failure ] [ iOS26+ ] error: 'mainScreen' is deprecated: first deprecated in iOS 26.0)
     auto screenBounds = UIScreen.mainScreen.bounds;
+ALLOW_DEPRECATED_DECLARATIONS_END
     CGFloat maxDimension = CGFloatMin(screenBounds.size.width, screenBounds.size.height);
     [_thumbnailView setMaxThumbnailSize:CGSizeMake(maxDimension, maxDimension)];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UI/ElementFullscreen.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UI/ElementFullscreen.mm
@@ -81,7 +81,10 @@ TEST(ElementFullscreen, ScrollViewSetToInitialScale)
     [fullscreenDelegate waitForDidEnterElementFullscreen];
     [webView waitForNextPresentationUpdate];
 
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    // FIXME: <rdar://155548417> ([ Build-Failure ] [ iOS26+ ] error: 'mainScreen' is deprecated: first deprecated in iOS 26.0)
     CGFloat expectedScale = std::min<CGFloat>(UIScreen.mainScreen.bounds.size.width / 1000, 1);
+ALLOW_DEPRECATED_DECLARATIONS_END
 
     EXPECT_EQ([webView scrollView].zoomScale, expectedScale);
     EXPECT_EQ([webView scrollView].minimumZoomScale, expectedScale);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
@@ -238,7 +238,10 @@ TEST(WKWebExtension, MultipleIconSizes)
 
     auto screenScale = 1.0;
 #if PLATFORM(IOS_FAMILY)
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    // FIXME: <rdar://155548417> ([ Build-Failure ] [ iOS26+ ] error: 'mainScreen' is deprecated: first deprecated in iOS 26.0)
     screenScale = UIScreen.mainScreen.scale;
+ALLOW_DEPRECATED_DECLARATIONS_END
 #else
     screenScale = NSScreen.mainScreen.backingScaleFactor;
 #endif

--- a/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
@@ -1372,7 +1372,10 @@ TEST(KeyboardInputTests, AutocorrectionIndicatorColorNotAffectedByAuthorDefinedA
     CGImagePixelReader snapshotReaderExpected { expected.get() };
     CGImagePixelReader snapshotReaderActual { actual.get() };
 
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    // FIXME: <rdar://155548417> ([ Build-Failure ] [ iOS26+ ] error: 'mainScreen' is deprecated: first deprecated in iOS 26.0)
     auto scale = UIScreen.mainScreen.scale;
+ALLOW_DEPRECATED_DECLARATIONS_END
 
     for (int x = 0; x < frame.size.width * scale; ++x) {
         for (int y = 0; y < frame.size.height * scale; ++y)


### PR DESCRIPTION
#### ea957d82ac0109a656f1468db30267150a4d5e92
<pre>
Build-Fix to allow deprecation warnings for mainScreen
<a href="https://rdar.apple.com/155548417">rdar://155548417</a>

Reviewed by Jonathan Bedard and Timothy Hatcher.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(-[_WKWebExtensionActionViewController _updatePopoverContentSize]):
* Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm:
(-[_WKARPresentationSession loadView]):
* Source/WebKit/UIProcess/ios/WKUSDPreviewView.mm:
(-[WKUSDPreviewView web_setContentProviderData:suggestedFilename:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UI/ElementFullscreen.mm:
(TEST(ElementFullscreen, ScrollViewSetToInitialScale)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm:
(TestWebKitAPI::TEST(WKWebExtension, MultipleIconSizes)):
* Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm:
(TestWebKitAPI::TEST(KeyboardInputTests, AutocorrectionIndicatorColorNotAffectedByAuthorDefinedAncestorColorProperty)):

Canonical link: <a href="https://commits.webkit.org/297218@main">https://commits.webkit.org/297218@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54caf4dbe8918796e7171764e1d7545adad18c65

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110981 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30647 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21078 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117011 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/61248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112943 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31328 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39229 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/84378 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/61248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25029 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99922 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64822 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/24383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18063 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60817 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94418 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18126 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/119832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38030 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/119832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38406 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96196 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/119832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23727 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38218 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/15955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/34011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37919 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43389 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37583 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40917 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39286 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->