### PR TITLE
REGRESSION (296274@main): [ iPadOS ] 17x  fast/page-color-sampling (layout-tests) are constant text failures

### DIFF
--- a/LayoutTests/fast/page-color-sampling/basic-fixed-container-edge-sampling.html
+++ b/LayoutTests/fast/page-color-sampling/basic-fixed-container-edge-sampling.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true obscuredInset.top=50 obscuredInset.left=50 ] -->
 <html>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <head>

--- a/LayoutTests/fast/page-color-sampling/color-sampling-fixed-ancestor-with-relative-container.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-fixed-ancestor-with-relative-container.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true obscuredInset.top=100 ] -->
 <html>
 <head>
     <meta charset="utf-8">
@@ -32,7 +32,6 @@
     jsTestIsAsync = true;
 
     addEventListener("load", async () => {
-        await UIHelper.setObscuredInsets(100, 0, 0, 0);
         await UIHelper.ensurePresentationUpdate();
         edgeColors = await UIHelper.fixedContainerEdgeColors();
         shouldBeEqualToString("edgeColors.top", "rgb(212, 214, 185)");

--- a/LayoutTests/fast/page-color-sampling/color-sampling-fixed-container-under-subscroller.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-fixed-container-under-subscroller.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true AsyncOverflowScrollingEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true AsyncOverflowScrollingEnabled=true obscuredInset.top=50 obscuredInset.left=50 ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/page-color-sampling/color-sampling-fixed-descendant-in-relative-container.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-fixed-descendant-in-relative-container.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true obscuredInset.top=100 ] -->
 <html>
 <head>
     <meta charset="utf-8">
@@ -38,7 +38,6 @@
     jsTestIsAsync = true;
 
     addEventListener("load", async () => {
-        await UIHelper.setObscuredInsets(100, 0, 0, 0);
         await UIHelper.ensurePresentationUpdate();
         edgeColors = await UIHelper.fixedContainerEdgeColors();
         shouldBeEqualToString("edgeColors.top", "rgb(255, 100, 0)");

--- a/LayoutTests/fast/page-color-sampling/color-sampling-fixed-popup.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-fixed-popup.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true obscuredInset.top=50 obscuredInset.left=50 ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/page-color-sampling/color-sampling-for-sticky-element-after-scrolling.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-for-sticky-element-after-scrolling.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true TopContentInsetBackgroundCanChangeAfterScrolling=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true TopContentInsetBackgroundCanChangeAfterScrolling=true pageTopColorSamplingEnabled=true useFlexibleViewport=true obscuredInset.top=100 ] -->
 <html>
 <head>
 <script src="../../resources/ui-helper.js"></script>
@@ -54,7 +54,6 @@ body {
 jsTestIsAsync = true;
 
 addEventListener("load", async () => {
-    await UIHelper.setObscuredInsets(100, 0, 0, 0);
     await UIHelper.ensurePresentationUpdate();
 
     colorsBeforeScrolling = await UIHelper.fixedContainerEdgeColors();

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-backdrop-filters.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-backdrop-filters.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true obscuredInset.top=75 ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-empty-container.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-empty-container.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true obscuredInset.top=50 ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-images.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-images.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true obscuredInset.top=75 ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-large-sticky-container.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-large-sticky-container.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true obscuredInset.top=50 obscuredInset.left=50 ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-non-fixed-content.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-non-fixed-content.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true obscuredInset.top=100 ] -->
 <html>
 <head>
     <meta charset="utf-8">
@@ -39,7 +39,6 @@
     jsTestIsAsync = true;
 
     addEventListener("load", async () => {
-        await UIHelper.setObscuredInsets(100, 0, 0, 0);
         await UIHelper.ensurePresentationUpdate();
         colorBeforeFading = await UIHelper.fixedContainerEdgeColors();
 

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-subscrollers.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-subscrollers.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true obscuredInset.top=50 obscuredInset.left=50 ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-text.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-text.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true obscuredInset.top=100 ] -->
 <html>
 <head>
     <meta charset="utf-8">
@@ -34,8 +34,6 @@
     jsTestIsAsync = true;
 
     addEventListener("load", async () => {
-        await UIHelper.setObscuredInsets(100, 0, 0, 0);
-
         let header = document.querySelector("header");
         sampledTopColors = []
         for (let i = 0; i < 10; ++i) {

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-transparent-pointer-events-none-container.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-transparent-pointer-events-none-container.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true TopContentInsetBackgroundCanChangeAfterScrolling=true ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/page-color-sampling/color-sampling-in-position-sticky.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-in-position-sticky.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true obscuredInset.top=100 ] -->
 <html>
 <head>
     <meta charset="utf-8">
@@ -51,7 +51,6 @@
     jsTestIsAsync = true;
 
     addEventListener("load", async () => {
-        await UIHelper.setObscuredInsets(100, 0, 0, 0);
         await UIHelper.ensurePresentationUpdate();
         colorsBeforeScrolling = await UIHelper.fixedContainerEdgeColors();
         shouldBeEqualToString("colorsBeforeScrolling.top", "rgb(250, 60, 0)");

--- a/LayoutTests/fast/page-color-sampling/color-sampling-includes-sides-that-had-insets.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-includes-sides-that-had-insets.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true TopContentInsetBackgroundCanChangeAfterScrolling=true ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/page-color-sampling/color-sampling-includes-subframes.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-includes-subframes.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true obscuredInset.top=100 ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/page-color-sampling/color-sampling-modal-popup.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-modal-popup.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true obscuredInset.top=50 obscuredInset.left=50 ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/page-color-sampling/color-sampling-stability-for-same-element.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-stability-for-same-element.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true obscuredInset.top=100 ] -->
 <html>
 <head>
     <meta charset="utf-8">
@@ -38,7 +38,6 @@
     jsTestIsAsync = true;
 
     addEventListener("load", async () => {
-        await UIHelper.setObscuredInsets(100, 0, 0, 0);
         await UIHelper.ensurePresentationUpdate();
 
         const header = document.querySelector("header");

--- a/LayoutTests/fast/page-color-sampling/color-sampling-while-rubber-banding.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-while-rubber-banding.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true obscuredInset.top=100 ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/page-color-sampling/maintain-sampled-color-when-scrolled-to-top.html
+++ b/LayoutTests/fast/page-color-sampling/maintain-sampled-color-when-scrolled-to-top.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true obscuredInset.top=80 ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/page-color-sampling/no-resampling-after-scrolling.html
+++ b/LayoutTests/fast/page-color-sampling/no-resampling-after-scrolling.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true TopContentInsetBackgroundCanChangeAfterScrolling=false pageTopColorSamplingEnabled=false useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true TopContentInsetBackgroundCanChangeAfterScrolling=false pageTopColorSamplingEnabled=false useFlexibleViewport=true obscuredInset.top=50 ] -->
 <html>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <head>
@@ -36,7 +36,6 @@ body, html {
 jsTestIsAsync = true;
 
 addEventListener("load", async () => {
-    await UIHelper.setObscuredInsets(50, 0, 0, 0);
     await UIHelper.ensurePresentationUpdate();
     await UIHelper.scrollDown();
     await UIHelper.waitForZoomingOrScrollingToEnd();

--- a/LayoutTests/fast/page-color-sampling/page-color-sampling-skips-border-top.html
+++ b/LayoutTests/fast/page-color-sampling/page-color-sampling-skips-border-top.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true obscuredInset.top=100 ] -->
 <html>
 <head>
 <meta charset="utf-8">
@@ -39,8 +39,6 @@ async function sampledTopColor() {
 }
 
 addEventListener("load", async () => {
-    await UIHelper.setObscuredInsets(100, 0, 0, 0);
-
     let header = document.querySelector("header");
     description("To manually test, scroll this page down; the top sampled color should remain solid white");
 

--- a/LayoutTests/fast/page-color-sampling/page-color-sampling-skips-small-elements.html
+++ b/LayoutTests/fast/page-color-sampling/page-color-sampling-skips-small-elements.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true obscuredInset.top=100 obscuredInset.left=100 ] -->
 <html>
 <head>
     <meta charset="utf-8">
@@ -42,7 +42,6 @@
     jsTestIsAsync = true;
 
     addEventListener("load", async () => {
-        await UIHelper.setObscuredInsets(100, 100, 0, 0);
         await UIHelper.ensurePresentationUpdate();
         edgeColors = await UIHelper.fixedContainerEdgeColors();
         shouldBeNull("edgeColors.top");

--- a/LayoutTests/platform/ipad/TestExpectations
+++ b/LayoutTests/platform/ipad/TestExpectations
@@ -115,22 +115,3 @@ webkit.org/b/271712 fast/forms/datalist/datalist-textinput-dynamically-add-optio
 fast/forms/datalist/datalist-option-labels.html [ Pass Timeout ]
 
 webkit.org/b/294218 media/video-suppress-hdr-fullscreen.html [ Failure ]
-
-# webkit.org/b/295720 17x fast/page-color-sampling (layout-tests) are constant text failures
-fast/page-color-sampling/color-sampling-fixed-ancestor-with-relative-container.html [ Failure ]
-fast/page-color-sampling/color-sampling-fixed-container-under-subscroller.html [ Failure ]
-fast/page-color-sampling/color-sampling-fixed-descendant-in-relative-container.html [ Failure ]
-fast/page-color-sampling/color-sampling-fixed-popup.html [ Failure ]
-fast/page-color-sampling/color-sampling-ignores-backdrop-filters.html [ Failure ]
-fast/page-color-sampling/color-sampling-ignores-images.html [ Failure ]
-fast/page-color-sampling/color-sampling-ignores-non-fixed-content.html [ Failure ]
-fast/page-color-sampling/color-sampling-ignores-text.html [ Failure ]
-fast/page-color-sampling/color-sampling-ignores-transparent-pointer-events-none-container.html [ Failure ]
-fast/page-color-sampling/color-sampling-in-position-sticky.html [ Failure ]
-fast/page-color-sampling/color-sampling-includes-sides-that-had-insets.html [ Failure ]
-fast/page-color-sampling/color-sampling-includes-subframes.html [ Failure ]
-fast/page-color-sampling/color-sampling-modal-popup.html [ Failure ]
-fast/page-color-sampling/color-sampling-stability-for-same-element.html [ Failure ]
-fast/page-color-sampling/color-sampling-while-rubber-banding.html [ Failure ]
-fast/page-color-sampling/maintain-sampled-color-when-scrolled-to-top.html [ Failure ]
-fast/page-color-sampling/page-color-sampling-skips-border-top.html [ Failure ]

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -216,6 +216,7 @@ const TestFeatures& TestOptions::defaults()
         features.doubleTestRunnerFeatures = {
             { "contentInset.top", 0 },
             { "obscuredInset.top", 0 },
+            { "obscuredInset.left", 0 },
             { "horizontalSystemMinimumLayoutMargin", 0 },
             { "deviceScaleFactor", 1 },
             { "viewHeight", 600 },
@@ -291,6 +292,7 @@ const std::unordered_map<std::string, TestHeaderKeyType>& TestOptions::keyTypeMa
 
         { "contentInset.top", TestHeaderKeyType::DoubleTestRunner },
         { "obscuredInset.top", TestHeaderKeyType::DoubleTestRunner },
+        { "obscuredInset.left", TestHeaderKeyType::DoubleTestRunner },
         { "horizontalSystemMinimumLayoutMargin", TestHeaderKeyType::DoubleTestRunner },
         { "deviceScaleFactor", TestHeaderKeyType::DoubleTestRunner },
         { "viewHeight", TestHeaderKeyType::DoubleTestRunner },

--- a/Tools/WebKitTestRunner/TestOptions.h
+++ b/Tools/WebKitTestRunner/TestOptions.h
@@ -93,6 +93,7 @@ public:
     bool pageTopColorSamplingEnabled() const { return boolTestRunnerFeatureValue("pageTopColorSamplingEnabled"); }
     double contentInsetTop() const { return doubleTestRunnerFeatureValue("contentInset.top"); }
     double obscuredInsetTop() const { return doubleTestRunnerFeatureValue("obscuredInset.top"); }
+    double obscuredInsetLeft() const { return doubleTestRunnerFeatureValue("obscuredInset.left"); }
     double horizontalSystemMinimumLayoutMargin() const { return doubleTestRunnerFeatureValue("horizontalSystemMinimumLayoutMargin"); }
     double deviceScaleFactor() const { return doubleTestRunnerFeatureValue("deviceScaleFactor"); }
     double viewHeight() const { return doubleTestRunnerFeatureValue("viewHeight"); }

--- a/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
@@ -397,9 +397,12 @@ bool TestController::platformResetStateToConsistentValues(const TestOptions& opt
             scrollView.contentOffset = CGPointMake(-contentInset.left, -contentInset.top);
         }
 
-        auto obscuredInsetTop = options.obscuredInsetTop();
-        if (auto obscuredInset = webView._obscuredInsets; obscuredInset.top != obscuredInsetTop) {
-            obscuredInset.top = obscuredInsetTop;
+        auto newObscuredInsetTop = options.obscuredInsetTop();
+        auto newObscuredInsetLeft = options.obscuredInsetLeft();
+        auto obscuredInset = webView._obscuredInsets;
+        if (obscuredInset.top != newObscuredInsetTop || obscuredInset.left != newObscuredInsetLeft) {
+            obscuredInset.top = newObscuredInsetTop;
+            obscuredInset.left = newObscuredInsetLeft;
             webView._obscuredInsets = obscuredInset;
         }
 

--- a/Tools/WebKitTestRunner/mac/TestControllerMac.mm
+++ b/Tools/WebKitTestRunner/mac/TestControllerMac.mm
@@ -179,6 +179,17 @@ bool TestController::platformResetStateToConsistentValues(const TestOptions& opt
 {
     cocoaResetStateToConsistentValues(options);
 
+    if (RetainPtr webView = m_mainWebView ? m_mainWebView->platformView() : nil) {
+        auto newObscuredInsetTop = options.obscuredInsetTop();
+        auto newObscuredInsetLeft = options.obscuredInsetLeft();
+        auto obscuredInset = [webView _obscuredContentInsets];
+        if (obscuredInset.top != newObscuredInsetTop || obscuredInset.left != newObscuredInsetLeft) {
+            obscuredInset.top = newObscuredInsetTop;
+            obscuredInset.left = newObscuredInsetLeft;
+            [webView _setObscuredContentInsets:obscuredInset immediate:YES];
+        }
+    }
+
     if (m_defaultAppAccentColor && ![NSApp._effectiveAccentColor isEqual:m_defaultAppAccentColor.get()])
         NSApp._accentColor = m_defaultAppAccentColor.get();
 


### PR DESCRIPTION
#### e73bac5a990a922990c3182300f784c018472364
<pre>
REGRESSION (296274@main): [ iPadOS ] 17x  fast/page-color-sampling (layout-tests) are constant text failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=295720">https://bugs.webkit.org/show_bug.cgi?id=295720</a>
<a href="https://rdar.apple.com/155542222">rdar://155542222</a>

Reviewed by Abrar Rahman Protyasha.

The changes in 296274@main caused a number of layout tests to begin failing on iPad. This is
(mostly) due to the fact that these tests currently set nonzero obscured content insets only after
page load, which — due to scrolling — cause the sampled top color to be frozen at their current
value for the rest of the test. This scrolling occurs as iOS automatically maintains the scroll
origin at the top left (accounting for obscured insets).

This does not affect iPhone, because this new behavior is limited to only when the user interface
idiom is not &quot;small screen&quot;.

To fix this, we ensure that the web view either starts with the expected top and left obscured
insets on iPad, or otherwise enables `TopContentInsetBackgroundCanChangeAfterScrolling` if the test
exercises dynamic color sampling when the top fixed element changes. This more closely simulates the
real user-facing scenario in Safari anyways, where the obscured inset doesn&apos;t change after the
document has already been loaded.

* LayoutTests/fast/page-color-sampling/basic-fixed-container-edge-sampling.html:
* LayoutTests/fast/page-color-sampling/color-sampling-fixed-ancestor-with-relative-container.html:
* LayoutTests/fast/page-color-sampling/color-sampling-fixed-container-under-subscroller.html:
* LayoutTests/fast/page-color-sampling/color-sampling-fixed-descendant-in-relative-container.html:
* LayoutTests/fast/page-color-sampling/color-sampling-fixed-popup.html:
* LayoutTests/fast/page-color-sampling/color-sampling-for-sticky-element-after-scrolling.html:
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-backdrop-filters.html:
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-empty-container.html:
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-images.html:
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-large-sticky-container.html:
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-non-fixed-content.html:
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-subscrollers.html:
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-text.html:
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-transparent-pointer-events-none-container.html:
* LayoutTests/fast/page-color-sampling/color-sampling-in-position-sticky.html:
* LayoutTests/fast/page-color-sampling/color-sampling-includes-sides-that-had-insets.html:
* LayoutTests/fast/page-color-sampling/color-sampling-includes-subframes.html:
* LayoutTests/fast/page-color-sampling/color-sampling-modal-popup.html:
* LayoutTests/fast/page-color-sampling/color-sampling-stability-for-same-element.html:
* LayoutTests/fast/page-color-sampling/color-sampling-while-rubber-banding.html:
* LayoutTests/fast/page-color-sampling/maintain-sampled-color-when-scrolled-to-top.html:
* LayoutTests/fast/page-color-sampling/no-resampling-after-scrolling.html:
* LayoutTests/fast/page-color-sampling/page-color-sampling-skips-border-top.html:
* LayoutTests/fast/page-color-sampling/page-color-sampling-skips-small-elements.html:

Deploy the new test option in all `fast/page-color-sampling` layout tests, to ensure that the top
and left inset values don&apos;t need to change on the fly after page load. For a small handful of tests
that must either change obscured insets on the fly or add bottom/right insets, we continue using
`UIHelper.setObscuredInsets`.

* LayoutTests/platform/ipad/TestExpectations:
* Tools/WebKitTestRunner/TestOptions.cpp:
(WTR::TestOptions::defaults):
(WTR::TestOptions::keyTypeMapping):
* Tools/WebKitTestRunner/TestOptions.h:
(WTR::TestOptions::obscuredInsetLeft const):
* Tools/WebKitTestRunner/ios/TestControllerIOS.mm:
(WTR::TestController::platformResetStateToConsistentValues):
* Tools/WebKitTestRunner/mac/TestControllerMac.mm:
(WTR::TestController::platformResetStateToConsistentValues):

Add support for an `obscuredInset.left` test option, and additionally add support for both
`obscuredInset.(top|left)` on macOS.

Canonical link: <a href="https://commits.webkit.org/297238@main">https://commits.webkit.org/297238@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/854806eb1a694ec1aeac166616644871222a5e35

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110997 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30663 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21094 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117027 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61264 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112959 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31344 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39245 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84389 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113944 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25041 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99953 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64835 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24389 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18094 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60838 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94426 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18160 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119850 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38046 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28280 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93336 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38422 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96227 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93160 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23740 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38228 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15979 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34027 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37935 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37599 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40933 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39302 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->