### PR TITLE
Remove deprecated sessionDisplayTitlePublisher and sessionDisplaySubtitlePublisher from Playable

### DIFF
--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift
@@ -526,11 +526,11 @@ extension WKSLinearMediaPlayer {
     public var isMutedPublisher: AnyPublisher<Bool, Never> {
         publisher(for: \.isMuted).eraseToAnyPublisher()
     }
-
+#if !canImport(AVKit, _version: 1270)
     public var sessionDisplayTitlePublisher: AnyPublisher<String?, Never> {
         publisher(for: \.sessionDisplayTitle).eraseToAnyPublisher()
     }
-
+#endif
     public var sessionThumbnailPublisher: AnyPublisher<UIImage?, Never> {
         publisher(for: \.sessionThumbnail).eraseToAnyPublisher()
     }


### PR DESCRIPTION
#### 0482b0802378f9131ad7b8e50ae0717c215f16b4
<pre>
Remove deprecated sessionDisplayTitlePublisher and sessionDisplaySubtitlePublisher from Playable
<a href="https://bugs.webkit.org/show_bug.cgi?id=295812">https://bugs.webkit.org/show_bug.cgi?id=295812</a>
<a href="https://rdar.apple.com/155265597">rdar://149973651</a>

Reviewed by Andy Estes.

Wrapped the sessionDisplaySubtitlePublisher block with an availability check to ensure it is only
executed on supported OS versions since it is deprecated to prevent crashes while avoiding usage on
newer systems.

* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift:

Canonical link: <a href="https://commits.webkit.org/297549@main">https://commits.webkit.org/297549@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45bb061adf0582a72e96ee7b51d352cbf92dc11e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111749 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21890 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117774 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61993 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32099 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39996 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84898 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35594 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114696 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25628 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100566 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65336 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24957 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61604 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95011 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18771 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121023 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38789 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28832 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93787 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39169 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96822 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93821 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23957 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38765 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16548 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/34813 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38684 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44177 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38332 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41658 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40042 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->