### PR TITLE
[bmalloc] Add fuzzing option for TZone compaction

### DIFF
--- a/Source/bmalloc/bmalloc/BPlatform.h
+++ b/Source/bmalloc/bmalloc/BPlatform.h
@@ -33,6 +33,14 @@
 #include <TargetConditionals.h>
 #endif
 
+#ifndef BASSERT_ENABLED
+#ifdef NDEBUG
+#define BASSERT_ENABLED 0
+#else
+#define BASSERT_ENABLED 1
+#endif
+#endif
+
 #define BPLATFORM(PLATFORM) (defined BPLATFORM_##PLATFORM && BPLATFORM_##PLATFORM)
 #define BOS(OS) (defined BOS_##OS && BOS_##OS)
 
@@ -382,5 +390,13 @@
 #define BUSE_TZONE 1
 #else
 #define BUSE_TZONE 0
+#endif
+#endif
+
+#if !defined(BUSE_DYNAMIC_TZONE_COMPACTION)
+#if BUSE(TZONE) && (BASAN_ENABLED || BASSERT_ENABLED)
+#define BUSE_DYNAMIC_TZONE_COMPACTION 1
+#else
+#define BUSE_DYNAMIC_TZONE_COMPACTION 0
 #endif
 #endif

--- a/Source/bmalloc/bmalloc/TZoneHeap.cpp
+++ b/Source/bmalloc/bmalloc/TZoneHeap.cpp
@@ -109,6 +109,18 @@ void tzoneFree(void* p)
     bmalloc_deallocate_inline(p);
 }
 
+#if BUSE_DYNAMIC_TZONE_COMPACTION
+
+bool shouldDynamicallyCompactImpl(const TZoneSpecification& spec)
+{
+    BASSERT(TZoneHeapManager::singleton().tzoneDynamicCompactModeEnabled());
+    uint64_t key = spec.dynamicCompactionKey;
+    uint64_t signature = __builtin_popcountll(key & TZoneHeapManager::singleton().dynamicCompactionSalt());
+    return signature & 0x1;
+}
+
+#endif
+
 #undef TO_PAS_HEAPREF
 
 } } // namespace bmalloc::api

