### PR TITLE
[JSC] Use BBQ parallel move algorithm for Air shuffles

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirEmitShuffle.cpp
+++ b/Source/JavaScriptCore/b3/air/AirEmitShuffle.cpp
@@ -30,6 +30,7 @@
 
 #include "AirCode.h"
 #include "AirInstInlines.h"
+#include "CCallHelpers.h"
 #include <wtf/GraphNodeWorklist.h>
 #include <wtf/ListDump.h>
 
@@ -40,35 +41,6 @@ namespace {
 namespace AirEmitShuffleInternal {
 static constexpr bool verbose = false;
 }
-
-enum ScratchMode {
-    FreezeScratch,
-    UpdateScratch,
-};
-
-template<typename Functor>
-Tmp findPossibleScratch(Code& code, Bank bank, const Functor& functor) {
-    for (Reg reg : code.regsInPriorityOrder(bank)) {
-        Tmp tmp(reg);
-        if (functor(tmp))
-            return tmp;
-    }
-    return Tmp();
-}
-
-Tmp findPossibleScratch(Code& code, Bank bank, const Arg& arg1, const Arg& arg2) {
-    return findPossibleScratch(
-        code, bank,
-        [&] (Tmp tmp) -> bool {
-            return !arg1.usesTmp(tmp) && !arg2.usesTmp(tmp);
-        });
-}
-
-// Example: (a => b, b => a, a => c, b => d)
-struct Rotate {
-    Vector<ShufflePair> loop; // in the example, this is the loop: (a => b, b => a)
-    Vector<ShufflePair> fringe; // in the example, these are the associated shifts: (a => c, b => d)
-};
 
 } // anonymous namespace
 
@@ -88,31 +60,46 @@ Bank ShufflePair::bank() const
     return FP;
 }
 
-Vector<Inst, 2> ShufflePair::insts(Code& code, Value* origin) const
+void emitMoveForPair(InsertionLocation insertionLocation, const ShufflePair& pair, const Arg& scratch, Value* origin)
 {
-    if (src().isMemory() && dst().isMemory()) [[unlikely]]
-        return { Inst(moveFor(bank(), width()), origin, src(), dst(), code.newTmp(bank())) };
+    const auto& src = pair.src();
+    const auto& dst = pair.dst();
+    auto bank = pair.bank();
+    auto width = pair.width();
+    auto moveOp = moveFor(bank, width);
+    if (src.isMemory() && dst.isMemory()) [[unlikely]] {
+        insertionLocation.insert(Inst(moveOp, origin, src, dst, scratch));
+        return;
+    }
 
-    if (isValidForm(moveFor(bank(), width()), src().kind(), dst().kind()))
-        return { Inst(moveFor(bank(), width()), origin, src(), dst()) };
+    if (isValidForm(moveOp, src.kind(), dst.kind())) {
+        insertionLocation.insert(Inst(moveOp, origin, src, dst));
+        return;
+    }
 
     // We must be a store immediate or a move immediate if we reach here. The reason:
     // 1. We're not a mem->mem move, given the above check.
     // 2. It's always valid to do a load from Addr into a tmp using Move/Move32/MoveFloat/MoveDouble.
-    ASSERT(isValidForm(moveFor(bank(), width()), Arg::Addr, Arg::Tmp));
+    ASSERT(isValidForm(moveOp, Arg::Addr, Arg::Tmp));
     // 3. It's also always valid to do a Tmp->Tmp move.
-    ASSERT(isValidForm(moveFor(bank(), width()), Arg::Tmp, Arg::Tmp));
+    ASSERT(isValidForm(moveOp, Arg::Tmp, Arg::Tmp));
     // 4. It's always valid to do a Tmp->Addr store.
-    ASSERT(isValidForm(moveFor(bank(), width()), Arg::Tmp, Arg::Addr));
+    ASSERT(isValidForm(moveOp, Arg::Tmp, Arg::Addr));
 
-    ASSERT(src().isSomeImm());
-    Tmp tmp = code.newTmp(bank());
+    ASSERT(src.isSomeImm());
     ASSERT(isValidForm(Move, Arg::BigImm, Arg::Tmp));
-    ASSERT(isValidForm(moveFor(bank(), width()), Arg::Tmp, dst().kind()));
-    return {
-        Inst(Move, origin, Arg::bigImm(src().value()), tmp),
-        Inst(moveFor(bank(), width()), origin, tmp, dst()),
-    };
+    ASSERT(isValidForm(moveOp, Arg::Tmp, dst.kind()));
+
+    if (dst.isMemory()) {
+        insertionLocation.insert(Inst(Move, origin, Arg::bigImm(src.value()), scratch));
+        insertionLocation.insert(Inst(moveOp, origin, scratch, dst));
+        return;
+    }
+
+    // If we aren't storing the immediate, then we don't need a second move
+    // into the destination - the immediate should already be the correct
+    // representation for the destination type.
+    insertionLocation.insert(Inst(Move, origin, Arg::bigImm(src.value()), dst));
 }
 
 void ShufflePair::dump(PrintStream& out) const
