### PR TITLE
[macOS Tahoe] Upstream layout test for default-button appearance

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -186,6 +186,9 @@ fast/forms/search/search-recent-searches.html [ Skip ]
 fast/forms/fixed-size-checkbox-vertically-centered.html [ Skip ]
 fast/forms/fixed-size-radio-vertically-centered.html [ Skip ]
 
+# Only applicable on macOS, and only testable with the Liquid Glass-aligned redesign.
+fast/forms/appearance-default-button.html  [ Skip ]
+
 # Only applicable on platforms with dark mode support
 css-dark-mode [ Skip ]
 fast/css/apple-system-control-colors.html [ Skip ]

--- a/LayoutTests/fast/forms/appearance-default-button-expected.html
+++ b/LayoutTests/fast/forms/appearance-default-button-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html><!-- webkit-test-runner [ UseSystemAppearance=true ] -->
+<html>
+<body>
+<input type="submit">
+</body>
+</html>

--- a/LayoutTests/fast/forms/appearance-default-button.html
+++ b/LayoutTests/fast/forms/appearance-default-button.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html><!-- webkit-test-runner [ UseSystemAppearance=true ] -->
+<html>
+<head>
+<style>
+button {
+    appearance: default-button;
+}
+</style>
+</head>
+<body>
+<button>Submit</button>
+</body>
+</html>

--- a/LayoutTests/platform/mac-sequoia/TestExpectations
+++ b/LayoutTests/platform/mac-sequoia/TestExpectations
@@ -37,6 +37,7 @@ fast/forms/range/input-appearance-range-rtl.html [ Pass ]
 fast/forms/range/slider-in-multi-column.html [ Pass ]
 
 # Tests which pass only with form control refresh enabled (support added in Tahoe)
+fast/forms/appearance-default-button.html  [ Skip ]
 fast/forms/form-control-refresh [ Skip ]
 imported/w3c/web-platform-tests/css/css-ui/button-author-level-padding-applies.html [ Skip ]
 

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2492,5 +2492,6 @@ fast/forms/range/input-appearance-range-rtl.html [ ImageOnlyFailure ]
 fast/forms/range/slider-in-multi-column.html [ Failure ]
 
 # Tests which pass only with form control refresh enabled
+fast/forms/appearance-default-button.html  [ Pass ]
 fast/forms/form-control-refresh [ Pass ]
 imported/w3c/web-platform-tests/css/css-ui/button-author-level-padding-applies.html [ Pass ]


### PR DESCRIPTION
#### 0f10e9297b1f001c6e8d2fdb2dc94ae27e591d77
<pre>
[macOS Tahoe] Upstream layout test for default-button appearance
<a href="https://bugs.webkit.org/show_bug.cgi?id=295757">https://bugs.webkit.org/show_bug.cgi?id=295757</a>
<a href="https://rdar.apple.com/155576273">rdar://155576273</a>

Reviewed by Abrar Rahman Protyasha and Tim Nguyen.

With the redesigned controls in macOS Tahoe, `default-button` and submit buttons
have the same look, making them testable using a reference test.

* LayoutTests/TestExpectations:
* LayoutTests/fast/forms/appearance-default-button-expected.html: Added.
* LayoutTests/fast/forms/appearance-default-button.html: Added.
* LayoutTests/platform/mac-sequoia/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/297266@main">https://commits.webkit.org/297266@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b3c2e0e9ba1e1cfba4eae7facea05596108004a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111054 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30720 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21151 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117084 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61321 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31401 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39302 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84423 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114001 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25087 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99987 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64869 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24430 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18131 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60902 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94466 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18196 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119926 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38103 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28314 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93366 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38479 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96263 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93190 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38271 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16013 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34084 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17918 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37992 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37656 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40990 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39359 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->