--- a/Source/bmalloc/bmalloc/TZoneHeapInlines.h
+++ b/Source/bmalloc/bmalloc/TZoneHeapInlines.h
@@ -55,7 +55,7 @@ public: \
     void* operator new(size_t size) \
     { \
         static HeapRef s_heapRef; \
-        static const TZoneSpecification s_heapSpec = { &s_heapRef, sizeof(_type), ::bmalloc::api::compactAllocationMode<_type>(), SizeAndAlignment::encode<_type>() TZONE_SPEC_NAME_ARG(#_type) }; \
+        static const TZoneSpecification s_heapSpec = { &s_heapRef, sizeof(_type), ::bmalloc::api::compactAllocationMode<_type>(), SizeAndAlignment::encode<_type>() TZONE_SPEC_NAME_ARG(#_type) TZONE_DYNAMIC_COMPACTION_ARG(_type) }; \
     \
         if (!s_heapRef || size != sizeof(_type)) { [[unlikely]] \
             if constexpr (::bmalloc::api::compactAllocationMode<_type>() == CompactAllocationMode::Compact) \
@@ -64,6 +64,8 @@ public: \
         } \
         BASSERT(::bmalloc::api::tzoneMallocFallback > TZoneMallocFallback::ForceDebugMalloc); \
         if constexpr (::bmalloc::api::compactAllocationMode<_type>() == CompactAllocationMode::Compact) \
+            return ::bmalloc::api::tzoneAllocateCompact(s_heapRef); \
+        if (::bmalloc::api::shouldDynamicallyCompact(s_heapSpec)) \
             return ::bmalloc::api::tzoneAllocateCompact(s_heapRef); \
         return ::bmalloc::api::tzoneAllocate ## _compactMode(s_heapRef); \
     } \
@@ -90,11 +92,13 @@ private: \
 #define MAKE_BTZONE_MALLOCED_IMPL(_type, _compactMode) \
 ::bmalloc::api::HeapRef _type::s_heapRef; \
 \
-const TZoneSpecification _type::s_heapSpec = { &_type::s_heapRef, sizeof(_type), ::bmalloc::api::compactAllocationMode<_type>(), SizeAndAlignment::encode<_type>() TZONE_SPEC_NAME_ARG(#_type) }; \
+const TZoneSpecification _type::s_heapSpec = { &_type::s_heapRef, sizeof(_type), ::bmalloc::api::compactAllocationMode<_type>(), SizeAndAlignment::encode<_type>() TZONE_SPEC_NAME_ARG(#_type) TZONE_DYNAMIC_COMPACTION_ARG(_type) }; \
 \
 void* _type::operatorNewSlow(size_t size) \
 { \
     if constexpr (::bmalloc::api::compactAllocationMode<_type>() == CompactAllocationMode::Compact) \
+        return ::bmalloc::api::tzoneAllocateCompactSlow(size, s_heapSpec); \
+    if (::bmalloc::api::shouldDynamicallyCompact(s_heapSpec)) \
         return ::bmalloc::api::tzoneAllocateCompactSlow(size, s_heapSpec); \
     return ::bmalloc::api::tzoneAllocate ## _compactMode ## Slow(size, s_heapSpec); \
 } \

--- a/Source/bmalloc/bmalloc/TZoneHeapManager.cpp
+++ b/Source/bmalloc/bmalloc/TZoneHeapManager.cpp
@@ -293,6 +293,7 @@ void TZoneHeapManager::init()
     }
 
     s_state = State::Seeded;
+    initializeTZoneDynamicCompactMode();
 
     if (verbose)
         atexit(dumpRegisteredTypesAtExit);
@@ -509,6 +510,42 @@ BINLINE unsigned TZoneHeapManager::tzoneBucketForKey(const TZoneSpecification& s
     return bucket;
 }
 
+#if BUSE_DYNAMIC_TZONE_COMPACTION
+bool g_tzoneDynamicCompactModeEnabled = false;
+#endif
+
+void TZoneHeapManager::initializeTZoneDynamicCompactMode()
+{
+#if BUSE_DYNAMIC_TZONE_COMPACTION
+    RELEASE_BASSERT(s_state >= State::Seeded);
+    const char* envEnable = getenv("bmalloc_TZoneDynamicCompactModeEnable");
+    if (envEnable && (!strcasecmp(envEnable, "true") || !strcasecmp(envEnable, "yes") || !strcmp(envEnable, "1"))) {
+        g_tzoneDynamicCompactModeEnabled = true;
+
+        const char* envSeed = getenv("bmalloc_TZoneDynamicCompactModeSeed");
+        if (envSeed) {
+            errno = 0;
+            m_tzoneDynamicCompactModeSeed = std::strtoull(envSeed, nullptr, 16);
+            if (verbose && errno)
+                TZONE_LOG_DEBUG("Error in strtoull for bmalloc_TZoneDynamicCompactModeSeed: %s\n", strerror(errno));
+            RELEASE_BASSERT(!errno);
+        } else
+            m_tzoneDynamicCompactModeSeed = m_tzoneKeySeed;
+
+        // The generated seed can be zero, but that's OK:
+        // that corresponds to dynamic compaction being enabled for no types,
+        // which is a valid configuration that's worth fuzzing.
+        m_tzoneDynamicCompactModeSalt = WeakRandom::generate(m_tzoneDynamicCompactModeSeed);
+
+        if constexpr (verbose) {
+            TZONE_LOG_DEBUG("dynamicCompactionSeed: 0x%llx\n", m_tzoneDynamicCompactModeSeed);
+            TZONE_LOG_DEBUG("dynamicCompactionSalt: 0x%llx\n", m_tzoneDynamicCompactModeSalt);
+        }
+        RELEASE_BASSERT(m_tzoneDynamicCompactModeSalt);
+    }
+#endif
+}
+
 BALLOW_UNSAFE_BUFFER_USAGE_END
 
 TZoneHeapManager::TZoneTypeBuckets* TZoneHeapManager::populateBucketsForSizeClass(LockHolder& lock, SizeAndAlignment::Value sizeAndAlignment)
@@ -637,7 +674,10 @@ pas_heap_ref* TZoneHeapManager::TZoneHeapManager::heapRefForTZoneTypeDifferentSi
         spec.allocationMode,
         SizeAndAlignment::encode(newSize, alignment),
 #if BUSE_TZONE_SPEC_NAME_ARG
-        spec.name
+        spec.name,
+#endif
+#if BUSE_DYNAMIC_TZONE_COMPACTION
+        spec.dynamicCompactionKey,
 #endif
     };
     pas_heap_ref* result = heapRefForTZoneType(newSpec);

--- a/Source/bmalloc/bmalloc/TZoneHeapManager.h
+++ b/Source/bmalloc/bmalloc/TZoneHeapManager.h
@@ -44,6 +44,9 @@ namespace bmalloc { namespace api {
 #define TZONE_VERBOSE_DEBUG 0
 
 extern BEXPORT class TZoneHeapManager* tzoneHeapManager;
+#if BUSE_DYNAMIC_TZONE_COMPACTION
+BEXPORT extern bool g_tzoneDynamicCompactModeEnabled;
+#endif
 
 class TZoneHeapManager {
     enum class State {
@@ -132,6 +135,10 @@ public:
 
     BEXPORT static void requirePerBootSeed();
     BEXPORT static void setBucketParams(unsigned smallSizeCount, unsigned largeSizeCount = 0, unsigned smallSizeLimit = 0);
+#if BUSE_DYNAMIC_TZONE_COMPACTION
+    BINLINE uint64_t dynamicCompactionSalt() { return m_tzoneDynamicCompactModeSalt; }
+    BINLINE static bool tzoneDynamicCompactModeEnabled() { return g_tzoneDynamicCompactModeEnabled; }
+#endif
 
     BEXPORT static bool isReady();
 
@@ -165,6 +172,8 @@ private:
 
     inline static unsigned bucketCountForSizeClass(SizeAndAlignment::Value);
 
+    void initializeTZoneDynamicCompactMode();
+
     inline unsigned tzoneBucketForKey(const TZoneSpecification&, unsigned bucketCountForSize, LockHolder&);
     TZoneTypeBuckets* populateBucketsForSizeClass(LockHolder&, SizeAndAlignment::Value);
 
@@ -175,6 +184,10 @@ private:
 #if TZONE_VERBOSE_DEBUG
     unsigned largestBucketCount { 0 };
     Vector<SizeAndAlignment::Value> m_typeSizes;
+#endif
+#if BUSE_DYNAMIC_TZONE_COMPACTION
+    uint64_t m_tzoneDynamicCompactModeSeed;
+    uint64_t m_tzoneDynamicCompactModeSalt;
 #endif
     Map<SizeAndAlignment::Value, TZoneTypeBuckets*, SizeAndAlignment> m_heapRefsBySizeAndAlignment;
     Map<TZoneTypeKey, pas_heap_ref*, TZoneTypeKey> m_differentSizedHeapRefs;


### PR DESCRIPTION
#### edcd534cc66fc2e5037f85a5acd120cd9b5d1f76
<pre>
[bmalloc] Add fuzzing option for TZone compaction
<a href="https://bugs.webkit.org/show_bug.cgi?id=295807">https://bugs.webkit.org/show_bug.cgi?id=295807</a>
<a href="https://rdar.apple.com/155639885">rdar://155639885</a>

Reviewed by Mark Lam.

This allows us to test different configurations for the compaction of
types allocated with TZoneMalloc.

Currently this is only compiled-in in Debug builds, as the extra runtime
check it requires on the malloc hot-path would otherwise be pessimizing.
When it is compiled in, it is enabled with the envvar
&apos;bmalloc_DynamicCompactModeEnable=1&apos;.
To change the seed used from the default (which is tied to the TZone
seed), you can also set &apos;bmalloc_DynamicCompactModeSeed=0x&lt;seed&gt;&apos;.

* Source/bmalloc/bmalloc/BPlatform.h:
* Source/bmalloc/bmalloc/TZoneHeap.cpp:
(bmalloc::api::getTZoneDynamicCompactionSalt):
(bmalloc::api::isTZoneDynamicCompactionEnabled):
* Source/bmalloc/bmalloc/TZoneHeap.h:
(bmalloc::api::fnv1aHash):
(bmalloc::api::encodeTZoneDynamicCompactionKey):
(bmalloc::api::shouldDynamicallyCompact):
(bmalloc::api::requiresCompactPointers):
* Source/bmalloc/bmalloc/TZoneHeapInlines.h:
* Source/bmalloc/bmalloc/TZoneHeapManager.cpp:
(bmalloc::api::TZoneHeapManager::dynamicCompactionSalt):
(bmalloc::api::TZoneHeapManager::init):
(bmalloc::api::TZoneHeapManager::initializeTZoneDynamicCompaction):
(bmalloc::api::TZoneHeapManager::TZoneHeapManager::heapRefForTZoneTypeDifferentSize):
* Source/bmalloc/bmalloc/TZoneHeapManager.h:
(bmalloc::api::TZoneHeapManager::tzoneDynamicCompactionEnabled):

Canonical link: <a href="https://commits.webkit.org/298007@main">https://commits.webkit.org/298007@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46f77ec0c7dd02c61898f632bbfff59e9eeb2fcb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113888 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33640 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120052 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/64672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34268 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42201 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/86561 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/64672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116836 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27278 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102294 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66934 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/26479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20424 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63771 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/106335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96646 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20540 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123284 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/112451 "Built successfully and passed tests") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40933 "Failed to checkout and rebase branch from PR 47911") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/30478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/95398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41306 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98506 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/95171 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24269 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40309 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/18115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40802 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/136657 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/40440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36598 "Found 1 new JSC stress test failure: stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint (failure)") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/43740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/42198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->