### PR TITLE
Stop using a CMBufferQueueRef for re-ordering samples.

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2245,6 +2245,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/MediaPlayerEnums.h
     platform/graphics/MediaPlayerIdentifier.h
     platform/graphics/MediaPlayerPrivate.h
+    platform/graphics/MediaReorderQueue.h
     platform/graphics/MediaResourceSniffer.h
     platform/graphics/MediaSourceConfiguration.h
     platform/graphics/MediaSourcePrivate.h

--- a/Source/WebCore/platform/graphics/MediaReorderQueue.h
+++ b/Source/WebCore/platform/graphics/MediaReorderQueue.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "MediaSample.h"
+#include <wtf/Deque.h>
+
+namespace WebCore {
+
+template <class T, class Compare = std::less_equal<T>>
+class MediaReorderQueue {
+public:
+    MediaReorderQueue() = default;
+
+    using ContainerType = Deque<T>;
+    ContainerType::iterator begin() LIFETIME_BOUND { return m_queue.begin(); }
+    ContainerType::iterator end() LIFETIME_BOUND { return m_queue.end(); }
+    ContainerType::const_iterator begin() const LIFETIME_BOUND { return m_queue.begin(); }
+    ContainerType::const_iterator end() const LIFETIME_BOUND { return m_queue.end(); }
+    ContainerType::reverse_iterator rbegin() LIFETIME_BOUND { return ContainerType::reverse_iterator(end()); }
+    ContainerType::reverse_iterator rend() LIFETIME_BOUND { return ContainerType::reverse_iterator(begin()); }
+    ContainerType::const_reverse_iterator rbegin() const LIFETIME_BOUND { return ContainerType::const_reverse_iterator(end()); }
+    ContainerType::const_reverse_iterator rend() const LIFETIME_BOUND { return ContainerType::const_reverse_iterator(begin()); }
+
+    bool isEmpty() const { return m_queue.isEmpty(); }
+    size_t size() const { return m_queue.size(); }
+
+    void append(T&& object)
+    {
+        m_queue.append(std::forward<T>(object));
+        auto begin = this->begin();
+        auto iter = std::prev(end());
+        while (iter != begin) {
+            auto prev = std::prev(iter);
+            if (m_compare(*prev, *iter))
+                return;
+            std::swap(*prev, *iter);
+            iter = prev;
+        }
+    }
+
+    std::optional<T> takeIfAvailable(bool& moreObjectsAvailable)
+    {
+        if (!isAvailable()) {
+            moreObjectsAvailable = false;
+            return { };
+        }
+
+        T object = m_queue.takeFirst();
+        moreObjectsAvailable = isAvailable();
+        return object;
+    }
+
+    T first() const
+    {
+        ASSERT(!isEmpty());
+        return m_queue.first();
+    }
+
+    T last() const
+    {
+        ASSERT(!isEmpty());
+        return m_queue.last();
+    }
+
+    T takeFirst()
+    {
+        ASSERT(!isEmpty());
+        return m_queue.takeFirst();
+    }
+
+    void removeFirst()
+    {
+        ASSERT(!isEmpty());
+        m_queue.removeFirst();
+    }
+
+    void clear() { m_queue.clear(); }
+    uint8_t reorderSize() const { return m_reorderSize; }
+    void setReorderSize(uint8_t size) { m_reorderSize = size; }
+    bool isAvailable() const { return m_queue.size() > m_reorderSize; }
+
+private:
+    ContainerType m_queue;
+    uint8_t m_reorderSize { 0 };
+    [[no_unique_address]] Compare m_compare;
+};
+
+struct MediaSampleReorderQueueComparator {
+    static bool operator()(const Ref<const MediaSample>& a, const Ref<const MediaSample>& b) { return a->presentationTime() <= b->presentationTime(); }
+};
+
+using MediaSampleReorderQueue = MediaReorderQueue<Ref<const MediaSample>, MediaSampleReorderQueueComparator>;
+
+}

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
@@ -32,6 +32,7 @@
 #include "GraphicsContextCG.h"
 #include "ImageBufferUtilitiesCG.h"
 #include "IntRect.h"
