### PR TITLE
AX:

### DIFF
--- a/LayoutTests/accessibility/element-outside-modal-with-zindex-expected.txt
+++ b/LayoutTests/accessibility/element-outside-modal-with-zindex-expected.txt
@@ -1,0 +1,15 @@
+This tests that content with a higher zindex than the active modal is exposed to accessibility.
+
+PASS: accessibilityController.accessibleElementById('modalButton').isIgnored === false
+PASS: accessibilityController.accessibleElementById('text1').childAtIndex(0).isIgnored === false
+PASS: accessibilityController.accessibleElementById('text2') == null === true
+PASS: accessibilityController.accessibleElementById('floatingButton').isIgnored === false
+PASS: accessibilityController.accessibleElementById('displayContentsButton').isIgnored === false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+This is content floating above the modal.This is content floating beneath the modal.
+My Button
+Display Contents Button

--- a/LayoutTests/accessibility/element-outside-modal-with-zindex.html
+++ b/LayoutTests/accessibility/element-outside-modal-with-zindex.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="../resources/js-test.js"></script>
+    <script src="../resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<div role="dialog" aria-modal="true" style="z-index: 10">
+    <button id="modalButton" aria-label="Button"></button>
+</div>
+
+<div id="text1" style="z-index: 50; width: 200px; position: absolute;">This is content floating above the modal.</div>
+
+<div id="text2" style="position: absolute; width: 200px;">This is content floating beneath the modal.</div>
+
+<div style="position: absolute; width: 200px; z-index: 100;">
+    <div role="group">
+        <button id="floatingButton">My Button</button>
+    </div>
+</div>
+
+<div role="group" aria-label="content" style="position: absolute; width: 200px; z-index: 100">
+    <button style="display:contents" id="displayContentsButton">Display Contents Button</button>
+</div>
+
+<script>
+var output = "This tests that content with a higher zindex than the active modal is exposed to accessibility.\n\n"
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    document.getElementById("modalButton").focus();
+    setTimeout(async function() {
+        await waitFor(() => accessibilityController.accessibleElementById('text2') == null);
+        output += expect("accessibilityController.accessibleElementById('modalButton').isIgnored", "false");
+        output += expect("accessibilityController.accessibleElementById('text1').childAtIndex(0).isIgnored", "false");
+        output += expect("accessibilityController.accessibleElementById('text2') == null", "true");
+        output += expect("accessibilityController.accessibleElementById('floatingButton').isIgnored", "false");
+        output += expect("accessibilityController.accessibleElementById('displayContentsButton').isIgnored", "false");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -902,6 +902,9 @@ http/wpt/service-workers/mac [ Skip ]
 # TextMarkerRangeForElement is only implemented on Cocoa platforms.
 accessibility/full-size-kana-untransformed.html [ Skip ]
 
+# Static text are not exposed as accessibility elements on glib appointments.
+accessibility/element-outside-modal-with-zindex.html [ Skip ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of Accessibility-related bugs
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -1220,7 +1220,7 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
 
 TextStream& operator<<(TextStream& stream, const AXCoreObject& object)
 {
-    constexpr OptionSet<AXStreamOptions> options = { AXStreamOptions::ObjectID, AXStreamOptions::Role, AXStreamOptions::ParentID, AXStreamOptions::IdentifierAttribute, AXStreamOptions::OuterHTML, AXStreamOptions::DisplayContents, AXStreamOptions::Address };
+    constexpr OptionSet<AXStreamOptions> options = { AXStreamOptions::ObjectID, AXStreamOptions::Role, AXStreamOptions::ParentID, AXStreamOptions::IdentifierAttribute, AXStreamOptions::OuterHTML, AXStreamOptions::DisplayContents, AXStreamOptions::Address, AXStreamOptions::RendererOrNode };
     streamAXCoreObject(stream, object, options);
     return stream;
 }
@@ -1233,7 +1233,7 @@ TextStream& operator<<(TextStream& stream, AXIsolatedTree& tree)
     stream << "treeID " << tree.treeID();
     stream.dumpProperty("rootNodeID"_s, tree.rootNode()->objectID());
     stream.dumpProperty("focusedNodeID"_s, tree.m_focusedNodeID);
-    constexpr OptionSet<AXStreamOptions> options = { AXStreamOptions::ObjectID, AXStreamOptions::Role, AXStreamOptions::ParentID, AXStreamOptions::IdentifierAttribute, AXStreamOptions::OuterHTML, AXStreamOptions::DisplayContents, AXStreamOptions::Address };
+    constexpr OptionSet<AXStreamOptions> options = { AXStreamOptions::ObjectID, AXStreamOptions::Role, AXStreamOptions::ParentID, AXStreamOptions::IdentifierAttribute, AXStreamOptions::OuterHTML, AXStreamOptions::DisplayContents, AXStreamOptions::Address, AXStreamOptions::RendererOrNode };
     if (RefPtr root = tree.rootNode())
         streamSubtree(stream, root.releaseNonNull(), options);
     return stream;
@@ -1269,7 +1269,7 @@ TextStream& operator<<(TextStream& stream, AXObjectCache& axObjectCache)
     if (!document)
         stream << "No document!";
     else if (RefPtr root = axObjectCache.get(document->view())) {
-        constexpr OptionSet<AXStreamOptions> options = { AXStreamOptions::ObjectID, AXStreamOptions::Role, AXStreamOptions::ParentID, AXStreamOptions::IdentifierAttribute, AXStreamOptions::OuterHTML, AXStreamOptions::DisplayContents, AXStreamOptions::Address };
+        constexpr OptionSet<AXStreamOptions> options = { AXStreamOptions::ObjectID, AXStreamOptions::Role, AXStreamOptions::ParentID, AXStreamOptions::IdentifierAttribute, AXStreamOptions::OuterHTML, AXStreamOptions::DisplayContents, AXStreamOptions::Address, AXStreamOptions::RendererOrNode };
         streamSubtree(stream, root.releaseNonNull(), options);
     } else
         stream << "No root!";
@@ -1294,10 +1294,12 @@ void streamAXCoreObject(TextStream& stream, const AXCoreObject& object, const Op
 
     auto* axObject = dynamicDowncast<AccessibilityObject>(object);
     if (axObject) {
-        if (auto* renderer = axObject->renderer())
-            stream.dumpProperty("renderer"_s, renderer->debugDescription());
-        else if (auto* node = axObject->node())
-            stream.dumpProperty("node"_s, node->debugDescription());
+        if (options & AXStreamOptions::RendererOrNode) {
+            if (auto* renderer = axObject->renderer())
+                stream.dumpProperty("renderer"_s, renderer->debugDescription());
+            else if (auto* node = axObject->node())
+                stream.dumpProperty("node"_s, node->debugDescription());
+        }
     }
 
     if (options & AXStreamOptions::ParentID) {

--- a/Source/WebCore/accessibility/AXLogger.h
+++ b/Source/WebCore/accessibility/AXLogger.h
@@ -36,7 +36,7 @@ enum class AXLoggingOptions : uint8_t {
     OffMainThread = 1 << 1, // Logs messages off the main thread.
 };
 
-enum class AXStreamOptions : uint8_t {
+enum class AXStreamOptions : uint16_t {
     ObjectID = 1 << 0,
     Role = 1 << 1,
     ParentID = 1 << 2,
@@ -47,6 +47,7 @@ enum class AXStreamOptions : uint8_t {
 #if ENABLE(AX_THREAD_TEXT_APIS)
     TextRuns = 1 << 7,
 #endif
+    RendererOrNode = 1 << 8,
 };
 
 #if !LOG_DISABLED

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -5360,7 +5360,7 @@ AXTreeData AXObjectCache::treeData(std::optional<OptionSet<AXStreamOptions>> add
     stream << "\nAXObjectTree:\n";
     RefPtr document = this->document();
     if (RefPtr root = document ? get(document->view()) : nullptr) {
-        OptionSet<AXStreamOptions> options = { AXStreamOptions::ObjectID, AXStreamOptions::ParentID, AXStreamOptions::Role, AXStreamOptions::IdentifierAttribute, AXStreamOptions::OuterHTML };
+        OptionSet<AXStreamOptions> options = { AXStreamOptions::ObjectID, AXStreamOptions::ParentID, AXStreamOptions::Role };
         if (additionalOptions)
             options |= additionalOptions.value();
         streamSubtree(stream, *root, options);
@@ -5373,7 +5373,7 @@ AXTreeData AXObjectCache::treeData(std::optional<OptionSet<AXStreamOptions>> add
         stream << "\nAXIsolatedTree:\n";
         RefPtr tree = getOrCreateIsolatedTree();
         if (RefPtr root = tree ? tree->rootNode() : nullptr) {
-            OptionSet<AXStreamOptions> options = { AXStreamOptions::ObjectID, AXStreamOptions::ParentID };
+            OptionSet<AXStreamOptions> options = { AXStreamOptions::ObjectID, AXStreamOptions::ParentID, AXStreamOptions::Role };
             if (additionalOptions)
                 options |= additionalOptions.value();
             streamSubtree(stream, root.releaseNonNull(), options);

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -74,7 +74,7 @@ class Scrollbar;
 class ScrollView;
 class VisiblePosition;
 class Widget;
-enum class AXStreamOptions : uint8_t;
+enum class AXStreamOptions : uint16_t;
 
 struct CharacterOffset {
     RefPtr<Node> node;
@@ -651,7 +651,7 @@ public:
 
     static ASCIILiteral notificationPlatformName(AXNotification);
 
-    AXTreeData treeData(std::optional<OptionSet<AXStreamOptions>> = std::nullopt);
+    WEBCORE_EXPORT AXTreeData treeData(std::optional<OptionSet<AXStreamOptions>> = std::nullopt);
 
     enum class UpdateRelations : bool { No, Yes };
     // Returns the IDs of the objects that relate to the given object with the specified relationship.
@@ -677,6 +677,7 @@ public:
     void willUpdateObjectRegions() { m_geometryManager->willUpdateObjectRegions(); }
     WEBCORE_EXPORT static bool isIsolatedTreeEnabled();
     WEBCORE_EXPORT static void initializeAXThreadIfNeeded();
+    WEBCORE_EXPORT static bool isAXThreadInitialized();
 private:
     static bool clientSupportsIsolatedTree();
     // Propagates the root of the isolated tree back into the Core and WebKit.

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -243,6 +243,7 @@ public:
     Element* element() const final;
     Node* node() const override { return nullptr; }
     RenderObject* renderer() const override { return nullptr; }
+    RenderObject* rendererOrNearestAncestor() const;
     // Resolves the computed style if necessary (and safe to do so).
     const RenderStyle* style() const;
 

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -53,7 +53,7 @@ class AXGeometryManager;
 class AXObjectCache;
 class AccessibilityObject;
 class Page;
-enum class AXStreamOptions : uint8_t;
+enum class AXStreamOptions : uint16_t;
 
 static constexpr uint16_t lastPropertyFlagIndex = 21;
 // The most common boolean properties are stored in a bitfield rather than in a HashMap.

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -724,9 +724,11 @@ bool AXObjectCache::isIsolatedTreeEnabled()
     return enabled;
 }
 
+
+static bool axThreadInitialized = false;
+
 void AXObjectCache::initializeAXThreadIfNeeded()
 {
-    static bool axThreadInitialized = false;
     if (axThreadInitialized || !isMainThread()) [[likely]]
         return;
 
@@ -739,6 +741,11 @@ void AXObjectCache::initializeAXThreadIfNeeded()
         _AXUIElementUseSecondaryAXThread(true);
         axThreadInitialized = true;
     }
+}
+
+bool AXObjectCache::isAXThreadInitialized()
+{
+    return axThreadInitialized;
 }
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -2478,7 +2478,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         if (!cache)
             return;
 
-        AXTreeData data = cache->treeData(); // Can specify AXStreamOptions here if needed (e.g., TextRuns)
+        AXTreeData data = cache->treeData({ { AXStreamOptions::IdentifierAttribute, AXStreamOptions::OuterHTML, AXStreamOptions::RendererOrNode } }); // Can specify AXStreamOptions here if needed (e.g., TextRuns)
         SAFE_FPRINTF(stderr, "==AX Trees==\n%s\n%s\n", data.liveTree.utf8(), data.isolatedTree.utf8());
     });
 }

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -20,6 +20,7 @@
 #include "config.h"
 #include "Page.h"
 
+#include "AXLogger.h"
 #include "ActivityStateChangeObserver.h"
 #include "AdvancedPrivacyProtections.h"
 #include "AlternativeTextClient.h"
@@ -793,14 +794,14 @@ void Page::settingsDidChange()
 #endif
 }
 
-std::optional<AXTreeData> Page::accessibilityTreeData() const
+std::optional<AXTreeData> Page::accessibilityTreeData(bool limited) const
 {
     RefPtr localTopDocument = this->localTopDocument();
     if (!localTopDocument)
         return std::nullopt;
 
     if (CheckedPtr cache = localTopDocument->existingAXObjectCache())
-        return { cache->treeData() };
+        return { limited ? cache->treeData() : cache->treeData({ { AXStreamOptions::IdentifierAttribute, AXStreamOptions::OuterHTML, AXStreamOptions::RendererOrNode } }) };
     return std::nullopt;
 }
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1207,7 +1207,7 @@ public:
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     bool shouldUpdateAccessibilityRegions() const;
 #endif
-    WEBCORE_EXPORT std::optional<AXTreeData> accessibilityTreeData() const;
+    WEBCORE_EXPORT std::optional<AXTreeData> accessibilityTreeData(bool = false) const;
 #if USE(ATSPI)
     AccessibilityRootAtspi* accessibilityRootObject() const;
     void setAccessibilityRootObject(AccessibilityRootAtspi*);

--- a/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.h
+++ b/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.h
@@ -74,6 +74,9 @@ WK_EXPORT bool WKPageIsURLKnownHSTSHost(WKPageRef page, WKURLRef url);
 WK_EXPORT bool WKPageIsPlayingVideoInEnhancedFullscreen(WKPageRef page);
 #endif
 
+WK_EXPORT bool WKPageAccessibilityIsEnabled(WKPageRef page);
+WK_EXPORT bool WKPageAccesssibilityThreadInitialized(WKPageRef page);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
+++ b/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
@@ -172,3 +172,12 @@ id <_WKFullscreenDelegate> WKPageGetFullscreenDelegate(WKPageRef page)
 #endif
 }
 
+bool WKPageAccessibilityIsEnabled(WKPageRef pageRef)
+{
+    return WebKit::toImpl(pageRef)->isAccessibilityEnabled();
+}
+
+bool WKPageAccesssibilityThreadInitialized(WKPageRef pageRef)
+{
+    return WebKit::toImpl(pageRef)->isAccessibilityThreadInitialized();
+}

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewPrivateForTestingMac.h
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewPrivateForTestingMac.h
@@ -52,6 +52,7 @@
 - (NSSet<NSView *> *)_pdfHUDs;
 
 - (void)_retrieveAccessibilityTreeData:(void (^)(NSData *, NSError *))completionHandler;
+- (void)_retrieveLimitedAccessibilityTreeData:(void (^)(NSData *, NSError *))completionHandler;
 
 - (void)_setSelectedColorForColorPicker:(NSColor *)color;
 

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewTestingMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewTestingMac.mm
@@ -124,7 +124,14 @@
 
 - (void)_retrieveAccessibilityTreeData:(void (^)(NSData *, NSError *))completionHandler
 {
-    _page->getAccessibilityTreeData([completionHandler = makeBlockPtr(completionHandler)] (API::Data* data) {
+    _page->getAccessibilityTreeData(false, [completionHandler = makeBlockPtr(completionHandler)] (API::Data* data) {
+        completionHandler(wrapper(data), nil);
+    });
+}
+
+- (void)_retrieveLimitedAccessibilityTreeData:(void (^)(NSData *, NSError *))completionHandler
+{
+    _page->getAccessibilityTreeData(true, [completionHandler = makeBlockPtr(completionHandler)] (API::Data* data) {
         completionHandler(wrapper(data), nil);
     });
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5727,6 +5727,31 @@ void WebPageProxy::enableAccessibilityForAllProcesses()
     });
 }
 
+bool WebPageProxy::isAccessibilityEnabled()
+{
+    const Seconds messageTimeout(2);
+    auto sendResult = protectedLegacyMainFrameProcess()->sendSync(Messages::WebPage::IsAccessibilityEnabled(), webPageIDInMainFrameProcess(), messageTimeout);
+
+    if (!sendResult.succeeded())
+        return false;
+
+    auto [result] = sendResult.takeReplyOr(false);
+    return result;
+}
+
+bool WebPageProxy::isAccessibilityThreadInitialized()
+{
+    const Seconds messageTimeout(2);
+    auto sendResult = protectedLegacyMainFrameProcess()->sendSync(Messages::WebPage::IsAccessibilityThreadInitialized(), webPageIDInMainFrameProcess(), messageTimeout);
+
+    if (!sendResult.succeeded())
+        return false;
+
+    auto [result] = sendResult.takeReplyOr(false);
+    return result;
+}
+
+
 void WebPageProxy::setUseFixedLayout(bool fixed)
 {
     // This check is fine as the value is initialized in the web
@@ -6475,9 +6500,9 @@ void WebPageProxy::getWebArchive(CompletionHandler<void(API::Data*)>&& completio
 #endif
 }
 
-void WebPageProxy::getAccessibilityTreeData(CompletionHandler<void(API::Data*)>&& callback)
+void WebPageProxy::getAccessibilityTreeData(bool limited, CompletionHandler<void(API::Data*)>&& callback)
 {
-    sendWithAsyncReply(Messages::WebPage::GetAccessibilityTreeData(), toAPIDataCallback(WTFMove(callback)));
+    sendWithAsyncReply(Messages::WebPage::GetAccessibilityTreeData(limited), toAPIDataCallback(WTFMove(callback)));
 }
 
 void WebPageProxy::updateRenderingWithForcedRepaint(CompletionHandler<void()>&& callback)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1433,6 +1433,9 @@ public:
     void accessibilitySettingsDidChange();
     void enableAccessibilityForAllProcesses();
 
+    bool isAccessibilityEnabled();
+    bool isAccessibilityThreadInitialized();
+
 #if ENABLE(INITIALIZE_ACCESSIBILITY_ON_DEMAND)
     void initializeAccessibility();
 #endif
@@ -1602,7 +1605,7 @@ public:
     void getWebArchive(CompletionHandler<void(API::Data*)>&&);
     void runJavaScriptInMainFrame(RunJavaScriptParameters&&, bool, CompletionHandler<void(Expected<JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>)>&&);
     void runJavaScriptInFrameInScriptWorld(RunJavaScriptParameters&&, std::optional<WebCore::FrameIdentifier>, API::ContentWorld&, bool, CompletionHandler<void(Expected<JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>)>&&);
-    void getAccessibilityTreeData(CompletionHandler<void(API::Data*)>&&);
+    void getAccessibilityTreeData(bool, CompletionHandler<void(API::Data*)>&&);
     void updateRenderingWithForcedRepaint(CompletionHandler<void()>&&);
 
     float headerHeightForPrinting(WebFrameProxy&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2736,6 +2736,16 @@ void WebPage::enableAccessibility()
         WebCore::AXObjectCache::enableAccessibility();
 }
 
+void WebPage::isAccessibilityEnabled(CompletionHandler<void(bool)>&& completionHandler)
+{
+    completionHandler(WebCore::AXObjectCache::accessibilityEnabled());
+}
+
+void WebPage::isAccessibilityThreadInitialized(CompletionHandler<void(bool)>&& completionHandler)
+{
+    completionHandler(WebCore::AXObjectCache::isAXThreadInitialized());
+}
+
 void WebPage::screenPropertiesDidChange()
 {
     protectedCorePage()->screenPropertiesDidChange();
@@ -4651,11 +4661,11 @@ void WebPage::getWebArchiveOfFrame(std::optional<FrameIdentifier> frameID, Compl
 #endif
 }
 
-void WebPage::getAccessibilityTreeData(CompletionHandler<void(const std::optional<IPC::SharedBufferReference>&)>&& callback)
+void WebPage::getAccessibilityTreeData(bool limited, CompletionHandler<void(const std::optional<IPC::SharedBufferReference>&)>&& callback)
 {
     IPC::SharedBufferReference dataBuffer;
 #if PLATFORM(COCOA)
-    if (auto treeData = protectedCorePage()->accessibilityTreeData()) {
+    if (auto treeData = protectedCorePage()->accessibilityTreeData(limited)) {
         auto stream = adoptCF(CFWriteStreamCreateWithAllocatedBuffers(0, 0));
         CFWriteStreamOpen(stream.get());
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -809,6 +809,9 @@ public:
     void enableAccessibilityForAllProcesses();
     void enableAccessibility();
 
+    void isAccessibilityEnabled(CompletionHandler<void(bool)>&&);
+    void isAccessibilityThreadInitialized(CompletionHandler<void(bool)>&&);
+
 #if ENABLE(INITIALIZE_ACCESSIBILITY_ON_DEMAND)
     void initializeAccessibility(Vector<SandboxExtension::Handle>&&);
 #endif
@@ -2232,7 +2235,7 @@ private:
     void getWebArchiveOfFrameWithFileName(WebCore::FrameIdentifier, const Vector<WebCore::MarkupExclusionRule>&, const String& fileName, CompletionHandler<void(const std::optional<IPC::SharedBufferReference>&)>&&);
     void runJavaScript(WebFrame*, RunJavaScriptParameters&&, ContentWorldIdentifier, bool, CompletionHandler<void(Expected<JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>)>&&);
     void runJavaScriptInFrameInScriptWorld(RunJavaScriptParameters&&, std::optional<WebCore::FrameIdentifier>, const ContentWorldData&, bool, CompletionHandler<void(Expected<JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>)>&&);
-    void getAccessibilityTreeData(CompletionHandler<void(const std::optional<IPC::SharedBufferReference>&)>&&);
+    void getAccessibilityTreeData(bool, CompletionHandler<void(const std::optional<IPC::SharedBufferReference>&)>&&);
     void updateRenderingWithForcedRepaint(CompletionHandler<void()>&&);
     void takeSnapshot(WebCore::IntRect snapshotRect, WebCore::IntSize bitmapSize, SnapshotOptions, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -242,7 +242,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
 
     RunJavaScriptInFrameInScriptWorld(struct WebKit::RunJavaScriptParameters parameters, std::optional<WebCore::FrameIdentifier> frameID, struct WebKit::ContentWorldData world, bool wantsResult) -> (Expected<WebKit::JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>> result)
 
-    GetAccessibilityTreeData() -> (std::optional<IPC::SharedBufferReference> dataReference)
+    GetAccessibilityTreeData(bool limited) -> (std::optional<IPC::SharedBufferReference> dataReference)
     UpdateRenderingWithForcedRepaint() -> ()
     SelectAll()
     ScheduleFullEditorStateUpdate()
@@ -508,6 +508,9 @@ messages -> WebPage WantsAsyncDispatchMessage {
     UpdateRemotePageAccessibilityOffset(WebCore::FrameIdentifier frameID, WebCore::IntPoint offset);
     ResolveAccessibilityHitTestForTesting(WebCore::FrameIdentifier frameID, WebCore::IntPoint point) -> (String result)
     EnableAccessibility()
+
+    IsAccessibilityEnabled() -> (bool result) Synchronous
+    IsAccessibilityThreadInitialized() -> (bool result) Synchronous
 
 #if ENABLE(INITIALIZE_ACCESSIBILITY_ON_DEMAND)
     InitializeAccessibility(Vector<WebKit::SandboxExtensionHandle> handles);


### PR DESCRIPTION
#### faf526c4b1990de549ad44dbb9b4b95528f77633
<pre>
AX: Add debug IPC for web process bits, limited tree dump
<a href="https://bugs.webkit.org/show_bug.cgi?id=295747">https://bugs.webkit.org/show_bug.cgi?id=295747</a>
<a href="https://rdar.apple.com/155563271">rdar://155563271</a>

Reviewed by NOBODY (OOPS!).

This patch adds some new IPC messages to provide better accessibility debug
tooling down the road. These additions and enhancements include:
- New IPC for if accessibility is enabled in the web process
- New IPC for whether the accessibility thread has been initialized
in the web process
- Updating the AXObjectCache::treeData() method to not return the renderer,
node, or outerHTML info by default. This allows for easier comparison between
the live and isolated trees. To not regress existing calls to this method, I
added in those stream options to the other call sites.

* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
(WebCore::streamAXCoreObject):
* Source/WebCore/accessibility/AXLogger.h:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::treeData):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::AXObjectCache::initializeAXThreadIfNeeded):
(WebCore::AXObjectCache::isAXThreadInitialized):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper _accessibilityPrintTrees]):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::accessibilityTreeData const):
* Source/WebCore/page/Page.h:
* Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.h:
* Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm:
(WKPageAccessibilityIsEnabled):
(WKPageAccesssibilityThreadInitialized):
* Source/WebKit/UIProcess/API/mac/WKWebViewPrivateForTestingMac.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewTestingMac.mm:
(-[WKWebView _retrieveAccessibilityTreeData:]):
(-[WKWebView _retrieveLimitedAccessibilityTreeData:]):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::isAccessibilityEnabled):
(WebKit::WebPageProxy::isAccessibilityThreadInitialized):
(WebKit::WebPageProxy::getAccessibilityTreeData):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::isAccessibilityEnabled):
(WebKit::WebPage::isAccessibilityThreadInitialized):
(WebKit::WebPage::getAccessibilityTreeData):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
</pre>
----------------------------------------------------------------------
#### b79078d38f0d9ca8e7f2e9d728a32087b051a581
<pre>
AX: consider z-index when computing ignored when a modal is present
<a href="https://bugs.webkit.org/show_bug.cgi?id=295404">https://bugs.webkit.org/show_bug.cgi?id=295404</a>
<a href="https://rdar.apple.com/154886931">rdar://154886931</a>

Reviewed by NOBODY (OOPS!).

There can be authoring errors when using aria-modal, and frequently, absolutely positioned
content that should be floating above the modal is excluded from accessibility because of
our modal heuristics. We can be more forgiving by also checking if content has a higher
z-index than the modal, indicating that it should be accessible.

* LayoutTests/accessibility/element-outside-modal-with-zindex-expected.txt: Added.
* LayoutTests/accessibility/element-outside-modal-with-zindex.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::nearestRendererFromNode):
(WebCore::zIndexFromRenderer):
(WebCore::AccessibilityObject::ignoredFromModalPresence const):
(WebCore::AccessibilityObject::rendererOrNearestAncestor const):
* Source/WebCore/accessibility/AccessibilityObject.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/faf526c4b1990de549ad44dbb9b4b95528f77633

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111014 "Failed to checkout and rebase branch from PR 47853") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/30680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21111 "Failed to checkout and rebase branch from PR 47853") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/117044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/61281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112976 "Failed to checkout and rebase branch from PR 47853") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/31361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/39262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/117044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/61281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113961 "Failed to checkout and rebase branch from PR 47853") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/31361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/21111 "Failed to checkout and rebase branch from PR 47853") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/117044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/31361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/21111 "Failed to checkout and rebase branch from PR 47853") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/60857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/31361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/21111 "Failed to checkout and rebase branch from PR 47853") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/119872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/38063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/39262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/119872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/38439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/21111 "Failed to checkout and rebase branch from PR 47853") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/119872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/21111 "Failed to checkout and rebase branch from PR 47853") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/34044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/37952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/43425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/37616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/40950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/39319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->