### PR TITLE
[JSC] Make JSRopeString non destructible

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -16506,7 +16506,7 @@ void SpeculativeJIT::compileMakeRope(Node* node)
 
     JumpList slowPath;
     Allocator allocatorValue = allocatorForConcurrently<JSRopeString>(vm(), sizeof(JSRopeString), AllocatorForMode::AllocatorIfExists);
-    emitAllocateJSCell(resultGPR, JITAllocator::constant(allocatorValue), allocatorGPR, TrustedImmPtr(m_graph.registerStructure(vm().stringStructure.get())), scratchGPR, slowPath, SlowAllocationResult::UndefinedBehavior);
+    emitAllocateJSCell(resultGPR, JITAllocator::constant(allocatorValue), allocatorGPR, TrustedImmPtr(m_graph.stringStructure), scratchGPR, slowPath, SlowAllocationResult::UndefinedBehavior);
 
     // This puts nullptr for the first fiber. It makes visitChildren safe even if this JSRopeString is discarded due to the speculation failure in the following path.
     storePtr(TrustedImmPtr(JSString::isRopeInPointer), Address(resultGPR, JSRopeString::offsetOfFiber0()));

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -10863,7 +10863,7 @@ IGNORE_CLANG_WARNINGS_END
 
         Allocator allocator = allocatorForConcurrently<JSRopeString>(vm(), sizeof(JSRopeString), AllocatorForMode::AllocatorIfExists);
 
-        LValue result = allocateCell(m_out.constIntPtr(allocator.localAllocator()), vm().stringStructure.get(), slowPath);
+        LValue result = allocateCell(m_out.constIntPtr(allocator.localAllocator()), m_graph.stringStructure.get(), slowPath);
 
         // This puts nullptr for the first fiber. It makes visitChildren safe even if this JSRopeString is discarded due to the speculation failure in the following path.
         m_out.storePtr(m_out.constIntPtr(JSString::isRopeInPointer), result, m_heaps.JSRopeString_fiber0);

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -143,7 +143,7 @@ class Heap;
     v(propertyTableSpace, destructibleCellHeapCellType, PropertyTable) \
     v(regExpSpace, destructibleCellHeapCellType, RegExp) \
     v(regExpObjectSpace, cellHeapCellType, RegExpObject) \
-    v(ropeStringSpace, ropeStringHeapCellType, JSRopeString) \
+    v(ropeStringSpace, cellHeapCellType, JSRopeString) \
     v(scopedArgumentsSpace, cellHeapCellType, ScopedArguments) \
     v(sparseArrayValueMapSpace, destructibleCellHeapCellType, SparseArrayValueMap) \
     v(stringSpace, stringHeapCellType, JSString) \
@@ -1018,7 +1018,6 @@ public:
     IsoHeapCellType moduleNamespaceObjectHeapCellType;
     IsoHeapCellType nativeStdFunctionHeapCellType;
     IsoInlinedHeapCellType<JSString> stringHeapCellType;
-    IsoInlinedHeapCellType<JSRopeString> ropeStringHeapCellType;
     IsoHeapCellType weakMapHeapCellType;
     IsoHeapCellType weakSetHeapCellType;
     JSDestructibleObjectHeapCellType destructibleObjectHeapCellType;

--- a/Source/JavaScriptCore/heap/SlotVisitor.cpp
+++ b/Source/JavaScriptCore/heap/SlotVisitor.cpp
@@ -373,7 +373,7 @@ ALWAYS_INLINE void SlotVisitor::visitChildren(const JSCell* cell)
     case StringType:
         JSString::visitChildren(const_cast<JSCell*>(cell), *this);
         break;
-        
+
     case FinalObjectType:
         JSFinalObject::visitChildren(const_cast<JSCell*>(cell), *this);
         break;

