### PR TITLE
Allow to use Ref/RefPtr for webrtc::RefCountInterface objects

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2492,6 +2492,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/mediastream/libwebrtc/LibWebRTCAudioModule.h
     platform/mediastream/libwebrtc/LibWebRTCMacros.h
     platform/mediastream/libwebrtc/LibWebRTCProvider.h
+    platform/mediastream/libwebrtc/LibWebRTCRefWrappers.h
     platform/mediastream/libwebrtc/LibWebRTCSocketIdentifier.h
 
     platform/mock/DeviceOrientationClientMock.h

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.cpp
@@ -64,9 +64,8 @@ webrtc::DataChannelInit LibWebRTCDataChannelHandler::fromRTCDataChannelInit(cons
 }
 
 LibWebRTCDataChannelHandler::LibWebRTCDataChannelHandler(webrtc::scoped_refptr<webrtc::DataChannelInterface>&& channel)
-    : m_channel(WTFMove(channel))
+    : m_channel(toRef(WTFMove(channel)))
 {
-    ASSERT(m_channel);
     checkState();
     m_channel->RegisterObserver(this);
 }

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.h
@@ -27,6 +27,7 @@
 #if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
 #include "LibWebRTCMacros.h"
+#include "LibWebRTCRefWrappers.h"
 #include "ProcessQualified.h"
 #include "RTCDataChannelHandler.h"
 #include "RTCDataChannelState.h"
