### PR TITLE
Digital Credentials: Add JS console logging that contains more informative debug descriptions

### DIFF
--- a/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentController.swift
+++ b/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentController.swift
@@ -80,16 +80,23 @@ extension WKIdentityDocumentPresentmentController {
                 }
 
                 return .init(protocolString: Self.isoMdocProtocol, responseData: response.responseData)
-            } catch IdentityDocumentWebPresentmentError.unknown {
-                throw WKIdentityDocumentPresentmentError(.unknown)
-            } catch IdentityDocumentWebPresentmentError.invalidRequest {
-                throw WKIdentityDocumentPresentmentError(.invalidRequest)
-            } catch IdentityDocumentWebPresentmentError.requestInProgress {
-                throw WKIdentityDocumentPresentmentError(.requestInProgress)
-            } catch IdentityDocumentWebPresentmentError.cancelled {
-                throw WKIdentityDocumentPresentmentError(.cancelled)
-            } catch IdentityDocumentWebPresentmentError.notEntitled {
-                throw WKIdentityDocumentPresentmentError(.notEntitled)
+            } catch let error as IdentityDocumentPresentmentError {
+                let userInfo = [NSDebugDescriptionErrorKey: error.debugDescription]
+
+                switch error {
+                case .unknown:
+                    throw WKIdentityDocumentPresentmentError(.unknown, userInfo: userInfo)
+                case .invalidRequest:
+                    throw WKIdentityDocumentPresentmentError(.invalidRequest, userInfo: userInfo)
+                case .requestInProgress:
+                    throw WKIdentityDocumentPresentmentError(.requestInProgress, userInfo: userInfo)
+                case .cancelled:
+                    throw WKIdentityDocumentPresentmentError(.cancelled, userInfo: userInfo)
+                case .notEntitled:
+                    throw WKIdentityDocumentPresentmentError(.notEntitled, userInfo: userInfo)
+                default:
+                    throw WKIdentityDocumentPresentmentError(.unknown, userInfo: userInfo)
+                }
             } catch {
                 throw WKIdentityDocumentPresentmentError(.unknown)
             }

--- a/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentRawRequestValidator.h
+++ b/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentRawRequestValidator.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface WKIdentityDocumentRawRequestValidator : NSObject
 
-- (nullable WKIdentityDocumentPresentmentMobileDocumentRequest *)validateISO18013Request:(WKISO18013Request *)iso18013Request origin:(NSURL *)origin;
+- (nullable WKIdentityDocumentPresentmentMobileDocumentRequest *)validateISO18013Request:(WKISO18013Request *)iso18013Request origin:(NSURL *)origin error:(NSError **)error;
 
 @end
 


### PR DESCRIPTION
#### 2fa9cdf6f512d9e0947e47f9d650d8a7caeed99b
<pre>
Digital Credentials: Add JS console logging that contains more informative debug descriptions
<a href="https://bugs.webkit.org/show_bug.cgi?id=295734">https://bugs.webkit.org/show_bug.cgi?id=295734</a>
<a href="https://rdar.apple.com/151300375">rdar://151300375</a>

Reviewed by Aditya Keerthi and Wenson Hsieh.

There are many different errors that can occur that cause a request to be
invalid. We should log information in the JS console to help developers
understand the errors that we throw. This change also allows us to move
away from the deprecated IdentityDocumentWebPresentmentError.

Original patch authored by Erik Melone.

* Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm:
(-[WKDigitalCredentialsPicker handleNSError:]):
* Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentController.swift:
(Base.perform(_:)):
* Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentRawRequestValidator.h:
* Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentRawRequestValidator.swift:
(WKIdentityDocumentRawRequestValidator.validate(_:origin:)):
* Source/WebKit/WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.mm:
(WebKit::DigitalCredentials::validateRequests):

Canonical link: <a href="https://commits.webkit.org/297237@main">https://commits.webkit.org/297237@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ab3538a17519577fee477d488cdfc8a203322b1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111020 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30686 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21117 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117050 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/61287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39268 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84402 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/61287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113967 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25052 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99959 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64848 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24404 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60863 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94435 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18167 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119878 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38069 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/28287 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93348 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38445 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96234 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93172 "Found 3 new API test failures: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestResources:/webkit/WebKitWebResource/get-data-error (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23739 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38248 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15985 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34050 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37958 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43434 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37622 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40956 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39325 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->