### PR TITLE
Compute padding percentage correctly for position-area

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-percents-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-percents-001-expected.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<title>Percentage inset/margin/padding in position-area</title>
+
+<style>
+  .container {
+    width: 100px; height: 100px;
+    border: solid gray;
+    margin: 6px;
+    position: relative;
+    float: left;
+  }
+
+  .anchor {
+    position: absolute;
+    background: silver;
+    inset: 20px 20px 40px 20px;
+  }
+
+  .anchored {
+    border: solid blue 2px;
+    position: absolute;
+    place-self: stretch;
+    inset: 60px 0 0 20px; /* occupy the bottom center-right area */
+    background: content-box aqua;
+  }
+
+  /* insets (top / left margins here) compute against their own axis */
+  /* margins (bottom / right margins here) and padding compute against inline axis */
+  .horizontal { /* margin/padding computes against horizontal */
+    margin: 8px 4px 4px 16px;
+    padding: 8px;
+  }
+  .vertical { /* margin/padding computes against vertical */
+    margin: 8px 2px 2px 16px;
+    padding: 4px;
+  }
+</style>
+
+<div class=container>
+  <div class="anchor"></div>
+  <div class="anchored horizontal"></div>
+</div>
+
+<div class=container>
+  <div class="anchor"></div>
+  <div class="anchored horizontal"></div>
+</div>
+
+<div class=container>
+  <div class="anchor"></div>
+  <div class="anchored vertical"></div>
+</div>
+
+<div class=container>
+  <div class="anchor"></div>
+  <div class="anchored vertical"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-percents-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-percents-001-ref.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<title>Percentage inset/margin/padding in position-area</title>
+
+<style>
+  .container {
+    width: 100px; height: 100px;
+    border: solid gray;
+    margin: 6px;
+    position: relative;
+    float: left;
+  }
+
+  .anchor {
+    position: absolute;
+    background: silver;
+    inset: 20px 20px 40px 20px;
+  }
+
+  .anchored {
+    border: solid blue 2px;
+    position: absolute;
+    place-self: stretch;
+    inset: 60px 0 0 20px; /* occupy the bottom center-right area */
+    background: content-box aqua;
+  }
+
+  /* insets (top / left margins here) compute against their own axis */
+  /* margins (bottom / right margins here) and padding compute against inline axis */
+  .horizontal { /* margin/padding computes against horizontal */
+    margin: 8px 4px 4px 16px;
+    padding: 8px;
+  }
+  .vertical { /* margin/padding computes against vertical */
+    margin: 8px 2px 2px 16px;
+    padding: 4px;
+  }
+</style>
+
+<div class=container>
+  <div class="anchor"></div>
+  <div class="anchored horizontal"></div>
+</div>
+
+<div class=container>
+  <div class="anchor"></div>
+  <div class="anchored horizontal"></div>
+</div>
+
+<div class=container>
+  <div class="anchor"></div>
+  <div class="anchored vertical"></div>
+</div>
+
+<div class=container>
+  <div class="anchor"></div>
+  <div class="anchored vertical"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-percents-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-percents-001.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<title>Percentage inset/margin/padding in position-area</title>
+
+<link rel="help" href="https://www.w3.org/TR/css-anchor-position/#position-area">
+<link rel="match" href="position-area-percents-001-ref.html">
+<link rel="author" name="Elika J. Etemad" href="http://fantasai.inkedblade.net/contact">
+
+<style>
+  .container {
+    width: 100px; height: 100px;
+    border: solid gray;
+    margin: 6px;
+    position: relative;
+    float: left;
+  }
+
+  .anchor {
+    position: absolute;
+    background: silver;
+    inset: 20px 20px 40px 20px;
+    /* Makes bottom center-right area 80px wide by 40px tall */
+    anchor-name: --foo;
+  }
+
+  .anchored {
+    border: solid blue 2px;
+    position: absolute;
+    position-anchor: --foo;
+    position-area: bottom span-right;
+    place-self: stretch;
+    inset: 20% 0 0 20%;
+    margin: 0 5% 5% 0;
+    padding: 10%;
+    background: content-box aqua;
+  }
+</style>
+
+<div class=container>
+  <div class="anchor"></div>
+  <div class="anchored"></div>
+</div>
+
+<div class=container>
+  <div class="anchor"></div>
+  <div class="anchored" style="writing-mode: vertical-rl"></div>
+</div>
+
+<div class=container style="writing-mode: vertical-rl">
+  <div class="anchor"></div>
+  <div class="anchored"></div>
+</div>
+<div class=container style="writing-mode: vertical-rl">
+  <div class="anchor"></div>
+  <div class="anchored" style="writing-mode: horizontal-tb"></div>
+</div>
+

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
@@ -58,12 +58,19 @@ static bool shouldFlipStaticPositionInParent(const RenderBox& outOfFlowBox, cons
     return parent->writingMode().isBlockFlipped() && parent->isWritingModeRoot();
 }
 