+#include "NativeImage.h"
 #include "PixelBuffer.h"
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -216,6 +216,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/LayoutUnitTests.cpp
         Tests/WebCore/MIMESniffer.cpp
         Tests/WebCore/MIMETypeRegistry.cpp
+        Tests/WebCore/MediaReorderQueue.cpp
         Tests/WebCore/MixedContentChecker.cpp
         Tests/WebCore/MonospaceFontTests.cpp
         Tests/WebCore/NowPlayingInfoTests.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -238,6 +238,7 @@
 		516B289E2CFEA5BC003C544C /* AudioSampleFormat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 516B289D2CFEA5BC003C544C /* AudioSampleFormat.cpp */; };
 		5175C7A226F876230003AF5C /* BundlePageConsoleMessage.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5175C7A126F876230003AF5C /* BundlePageConsoleMessage.mm */; };
 		51820A4D22F4EE7F00DF0A01 /* JavascriptURLNavigation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51820A4C22F4EE7700DF0A01 /* JavascriptURLNavigation.mm */; };
+		518C1C532E2149EE00083695 /* MediaReorderQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 518C1C522E2149EE00083695 /* MediaReorderQueue.cpp */; };
 		51DB16CE1F085137001FA4C5 /* WebViewIconLoading.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51DB16CD1F085047001FA4C5 /* WebViewIconLoading.mm */; };
 		51EB125724C67257000CB030 /* VirtualGamepad.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51EB125624C66FE8000CB030 /* VirtualGamepad.mm */; };
 		51EB125924C68592000CB030 /* HIDGamepads.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51EB125824C68589000CB030 /* HIDGamepads.mm */; };
@@ -2990,6 +2991,7 @@
 		51820A4C22F4EE7700DF0A01 /* JavascriptURLNavigation.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = JavascriptURLNavigation.mm; sourceTree = "<group>"; };
 		5182C22D1F2BCB410059BA7C /* WKURLSchemeHandler-leaks.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = "WKURLSchemeHandler-leaks.mm"; sourceTree = "<group>"; };
 		518C1152205B04F9001FF4AE /* ProcessSwapOnNavigation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ProcessSwapOnNavigation.mm; sourceTree = "<group>"; };
+		518C1C522E2149EE00083695 /* MediaReorderQueue.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MediaReorderQueue.cpp; sourceTree = "<group>"; };
 		518EE51A20A78CFB00E024F3 /* DoAfterNextPresentationUpdateAfterCrash.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = DoAfterNextPresentationUpdateAfterCrash.mm; sourceTree = "<group>"; };
 		518EE51C20A78D3300E024F3 /* DecidePolicyForNavigationAction.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = DecidePolicyForNavigationAction.mm; sourceTree = "<group>"; };
 		51A24D10294BE9B300E43A29 /* Badging.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = Badging.mm; sourceTree = "<group>"; };
@@ -5222,6 +5224,7 @@
 				076E507E1F45031E006E9F5A /* Logging.cpp */,
 				6BF4A682239ED4CD00E2F45B /* LoginStatus.cpp */,
 				CE1866471F72E8F100A0CAB6 /* MarkedText.cpp */,
+				518C1C522E2149EE00083695 /* MediaReorderQueue.cpp */,
 				512F290F2BA1D03100F1C326 /* MIMESniffer.cpp */,
 				A5B149DD1F5A19DC00C6DAFF /* MIMETypeRegistry.cpp */,
 				EB6836D32CC967E00073A8E5 /* MixedContentChecker.cpp */,
@@ -7822,6 +7825,7 @@
 				CE1866491F72E8F100A0CAB6 /* MarkedText.cpp in Sources */,
 				A17C57EB2C9A5383009DD0B5 /* MediaLoading.mm in Sources */,
 				CDA315981ED53651009F60D3 /* MediaPlaybackSleepAssertion.mm in Sources */,
