### PR TITLE
Anchor-positioned, fixed-positioned element might get clipped by the viewport

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-fixedpos-003-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-fixedpos-003-expected.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+
+<style>
+  body {
+    margin: 0;
+  }
+
+  div {
+    width: 100px;
+    height: 100px;
+    font-size: 16px;
+    background: green;
+    color: white;
+  }
+
+  #anchor {
+    margin-top: 105vh;
+    background: orange;
+  }
+
+  #anchored {
+    position: absolute;
+    top: calc(105vh - 100px);
+    background: green;
+  }
+</style>
+
+<body>
+  <div id="anchor"></div>
+  <div id="anchored">Anchored element</div>
+
+  <script>
+    const anchor = document.getElementById("anchor");
+    anchor.scrollIntoView(false);
+  </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-fixedpos-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-fixedpos-003.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+
+<title>Tests that fixed-positioned anchor-positioned elements doesn't get clipped by the viewport</title>
+<link rel="author" href="mailto:kiet.ho@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-1/">
+<link rel="match" href="reference/anchor-scroll-fixedpos-ref.html">
+
+<style>
+  body {
+    margin: 0;
+  }
+
+  div {
+    width: 100px;
+    height: 100px;
+    font-size: 16px;
+  }
+
+  #anchor {
+    anchor-name: --a1;
+    margin-top: 105vh;
+    background: orange;
+  }
+
+  #anchored {
+    position: fixed;
+    position-anchor: --a1;
+    left: anchor(left);
+    bottom: anchor(top);
+    background: green;
+    color: white;
+  }
+</style>
+
+<body>
+  <div id="anchor"></div>
+  <div id="anchored">Anchored element</div>
+
+  <script>
+    const anchor = document.getElementById("anchor");
+    anchor.scrollIntoView(false);
+  </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/anchor-scroll-fixedpos-003-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/anchor-scroll-fixedpos-003-ref.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+
+<style>
+  body {
+    margin: 0;
+  }
+
+  div {
+    width: 100px;
+    height: 100px;
+    font-size: 16px;
+    background: green;
+    color: white;
+  }
+
+  #anchor {
+    margin-top: 105vh;
+    background: orange;
+  }
+
+  #anchored {
+    position: absolute;
+    top: calc(105vh - 100px);
+    background: green;
+  }
+</style>
+
+<body>
+  <div id="anchor"></div>
+  <div id="anchored">Anchored element</div>
+
+  <script>
+    const anchor = document.getElementById("anchor");
+    anchor.scrollIntoView(false);
+  </script>
+</body>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1712,7 +1712,7 @@ void RenderLayer::updateTransformFromStyle(TransformationMatrix& transform, cons
 
 void RenderLayer::updateTransform()
 {
-    bool hasTransform = renderer().isTransformed() || m_snapshottedScrollOffsetForAnchorPositioning;
+    bool hasTransform = isTransformed();
     bool had3DTransform = has3DTransform();
 
     std::unique_ptr<TransformationMatrix> oldTransform;

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -1443,6 +1443,9 @@ private:
 
     std::unique_ptr<TransformationMatrix> m_transform;
 
+    // If the RenderLayer contains an anchor-positioned box, this is the "default scroll shift"
+    // for scroll compensation purpose. This offset aligns the anchor-positioned box with the anchor
+    // after scroll, and is applied as a transform.
     std::optional<LayoutSize> m_snapshottedScrollOffsetForAnchorPositioning;
 
     // May ultimately be extended to many replicas (with their own paint order).

--- a/Source/WebCore/rendering/RenderLayerInlines.h
+++ b/Source/WebCore/rendering/RenderLayerInlines.h
@@ -33,7 +33,6 @@ inline bool RenderLayer::canPaintTransparencyWithSetOpacity() const { return isB
 inline bool RenderLayer::hasBackdropFilter() const { return renderer().hasBackdropFilter(); }
 inline bool RenderLayer::hasFilter() const { return renderer().hasFilter(); }
 inline bool RenderLayer::hasPerspective() const { return renderer().style().hasPerspective(); }
-inline bool RenderLayer::isTransformed() const { return renderer().isTransformed(); }
 inline bool RenderLayer::isTransparent() const { return renderer().isTransparent() || renderer().hasMask(); }
 inline bool RenderLayer::overlapBoundsIncludeChildren() const { return hasFilter() && renderer().style().filter().hasFilterThatMovesPixels(); }
 inline bool RenderLayer::preserves3D() const { return renderer().style().preserves3D(); }
@@ -45,6 +44,13 @@ inline Ref<Page> RenderLayer::protectedPage() const { return renderer().page(); 
 inline bool RenderLayer::hasAppleVisualEffect() const { return renderer().hasAppleVisualEffect(); }
 inline bool RenderLayer::hasAppleVisualEffectRequiringBackdropFilter() const { return renderer().hasAppleVisualEffectRequiringBackdropFilter(); }
 #endif
+
+inline bool RenderLayer::isTransformed() const
+{
+    // If the scroll offset is present, a transform is applied on top of existing
+    // transforms from the renderer.
+    return renderer().isTransformed() || m_snapshottedScrollOffsetForAnchorPositioning;
+}
 
 inline bool RenderLayer::hasBlendMode() const { return renderer().hasBlendMode(); } // FIXME: Why ask the renderer this given we have m_blendMode?
 


### PR DESCRIPTION
#### 6ea33a67c88a53700c833449790e27f6bd0e68c3
<pre>
Anchor-positioned, fixed-positioned element might get clipped by the viewport
<a href="https://rdar.apple.com/154908754">rdar://154908754</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=295322">https://bugs.webkit.org/show_bug.cgi?id=295322</a>

Reviewed by Simon Fraser.

RenderLayerBacking::shouldClipCompositedBounds() determines whether to clip
the RenderLayer or not (in the case of a fixed-positioned element, clip to the
viewport). It calls RenderLayer::isTransformed() to check if the RenderLayer
have transforms, and it wouldn&apos;t clip if there&apos;re transforms
(RenderLayerBacking::shouldClipCompositedBounds() -&gt;
layerOrAncestorIsTransformedOrUsingCompositedScrolling -&gt;
RenderLayer::isTransformed())

A RenderLayer has transforms if the renderer has transforms, but also when
&quot;scroll compensation&quot; [1] is applied. This is part of anchor positioning,
to adjust the position of anchor-positioned boxes in response to its
anchor scrolling. The adjustment is applied as a transform, so a RenderLayer
where the renderer doesn&apos;t have transforms could still have transforms.
But RenderLayer::isTransformed() wasn&apos;t updated to include this new condition.
The result: if an anchor-positioned, fixed-positioned element got scroll
compensated, it&apos;ll be clipped by the viewport (it shouldn&apos;t)

[1]: <a href="https://drafts.csswg.org/css-anchor-position-1/#compensate-for-scroll">https://drafts.csswg.org/css-anchor-position-1/#compensate-for-scroll</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-fixedpos-003-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-fixedpos-003.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/anchor-scroll-fixedpos-003-ref.html: Added.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::updateTransform):
    - Use RenderLayer::isTransformed() to get whether the layer has transforms,
      instead of repeating the code.

* Source/WebCore/rendering/RenderLayer.h:
    - Added comments about scroll compensation behavior.

* Source/WebCore/rendering/RenderLayerInlines.h:
(WebCore::RenderLayer::isTransformed const):
    - RenderLayer has transforms if there&apos;s scroll compensation too.

Canonical link: <a href="https://commits.webkit.org/297297@main">https://commits.webkit.org/297297@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a60ed3539d77e4ed3abe3c84bb9e23e6f5c61a17

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111180 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30846 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117211 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61448 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113142 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31527 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39428 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84515 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114127 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; Passed webkitperl tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25176 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100135 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64961 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24522 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/18276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61031 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94557 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18343 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120249 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38229 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28404 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93449 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38605 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96410 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93274 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23776 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38361 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/16153 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34214 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38118 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43595 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37783 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41116 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39485 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->