--- a/Source/JavaScriptCore/runtime/JSFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSFunction.cpp
@@ -540,7 +540,7 @@ String getCalculatedDisplayName(VM& vm, JSObject* object)
     if (offset != invalidOffset && !(attributes & (PropertyAttribute::Accessor | PropertyAttribute::CustomAccessorOrValue))) {
         JSValue displayName = object->getDirect(offset);
         if (displayName && displayName.isString())
-            return asString(displayName)->tryGetValueWithoutGC();
+            return makeString(asString(displayName));
     }
 
     if (auto* function = jsDynamicCast<JSFunction*>(object)) {

--- a/Source/JavaScriptCore/runtime/JSString.cpp
+++ b/Source/JavaScriptCore/runtime/JSString.cpp
@@ -106,37 +106,41 @@ void JSString::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     JSString* thisObject = asString(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    
     uintptr_t pointer = thisObject->fiberConcurrently();
-    if (pointer & isRopeInPointer) {
-        if (pointer & JSRopeString::isSubstringInPointer) {
-            visitor.appendUnbarriered(static_cast<JSRopeString*>(thisObject)->fiber1());
-            return;
-        }
-        for (unsigned index = 0; index < JSRopeString::s_maxInternalRopeLength; ++index) {
-            JSString* fiber = nullptr;
-            switch (index) {
-            case 0:
-                fiber = std::bit_cast<JSString*>(pointer & JSRopeString::stringMask);
-                break;
-            case 1:
-                fiber = static_cast<JSRopeString*>(thisObject)->fiber1();
-                break;
-            case 2:
-                fiber = static_cast<JSRopeString*>(thisObject)->fiber2();
-                break;
-            default:
-                ASSERT_NOT_REACHED();
-                return;
-            }
-            if (!fiber)
-                break;
-            visitor.appendUnbarriered(fiber);
-        }
+
+    // This JSString is not JSRopeString. Thus we report held string's cost.
+    if (thisObject->isStringImplOwner()) {
+        ASSERT(!(pointer & isRopeInPointer));
+        if (StringImpl* impl = std::bit_cast<StringImpl*>(pointer))
+            visitor.reportExtraMemoryVisited(impl->costDuringGC());
         return;
     }
-    if (StringImpl* impl = std::bit_cast<StringImpl*>(pointer))
-        visitor.reportExtraMemoryVisited(impl->costDuringGC());
+
+    if (!(pointer & isRopeInPointer)) {
+        // When rope is resolved, fiber2 is a holder of the resolved string.
+        if (auto* fiber = static_cast<JSRopeString*>(thisObject)->fiber2())
+            visitor.appendUnbarriered(fiber);
+        return;
+    }
+
+    if (pointer & JSRopeString::isSubstringInPointer) {
+        visitor.appendUnbarriered(static_cast<JSRopeString*>(thisObject)->fiber1());
+        return;
+    }
+    if (auto* fiber = std::bit_cast<JSString*>(pointer & JSRopeString::stringMask))
+        visitor.appendUnbarriered(fiber);
+    else
+        return;
+
+    if (auto* fiber = static_cast<JSRopeString*>(thisObject)->fiber1())
+        visitor.appendUnbarriered(fiber);
+    else
+        return;
+
+    if (auto* fiber = static_cast<JSRopeString*>(thisObject)->fiber2())
+        visitor.appendUnbarriered(fiber);
+    else
+        return;
 }
 
 DEFINE_VISIT_CHILDREN(JSString);
@@ -159,8 +163,7 @@ GCOwnedDataScope<AtomStringImpl*> JSRopeString::resolveRopeToAtomString(JSGlobal
 
     if (length() > maxLengthForOnStackResolve) {
         scope.release();
-        constexpr bool reportAllocation = true;
-        return convertToAtomString(resolveRopeWithFunction<reportAllocation>(globalObject, [&] (Ref<StringImpl>&& newImpl) {
+        return convertToAtomString(resolveRopeWithFunction(globalObject, [&] (Ref<StringImpl>&& newImpl) {
             return AtomStringImpl::add(newImpl.ptr());
         }));
     }
@@ -180,10 +183,7 @@ GCOwnedDataScope<AtomStringImpl*> JSRopeString::resolveRopeToAtomString(JSGlobal
     } else
         atomString = StringView { substringBase()->valueInternal() }.substring(substringOffset(), length()).toAtomString();
 
-    size_t sizeToReport = atomString.impl()->hasOneRef() ? atomString.impl()->cost() : 0;
-    convertToNonRope(String { atomString.releaseImpl() });
-    // If we resolved a string that didn't previously exist, notify the heap that we've grown.
-    vm.heap.reportExtraMemoryAllocated(this, sizeToReport);
+    convertToNonRope(vm, String { atomString.releaseImpl() });
     return { this, static_cast<AtomStringImpl*>(valueInternal().impl()) };
 }
 
@@ -194,8 +194,7 @@ GCOwnedDataScope<AtomStringImpl*> JSRopeString::resolveRopeToExistingAtomString(
 
     if (length() > maxLengthForOnStackResolve) {
         RefPtr<AtomStringImpl> existingAtomString;
-        constexpr bool reportAllocation = true;
-        resolveRopeWithFunction<reportAllocation>(globalObject, [&] (Ref<StringImpl>&& newImpl) -> Ref<StringImpl> {
+        resolveRopeWithFunction(globalObject, [&] (Ref<StringImpl>&& newImpl) -> Ref<StringImpl> {
             existingAtomString = AtomStringImpl::lookUp(newImpl.ptr());
             if (existingAtomString)
                 return Ref { *existingAtomString };
@@ -221,11 +220,11 @@ GCOwnedDataScope<AtomStringImpl*> JSRopeString::resolveRopeToExistingAtomString(
         existingAtomString = StringView { substringBase()->valueInternal() }.substring(substringOffset(), length()).toExistingAtomString().releaseImpl();
 
     if (existingAtomString)
-        convertToNonRope(*existingAtomString);
+        convertToNonRope(vm, *existingAtomString);
     return { this, existingAtomString.get() };
 }
 
-template<bool reportAllocation, typename Function>
+template<typename Function>
 const String& JSRopeString::resolveRopeWithFunction(JSGlobalObject* nullOrGlobalObjectForOOM, Function&& function) const
 {
     ASSERT(isRope());
@@ -234,7 +233,7 @@ const String& JSRopeString::resolveRopeWithFunction(JSGlobalObject* nullOrGlobal
     if (isSubstring()) {
         ASSERT(!substringBase()->isRope());
         auto newImpl = substringBase()->valueInternal().substringSharingImpl(substringOffset(), length());
-        convertToNonRope(function(newImpl.releaseImpl().releaseNonNull()));
+        convertToNonRope(vm, function(newImpl.releaseImpl().releaseNonNull()));
         return valueInternal();
     }
     
@@ -246,12 +245,9 @@ const String& JSRopeString::resolveRopeWithFunction(JSGlobalObject* nullOrGlobal
             return nullString();
         }
 
-        size_t sizeToReport = newImpl->cost();
         uint8_t* stackLimit = std::bit_cast<uint8_t*>(vm.softStackLimit());
         resolveRopeInternalNoSubstring(buffer, stackLimit);
-        convertToNonRope(function(newImpl.releaseNonNull()));
-        if constexpr (reportAllocation)
-            vm.heap.reportExtraMemoryAllocated(this, sizeToReport);
+        convertToNonRope(vm, function(newImpl.releaseNonNull()));
         return valueInternal();
     }
     
@@ -262,27 +258,15 @@ const String& JSRopeString::resolveRopeWithFunction(JSGlobalObject* nullOrGlobal
         return nullString();
     }
     
-    size_t sizeToReport = newImpl->cost();
     uint8_t* stackLimit = std::bit_cast<uint8_t*>(vm.softStackLimit());
     resolveRopeInternalNoSubstring(buffer, stackLimit);
-    convertToNonRope(function(newImpl.releaseNonNull()));
-    if constexpr (reportAllocation)
-        vm.heap.reportExtraMemoryAllocated(this, sizeToReport);
+    convertToNonRope(vm, function(newImpl.releaseNonNull()));
     return valueInternal();
 }
 
 const String& JSRopeString::resolveRope(JSGlobalObject* nullOrGlobalObjectForOOM) const
 {
-    constexpr bool reportAllocation = true;
-    return resolveRopeWithFunction<reportAllocation>(nullOrGlobalObjectForOOM, [] (Ref<StringImpl>&& newImpl) {
-        return WTFMove(newImpl);
-    });
-}
-
-const String& JSRopeString::resolveRopeWithoutGC() const
-{
-    constexpr bool reportAllocation = false;
-    return resolveRopeWithFunction<reportAllocation>(nullptr, [] (Ref<StringImpl>&& newImpl) {
+    return resolveRopeWithFunction(nullOrGlobalObjectForOOM, [] (Ref<StringImpl>&& newImpl) {
         return WTFMove(newImpl);
     });
 }
@@ -338,15 +322,6 @@ bool JSString::getStringPropertyDescriptor(JSGlobalObject* globalObject, Propert
     }
     
     return false;
-}
-
-GCOwnedDataScope<const String&> JSString::tryGetValueWithoutGC() const
-{
-    if (isRope()) {
-        // Pass nullptr for the JSGlobalObject so that resolveRope does not throw in the event of an OOM error.
-        return { this, static_cast<const JSRopeString*>(this)->resolveRopeWithoutGC() };
-    }
-    return { this, valueInternal() };
 }
 
 JSString* jsStringWithCacheSlowCase(VM& vm, StringImpl& stringImpl)

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -88,7 +88,10 @@ JSString* asString(JSValue);
 // Since length of JSRopeString should be frequently accessed compared to each fiber, we put length in contiguous 32byte field, and compress 2nd
 // and 3rd fibers into the following 80byte fields. One problem is that now 2nd and 3rd fibers are split. Storing and loading 2nd and 3rd fibers
 // are not one pointer load operation. To make concurrent collector work correctly, we must initialize 2nd and 3rd fibers at JSRopeString creation
-// and we must not modify these part later.
+//
+// JSRopeString does not have String ownership even after it gets resolved. When resolving a JSRopeString, we create a new JSString, keeping it referenced
+// from JSRopeString, and JSRopeString exposes this StringImpl* without maintaining the ownership. This allows JSRopeString to be non-destructible.
+// We store this newly created owner JSString* holder to 3rd fiber since it can be concurrently updated.
 //
 //              0                        8        10               16          20           24           26           28           32
 // JSString     [   ID      ][  header  ][   String pointer      0]
@@ -158,6 +161,7 @@ private:
     JSString(VM& vm, Ref<StringImpl>&& value)
         : JSCell(CreatingWellDefinedBuiltinCell, vm.stringStructure.get()->id(), defaultTypeInfoBlob())
     {
+        setPerCellBit(true);
         new (&uninitializedValueInternal()) String(WTFMove(value));
     }
 
@@ -233,7 +237,6 @@ public:
     inline bool equal(JSGlobalObject*, JSString* other) const;
     GCOwnedDataScope<const String&> value(JSGlobalObject*) const;
     inline GCOwnedDataScope<const String&> tryGetValue(bool allocationAllowed = true) const;
-    GCOwnedDataScope<const String&> tryGetValueWithoutGC() const;
     StringImpl* getValueImpl() const;
     StringImpl* tryGetValueImpl() const;
     ALWAYS_INLINE unsigned length() const;
@@ -284,6 +287,8 @@ protected:
     friend class JSValue;
     friend class JSCell;
 
+    ALWAYS_INLINE bool isStringImplOwner() const { return perCellBit(); }
+
     JS_EXPORT_PRIVATE bool equalSlowCase(JSGlobalObject*, JSString* other) const;
 
     inline JSString* tryReplaceOneCharImpl(JSGlobalObject*, char16_t search, JSString* replacement, uint8_t* stackLimit, bool& found);
@@ -327,8 +332,9 @@ class JSRopeString final : public JSString {
     friend class JSString;
     friend class RegExpObject;
     friend class RegExpSubstringGlobalAtomCache;
+    using Base = JSString;
 public:
-    static constexpr DestructionMode needsDestruction = MayNeedDestruction;
+    static constexpr DestructionMode needsDestruction = DoesNotNeedDestruction;
     static constexpr uint8_t numberOfLowerTierPreciseCells = 0;
     static void destroy(JSCell*);
 
@@ -349,13 +355,21 @@ public:
     static_assert(sizeof(uintptr_t) == sizeof(uint64_t));
     class CompactFibers {
     public:
+        CompactFibers() = default;
+
+        struct Latter {
+            uint16_t m_fiber1Upper { 0 };
+            uint16_t m_fiber2Lower { 0 };
+            uint32_t m_fiber2Upper { 0 };
+        };
+
         static constexpr uintptr_t addressMask = (1ULL << OS_CONSTANT(EFFECTIVE_ADDRESS_WIDTH)) - 1;
         JSString* fiber1() const
         {
 #if CPU(LITTLE_ENDIAN)
             return std::bit_cast<JSString*>(WTF::unalignedLoad<uintptr_t>(&m_fiber1Lower) & addressMask);
 #else
-            return std::bit_cast<JSString*>(static_cast<uintptr_t>(m_fiber1Lower) | (static_cast<uintptr_t>(m_fiber1Upper) << 32));
+            return std::bit_cast<JSString*>(static_cast<uintptr_t>(m_fiber1Lower) | (static_cast<uintptr_t>(m_latter.m_fiber1Upper) << 32));
 #endif
         }
 
@@ -363,22 +377,40 @@ public:
         {
             uintptr_t pointer = std::bit_cast<uintptr_t>(fiber);
             m_fiber1Lower = static_cast<uint32_t>(pointer);
-            m_fiber1Upper = static_cast<uint16_t>(pointer >> 32);
+            m_latter.m_fiber1Upper = static_cast<uint16_t>(pointer >> 32);
         }
 
         JSString* fiber2() const
         {
 #if CPU(LITTLE_ENDIAN)
-            return std::bit_cast<JSString*>(WTF::unalignedLoad<uintptr_t>(&m_fiber1Upper) >> 16);
+            return std::bit_cast<JSString*>(m_latterBits >> 16);
 #else
-            return std::bit_cast<JSString*>(static_cast<uintptr_t>(m_fiber2Lower) | (static_cast<uintptr_t>(m_fiber2Upper) << 16));
+            return std::bit_cast<JSString*>(static_cast<uintptr_t>(m_latter.m_fiber2Lower) | (static_cast<uintptr_t>(m_latter.m_fiber2Upper) << 16));
 #endif
         }
         void initializeFiber2(JSString* fiber)
         {
             uintptr_t pointer = std::bit_cast<uintptr_t>(fiber);
-            m_fiber2Lower = static_cast<uint16_t>(pointer);
-            m_fiber2Upper = static_cast<uint32_t>(pointer >> 16);
+            m_latter.m_fiber2Lower = static_cast<uint16_t>(pointer);
+            m_latter.m_fiber2Upper = static_cast<uint32_t>(pointer >> 16);
+        }
+
+        void replaceFiber2(JSString* fiber)
+        {
+#if CPU(LITTLE_ENDIAN)
+            uintptr_t pointer = std::bit_cast<uintptr_t>(fiber);
+            m_latterBits = (m_latterBits & 0xffff) | (pointer << 16);
+#else
+            uint16_t fiber1Upper = m_latter.m_fiber1Upper;
+            uint16_t fiber2Lower = static_cast<uint16_t>(pointer);
+            uint32_t fiber2Upper = static_cast<uint32_t>(pointer >> 16);
+            Latter value {
+                fiber1Upper,
+                fiber2Lower,
+                fiber2Upper
+            };
+            m_latterBits = std::bit_cast<uint64_t>(value);
+#endif
         }
 
         unsigned length() const { return m_length; }
@@ -389,16 +421,17 @@ public:
 
         static constexpr ptrdiff_t offsetOfLength() { return OBJECT_OFFSETOF(CompactFibers, m_length); }
         static constexpr ptrdiff_t offsetOfFiber1() { return OBJECT_OFFSETOF(CompactFibers, m_length); }
-        static constexpr ptrdiff_t offsetOfFiber2() { return OBJECT_OFFSETOF(CompactFibers, m_fiber1Upper); }
+        static constexpr ptrdiff_t offsetOfFiber2() { return OBJECT_OFFSETOF(CompactFibers, m_latter.m_fiber1Upper); }
 
     private:
         friend class LLIntOffsetsExtractor;
 
         uint32_t m_length { 0 };
         uint32_t m_fiber1Lower { 0 };
-        uint16_t m_fiber1Upper { 0 };
-        uint16_t m_fiber2Lower { 0 };
-        uint32_t m_fiber2Upper { 0 };
+        union {
+            Latter m_latter { };
+            uint64_t m_latterBits;
+        };
     };
     static_assert(sizeof(CompactFibers) == sizeof(void*) * 2);
 #else
@@ -418,6 +451,10 @@ public:
             return m_fiber2;
         }
         void initializeFiber2(JSString* fiber)
+        {
+            m_fiber2 = fiber;
+        }
+        void replaceFiber2(JSString* fiber)
         {
             m_fiber2 = fiber;
         }
@@ -527,7 +564,7 @@ public:
 private:
     friend class LLIntOffsetsExtractor;
 
-    void convertToNonRope(String&&) const;
+    void convertToNonRope(VM&, String&&) const;
 
     void initializeIs8Bit(bool flag) const
     {
@@ -619,7 +656,6 @@ public:
     // If nullOrExecForOOM is null, resolveRope() will be do nothing in the event of an OOM error.
     // The rope value will remain a null string in that case.
     JS_EXPORT_PRIVATE const String& resolveRope(JSGlobalObject* nullOrGlobalObjectForOOM) const;
-    JS_EXPORT_PRIVATE const String& resolveRopeWithoutGC() const;
 
     template<typename CharacterType>
     static void resolveToBuffer(JSString*, JSString*, JSString*, std::span<CharacterType> buffer, uint8_t* stackLimit);
@@ -660,7 +696,7 @@ private:
 
     friend JSValue jsStringFromRegisterArray(JSGlobalObject*, Register*, unsigned);
 
-    template<bool reportAllocation, typename Function> const String& resolveRopeWithFunction(JSGlobalObject* nullOrGlobalObjectForOOM, Function&&) const;
+    template<typename Function> const String& resolveRopeWithFunction(JSGlobalObject* nullOrGlobalObjectForOOM, Function&&) const;
     JS_EXPORT_PRIVATE GCOwnedDataScope<AtomStringImpl*> resolveRopeToAtomString(JSGlobalObject*) const;
     JS_EXPORT_PRIVATE GCOwnedDataScope<AtomStringImpl*> resolveRopeToExistingAtomString(JSGlobalObject*) const;
     template<typename CharacterType> void resolveRopeInternalNoSubstring(std::span<CharacterType>, uint8_t* stackLimit) const;
@@ -849,7 +885,15 @@ ALWAYS_INLINE void JSString::swapToAtomString(VM& vm, RefPtr<AtomStringImpl>&& a
     ASSERT(!isCompilationThread() && !Thread::mayBeGCThread());
     String target(WTFMove(atom));
     WTF::storeStoreFence(); // Ensure AtomStringImpl's string is fully initialized when it is exposed to concurrent threads.
-    valueInternal().swap(target);
+
+    ASSERT(!isRope());
+    if (isStringImplOwner())
+        valueInternal().swap(target);
+    else {
+        auto* holder = jsCast<const JSRopeString*>(this)->fiber2();
+        holder->valueInternal().swap(target);
+        m_fiber = std::bit_cast<uintptr_t>(holder->getValueImpl());
+    }
     vm.heap.appendPossiblyAccessedStringFromConcurrentThreads(WTFMove(target));
 }
 

--- a/Source/JavaScriptCore/runtime/JSStringInlines.h
+++ b/Source/JavaScriptCore/runtime/JSStringInlines.h
@@ -197,17 +197,22 @@ inline JSString* repeatCharacter(JSGlobalObject* globalObject, CharacterType cha
     RELEASE_AND_RETURN(scope, jsString(vm, impl.releaseNonNull()));
 }
 
-inline void JSRopeString::convertToNonRope(String&& string) const
+inline void JSRopeString::convertToNonRope(VM& vm, String&& string) const
 {
     // Concurrent compiler threads can access String held by JSString. So we always emit
     // store-store barrier here to ensure concurrent compiler threads see initialized String.
     ASSERT(JSString::isRope());
+    ASSERT(!isStringImplOwner());
+    auto* holder = jsString(vm, WTFMove(string));
     WTF::storeStoreFence();
-    new (&uninitializedValueInternal()) String(WTFMove(string));
+    // Do not ref / deref String here. Actual ownership is held by the holder.
+    m_fiber = std::bit_cast<uintptr_t>(holder->getValueImpl());
+    m_compactFibers.replaceFiber2(holder);
+    vm.writeBarrier(this, holder);
     static_assert(sizeof(String) == sizeof(RefPtr<StringImpl>), "JSString's String initialization must be done in one pointer move.");
     // We do not clear the trailing fibers and length information (fiber1 and fiber2) because we could be reading the length concurrently.
     ASSERT(!JSString::isRope());
-    notifyNeedsDestruction();
+    ASSERT(!isStringImplOwner());
 }
 
 inline StringImpl* JSRopeString::tryGetLHS(ASCIILiteral rhs) const
@@ -449,9 +454,7 @@ inline JSString* jsAtomString(JSGlobalObject* globalObject, VM& vm, JSString* st
 
     auto createFromRope = [&](VM& vm, auto& buffer) {
         auto impl = AtomStringImpl::add(buffer);
-        size_t sizeToReport = impl->hasOneRef() ? impl->cost() : 0;
-        ropeString->convertToNonRope(String { WTFMove(impl) });
-        vm.heap.reportExtraMemoryAllocated(ropeString, sizeToReport);
+        ropeString->convertToNonRope(vm, String { WTFMove(impl) });
         return ropeString;
     };
 

--- a/Source/WTF/wtf/Atomics.h
+++ b/Source/WTF/wtf/Atomics.h
@@ -148,13 +148,13 @@ struct Atomic {
         return transaction(func, std::memory_order_relaxed);
     }
 
-    Atomic() = default;
+    constexpr Atomic() = default;
     constexpr Atomic(T initial)
         : value(std::forward<T>(initial))
     {
     }
 
-    std::atomic<T> value;
+    std::atomic<T> value { };
 };
 
 template<typename T>


### PR DESCRIPTION
#### d7b590ea57cb326ed41fe380796d01f8363a50dd
<pre>
[JSC] Make JSRopeString non destructible
<a href="https://bugs.webkit.org/show_bug.cgi?id=295822">https://bugs.webkit.org/show_bug.cgi?id=295822</a>
<a href="https://rdar.apple.com/155652531">rdar://155652531</a>

Reviewed by NOBODY (OOPS!).

Previously JSRopeString was destructible since it may hold a resolved
string. This makes sweeping a bit complicated since JSRopeString is one
of the most frequently allocated cells while only up to 20% of cells are
actually having resolved strings.
This patch makes JSRopeString non destructible. When the string is
resolved, we allocate JSString as a holder and making sure that this
string is owning the resolved string. And JSRopeString is visiting this
string so that it indirectly keeps StringImpl alive. But JSRopeString
itself is not keeping String so we no longer need to call a destructor
of JSRopeString.

* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileMakeRope):
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/heap/SlotVisitor.cpp:
(JSC::SlotVisitor::visitChildren):
* Source/JavaScriptCore/runtime/JSFunction.cpp:
(JSC::getCalculatedDisplayName):
* Source/JavaScriptCore/runtime/JSString.cpp:
(JSC::JSString::visitChildrenImpl):
(JSC:: const):
(JSC::JSRopeString::resolveRopeWithFunction const):
(JSC::JSRopeString::resolveRope const):
(JSC::JSRopeString::resolveRopeWithoutGC const): Deleted.
* Source/JavaScriptCore/runtime/JSString.h:
(JSC::JSString::JSString):
(JSC::JSString::swapToAtomString const):
* Source/JavaScriptCore/runtime/JSStringInlines.h:
(JSC::JSRopeString::convertToNonRope const):
(JSC::jsAtomString):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7b590ea57cb326ed41fe380796d01f8363a50dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111600 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31267 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21741 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117635 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61871 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31955 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39852 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84789 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35560 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114547 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25505 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100442 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65230 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24843 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18577 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61466 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/104097 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94889 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18646 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120881 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/110158 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38653 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28713 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93693 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39030 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96702 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93518 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38655 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16444 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34689 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38542 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44026 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/134430 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38205 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36219 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41541 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39907 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->