### PR TITLE
[macOS] [DumpRenderTree] Several editing/pasteboard/entries-api tests are flaky timeouts

### DIFF
--- a/Tools/DumpRenderTree/mac/EventSendingController.mm
+++ b/Tools/DumpRenderTree/mac/EventSendingController.mm
@@ -789,7 +789,7 @@ static NSUInteger swizzledEventPressedMouseButtons()
                                                       location:lastMousePosition]);
 #endif // !PLATFORM(IOS_FAMILY)
 
-    NSView *subView = [[mainFrame webView] hitTest:[event locationInWindow]];
+    NSView *subView = [[mainFrame webView] hitTest:lastMousePosition];
     if (subView) {
 #if !PLATFORM(IOS_FAMILY)
         [NSApp _setCurrentEvent:event.get()];


### PR DESCRIPTION
#### 30073f94944a2dbbdc2a05cbbd1dc37ba933341e
<pre>
[macOS] [DumpRenderTree] Several editing/pasteboard/entries-api tests are flaky timeouts
<a href="https://bugs.webkit.org/show_bug.cgi?id=295816">https://bugs.webkit.org/show_bug.cgi?id=295816</a>

Reviewed by Abrar Rahman Protyasha.

This is a speculative fix to try and stabilize several flaky WebKit1 layout tests — some of these
tests occasionally time out, because a drop is never handled when dispatching `mouseUp`, after
simulating a drag session.

This happens when `-[NSEvent locationInWindow]` for the synthesized mouse event returns an offset
that is far offscreen — e.g. `(-9804, 10726)` — instead of the real offset relative to the window.
After a bit more investigation, the concatenated window transform (`CGSGetCatenatedWindowTransform`)
on `DumpRenderTreeWindow` ends up having an offset close to the origin (0, 0) in the failing case,
rather than large positive x and y translation offsets in the passing case. This is important
because the value of `-locationInWindow` is internally round-tripped in AppKit through
`-[NSEvent _initWithCGEvent:eventRef:]`, which means we end up taking `newMousePosition`, mapping
it to screen coordinates when extracting the `CGEventRef`, and then have AppKit try to map the point
in screen coordinates back to window coordinates in that internal initializer.

Instead of going through all the above, we can instead simply call `-hitTest:` using our original
mouse position which is already in window coordinates.

* Tools/DumpRenderTree/mac/EventSendingController.mm:
(-[EventSendingController mouseMoveToX:Y:]):

Canonical link: <a href="https://commits.webkit.org/297298@main">https://commits.webkit.org/297298@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/394d883afcfff9e0be05e4d2e6917fe4ef99d055

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21334 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117252 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/61489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113183 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31568 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39469 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84536 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/61489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114168 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25210 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100131 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64982 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24552 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18272 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61072 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94588 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18339 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120340 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38270 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28435 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93467 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38646 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96406 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93292 "Found 2 new API test failures: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23778 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38383 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16149 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34255 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38159 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37824 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41157 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39526 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->