### PR TITLE
AX: WebKit should match other browsers, and the main-thread text implementation, and not generate text positions for SVG graphics elements

### DIFF
--- a/LayoutTests/accessibility/mac/index-for-text-markers-svg-graphics-elements-expected.txt
+++ b/LayoutTests/accessibility/mac/index-for-text-markers-svg-graphics-elements-expected.txt
@@ -1,0 +1,37 @@
+This test ensures we don't consider SVG graphics elements something that can be walked over in a next-text-marker traversal, nor something that is counted in the AXIndexForTextMarker-style APIs.
+
+Text marker 0 had index 0
+Text marker 1 had index 1
+Text marker 2 had index 2
+Text marker 3 had index 3
+Text marker 4 had index 4
+Text marker 5 had index 5
+Text marker 6 had index 6
+Text marker 7 had index 7
+Text marker 8 had index 8
+Text marker 9 had index 9
+Text marker 10 had index 10
+Text marker 11 had index 11
+Text marker 12 had index 12
+Text marker 13 had index 13
+Text marker 14 had index 14
+Text marker 15 had index 15
+Text marker 16 had index 16
+Text marker 17 had index 17
+Text marker 18 had index 18
+Text marker 19 had index 19
+Text marker 20 had index 20
+Text marker 21 had index 21
+Text marker 22 had index 22
+Text marker 23 had index 23
+Text marker 24 had index 24
+Text marker 25 had index 25
+Text marker 26 had index 26
+Text marker 27 had index 27
+Text marker 28 had index 0
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+This text should be counted
+

--- a/LayoutTests/accessibility/mac/index-for-text-markers-svg-graphics-elements.html
+++ b/LayoutTests/accessibility/mac/index-for-text-markers-svg-graphics-elements.html
@@ -1,0 +1,51 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<svg>
+    <path d="M0 0" fill="#252526"/>
+    <path d="M1000 1000" fill="#252526"/>
+    <path d="M50 50" fill="#252526"/>
+    <path d="M10 10" fill="#252526"/>
+    <path d="M42 42" fill="#252526"/>
+    <path d="M9999 9999" fill="#252526"/>
+
+    <clipPath id="clip">
+        <circle cx="40" cy="35" r="35" />
+    </clipPath>
+
+    <path id="foo-path" d="M10,30 A20,20,0,0,1,50,30 Z" />
+    <use clip-path="url(#clip)" href="#foo-path" fill="red" />
+
+    <symbol id="dot" width="10" height="15" viewBox="0 0 3 2">
+        <circle cx="2" cy="3" r="4" />
+    </symbol>
+    <use href="#dot" x="5" y="5" opacity="1.0" />
+
+    <circle id="circle" cx="5" cy="5" r="4" stroke="blue" />
+    <use href="#circle" x="10" fill="blue" />
+
+    <image href="../resources/cake.png" height="200" width="200" />
+
+    <text>This text should be counted</text>
+</svg>
+
+<script>
+var output = "This test ensures we don't consider SVG graphics elements something that can be walked over in a next-text-marker traversal, nor something that is counted in the AXIndexForTextMarker-style APIs.\n\n";
+
+if (window.accessibilityController) {
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
+    var textMarker = webArea.startTextMarker;
+    for (let i = 0; i < 29; i++) {
+        output += `Text marker ${i} had index ${webArea.indexForTextMarker(textMarker)}\n`;
+        textMarker = webArea.nextTextMarker(textMarker);
+    }
+    debug(output);
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1454,6 +1454,11 @@ AXTextRuns AccessibilityRenderObject::textRuns()
         );
     }
 
+    if (is<SVGGraphicsElement>(element())) {
+        // Match TextIterator (and other browsers) and don't emit text positions for SVG graphics elements.
+        return { };
+    }
+
     if (isReplacedElement()) {
         auto* containingBlock = renderer ? renderer->containingBlock() : nullptr;
         FloatRect rect = frameRect();


### PR DESCRIPTION
#### 1856c3a7da49090338b273e575e05092e58096d2
<pre>
AX: WebKit should match other browsers, and the main-thread text implementation, and not generate text positions for SVG graphics elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=295802">https://bugs.webkit.org/show_bug.cgi?id=295802</a>
<a href="https://rdar.apple.com/155637541">rdar://155637541</a>

Reviewed by Joshua Hoffman.

This discrepancy was discovered when investigating an infinite word-navigation loop with VoiceOver in which we would
constantly cycle between the last two words. This fixes that issue, but is likely not the root cause — invesigation
will continue beyond this commit. But this behavior change is right regardless, as it matches other browsers and the
WebKit main-thread text implementation.

Minimal reproduction:

```
&lt;div style=&quot;width: 580px&quot;&gt;
&lt;svg&gt;
    &lt;path d=&quot;M0 0&quot; fill=&quot;#252526&quot;/&gt;
    &lt;path d=&quot;M1000 1000&quot; fill=&quot;#252526&quot;/&gt;
    &lt;path d=&quot;M50 50&quot; fill=&quot;#252526&quot;/&gt;
    &lt;path d=&quot;M10 10&quot; fill=&quot;#252526&quot;/&gt;
    &lt;path d=&quot;M42 42&quot; fill=&quot;#252526&quot;/&gt;
    &lt;path d=&quot;M9999 9999&quot; fill=&quot;#252526&quot;/&gt;
&lt;/svg&gt;
&lt;p&gt;The quick fox&lt;/p&gt;
&lt;/div&gt;
```

* LayoutTests/accessibility/mac/index-for-text-markers-svg-graphics-elements-expected.txt: Added.
* LayoutTests/accessibility/mac/index-for-text-markers-svg-graphics-elements.html: Added.
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::textRuns):

Canonical link: <a href="https://commits.webkit.org/297307@main">https://commits.webkit.org/297307@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eef6a01a796b132fbe38db37b700dd6b197469b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111278 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30944 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21409 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117310 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61546 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113240 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31625 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39526 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84579 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114225 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25253 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100188 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65025 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24595 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18328 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61129 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94633 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18396 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120441 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38327 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28479 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93505 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38703 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96463 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93329 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23785 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38427 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16203 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34319 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38216 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43693 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37881 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41214 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39583 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->