### PR TITLE
[Grid][Baseline] Fix default baseline alignment of RowAxisPosition for grid layout.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-002-expected.txt
@@ -16,11 +16,15 @@ FAIL #target > div 1 assert_equals:
 offsetLeft expected 120 but got 0
 FAIL #target > div 2 assert_equals:
 <div data-offset-x="105">line1<br>line2</div>
-offsetLeft expected 105 but got 35
+offsetLeft expected 105 but got 140
 FAIL #target > div 3 assert_equals:
 <div data-offset-x="126">line1<br>line2</div>
-offsetLeft expected 126 but got 42
+offsetLeft expected 126 but got 168
 PASS #target > div 4
-PASS #target > div 5
-PASS #target > div 6
+FAIL #target > div 5 assert_equals:
+<div data-offset-x="35">line1<br>line2</div>
+offsetLeft expected 35 but got 140
+FAIL #target > div 6 assert_equals:
+<div data-offset-x="42">line1<br>line2</div>
+offsetLeft expected 42 but got 168
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-003-expected.txt
@@ -2,13 +2,11 @@
 
 
 
-FAIL #target > div 1 assert_equals:
-<div data-offset-y="40"><span></span><br><span></span></div>
-offsetTop expected 40 but got 0
+PASS #target > div 1
 FAIL #target > div 2 assert_equals:
 <div data-offset-y="20"><span></span><br><span></span></div>
-offsetTop expected 20 but got 40
+offsetTop expected 20 but got 60
 FAIL #target > div 3 assert_equals:
 <div data-offset-y="75"><span></span><br><span></span></div>
-offsetTop expected 75 but got 35
+offsetTop expected 75 but got 110
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-004-expected.txt
@@ -2,13 +2,11 @@
 
 
 
-FAIL #target > div 1 assert_equals:
-<div data-offset-y="40"><span></span><br><span></span></div>
-offsetTop expected 40 but got 0
+PASS #target > div 1
 FAIL #target > div 2 assert_equals:
 <div data-offset-y="20"><span></span><br><span></span></div>
-offsetTop expected 20 but got 40
+offsetTop expected 20 but got 60
 FAIL #target > div 3 assert_equals:
 <div data-offset-y="75"><span></span><br><span></span></div>
-offsetTop expected 75 but got 35
+offsetTop expected 75 but got 110
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-005-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-005-expected.txt
@@ -14,5 +14,5 @@ offsetLeft expected 100 but got 0
 PASS #target > div 3
 FAIL #target > div 4 assert_equals:
 <div style="grid-row: 4; grid-column: span 3; justify-self: last baseline;" data-offset-x="10">line1<br>line2</div>
-offsetLeft expected 10 but got 0
+offsetLeft expected 10 but got 110
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-009-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-009-expected.txt
@@ -6,39 +6,35 @@
 
 
 PASS .item 1
-FAIL .item 2 assert_equals:
-<div data-offset-x="237" class="item last">
-        <span></span><br><span></span>
-      </div>
-offsetLeft expected 237 but got 292
+PASS .item 2
 PASS .item 3
-FAIL .item 4 assert_equals:
-<div data-offset-x="57" class="item last">
-        <span></span><br><span></span>
-      </div>
-offsetLeft expected 57 but got 112
+PASS .item 4
 FAIL .item 5 assert_equals:
 <div data-offset-x="475" class="item first">
       <span></span><br><span></span>
     </div>
 offsetLeft expected 475 but got 420
-PASS .item 6
+FAIL .item 6 assert_equals:
+<div data-offset-x="420" class="item last">
+      <span></span><br><span></span>
+    </div>
+offsetLeft expected 420 but got 475
 FAIL .item 7 assert_equals:
 <div data-offset-x="177" class="item small first"></div>
 offsetLeft expected 177 but got 60
 FAIL .item 8 assert_equals:
 <div data-offset-x="102" class="item small last"></div>
-offsetLeft expected 102 but got 40
+offsetLeft expected 102 but got 182
 FAIL .item 9 assert_equals:
 <div data-offset-x="357" class="item small first"></div>
 offsetLeft expected 357 but got 272
 FAIL .item 10 assert_equals:
 <div data-offset-x="282" class="item small last"></div>
-offsetLeft expected 282 but got 252
+offsetLeft expected 282 but got 370
 FAIL .item 11 assert_equals:
 <div data-offset-x="540" class="item small first"></div>
 offsetLeft expected 540 but got 460
 FAIL .item 12 assert_equals:
 <div data-offset-x="465" class="item small last"></div>
-offsetLeft expected 465 but got 440
+offsetLeft expected 465 but got 570
 

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -2223,9 +2223,11 @@ GridAxisPosition RenderGrid::rowAxisPositionForGridItem(const RenderBox& gridIte
     case ItemPosition::Stretch:
         return GridAxisPosition::GridAxisStart;
     case ItemPosition::Baseline:
-    case ItemPosition::LastBaseline:
-        // FIXME: Implement the previous values. For now, we always 'start' align the grid item.
+        // FIXME: Handle bidi-rtl and orthogonal grid items.
         return GridAxisPosition::GridAxisStart;
+    case ItemPosition::LastBaseline:
+        // FIXME: Handle bidi-rtl and orthogonal grid items.
+        return GridAxisPosition::GridAxisEnd;
     case ItemPosition::Legacy:
     case ItemPosition::Auto:
     case ItemPosition::Normal:


### PR DESCRIPTION
#### 3f62998b9ab636efbf9b11d936aec4a7f8b94258
<pre>
[Grid][Baseline] Fix default baseline alignment of RowAxisPosition for grid layout.
<a href="https://bugs.webkit.org/show_bug.cgi?id=295779">https://bugs.webkit.org/show_bug.cgi?id=295779</a>
&lt;<a href="https://rdar.apple.com/155323643">rdar://155323643</a>&gt;

Reviewed by NOBODY (OOPS!).

This PR sets the default alignment for first and last baseline
to `GridAxisPosition::GridAxisStart` and `GridAxisPosition::GridAxisEnd`

as per:

<a href="https://www.w3.org/TR/css-align-3/#baseline-values">https://www.w3.org/TR/css-align-3/#baseline-values</a>

A follow up PR will handles flow-relative and orthogonal writing modes.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-004-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-005-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-009-expected.txt:
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::rowAxisPositionForGridItem const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f62998b9ab636efbf9b11d936aec4a7f8b94258

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111597 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31264 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21738 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117632 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/61868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113559 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39849 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84787 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/61868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114544 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25501 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100440 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65228 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24840 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18575 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61463 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94886 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18644 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120877 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38650 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28709 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93688 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39027 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/96700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93512 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38647 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16442 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/34686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38539 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44023 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/38202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41538 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39904 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->