### PR TITLE
REGRESSION(297011@main): test-webkitpy is failing on Linux and Sonoma

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/swift_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/swift_unittest.py
@@ -23,42 +23,44 @@
 """Unit tests for swift.py."""
 
 import os
+import platform
 import unittest
 
 from webkitpy.style.checkers.swift import SwiftChecker
 
 
-class SwiftCheckerTest(unittest.TestCase):
+if platform.system() == 'Darwin' and [int(i) for i in platform.mac_ver()[0].split('.')] >= [15,]:
+    class SwiftCheckerTest(unittest.TestCase):
 
-    """Tests the SwiftChecker class."""
+        """Tests the SwiftChecker class."""
 
-    def test_init(self):
-        """Test __init__() method."""
-        def _mock_handle_style_error(self):
-            pass
+        def test_init(self):
+            """Test __init__() method."""
+            def _mock_handle_style_error(self):
+                pass
 
-        checker = SwiftChecker("foo.txt", _mock_handle_style_error)
-        self.assertEqual(checker.file_path, "foo.txt")
-        self.assertEqual(checker.handle_style_error, _mock_handle_style_error)
+            checker = SwiftChecker("foo.txt", _mock_handle_style_error)
+            self.assertEqual(checker.file_path, "foo.txt")
+            self.assertEqual(checker.handle_style_error, _mock_handle_style_error)
 
-    def test_check(self):
-        """Test check() method."""
-        errors = []
+        def test_check(self):
+            """Test check() method."""
+            errors = []
 
-        def _mock_handle_style_error(line_number, category, confidence, message):
-            error = (line_number, category, confidence, message)
-            errors.append(error)
+            def _mock_handle_style_error(line_number, category, confidence, message):
+                error = (line_number, category, confidence, message)
+                errors.append(error)
 
-        current_dir = os.path.dirname(__file__)
-        file_path = os.path.join(current_dir, "swift_unittest_input.swift")
+            current_dir = os.path.dirname(__file__)
+            file_path = os.path.join(current_dir, "swift_unittest_input.swift")
 
-        checker = SwiftChecker(file_path, _mock_handle_style_error)
-        checker.check(lines=[])
+            checker = SwiftChecker(file_path, _mock_handle_style_error)
+            checker.check(lines=[])
 
-        expected_errors = [
-            (3, "NeverForceUnwrap", 5, "do not force unwrap \'URL(string: \"https://www.apple.com\")\'"),
-            (2, "Spacing", 5, "remove 1 space"),
-            (3, "Indentation", 5, "replace leading whitespace with 4 spaces"),
-        ]
+            expected_errors = [
+                (3, "NeverForceUnwrap", 5, "do not force unwrap \'URL(string: \"https://www.apple.com\")\'"),
+                (2, "Spacing", 5, "remove 1 space"),
+                (3, "Indentation", 5, "replace leading whitespace with 4 spaces"),
+            ]
 
-        self.assertEqual(errors, expected_errors)
+            self.assertEqual(errors, expected_errors)


### PR DESCRIPTION
#### 62203df94ca047418e2c7a4571f3ba4e9680ef4f
<pre>
REGRESSION(297011@main): test-webkitpy is failing on Linux and Sonoma
<a href="https://bugs.webkit.org/show_bug.cgi?id=295648">https://bugs.webkit.org/show_bug.cgi?id=295648</a>
<a href="https://rdar.apple.com/155452018">rdar://155452018</a>

Reviewed by Richard Robinson.

* Tools/Scripts/webkitpy/style/checkers/swift_unittest.py:
(SwiftCheckerTest): Only run tests on machine with Swift style checker.

Canonical link: <a href="https://commits.webkit.org/297293@main">https://commits.webkit.org/297293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb258ea11cf1521f2987517b739f0381c2d4878f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111230 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/30896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21347 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/117261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/61498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113192 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31577 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/39478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/117261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/61498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114177 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/25216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/100134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/117261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/110663 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/24558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/18275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/61081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/94594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18342 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/120341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/38279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/39478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/120341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/38655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96409 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/120341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/16152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/34264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17936 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/38168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/37833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/41166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/39535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->