### PR TITLE
XMLHttpRequestProgressEventThrottle can be a weak pointer without being refable

### DIFF
--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -1227,4 +1227,9 @@ bool XMLHttpRequest::virtualHasPendingActivity() const
     return false;
 }
 
+void XMLHttpRequest::dispatchThrottledProgressEventIfNeeded()
+{
+    m_progressEventThrottle->dispatchThrottledProgressEventIfNeeded();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/xml/XMLHttpRequest.h
+++ b/Source/WebCore/xml/XMLHttpRequest.h
@@ -140,6 +140,8 @@ public:
     using EventTarget::dispatchEvent;
     void dispatchEvent(Event&) override;
 
+    void dispatchThrottledProgressEventIfNeeded();
+
 private:
     friend class XMLHttpRequestUpload;
     explicit XMLHttpRequest(ScriptExecutionContext&);

--- a/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp
+++ b/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp
@@ -68,10 +68,10 @@ void XMLHttpRequestProgressEventThrottle::updateProgress(bool isAsync, bool leng
 
         dispatchEventWhenPossible(XMLHttpRequestProgressEvent::create(eventNames().progressEvent, lengthComputable, loaded, total));
         m_dispatchThrottledProgressEventTimer = target->protectedScriptExecutionContext()->checkedEventLoop()->scheduleRepeatingTask(
-            minimumProgressEventDispatchingInterval, minimumProgressEventDispatchingInterval, TaskSource::Networking, [weakThis = WeakPtr { *this }] {
-                if (weakThis)
-                    weakThis->dispatchThrottledProgressEventTimerFired();
-            });
+            minimumProgressEventDispatchingInterval, minimumProgressEventDispatchingInterval, TaskSource::Networking, [weakTarget = WeakPtr { m_target.get() }] {
+            if (RefPtr protectedTarget = weakTarget.get())
+                protectedTarget->dispatchThrottledProgressEventIfNeeded();
+        });
         m_hasPendingThrottledProgressEvent = false;
         return;
     }
@@ -131,7 +131,7 @@ void XMLHttpRequestProgressEventThrottle::flushProgressEvent()
     dispatchEventWhenPossible(XMLHttpRequestProgressEvent::create(eventNames().progressEvent, m_lengthComputable, m_loaded, m_total));
 }
 
-void XMLHttpRequestProgressEventThrottle::dispatchThrottledProgressEventTimerFired()
+void XMLHttpRequestProgressEventThrottle::dispatchThrottledProgressEventIfNeeded()
 {
     ASSERT(m_dispatchThrottledProgressEventTimer);
     if (!m_hasPendingThrottledProgressEvent) {

--- a/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.h
+++ b/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.h
@@ -36,11 +36,6 @@ namespace WebCore {
 class XMLHttpRequestProgressEventThrottle;
 }
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::XMLHttpRequestProgressEventThrottle> : std::true_type { };
-}
-
 namespace WebCore {
 
 class Event;
@@ -53,7 +48,7 @@ enum ProgressEventAction {
 
 // This implements the XHR2 progress event dispatching: "dispatch a progress event called progress
 // about every 50ms or for every byte received, whichever is least frequent".
-class XMLHttpRequestProgressEventThrottle : public CanMakeWeakPtr<XMLHttpRequestProgressEventThrottle> {
+class XMLHttpRequestProgressEventThrottle {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(XMLHttpsRequestProgressEventThrottle);
 public:
     explicit XMLHttpRequestProgressEventThrottle(XMLHttpRequest&);
@@ -67,10 +62,11 @@ public:
     void suspend();
     void resume();
 
+    void dispatchThrottledProgressEventIfNeeded();
+
 private:
     static const Seconds minimumProgressEventDispatchingInterval;
 
-    void dispatchThrottledProgressEventTimerFired();
     void flushProgressEvent();
     void dispatchEventWhenPossible(Event&);
 


### PR DESCRIPTION
#### 0bce4652d6d810addfc0f462796a4f6683e982e2
<pre>
XMLHttpRequestProgressEventThrottle can be a weak pointer without being refable
<a href="https://rdar.apple.com/155610120">rdar://155610120</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=295774">https://bugs.webkit.org/show_bug.cgi?id=295774</a>

Reviewed by Anne Van Kesteren.

We no longer need to make XMLHttpRequestProgressEventThrottle a weak pointer.
Instead, we take a weak pointer of its weak target and inform its weak target that the timer fired.

No observable change of behavior.

* Source/WebCore/xml/XMLHttpRequest.h:
* Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp:
(WebCore::XMLHttpRequestProgressEventThrottle::updateProgress):
(WebCore::XMLHttpRequestProgressEventThrottle::dispatchThrottledProgressEventIfNeeded):
(WebCore::XMLHttpRequestProgressEventThrottle::dispatchThrottledProgressEventTimerFired): Deleted.
* Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.h:

Canonical link: <a href="https://commits.webkit.org/297934@main">https://commits.webkit.org/297934@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58a5d8ebe5bafbc6daba55a0fe7c878ade8bbc48

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113496 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119677 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64262 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115393 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33819 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41778 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86351 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/64262 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116444 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27013 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102031 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66679 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26280 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20151 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63403 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96396 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20229 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122911 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40510 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30267 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95211 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40901 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98235 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94957 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24225 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40079 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17892 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36673 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40394 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45895 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40052 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43365 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41809 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->