### PR TITLE
docs.google.com: Can't type with Devanagari input source

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3597,6 +3597,21 @@ InlineMediaPlaybackRequiresPlaysInlineAttribute:
     WebCore:
       default: false
 
+InputMethodUsesCorrectKeyEventOrder:
+  type: bool
+  status: testable
+  category: dom
+  humanReadableName: "Correct key event ordering with composition events"
+  condition: PLATFORM(MAC)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+  sharedPreferenceForWebProcess: true
+
 InputTypeColorEnabled:
   type: bool
   status: mature

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -4093,6 +4093,10 @@ bool EventHandler::internalKeyEvent(const PlatformKeyboardEvent& initialKeyEvent
         return keydownResult;
     auto keypress = KeyboardEvent::create(keyPressEvent, &frame->windowProxy());
     keypress->setTarget(element.copyRef());
+    if (keypress->isComposing()) {
+        frame->editor().handleKeyboardEvent(keypress);
+        return keydownResult;
+    }
     if (keydownResult)
         keypress->preventDefault();
 #if PLATFORM(COCOA)

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -520,6 +520,12 @@ bool Quirks::needsDeferKeyDownAndKeyPressTimersUntilNextEditingCommand() const
 #endif
 }
 
+// docs.google.com https://bugs.webkit.org/show_bug.cgi?id=199587
+bool Quirks::inputMethodUsesCorrectKeyEventOrder() const
+{
+    return needsQuirks() && m_quirksData.inputMethodUsesCorrectKeyEventOrder;
+}
+
 // FIXME: Remove after the site is fixed, <rdar://problem/50374200>
 // mail.google.com rdar://49403416
 bool Quirks::needsGMailOverflowScrollQuirk() const
@@ -2473,6 +2479,7 @@ static void handleGoogleQuirks(QuirksData& quirksData, const URL& quirksURL, con
         quirksData.shouldAvoidResizingWhenInputViewBoundsChangeQuirk = true;
     }
     quirksData.isGoogleDocs = topDocumentHost == "docs.google.com"_s;