+PositionedLayoutConstraints::PositionedLayoutConstraints(const RenderBox& renderer, LogicalBoxAxis selfAxis)
+    : PositionedLayoutConstraints(renderer, renderer.style(), selfAxis)
+{
+}
+
 PositionedLayoutConstraints::PositionedLayoutConstraints(const RenderBox& renderer, const RenderStyle& style, LogicalBoxAxis selfAxis)
-    : m_container(downcast<RenderBoxModelObject>(*renderer.container())) // Using containingBlock() would be wrong for relpositioned inlines.
+    : m_renderer(renderer)
+    , m_container(downcast<RenderBoxModelObject>(*renderer.container())) // Using containingBlock() would be wrong for relpositioned inlines.
     , m_containingWritingMode(m_container->writingMode())
     , m_writingMode(style.writingMode())
-    , m_physicalAxis(selfAxis == LogicalBoxAxis::Inline ? m_writingMode.inlineAxis() : m_writingMode.blockAxis())
+    , m_selfAxis(selfAxis)
     , m_containingAxis(!isOrthogonal() ? selfAxis : oppositeAxis(selfAxis))
+    , m_physicalAxis(selfAxis == LogicalBoxAxis::Inline ? m_writingMode.inlineAxis() : m_writingMode.blockAxis())
     , m_style(style)
     , m_alignment(m_containingAxis == LogicalBoxAxis::Inline ? style.justifySelf() : style.alignSelf())
     , m_defaultAnchorBox(needsAnchor() ? Style::AnchorPositionEvaluator::defaultAnchorForBox(renderer) : nullptr)