+				518C1C532E2149EE00083695 /* MediaReorderQueue.cpp in Sources */,
 				075A9CF526177218006DFA3A /* MediaSessionCoordinatorTest.mm in Sources */,
 				CDC9442E1EF1FC080059C3C4 /* MediaStreamTrackDetached.mm in Sources */,
 				7CCE7EC51A411A7E00447C4C /* MemoryCacheDisableWithinResourceLoadDelegate.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/MediaReorderQueue.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MediaReorderQueue.cpp
@@ -1,0 +1,227 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <WebCore/MediaReorderQueue.h>
+
+using namespace WebCore;
+
+namespace TestWebKitAPI {
+
+class TestSample : public MediaSample {
+public:
+    static Ref<TestSample> create(const MediaTime& presentationTime, const MediaTime& decodeTime, const MediaTime& duration, SampleFlags flags)
+    {
+        return adoptRef(*new TestSample(presentationTime, decodeTime, duration, flags));
+    }
+
+    MediaTime presentationTime() const final { return m_presentationTime; }
+    MediaTime decodeTime() const final { return m_decodeTime; }
+    MediaTime duration() const final { return m_duration; }
+    TrackID trackID() const final { return m_trackID; }
+    size_t sizeInBytes() const final { return m_sizeInBytes; }
+    FloatSize presentationSize() const final { return m_presentationSize; }
+    void offsetTimestampsBy(const MediaTime& offset) final { m_presentationTime += offset; m_decodeTime += offset; }
+    void setTimestamps(const MediaTime& presentationTime, const MediaTime& decodeTime) final
+    {
+        m_presentationTime = presentationTime;
+        m_decodeTime = decodeTime;
+    };
+    Ref<MediaSample> createNonDisplayingCopy() const final
+    {
+        return create(m_presentationTime, m_decodeTime, m_duration, static_cast<SampleFlags>(m_flags | IsNonDisplaying));
+    }
+    SampleFlags flags() const final { return m_flags; }
+    PlatformSample platformSample() const final { return { PlatformSample::None, { nullptr } }; }
+    PlatformSample::Type platformSampleType() const final { return PlatformSample::None; }
+
+    void dump(PrintStream&) const final { }
+
+private:
+    TestSample(const MediaTime& presentationTime, const MediaTime& decodeTime, const MediaTime& duration, SampleFlags flags)
+        : m_presentationTime(presentationTime)
+        , m_decodeTime(decodeTime)
+        , m_duration(duration)
+        , m_flags(flags)
+    {
+    }
+
+    MediaTime m_presentationTime;
+    MediaTime m_decodeTime;
+    MediaTime m_duration;
+    FloatSize m_presentationSize;
+    TrackID m_trackID;
+    size_t m_sizeInBytes { 0 };
+    SampleFlags m_flags { None };
+};
+
+TEST(MediaReorderQueue, MediaSample)
+{
+    MediaSampleReorderQueue queue;
+    queue.append(TestSample::create(MediaTime(0, 1), MediaTime(0, 1), MediaTime(1, 1), MediaSample::IsSync));
+    queue.append(TestSample::create(MediaTime(3, 1), MediaTime(1, 1), MediaTime(1, 1), MediaSample::None));
+    queue.append(TestSample::create(MediaTime(2, 1), MediaTime(2, 1), MediaTime(1, 1), MediaSample::None));
+    queue.append(TestSample::create(MediaTime(1, 1), MediaTime(3, 1), MediaTime(1, 1), MediaSample::None));
+    queue.append(TestSample::create(MediaTime(4, 1), MediaTime(4, 1), MediaTime(1, 1), MediaSample::IsSync));
+    queue.append(TestSample::create(MediaTime(8, 1), MediaTime(5, 1), MediaTime(1, 1), MediaSample::None));
+    queue.append(TestSample::create(MediaTime(7, 1), MediaTime(6, 1), MediaTime(1, 1), MediaSample::None));
+    queue.append(TestSample::create(MediaTime(6, 1), MediaTime(7, 1), MediaTime(1, 1), MediaSample::None));
+    queue.append(TestSample::create(MediaTime(5, 1), MediaTime(8, 1), MediaTime(1, 1), MediaSample::None));
+
+    ASSERT_FALSE(queue.isEmpty());
+    RefPtr currentSample = queue.takeFirst();
+    while (!queue.isEmpty()) {
+        RefPtr nextSample = queue.takeFirst();
+        ASSERT_LE(currentSample->presentationTime(), nextSample->presentationTime());
+        currentSample = WTFMove(nextSample);
+    }
+}
+
+TEST(MediaReorderQueue, MediaSampleKeepOrderIfEqual)
+{
+    MediaSampleReorderQueue queue;
+    queue.append(TestSample::create(MediaTime(0, 1), MediaTime(0, 1), MediaTime(1, 1), MediaSample::IsSync));
+    queue.append(TestSample::create(MediaTime(0, 1), MediaTime(1, 1), MediaTime(1, 1), MediaSample::None));
+    queue.append(TestSample::create(MediaTime(2, 1), MediaTime(2, 1), MediaTime(1, 1), MediaSample::None));
+    queue.append(TestSample::create(MediaTime(1, 1), MediaTime(3, 1), MediaTime(1, 1), MediaSample::None));
+    queue.append(TestSample::create(MediaTime(4, 1), MediaTime(4, 1), MediaTime(1, 1), MediaSample::IsSync));
+    queue.append(TestSample::create(MediaTime(7, 1), MediaTime(5, 1), MediaTime(1, 1), MediaSample::None));
+    queue.append(TestSample::create(MediaTime(7, 1), MediaTime(6, 1), MediaTime(1, 1), MediaSample::None));
+    queue.append(TestSample::create(MediaTime(7, 1), MediaTime(7, 1), MediaTime(1, 1), MediaSample::None));
+    queue.append(TestSample::create(MediaTime(6, 1), MediaTime(8, 1), MediaTime(1, 1), MediaSample::None));
+
+    ASSERT_FALSE(queue.isEmpty());
+    auto current = queue.takeFirst();
+    while (!queue.isEmpty()) {
+        auto next = queue.takeFirst();
+        if (current->presentationTime() == next->presentationTime())
+            ASSERT_LT(current->decodeTime(), next->decodeTime());
+        ASSERT_LE(current->presentationTime(), next->presentationTime());
+        current = next;
+    }
+}
+
+
+TEST(MediaReorderQueue, Int)
+{
+    MediaReorderQueue<int> queue;
+    queue.append(0);
+    queue.append(3);
+    queue.append(2);
+    queue.append(1);
+    queue.append(4);
+    queue.append(8);
+    queue.append(7);
+    queue.append(6);
+    queue.append(5);
+
+    ASSERT_FALSE(queue.isEmpty());
+    auto current = queue.takeFirst();
+    while (!queue.isEmpty()) {
+        auto next = queue.takeFirst();
+        ASSERT_LT(current, next);
+        current = next;
+    }
+}
+
+TEST(MediaReorderQueue, Pair)
+{
+    MediaReorderQueue<std::pair<int, int>> queue;
+    queue.append({ 0, 1 });
+    queue.append({ 0, 2 });
+    queue.append({ 2, 3 });
+    queue.append({ 1, 4 });
+    queue.append({ 4, 5 });
+    queue.append({ 8, 6 });
+    queue.append({ 7, 7 });
+    queue.append({ 6, 8 });
+    queue.append({ 5, 9 });
+
+    ASSERT_FALSE(queue.isEmpty());
+    auto current = queue.takeFirst();
+    while (!queue.isEmpty()) {
+        auto next = queue.takeFirst();
+        if (current.first == next.first)
+            ASSERT_LT(current.second, next.second);
+        ASSERT_LE(current, next);
+        current = next;
+    }
+}
+
+TEST(MediaReorderQueue, takeIfAvailable)
+{
+    MediaReorderQueue<int> queue;
+    queue.setReorderSize(4);
+    bool moreObjectsAvailable = false;
+    auto object = queue.takeIfAvailable(moreObjectsAvailable);
+    ASSERT_FALSE(moreObjectsAvailable);
+    ASSERT_TRUE(!object);
+    queue.append(0);
+    object = queue.takeIfAvailable(moreObjectsAvailable);
+    ASSERT_FALSE(moreObjectsAvailable);
+    ASSERT_TRUE(!object);
+    queue.append(3);
+    object = queue.takeIfAvailable(moreObjectsAvailable);
+    ASSERT_FALSE(moreObjectsAvailable);
+    ASSERT_TRUE(!object);
+    queue.append(2);
+    object = queue.takeIfAvailable(moreObjectsAvailable);
+    ASSERT_FALSE(moreObjectsAvailable);
+    ASSERT_TRUE(!object);
+    queue.append(1);
+    object = queue.takeIfAvailable(moreObjectsAvailable);
+    ASSERT_FALSE(moreObjectsAvailable);
+    ASSERT_TRUE(!object);
+    queue.append(4);
+    object = queue.takeIfAvailable(moreObjectsAvailable);
+    ASSERT_FALSE(moreObjectsAvailable);
+    ASSERT_FALSE(!object);
+    ASSERT_EQ(0, *object);
+    queue.append(8);
+    queue.append(7);
+    queue.append(6);
+    queue.append(5);
+    object = queue.takeIfAvailable(moreObjectsAvailable);
+    ASSERT_TRUE(moreObjectsAvailable);
+    ASSERT_FALSE(!object);
+    ASSERT_EQ(1, *object);
+    object = queue.takeIfAvailable(moreObjectsAvailable);
+    ASSERT_TRUE(moreObjectsAvailable);
+    ASSERT_FALSE(!object);
+    ASSERT_EQ(2, *object);
+    object = queue.takeIfAvailable(moreObjectsAvailable);
+    ASSERT_TRUE(moreObjectsAvailable);
+    ASSERT_FALSE(!object);
+    ASSERT_EQ(3, *object);
+    object = queue.takeIfAvailable(moreObjectsAvailable);
+    ASSERT_FALSE(moreObjectsAvailable);
+    ASSERT_FALSE(!object);
+    ASSERT_EQ(4, *object);
+    object = queue.takeIfAvailable(moreObjectsAvailable);
+    ASSERT_FALSE(moreObjectsAvailable);
+    ASSERT_TRUE(!object);
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### c755d07d28c8ebe6f680c7bd19045baf8c0f31ce
<pre>
Stop using a CMBufferQueueRef for re-ordering samples.
<a href="https://bugs.webkit.org/show_bug.cgi?id=295787">https://bugs.webkit.org/show_bug.cgi?id=295787</a>
<a href="https://rdar.apple.com/155621751">rdar://155621751</a>

Reviewed by Gerald Squelart.

CMBufferQueue is a priority queue using a CFArray as backend.
It&apos;s not particularly adapted for our use as a dequeue where we will append
on one end to pop on the other.
It&apos;s also particularly inefficient in adding samples that aren&apos;t out of order.

So we introduced a MediaReorderQueue that is using a Deque as backend
and will only perform re-ordering as needed. So for YouTube in particular
adding and removing a frame are in O(1).
When re-ordering the frame, we will use bubble sort from the end of the queue
which is very optimal for our use case where the queue is already ordered
and only a few samples may be out of order at the end.

We migrate most of VideoMediaSampleRenderer use of CoreMedia objects
to webkit&apos;s MediaTime/MediaSample for ease.

YouTube Profiling shows a significant reduction in memory allocations and
time spent in VideoMediaSampleRenderer::purgeDecodedSampleQueue.

Adding API tests, no observable changes, covered by existing tests.

* Source/WebCore/platform/graphics/MediaReorderQueue.h: Added.
(WTF::CFTypeTrait&lt;CMSampleBufferRef&gt;::typeID): Deleted.
(WebCore::getDecodeTime): Deleted.
(WebCore::getPresentationTime): Deleted.
(WebCore::getDuration): Deleted.
(WebCore::compareBuffers): Deleted.
(WebCore::createBufferQueue): Deleted.
(WebCore::sampleCallback): Deleted.
* Tools/TestWebKitAPI/Tests/WebCore/MediaReorderQueue.cpp: Added.
(TestWebKitAPI::TestSample::create):
(TestWebKitAPI::TestSample::TestSample):
(TestWebKitAPI::TEST(MediaReorderQueue, MediaSample)):
(TestWebKitAPI::TEST(MediaReorderQueue, Int)):
(TestWebKitAPI::TEST(MediaReorderQueue, Pair)):

Canonical link: <a href="https://commits.webkit.org/297392@main">https://commits.webkit.org/297392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/392ce3cfc0ba09ab16632c321ec40f97775f6373

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21781 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117675 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/61923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113602 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31995 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39892 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84819 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/61923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114587 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25539 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100478 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65260 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24875 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18613 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61507 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94924 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18681 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120923 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38693 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28746 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93719 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39071 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96735 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93545 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23845 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38684 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16477 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34729 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38582 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44067 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38245 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41581 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39947 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->