### PR TITLE
anchor-scope name match is tree-scoped

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scope-shadow-all-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scope-shadow-all-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL anchor-scope:all is tree-scoped assert_equals: expected "10px" but got "1px"
+PASS anchor-scope:all is tree-scoped
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scope-shadow-names-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scope-shadow-names-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL anchor-scope matches tree-scoped names assert_equals: expected "10px" but got "1px"
-FAIL anchor-scope in shadow does not affect slotted-in element assert_equals: expected "10px" but got "1px"
-FAIL anchor-scope in ::slotted() rule does not affect anchoring outside assert_equals: expected "10px" but got "1px"
-FAIL anchor-scope in shadow does not affected slotted-in element (:host) assert_equals: expected "10px" but got "1px"
+PASS anchor-scope matches tree-scoped names
+PASS anchor-scope in shadow does not affect slotted-in element
+PASS anchor-scope in ::slotted() rule does not affect anchoring outside
+PASS anchor-scope in shadow does not affected slotted-in element (:host)
 PASS anchor-scope in ::part() affects slotted-in element
 

--- a/Source/WebCore/rendering/style/NameScope.h
+++ b/Source/WebCore/rendering/style/NameScope.h
@@ -36,27 +36,16 @@ struct NameScope {
 
     Type type { Type::None };
     ListHashSet<AtomString> names;
+    Style::ScopeOrdinal scopeOrdinal { Style::ScopeOrdinal::Element };
 
     friend bool operator==(const NameScope&, const NameScope&);
 };
 
 inline bool operator==(const NameScope& lhs, const NameScope& rhs)
 {
-    switch (lhs.type) {
-    case NameScope::Type::None:
-        return rhs.type == NameScope::Type::None;
-
-    case NameScope::Type::All:
-        return rhs.type == NameScope::Type::All;
-
-    case NameScope::Type::Ident:
-        // Two name lists are equal if they contain the same values
-        // in the same order.
-        return std::equal(lhs.names.begin(), lhs.names.end(), rhs.names.begin(), rhs.names.end());
-    }
-
-    ASSERT_NOT_REACHED();
-    return false;
+    return lhs.type == rhs.type && lhs.scopeOrdinal == rhs.scopeOrdinal
+        // Two name lists are equal if they contain the same values in the same order.
+        && (lhs.names.isEmpty() || std::equal(lhs.names.begin(), lhs.names.end(), rhs.names.begin(), rhs.names.end()));
 }
 
 inline TextStream& operator<<(TextStream& ts, const NameScope& scope)
@@ -72,6 +61,7 @@ inline TextStream& operator<<(TextStream& ts, const NameScope& scope)
         ts << "ident: "_s << scope.names;
         break;
     }
+    ts << " (style scope: " << scope.scopeOrdinal << ")";
     return ts;
 }
 

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -2323,9 +2323,9 @@ inline NameScope BuilderConverter::convertNameScope(BuilderState& builderState, 
         case CSSValueNone:
             return { };
         case CSSValueAll:
-            return { NameScope::Type::All, { } };
+            return { NameScope::Type::All, { }, builderState.styleScopeOrdinal() };
         default:
-            return { NameScope::Type::Ident, { AtomString { primitiveValue->stringValue() } } };
+            return { NameScope::Type::Ident, { AtomString { primitiveValue->stringValue() } }, builderState.styleScopeOrdinal() };
         }
     }
 
@@ -2337,7 +2337,7 @@ inline NameScope BuilderConverter::convertNameScope(BuilderState& builderState, 
     for (auto& name : *list)
         nameHashSet.add(AtomString { name.stringValue() });
 
-    return { NameScope::Type::Ident, WTFMove(nameHashSet) };
+    return { NameScope::Type::Ident, WTFMove(nameHashSet), builderState.styleScopeOrdinal() };
 }
 
 inline FixedVector<PositionTryFallback> BuilderConverter::convertPositionTryFallbacks(BuilderState& builderState, const CSSValue& value)

--- a/Source/WebCore/style/StyleScopeOrdinal.h
+++ b/Source/WebCore/style/StyleScopeOrdinal.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <wtf/EnumTraits.h>
+#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 namespace Style {
@@ -50,6 +51,12 @@ inline ScopeOrdinal& operator--(ScopeOrdinal& ordinal)
 {
     ASSERT(ordinal > ScopeOrdinal::ContainingHostLimit);
     return ordinal = static_cast<ScopeOrdinal>(enumToUnderlyingType(ordinal) - 1);
+}
+
+inline TextStream& operator<<(TextStream& ts, const ScopeOrdinal scopeOrdinal)
+{
+    ts << static_cast<int8_t>(scopeOrdinal);
+    return ts;
 }
 
 }


### PR DESCRIPTION
#### 4774b6e10334f22c7d810df5f7c0eadca642356d
<pre>
anchor-scope name match is tree-scoped
<a href="https://bugs.webkit.org/show_bug.cgi?id=293766">https://bugs.webkit.org/show_bug.cgi?id=293766</a>
<a href="https://rdar.apple.com/152271352">rdar://152271352</a>

Reviewed by Tim Nguyen.

1. Use style-scoped names for anchor-name by storing scope info with anchor-name.
2. Perform scoped name matches when checking anchor-scope in AnchorPositionEvaluator.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scope-shadow-all-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scope-shadow-names-expected.txt:
Update tests to passing!

* Source/WebCore/rendering/style/NameScope.h:
(WebCore::operator==):
(WebCore::operator&lt;&lt;):
Introduce a scopeOrdinal data member to NameScope, to represent scoped names.

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::anchorScopeForAnchorName):
(WebCore::Style::isAcceptableAnchorElement):
(WebCore::Style::findLastAcceptableAnchorWithName):
Update anchor-scope name matching to account for style scope.

* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertNameScope):
Update NameScope builder to capture the style scope.

* Source/WebCore/style/StyleScopeOrdinal.h:
(WebCore::Style::operator&lt;&lt;):

Canonical link: <a href="https://commits.webkit.org/297285@main">https://commits.webkit.org/297285@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b5c8a570311ec37f5c74dd9258ce5f7799db161

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30831 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21283 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117196 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61433 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113127 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39413 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84506 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114112 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25173 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100090 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64952 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24519 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/18236 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61016 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/94554 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18299 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120197 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38214 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28398 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93442 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38590 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96366 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93267 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23766 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38355 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16109 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34199 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38103 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43580 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37768 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41101 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39470 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->