@@ -128,14 +115,42 @@ Inst createShuffle(Value* origin, const Vector<ShufflePair>& pairs)
     return result;
 }
 
-Vector<Inst> emitShuffle(
-    Code& code, Vector<ShufflePair> pairs, std::array<Arg, 2> scratches, Bank bank,
+using ShuffleStatus = CCallHelpers::ShuffleStatus;
+using StatusVector = Vector<ShuffleStatus, 16>;
+
+static void emitShufflePair(InsertionLocation insertionLocation, Vector<ShufflePair, 8>& pairs, StatusVector& status, unsigned index, const std::array<Arg, 2>& scratches, Value* origin)
+{
+    ShufflePair& pair = pairs[index];
+    ASSERT(pair.src() != pair.dst());
+
+    status[index] = ShuffleStatus::BeingMoved;
+    for (unsigned i = 0; i < pairs.size(); i ++) {
+        if (pairs[i].src() == pair.dst()) {
+            switch (status[i]) {
+            case ShuffleStatus::ToMove:
+                emitShufflePair(insertionLocation, pairs, status, i, scratches, origin);
+                break;
+            case ShuffleStatus::BeingMoved: {
+                emitMoveForPair(insertionLocation, ShufflePair(pairs[i].src(), scratches[0], pairs[i].width()), scratches[1], origin);
+                pairs[i].setSrc(scratches[0]);
+                break;
+            }
+            case ShuffleStatus::Moved:
+                break;
+            }
+        }
+    }
+    emitMoveForPair(insertionLocation, pair, scratches[1], origin);
+    status[index] = ShuffleStatus::Moved;
+}
+
+void emitShuffle(
+    InsertionLocation insertionLocation, Vector<ShufflePair, 8>& pairs, std::array<Arg, 2> scratches, Bank bank,
     Value* origin)
 {
     if (AirEmitShuffleInternal::verbose) {
         dataLog(
-            "Dealing with pairs: ", listDump(pairs), " and scratches ", scratches[0], ", ",
-            scratches[1], "\n");
+            "Dealing with pairs: ", listDump(pairs), " and scratches ", scratches[0], ", ", scratches[1], "\n");
     }
     
     pairs.removeAllMatching(
@@ -143,6 +158,14 @@ Vector<Inst> emitShuffle(
             return pair.src() == pair.dst();
         });
     
+    if (pairs.isEmpty())
+        return;
+
+    if (pairs.size() == 1) {
+        emitMoveForPair(insertionLocation, pairs[0], scratches[0], origin);
+        return;
+    }
+
     // First validate that this is the kind of shuffle that we know how to deal with.
 #if ASSERT_ENABLED
     for (const ShufflePair& pair : pairs) {
@@ -150,423 +173,24 @@ Vector<Inst> emitShuffle(
         ASSERT(pair.dst().isBank(bank));
         ASSERT(pair.dst().isTmp() || pair.dst().isMemory());
     }
+#else
+    UNUSED_VARIABLE(bank);
 #endif // ASSERT_ENABLED
 
-    // There are two possible kinds of operations that we will do:
-    //
-    // - Shift. Example: (a => b, b => c). We emit this as "Move b, c; Move a, b". This only requires
-    //   scratch registers if there are memory->memory moves. We want to find as many of these as
-    //   possible because they are cheaper. Note that shifts can involve the same source mentioned
-    //   multiple times. Example: (a => b, a => c, b => d, b => e).
-    //
-    // - Rotate. Example: (a => b, b => a). We want to emit this as "Swap a, b", but that instruction
-    //   may not be available, in which case we may need a scratch register or a scratch memory
-    //   location. A gnarlier example is (a => b, b => c, c => a). We can emit this as "Swap b, c;
-    //   Swap a, b". Note that swapping has to be careful about differing widths.
-    //
-    // Note that a rotate can have "fringe". For example, we might have (a => b, b => a, a =>c,
-    // b => d). This has a rotate loop (a => b, b => a) and some fringe (a => c, b => d). We treat
-    // the whole thing as a single rotate.
-    //
-    // We will find multiple disjoint such operations. We can execute them in any order.
-
-    // We interpret these as Moves that should be executed backwards. All shifts are keyed by their
-    // starting source.
-    UncheckedKeyHashMap<Arg, Vector<ShufflePair>> shifts;
-
-    // We interpret these as Swaps over src()'s that should be executed backwards, i.e. for a list
-    // of size 3 we would do "Swap list[1].src(), list[2].src(); Swap list[0].src(), list[1].src()".
-    // Note that we actually can't do that if the widths don't match or other bad things happen.
-    // But, prior to executing all of that, we need to execute the fringe: the shifts comming off the
-    // rotate.
-    Vector<Rotate> rotates;
-
-    {
-        UncheckedKeyHashMap<Arg, Vector<ShufflePair>> mapping;
-        for (const ShufflePair& pair : pairs)
-            mapping.add(pair.src(), Vector<ShufflePair>()).iterator->value.append(pair);
-
-        Vector<ShufflePair> currentPairs;
-
-        while (!mapping.isEmpty()) {
-            ASSERT(currentPairs.isEmpty());
-            Arg originalSrc = mapping.begin()->key;
-            ASSERT(!shifts.contains(originalSrc));
-            if (AirEmitShuffleInternal::verbose)
-                dataLog("Processing from ", originalSrc, "\n");
-            
-            GraphNodeWorklist<Arg> worklist;
-            worklist.push(originalSrc);
-            while (Arg src = worklist.pop()) {
-                UncheckedKeyHashMap<Arg, Vector<ShufflePair>>::iterator iter = mapping.find(src);
-                if (iter == mapping.end()) {
-                    // With a shift it's possible that we previously built the tail of this shift.
-                    // See if that's the case now.
-                    if (AirEmitShuffleInternal::verbose)
-                        dataLog("Trying to append shift at ", src, "\n");
-                    currentPairs.appendVector(shifts.take(src));
-                    continue;
-                }
-                Vector<ShufflePair> pairs = WTFMove(iter->value);
-                mapping.remove(iter);
-
-                for (const ShufflePair& pair : pairs) {
-                    currentPairs.append(pair);
-                    ASSERT(pair.src() == src);
-                    worklist.push(pair.dst());
-                }
-            }
-
-            ASSERT(currentPairs.size());
-            ASSERT(currentPairs[0].src() == originalSrc);
-
-            if (AirEmitShuffleInternal::verbose)
-                dataLog("currentPairs = ", listDump(currentPairs), "\n");
-
-            bool isRotate = false;
-            for (const ShufflePair& pair : currentPairs) {
-                if (pair.dst() == originalSrc) {
-                    isRotate = true;
-                    break;
-                }
-            }
-
-            if (isRotate) {
-                if (AirEmitShuffleInternal::verbose)
-                    dataLog("It's a rotate.\n");
-                Rotate rotate;
-
-                // The common case is that the rotate does not have fringe. The only way to
-                // check for this is to examine the whole rotate.
-                bool ok;
-                if (currentPairs.last().dst() == originalSrc) {
-                    ok = true;
-                    for (unsigned i = currentPairs.size() - 1; i--;)
-                        ok &= currentPairs[i].dst() == currentPairs[i + 1].src();
-                } else
-                    ok = false;
-                
-                if (ok)
-                    rotate.loop = WTFMove(currentPairs);
-                else {
-                    // This is the slow path. The rotate has fringe.
-                    
-                    UncheckedKeyHashMap<Arg, ShufflePair> dstMapping;
-                    for (const ShufflePair& pair : currentPairs)
-                        dstMapping.add(pair.dst(), pair);
-
-                    ShufflePair pair = dstMapping.take(originalSrc);
-                    for (;;) {
-                        rotate.loop.append(pair);
-
-                        auto iter = dstMapping.find(pair.src());
-                        if (iter == dstMapping.end())
-                            break;
-                        pair = iter->value;
-                        dstMapping.remove(iter);
-                    }
-
-                    rotate.loop.reverse();
-
-                    // Make sure that the fringe appears in the same order as how it appeared in the
-                    // currentPairs, since that's the DFS order.
-                    for (const ShufflePair& pair : currentPairs) {
-                        // But of course we only include it if it's not in the loop.
-                        if (dstMapping.contains(pair.dst()))
-                            rotate.fringe.append(pair);
-                    }
-                }
-                
-                // If the graph search terminates because we returned to the first source, then the
-                // pair list has to have a very particular shape.
-                for (unsigned i = rotate.loop.size() - 1; i--;)
-                    ASSERT(rotate.loop[i].dst() == rotate.loop[i + 1].src());
-                rotates.append(WTFMove(rotate));
-                currentPairs.shrink(0);
-            } else {
-                if (AirEmitShuffleInternal::verbose)
-                    dataLog("It's a shift.\n");
-                shifts.add(originalSrc, WTFMove(currentPairs));
-            }
-        }
+    StatusVector statusVector(pairs.size(), ShuffleStatus::ToMove);
+    for (unsigned i = 0; i < pairs.size(); i ++) {
+        if (statusVector[i] == ShuffleStatus::ToMove)
+            emitShufflePair(insertionLocation, pairs, statusVector, i, scratches, origin);
     }
-
-    if (AirEmitShuffleInternal::verbose) {
-        dataLog("Shifts:\n");
-        for (auto& entry : shifts)
-            dataLog("    ", entry.key, ": ", listDump(entry.value), "\n");
-        dataLog("Rotates:\n");
-        for (auto& rotate : rotates)
-            dataLog("    loop = ", listDump(rotate.loop), ", fringe = ", listDump(rotate.fringe), "\n");
-    }
-
-    // In the worst case, we need two scratch registers. The way we do this is that the client passes
-    // us what scratch registers he happens to have laying around. We will need scratch registers in
-    // the following cases:
-    //
-    // - Shuffle pairs where both src and dst refer to memory.
-    // - Rotate when no Swap instruction is available.
-    //
-    // Lucky for us, we are guaranteed to have extra scratch registers anytime we have a Shift that
-    // ends with a register. We search for such a register right now.
-
-    auto moveForWidth = [&] (Width width) -> Opcode {
-        return moveFor(bank, width);
-    };
-
-    Opcode conservativeMove = moveForWidth(code.usesSIMD() ? conservativeWidth(bank) : conservativeWidthWithoutVectors(bank));
-
-    // We will emit things in reverse. We maintain a list of packs of instructions, and then we emit
-    // append them together in reverse (for example the thing at the end of resultPacks is placed
-    // first). This is useful because the last thing we emit frees up its destination registers, so
-    // it affects how we emit things before it.
-    Vector<Vector<Inst>> resultPacks;
-    Vector<Inst> result;
-
-    auto commitResult = [&] () {
-        resultPacks.append(WTFMove(result));
-    };
-
-    auto getScratch = [&] (unsigned index, Tmp possibleScratch) -> Tmp {
-        if (scratches[index].isTmp())
-            return scratches[index].tmp();
-
-        if (!possibleScratch)
-            return Tmp();
-        result.append(Inst(conservativeMove, origin, possibleScratch, scratches[index]));
-        return possibleScratch;
-    };
-
-    auto returnScratch = [&] (unsigned index, Tmp tmp) {
-        if (Arg(tmp) != scratches[index])
-            result.append(Inst(conservativeMove, origin, scratches[index], tmp));
-    };
-
-    auto handleShiftPair = [&] (const ShufflePair& pair, unsigned scratchIndex) {
-        Opcode move = moveForWidth(pair.width());
-        
-        if (!isValidForm(move, pair.src().kind(), pair.dst().kind())) {
-            Tmp scratch =
-                getScratch(scratchIndex, findPossibleScratch(code, bank, pair.src(), pair.dst()));
-            RELEASE_ASSERT(scratch);
-            if (isValidForm(move, pair.src().kind(), Arg::Tmp))
-                result.append(Inst(moveForWidth(pair.width()), origin, pair.src(), scratch));
-            else {
-                ASSERT(pair.src().isSomeImm());
-                ASSERT(move == Move32);
-                result.append(Inst(Move, origin, Arg::bigImm(pair.src().value()), scratch));
-            }
-            result.append(Inst(moveForWidth(pair.width()), origin, scratch, pair.dst()));
-            returnScratch(scratchIndex, scratch);
-            return;
-        }
-        
-        result.append(Inst(move, origin, pair.src(), pair.dst()));
-    };
-
-    auto handleShift = [&] (Vector<ShufflePair>& shift, ScratchMode scratchMode) {
-        // FIXME: We could optimize the spill behavior of the shifter by checking if any of the
-        // shifts need spills. If they do, then we could try to get a register out here. Note that
-        // this may fail where the current strategy succeeds: out here we need a register that does
-        // not interfere with any of the shifts, while the current strategy only needs to find a
-        // scratch register that does not interfer with a particular shift. So, this optimization
-        // will be opportunistic: if it succeeds, then the individual shifts can use that scratch,
-        // otherwise they will do what they do now.
-        
-        for (unsigned i = shift.size(); i--;)
-            handleShiftPair(shift[i], 0);
-
-        Arg lastDst = shift.last().dst();
-        if (scratchMode == UpdateScratch && lastDst.isTmp()) {
-            for (Arg& scratch : scratches) {
-                ASSERT(scratch != lastDst);
-                if (!scratch.isTmp()) {
-                    scratch = lastDst;
-                    break;
-                }
-            }
-        }
-    };
-
-    // First handle shifts whose last destination is a tmp because these free up scratch registers.
-    // These end up last in the final sequence, so the final destination of these shifts will be
-    // available as a scratch location for anything emitted prior (so, after, since we're emitting in
-    // reverse).
-    for (auto& entry : shifts) {
-        Vector<ShufflePair>& shift = entry.value;
-        if (shift.last().dst().isTmp())
-            handleShift(shift, UpdateScratch);
-        commitResult();
-    }
-
-    // Now handle the rest of the shifts.
-    for (auto& entry : shifts) {
-        Vector<ShufflePair>& shift = entry.value;
-        if (!shift.last().dst().isTmp())
-            handleShift(shift, UpdateScratch);
-        commitResult();
-    }
-
-    // From now on, we cannot use new shift destinations as scratches.
-    // The final order of these operations after all of the reversing is:
-    // [Fringe, Rotate]*, [Shift]*
-    // A fringe's last destination should not be clobbered.
-
-    for (Rotate& rotate : rotates) {
-        if (!rotate.fringe.isEmpty()) {
-            // Make sure we do the fringe first! This won't clobber any of the registers that are
-            // part of the rotation.
-            handleShift(rotate.fringe, FreezeScratch);
-        }
-        
-        bool canSwap = false;
-        Opcode swap = Oops;
-        Width swapWidth = Width8; // bogus value
-
-        // Currently, the swap instruction is not available for floating point on any architecture we
-        // support.
-        if (bank == GP) {
-            // Figure out whether we will be doing 64-bit swaps or 32-bit swaps. If we have a mix of
-            // widths we handle that by fixing up the relevant register with zero-extends.
-            swap = Swap32;
-            swapWidth = Width32;
-            bool hasMemory = false;
-            bool hasIndex = false;
-            for (ShufflePair& pair : rotate.loop) {
-                switch (pair.width()) {
-                case Width32:
-                    break;
-                case Width64:
-                    swap = Swap64;
-                    swapWidth = Width64;
-                    break;
-                default:
-                    RELEASE_ASSERT_NOT_REACHED();
-                    break;
-                }
-
-                hasMemory |= pair.src().isMemory() || pair.dst().isMemory();
-                hasIndex |= pair.src().isIndex() || pair.dst().isIndex();
-            }
-            
-            canSwap = isValidForm(swap, Arg::Tmp, Arg::Tmp);
-
-            // We can totally use swaps even if there are shuffles involving memory. But, we play it
-            // safe in that case. There are corner cases we don't handle, and our ability to do it is
-            // contingent upon swap form availability.
-            
-            if (hasMemory) {
-                canSwap &= isValidForm(swap, Arg::Tmp, Arg::Addr);
-                
-                // We don't take the swapping path if there is a mix of widths and some of the
-                // shuffles involve memory. That gets too confusing. We might be able to relax this
-                // to only bail if there are subwidth pairs involving memory, but I haven't thought
-                // about it very hard. Anyway, this case is not common: rotates involving memory
-                // don't arise for function calls, and they will only happen for rotates in user code
-                // if some of the variables get spilled. It's hard to imagine a program that rotates
-                // data around in variables while also doing a combination of uint32->uint64 and
-                // int64->int32 casts.
-                for (ShufflePair& pair : rotate.loop)
-                    canSwap &= pair.width() == swapWidth;
-            }
-
-            if (hasIndex)
-                canSwap &= isValidForm(swap, Arg::Tmp, Arg::Index);
-        }
-
-        if (canSwap) {
-            for (unsigned i = rotate.loop.size() - 1; i--;) {
-                Arg left = rotate.loop[i].src();
-                Arg right = rotate.loop[i + 1].src();
-
-                if (left.isMemory() && right.isMemory()) {
-                    // Note that this is a super rare outcome. Rotates are rare. Spills are rare.
-                    // Moving data between two spills is rare. To get here a lot of rare stuff has to
-                    // all happen at once.
-                    
-                    Tmp scratch = getScratch(0, findPossibleScratch(code, bank, left, right));
-                    RELEASE_ASSERT(scratch);
-                    result.append(Inst(moveForWidth(swapWidth), origin, left, scratch));
-                    result.append(Inst(swap, origin, scratch, right));
-                    result.append(Inst(moveForWidth(swapWidth), origin, scratch, left));
-                    returnScratch(0, scratch);
-                    continue;
-                }
-
-                if (left.isMemory())
-                    std::swap(left, right);
-                
-                result.append(Inst(swap, origin, left, right));
-            }
-
-            for (ShufflePair pair : rotate.loop) {
-                if (pair.width() == swapWidth)
-                    continue;
-
-                RELEASE_ASSERT(pair.width() == Width32);
-                RELEASE_ASSERT(swapWidth == Width64);
-                RELEASE_ASSERT(pair.dst().isTmp());
-
-                // Need to do an extra zero extension.
-                result.append(Inst(Move32, origin, pair.dst(), pair.dst()));
-            }
-        } else {
-            // We can treat this as a shift so long as we take the last destination (i.e. first
-            // source) and save it first. Then we handle the first entry in the pair in the rotate
-            // specially, after we restore the last destination. This requires some special care to
-            // find a scratch register. It's possible that we have a rotate that uses the entire
-            // available register file.
-
-            Tmp scratch = findPossibleScratch(
-                code, bank,
-                [&] (Tmp tmp) -> bool {
-                    for (ShufflePair pair : rotate.loop) {
-                        if (pair.src().usesTmp(tmp))
-                            return false;
-                        if (pair.dst().usesTmp(tmp))
-                            return false;
-                    }
-                    return true;
-                });
-
-            // NOTE: This is the most likely use of scratch registers.
-            scratch = getScratch(0, scratch);
-
-            // We may not have found a scratch register. When this happens, we can just use the spill
-            // slot directly.
-            Arg rotateSave = scratch ? Arg(scratch) : scratches[0];
-            
-            handleShiftPair(
-                ShufflePair(rotate.loop.last().dst(), rotateSave, rotate.loop[0].width()), 1);
-
-            for (unsigned i = rotate.loop.size(); i-- > 1;)
-                handleShiftPair(rotate.loop[i], 1);
-
-            handleShiftPair(
-                ShufflePair(rotateSave, rotate.loop[0].dst(), rotate.loop[0].width()), 1);
-
-            if (scratch)
-                returnScratch(0, scratch);
-        }
-
-        commitResult();
-    }
-
-    ASSERT(result.isEmpty());
-
-    for (unsigned i = resultPacks.size(); i--;)
-        result.appendVector(resultPacks[i]);
-
-    return result;
 }
 
-Vector<Inst> emitShuffle(
-    Code& code, const Vector<ShufflePair>& pairs,
+void emitShuffle(
+    InsertionLocation insertionLocation, const Vector<ShufflePair>& pairs,
     const std::array<Arg, 2>& gpScratch, const std::array<Arg, 2>& fpScratch,
     Value* origin)
 {
-    Vector<ShufflePair> gpPairs;
-    Vector<ShufflePair> fpPairs;
+    Vector<ShufflePair, 8> gpPairs;
+    Vector<ShufflePair, 8> fpPairs;
     for (const ShufflePair& pair : pairs) {
         switch (pair.bank()) {
         case GP:
@@ -578,10 +202,8 @@ Vector<Inst> emitShuffle(
         }
     }
 
-    Vector<Inst> result;
-    result.appendVector(emitShuffle(code, gpPairs, gpScratch, GP, origin));
-    result.appendVector(emitShuffle(code, fpPairs, fpScratch, FP, origin));
-    return result;
+    emitShuffle(insertionLocation, gpPairs, gpScratch, GP, origin);
+    emitShuffle(insertionLocation, fpPairs, fpScratch, FP, origin);
 }
 
 } } } // namespace JSC::B3::Air

--- a/Source/JavaScriptCore/b3/air/AirEmitShuffle.h
+++ b/Source/JavaScriptCore/b3/air/AirEmitShuffle.h
@@ -28,6 +28,7 @@
 #if ENABLE(B3_JIT)
 
 #include "AirArg.h"
+#include "AirInsertionSet.h"
 #include "AirInst.h"
 #include <wtf/Vector.h>
 
@@ -71,15 +72,17 @@ public:
     const Arg& src() const { return m_src; }
     const Arg& dst() const { return m_dst; }
 
+    void setSrc(const Arg& arg)
+    {
+        ASSERT(m_src.bank() == arg.bank());
+        m_src = arg;
+    }
+
     // The width determines the kind of move we do. You can only choose Width32 or Width64 right now.
     // For GP, it picks between Move32 and Move. For FP, it picks between MoveFloat and MoveDouble.
     Width width() const { return m_width; }
     
     Bank bank() const;
-
-    // Creates an instruction sequence for the move represented by this shuffle pair.
-    // You need to pass Code because we may need to create a tmp.
-    Vector<Inst, 2> insts(Code&, Value* origin) const;
 
     void dump(PrintStream&) const;
     
@@ -88,6 +91,16 @@ private:
     Arg m_dst;
     Width m_width { Width8 };
 };
