### PR TITLE
[Absolute Positioning] Incorrect static position when containing block is a grid.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5251,9 +5251,7 @@ imported/w3c/web-platform-tests/html/canvas/element/compositing/2d.composite.gri
 imported/w3c/web-platform-tests/html/canvas/element/compositing/2d.composite.grid.no_filter.shadow.fillRect.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/canvas/element/compositing/2d.composite.grid.no_filter.shadow.pattern.html [ ImageOnlyFailure ]
 
-webkit.org/b/209460 imported/w3c/web-platform-tests/css/css-grid/abspos/descendant-static-position-001.html [ ImageOnlyFailure ]
 webkit.org/b/209460 imported/w3c/web-platform-tests/css/css-grid/abspos/descendant-static-position-002.html [ ImageOnlyFailure ]
-webkit.org/b/209460 imported/w3c/web-platform-tests/css/css-grid/abspos/descendant-static-position-003.html [ ImageOnlyFailure ]
 webkit.org/b/212246 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-baseline-align-cycles-001.html [ ImageOnlyFailure ]
 webkit.org/b/231021 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-inline-baseline.html [ ImageOnlyFailure ]
 webkit.org/b/212246 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-item-content-baseline-001.html [ ImageOnlyFailure ]

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.h
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.h
@@ -91,6 +91,7 @@ private:
     void captureAnchorGeometry();
     LayoutRange adjustForPositionArea(const LayoutRange rangeToAdjust, const LayoutRange anchorArea, const BoxAxis containerAxis);
 
+    bool needsGridAreaAdjustmentBeforeStaticPositioning() const;
     void computeStaticPosition();
     void computeInlineStaticDistance();
     void computeBlockStaticDistance();


### PR DESCRIPTION
#### 221d56a321d694a2a1bbd40e01b929b57735677d
<pre>
[Absolute Positioning] Incorrect static position when containing block is a grid.
<a href="https://bugs.webkit.org/show_bug.cgi?id=295818">https://bugs.webkit.org/show_bug.cgi?id=295818</a>
<a href="https://rdar.apple.com/155650719">rdar://155650719</a>

Reviewed by Alan Baradlay.

compute{Inline,Block}StaticDistance are two helper functions that are
used to compute the static position of a box when we need it for one
of its inset values. The way that this works at a high level is by
taking the static position that lives on the associated RenderLayer,
which is in the coordinate space of the parent, and mapping it to the
box&apos;s containing block. One important detail regarding this coordinate
space transformation is that the resulting static position is the box&apos;s
position within the containing block&apos;s *padding* box since we subtract
out its border. In general, this works for most pieces of content;
however, this could result in an incorrect static position for a box when
its containing block is a grid.

To make the underlying problem a bit easier to understand, I think it&apos;s
important to look at an example that has a containing block which is
not a grid and one with a grid containing block. To keep this as simple
as possible, we will only be worrying about the static position in the
inline axis by setting top to 0.

Block container as containing block:

.block {
  position: relative;
  width: 40px;
  height: 40px;
  border-left: 50px solid black;
  padding-left: 30px;
}

.grid &gt; div {
  background: red;
}
.absolute {
  position: absolute;
  background: red;
  grid-column: 1 / 2;
  top: 0;
}
.content {
  float: left;
  width: 20px;
  height: 40px;
  background: green;
}

&lt;div class=&quot;block&quot;&gt;
  &lt;div&gt;
    &lt;div class=&quot;absolute&quot;&gt;
      &lt;div class=&quot;content&quot;&gt;&lt;/div&gt;
      &lt;div class=&quot;content&quot;&gt;&lt;/div&gt;
    &lt;/div&gt;
  &lt;/div&gt;
&lt;/div&gt;

 _______________________________________________
|                                               | &lt;- 120px border box width
 -----------------------------------------------
| border          |          |                  |
| 50px            |          |                  |
|                 |          |                  |
|                 | padding  |                  |
|                 | 30px     |                  |
|                 |          |                  |
|                 |          | content          |
|                 |          | 40px             |
|                 |          |                  |
|                 |          |                  |
|                 |          |                  |
|                 |          |                  |
 -----------------------------------------------
                  |                             | &lt;- original containing block for abspos
                   -----------------------------

