### PR TITLE
[HDR] Add an option to let the system compositor apply tone mapping.

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7293,6 +7293,21 @@ StorageBlockingPolicy:
     WebCore:
       default: StorageBlockingPolicy::AllowAll
 
+SupportHDRCompositorTonemappingEnabled:
+  type: bool
+  status: testable
+  category: media
+  webcoreOnChange: updateDisplayEDRHeadroom
+  humanReadableName: "Support HDR Compositor tonemapping"
+  humanReadableDescription: "Support HDR tonemapping during compositing"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 SupportHDRDisplayEnabled:
   type: bool
   status: Supporthdrdisplay_feature_status

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1350,6 +1350,7 @@ public:
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
     Headroom displayEDRHeadroom() const { return m_displayEDRHeadroom; }
+    bool hdrLayersRequireTonemapping() const { return m_hdrLayersRequireTonemapping; }
     void updateDisplayEDRHeadroom();
     void updateDisplayEDRSuppression();
 #endif
@@ -1786,6 +1787,7 @@ private:
 #if HAVE(SUPPORT_HDR_DISPLAY)
     Headroom m_displayEDRHeadroom { Headroom::None };
     bool m_screenSupportsHDR { false };
+    bool m_hdrLayersRequireTonemapping { false };
 #endif
 
     HashSet<std::pair<URL, ScriptTrackingPrivacyCategory>> m_scriptTrackingPrivacyReports;

--- a/Source/WebCore/page/SettingsBase.cpp
+++ b/Source/WebCore/page/SettingsBase.cpp
@@ -333,6 +333,14 @@ void SettingsBase::setNeedsRelayoutAllFrames()
     }
 }
 
+void SettingsBase::updateDisplayEDRHeadroom()
+{
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    if (m_page)
+        m_page->updateDisplayEDRHeadroom();
+#endif
+}
+
 void SettingsBase::mediaTypeOverrideChanged()
 {
     RefPtr page = m_page.get();

--- a/Source/WebCore/page/SettingsBase.h
+++ b/Source/WebCore/page/SettingsBase.h
@@ -167,6 +167,7 @@ protected:
 #endif
     void useSystemAppearanceChanged();
     void fontFallbackPrefersPictographsChanged();
+    void updateDisplayEDRHeadroom();
     RefPtr<Page> protectedPage() const;
 
     WeakPtr<Page> m_page;

--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -454,6 +454,12 @@ void GraphicsLayer::setDrawsHDRContent(bool b)
     m_drawsHDRContent = b;
 }
 
+void GraphicsLayer::setTonemappingEnabled(bool b)
+{
+    ASSERT(m_type != Type::Structural);
+    m_tonemappingEnabled = b;
+}
+
 void GraphicsLayer::setNeedsDisplayIfEDRHeadroomExceeds(float)
 {
 }

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -430,6 +430,9 @@ public:
     bool drawsHDRContent() const { return m_drawsHDRContent; }
     WEBCORE_EXPORT virtual void setDrawsHDRContent(bool);
 
+    bool tonemappingEnabled() const { return m_tonemappingEnabled; }
+    WEBCORE_EXPORT virtual void setTonemappingEnabled(bool);
+
     WEBCORE_EXPORT virtual void setNeedsDisplayIfEDRHeadroomExceeds(float);
 #endif
 
@@ -832,6 +835,7 @@ protected:
     bool m_drawsContent : 1;
 #if HAVE(SUPPORT_HDR_DISPLAY)
     bool m_drawsHDRContent : 1 { false };
+    bool m_tonemappingEnabled : 1 { false };
 #endif
     bool m_contentsVisible : 1;
     bool m_contentsRectClipsDescendants : 1;

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -745,6 +745,15 @@ void GraphicsLayerCA::setDrawsHDRContent(bool drawsHDRContent)
     noteLayerPropertyChanged(DrawsHDRContentChanged | DebugIndicatorsChanged);
 }
 