+
+struct InsertionLocation {
+    InsertionSet& insertionSet;
+    unsigned index;
+
+    inline void insert(Inst&& inst) { insertionSet.insert(index, inst); }
+};
+
+// Add a move for a ShufflePair to an insertion set.
+void emitMoveForPair(InsertionLocation, const ShufflePair&, const Arg&, Value*);
 
 // Create a Shuffle instruction.
 Inst createShuffle(Value* origin, const Vector<ShufflePair>&);
@@ -123,13 +136,13 @@ Inst createShuffle(Value* origin, const Vector<ShufflePair>&);
 //
 // NOTE: Use this method (and its friend below) to emit shuffles after register allocation. Before
 // register allocation it is much better to simply use the Shuffle instruction.
-Vector<Inst> emitShuffle(
-    Code& code, Vector<ShufflePair>, std::array<Arg, 2> scratch, Bank, Value* origin);
+void emitShuffle(
+    InsertionLocation, Vector<ShufflePair, 8>&, std::array<Arg, 2> scratch, Bank, Value* origin);
 
 // Perform a shuffle that involves any number of types. Pass scratch registers or memory locations
 // for each type according to the rules above.
-Vector<Inst> emitShuffle(
-    Code& code, const Vector<ShufflePair>&,
+void emitShuffle(
+    InsertionLocation, const Vector<ShufflePair>&,
     const std::array<Arg, 2>& gpScratch, const std::array<Arg, 2>& fpScratch,
     Value* origin);
 

--- a/Source/JavaScriptCore/b3/air/AirLowerAfterRegAlloc.cpp
+++ b/Source/JavaScriptCore/b3/air/AirLowerAfterRegAlloc.cpp
@@ -172,8 +172,7 @@ void lowerAfterRegAlloc(Code& code)
                 }
                 std::array<Arg, 2> gpScratch = getScratches(set, GP);
                 std::array<Arg, 2> fpScratch = getScratches(set, FP);
