### PR TITLE
[WASM] BBQ should make use of IPInt expression stack size to compute stack frame size

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -647,7 +647,7 @@ void ControlData::fillLabels(CCallHelpers::Label label)
         *box = label;
 }
 
-BBQJIT::BBQJIT(CCallHelpers& jit, const TypeDefinition& signature, BBQCallee& callee, const FunctionData& function, FunctionCodeIndex functionIndex, const ModuleInformation& info, Vector<UnlinkedWasmToWasmCall>& unlinkedWasmToWasmCalls, MemoryMode mode, InternalFunction* compilation, std::optional<bool> hasExceptionHandlers, unsigned loopIndexForOSREntry)
+BBQJIT::BBQJIT(CCallHelpers& jit, const TypeDefinition& signature, BBQCallee& callee, const FunctionData& function, FunctionCodeIndex functionIndex, const ModuleInformation& info, Vector<UnlinkedWasmToWasmCall>& unlinkedWasmToWasmCalls, MemoryMode mode, InternalFunction* compilation, const LowerTierInformation& lowerTierInfo, unsigned loopIndexForOSREntry)
     : m_jit(jit)
     , m_callee(callee)
     , m_function(function)
@@ -657,7 +657,8 @@ BBQJIT::BBQJIT(CCallHelpers& jit, const TypeDefinition& signature, BBQCallee& ca
     , m_mode(mode)
     , m_unlinkedWasmToWasmCalls(unlinkedWasmToWasmCalls)
     , m_directCallees(m_info.internalFunctionCount())
-    , m_hasExceptionHandlers(hasExceptionHandlers)
+    , m_knownExpressionStackSize(lowerTierInfo.maxExpressionStackSize)
+    , m_hasExceptionHandlers(lowerTierInfo.hasExceptionHandlers)
     , m_loopIndexForOSREntry(loopIndexForOSREntry)
     , m_gprLRU(jit.numberOfRegisters())
     , m_fprLRU(jit.numberOfFPRegisters())
@@ -716,7 +717,11 @@ BBQJIT::BBQJIT(CCallHelpers& jit, const TypeDefinition& signature, BBQCallee& ca
     ASSERT(callInfo.params.size() == m_functionSignature->argumentCount());
     for (unsigned i = 0; i < m_functionSignature->argumentCount(); i ++) {
         const Type& type = m_functionSignature->argumentType(i);
-        m_localSlots.append(allocateStack(Value::fromLocal(type.kind, i)));
+
+        unsigned typeSize = sizeOfType(type.kind);
+        m_localStorage = WTF::roundUpToMultipleOf(typeSize, m_localStorage);
+        m_localStorage += typeSize;
+        m_localSlots.append(Location::fromStack(-m_localStorage));
         m_locals.append(Location::none());
         m_localTypes.append(type.kind);
 
@@ -724,7 +729,6 @@ BBQJIT::BBQJIT(CCallHelpers& jit, const TypeDefinition& signature, BBQCallee& ca
         bind(parameter, Location::fromArgumentLocation(callInfo.params[i], type.kind));
         m_arguments.append(i);
     }
-    m_localStorage = m_frameSize; // All stack slots allocated so far are locals.
 }
 
 bool BBQJIT::canTierUpToOMG() const
@@ -815,9 +819,10 @@ PartialResult BBQJIT::addDrop(Value value)
 PartialResult BBQJIT::addLocal(Type type, uint32_t numberOfLocals)
 {
     for (uint32_t i = 0; i < numberOfLocals; i ++) {
-        uint32_t localIndex = m_locals.size();
-        m_localSlots.append(allocateStack(Value::fromLocal(type.kind, localIndex)));
-        m_localStorage = m_frameSize;
+        unsigned typeSize = sizeOfType(type.kind);
+        m_localStorage = WTF::roundUpToMultipleOf(typeSize, m_localStorage);
+        m_localStorage += typeSize;
+        m_localSlots.append(Location::fromStack(-m_localStorage));
         m_locals.append(m_localSlots.last());
         m_localTypes.append(type.kind);
     }
@@ -3010,25 +3015,27 @@ ControlData WARN_UNUSED_RETURN BBQJIT::addTopLevel(BlockSignature signature)
     } else
         m_jit.storePairPtr(GPRInfo::wasmContextInstancePointer, wasmScratchGPR, GPRInfo::callFrameRegister, CCallHelpers::TrustedImm32(CallFrameSlot::codeBlock * sizeof(Register)));
 
-    m_frameSizeLabels.append(m_jit.moveWithPatch(TrustedImmPtr(nullptr), wasmScratchGPR));
-
     bool mayHaveExceptionHandlers = !m_hasExceptionHandlers || m_hasExceptionHandlers.value();
     if (mayHaveExceptionHandlers)
         m_jit.store32(CCallHelpers::TrustedImm32(PatchpointExceptionHandle::s_invalidCallSiteIndex), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
 
-    // Because we compile in a single pass, we always need to pessimistically check for stack underflow/overflow.
-    static_assert(wasmScratchGPR == GPRInfo::nonPreservedNonArgumentGPR0);
-    m_jit.subPtr(GPRInfo::callFrameRegister, wasmScratchGPR, wasmScratchGPR);
+    if (m_knownExpressionStackSize) {
+        m_knownFrameSize = WTF::roundUpToMultipleOf<tempSlotSize>(m_localStorage) + *m_knownExpressionStackSize * tempSlotSize;
+        m_jit.subPtr(GPRInfo::callFrameRegister, TrustedImm32(*m_knownFrameSize), MacroAssembler::stackPointerRegister);
+    } else {
+        m_frameSizeLabels.append(m_jit.moveWithPatch(TrustedImmPtr(nullptr), wasmScratchGPR));
+        static_assert(wasmScratchGPR == GPRInfo::nonPreservedNonArgumentGPR0);
+        m_jit.subPtr(GPRInfo::callFrameRegister, wasmScratchGPR, MacroAssembler::stackPointerRegister);
+    }
 
+    // Because we compile in a single pass, we always need to pessimistically check for stack underflow/overflow.
     MacroAssembler::JumpList overflow;
     JIT_COMMENT(m_jit, "Stack overflow check");
 #if !CPU(ADDRESS64)
-    overflow.append(m_jit.branchPtr(CCallHelpers::Above, wasmScratchGPR, GPRInfo::callFrameRegister));
+    overflow.append(m_jit.branchPtr(CCallHelpers::Above, MacroAssembler::stackPointerRegister, GPRInfo::callFrameRegister));
 #endif
-    overflow.append(m_jit.branchPtr(CCallHelpers::LessThan, wasmScratchGPR, CCallHelpers::Address(GPRInfo::wasmContextInstancePointer, JSWebAssemblyInstance::offsetOfSoftStackLimit())));
+    overflow.append(m_jit.branchPtr(CCallHelpers::LessThan, MacroAssembler::stackPointerRegister, CCallHelpers::Address(GPRInfo::wasmContextInstancePointer, JSWebAssemblyInstance::offsetOfSoftStackLimit())));
     overflow.linkThunk(CodeLocationLabel<JITThunkPtrTag>(Thunks::singleton().stub(throwStackOverflowFromWasmThunkGenerator).code()), &m_jit);
-
-    m_jit.move(wasmScratchGPR, MacroAssembler::stackPointerRegister);
 
     LocalOrTempIndex i = 0;
     for (; i < m_arguments.size(); ++i)
@@ -3307,8 +3314,6 @@ StackMap BBQJIT::makeStackMap(const ControlData& data, Stack& enclosingStack)
             stackMap[stackMapIndex ++] = OSREntryValue(toB3Rep(locationOf(expr.value())), toB3Type(expr.type().kind));
         for (unsigned i = 0; i < data.argumentLocations().size(); i ++)
             stackMap[stackMapIndex ++] = OSREntryValue(toB3Rep(data.argumentLocations()[i]), toB3Type(data.argumentType(i).kind));
-
-
     } else {
         for (const ControlEntry& entry : m_parser->controlStack()) {
             for (const TypedExpression& expr : entry.enclosedExpressionStack)
@@ -4316,13 +4321,17 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addCall(FunctionSpaceIndex functionInde
     }
 
     // Our callee could have tail called someone else and changed SP so we need to restore it. Do this before restoring our results since results are stored at the top of the reserved stack space.
-    m_frameSizeLabels.append(m_jit.moveWithPatch(TrustedImmPtr(nullptr), wasmScratchGPR));
+
+    if (!m_knownFrameSize) {
+        m_frameSizeLabels.append(m_jit.moveWithPatch(TrustedImmPtr(nullptr), wasmScratchGPR));
 #if CPU(ARM_THUMB2)
-    m_jit.subPtr(GPRInfo::callFrameRegister, wasmScratchGPR, wasmScratchGPR);
-    m_jit.move(wasmScratchGPR, MacroAssembler::stackPointerRegister);
+        m_jit.subPtr(GPRInfo::callFrameRegister, wasmScratchGPR, wasmScratchGPR);
+        m_jit.move(wasmScratchGPR, MacroAssembler::stackPointerRegister);
 #else
-    m_jit.subPtr(GPRInfo::callFrameRegister, wasmScratchGPR, MacroAssembler::stackPointerRegister);
+        m_jit.subPtr(GPRInfo::callFrameRegister, wasmScratchGPR, MacroAssembler::stackPointerRegister);
 #endif
+    } else
+        m_jit.subPtr(GPRInfo::callFrameRegister, TrustedImm32(*m_knownFrameSize), MacroAssembler::stackPointerRegister);
 
     // Push return value(s) onto the expression stack
     returnValuesFromCall(results, functionType, callInfo);
@@ -4360,13 +4369,16 @@ void BBQJIT::emitIndirectCall(const char* opcode, const Value& callee, GPRReg ca
     m_jit.call(calleeCode, WasmEntryPtrTag);
 
     // Our callee could have tail called someone else and changed SP so we need to restore it. Do this before restoring our results since results are stored at the top of the reserved stack space.
-    m_frameSizeLabels.append(m_jit.moveWithPatch(TrustedImmPtr(nullptr), wasmScratchGPR));
+    if (!m_knownFrameSize) {
+        m_frameSizeLabels.append(m_jit.moveWithPatch(TrustedImmPtr(nullptr), wasmScratchGPR));
 #if CPU(ARM_THUMB2)
-    m_jit.subPtr(GPRInfo::callFrameRegister, wasmScratchGPR, wasmScratchGPR);
-    m_jit.move(wasmScratchGPR, MacroAssembler::stackPointerRegister);
+        m_jit.subPtr(GPRInfo::callFrameRegister, wasmScratchGPR, wasmScratchGPR);
+        m_jit.move(wasmScratchGPR, MacroAssembler::stackPointerRegister);
 #else
-    m_jit.subPtr(GPRInfo::callFrameRegister, wasmScratchGPR, MacroAssembler::stackPointerRegister);
+        m_jit.subPtr(GPRInfo::callFrameRegister, wasmScratchGPR, MacroAssembler::stackPointerRegister);
 #endif
+    } else
+        m_jit.subPtr(GPRInfo::callFrameRegister, TrustedImm32(*m_knownFrameSize), MacroAssembler::stackPointerRegister);
 
     returnValuesFromCall(results, *signature.as<FunctionSignature>(), wasmCalleeInfo);
 
@@ -5173,17 +5185,12 @@ Location BBQJIT::canonicalSlot(Value value)
 
     LocalOrTempIndex tempIndex = value.asTemp();
     int slotOffset = WTF::roundUpToMultipleOf<tempSlotSize>(m_localStorage) + (tempIndex + 1) * tempSlotSize;
-    if (m_frameSize < slotOffset)
+    if (m_frameSize < slotOffset) {
         m_frameSize = slotOffset;
+        if (m_knownFrameSize)
+            RELEASE_ASSERT(static_cast<unsigned>(m_frameSize) <= *m_knownFrameSize);
+    }
     return Location::fromStack(-slotOffset);
-}
-
-Location BBQJIT::allocateStack(Value value)
-{
-    // Align stack for value size.
-    m_frameSize = WTF::roundUpToMultipleOf(value.size(), m_frameSize);
-    m_frameSize += value.size();
-    return Location::fromStack(-m_frameSize);
 }
 
 void BBQJIT::emitArrayGetPayload(StorageType type, GPRReg arrayGPR, GPRReg payloadGPR)
@@ -5203,7 +5210,7 @@ void BBQJIT::emitArrayGetPayload(StorageType type, GPRReg arrayGPR, GPRReg paylo
 
 } // namespace JSC::Wasm::BBQJITImpl
 
-Expected<std::unique_ptr<InternalFunction>, String> parseAndCompileBBQ(CompilationContext& compilationContext, BBQCallee& callee, const FunctionData& function, const TypeDefinition& signature, Vector<UnlinkedWasmToWasmCall>& unlinkedWasmToWasmCalls, const ModuleInformation& info, MemoryMode mode, FunctionCodeIndex functionIndex, std::optional<bool> hasExceptionHandlers, unsigned loopIndexForOSREntry)
+Expected<std::unique_ptr<InternalFunction>, String> parseAndCompileBBQ(CompilationContext& compilationContext, BBQCallee& callee, const FunctionData& function, const TypeDefinition& signature, Vector<UnlinkedWasmToWasmCall>& unlinkedWasmToWasmCalls, const ModuleInformation& info, MemoryMode mode, FunctionCodeIndex functionIndex, const LowerTierInformation& lowerTierInfo, unsigned loopIndexForOSREntry)
 {
     CompilerTimingScope totalTime("BBQ"_s, "Total BBQ"_s);
 
@@ -5213,7 +5220,7 @@ Expected<std::unique_ptr<InternalFunction>, String> parseAndCompileBBQ(Compilati
 
     compilationContext.wasmEntrypointJIT = makeUnique<CCallHelpers>();
 
-    BBQJIT irGenerator(*compilationContext.wasmEntrypointJIT, signature, callee, function, functionIndex, info, unlinkedWasmToWasmCalls, mode, result.get(), hasExceptionHandlers, loopIndexForOSREntry);
+    BBQJIT irGenerator(*compilationContext.wasmEntrypointJIT, signature, callee, function, functionIndex, info, unlinkedWasmToWasmCalls, mode, result.get(), lowerTierInfo, loopIndexForOSREntry);
     FunctionParser<BBQJIT> parser(irGenerator, function.data, signature, info);
     WASM_FAIL_IF_HELPER_FAILS(parser.parse());
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -28,6 +28,7 @@
 #if ENABLE(WEBASSEMBLY_BBQJIT)
 
 #include "PCToCodeOriginMap.h"
+#include "WasmCallee.h"
 #include "WasmCallingConvention.h"
 #include "WasmCompilationContext.h"
 #include "WasmFunctionParser.h"
@@ -859,7 +860,7 @@ public:
     static constexpr bool tierSupportsSIMD = true;
     static constexpr bool validateFunctionBodySize = true;
 
-    BBQJIT(CCallHelpers& jit, const TypeDefinition& signature, BBQCallee& callee, const FunctionData& function, FunctionCodeIndex functionIndex, const ModuleInformation& info, Vector<UnlinkedWasmToWasmCall>& unlinkedWasmToWasmCalls, MemoryMode mode, InternalFunction* compilation, std::optional<bool> hasExceptionHandlers, unsigned loopIndexForOSREntry);
+    BBQJIT(CCallHelpers& jit, const TypeDefinition& signature, BBQCallee& callee, const FunctionData& function, FunctionCodeIndex functionIndex, const ModuleInformation& info, Vector<UnlinkedWasmToWasmCall>& unlinkedWasmToWasmCalls, MemoryMode mode, InternalFunction* compilation, const LowerTierInformation& lowerTierInfo, unsigned loopIndexForOSREntry);
 
     ALWAYS_INLINE static Value emptyExpression()
     {
@@ -2247,8 +2248,6 @@ private:
 
     Location canonicalSlot(Value value);
 
-    Location allocateStack(Value value);
-
     constexpr static int tempSlotSize = 16; // Size of the stack slot for a stack temporary. Currently the size of the largest possible temporary (a v128).
 
     enum class ShiftI64HelperOp { Lshift, Urshift, Rshift };
@@ -2272,6 +2271,8 @@ private:
     MemoryMode m_mode;
     Vector<UnlinkedWasmToWasmCall>& m_unlinkedWasmToWasmCalls;
     FixedBitVector m_directCallees;
+    std::optional<unsigned> m_knownExpressionStackSize;
+    std::optional<unsigned> m_knownFrameSize;
     std::optional<bool> m_hasExceptionHandlers;
     FunctionParser<BBQJIT>* m_parser;
     Vector<uint32_t, 4> m_arguments;
@@ -2339,7 +2340,7 @@ using MinOrMax = BBQJIT::MinOrMax;
 class BBQCallee;
 
 using BBQJIT = BBQJITImpl::BBQJIT;
-Expected<std::unique_ptr<InternalFunction>, String> parseAndCompileBBQ(CompilationContext&, BBQCallee&, const FunctionData&, const TypeDefinition&, Vector<UnlinkedWasmToWasmCall>&, const ModuleInformation&, MemoryMode, FunctionCodeIndex functionIndex, std::optional<bool> hasExceptionHandlers, unsigned);
+Expected<std::unique_ptr<InternalFunction>, String> parseAndCompileBBQ(CompilationContext&, BBQCallee&, const FunctionData&, const TypeDefinition&, Vector<UnlinkedWasmToWasmCall>&, const ModuleInformation&, MemoryMode, FunctionCodeIndex functionIndex, const LowerTierInformation&, unsigned);
 
 } } // namespace JSC::Wasm
 

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
@@ -50,11 +50,11 @@ namespace WasmBBQPlanInternal {
 static constexpr bool verbose = false;
 }
 
-BBQPlan::BBQPlan(VM& vm, Ref<ModuleInformation>&& moduleInformation, FunctionCodeIndex functionIndex, std::optional<bool> hasExceptionHandlers, Ref<CalleeGroup>&& calleeGroup, CompletionTask&& completionTask)
+BBQPlan::BBQPlan(VM& vm, Ref<ModuleInformation>&& moduleInformation, FunctionCodeIndex functionIndex, const LowerTierInformation& lowerTierInfo, Ref<CalleeGroup>&& calleeGroup, CompletionTask&& completionTask)
     : Plan(vm, WTFMove(moduleInformation), WTFMove(completionTask))
     , m_calleeGroup(WTFMove(calleeGroup))
     , m_functionIndex(functionIndex)
-    , m_hasExceptionHandlers(hasExceptionHandlers)
+    , m_lowerTierInfo(lowerTierInfo)
 {
     ASSERT(Options::useBBQJIT());
     setMode(m_calleeGroup->mode());
@@ -186,7 +186,7 @@ std::unique_ptr<InternalFunction> BBQPlan::compileFunction(FunctionCodeIndex fun
 
     beginCompilerSignpost(callee);
     RELEASE_ASSERT(mode() == m_calleeGroup->mode());
-    parseAndCompileResult = parseAndCompileBBQ(context, callee, function, signature, unlinkedWasmToWasmCalls, m_moduleInformation.get(), m_mode, functionIndex, m_hasExceptionHandlers, UINT32_MAX);
+    parseAndCompileResult = parseAndCompileBBQ(context, callee, function, signature, unlinkedWasmToWasmCalls, m_moduleInformation.get(), m_mode, functionIndex, m_lowerTierInfo, UINT32_MAX);
     endCompilerSignpost(callee);
 
     if (!parseAndCompileResult) [[unlikely]] {

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.h
@@ -52,9 +52,9 @@ class BBQPlan final : public Plan {
 public:
     using Base = Plan;
 
-    static Ref<BBQPlan> create(VM& vm, Ref<ModuleInformation>&& info, FunctionCodeIndex functionIndex, std::optional<bool> hasExceptionHandlers, Ref<CalleeGroup>&& calleeGroup, CompletionTask&& completionTask)
+    static Ref<BBQPlan> create(VM& vm, Ref<ModuleInformation>&& info, FunctionCodeIndex functionIndex, const LowerTierInformation& lowerTierInfo, Ref<CalleeGroup>&& calleeGroup, CompletionTask&& completionTask)
     {
-        return adoptRef(*new BBQPlan(vm, WTFMove(info), functionIndex, hasExceptionHandlers, WTFMove(calleeGroup), WTFMove(completionTask)));
+        return adoptRef(*new BBQPlan(vm, WTFMove(info), functionIndex, lowerTierInfo, WTFMove(calleeGroup), WTFMove(completionTask)));
     }
 
     bool hasWork() const final { return !m_completed; }
@@ -65,7 +65,7 @@ public:
 
 
 private:
-    BBQPlan(VM&, Ref<ModuleInformation>&&, FunctionCodeIndex functionIndex, std::optional<bool> hasExceptionHandlers, Ref<CalleeGroup>&&, CompletionTask&&);
+    BBQPlan(VM&, Ref<ModuleInformation>&&, FunctionCodeIndex functionIndex, const LowerTierInformation&, Ref<CalleeGroup>&&, CompletionTask&&);
 
     bool dumpDisassembly(CompilationContext&, LinkBuffer&, FunctionCodeIndex functionIndex, const TypeDefinition&, FunctionSpaceIndex functionIndexSpace);
 
@@ -80,7 +80,7 @@ private:
     const Ref<CalleeGroup> m_calleeGroup;
     FunctionCodeIndex m_functionIndex;
     bool m_completed { false };
-    std::optional<bool> m_hasExceptionHandlers;
+    LowerTierInformation m_lowerTierInfo;
 };
 
 

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -246,6 +246,7 @@ IPIntCallee::IPIntCallee(FunctionIPIntMetadataGenerator& generator, FunctionSpac
     , m_numRethrowSlotsToAlloc(generator.m_numAlignedRethrowSlots)
     , m_numLocals(generator.m_numLocals)
     , m_numArgumentsOnStack(generator.m_numArgumentsOnStack)
+    , m_maxExpressionStackSize(generator.m_maxExpressionStackSize)
     , m_maxFrameSizeInV128(generator.m_maxFrameSizeInV128)
     , m_tierUpCounter(WTFMove(generator.m_tierUpCounter))
 {

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -430,6 +430,10 @@ private:
 };
 #endif
 
+struct LowerTierInformation {
+    std::optional<unsigned> maxExpressionStackSize;
+    std::optional<bool> hasExceptionHandlers;
+};
 
 class IPIntCallee final : public Callee {
     WTF_MAKE_COMPACT_TZONE_ALLOCATED(IPIntCallee);
@@ -449,6 +453,15 @@ public:
     unsigned numLocals() const { return m_numLocals; }
     unsigned localSizeToAlloc() const { return m_localSizeToAlloc; }
     unsigned rethrowSlots() const { return m_numRethrowSlotsToAlloc; }
+    unsigned maxExpressionStackSize() const { return m_maxExpressionStackSize; }
+
+    LowerTierInformation lowerTierInfo() const
+    {
+        return {
+            .maxExpressionStackSize = maxExpressionStackSize(),
+            .hasExceptionHandlers = hasExceptionHandlers(),
+        };
+    }
 
     const TypeDefinition& signature(unsigned index) const
     {
@@ -485,6 +498,7 @@ private:
     unsigned m_numRethrowSlotsToAlloc;
     unsigned m_numLocals;
     unsigned m_numArgumentsOnStack;
+    unsigned m_maxExpressionStackSize;
     unsigned m_maxFrameSizeInV128;
 
     IPIntTierUpCounter m_tierUpCounter;
@@ -509,6 +523,14 @@ public:
     const FixedVector<Type>& constantTypes() const { return m_constantTypes; }
     const FixedVector<uint64_t>& constants() const { return m_constants; }
     const WasmInstructionStream& instructions() const { return *m_instructions; }
+
+    LowerTierInformation lowerTierInfo() const
+    {
+        return {
+            .maxExpressionStackSize = std::nullopt,
+            .hasExceptionHandlers = hasExceptionHandlers(),
+        };
+    }
 
     ALWAYS_INLINE uint64_t getConstant(VirtualRegister reg) const { return m_constants[reg.toConstantIndex()]; }
     ALWAYS_INLINE Type getConstantType(VirtualRegister reg) const

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
@@ -128,6 +128,7 @@ private:
 
     uint32_t m_bytecodeOffset { 0 };
     unsigned m_maxFrameSizeInV128 { 0 };
+    unsigned m_maxExpressionStackSize { 0 };
     unsigned m_numLocals { 0 };
     unsigned m_numAlignedRethrowSlots { 0 };
     unsigned m_numArguments { 0 };

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -3004,6 +3004,8 @@ std::unique_ptr<FunctionIPIntMetadataGenerator> IPIntGenerator::finalize()
     m_metadata->m_maxFrameSizeInV128 += m_metadata->m_numAlignedRethrowSlots / 2;
     m_metadata->m_maxFrameSizeInV128 += m_maxStackSize;
 
+    m_metadata->m_maxExpressionStackSize = m_maxStackSize;
+
     return WTFMove(m_metadata);
 }
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -145,7 +145,7 @@ static inline RefPtr<Wasm::JITCallee> jitCompileAndSetHeuristics(Wasm::IPIntCall
     if (compile) {
         Wasm::FunctionCodeIndex functionIndex = callee->functionIndex();
         if (Wasm::BBQPlan::ensureGlobalBBQAllowlist().containsWasmFunction(functionIndex)) {
-            auto plan = Wasm::BBQPlan::create(instance->vm(), const_cast<Wasm::ModuleInformation&>(instance->module().moduleInformation()), functionIndex, callee->hasExceptionHandlers(), Ref(*instance->calleeGroup()), Wasm::Plan::dontFinalize());
+            auto plan = Wasm::BBQPlan::create(instance->vm(), const_cast<Wasm::ModuleInformation&>(instance->module().moduleInformation()), functionIndex, callee->lowerTierInfo(), Ref(*instance->calleeGroup()), Wasm::Plan::dontFinalize());
             Wasm::ensureWorklist().enqueue(plan.get());
             if (!Options::useConcurrentJIT() || !Options::useWasmIPInt()) [[unlikely]]
                 plan->waitForCompletion();
@@ -198,7 +198,7 @@ static inline Expected<RefPtr<Wasm::JITCallee>, Wasm::Plan::Error> jitCompileSIM
 
     Wasm::FunctionCodeIndex functionIndex = callee->functionIndex();
     ASSERT(instance->module().moduleInformation().usesSIMD(functionIndex));
-    auto plan = Wasm::BBQPlan::create(instance->vm(), const_cast<Wasm::ModuleInformation&>(instance->module().moduleInformation()), functionIndex, callee->hasExceptionHandlers(), Ref(*instance->calleeGroup()), Wasm::Plan::dontFinalize());
+    auto plan = Wasm::BBQPlan::create(instance->vm(), const_cast<Wasm::ModuleInformation&>(instance->module().moduleInformation()), functionIndex, callee->lowerTierInfo(), Ref(*instance->calleeGroup()), Wasm::Plan::dontFinalize());
     Wasm::ensureWorklist().enqueue(plan.get());
     plan->waitForCompletion();
     if (plan->failed())

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
@@ -156,7 +156,7 @@ static inline RefPtr<Wasm::JITCallee> jitCompileAndSetHeuristics(Wasm::LLIntCall
     if (compile) {
         Wasm::FunctionCodeIndex functionIndex = callee->functionIndex();
         if (Wasm::BBQPlan::ensureGlobalBBQAllowlist().containsWasmFunction(functionIndex)) {
-            auto plan = Wasm::BBQPlan::create(instance->vm(), const_cast<Wasm::ModuleInformation&>(instance->module().moduleInformation()), functionIndex, callee->hasExceptionHandlers(), Ref(*instance->calleeGroup()), Wasm::Plan::dontFinalize());
+            auto plan = Wasm::BBQPlan::create(instance->vm(), const_cast<Wasm::ModuleInformation&>(instance->module().moduleInformation()), functionIndex, callee->lowerTierInfo(), Ref(*instance->calleeGroup()), Wasm::Plan::dontFinalize());
             Wasm::ensureWorklist().enqueue(plan.get());
             dataLogLnIf(Options::verboseOSR(), "\tStarted BBQ compilation.");
             if (!Options::useConcurrentJIT() || !Options::useWasmLLInt()) [[unlikely]]
@@ -210,7 +210,7 @@ static inline Expected<RefPtr<Wasm::JITCallee>, Wasm::Plan::Error> jitCompileSIM
 
     Wasm::FunctionCodeIndex functionIndex = callee->functionIndex();
     ASSERT(instance->module().moduleInformation().usesSIMD(functionIndex));
-    auto plan = Wasm::BBQPlan::create(instance->vm(), const_cast<Wasm::ModuleInformation&>(instance->module().moduleInformation()), functionIndex, callee->hasExceptionHandlers(), Ref(*instance->calleeGroup()), Wasm::Plan::dontFinalize());
+    auto plan = Wasm::BBQPlan::create(instance->vm(), const_cast<Wasm::ModuleInformation&>(instance->module().moduleInformation()), functionIndex, callee->lowerTierInfo(), Ref(*instance->calleeGroup()), Wasm::Plan::dontFinalize());
     Wasm::ensureWorklist().enqueue(plan.get());
     plan->waitForCompletion();
     if (plan->failed())


### PR DESCRIPTION
#### 3ee4a1a0bf0f4bfda04ee20d7f23a37d249ad68e
<pre>
[WASM] BBQ should make use of IPInt expression stack size to compute stack frame size
<a href="https://bugs.webkit.org/show_bug.cgi?id=295745">https://bugs.webkit.org/show_bug.cgi?id=295745</a>
<a href="https://rdar.apple.com/155561821">rdar://155561821</a>

Reviewed by NOBODY (OOPS!).

Passes the maximum stack size computed by the IPInt generator into BBQ, and
changes BBQ to use this value when available to use an immediate frame size
when allocating the stack frame or restoring it after a call.

* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::BBQJIT):
(JSC::Wasm::BBQJITImpl::BBQJIT::addLocal):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTopLevel):
(JSC::Wasm::BBQJITImpl::BBQJIT::makeStackMap):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCall):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitIndirectCall):
(JSC::Wasm::BBQJITImpl::BBQJIT::canonicalSlot):
(JSC::Wasm::parseAndCompileBBQ):
(JSC::Wasm::BBQJITImpl::BBQJIT::allocateStack): Deleted.
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::BBQPlan):
(JSC::Wasm::BBQPlan::compileFunction):
* Source/JavaScriptCore/wasm/WasmBBQPlan.h:
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::IPIntCallee::IPIntCallee):
* Source/JavaScriptCore/wasm/WasmCallee.h:
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h:
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::finalize):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::jitCompileAndSetHeuristics):
(JSC::IPInt::jitCompileSIMDFunction):
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::jitCompileAndSetHeuristics):
(JSC::LLInt::jitCompileSIMDFunction):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ee4a1a0bf0f4bfda04ee20d7f23a37d249ad68e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21123 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117056 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61293 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31373 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39274 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84405 "Found 6 new test failures: imported/w3c/web-platform-tests/wasm/core/call.wast.js.html imported/w3c/web-platform-tests/wasm/core/call_indirect.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_address.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_load_extend.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_load_splat.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_load_zero.wast.js.html (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113973 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25062 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99962 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64851 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24407 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18105 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60880 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/103517 "Found 394 new JSC stress test failures: wasm.yaml/wasm/extended-const-spec-tests/global.wast.js.wasm-simd, wasm.yaml/wasm/function-tests/context-switch.js.default-wasm, wasm.yaml/wasm/function-tests/context-switch.js.wasm-aggressive-inline, wasm.yaml/wasm/function-tests/context-switch.js.wasm-collect-continuously, wasm.yaml/wasm/function-tests/context-switch.js.wasm-eager, wasm.yaml/wasm/function-tests/context-switch.js.wasm-eager-jettison, wasm.yaml/wasm/function-tests/context-switch.js.wasm-graph-reg-alloc, wasm.yaml/wasm/function-tests/context-switch.js.wasm-no-cjit, wasm.yaml/wasm/function-tests/context-switch.js.wasm-omg, wasm.yaml/wasm/function-tests/context-switch.js.wasm-simd ... (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94444 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18170 "Found 5 new test failures: imported/w3c/web-platform-tests/wasm/core/call.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_address.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_load_extend.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_load_splat.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_load_zero.wast.js.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119885 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109579 "Found 384 new JSC stress test failures: wasm.yaml/wasm/extended-const-spec-tests/global.wast.js.wasm-simd, wasm.yaml/wasm/function-tests/context-switch.js.default-wasm, wasm.yaml/wasm/function-tests/context-switch.js.wasm-aggressive-inline, wasm.yaml/wasm/function-tests/context-switch.js.wasm-collect-continuously, wasm.yaml/wasm/function-tests/context-switch.js.wasm-eager, wasm.yaml/wasm/function-tests/context-switch.js.wasm-eager-jettison, wasm.yaml/wasm/function-tests/context-switch.js.wasm-graph-reg-alloc, wasm.yaml/wasm/function-tests/context-switch.js.wasm-no-cjit, wasm.yaml/wasm/function-tests/context-switch.js.wasm-omg, wasm.yaml/wasm/function-tests/context-switch.js.wasm-simd ... (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38075 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28290 "Found 6 new test failures: imported/w3c/web-platform-tests/wasm/core/call.wast.js.html imported/w3c/web-platform-tests/wasm/core/call_indirect.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_address.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_load_extend.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_load_splat.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_load_zero.wast.js.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93352 "Found 5 new test failures: imported/w3c/web-platform-tests/wasm/core/call.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_address.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_load_extend.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_load_splat.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_load_zero.wast.js.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38451 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96237 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93176 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38244 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15988 "Found 6 new test failures: imported/w3c/web-platform-tests/wasm/core/call.wast.js.html imported/w3c/web-platform-tests/wasm/core/call_indirect.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_address.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_load_extend.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_load_splat.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_load_zero.wast.js.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34056 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37964 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43440 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/133855 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37628 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36117 "Found 72 new JSC stress test failures: wasm.yaml/wasm/function-tests/factorial.js.default-wasm, wasm.yaml/wasm/function-tests/factorial.js.wasm-bbq, wasm.yaml/wasm/function-tests/factorial.js.wasm-bbq-no-consts, wasm.yaml/wasm/function-tests/factorial.js.wasm-collect-continuously, wasm.yaml/wasm/function-tests/factorial.js.wasm-eager, wasm.yaml/wasm/function-tests/factorial.js.wasm-no-cjit, wasm.yaml/wasm/function-tests/factorial.js.wasm-slow-memory, wasm.yaml/wasm/function-tests/stack-overflow.js.default-wasm, wasm.yaml/wasm/function-tests/stack-overflow.js.wasm-bbq, wasm.yaml/wasm/function-tests/stack-overflow.js.wasm-bbq-no-consts ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40962 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39331 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->