+void GraphicsLayerCA::setTonemappingEnabled(bool tonemappingEnabled)
+{
+    if (tonemappingEnabled == m_tonemappingEnabled)
+        return;
+
+    GraphicsLayer::setTonemappingEnabled(tonemappingEnabled);
+    noteLayerPropertyChanged(TonemappingEnabledChanged);
+}
+
 void GraphicsLayerCA::setNeedsDisplayIfEDRHeadroomExceeds(float headroom)
 {
     if (protectedLayer()->setNeedsDisplayIfEDRHeadroomExceeds(headroom)) {
@@ -1469,6 +1478,9 @@ void GraphicsLayerCA::setContentsDisplayDelegate(RefPtr<GraphicsLayerContentsDis
         // backing store settings accordingly.
         contentsLayer->setBackingStoreAttached(true);
         contentsLayer->setAcceleratesDrawing(true);
+#if HAVE(SUPPORT_HDR_DISPLAY)
+        contentsLayer->setTonemappingEnabled(true);
+#endif
         delegate->prepareToDelegateDisplay(contentsLayer);
     }
 
@@ -2157,6 +2169,9 @@ void GraphicsLayerCA::commitLayerChangesBeforeSublayers(CommitState& commitState
 #if HAVE(SUPPORT_HDR_DISPLAY)
     if (m_uncommittedChanges & DrawsHDRContentChanged)
         updateDrawsHDRContent();
+
+    if (m_uncommittedChanges & TonemappingEnabledChanged)
+        updateTonemappingEnabled();
 #endif
 
     if (m_uncommittedChanges & NameChanged)
@@ -3336,6 +3351,11 @@ void GraphicsLayerCA::updateDrawsHDRContent()
 {
     auto contentsFormat = PlatformCALayer::contentsFormatForLayer(this);
     protectedLayer()->setContentsFormat(contentsFormat);
+}
+
+void GraphicsLayerCA::updateTonemappingEnabled()
+{
+    protectedLayer()->setTonemappingEnabled(m_tonemappingEnabled);
 }
 #endif
 
@@ -4671,6 +4691,7 @@ ASCIILiteral GraphicsLayerCA::layerChangeAsString(LayerChange layerChange)
 #endif
 #if HAVE(SUPPORT_HDR_DISPLAY)
     case LayerChange::DrawsHDRContentChanged: return "DrawsHDRContentChanged"_s;
+    case LayerChange::TonemappingEnabledChanged: return "TonemappingEnabledChanged"_s;
 #endif
     }
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -103,6 +103,7 @@ public:
     WEBCORE_EXPORT void setDrawsContent(bool) override;
 #if HAVE(SUPPORT_HDR_DISPLAY)
     WEBCORE_EXPORT void setDrawsHDRContent(bool) override;
+    WEBCORE_EXPORT void setTonemappingEnabled(bool) override;
     WEBCORE_EXPORT void setNeedsDisplayIfEDRHeadroomExceeds(float) override;
 #endif
     WEBCORE_EXPORT void setContentsVisible(bool) override;
@@ -284,6 +285,7 @@ private:
 #if HAVE(SUPPORT_HDR_DISPLAY)
     bool drawsHDRContent() const override { return m_drawsHDRContent; }
     void updateDrawsHDRContent();
+    void updateTonemappingEnabled();
 #endif
 
     WEBCORE_EXPORT void setAllowsBackingStoreDetaching(bool) override;
@@ -672,6 +674,7 @@ private:
 #endif
 #if HAVE(SUPPORT_HDR_DISPLAY)
         DrawsHDRContentChanged                  = 1LLU << 47,
+        TonemappingEnabledChanged               = 1LLU << 48,
 #endif
     };
     typedef uint64_t LayerChangeFlags;

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
@@ -302,6 +302,9 @@ public:
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
     virtual bool setNeedsDisplayIfEDRHeadroomExceeds(float);
+
+    virtual void setTonemappingEnabled(bool);
+    virtual bool tonemappingEnabled() const;
 #endif
 
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
@@ -263,6 +263,15 @@ bool PlatformCALayer::setNeedsDisplayIfEDRHeadroomExceeds(float)
 {
     return false;
 }
+
+void PlatformCALayer::setTonemappingEnabled(bool)
+{
+}
+
+bool PlatformCALayer::tonemappingEnabled() const
+{
+    return false;
+}
 #endif
 
 void PlatformCALayer::dumpAdditionalProperties(TextStream&, OptionSet<PlatformLayerTreeAsTextFlags>)

--- a/Source/WebCore/platform/graphics/ca/TileController.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileController.cpp
@@ -240,6 +240,20 @@ bool TileController::setNeedsDisplayIfEDRHeadroomExceeds(float headroom)
 {
     return tileGrid().setNeedsDisplayIfEDRHeadroomExceeds(headroom);
 }
+
+void TileController::setTonemappingEnabled(bool enabled)
+{
+    if (m_tonemappingEnabled == enabled)
+        return;
+
+    m_tonemappingEnabled = enabled;
+    tileGrid().updateTileLayerProperties();
+}
+
+bool TileController::tonemappingEnabled() const
+{
+    return m_tonemappingEnabled;
+}
 #endif
 
 void TileController::setContentsFormat(ContentsFormat contentsFormat)
@@ -867,6 +881,9 @@ Ref<PlatformCALayer> TileController::createTileLayer(const IntRect& tileRect, Ti
     layer->setContentsScale(m_deviceScaleFactor * temporaryScaleFactor);
     layer->setAcceleratesDrawing(m_acceleratesDrawing);
     layer->setContentsFormat(m_contentsFormat);
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    layer->setTonemappingEnabled(m_tonemappingEnabled);
+#endif
     layer->setNeedsDisplay();
     return layer;
 }

--- a/Source/WebCore/platform/graphics/ca/TileController.h
+++ b/Source/WebCore/platform/graphics/ca/TileController.h
@@ -82,6 +82,8 @@ public:
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
     WEBCORE_EXPORT bool setNeedsDisplayIfEDRHeadroomExceeds(float);
+    WEBCORE_EXPORT void setTonemappingEnabled(bool);
+    WEBCORE_EXPORT bool tonemappingEnabled() const;
 #endif
 
     bool acceleratesDrawing() const { return m_acceleratesDrawing; }
@@ -274,6 +276,9 @@ private:
     bool m_tileSizeLocked { false };
     bool m_haveExternalVelocityData { false };
     bool m_isTileSizeUpdateDelayDisabledForTesting { false };
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    bool m_tonemappingEnabled { false };
+#endif
 
     ContentsFormat m_contentsFormat { ContentsFormat::RGBA8 };
 

--- a/Source/WebCore/platform/graphics/ca/TileGrid.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.cpp
@@ -220,12 +220,18 @@ void TileGrid::updateTileLayerProperties()
     bool opaque = m_controller->tilesAreOpaque();
     Color tileDebugBorderColor = m_controller->tileDebugBorderColor();
     float tileDebugBorderWidth = m_controller->tileDebugBorderWidth();
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    bool tonemappingEnabled = m_controller->tonemappingEnabled();
+#endif
     for (auto& tileInfo : m_tiles.values()) {
         tileInfo.layer->setAcceleratesDrawing(acceleratesDrawing);
         tileInfo.layer->setContentsFormat(contentsFormat);
         tileInfo.layer->setOpaque(opaque);
         tileInfo.layer->setBorderColor(tileDebugBorderColor);
         tileInfo.layer->setBorderWidth(tileDebugBorderWidth);
+#if HAVE(SUPPORT_HDR_DISPLAY)
+        tileInfo.layer->setTonemappingEnabled(tonemappingEnabled);
+#endif
     }
 }
 

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -2059,7 +2059,9 @@ void RenderLayerBacking::updateDrawsContent(PaintedContentsInfo& contentsInfo)
     if (contentsInfo.paintsHDRContent() || contentsInfo.rendererHasHDRContent()) {
         LOG_WITH_STREAM(HDR, stream << "RenderLayerBacking " << *this << " updateDrawContent headroom " << m_owningLayer.page().displayEDRHeadroom());
         m_graphicsLayer->setNeedsDisplayIfEDRHeadroomExceeds(m_owningLayer.page().displayEDRHeadroom());
-    }
+        m_graphicsLayer->setTonemappingEnabled(m_owningLayer.page().hdrLayersRequireTonemapping());
+    } else
+        m_graphicsLayer->setTonemappingEnabled(false);
 #endif
 }
 

