### PR TITLE
[Absolute Positioning] Add skeleton code for alignment within static position rectangle.

### DIFF
--- a/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
@@ -275,6 +275,32 @@ LayoutRange PositionedLayoutConstraints::adjustForPositionArea(const LayoutRange
 
 // MARK: - Resolving margins and alignment (after sizing).
 
+bool PositionedLayoutConstraints::isEligibleForStaticRangeAlignment() const
+{
+
+    if (m_containingAxis == LogicalBoxAxis::Inline)
+        return false;
+
+    auto* parent = m_renderer->parent();
+
+    if (parent->isRenderBlockFlow())
+        return false;
+
+    if (parent->style().isDisplayInlineType())
+        return false;
+
+    if (parent->isRenderFlexibleBox())
+        return false;
+
+    if (parent->isRenderGrid())
+        return false;
+
+    // We can hit this in certain pieces of content (e.g. see mathml/crashtests/fixed-pos-children.html),
+    // but the spec has no definition for a static position rectangle.
+    return false;
+
+}
+
 void PositionedLayoutConstraints::resolvePosition(RenderBox::LogicalExtentComputedValues& computedValues) const
 {
     // Static position should have resolved one of our insets by now.
@@ -322,6 +348,13 @@ void PositionedLayoutConstraints::resolvePosition(RenderBox::LogicalExtentComput
         // Align into remaining space.
         if (!hasAutoBeforeInset && !hasAutoAfterInset && !hasAutoBeforeMargin && !hasAutoAfterMargin && remainingSpace)
             return resolveAlignmentShift(remainingSpace, computedValues.m_extent + usedMarginBefore + usedMarginAfter);
+
+        if (m_useStaticPosition) {
+            if (isEligibleForStaticRangeAlignment()) {
+                ASSERT_NOT_IMPLEMENTED_YET();
+                return { };
+            }
+        }
 
         if (hasAutoBeforeInset)
             return remainingSpace;

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.h
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.h
@@ -97,6 +97,7 @@ private:
     LayoutRange adjustForPositionArea(const LayoutRange rangeToAdjust, const LayoutRange anchorArea, const BoxAxis containerAxis);
 
     bool needsGridAreaAdjustmentBeforeStaticPositioning() const;
+    bool isEligibleForStaticRangeAlignment() const;
     void computeStaticPosition();
     void computeInlineStaticDistance();
     void computeBlockStaticDistance();


### PR DESCRIPTION
#### 702340cc2699d48588d883239c7b4cb0141e0954
<pre>
[Absolute Positioning] Add skeleton code for alignment within static position rectangle.
<a href="https://bugs.webkit.org/show_bug.cgi?id=295922">https://bugs.webkit.org/show_bug.cgi?id=295922</a>
<a href="https://rdar.apple.com/problem/155818136">rdar://problem/155818136</a>

Reviewed by Alan Baradlay.

css-align defines how the self-alignment properties are supposed to work
in regards to absolutely positioned boxes.

<a href="https://drafts.csswg.org/css-align-3/#justify-abspos">https://drafts.csswg.org/css-align-3/#justify-abspos</a>
<a href="https://drafts.csswg.org/css-align-3/#align-abspos">https://drafts.csswg.org/css-align-3/#align-abspos</a>

When the inset properties in the respective axis are both set to auto,
then the alignment container for the subject, which is the absolutely
positioned box&apos;s margin box, is supposed to be the static position
rectangle.

<a href="https://drafts.csswg.org/css-align-3/#static-position-rectangle">https://drafts.csswg.org/css-align-3/#static-position-rectangle</a>

It does not look like our alignment code in PositionedLayoutConstraints
has any sort of logic to handle this type of alignment, so this patch
serves as a first step towards that goal by introducing some skeleton
code that will be implemented piecemeal.

* Source/WebCore/rendering/PositionedLayoutConstraints.cpp:
(WebCore::PositionedLayoutConstraints::isEligibleForStaticRangeAlignment const):
This will be the primary function that determines whether or not the
content is eligible to use the new logic. Since the definition of the
static position rectangle is dependent upon the formatting context the
box would have participated in, this is the main gate that will make any
other additional restrictions. For example, items that would have
participated in a Grid Formatting Context would fall into the RenderGrid
case, and that branch may have additional criteria specific to it which
may impact the eligibility.

(WebCore::PositionedLayoutConstraints::resolvePosition const):
This is where we will call into the eligibility code and build up our
logic as we allow more content to take this path. From a cursory look, we
should be able to hook into resolveAlignmentShift to compute the correct
for the box&apos;s alignment, but we will do this on a case-by-case basis.

Canonical link: <a href="https://commits.webkit.org/297724@main">https://commits.webkit.org/297724@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e35c98835d1f8fae083cd916980ff291a46f2795

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112613 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32345 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22823 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118812 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63130 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114575 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32997 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40908 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85706 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36351 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115560 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26332 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101302 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66011 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25628 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19439 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62571 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95721 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19514 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122033 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39687 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29561 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94575 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40070 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97540 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94312 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24085 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39428 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17230 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35775 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39575 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45063 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39213 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42547 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40953 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->