@@ -35,12 +36,6 @@
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
-
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
-
-#include <webrtc/api/data_channel_interface.h>
-
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace webrtc {
 struct DataChannelInit;
@@ -92,7 +87,7 @@ private:
 
     void postTask(Function<void()>&&);
 
-    webrtc::scoped_refptr<webrtc::DataChannelInterface> m_channel;
+    const Ref<webrtc::DataChannelInterface> m_channel;
     Lock m_clientLock;
     bool m_hasClient WTF_GUARDED_BY_LOCK(m_clientLock)  { false };
     WeakPtr<RTCDataChannelHandlerClient> m_client WTF_GUARDED_BY_LOCK(m_clientLock) { nullptr };

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDtlsTransportBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDtlsTransportBackend.h
@@ -27,37 +27,28 @@
 #if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
 #include "LibWebRTCMacros.h"
+#include "LibWebRTCRefWrappers.h"
 #include "RTCDtlsTransportBackend.h"
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
-
-ALLOW_UNUSED_PARAMETERS_BEGIN
-
-#include <webrtc/api/scoped_refptr.h>
-
-ALLOW_UNUSED_PARAMETERS_END
-
-namespace webrtc {
-class DtlsTransportInterface;
-}
 
 namespace WebCore {
 class LibWebRTCDtlsTransportBackendObserver;
 class LibWebRTCDtlsTransportBackend final : public RTCDtlsTransportBackend, public CanMakeWeakPtr<LibWebRTCDtlsTransportBackend> {
     WTF_MAKE_TZONE_ALLOCATED(LibWebRTCDtlsTransportBackend);
 public:
-    explicit LibWebRTCDtlsTransportBackend(webrtc::scoped_refptr<webrtc::DtlsTransportInterface>&&);
+    explicit LibWebRTCDtlsTransportBackend(Ref<webrtc::DtlsTransportInterface>&&);
     ~LibWebRTCDtlsTransportBackend();
 
 private:
     // RTCDtlsTransportBackend
-    const void* backend() const final { return m_backend.get(); }
+    const void* backend() const final { return m_backend.ptr(); }
     UniqueRef<RTCIceTransportBackend> iceTransportBackend() final;
     void registerClient(RTCDtlsTransportBackendClient&) final;
     void unregisterClient() final;
 
-    webrtc::scoped_refptr<webrtc::DtlsTransportInterface> m_backend;
-    RefPtr<LibWebRTCDtlsTransportBackendObserver> m_observer;
+    const Ref<webrtc::DtlsTransportInterface> m_backend;
+    const RefPtr<LibWebRTCDtlsTransportBackendObserver> m_observer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCIceTransportBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCIceTransportBackend.h
@@ -27,18 +27,9 @@
 #if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
 #include "LibWebRTCMacros.h"
+#include "LibWebRTCRefWrappers.h"
 #include "RTCIceTransportBackend.h"
 #include <wtf/TZoneMalloc.h>
-
-ALLOW_UNUSED_PARAMETERS_BEGIN
-
-#include <webrtc/api/scoped_refptr.h>
-
-ALLOW_UNUSED_PARAMETERS_END
-
-namespace webrtc {
-class IceTransportInterface;
-}
 
 namespace WebCore {
 
@@ -52,12 +43,12 @@ public:
 
 private:
     // RTCIceTransportBackend
-    const void* backend() const final { return m_backend.get(); }
+    const void* backend() const final { return m_backend.ptr(); }
     void registerClient(RTCIceTransportBackendClient&) final;
     void unregisterClient() final;
 
-    webrtc::scoped_refptr<webrtc::IceTransportInterface> m_backend;
-    RefPtr<LibWebRTCIceTransportBackendObserver> m_observer;
+    const Ref<webrtc::IceTransportInterface> m_backend;
+    const RefPtr<LibWebRTCIceTransportBackendObserver> m_observer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
@@ -28,6 +28,7 @@
 
 #include "LibWebRTCObservers.h"
 #include "LibWebRTCProvider.h"
+#include "LibWebRTCRefWrappers.h"
 #include "LibWebRTCRtpSenderBackend.h"
 #include "RTCRtpReceiver.h"
 #include "Timer.h"
@@ -170,7 +171,7 @@ private:
         return result ? webrtc::RefCountReleaseStatus::kOtherRefsRemained : webrtc::RefCountReleaseStatus::kDroppedLastRef;
     }
 
-    std::pair<LibWebRTCRtpSenderBackend::Source, webrtc::scoped_refptr<webrtc::MediaStreamTrackInterface>> createSourceAndRTCTrack(MediaStreamTrack&);
+    std::pair<LibWebRTCRtpSenderBackend::Source, Ref<webrtc::MediaStreamTrackInterface>> createSourceAndRTCTrack(MediaStreamTrack&);
     RefPtr<RealtimeMediaSource> sourceFromNewReceiver(webrtc::RtpReceiverInterface&);
 
 #if !RELEASE_LOG_DISABLED
@@ -185,8 +186,8 @@ private:
     RefPtr<LibWebRTCPeerConnectionBackend> protectedPeerConnectionBackend() const;
 
     WeakPtr<LibWebRTCPeerConnectionBackend> m_peerConnectionBackend;
-    webrtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> m_peerConnectionFactory;
-    webrtc::scoped_refptr<webrtc::PeerConnectionInterface> m_backend;
+    const Ref<webrtc::PeerConnectionFactoryInterface> m_peerConnectionFactory;
+    RefPtr<webrtc::PeerConnectionInterface> m_backend;
 
     friend CreateSessionDescriptionObserver<LibWebRTCMediaEndpoint>;
     friend SetLocalSessionDescriptionObserver<LibWebRTCMediaEndpoint>;
@@ -201,7 +202,7 @@ private:
     bool m_isInitiator { false };
     Timer m_statsLogTimer;
 
-    MemoryCompactRobinHoodHashMap<String, webrtc::scoped_refptr<webrtc::MediaStreamInterface>> m_localStreams;
+    MemoryCompactRobinHoodHashMap<String, Ref<webrtc::MediaStreamInterface>> m_localStreams;
 
     const std::unique_ptr<LibWebRTCProvider::SuspendableSocketFactory> m_rtcSocketFactory;
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
@@ -224,7 +224,9 @@ void LibWebRTCPeerConnectionBackend::getStats(RTCRtpSender& sender, Ref<Deferred
 
 void LibWebRTCPeerConnectionBackend::getStats(RTCRtpReceiver& receiver, Ref<DeferredPromise>&& promise)
 {
-    webrtc::RtpReceiverInterface* rtcReceiver = receiver.backend() ? static_cast<LibWebRTCRtpReceiverBackend*>(receiver.backend())->rtcReceiver() : nullptr;
+    RefPtr<webrtc::RtpReceiverInterface> rtcReceiver;
+    if (auto* backend = receiver.backend())
+        rtcReceiver = &static_cast<LibWebRTCRtpReceiverBackend*>(backend)->rtcReceiver();
 
     if (!rtcReceiver) {
         m_endpoint->getStats(WTFMove(promise));

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.h
@@ -27,13 +27,10 @@
 #if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
 #include "LibWebRTCMacros.h"
+#include "LibWebRTCRefWrappers.h"
 #include "RTCRtpReceiverBackend.h"
 #include <webrtc/api/scoped_refptr.h>
 #include <wtf/TZoneMalloc.h>
-
-namespace webrtc {
-class RtpReceiverInterface;
-}
 
 namespace WebCore {
 class Document;
@@ -42,10 +39,10 @@ class RealtimeMediaSource;
 class LibWebRTCRtpReceiverBackend final : public RTCRtpReceiverBackend {
     WTF_MAKE_TZONE_ALLOCATED(LibWebRTCRtpReceiverBackend);
 public:
-    explicit LibWebRTCRtpReceiverBackend(webrtc::scoped_refptr<webrtc::RtpReceiverInterface>&&);
+    explicit LibWebRTCRtpReceiverBackend(Ref<webrtc::RtpReceiverInterface>&&);
     ~LibWebRTCRtpReceiverBackend();
 
-    webrtc::RtpReceiverInterface* rtcReceiver() { return m_rtcReceiver.get(); }
+    webrtc::RtpReceiverInterface& rtcReceiver() { return m_rtcReceiver.get(); }
 
     Ref<RealtimeMediaSource> createSource(Document&);
 
@@ -56,8 +53,8 @@ private:
     Ref<RTCRtpTransformBackend> rtcRtpTransformBackend() final;
     std::unique_ptr<RTCDtlsTransportBackend> dtlsTransportBackend() final;
 
-    webrtc::scoped_refptr<webrtc::RtpReceiverInterface> m_rtcReceiver;
-    RefPtr<RTCRtpTransformBackend> m_transformBackend;
+    const Ref<webrtc::RtpReceiverInterface> m_rtcReceiver;
+    const RefPtr<RTCRtpTransformBackend> m_transformBackend;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverTransformBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverTransformBackend.cpp
@@ -36,8 +36,8 @@ static inline LibWebRTCRtpReceiverTransformBackend::MediaType mediaTypeFromRecei
     return receiver.media_type() == webrtc::MediaType::AUDIO ? RTCRtpTransformBackend::MediaType::Audio : RTCRtpTransformBackend::MediaType::Video;
 }
 
-LibWebRTCRtpReceiverTransformBackend::LibWebRTCRtpReceiverTransformBackend(webrtc::scoped_refptr<webrtc::RtpReceiverInterface> rtcReceiver)
-    : LibWebRTCRtpTransformBackend(mediaTypeFromReceiver(*rtcReceiver), Side::Receiver)
+LibWebRTCRtpReceiverTransformBackend::LibWebRTCRtpReceiverTransformBackend(Ref<webrtc::RtpReceiverInterface>&& rtcReceiver)
+    : LibWebRTCRtpTransformBackend(mediaTypeFromReceiver(rtcReceiver), Side::Receiver)
     , m_rtcReceiver(WTFMove(rtcReceiver))
 {
 }

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverTransformBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverTransformBackend.h
@@ -26,37 +26,25 @@
 
 #if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
+#include "LibWebRTCRtpReceiverBackend.h"
 #include "LibWebRTCRtpTransformBackend.h"
-#include <wtf/Ref.h>
-
-ALLOW_UNUSED_PARAMETERS_BEGIN
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-
-#include <webrtc/api/rtp_receiver_interface.h>
-
-ALLOW_DEPRECATED_DECLARATIONS_END
-ALLOW_UNUSED_PARAMETERS_END
-
-namespace webrtc {
-class RtpReceiverInterface;
-}
 
 namespace WebCore {
 
 class LibWebRTCRtpReceiverTransformBackend final : public LibWebRTCRtpTransformBackend {
 public:
-    static Ref<LibWebRTCRtpReceiverTransformBackend> create(webrtc::scoped_refptr<webrtc::RtpReceiverInterface> receiver) { return adoptRef(*new LibWebRTCRtpReceiverTransformBackend(WTFMove(receiver))); }
+    static Ref<LibWebRTCRtpReceiverTransformBackend> create(Ref<webrtc::RtpReceiverInterface>&& receiver) { return adoptRef(*new LibWebRTCRtpReceiverTransformBackend(WTFMove(receiver))); }
     ~LibWebRTCRtpReceiverTransformBackend();
 
 private:
-    explicit LibWebRTCRtpReceiverTransformBackend(webrtc::scoped_refptr<webrtc::RtpReceiverInterface>);
+    explicit LibWebRTCRtpReceiverTransformBackend(Ref<webrtc::RtpReceiverInterface>&&);
 
     // RTCRtpTransformBackend
     void setTransformableFrameCallback(Callback&&) final;
     bool requestKeyFrame(const String&) final;
 
     bool m_isRegistered { false };
-    webrtc::scoped_refptr<webrtc::RtpReceiverInterface> m_rtcReceiver;
+    const Ref<webrtc::RtpReceiverInterface> m_rtcReceiver;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.cpp
@@ -43,13 +43,13 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(LibWebRTCRtpSenderBackend);
 
-LibWebRTCRtpSenderBackend::LibWebRTCRtpSenderBackend(LibWebRTCPeerConnectionBackend& backend, webrtc::scoped_refptr<webrtc::RtpSenderInterface>&& rtcSender)
+LibWebRTCRtpSenderBackend::LibWebRTCRtpSenderBackend(LibWebRTCPeerConnectionBackend& backend, RefPtr<webrtc::RtpSenderInterface>&& rtcSender)
     : m_peerConnectionBackend(backend)
     , m_rtcSender(WTFMove(rtcSender))
 {
 }
 
-LibWebRTCRtpSenderBackend::LibWebRTCRtpSenderBackend(LibWebRTCPeerConnectionBackend& backend, webrtc::scoped_refptr<webrtc::RtpSenderInterface>&& rtcSender, Source&& source)
+LibWebRTCRtpSenderBackend::LibWebRTCRtpSenderBackend(LibWebRTCPeerConnectionBackend& backend, RefPtr<webrtc::RtpSenderInterface>&& rtcSender, Source&& source)
     : m_peerConnectionBackend(backend)
     , m_rtcSender(WTFMove(rtcSender))
     , m_source(WTFMove(source))
@@ -210,20 +210,20 @@ void LibWebRTCRtpSenderBackend::setParameters(const RTCRtpSendParameters& parame
 
 std::unique_ptr<RTCDTMFSenderBackend> LibWebRTCRtpSenderBackend::createDTMFBackend()
 {
-    return makeUnique<LibWebRTCDTMFSenderBackend>(m_rtcSender->GetDtmfSender());
+    return makeUnique<LibWebRTCDTMFSenderBackend>(toRef(m_rtcSender->GetDtmfSender()));
 }
 
 Ref<RTCRtpTransformBackend> LibWebRTCRtpSenderBackend::rtcRtpTransformBackend()
 {
     if (!m_transformBackend)
-        m_transformBackend = LibWebRTCRtpSenderTransformBackend::create(m_rtcSender);
+        lazyInitialize(m_transformBackend, LibWebRTCRtpSenderTransformBackend::create(*m_rtcSender));
     return *m_transformBackend;
 }
 
 std::unique_ptr<RTCDtlsTransportBackend> LibWebRTCRtpSenderBackend::dtlsTransportBackend()
 {
-    auto backend = m_rtcSender->dtls_transport();
-    return backend ? makeUnique<LibWebRTCDtlsTransportBackend>(WTFMove(backend)) : nullptr;
+    RefPtr backend = toRefPtr(m_rtcSender->dtls_transport());
+    return backend ? makeUnique<LibWebRTCDtlsTransportBackend>(backend.releaseNonNull()) : nullptr;
 }
 
 void LibWebRTCRtpSenderBackend::setMediaStreamIds(const FixedVector<String>& streamIds)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.h
@@ -28,18 +28,12 @@
 
 #include "LibWebRTCMacros.h"
 #include "LibWebRTCPeerConnectionBackend.h"
+#include "LibWebRTCRefWrappers.h"
 #include "RTCRtpSenderBackend.h"
 #include "RealtimeOutgoingAudioSource.h"
 #include "RealtimeOutgoingVideoSource.h"
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
-
-ALLOW_UNUSED_PARAMETERS_BEGIN
-
-#include <webrtc/api/rtp_sender_interface.h>
-#include <webrtc/api/scoped_refptr.h>
-
-ALLOW_UNUSED_PARAMETERS_END
 
 namespace WebCore {
 class LibWebRTCRtpSenderBackend;
@@ -58,12 +52,13 @@ class LibWebRTCRtpSenderBackend final : public RTCRtpSenderBackend, public CanMa
     WTF_MAKE_TZONE_ALLOCATED(LibWebRTCRtpSenderBackend);
 public:
     using Source = Variant<std::nullptr_t, Ref<RealtimeOutgoingAudioSource>, Ref<RealtimeOutgoingVideoSource>>;
-    LibWebRTCRtpSenderBackend(LibWebRTCPeerConnectionBackend&, webrtc::scoped_refptr<webrtc::RtpSenderInterface>&&, Source&&);
-    LibWebRTCRtpSenderBackend(LibWebRTCPeerConnectionBackend&, webrtc::scoped_refptr<webrtc::RtpSenderInterface>&&);
+    LibWebRTCRtpSenderBackend(LibWebRTCPeerConnectionBackend&, RefPtr<webrtc::RtpSenderInterface>&&, Source&&);
+    LibWebRTCRtpSenderBackend(LibWebRTCPeerConnectionBackend&, RefPtr<webrtc::RtpSenderInterface>&&);
     ~LibWebRTCRtpSenderBackend();
 
-    void setRTCSender(webrtc::scoped_refptr<webrtc::RtpSenderInterface>&& rtcSender) { m_rtcSender = WTFMove(rtcSender); }
+    void setRTCSender(RefPtr<webrtc::RtpSenderInterface>&& rtcSender) { m_rtcSender = WTFMove(rtcSender); }
     webrtc::RtpSenderInterface* rtcSender() { return m_rtcSender.get(); }
+    RefPtr<webrtc::RtpSenderInterface> protectedRTCSender() { return m_rtcSender; }
 
     RealtimeOutgoingVideoSource* videoSource();
     void clearSource() { setSource(nullptr); }
@@ -86,9 +81,9 @@ private:
     RefPtr<LibWebRTCPeerConnectionBackend> protectedPeerConnectionBackend() const;
 
     WeakPtr<LibWebRTCPeerConnectionBackend> m_peerConnectionBackend;
-    webrtc::scoped_refptr<webrtc::RtpSenderInterface> m_rtcSender;
+    RefPtr<webrtc::RtpSenderInterface> m_rtcSender;
     Source m_source;
-    RefPtr<RTCRtpTransformBackend> m_transformBackend;
+    const RefPtr<RTCRtpTransformBackend> m_transformBackend;
     mutable std::optional<webrtc::RtpParameters> m_currentParameters;
 };
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderTransformBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderTransformBackend.cpp
@@ -39,8 +39,8 @@ static inline LibWebRTCRtpSenderTransformBackend::MediaType mediaTypeFromSender(
     return sender.media_type() == webrtc::MediaType::AUDIO ? RTCRtpTransformBackend::MediaType::Audio : RTCRtpTransformBackend::MediaType::Video;
 }
 
-LibWebRTCRtpSenderTransformBackend::LibWebRTCRtpSenderTransformBackend(webrtc::scoped_refptr<webrtc::RtpSenderInterface> rtcSender)
-    : LibWebRTCRtpTransformBackend(mediaTypeFromSender(*rtcSender), Side::Sender)
+LibWebRTCRtpSenderTransformBackend::LibWebRTCRtpSenderTransformBackend(Ref<webrtc::RtpSenderInterface>&& rtcSender)
+    : LibWebRTCRtpTransformBackend(mediaTypeFromSender(rtcSender), Side::Sender)
     , m_rtcSender(WTFMove(rtcSender))
 {
 }

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderTransformBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderTransformBackend.h
@@ -26,21 +26,8 @@
 
 #if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
+#include "LibWebRTCRtpSenderBackend.h"
 #include "LibWebRTCRtpTransformBackend.h"
-#include <wtf/Ref.h>
-#include <wtf/TZoneMalloc.h>
-
-ALLOW_UNUSED_PARAMETERS_BEGIN
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-
-#include <webrtc/api/rtp_sender_interface.h>
-
-ALLOW_DEPRECATED_DECLARATIONS_END
-ALLOW_UNUSED_PARAMETERS_END
-
-namespace webrtc {
-class RtpSenderInterface;
-}
 
 namespace WebCore {
 
@@ -49,18 +36,18 @@ class LibWebRTCSenderTransformer;
 class LibWebRTCRtpSenderTransformBackend final : public LibWebRTCRtpTransformBackend {
     WTF_MAKE_TZONE_ALLOCATED(LibWebRTCRtpSenderTransformBackend);
 public:
-    static Ref<LibWebRTCRtpSenderTransformBackend> create(webrtc::scoped_refptr<webrtc::RtpSenderInterface> sender) { return adoptRef(*new LibWebRTCRtpSenderTransformBackend(WTFMove(sender))); }
+    static Ref<LibWebRTCRtpSenderTransformBackend> create(Ref<webrtc::RtpSenderInterface>&& sender) { return adoptRef(*new LibWebRTCRtpSenderTransformBackend(WTFMove(sender))); }
     ~LibWebRTCRtpSenderTransformBackend();
 
 private:
-    explicit LibWebRTCRtpSenderTransformBackend(webrtc::scoped_refptr<webrtc::RtpSenderInterface>);
+    explicit LibWebRTCRtpSenderTransformBackend(Ref<webrtc::RtpSenderInterface>&&);
 
     // RTCRtpTransformBackend
     void setTransformableFrameCallback(Callback&&) final;
     bool requestKeyFrame(const String&) final;
 
     bool m_isRegistered { false };
-    webrtc::scoped_refptr<webrtc::RtpSenderInterface> m_rtcSender;
+    const Ref<webrtc::RtpSenderInterface> m_rtcSender;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransceiverBackend.cpp
@@ -41,12 +41,12 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(LibWebRTCRtpTransceiverBackend);
 
 std::unique_ptr<LibWebRTCRtpReceiverBackend> LibWebRTCRtpTransceiverBackend::createReceiverBackend()
 {
-    return makeUnique<LibWebRTCRtpReceiverBackend>(m_rtcTransceiver->receiver());
+    return makeUnique<LibWebRTCRtpReceiverBackend>(toRef(m_rtcTransceiver->receiver()));
 }
 
 std::unique_ptr<LibWebRTCRtpSenderBackend> LibWebRTCRtpTransceiverBackend::createSenderBackend(LibWebRTCPeerConnectionBackend& backend, LibWebRTCRtpSenderBackend::Source&& source)
 {
-    return makeUnique<LibWebRTCRtpSenderBackend>(backend, m_rtcTransceiver->sender(), WTFMove(source));
+    return makeUnique<LibWebRTCRtpSenderBackend>(backend, toRefPtr(m_rtcTransceiver->sender()), WTFMove(source));
 }
 
 RTCRtpTransceiverDirection LibWebRTCRtpTransceiverBackend::direction() const

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransceiverBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransceiverBackend.h
@@ -27,18 +27,10 @@
 #if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
 #include "LibWebRTCMacros.h"
+#include "LibWebRTCRefWrappers.h"
 #include "LibWebRTCRtpSenderBackend.h"
 #include "RTCRtpTransceiverBackend.h"
 #include <wtf/TZoneMalloc.h>
-
-ALLOW_UNUSED_PARAMETERS_BEGIN
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-
-#include <webrtc/api/rtp_transceiver_interface.h>
-#include <webrtc/api/scoped_refptr.h>
-
-ALLOW_DEPRECATED_DECLARATIONS_END
-ALLOW_UNUSED_PARAMETERS_END
 
 namespace WebCore {
 
@@ -47,7 +39,7 @@ class LibWebRTCRtpReceiverBackend;
 class LibWebRTCRtpTransceiverBackend final : public RTCRtpTransceiverBackend {
     WTF_MAKE_TZONE_ALLOCATED(LibWebRTCRtpTransceiverBackend);
 public:
-    explicit LibWebRTCRtpTransceiverBackend(webrtc::scoped_refptr<webrtc::RtpTransceiverInterface>&& rtcTransceiver)
+    explicit LibWebRTCRtpTransceiverBackend(Ref<webrtc::RtpTransceiverInterface>&& rtcTransceiver)
         : m_rtcTransceiver(WTFMove(rtcTransceiver))
     {
     }
@@ -55,7 +47,7 @@ public:
     std::unique_ptr<LibWebRTCRtpReceiverBackend> createReceiverBackend();
     std::unique_ptr<LibWebRTCRtpSenderBackend> createSenderBackend(LibWebRTCPeerConnectionBackend&, LibWebRTCRtpSenderBackend::Source&&);
 
-    webrtc::RtpTransceiverInterface* rtcTransceiver() { return m_rtcTransceiver.get(); }
+    webrtc::RtpTransceiverInterface* rtcTransceiver() { return m_rtcTransceiver.ptr(); }
 
 private:
     RTCRtpTransceiverDirection direction() const final;
@@ -66,7 +58,7 @@ private:
     bool stopped() const final;
     ExceptionOr<void> setCodecPreferences(const Vector<RTCRtpCodecCapability>&) final;
 
-    webrtc::scoped_refptr<webrtc::RtpTransceiverInterface> m_rtcTransceiver;
+    const Ref<webrtc::RtpTransceiverInterface> m_rtcTransceiver;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformBackend.cpp
@@ -42,7 +42,7 @@ void LibWebRTCRtpTransformBackend::clearTransformableFrameCallback()
     setInputCallback({ });
 }
 
-void LibWebRTCRtpTransformBackend::addOutputCallback(webrtc::scoped_refptr<webrtc::TransformedFrameCallback>&& callback, uint32_t ssrc)
+void LibWebRTCRtpTransformBackend::addOutputCallback(Ref<webrtc::TransformedFrameCallback>&& callback, uint32_t ssrc)
 {
     Locker locker { m_outputCallbacksLock };
     m_outputCallbacks.insert_or_assign(ssrc, WTFMove(callback));
@@ -87,12 +87,12 @@ void LibWebRTCRtpTransformBackend::Transform(std::unique_ptr<webrtc::Transformab
 
 void LibWebRTCRtpTransformBackend::RegisterTransformedFrameCallback(webrtc::scoped_refptr<webrtc::TransformedFrameCallback> callback)
 {
-    addOutputCallback(WTFMove(callback), 0);
+    addOutputCallback(toRef(WTFMove(callback)), 0);
 }
 
 void LibWebRTCRtpTransformBackend::RegisterTransformedFrameSinkCallback(webrtc::scoped_refptr<webrtc::TransformedFrameCallback> callback, uint32_t ssrc)
 {
-    addOutputCallback(WTFMove(callback), ssrc);
+    addOutputCallback(toRef(WTFMove(callback)), ssrc);
 }
 
 void LibWebRTCRtpTransformBackend::UnregisterTransformedFrameCallback()

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformBackend.h
@@ -27,16 +27,11 @@
 #if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
 #include "LibWebRTCMacros.h"
+#include "LibWebRTCRefWrappers.h"
 #include "RTCRtpTransformBackend.h"
 #include <webrtc/api/scoped_refptr.h>
 #include <wtf/Lock.h>
 #include <wtf/StdUnorderedMap.h>
-
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
-
-#include <webrtc/api/frame_transformer_interface.h>
-
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace WebCore {
 
@@ -50,7 +45,7 @@ protected:
 
 private:
     void sendFrameToOutput(std::unique_ptr<webrtc::TransformableFrameInterface>&&);
-    void addOutputCallback(webrtc::scoped_refptr<webrtc::TransformedFrameCallback>&&, uint32_t ssrc);
+    void addOutputCallback(Ref<webrtc::TransformedFrameCallback>&&, uint32_t ssrc);
     void removeOutputCallback(uint32_t ssrc);
 
     // RTCRtpTransformBackend
@@ -74,7 +69,7 @@ private:
     Callback m_inputCallback WTF_GUARDED_BY_LOCK(m_inputCallbackLock);
 
     Lock m_outputCallbacksLock;
-    StdUnorderedMap<uint32_t, webrtc::scoped_refptr<webrtc::TransformedFrameCallback>> m_outputCallbacks WTF_GUARDED_BY_LOCK(m_outputCallbacksLock);
+    StdUnorderedMap<uint32_t, Ref<webrtc::TransformedFrameCallback>> m_outputCallbacks WTF_GUARDED_BY_LOCK(m_outputCallbacksLock);
 };
 
 inline LibWebRTCRtpTransformBackend::LibWebRTCRtpTransformBackend(MediaType mediaType, Side side)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCSctpTransportBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCSctpTransportBackend.h
@@ -26,40 +26,27 @@
 
 #if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
-#include "LibWebRTCMacros.h"
+#include "LibWebRTCDtlsTransportBackend.h"
 #include "RTCSctpTransportBackend.h"
-#include <wtf/TZoneMalloc.h>
-#include <wtf/WeakPtr.h>
-
-ALLOW_UNUSED_PARAMETERS_BEGIN
-
-#include <webrtc/api/scoped_refptr.h>
-
-ALLOW_UNUSED_PARAMETERS_END
-
-namespace webrtc {
-class DtlsTransportInterface;
-class SctpTransportInterface;
-}
 
 namespace WebCore {
 class LibWebRTCSctpTransportBackendObserver;
 class LibWebRTCSctpTransportBackend final : public RTCSctpTransportBackend, public CanMakeWeakPtr<LibWebRTCSctpTransportBackend> {
     WTF_MAKE_TZONE_ALLOCATED(LibWebRTCSctpTransportBackend);
 public:
-    explicit LibWebRTCSctpTransportBackend(webrtc::scoped_refptr<webrtc::SctpTransportInterface>&&, webrtc::scoped_refptr<webrtc::DtlsTransportInterface>&&);
+    explicit LibWebRTCSctpTransportBackend(Ref<webrtc::SctpTransportInterface>&&, Ref<webrtc::DtlsTransportInterface>&&);
     ~LibWebRTCSctpTransportBackend();
 
 private:
     // RTCSctpTransportBackend
-    const void* backend() const final { return m_backend.get(); }
+    const void* backend() const final { return m_backend.ptr(); }
     UniqueRef<RTCDtlsTransportBackend> dtlsTransportBackend() final;
     void registerClient(RTCSctpTransportBackendClient&) final;
     void unregisterClient() final;
 
-    webrtc::scoped_refptr<webrtc::SctpTransportInterface> m_backend;
-    webrtc::scoped_refptr<webrtc::DtlsTransportInterface> m_dtlsBackend;
-    RefPtr<LibWebRTCSctpTransportBackendObserver> m_observer;
+    const Ref<webrtc::SctpTransportInterface> m_backend;
+    const Ref<webrtc::DtlsTransportInterface> m_dtlsBackend;
+    const RefPtr<LibWebRTCSctpTransportBackendObserver> m_observer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -52,9 +52,7 @@ Modules/mediastream/RTCRtpScriptTransformer.cpp
 Modules/mediastream/RTCRtpSender.cpp
 Modules/mediastream/RTCRtpTransform.cpp
 Modules/mediastream/UserMediaRequest.cpp
-Modules/mediastream/libwebrtc/LibWebRTCDtlsTransportBackend.cpp
 Modules/mediastream/libwebrtc/LibWebRTCObservers.h
-Modules/mediastream/libwebrtc/LibWebRTCSctpTransportBackend.cpp
 Modules/model-element/HTMLModelElement.cpp
 Modules/model-element/scenekit/SceneKitModelPlayer.mm
 Modules/pictureinpicture/HTMLVideoElementPictureInPicture.cpp

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
@@ -32,6 +32,7 @@
 #include "CVUtilities.h"
 #include "IOSurface.h"
 #include "LibWebRTCDav1dDecoder.h"
+#include "LibWebRTCRefWrappers.h"
 #include "Logging.h"
 #include "VP9Utilities.h"
 #include "VideoFrameLibWebRTC.h"
@@ -260,7 +261,7 @@ int32_t LibWebRTCVPXInternalVideoDecoder::Decoded(webrtc::VideoFrame& frame)
     bool isFullRange = (m_configuration && m_configuration->videoFullRangeFlag == VPConfigurationRange::FullRange) || (m_colorSpace && m_colorSpace->fullRange.value_or(false));
     auto colorSpace = m_colorSpace ? m_colorSpace : m_configuration ? colorSpaceFromVPCodecConfigurationRecord(*m_configuration) : VideoFrameLibWebRTC::colorSpaceFromFrame(frame);
 
-    auto videoFrame = VideoFrameLibWebRTC::create({ }, false, VideoFrame::Rotation::None, VideoFrameLibWebRTC::colorSpaceFromFrame(frame), frame.video_frame_buffer(), [protectedThis = Ref { *this }, colorSpace, isFullRange] (auto& buffer) {
+    auto videoFrame = VideoFrameLibWebRTC::create({ }, false, VideoFrame::Rotation::None, VideoFrameLibWebRTC::colorSpaceFromFrame(frame), toRef(frame.video_frame_buffer()), [protectedThis = Ref { *this }, colorSpace, isFullRange] (auto& buffer) {
         return adoptCF(webrtc::createPixelBufferFromFrameBuffer(buffer, [protectedThis, colorSpace, isFullRange](size_t width, size_t height, webrtc::BufferType bufferType) -> CVPixelBufferRef {
             auto pixelBuffer = protectedThis->createPixelBuffer(width, height, bufferType, isFullRange);
             if (colorSpace)

--- a/Source/WebCore/platform/mediastream/RealtimeIncomingAudioSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeIncomingAudioSource.cpp
@@ -35,15 +35,15 @@
 
 #include "LibWebRTCAudioFormat.h"
 #include "LibWebRTCAudioModule.h"
+#include "LibWebRTCRefWrappers.h"
 #include "Logging.h"
 
 namespace WebCore {
 
-RealtimeIncomingAudioSource::RealtimeIncomingAudioSource(webrtc::scoped_refptr<webrtc::AudioTrackInterface>&& audioTrack, String&& audioTrackId)
+RealtimeIncomingAudioSource::RealtimeIncomingAudioSource(Ref<webrtc::AudioTrackInterface>&& audioTrack, String&& audioTrackId)
     : RealtimeMediaSource(CaptureDevice { WTFMove(audioTrackId), CaptureDevice::DeviceType::Microphone, "remote audio"_s })
     , m_audioTrack(WTFMove(audioTrack))
 {
-    ASSERT(m_audioTrack);
     m_audioTrack->RegisterObserver(this);
 }
 

--- a/Source/WebCore/platform/mediastream/RealtimeIncomingAudioSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeIncomingAudioSource.h
@@ -54,7 +54,7 @@ class RealtimeIncomingAudioSource
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeIncomingAudioSource, WTF::DestructionThread::MainRunLoop>
 {
 public:
-    static Ref<RealtimeIncomingAudioSource> create(webrtc::scoped_refptr<webrtc::AudioTrackInterface>&&, String&&);
+    static Ref<RealtimeIncomingAudioSource> create(Ref<webrtc::AudioTrackInterface>&&, String&&);
 
     void setAudioModule(RefPtr<LibWebRTCAudioModule>&&);
     LibWebRTCAudioModule* audioModule() { return m_audioModule.get(); }
@@ -62,7 +62,7 @@ public:
     WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
     ~RealtimeIncomingAudioSource();
 protected:
-    RealtimeIncomingAudioSource(webrtc::scoped_refptr<webrtc::AudioTrackInterface>&&, String&&);
+    RealtimeIncomingAudioSource(Ref<webrtc::AudioTrackInterface>&&, String&&);
 
 #if !RELEASE_LOG_DISABLED
     ASCIILiteral logClassName() const final { return "RealtimeIncomingAudioSource"_s; }
@@ -85,7 +85,7 @@ private:
     bool isIncomingAudioSource() const final { return true; }
 
     RealtimeMediaSourceSettings m_currentSettings;
-    webrtc::scoped_refptr<webrtc::AudioTrackInterface> m_audioTrack;
+    const Ref<webrtc::AudioTrackInterface> m_audioTrack;
     RefPtr<LibWebRTCAudioModule> m_audioModule;
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.cpp
@@ -47,12 +47,10 @@ static RealtimeMediaSourceSupportedConstraints supportedRealtimeIncomingVideoSou
     return constraints;
 }
 
-RealtimeIncomingVideoSource::RealtimeIncomingVideoSource(webrtc::scoped_refptr<webrtc::VideoTrackInterface>&& videoTrack, String&& videoTrackId)
+RealtimeIncomingVideoSource::RealtimeIncomingVideoSource(Ref<webrtc::VideoTrackInterface>&& videoTrack, String&& videoTrackId)
     : RealtimeMediaSource(CaptureDevice { WTFMove(videoTrackId), CaptureDevice::DeviceType::Camera, "remote video"_s })
     , m_videoTrack(WTFMove(videoTrack))
 {
-    ASSERT(m_videoTrack);
-
     m_currentSettings = RealtimeMediaSourceSettings { };
     m_currentSettings->setSupportedConstraints(supportedRealtimeIncomingVideoSourceSettingConstraints());
 

--- a/Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.h
@@ -33,14 +33,8 @@
 #if USE(LIBWEBRTC)
 
 #include "LibWebRTCMacros.h"
+#include "LibWebRTCRefWrappers.h"
 #include "RealtimeMediaSource.h"
-
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
-
-#include <webrtc/api/media_stream_interface.h>
-
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
-
 #include <wtf/RetainPtr.h>
 
 namespace WebCore {
@@ -55,14 +49,14 @@ class RealtimeIncomingVideoSource
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeIncomingVideoSource, WTF::DestructionThread::MainRunLoop>
 {
 public:
-    static Ref<RealtimeIncomingVideoSource> create(webrtc::scoped_refptr<webrtc::VideoTrackInterface>&&, String&&);
+    static Ref<RealtimeIncomingVideoSource> create(Ref<webrtc::VideoTrackInterface>&&, String&&);
     ~RealtimeIncomingVideoSource();
     WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 
     void enableFrameRatedMonitoring();
 
 protected:
-    RealtimeIncomingVideoSource(webrtc::scoped_refptr<webrtc::VideoTrackInterface>&&, String&&);
+    RealtimeIncomingVideoSource(Ref<webrtc::VideoTrackInterface>&&, String&&);
 
 #if !RELEASE_LOG_DISABLED
     ASCIILiteral logClassName() const final { return "RealtimeIncomingVideoSource"_s; }
@@ -87,7 +81,7 @@ private:
     void OnChanged() final;
 
     std::optional<RealtimeMediaSourceSettings> m_currentSettings;
-    webrtc::scoped_refptr<webrtc::VideoTrackInterface> m_videoTrack;
+    const Ref<webrtc::VideoTrackInterface> m_videoTrack;
 
     double m_currentFrameRate { -1 };
     std::unique_ptr<FrameRateMonitor> m_frameRateMonitor;

--- a/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.cpp
@@ -235,7 +235,7 @@ void RealtimeOutgoingVideoSource::sendBlackFramesIfNeeded()
         if (!m_shouldApplyRotation && (m_currentRotation == webrtc::kVideoRotation_270 || m_currentRotation == webrtc::kVideoRotation_90))
             std::swap(width, height);
 
-        m_blackFrame = createBlackFrame(width, height);
+        m_blackFrame = WTF::toRef(createBlackFrame(width, height));
         ASSERT(m_blackFrame);
         if (!m_blackFrame) {
             ALWAYS_LOG(LOGIDENTIFIER, "Unable to send black frames");
@@ -249,7 +249,7 @@ void RealtimeOutgoingVideoSource::sendBlackFramesIfNeeded()
 void RealtimeOutgoingVideoSource::sendOneBlackFrame()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    sendFrame(webrtc::scoped_refptr<webrtc::VideoFrameBuffer>(m_blackFrame));
+    sendFrame(webrtc::scoped_refptr { m_blackFrame.get() });
 }
 
 void RealtimeOutgoingVideoSource::sendFrame(webrtc::scoped_refptr<webrtc::VideoFrameBuffer>&& buffer)

--- a/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h
@@ -31,16 +31,10 @@
 #if USE(LIBWEBRTC)
 
 #include "LibWebRTCMacros.h"
+#include "LibWebRTCRefWrappers.h"
 #include "MediaStreamTrackPrivate.h"
 #include "Timer.h"
 #include <wtf/Lock.h>
-
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
-
-#include <webrtc/api/media_stream_interface.h>
-
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
-
 #include <wtf/LoggerHelper.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
@@ -142,7 +136,7 @@ private:
 
     Ref<MediaStreamTrackPrivate> m_videoSource;
     Timer m_blackFrameTimer;
-    webrtc::scoped_refptr<webrtc::VideoFrameBuffer> m_blackFrame;
+    RefPtr<webrtc::VideoFrameBuffer> m_blackFrame;
 
     mutable Lock m_sinksLock;
     HashSet<webrtc::VideoSinkInterface<webrtc::VideoFrame>*> m_sinks WTF_GUARDED_BY_LOCK(m_sinksLock);

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDTMFSenderBackend.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDTMFSenderBackend.cpp
@@ -40,7 +40,7 @@ static inline String toWTFString(const std::string& value)
     return String::fromUTF8(value);
 }
 
-LibWebRTCDTMFSenderBackend::LibWebRTCDTMFSenderBackend(webrtc::scoped_refptr<webrtc::DtmfSenderInterface>&& sender)
+LibWebRTCDTMFSenderBackend::LibWebRTCDTMFSenderBackend(Ref<webrtc::DtmfSenderInterface>&& sender)
     : m_sender(WTFMove(sender))
 {
     m_sender->RegisterObserver(this);

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDTMFSenderBackend.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDTMFSenderBackend.h
@@ -27,16 +27,10 @@
 #if USE(LIBWEBRTC)
 
 #include "LibWebRTCMacros.h"
+#include "LibWebRTCRefWrappers.h"
 #include "RTCDTMFSenderBackend.h"
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
-
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
-
-#include <webrtc/api/dtmf_sender_interface.h>
-#include <webrtc/api/scoped_refptr.h>
-
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace WebCore {
 class LibWebRTCDTMFSenderBackend;
@@ -53,7 +47,7 @@ namespace WebCore {
 class LibWebRTCDTMFSenderBackend final : public RTCDTMFSenderBackend, private webrtc::DtmfSenderObserverInterface, public CanMakeWeakPtr<LibWebRTCDTMFSenderBackend, WeakPtrFactoryInitialization::Eager> {
     WTF_MAKE_TZONE_ALLOCATED(LibWebRTCDTMFSenderBackend);
 public:
-    explicit LibWebRTCDTMFSenderBackend(webrtc::scoped_refptr<webrtc::DtmfSenderInterface>&&);
+    explicit LibWebRTCDTMFSenderBackend(Ref<webrtc::DtmfSenderInterface>&&);
     ~LibWebRTCDTMFSenderBackend();
 
 private:
@@ -68,7 +62,7 @@ private:
     // DtmfSenderObserverInterface
     void OnToneChange(const std::string& tone, const std::string&) final;
 
-    webrtc::scoped_refptr<webrtc::DtmfSenderInterface> m_sender;
+    const Ref<webrtc::DtmfSenderInterface> m_sender;
     Function<void()> m_onTonePlayed;
 };
 

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
@@ -308,18 +308,18 @@ void LibWebRTCProvider::clearFactory()
     m_videoEncodingCapabilities = { };
 }
 
-webrtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> LibWebRTCProvider::createPeerConnectionFactory(webrtc::Thread* networkThread, webrtc::Thread* signalingThread)
+Ref<webrtc::PeerConnectionFactoryInterface> LibWebRTCProvider::createPeerConnectionFactory(webrtc::Thread* networkThread, webrtc::Thread* signalingThread)
 {
     willCreatePeerConnectionFactory();
 
     ASSERT(!m_audioModule);
     m_audioModule = LibWebRTCAudioModule::create();
 
-    return webrtc::CreatePeerConnectionFactory(networkThread, signalingThread, signalingThread, webrtc::scoped_refptr<webrtc::AudioDeviceModule>(m_audioModule.get()), webrtc::CreateBuiltinAudioEncoderFactory(), webrtc::CreateBuiltinAudioDecoderFactory(), createEncoderFactory(), createDecoderFactory(), nullptr, nullptr, nullptr, nullptr
+    return toRef(webrtc::CreatePeerConnectionFactory(networkThread, signalingThread, signalingThread, webrtc::scoped_refptr<webrtc::AudioDeviceModule>(m_audioModule.get()), webrtc::CreateBuiltinAudioEncoderFactory(), webrtc::CreateBuiltinAudioDecoderFactory(), createEncoderFactory(), createDecoderFactory(), nullptr, nullptr, nullptr, nullptr
 #if PLATFORM(COCOA)
         , webrtc::CreateTaskQueueGcdFactory()
 #endif
-    );
+    ));
 }
 
 std::unique_ptr<webrtc::VideoDecoderFactory> LibWebRTCProvider::createDecoderFactory()
@@ -340,7 +340,7 @@ void LibWebRTCProvider::startedNetworkThread()
 void LibWebRTCProvider::setPeerConnectionFactory(webrtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface>&& factory)
 {
     auto* thread = getStaticFactoryAndThreads(m_useNetworkThreadWithSocketServer).signalingThread.get();
-    m_factory = webrtc::PeerConnectionFactoryProxy::Create(thread, thread, WTFMove(factory));
+    m_factory = toRef<webrtc::PeerConnectionFactoryInterface>(webrtc::PeerConnectionFactoryProxy::Create(thread, thread, WTFMove(factory)));
 }
 
 webrtc::scoped_refptr<webrtc::PeerConnectionInterface> LibWebRTCProvider::createPeerConnection(ScriptExecutionContextIdentifier, webrtc::PeerConnectionObserver& observer, webrtc::PacketSocketFactory*, webrtc::PeerConnectionInterface::RTCConfiguration&& configuration)

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.h
@@ -28,6 +28,7 @@
 #if USE(LIBWEBRTC)
 
 #include "LibWebRTCMacros.h"
+#include "LibWebRTCRefWrappers.h"
 #include "ScriptExecutionContextIdentifier.h"
 #include "WebRTCProvider.h"
 #include <wtf/Compiler.h>
@@ -51,7 +52,6 @@ namespace webrtc {
 class AsyncDnsResolverFactory;
 class NetworkManager;
 class PacketSocketFactory;
-class PeerConnectionFactoryInterface;
 class RTCCertificateGenerator;
 class Thread;
 }
@@ -122,7 +122,7 @@ protected:
 
     webrtc::scoped_refptr<webrtc::PeerConnectionInterface> createPeerConnection(webrtc::PeerConnectionObserver&, webrtc::NetworkManager&, webrtc::PacketSocketFactory&, webrtc::PeerConnectionInterface::RTCConfiguration&&, std::unique_ptr<webrtc::AsyncDnsResolverFactoryInterface>&&);
 
-    webrtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> createPeerConnectionFactory(webrtc::Thread* networkThread, webrtc::Thread* signalingThread);
+    Ref<webrtc::PeerConnectionFactoryInterface> createPeerConnectionFactory(webrtc::Thread* networkThread, webrtc::Thread* signalingThread);
     virtual std::unique_ptr<webrtc::VideoDecoderFactory> createDecoderFactory();
     virtual std::unique_ptr<webrtc::VideoEncoderFactory> createEncoderFactory();
 
@@ -131,7 +131,7 @@ protected:
     PeerConnectionFactoryAndThreads& getStaticFactoryAndThreads(bool useNetworkThreadWithSocketServer);
 
     RefPtr<LibWebRTCAudioModule> m_audioModule;
-    webrtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> m_factory;
+    RefPtr<webrtc::PeerConnectionFactoryInterface> m_factory;
     // FIXME: Remove m_useNetworkThreadWithSocketServer member variable and make it a global.
     bool m_useNetworkThreadWithSocketServer { true };
 

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCRefWrappers.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCRefWrappers.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
+
+#include "LibWebRTCMacros.h"
+
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+IGNORE_CLANG_WARNINGS_BEGIN("nullability-completeness")
+#include <webrtc/api/data_channel_interface.h>
+#include <webrtc/api/dtls_transport_interface.h>
+#include <webrtc/api/dtmf_sender_interface.h>
+#include <webrtc/api/frame_transformer_interface.h>
+#include <webrtc/api/ice_transport_interface.h>
+#include <webrtc/api/media_stream_interface.h>
+#include <webrtc/api/peer_connection_interface.h>
+#include <webrtc/api/rtp_receiver_interface.h>
+#include <webrtc/api/rtp_sender_interface.h>
+#include <webrtc/api/rtp_transceiver_interface.h>
+#include <webrtc/api/sctp_transport_interface.h>
+IGNORE_CLANG_WARNINGS_END
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+
+namespace WTF {
+
+template<typename T> struct RTCDefaultRefDerefTraits {
+    static ALWAYS_INLINE T* refIfNotNull(T* buffer)
+    {
+        if (buffer) [[likely]]
+            buffer->AddRef();
+        return buffer;
+    }
+    static ALWAYS_INLINE T& ref(T& ref)
+    {
+        ref.AddRef();
+        return ref;
+    }
+    static ALWAYS_INLINE void derefIfNotNull(T* buffer)
+    {
+        if (buffer) [[likely]]
+            buffer->Release();
+    }
+};
+
+#define WEBRTC_REFTRAITS(T) template<> struct DefaultRefDerefTraits<T> : RTCDefaultRefDerefTraits<T> { };
+
+WEBRTC_REFTRAITS(webrtc::AudioTrackInterface);
+WEBRTC_REFTRAITS(webrtc::DataChannelInterface);
+WEBRTC_REFTRAITS(webrtc::DtlsTransportInterface);
+WEBRTC_REFTRAITS(webrtc::DtmfSenderInterface);
+WEBRTC_REFTRAITS(webrtc::IceTransportInterface);
+WEBRTC_REFTRAITS(webrtc::MediaStreamInterface);
+WEBRTC_REFTRAITS(webrtc::MediaStreamTrackInterface);
+WEBRTC_REFTRAITS(webrtc::PeerConnectionFactoryInterface);
+WEBRTC_REFTRAITS(webrtc::PeerConnectionInterface);
+WEBRTC_REFTRAITS(webrtc::RtpReceiverInterface);
+WEBRTC_REFTRAITS(webrtc::RtpSenderInterface);
+WEBRTC_REFTRAITS(webrtc::RtpTransceiverInterface);
+WEBRTC_REFTRAITS(webrtc::TransformedFrameCallback);
+WEBRTC_REFTRAITS(webrtc::SctpTransportInterface);
+WEBRTC_REFTRAITS(webrtc::VideoFrameBuffer);
+WEBRTC_REFTRAITS(webrtc::VideoTrackInterface);
+
+template<typename T>
+Ref<T> toRef(webrtc::scoped_refptr<T>&& buffer)
+{
+    ASSERT(buffer);
+    return adoptRef(*buffer.release());
+}
+
+template<typename T>
+RefPtr<T> toRefPtr(webrtc::scoped_refptr<T>&& buffer)
+{
+    return adoptRef(buffer.release());
+}
+}
+
+using WTF::toRef;
+using WTF::toRefPtr;
+
+#endif // ENABLE(WEB_RTC) && USE(LIBWEBRTC)

--- a/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.cpp
@@ -38,7 +38,7 @@ static PlatformVideoColorSpace defaultVPXColorSpace()
     return { PlatformVideoColorPrimaries::Bt709, PlatformVideoTransferCharacteristics::Bt709, PlatformVideoMatrixCoefficients::Bt709, false };
 }
 
-RefPtr<VideoFrameLibWebRTC> VideoFrameLibWebRTC::create(MediaTime presentationTime, bool isMirrored, Rotation rotation, std::optional<PlatformVideoColorSpace>&& colorSpace, webrtc::scoped_refptr<webrtc::VideoFrameBuffer>&& buffer, ConversionCallback&& conversionCallback)
+RefPtr<VideoFrameLibWebRTC> VideoFrameLibWebRTC::create(MediaTime presentationTime, bool isMirrored, Rotation rotation, std::optional<PlatformVideoColorSpace>&& colorSpace, Ref<webrtc::VideoFrameBuffer>&& buffer, ConversionCallback&& conversionCallback)
 {
     auto bufferType = buffer->type();
     if (bufferType != webrtc::VideoFrameBuffer::Type::kI420
@@ -197,7 +197,7 @@ std::optional<PlatformVideoColorSpace> VideoFrameLibWebRTC::colorSpaceFromFrame(
     return PlatformVideoColorSpace { primaries, transfer, matrix, fullRange };
 }
 
-VideoFrameLibWebRTC::VideoFrameLibWebRTC(MediaTime presentationTime, bool isMirrored, Rotation rotation, PlatformVideoColorSpace&& colorSpace, webrtc::scoped_refptr<webrtc::VideoFrameBuffer>&& buffer, ConversionCallback&& conversionCallback)
+VideoFrameLibWebRTC::VideoFrameLibWebRTC(MediaTime presentationTime, bool isMirrored, Rotation rotation, PlatformVideoColorSpace&& colorSpace, Ref<webrtc::VideoFrameBuffer>&& buffer, ConversionCallback&& conversionCallback)
     : VideoFrame(presentationTime, isMirrored, rotation, WTFMove(colorSpace))
     , m_buffer(WTFMove(buffer))
     , m_size(m_buffer->width(),  m_buffer->height())
@@ -223,13 +223,13 @@ CVPixelBufferRef VideoFrameLibWebRTC::pixelBuffer() const
 {
     Locker locker { m_pixelBufferLock };
     if (!m_pixelBuffer && m_conversionCallback)
-        m_pixelBuffer = std::exchange(m_conversionCallback, { })(*m_buffer);
+        m_pixelBuffer = std::exchange(m_conversionCallback, { })(m_buffer.get());
     return m_pixelBuffer.get();
 }
 
 Ref<VideoFrame> VideoFrameLibWebRTC::clone()
 {
-    return adoptRef(*new VideoFrameLibWebRTC(presentationTime(), isMirrored(), rotation(), PlatformVideoColorSpace { colorSpace() }, webrtc::scoped_refptr<webrtc::VideoFrameBuffer> { m_buffer }, ConversionCallback { m_conversionCallback }));
+    return adoptRef(*new VideoFrameLibWebRTC(presentationTime(), isMirrored(), rotation(), PlatformVideoColorSpace { colorSpace() }, m_buffer.get(), ConversionCallback { m_conversionCallback }));
 }
 
 }

--- a/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.h
@@ -27,6 +27,7 @@
 
 #if PLATFORM(COCOA) && USE(LIBWEBRTC)
 
+#include "LibWebRTCUtils.h"
 #include "VideoFrame.h"
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
@@ -38,20 +39,19 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 typedef struct CF_BRIDGED_TYPE(id) __CVBuffer *CVPixelBufferRef;
 
-
 namespace WebCore {
 
 class VideoFrameLibWebRTC final : public VideoFrame {
 public:
     using ConversionCallback = std::function<RetainPtr<CVPixelBufferRef>(webrtc::VideoFrameBuffer&)>;
-    static RefPtr<VideoFrameLibWebRTC> create(MediaTime, bool isMirrored, Rotation, std::optional<PlatformVideoColorSpace>&&, webrtc::scoped_refptr<webrtc::VideoFrameBuffer>&&, ConversionCallback&&);
+    static RefPtr<VideoFrameLibWebRTC> create(MediaTime, bool isMirrored, Rotation, std::optional<PlatformVideoColorSpace>&&, Ref<webrtc::VideoFrameBuffer>&&, ConversionCallback&&);
 
-    webrtc::scoped_refptr<webrtc::VideoFrameBuffer> buffer() const { return m_buffer; }
+    webrtc::scoped_refptr<webrtc::VideoFrameBuffer> buffer() const { return webrtc::scoped_refptr { m_buffer.ptr() }; }
 
     static std::optional<PlatformVideoColorSpace> colorSpaceFromFrame(const webrtc::VideoFrame&);
 
 private:
-    VideoFrameLibWebRTC(MediaTime, bool isMirrored, Rotation, PlatformVideoColorSpace&&, webrtc::scoped_refptr<webrtc::VideoFrameBuffer>&&, ConversionCallback&&);
+    VideoFrameLibWebRTC(MediaTime, bool isMirrored, Rotation, PlatformVideoColorSpace&&, Ref<webrtc::VideoFrameBuffer>&&, ConversionCallback&&);
 
     // VideoFrame
     IntSize presentationSize() const final { return m_size; }
@@ -60,7 +60,7 @@ private:
 
     Ref<VideoFrame> clone() final;
 
-    const webrtc::scoped_refptr<webrtc::VideoFrameBuffer> m_buffer;
+    const Ref<webrtc::VideoFrameBuffer> m_buffer;
     IntSize m_size;
     uint32_t m_videoPixelFormat { 0 };
 

--- a/Source/WebCore/platform/mediastream/mac/RealtimeIncomingAudioSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/mac/RealtimeIncomingAudioSourceCocoa.cpp
@@ -41,14 +41,14 @@
 
 namespace WebCore {
 
-Ref<RealtimeIncomingAudioSource> RealtimeIncomingAudioSource::create(webrtc::scoped_refptr<webrtc::AudioTrackInterface>&& audioTrack, String&& audioTrackId)
+Ref<RealtimeIncomingAudioSource> RealtimeIncomingAudioSource::create(Ref<webrtc::AudioTrackInterface>&& audioTrack, String&& audioTrackId)
 {
     auto source = RealtimeIncomingAudioSourceCocoa::create(WTFMove(audioTrack), WTFMove(audioTrackId));
     source->start();
     return WTFMove(source);
 }
 
-Ref<RealtimeIncomingAudioSourceCocoa> RealtimeIncomingAudioSourceCocoa::create(webrtc::scoped_refptr<webrtc::AudioTrackInterface>&& audioTrack, String&& audioTrackId)
+Ref<RealtimeIncomingAudioSourceCocoa> RealtimeIncomingAudioSourceCocoa::create(Ref<webrtc::AudioTrackInterface>&& audioTrack, String&& audioTrackId)
 {
     return adoptRef(*new RealtimeIncomingAudioSourceCocoa(WTFMove(audioTrack), WTFMove(audioTrackId)));
 }
@@ -60,7 +60,7 @@ static inline AudioStreamBasicDescription streamDescription(size_t sampleRate, s
     return streamFormat;
 }
 
-RealtimeIncomingAudioSourceCocoa::RealtimeIncomingAudioSourceCocoa(webrtc::scoped_refptr<webrtc::AudioTrackInterface>&& audioTrack, String&& audioTrackId)
+RealtimeIncomingAudioSourceCocoa::RealtimeIncomingAudioSourceCocoa(Ref<webrtc::AudioTrackInterface>&& audioTrack, String&& audioTrackId)
     : RealtimeIncomingAudioSource(WTFMove(audioTrack), WTFMove(audioTrackId))
     , m_sampleRate(LibWebRTCAudioFormat::sampleRate)
     , m_numberOfChannels(1)

--- a/Source/WebCore/platform/mediastream/mac/RealtimeIncomingAudioSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/mac/RealtimeIncomingAudioSourceCocoa.h
@@ -41,10 +41,10 @@ namespace WebCore {
 
 class RealtimeIncomingAudioSourceCocoa final : public RealtimeIncomingAudioSource {
 public:
-    static Ref<RealtimeIncomingAudioSourceCocoa> create(webrtc::scoped_refptr<webrtc::AudioTrackInterface>&&, String&&);
+    static Ref<RealtimeIncomingAudioSourceCocoa> create(Ref<webrtc::AudioTrackInterface>&&, String&&);
 
 private:
-    RealtimeIncomingAudioSourceCocoa(webrtc::scoped_refptr<webrtc::AudioTrackInterface>&&, String&&);
+    RealtimeIncomingAudioSourceCocoa(Ref<webrtc::AudioTrackInterface>&&, String&&);
 
     // RealtimeMediaSource API
     void startProducingData() final;

--- a/Source/WebCore/platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.h
@@ -44,10 +44,10 @@ enum class VideoFrameRotation : uint16_t;
 
 class RealtimeIncomingVideoSourceCocoa final : public RealtimeIncomingVideoSource {
 public:
-    static Ref<RealtimeIncomingVideoSourceCocoa> create(webrtc::scoped_refptr<webrtc::VideoTrackInterface>&&, String&&);
+    static Ref<RealtimeIncomingVideoSourceCocoa> create(Ref<webrtc::VideoTrackInterface>&&, String&&);
 
 private:
-    RealtimeIncomingVideoSourceCocoa(webrtc::scoped_refptr<webrtc::VideoTrackInterface>&&, String&&);
+    RealtimeIncomingVideoSourceCocoa(Ref<webrtc::VideoTrackInterface>&&, String&&);
     RetainPtr<CVPixelBufferRef> pixelBufferFromVideoFrame(const webrtc::VideoFrame&);
     CVPixelBufferPoolRef pixelBufferPool(size_t width, size_t height, webrtc::BufferType);
     RefPtr<VideoFrame> toVideoFrame(const webrtc::VideoFrame&, VideoFrameRotation);

--- a/Source/WebCore/platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm
+++ b/Source/WebCore/platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm
@@ -45,19 +45,19 @@ ALLOW_UNUSED_PARAMETERS_END
 
 namespace WebCore {
 
-Ref<RealtimeIncomingVideoSource> RealtimeIncomingVideoSource::create(webrtc::scoped_refptr<webrtc::VideoTrackInterface>&& videoTrack, String&& trackId)
+Ref<RealtimeIncomingVideoSource> RealtimeIncomingVideoSource::create(Ref<webrtc::VideoTrackInterface>&& videoTrack, String&& trackId)
 {
     auto source = RealtimeIncomingVideoSourceCocoa::create(WTFMove(videoTrack), WTFMove(trackId));
     source->start();
     return WTFMove(source);
 }
 
-Ref<RealtimeIncomingVideoSourceCocoa> RealtimeIncomingVideoSourceCocoa::create(webrtc::scoped_refptr<webrtc::VideoTrackInterface>&& videoTrack, String&& trackId)
+Ref<RealtimeIncomingVideoSourceCocoa> RealtimeIncomingVideoSourceCocoa::create(Ref<webrtc::VideoTrackInterface>&& videoTrack, String&& trackId)
 {
     return adoptRef(*new RealtimeIncomingVideoSourceCocoa(WTFMove(videoTrack), WTFMove(trackId)));
 }
 
-RealtimeIncomingVideoSourceCocoa::RealtimeIncomingVideoSourceCocoa(webrtc::scoped_refptr<webrtc::VideoTrackInterface>&& videoTrack, String&& videoTrackId)
+RealtimeIncomingVideoSourceCocoa::RealtimeIncomingVideoSourceCocoa(Ref<webrtc::VideoTrackInterface>&& videoTrack, String&& videoTrackId)
     : RealtimeIncomingVideoSource(WTFMove(videoTrack), WTFMove(videoTrackId))
 {
 }
@@ -119,7 +119,7 @@ RefPtr<VideoFrame> RealtimeIncomingVideoSourceCocoa::toVideoFrame(const webrtc::
         return createVideoSampleFromCVPixelBuffer(WTFMove(pixelBuffer), rotation, frame.timestamp_us());
 
     // In case of in memory libwebrtc samples, we have non interleaved YUV data, let's lazily create CVPixelBuffers if needed.
-    return VideoFrameLibWebRTC::create(MediaTime(frame.timestamp_us(), 1000000), false, rotation, VideoFrameLibWebRTC::colorSpaceFromFrame(frame), frame.video_frame_buffer(), [protectedThis = Ref { *this }, this](auto& buffer) {
+    return VideoFrameLibWebRTC::create(MediaTime(frame.timestamp_us(), 1000000), false, rotation, VideoFrameLibWebRTC::colorSpaceFromFrame(frame), toRef(frame.video_frame_buffer()), [protectedThis = Ref { *this }, this](auto& buffer) {
         return adoptCF(webrtc::createPixelBufferFromFrameBuffer(buffer, [this](size_t width, size_t height, webrtc::BufferType bufferType) -> CVPixelBufferRef {
             Locker lock(m_pixelBufferPoolLock);
             auto pixelBufferPool = this->pixelBufferPool(width, height, bufferType);


### PR DESCRIPTION
#### fce4138231d1c4c2ff4ca1f32c65c51673477cfb
<pre>
Allow to use Ref/RefPtr for webrtc::RefCountInterface objects
<a href="https://rdar.apple.com/155595987">rdar://155595987</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=295766">https://bugs.webkit.org/show_bug.cgi?id=295766</a>

Reviewed by Jean-Yves Avenard.

We move away from using scoped_refptr objects in WebCore code and move to using Ref/RefPtr to allow better safer CPP validation of the webrtc code.
This also allows using more Ref vs. RefPtr which is nicer to read.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.cpp:
(WebCore::LibWebRTCDataChannelHandler::LibWebRTCDataChannelHandler):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDtlsTransportBackend.cpp:
(WebCore::LibWebRTCDtlsTransportBackendObserver::LibWebRTCDtlsTransportBackendObserver):
(WebCore::LibWebRTCDtlsTransportBackend::LibWebRTCDtlsTransportBackend):
(WebCore::LibWebRTCDtlsTransportBackend::registerClient):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDtlsTransportBackend.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCIceTransportBackend.cpp:
(WebCore::LibWebRTCIceTransportBackendObserver::LibWebRTCIceTransportBackendObserver):
(WebCore::LibWebRTCIceTransportBackend::LibWebRTCIceTransportBackend):
(WebCore::LibWebRTCIceTransportBackend::registerClient):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCIceTransportBackend.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp:
(WebCore::LibWebRTCMediaEndpoint::LibWebRTCMediaEndpoint):
(WebCore::LibWebRTCMediaEndpoint::restartIce):
(WebCore::LibWebRTCMediaEndpoint::setConfiguration):
(WebCore::LibWebRTCMediaEndpoint::isNegotiationNeeded const):
(WebCore::LibWebRTCMediaEndpoint::doSetLocalDescription):
(WebCore::LibWebRTCMediaEndpoint::doSetRemoteDescription):
(WebCore::LibWebRTCMediaEndpoint::addTrack):
(WebCore::LibWebRTCMediaEndpoint::removeTrack):
(WebCore::LibWebRTCMediaEndpoint::doCreateOffer):
(WebCore::LibWebRTCMediaEndpoint::doCreateAnswer):
(WebCore::LibWebRTCMediaEndpoint::gatherDecoderImplementationName):
(WebCore::LibWebRTCMediaEndpoint::getStats):
(WebCore::LibWebRTCMediaEndpoint::collectTransceivers):
(WebCore::LibWebRTCMediaEndpoint::canTrickleIceCandidates const):
(WebCore::LibWebRTCMediaEndpoint::createTransceiverBackends):
(WebCore::LibWebRTCMediaEndpoint::createSourceAndRTCTrack):
(WebCore::LibWebRTCMediaEndpoint::addTransceiver):
(WebCore::LibWebRTCMediaEndpoint::setSenderSourceFromTrack):
(WebCore::LibWebRTCMediaEndpoint::transceiverBackendFromSender):
(WebCore::LibWebRTCMediaEndpoint::close):
(WebCore::LibWebRTCMediaEndpoint::addIceCandidate):
(WebCore::LibWebRTCMediaEndpoint::OnIceCandidate):
(WebCore::SctpTransportState::SctpTransportState):
(WebCore::SctpTransportState::createBackend):
(WebCore::LibWebRTCMediaEndpoint::setLocalSessionDescriptionSucceeded):
(WebCore::LibWebRTCMediaEndpoint::setRemoteSessionDescriptionSucceeded):
(WebCore::LibWebRTCMediaEndpoint::gatherStatsForLogging):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp:
(WebCore::LibWebRTCPeerConnectionBackend::getStats):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp:
(WebCore::LibWebRTCRtpReceiverBackend::LibWebRTCRtpReceiverBackend):
(WebCore::LibWebRTCRtpReceiverBackend::createSource):
(WebCore::LibWebRTCRtpReceiverBackend::rtcRtpTransformBackend):
(WebCore::LibWebRTCRtpReceiverBackend::dtlsTransportBackend):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverTransformBackend.cpp:
(WebCore::LibWebRTCRtpReceiverTransformBackend::LibWebRTCRtpReceiverTransformBackend):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverTransformBackend.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.cpp:
(WebCore::LibWebRTCRtpSenderBackend::LibWebRTCRtpSenderBackend):
(WebCore::LibWebRTCRtpSenderBackend::createDTMFBackend):
(WebCore::LibWebRTCRtpSenderBackend::rtcRtpTransformBackend):
(WebCore::LibWebRTCRtpSenderBackend::dtlsTransportBackend):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderTransformBackend.cpp:
(WebCore::LibWebRTCRtpSenderTransformBackend::LibWebRTCRtpSenderTransformBackend):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderTransformBackend.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransceiverBackend.cpp:
(WebCore::LibWebRTCRtpTransceiverBackend::createReceiverBackend):
(WebCore::LibWebRTCRtpTransceiverBackend::createSenderBackend):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransceiverBackend.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformBackend.cpp:
(WebCore::LibWebRTCRtpTransformBackend::addOutputCallback):
(WebCore::LibWebRTCRtpTransformBackend::RegisterTransformedFrameCallback):
(WebCore::LibWebRTCRtpTransformBackend::RegisterTransformedFrameSinkCallback):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformBackend.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCSctpTransportBackend.cpp:
(WebCore::LibWebRTCSctpTransportBackendObserver::LibWebRTCSctpTransportBackendObserver):
(WebCore::LibWebRTCSctpTransportBackend::LibWebRTCSctpTransportBackend):
(WebCore::LibWebRTCSctpTransportBackend::dtlsTransportBackend):
(WebCore::LibWebRTCSctpTransportBackend::registerClient):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCSctpTransportBackend.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp:
(WebCore::LibWebRTCVPXInternalVideoDecoder::Decoded):
* Source/WebCore/platform/mediastream/RealtimeIncomingAudioSource.cpp:
(WebCore::RealtimeIncomingAudioSource::RealtimeIncomingAudioSource):
* Source/WebCore/platform/mediastream/RealtimeIncomingAudioSource.h:
* Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.cpp:
(WebCore::RealtimeIncomingVideoSource::RealtimeIncomingVideoSource):
(WebCore::m_videoTrack):
* Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.h:
* Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.cpp:
(WebCore::RealtimeOutgoingVideoSource::sendBlackFramesIfNeeded):
(WebCore::RealtimeOutgoingVideoSource::sendOneBlackFrame):
* Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h:
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDTMFSenderBackend.cpp:
(WebCore::LibWebRTCDTMFSenderBackend::LibWebRTCDTMFSenderBackend):
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDTMFSenderBackend.h:
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp:
(WebCore::LibWebRTCProvider::createPeerConnectionFactory):
(WebCore::LibWebRTCProvider::setPeerConnectionFactory):
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.h:
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCRefWrappers.h: Added.
(WTF::RTCDefaultRefDerefTraits::refIfNotNull):
(WTF::RTCDefaultRefDerefTraits::ref):
(WTF::RTCDefaultRefDerefTraits::derefIfNotNull):
(WTF::toRef):
(WTF::toRefPtr):
* Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.cpp:
(WebCore::VideoFrameLibWebRTC::create):
(WebCore::VideoFrameLibWebRTC::VideoFrameLibWebRTC):
(WebCore::VideoFrameLibWebRTC::pixelBuffer const):
(WebCore::VideoFrameLibWebRTC::clone):
* Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.h:
* Source/WebCore/platform/mediastream/mac/RealtimeIncomingAudioSourceCocoa.cpp:
(WebCore::RealtimeIncomingAudioSource::create):
(WebCore::RealtimeIncomingAudioSourceCocoa::create):
(WebCore::RealtimeIncomingAudioSourceCocoa::RealtimeIncomingAudioSourceCocoa):
* Source/WebCore/platform/mediastream/mac/RealtimeIncomingAudioSourceCocoa.h:
* Source/WebCore/platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.h:
* Source/WebCore/platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm:
(WebCore::RealtimeIncomingVideoSource::create):
(WebCore::RealtimeIncomingVideoSourceCocoa::create):
(WebCore::RealtimeIncomingVideoSourceCocoa::RealtimeIncomingVideoSourceCocoa):
(WebCore::RealtimeIncomingVideoSourceCocoa::toVideoFrame):

Canonical link: <a href="https://commits.webkit.org/297922@main">https://commits.webkit.org/297922@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b50e9444eea4f2d09bafb2f7d8c5fa3d1866ca8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111134 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30800 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117165 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61402 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31481 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39382 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84491 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114081 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25153 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100055 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64937 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24498 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18199 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60985 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94533 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18263 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120119 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38183 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28379 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93425 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38559 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96330 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93249 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24216 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38334 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16078 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34168 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38072 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43549 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37737 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41070 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39439 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->