-                insertionSet.insertInsts(
-                    instIndex, emitShuffle(code, pairs, gpScratch, fpScratch, inst.origin));
+                emitShuffle({ insertionSet, instIndex }, pairs, gpScratch, fpScratch, inst.origin);
                 inst = Inst();
                 break;
             }
@@ -240,8 +239,7 @@ void lowerAfterRegAlloc(Code& code)
                 if (AirLowerAfterRegAllocInternal::verbose)
                     dataLog("Pre-call pairs for ", inst, ": ", listDump(pairs), "\n");
                 
-                insertionSet.insertInsts(
-                    instIndex, emitShuffle(code, pairs, gpScratch, fpScratch, inst.origin));
+                emitShuffle({ insertionSet, instIndex }, pairs, gpScratch, fpScratch, inst.origin);
 
                 inst = buildCCall(code, inst.origin, destinations);
                 if (oldKind.effects)
@@ -272,8 +270,7 @@ void lowerAfterRegAlloc(Code& code)
                 gpScratch = getScratches(postUsed, GP);
                 fpScratch = getScratches(postUsed, FP);
                 
-                insertionSet.insertInsts(
-                    instIndex + 1, emitShuffle(code, pairs, gpScratch, fpScratch, inst.origin));
+                emitShuffle({ insertionSet, instIndex + 1 }, pairs, gpScratch, fpScratch, inst.origin);
                 break;
             }
 