+    quirksData.inputMethodUsesCorrectKeyEventOrder = quirksData.isGoogleDocs;
 #if PLATFORM(IOS_FAMILY)
     if (quirksData.isGoogleDocs) {
         // docs.google.com rdar://49864669

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -80,6 +80,7 @@ public:
 #endif
     bool shouldDisablePointerEventsQuirk() const;
     bool needsDeferKeyDownAndKeyPressTimersUntilNextEditingCommand() const;
+    WEBCORE_EXPORT bool inputMethodUsesCorrectKeyEventOrder() const;
     bool shouldExposeShowModalDialog() const;
     bool shouldNavigatorPluginsBeEmpty() const;
     bool returnNullPictureInPictureElementDuringFullscreenChange() const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -50,6 +50,7 @@ struct WEBCORE_EXPORT QuirksData {
 
     bool hasBrokenEncryptedMediaAPISupportQuirk : 1 { false };
     bool implicitMuteWhenVolumeSetToZero : 1 { false };
+    bool inputMethodUsesCorrectKeyEventOrder : 1 { false };
     bool maybeBypassBackForwardCache : 1 { false };
     bool needsBingGestureEventQuirk : 1 { false };
     bool needsBodyScrollbarWidthNoneDisabledQuirk : 1 { false };

--- a/Source/WebCore/platform/KeypressCommand.h
+++ b/Source/WebCore/platform/KeypressCommand.h
@@ -26,6 +26,9 @@
 #ifndef KeypressCommand_h
 #define KeypressCommand_h
 
+#include "CharacterRange.h"
+#include "CompositionHighlight.h"
+#include "CompositionUnderline.h"
 #include <wtf/Assertions.h>
 #include <wtf/text/WTFString.h>
 
@@ -49,8 +52,23 @@ struct KeypressCommand {
         ASSERT(commandName == "insertText:"_s || text.isEmpty());
     }
 
+    KeypressCommand(const String& commandName, const String& text, Vector<CompositionUnderline>&& underlines, Vector<CompositionHighlight>&& highlights, const CharacterRange& selectedRange, const CharacterRange& replacementRange)
+        : commandName(commandName)
+        , text(text)
+        , underlines(WTFMove(underlines))
+        , highlights(WTFMove(highlights))
+        , selectedRange(selectedRange)
+        , replacementRange(replacementRange)
+    {
+        ASSERT(commandName == "setMarkedText:"_s || (underlines.isEmpty() && highlights.isEmpty()));
+    }
+
     String commandName; // Actually, a selector name - it may have a trailing colon, and a name that can be different from an editor command name.
     String text;
+    Vector<CompositionUnderline> underlines;
+    Vector<CompositionHighlight> highlights;
+    CharacterRange selectedRange;
+    CharacterRange replacementRange;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/EditingRange.h
+++ b/Source/WebKit/Shared/EditingRange.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ArgumentCoders.h"
+#include <WebCore/CharacterRange.h>
 #include <wtf/RefPtr.h>
 
 namespace WebCore {
@@ -54,8 +55,16 @@ struct EditingRange {
     {
     }
 
+    EditingRange(const WebCore::CharacterRange& range)
+        : location(range.location)
+        , length(range.length)
+    {
+    }
+
     // (notFound, 0) is notably valid.
     bool isValid() const { return location + length >= location; }
+
+    WebCore::CharacterRange toCharacterRange() const { return WebCore::CharacterRange { location, length }; }
 
     static std::optional<WebCore::SimpleRange> toRange(WebCore::LocalFrame&, const EditingRange&, EditingRangeIsRelativeTo = EditingRangeIsRelativeTo::EditableRoot);
     static EditingRange fromRange(WebCore::LocalFrame&, const std::optional<WebCore::SimpleRange>&, EditingRangeIsRelativeTo = EditingRangeIsRelativeTo::EditableRoot);

--- a/Source/WebKit/Shared/EditorState.h
+++ b/Source/WebKit/Shared/EditorState.h
@@ -88,6 +88,7 @@ struct EditorState {
     bool isInPlugin { false };
 #if PLATFORM(MAC)
     bool canEnableAutomaticSpellingCorrection { true };
+    bool inputMethodUsesCorrectKeyEventOrder { false };
 #endif
 
     struct PostLayoutData {

--- a/Source/WebKit/Shared/EditorState.serialization.in
+++ b/Source/WebKit/Shared/EditorState.serialization.in
@@ -56,6 +56,7 @@ struct WebKit::EditorState {
     bool isInPlugin;
 #if PLATFORM(MAC)
     bool canEnableAutomaticSpellingCorrection;
+    bool inputMethodUsesCorrectKeyEventOrder;
 #endif
     std::optional<WebKit::EditorState::PostLayoutData> postLayoutData;
     std::optional<WebKit::EditorState::VisualData> visualData;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7708,6 +7708,10 @@ struct WebCore::DragItem {
 struct WebCore::KeypressCommand {
     String commandName;
     String text;
+    Vector<WebCore::CompositionUnderline> underlines;
+    Vector<WebCore::CompositionHighlight> highlights;
+    WebCore::CharacterRange selectedRange;
+    WebCore::CharacterRange replacementRange;
 }
 #endif
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -13642,10 +13642,10 @@ void WebPageProxy::getMarkedRangeAsync(CompletionHandler<void(const EditingRange
     sendWithAsyncReply(Messages::WebPage::GetMarkedRangeAsync(), WTFMove(callbackFunction));
 }
 
-void WebPageProxy::getSelectedRangeAsync(CompletionHandler<void(const EditingRange&)>&& callbackFunction)
+void WebPageProxy::getSelectedRangeAsync(CompletionHandler<void(const EditingRange& selectedRange, const EditingRange& compositionRange)>&& callbackFunction)
 {
     if (!hasRunningProcess()) {
-        callbackFunction(EditingRange());
+        callbackFunction({ }, { });
         return;
     }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1272,7 +1272,7 @@ public:
 
     void hasMarkedText(CompletionHandler<void(bool)>&&);
     void getMarkedRangeAsync(CompletionHandler<void(const EditingRange&)>&&);
-    void getSelectedRangeAsync(CompletionHandler<void(const EditingRange&)>&&);
+    void getSelectedRangeAsync(CompletionHandler<void(const EditingRange& selectedRange, const EditingRange& compositionRange)>&&);
     void characterIndexForPointAsync(const WebCore::IntPoint&, CompletionHandler<void(uint64_t)>&&);
     void firstRectForCharacterRangeAsync(const EditingRange&, CompletionHandler<void(const WebCore::IntRect&, const EditingRange&)>&&);
     void setCompositionAsync(const String& text, const Vector<WebCore::CompositionUnderline>&, const Vector<WebCore::CompositionHighlight>&, const HashMap<String, Vector<WebCore::CharacterRange>>&, const EditingRange& selectionRange, const EditingRange& replacementRange);

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -1012,13 +1012,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     // that has been already sent to WebCore.
     RetainPtr<NSEvent> m_keyDownEventBeingResent;
 
-    struct CheckedCommands : public CanMakeCheckedPtr<CheckedCommands> {
-        WTF_MAKE_FAST_ALLOCATED;
-        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CheckedCommands);
-    public:
-        Vector<WebCore::KeypressCommand> commands;
-    };
-    CheckedPtr<CheckedCommands> m_collectedKeypressCommands;
+    std::optional<Vector<WebCore::KeypressCommand>> m_collectedKeypressCommands;
+    std::optional<NSRange> m_stagedMarkedRange;
+    Vector<CompletionHandler<void()>> m_interpretKeyEventHoldingTank;
 
     String m_lastStringForCandidateRequest;
     NSInteger m_lastCandidateRequestSequenceNumber;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
@@ -180,7 +180,7 @@ private:
     bool shouldShowUnicodeMenu() final;
 #endif
 
-#if PLATFORM(GTK) || PLATFORM(WPE)
+#if PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(MAC)
     void didDispatchInputMethodKeydown(WebCore::KeyboardEvent&) final;
 #endif
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm
@@ -47,7 +47,7 @@
 
 namespace WebKit {
 using namespace WebCore;
-    
+
 void WebEditorClient::handleKeyboardEvent(KeyboardEvent& event)
 {
     if (m_page->handleEditingKeyboardEvent(event))
@@ -58,6 +58,11 @@ void WebEditorClient::handleInputMethodKeydown(KeyboardEvent& event)
 {
     if (event.handledByInputMethod())
         event.setDefaultHandled();
+}
+
+void WebEditorClient::didDispatchInputMethodKeydown(KeyboardEvent& event)
+{
+    m_page->handleEditingKeyboardEvent(event);
 }
 
 void WebEditorClient::setInsertionPasteboard(const String&)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7126,13 +7126,14 @@ void WebPage::getMarkedRangeAsync(CompletionHandler<void(const EditingRange&)>&&
     completionHandler(EditingRange::fromRange(*frame, frame->protectedEditor()->compositionRange()));
 }
 
-void WebPage::getSelectedRangeAsync(CompletionHandler<void(const EditingRange&)>&& completionHandler)
+void WebPage::getSelectedRangeAsync(CompletionHandler<void(const EditingRange& selectedRange, const EditingRange& compositionRange)>&& completionHandler)
 {
     RefPtr frame = corePage()->focusController().focusedOrMainFrame();
     if (!frame)
-        return completionHandler({ });
+        return completionHandler({ }, { });
 
-    completionHandler(EditingRange::fromRange(*frame, frame->selection().selection().toNormalizedRange()));
+    completionHandler(EditingRange::fromRange(*frame, frame->selection().selection().toNormalizedRange()),
+        EditingRange::fromRange(*frame, frame->protectedEditor()->compositionRange()));
 }
 
 void WebPage::characterIndexForPointAsync(const WebCore::IntPoint& point, CompletionHandler<void(uint64_t)>&& completionHandler)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1233,7 +1233,7 @@ public:
     void insertTextAsync(const String& text, const EditingRange& replacementRange, InsertTextOptions&&);
     void hasMarkedText(CompletionHandler<void(bool)>&&);
     void getMarkedRangeAsync(CompletionHandler<void(const EditingRange&)>&&);
-    void getSelectedRangeAsync(CompletionHandler<void(const EditingRange&)>&&);
+    void getSelectedRangeAsync(CompletionHandler<void(const EditingRange&, const EditingRange&)>&&);
     void characterIndexForPointAsync(const WebCore::IntPoint&, CompletionHandler<void(uint64_t)>&&);
     void firstRectForCharacterRangeAsync(const EditingRange&, CompletionHandler<void(const WebCore::IntRect&, const EditingRange&)>&&);
     void setCompositionAsync(const String& text, const Vector<WebCore::CompositionUnderline>&, const Vector<WebCore::CompositionHighlight>&, const HashMap<String, Vector<WebCore::CharacterRange>>&, const EditingRange& selectionRange, const EditingRange& replacementRange);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -534,7 +534,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
 
     HasMarkedText() -> (bool hasMarkedText)
     GetMarkedRangeAsync() -> (struct WebKit::EditingRange range)
-    GetSelectedRangeAsync() -> (struct WebKit::EditingRange range)
+    GetSelectedRangeAsync() -> (struct WebKit::EditingRange selectedRange, struct WebKit::EditingRange compositionRange)
     CharacterIndexForPointAsync(WebCore::IntPoint point) -> (uint64_t location)
     FirstRectForCharacterRangeAsync(struct WebKit::EditingRange range) -> (WebCore::IntRect rect, struct WebKit::EditingRange actualRange)
     SetCompositionAsync(String text, Vector<WebCore::CompositionUnderline> underlines, Vector<WebCore::CompositionHighlight> highlights, HashMap<String, Vector<WebCore::CharacterRange>> annotations, struct WebKit::EditingRange selectionRange, struct WebKit::EditingRange replacementRange)


### PR DESCRIPTION
#### 1322eea39d8f8bcaa4d562c9edca2f5016c7b6bc
<pre>
docs.google.com: Can&apos;t type with Devanagari input source
<a href="https://bugs.webkit.org/show_bug.cgi?id=295763">https://bugs.webkit.org/show_bug.cgi?id=295763</a>

Reviewed by Wenson Hsieh.

The bug was caused by WebKit dispatching keydown event after composition and input events when
handling key events with input methods.

This PR fixes the ordering of these events by deferring processing of setMarkedText until after
the corresponding keydown event is fired in WebContent process. In order to maintain the correct
ordering of input method processing of key events, we also defer calls to interpretKeyEvent
while another input method processing is taking place.

Because this behavior change is rather risky, we hide the new behavior behind a new runtime flag
and only enable it on docs.google.com as a quirk for now. We determine whether the quirk is needed
or not when computing EditorState and sends a boolean back to UI process to enable the behavior.
We expect to eventually ship the new behavior everywhere.

Unfortunately no new tests for now since we don&apos;t have an infrastructure to test this code yet.
Will follow up.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml: Added a new runtime flag.

* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::internalKeyEvent): When we&apos;re in the middle of processing a composition,
explicitly call Editor::handleKeyboardEvent to process keypress commands in the event. Without
this change, we would drop deferred composition updates, etc... on floor.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::inputMethodUsesCorrectKeyEventOrder const): Added.
(WebCore::handleGoogleQuirks): Added. Sets inputMethodUsesCorrectKeyEventOrder to true when the
top level document&apos;s host is docs.google.com.

* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:
(WebCore::QuirksData):

* Source/WebCore/platform/KeypressCommand.h:
(WebCore::KeypressCommand::KeypressCommand): Added a new constructor for setMarkedText. To defer
setMarkedText, store composition underline &amp; highlight, selected range, and replacement range.
This constructor is also now used by the IPC message decoder for KeypressCommand.

* Source/WebKit/Shared/EditingRange.h:
(WebKit::EditingRange::EditingRange): Added a new constructor which takes WebCore::CharacterRange.
(WebKit::EditingRange::toCharacterRange const): Added.

* Source/WebKit/Shared/EditorState.h:
(WebKit::EditorState):
* Source/WebKit/Shared/EditorState.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::getSelectedRangeAsync): Now returns selected range and composition range.

* Source/WebKit/UIProcess/WebPageProxy.h:

* Source/WebKit/UIProcess/mac/WebViewImpl.h:
(WebKit::WebViewImpl): Updated m_collectedKeypressCommands to be an optional of a Vector of
KeypressCommand instead of a CheckedPtr to a struct which contains the Vector. Also added
m_stagedMarkedRange which is a selection set by currently deferred setMarkedText, and
m_interpretKeyEventHoldingTank which is a Vector of completion handlers which will execute
deferred calls to WebViewImpl::interpretKeyEvent.

* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::collectKeyboardLayoutCommandsForEvent):
(WebKit::WebViewImpl::interpretKeyEvent): Defer all other calls to interpretKeyEvent and
setMarkedText while we&apos;re processing the current event via handleEventByInputMethod. Execute
the deferred setMarkedText via KeypressCommand and call all the completion handlers in
m_interpretKeyEventHoldingTank once the current call to interpretKeyEvent finishes.

(WebKit::WebViewImpl::doCommandBySelector):
(WebKit::WebViewImpl::insertText):
(WebKit::WebViewImpl::selectedRangeWithCompletionHandler): When m_stagedMarkedRange is set,
return the NSRange which reflects the effect of m_stagedMarkedRange.

(WebKit::WebViewImpl::setMarkedText): Defer this call to setMarkedText if we&apos;re in the middle
of processing key event via WebViewImpl::interpretKeyEvent. setMarkedText will be executed
later via KeypressCommand by WebPage::executeKeypressCommandsInternal.

(WebKit::WebViewImpl::keyUp): Remove the assertion that if handledByInputMethod is true then
commands is empty since this is no longer true after this PR.
(WebKit::WebViewImpl::keyDown): Ditto.

* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm:
(WebKit::WebEditorClient::didDispatchInputMethodKeydown): Added.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::getSelectedRangeAsync): Now sends back the composition range in addition to
the selected range.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::getPlatformEditorState const): Decide whether new behavior should be enabled
or not for this editable area.
(WebKit::WebPage::executeKeypressCommandsInternal): Added the processing of setMarkedText:.

Canonical link: <a href="https://commits.webkit.org/297270@main">https://commits.webkit.org/297270@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7670bcbf028cb7cc086ef7e519017999253bf95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111133 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30799 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21230 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117164 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61401 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113095 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31480 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39381 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/84492 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25149 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100052 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64938 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24494 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18196 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60984 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/103624 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/94529 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18260 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120134 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109686 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38182 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28378 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/93431 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38558 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96327 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93255 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38337 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16075 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34167 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17920 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38071 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43548 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/133962 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37736 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36136 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41069 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39438 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->