@@ -74,25 +81,28 @@ PositionedLayoutConstraints::PositionedLayoutConstraints(const RenderBox& render
 {
 
     // Compute basic containing block info.
-    auto containingWidth = renderer.containingBlockLogicalWidthForPositioned(*m_container, false);
+    auto containingInlineSize = renderer.containingBlockLogicalWidthForPositioned(*m_container, false);
     if (LogicalBoxAxis::Inline == m_containingAxis)
-        m_containingRange.set(m_container->borderLogicalLeft(), containingWidth);
+        m_containingRange.set(m_container->borderLogicalLeft(), containingInlineSize);
     else
         m_containingRange.set(m_container->borderBefore(), renderer.containingBlockLogicalHeightForPositioned(*m_container, false));
-    m_marginPercentageBasis = containingWidth;
+    m_containingInlineSize = containingInlineSize;
     m_originalContainingRange = m_containingRange;
 
     // Adjust for grid-area.
-    captureGridArea(renderer);
+    captureGridArea();
 
     // Capture the anchor geometry and adjust for position-area.
-    captureAnchorGeometry(renderer);
+    captureAnchorGeometry();
+}
 
+void PositionedLayoutConstraints::computeInsets()
+{
     // Cache insets and margins, etc.
-    captureInsets(renderer, selfAxis);
+    captureInsets();
 
     if (m_useStaticPosition)
-        computeStaticPosition(renderer, selfAxis);
+        computeStaticPosition();
 
     if (containingCoordsAreFlipped()) {
         // Ideally this check is incorporated into captureInsets() but currently it needs to happen after computeStaticPosition() because containingCoordsAreFlipped() depends on m_useStaticPosition.
@@ -104,11 +114,6 @@ PositionedLayoutConstraints::PositionedLayoutConstraints(const RenderBox& render
     m_insetModifiedContainingRange = m_containingRange;
     m_insetModifiedContainingRange.shiftMinEdgeBy(insetBeforeValue());
     m_insetModifiedContainingRange.shiftMaxEdgeBy(-insetAfterValue());
-}
-
-PositionedLayoutConstraints::PositionedLayoutConstraints(const RenderBox& renderer, LogicalBoxAxis selfAxis)
-    : PositionedLayoutConstraints(renderer, renderer.style(), selfAxis)
-{
 }
 
 bool PositionedLayoutConstraints::needsAnchor() const
@@ -123,19 +128,19 @@ bool PositionedLayoutConstraints::containingCoordsAreFlipped() const
     return !m_useStaticPosition && ((isBlockOpposing() && m_containingAxis == LogicalBoxAxis::Block) || (isOrthogonal() && orthogonalOpposing));
 }
 
-void PositionedLayoutConstraints::captureInsets(const RenderBox& renderer, const LogicalBoxAxis selfAxis)
+void PositionedLayoutConstraints::captureInsets()
 {
     bool isHorizontal = BoxAxis::Horizontal == m_physicalAxis;
 
     if (isHorizontal) {
-        m_bordersPlusPadding = renderer.borderLeft() + renderer.paddingLeft() + renderer.paddingRight() + renderer.borderRight();
+        m_bordersPlusPadding = m_renderer->borderLeft() + m_renderer->paddingLeft() + m_renderer->paddingRight() + m_renderer->borderRight();
         m_useStaticPosition = m_style.left().isAuto() && m_style.right().isAuto() && !m_defaultAnchorBox;
     } else {
-        m_bordersPlusPadding = renderer.borderTop() + renderer.paddingTop() + renderer.paddingBottom() + renderer.borderBottom();
+        m_bordersPlusPadding = m_renderer->borderTop() + m_renderer->paddingTop() + m_renderer->paddingBottom() + m_renderer->borderBottom();
         m_useStaticPosition = m_style.top().isAuto() && m_style.bottom().isAuto() && !m_defaultAnchorBox;
     }
 
-    if (LogicalBoxAxis::Inline == selfAxis) {
+    if (LogicalBoxAxis::Inline == m_selfAxis) {
         m_marginBefore = isHorizontal ? m_style.marginLeft() : m_style.marginTop();
         m_marginAfter = isHorizontal ? m_style.marginRight() : m_style.marginBottom();
         m_insetBefore = m_style.logicalLeft();
@@ -160,25 +165,25 @@ void PositionedLayoutConstraints::captureInsets(const RenderBox& renderer, const
 
 // MARK: - Adjustments to the containing block.
 
-void PositionedLayoutConstraints::captureGridArea(const RenderBox& renderer)
+void PositionedLayoutConstraints::captureGridArea()
 {
     const CheckedPtr gridContainer = dynamicDowncast<RenderGrid>(m_container.get());
     if (!gridContainer)
         return;
 
     if (LogicalBoxAxis::Inline == m_containingAxis) {
-        auto range = gridContainer->gridAreaColumnRangeForOutOfFlow(renderer);
+        auto range = gridContainer->gridAreaColumnRangeForOutOfFlow(m_renderer);
         if (!range)
             return;
         m_containingRange = *range;
-        m_marginPercentageBasis = range->size();
+        m_containingInlineSize = range->size();
     } else {
-        auto range = gridContainer->gridAreaRowRangeForOutOfFlow(renderer);
+        auto range = gridContainer->gridAreaRowRangeForOutOfFlow(m_renderer);
         if (range)
             m_containingRange = *range;
-        auto columnRange = gridContainer->gridAreaColumnRangeForOutOfFlow(renderer);
+        auto columnRange = gridContainer->gridAreaColumnRangeForOutOfFlow(m_renderer);
         if (columnRange)
-            m_marginPercentageBasis = columnRange->size();
+            m_containingInlineSize = columnRange->size();
     }
 
     if (!startIsBefore()) {
@@ -188,13 +193,13 @@ void PositionedLayoutConstraints::captureGridArea(const RenderBox& renderer)
     }
 }
 
-void PositionedLayoutConstraints::captureAnchorGeometry(const RenderBox& renderer)
+void PositionedLayoutConstraints::captureAnchorGeometry()
 {
     if (!m_defaultAnchorBox)
         return;
 
     // Store the anchor geometry.
-    LayoutRect anchorRect = Style::AnchorPositionEvaluator::computeAnchorRectRelativeToContainingBlock(*m_defaultAnchorBox, *renderer.containingBlock());
+    LayoutRect anchorRect = Style::AnchorPositionEvaluator::computeAnchorRectRelativeToContainingBlock(*m_defaultAnchorBox, *m_renderer->containingBlock());
     if (BoxAxis::Horizontal == m_physicalAxis)
         m_anchorArea.set(anchorRect.x(), anchorRect.width());
     else
@@ -211,16 +216,16 @@ void PositionedLayoutConstraints::captureAnchorGeometry(const RenderBox& rendere
 
     // Margin basis is always against the inline axis.
     if (LogicalBoxAxis::Inline == m_containingAxis) {
-        m_marginPercentageBasis = m_containingRange.size();
+        m_containingInlineSize = m_containingRange.size();
         return;
     }
     // Else we're representing the block axis, but need the inline dimensions.
     auto inlineAxis = oppositeAxis(m_physicalAxis);
-    LayoutRange inlineContainingBlock(m_container->borderLogicalLeft(), m_marginPercentageBasis);
+    LayoutRange inlineContainingBlock(m_container->borderLogicalLeft(), m_containingInlineSize);
     auto inlineAnchorArea = BoxAxis::Horizontal == inlineAxis
         ? LayoutRange { anchorRect.x(), anchorRect.width() }
         : LayoutRange { anchorRect.y(), anchorRect.height() };
-    m_marginPercentageBasis = adjustForPositionArea(inlineContainingBlock, inlineAnchorArea, inlineAxis).size();
+    m_containingInlineSize = adjustForPositionArea(inlineContainingBlock, inlineAnchorArea, inlineAxis).size();
 }
 
 LayoutRange PositionedLayoutConstraints::adjustForPositionArea(const LayoutRange rangeToAdjust, const LayoutRange anchorArea, const BoxAxis containerAxis)
@@ -319,8 +324,7 @@ void PositionedLayoutConstraints::resolvePosition(RenderBox::LogicalExtentComput
     auto position = m_insetModifiedContainingRange.min() + usedMarginBefore + alignmentShift();
 
     computedValues.m_position = position;
-    LogicalBoxAxis selfAxis = isOrthogonal() ? oppositeAxis(m_containingAxis) : m_containingAxis;
-    if (LogicalBoxAxis::Inline == selfAxis) {
+    if (LogicalBoxAxis::Inline == m_selfAxis) {
         if (m_writingMode.isLogicalLeftInlineStart() == !containingCoordsAreFlipped()) {
             computedValues.m_margins.m_start = usedMarginBefore;
             computedValues.m_margins.m_end = usedMarginAfter;
@@ -415,13 +419,13 @@ bool PositionedLayoutConstraints::alignmentAppliesStretch(ItemPosition normalAli
 
 // MARK: - Static Position Computation
 
-void PositionedLayoutConstraints::computeStaticPosition(const RenderBox& renderer, LogicalBoxAxis selfAxis)
+void PositionedLayoutConstraints::computeStaticPosition()
 {
     ASSERT(m_useStaticPosition);
 
     if (is<RenderGrid>(m_container)) {
         // Grid Containers have special behavior, see https://www.w3.org/TR/css-grid/#abspos
-        if (m_container.get() == renderer.parent()) {
+        if (m_container.get() == m_renderer->parent()) {
             // Fake the static layout right here so it integrates with grid-area properly.
             m_useStaticPosition = false; // Avoid the static position code path.
             m_insetBefore = 0_css_px;
@@ -451,23 +455,23 @@ void PositionedLayoutConstraints::computeStaticPosition(const RenderBox& rendere
         m_containingRange.moveTo(m_originalContainingRange.min());
     }
 
-    if (selfAxis == LogicalBoxAxis::Inline)
-        computeInlineStaticDistance(renderer);
+    if (m_selfAxis == LogicalBoxAxis::Inline)
+        computeInlineStaticDistance();
     else
-        computeBlockStaticDistance(renderer);
+        computeBlockStaticDistance();
 }
 
-void PositionedLayoutConstraints::computeInlineStaticDistance(const RenderBox& renderer)
+void PositionedLayoutConstraints::computeInlineStaticDistance()
 {
-    auto* parent = renderer.parent();
+    auto* parent = m_renderer->parent();
     auto parentWritingMode = parent->writingMode();
 
     // For orthogonal flows we don't care whether the parent is LTR or RTL because it does not affect the position in our inline axis.
     bool haveOrthogonalWritingModes = parentWritingMode.isOrthogonal(m_writingMode);
     if (parentWritingMode.isLogicalLeftInlineStart() || haveOrthogonalWritingModes) {
         LayoutUnit staticPosition = haveOrthogonalWritingModes
-            ? renderer.layer()->staticBlockPosition() - m_container->borderBefore()
-            : renderer.layer()->staticInlinePosition() - m_container->borderLogicalLeft();
+            ? m_renderer->layer()->staticBlockPosition() - m_container->borderBefore()
+            : m_renderer->layer()->staticInlinePosition() - m_container->borderLogicalLeft();
         for (auto* current = parent; current && current != m_container.get(); current = current->container()) {
             CheckedPtr renderBox = dynamicDowncast<RenderBox>(*current);
             if (!renderBox)
@@ -479,7 +483,7 @@ void PositionedLayoutConstraints::computeInlineStaticDistance(const RenderBox& r
         m_insetBefore = Style::InsetEdge::Fixed { staticPosition };
     } else {
         ASSERT(!haveOrthogonalWritingModes);
-        LayoutUnit staticPosition = renderer.layer()->staticInlinePosition() + containingSize() + m_container->borderLogicalLeft();
+        LayoutUnit staticPosition = m_renderer->layer()->staticInlinePosition() + containingSize() + m_container->borderLogicalLeft();
         auto& enclosingBox = parent->enclosingBox();
         if (&enclosingBox != m_container.get() && m_container->isDescendantOf(&enclosingBox)) {
             m_insetAfter = Style::InsetEdge::Fixed { staticPosition };
@@ -503,15 +507,17 @@ void PositionedLayoutConstraints::computeInlineStaticDistance(const RenderBox& r
     }
 }
 
-void PositionedLayoutConstraints::computeBlockStaticDistance(const RenderBox& renderer)
+void PositionedLayoutConstraints::computeBlockStaticDistance()
 {
-    auto* parent = renderer.parent();
+    auto* parent = m_renderer->parent();
     bool haveOrthogonalWritingModes = parent->writingMode().isOrthogonal(m_writingMode);
     // The static positions from the child's layer are relative to the container block's coordinate space (which is determined
     // by the writing mode and text direction), meaning that for orthogonal flows the logical top of the child (which depends on
     // the child's writing mode) is retrieved from the static inline position instead of the static block position.
-    auto staticLogicalTop = haveOrthogonalWritingModes ? renderer.layer()->staticInlinePosition() : renderer.layer()->staticBlockPosition();
-    if (shouldFlipStaticPositionInParent(renderer, *m_container)) {
+    auto staticLogicalTop = haveOrthogonalWritingModes
+        ? m_renderer->layer()->staticInlinePosition()
+        : m_renderer->layer()->staticBlockPosition();
+    if (shouldFlipStaticPositionInParent(m_renderer, *m_container)) {
         // Note that at this point we can't resolve static top position completely in flipped case as at this point the height of the child box has not been computed yet.
         // What we can compute here is essentially the "bottom position".
         staticLogicalTop = downcast<RenderBox>(*parent).flipForWritingMode(staticLogicalTop);
@@ -574,12 +580,12 @@ void PositionedLayoutConstraints::fixupLogicalLeftPosition(RenderBox::LogicalExt
 // The |containerLogicalHeightForPositioned| is already aware of orthogonal flows.
 // The logicalTop concept is confusing here. It's the logical top from the child's POV. This means that is the physical
 // y if the child is vertical or the physical x if the child is horizontal.
-void PositionedLayoutConstraints::fixupLogicalTopPosition(RenderBox::LogicalExtentComputedValues& computedValues, const RenderBox& renderer) const
+void PositionedLayoutConstraints::fixupLogicalTopPosition(RenderBox::LogicalExtentComputedValues& computedValues) const
 {
     // Deal with differing writing modes here. Our offset needs to be in the containing block's coordinate space. If the containing block is flipped
     // along this axis, then we need to flip the coordinate. This can only happen if the containing block is both a flipped mode and perpendicular to us.
     if (m_useStaticPosition) {
-        if (shouldFlipStaticPositionInParent(renderer, *m_container)) {
+        if (shouldFlipStaticPositionInParent(m_renderer, *m_container)) {
             // Let's finish computing static top postion inside parents with flipped writing mode now that we've got final height value.
             // see details in computeBlockStaticDistance.
             computedValues.m_position -= computedValues.m_extent;

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -1258,6 +1258,8 @@ bool AnchorPositionEvaluator::overflowsInsetModifiedContainingBlock(const Render
 
     auto inlineConstraints = PositionedLayoutConstraints { anchoredBox, LogicalBoxAxis::Inline };
     auto blockConstraints = PositionedLayoutConstraints { anchoredBox, LogicalBoxAxis::Block };
+    inlineConstraints.computeInsets();
+    blockConstraints.computeInsets();
 
     auto anchorInlineSize = anchoredBox.logicalWidth() + anchoredBox.marginStart() + anchoredBox.marginEnd();
     auto anchorBlockSize = anchoredBox.logicalHeight() + anchoredBox.marginBefore() + anchoredBox.marginAfter();

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1516,6 +1516,7 @@ void TreeResolver::sortPositionOptionsIfNeeded(PositionOptions& options, const S
 
     for (auto& optionStyle : options.optionStyles) {
         auto constraints = PositionedLayoutConstraints { *box, *optionStyle, boxAxis };
+        constraints.computeInsets();
         optionsForSorting.append({ WTFMove(optionStyle), constraints.insetModifiedContainingSize() });
     }
 


### PR DESCRIPTION
#### b59ae7a025c9154ab39f3c745f0c333c761d0b98
<pre>
Compute padding percentage correctly for position-area
<a href="https://bugs.webkit.org/show_bug.cgi?id=294256">https://bugs.webkit.org/show_bug.cgi?id=294256</a>
<a href="https://rdar.apple.com/153636536">rdar://153636536</a>

Reviewed by Alan Baradlay.

Percentage padding is supposed to be resolved against the inline size of the
containing block. The position-area property modifies the containing block,
but we weren&apos;t accounting for this in in our padding calculations.

This patch fixes this by updating containingBlockLogicalWidthForContent
(and containingBlockLogicalHeightForContent) to call PositionedLayoutConstraints,
which handles all of the complications for out-of-flow containing block sizing.

It also splits PositionedLayoutConstraints constructor into two pieces, so that
we aren&apos;t doing extra work when we don&apos;t need to, and does a bunch of additional
clean up in PositionedLayoutConstraints to make all of this clearer and cleaner.

Changes include:
 - reorganizing the API into methods that can be called with/without computeInsets()
 - rename m_marginPercentageBasis to m_containingInlineAxis and give it a getter
 - introduce new computeInsets() method to split out second half of constructor
 - store renderer and selfAxis internally, and delete them from method parameters
 - updating all call sites accordingly

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-percents-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-percents-001-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-percents-001.html: Added.

Test for percentage margin/padding/insets in both axes, with mixed writing modes.

* Source/WebCore/rendering/PositionedLayoutConstraints.cpp:
(WebCore::PositionedLayoutConstraints::PositionedLayoutConstraints):

Split the constructor&apos;s logic, keeping just the CB computation.
Store renderer/selfAxis parameters.
Rename local variables for consistency with new containingInlineSize() method.

(WebCore::PositionedLayoutConstraints::computeInsets):

New method for the second half of the constructor (inset/margin computation).

(WebCore::PositionedLayoutConstraints::captureInsets
(WebCore::PositionedLayoutConstraints::captureGridArea):
(WebCore::PositionedLayoutConstraints::captureAnchorGeometry):
(WebCore::PositionedLayoutConstraints::resolvePosition const):
(WebCore::PositionedLayoutConstraints::resolveAlignmentShift const):
(WebCore::PositionedLayoutConstraints::computeStaticPosition):
(WebCore::PositionedLayoutConstraints::computeInlineStaticDistance):
(WebCore::PositionedLayoutConstraints::computeBlockStaticDistance):
(WebCore::PositionedLayoutConstraints::fixupLogicalTopPosition const):

Delete parameters in favor of new data members.

* Source/WebCore/rendering/PositionedLayoutConstraints.h:
(WebCore::PositionedLayoutConstraints::containingSize const):
(WebCore::PositionedLayoutConstraints::containingInlineSize const):
(WebCore::PositionedLayoutConstraints::containingAxis const):
(WebCore::PositionedLayoutConstraints::container const):
(WebCore::PositionedLayoutConstraints::defaultAnchorBox const):
(WebCore::PositionedLayoutConstraints::alignment const):
(WebCore::PositionedLayoutConstraints::startIsBefore const):
(WebCore::PositionedLayoutConstraints::bordersPlusPadding const):
(WebCore::PositionedLayoutConstraints::marginBefore const):
(WebCore::PositionedLayoutConstraints::marginAfter const):
(WebCore::PositionedLayoutConstraints::insetBefore const):
(WebCore::PositionedLayoutConstraints::insetAfter const):
(WebCore::PositionedLayoutConstraints::marginBeforeValue const):
(WebCore::PositionedLayoutConstraints::marginAfterValue const):

Reorganize the API definition to clarify which methods can be called without
calling computeInsets().
Add new m_selfAxis and m_renderer members to cache these inputs.
Rename m_marginPercentageBasis to m_containingInlineSize.

* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::containingBlockLogicalWidthForContent const):
(WebCore::RenderBox::containingBlockLogicalHeightForContent const):

Update to use PositionedLayoutConstraints for out-of-flow boxes.

(WebCore::RenderBox::computePositionedLogicalWidth const):
(WebCore::RenderBox::computePositionedLogicalHeight const):
(WebCore::RenderBox::computePositionedLogicalWidthReplaced const):
(WebCore::RenderBox::computePositionedLogicalHeightReplaced const):
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::overflowsInsetModifiedContainingBlock):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::sortPositionOptionsIfNeeded):

Update PositionedLayoutConstraints call sites.

Canonical link: <a href="https://commits.webkit.org/297275@main">https://commits.webkit.org/297275@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ceaadcb7c0814b5705beafde332e566ee3d71586

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111142 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30808 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21239 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117173 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61410 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113104 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31489 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39390 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84493 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114089 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25156 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100060 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64939 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24501 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18204 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60993 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94536 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18268 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120143 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38191 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28383 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93429 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38567 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96335 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93260 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23762 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38340 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16083 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34176 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38080 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43557 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37745 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41078 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39447 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->