--- a/Source/JavaScriptCore/b3/air/AirLowerMacros.cpp
+++ b/Source/JavaScriptCore/b3/air/AirLowerMacros.cpp
@@ -75,29 +75,7 @@ void lowerMacros(Code& code)
                 }
                 ASSERT(offset = inst.args.size());
                 
-                if (hasRegisterSource) [[unlikely]]
-                    insertionSet.insertInst(instIndex, createShuffle(inst.origin, Vector<ShufflePair>(shufflePairs)));
-                else {
-                    // If none of the inputs are registers, then we can efficiently lower this
-                    // shuffle before register allocation. First we lower all of the moves to
-                    // memory, in the hopes that this is the last use of the operands. This
-                    // avoids creating interference between argument registers and arguments
-                    // that don't go into argument registers.
-                    for (ShufflePair& pair : shufflePairs) {
-                        if (pair.dst().isMemory())
-                            insertionSet.insertInsts(instIndex, pair.insts(code, inst.origin));
-                    }
-
-                    // Fill the argument registers by starting with the first one. This avoids
-                    // creating interference between things passed to low-numbered argument
-                    // registers and high-numbered argument registers. The assumption here is
-                    // that lower-numbered argument registers are more likely to be
-                    // incidentally clobbered.
-                    for (ShufflePair& pair : shufflePairs) {
-                        if (!pair.dst().isMemory())
-                            insertionSet.insertInsts(instIndex, pair.insts(code, inst.origin));
-                    }
-                }
+                insertionSet.insertInst(instIndex, createShuffle(inst.origin, Vector<ShufflePair>(shufflePairs)));
 
                 // Indicate that we're using our original callee argument.
                 destinations[0] = inst.args[1];


