### PR TITLE
Add comment explaining why we are using UncheckedKeyHashMap in SelectorCompiler.cpp

### DIFF
--- a/Source/WTF/wtf/SegmentedVector.h
+++ b/Source/WTF/wtf/SegmentedVector.h
@@ -29,10 +29,9 @@
 #pragma once
 
 #include <wtf/MallocCommon.h>
+#include <wtf/MallocPtr.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Vector.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WTF {
 
@@ -109,7 +108,7 @@ namespace WTF {
 
         ~SegmentedVector()
         {
-            deleteAllSegments();
+            destroyAllItems();
         }
 
         size_t size() const { return m_size; }
@@ -118,7 +117,7 @@ namespace WTF {
         T& at(size_t index) LIFETIME_BOUND
         {
             ASSERT_WITH_SECURITY_IMPLICATION(index < m_size);
-            return segmentFor(index)->entries[subscriptFor(index)];
+            return segmentFor(index)->entriesSpan()[subscriptFor(index)];
         }
 
         const T& at(size_t index) const LIFETIME_BOUND
@@ -199,7 +198,7 @@ namespace WTF {
 
         void clear()
         {
-            deleteAllSegments();
+            destroyAllItems();
             m_segments.clear();
             m_size = 0;
         }
@@ -222,14 +221,14 @@ namespace WTF {
     private:
         struct Segment {
             T entries[0];
+
+            std::span<T, SegmentSize> entriesSpan() { return unsafeMakeSpan<T, SegmentSize>(entries, SegmentSize); }
         };
 
-        void deleteAllSegments()
+        void destroyAllItems()
         {
             for (size_t i = 0; i < m_size; ++i)
                 at(i).~T();
-            for (size_t i = 0; i < m_segments.size(); ++i)
-                Malloc::free(m_segments[i]);
         }
 
         bool segmentExistsFor(size_t index)
@@ -239,10 +238,10 @@ namespace WTF {
 
         Segment* segmentFor(size_t index) LIFETIME_BOUND
         {
-            return m_segments[index / SegmentSize];
+            return m_segments[index / SegmentSize].get();
         }
 
-        size_t subscriptFor(size_t index)
+        static size_t subscriptFor(size_t index)
         {
             return index % SegmentSize;
         }
@@ -265,15 +264,13 @@ namespace WTF {
 
         void allocateSegment()
         {
-            m_segments.append(static_cast<Segment*>(Malloc::malloc(sizeof(T) * SegmentSize)));
+            m_segments.append(MallocPtr<Segment, Malloc>::malloc(sizeof(T) * SegmentSize));
         }
 
         size_t m_size { 0 };
-        Vector<Segment*, 0, CrashOnOverflow, 16, Malloc> m_segments;
+        Vector<MallocPtr<Segment>, 0, CrashOnOverflow, 16, Malloc> m_segments;
     };
 
 } // namespace WTF
 
 using WTF::SegmentedVector;
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -80,6 +80,7 @@
 namespace WebCore {
 namespace SelectorCompiler {
 
+// Using UncheckedKeyHashSet instead of HashSet improves performance on Speedometer 3.
 using PseudoClassesSet = UncheckedKeyHashSet<CSSSelector::PseudoClass, IntHash<CSSSelector::PseudoClass>, WTF::StrongEnumHashTraits<CSSSelector::PseudoClass>>;
 
 #if ENABLE(SELECTOR_OPERATION_STATS)


### PR DESCRIPTION
#### 22b8021db9caee73fcaeebc506638f0c10ea804d
<pre>
Add comment explaining why we are using UncheckedKeyHashMap in SelectorCompiler.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=295786">https://bugs.webkit.org/show_bug.cgi?id=295786</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/cssjit/SelectorCompiler.cpp:
</pre>
----------------------------------------------------------------------
#### 72bb08ca03892687be15597ff9ea7f8fd755a935
<pre>
SegmentedVector_safe_buffers
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22b8021db9caee73fcaeebc506638f0c10ea804d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111131 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/30797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21228 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/117162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/61399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113093 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31478 "Build is in progress. Recent messages:") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39379 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/117162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/61399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114078 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/31478 "Build is in progress. Recent messages:") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/100054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/117162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/31478 "Build is in progress. Recent messages:") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/18198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60982 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/103622 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/31478 "Build is in progress. Recent messages:") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/18262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/120113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109684 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/38180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/28376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/120113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/38556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/96329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/120113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/16077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/34165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/38069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43546 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/133960 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/37734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/36135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/41067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/39436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->