--- a/Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h
@@ -34,7 +34,7 @@ class RemoteLayerBackingStore;
 class RemoteLayerBackingStoreProperties;
 
 enum class LayerChangeIndex : size_t {
-    EventRegionChanged = 39,
+    EventRegionChanged = 40,
 #if ENABLE(SCROLLING_THREAD)
     ScrollingNodeIDChanged,
 #endif
@@ -93,6 +93,7 @@ enum class LayerChange : uint64_t {
     UserInteractionEnabledChanged       = 1LLU << 36,
     BackdropRootChanged                 = 1LLU << 37,
     BackdropRootIsOpaqueChanged         = 1LLU << 38,
+    TonemappingEnabledChanged           = 1LLU << 39,
     EventRegionChanged                  = 1LLU << static_cast<size_t>(LayerChangeIndex::EventRegionChanged),
 #if ENABLE(SCROLLING_THREAD)
     ScrollingNodeIDChanged              = 1LLU << static_cast<size_t>(LayerChangeIndex::ScrollingNodeIDChanged),
@@ -192,6 +193,7 @@ struct LayerProperties {
     bool userInteractionEnabled { true };
     bool backdropRoot { false };
     bool backdropRootIsOpaque { false };
+    bool tonemappingEnabled { false };
     WebCore::EventRegion eventRegion;
 
 #if ENABLE(SCROLLING_THREAD)

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
@@ -607,18 +607,14 @@ void RemoteLayerBackingStoreProperties::applyBackingStoreToLayer(CALayer *layer,
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     if (m_hasExtendedDynamicRange) {
         layer.wantsExtendedDynamicRangeContent = true;
-        // Painted contents have already been tonemapped, so disable it on the layer.
-        if (isDelegatedDisplay) {
-            layer.toneMapMode = CAToneMapModeIfSupported;
+        // Delegated contents set headroom via surface properties, not RemoteLayerBackingStore state.
+        if (isDelegatedDisplay)
             layer.contentsHeadroom = 0.f;
-        } else {
-            layer.toneMapMode = CAToneMapModeNever;
+        else
             layer.contentsHeadroom = m_maxRequestedEDRHeadroom;
-        }
     } else {
         layer.wantsExtendedDynamicRangeContent = false;
         layer.contentsHeadroom = 0.f;
-        layer.toneMapMode = CAToneMapModeAutomatic;
     }
     ALLOW_DEPRECATED_DECLARATIONS_END
 #endif

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -61,6 +61,7 @@ header: "RemoteLayerTreeTransaction.h"
     UserInteractionEnabledChanged
     BackdropRootChanged
     BackdropRootIsOpaqueChanged
+    TonemappingEnabledChanged
     EventRegionChanged
 #if ENABLE(SCROLLING_THREAD)
     ScrollingNodeIDChanged
@@ -275,6 +276,7 @@ headers: "LayerProperties.h" "PlatformCALayerRemote.h"
     [OptionalTupleBit=WebKit::LayerChange::UserInteractionEnabledChanged] bool userInteractionEnabled;
     [OptionalTupleBit=WebKit::LayerChange::BackdropRootChanged] bool backdropRoot;
     [OptionalTupleBit=WebKit::LayerChange::BackdropRootIsOpaqueChanged] bool backdropRootIsOpaque;
+    [OptionalTupleBit=WebKit::LayerChange::TonemappingEnabledChanged] bool tonemappingEnabled;
     [OptionalTupleBit=WebKit::LayerChange::EventRegionChanged] WebCore::EventRegion eventRegion;
 #if ENABLE(SCROLLING_THREAD)
     [OptionalTupleBit=WebKit::LayerChange::ScrollingNodeIDChanged] Markable<WebCore::ScrollingNodeID> scrollingNodeID;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -514,6 +514,12 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, Remo
     if (properties.changedProperties & LayerChange::BackdropRootChanged)
         layer.shouldRasterize = properties.backdropRoot;
 
+    if (properties.changedProperties & LayerChange::TonemappingEnabledChanged) {
+#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
+        layer.toneMapMode = properties.tonemappingEnabled ? CAToneMapModeIfSupported : CAToneMapModeNever;
+#endif
+    }
+
 #if HAVE(CORE_ANIMATION_SEPARATED_PORTALS)
     if (properties.changedProperties & LayerChange::SeparatedPortalChanged) {
         // FIXME: Implement SeparatedPortalChanged.

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
@@ -256,6 +256,9 @@ void GraphicsLayerCARemote::setLayerContentsToImageBuffer(PlatformCALayer* layer
     ASSERT(backendHandle);
 
     layer->setAcceleratesDrawing(true);
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    layer->setTonemappingEnabled(true);
+#endif
     downcast<PlatformCALayerRemote>(layer)->setRemoteDelegatedContents({ ImageBufferBackendHandle { *backendHandle }, { }, std::nullopt  });
 }
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
@@ -225,6 +225,8 @@ public:
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
     bool setNeedsDisplayIfEDRHeadroomExceeds(float) override;
+    void setTonemappingEnabled(bool) override;
+    bool tonemappingEnabled() const override;
 #endif
 
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -1085,6 +1085,20 @@ bool PlatformCALayerRemote::setNeedsDisplayIfEDRHeadroomExceeds(float headroom)
         return m_properties.backingStoreOrProperties.store->setNeedsDisplayIfEDRHeadroomExceeds(headroom);
     return false;
 }
+
+void PlatformCALayerRemote::setTonemappingEnabled(bool value)
+{
+    if (m_properties.tonemappingEnabled == value)
+        return;
+
+    m_properties.tonemappingEnabled = value;
+    m_properties.notePropertiesChanged(LayerChange::TonemappingEnabledChanged);
+}
+
+bool PlatformCALayerRemote::tonemappingEnabled() const
+{
+    return m_properties.tonemappingEnabled;
+}
 #endif
 
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteTiledBacking.cpp
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteTiledBacking.cpp
@@ -92,6 +92,12 @@ bool PlatformCALayerRemoteTiledBacking::setNeedsDisplayIfEDRHeadroomExceeds(floa
 {
     return m_tileController->setNeedsDisplayIfEDRHeadroomExceeds(headroom);
 }
+
+void PlatformCALayerRemoteTiledBacking::setTonemappingEnabled(bool enabled)
+{
+    PlatformCALayerRemote::setTonemappingEnabled(enabled);
+    m_tileController->setTonemappingEnabled(enabled);
+}
 #endif
 
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteTiledBacking.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteTiledBacking.h
@@ -55,6 +55,7 @@ private:
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
     bool setNeedsDisplayIfEDRHeadroomExceeds(float) override;
+    void setTonemappingEnabled(bool) override;
 #endif
 
     WebCore::ContentsFormat contentsFormat() const override;


### PR DESCRIPTION
#### 9a1f28636a83147a1869bca262371225d4c6ed40
<pre>
[HDR] Add an option to let the system compositor apply tone mapping.
<a href="https://bugs.webkit.org/show_bug.cgi?id=295754">https://bugs.webkit.org/show_bug.cgi?id=295754</a>
&lt;<a href="https://rdar.apple.com/155574245">rdar://155574245</a>&gt;

Reviewed by Simon Fraser.

Makes the tonemap mode an explicit property in LayerProperties, rather than
inferring it in RemoteLayerBackingStoreProperties.

Page makes a decision about whether to tonemap at paint time or composite time
based on the setting and available headroom, and this is used an input to the
computed tonemap mode on the layer.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateDisplayEDRHeadroom):
* Source/WebCore/page/Page.h:
(WebCore::Page::hdrLayersRequireTonemapping const):
* Source/WebCore/page/SettingsBase.cpp:
(WebCore::SettingsBase::updateDisplayEDRHeadroom):
* Source/WebCore/page/SettingsBase.h:
* Source/WebCore/platform/graphics/GraphicsLayer.cpp:
(WebCore::GraphicsLayer::setTonemappingEnabled):
* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::tonemappingEnabled const):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::setTonemappingEnabled):
(WebCore::GraphicsLayerCA::setContentsDisplayDelegate):
(WebCore::GraphicsLayerCA::commitLayerChangesBeforeSublayers):
(WebCore::GraphicsLayerCA::ensureStructuralLayer):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayer.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayer.mm:
(WebCore::PlatformCALayer::setTonemappingEnabled):
(WebCore::PlatformCALayer::tonemappingEnabled const):
* Source/WebCore/platform/graphics/ca/TileController.cpp:
(WebCore::TileController::setTonemappingEnabled):
(WebCore::TileController::tonemappingEnabled const):
(WebCore::TileController::createTileLayer):
* Source/WebCore/platform/graphics/ca/TileController.h:
* Source/WebCore/platform/graphics/ca/TileGrid.cpp:
(WebCore::TileGrid::updateTileLayerProperties):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateDrawsContent):
* Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStoreProperties::applyBackingStoreToLayer):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm:
(WebKit::GraphicsLayerCARemote::setLayerContentsToImageBuffer):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm:
(WebKit::PlatformCALayerRemote::setTonemappingEnabled):
(WebKit::PlatformCALayerRemote::tonemappingEnabled const):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteTiledBacking.cpp:
(WebKit::PlatformCALayerRemoteTiledBacking::setTonemappingEnabled):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteTiledBacking.h:

Canonical link: <a href="https://commits.webkit.org/297244@main">https://commits.webkit.org/297244@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b6af7293d6a6f81b001f8ee5e8f7d435840abce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111061 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30727 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21158 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117092 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61328 "Build is in progress. Recent messages:") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113023 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31408 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39309 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/84431 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/61328 "Build is in progress. Recent messages:") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114008 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25091 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99990 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64877 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/24435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18135 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60911 "Failed to checkout and rebase branch from PR 47864") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/103552 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94471 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18200 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119934 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109614 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38110 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28320 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/93373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38486 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96267 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/93197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23744 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38274 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/16016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/34091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37999 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43475 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/133890 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37663 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36124 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40997 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39366 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->