### PR DESCRIPTION
#### fa993fa0b3fab96003e6223456f43e759eee3a95
<pre>
[JSC] Use BBQ parallel move algorithm for Air shuffles
<a href="https://bugs.webkit.org/show_bug.cgi?id=295740">https://bugs.webkit.org/show_bug.cgi?id=295740</a>
<a href="https://rdar.apple.com/111112446">rdar://111112446</a>

Reviewed by NOBODY (OOPS!).

Makes Air shuffle instructions use the same parallel move resolution
algorithm we use in BBQ and CCallHelpers, removing the much more
complicated and expensive algorithm we currently rely on.

* Source/JavaScriptCore/b3/air/AirEmitShuffle.cpp:
(JSC::B3::Air::emitMoveForPair):
(JSC::B3::Air::emitShufflePair):
(JSC::B3::Air::emitShuffle):
(JSC::B3::Air::ShufflePair::insts const): Deleted.
* Source/JavaScriptCore/b3/air/AirEmitShuffle.h:
(JSC::B3::Air::ShufflePair::setSrc):
(JSC::B3::Air::InsertionLocation::insert):
* Source/JavaScriptCore/b3/air/AirLowerAfterRegAlloc.cpp:
(JSC::B3::Air::lowerAfterRegAlloc):
* Source/JavaScriptCore/b3/air/AirLowerMacros.cpp:
(JSC::B3::Air::lowerMacros):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa993fa0b3fab96003e6223456f43e759eee3a95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30659 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21090 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117023 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61260 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31340 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39241 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84387 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113940 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25045 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99935 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64833 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24392 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18077 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60833 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/103484 "Found 1 new JSC binary failure: testair (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94429 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18143 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119846 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109546 "Found 1 new JSC binary failure: testair (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38042 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28276 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93334 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38418 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96210 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93158 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38227 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15964 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34023 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37931 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43402 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/133822 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37595 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36111 "Found 1 new JSC binary failure: testair, Found 2 new JSC stress test failures: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js.default, wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40929 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39298 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->