In this example, the original containing block for the absolutely
positioned box is the block container&apos;s padding box. When we convert the
static position to the coordinate space, we end up with a value of 30px.
This comes from the fact that the position is located at 120px in the
block container&apos;s border box, but we compute it as the location in the
padding box, so 120px - 50px. This value then gets set to the left inset
value for the box, which is okay since the location in the padding box is
exactly the same as the offset from that edge to its static position.

Example with grid as containing block (most styling is the same, only .grid
is different):

.grid {
  position: relative;
  display: grid;
  grid: 40px / 40px;
  border-left: 50px solid black;
  padding-left: 30px;
  width: 20px;
}

.grid &gt; div {
  background: red;
}
.absolute {
  position: absolute;
  background: red;
  grid-column: 1 / 2;
  top: 0;
}
.content {
  float: left;
  width: 20px;
  height: 40px;
  background: green;
}

&lt;div class=&quot;grid&quot;&gt;
  &lt;div&gt;
    &lt;div class=&quot;absolute&quot;&gt;
      &lt;div class=&quot;content&quot;&gt;&lt;/div&gt;
      &lt;div class=&quot;content&quot;&gt;&lt;/div&gt;
    &lt;/div&gt;
  &lt;/div&gt;
&lt;/div&gt;

 _______________________________________________
|                                               | &lt;- 120px border box width
 -----------------------------------------------
| border          |          |                  |
| 50px            |          |                  |
|                 |          |                  |
|                 | padding  |                  |
|                 | 30px     |                  |
|                 |          |                  |
|                 |          | grid area
|                 |          | 40px             |
|                 |          |                  |
|                 |          |                  |
|                 |          |                  |
|                 |          |                  |
 -----------------------------------------------
                             |                  | &lt;- original containing block for abspos
                              ------------------

In order to not overcomplicate this with extra grid details, the grid
area was computed to be the same size as the block container from the
previous example, and the absolute positioned box&apos;s grid properties
specify exactly this area.

This example is almost exactly the same as the previous; however, it is
important to note the difference in the containing block. In this case,
since the containing block is the grid, then its containing block is
set to the grid area determined by its grid area properties.

<a href="https://drafts.csswg.org/css-grid-2/#abspos-items">https://drafts.csswg.org/css-grid-2/#abspos-items</a>

When we convert the static position this time, we end up getting the same
exact value before, which should not be super surprising since the
static position set by the RenderLayer is also the same value. However,
this value no longer makes sense from the perspective of it being the
offset from the containing block. This can end up in an incorrectly
sized and located inset modified containing block. In this case, the location
in the padding box cannot be used as the offset from the containing block since
the containing block starts in the grid area (which in this case is just
the same as the content box, but that is certainly not always the case).

In order to rectify this, we must slightly change how we compute the value
used for the inset. Instead of just computing and directly using the
location in the padding box, we should:

1.) Compute the box&apos;s location in the containing block&apos;s border box.
2.) Take that value and subtract it from the location of the containing
block, which should be in the same coordinate space.

In the cases where the inset/static position is computed to be the
offset from the padding box, this works out since the containing block&apos;s
location is set to the padding box origin.

Unfortunately, this is not the only area that prevents us from computing
the correct value where the containing block is a grid. Before we
actually begin computing the static position code, we have logic that
performs some form of adjustment before we enter the helper functions
(see PositionedLayoutConstraints::computeStaticPosition). It is not
super clear what this is attempting to do, but it completely throws off
the location of the containing block and results in an incorrect static
position. In theory, we should just be able to get rid of this special
logic and apply the new static position computation, but that resulted in
some regressions. So instead, we will just restrict and apply this logic
for certain types of content and grow it over time. Eventually, with
some debugging, we should be able to get to a point where we can remove
it. For now, it is only applied when we are computing the inline offsets,
the direction is LTR, and the parent does not have an orthogonal writing
mode to the containing block.

Canonical link: <a href="https://commits.webkit.org/297403@main">https://commits.webkit.org/297403@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52b02deaa5529b8bcc38daf1197a3defb716b9cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111220 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30886 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21333 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117251 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61488 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113182 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31567 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39468 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84537 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114167 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25207 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100130 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64983 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24549 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18271 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61071 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94585 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18338 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120324 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38269 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28437 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93464 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38645 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96405 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93289 "Found 2 new API test failures: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23852 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38386 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16148 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34254 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38158 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43635 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37823 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41156 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39525 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->