### PR TITLE
[JSC] Fix Uint8Array fromBase64 and setFromBase64 for invalid 1-chunk input

### DIFF
--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1075,15 +1075,6 @@ test/built-ins/TypedArrayConstructors/internals/Set/key-is-valid-index-prototype
 test/built-ins/TypedArrayConstructors/internals/Set/key-is-valid-index-reflect-set.js:
   default: 'Test262Error: target[0] should remain unchanged (receiver: empty object) Expected SameValue(«2.3», «0») to be true (Testing with Float64Array.)'
   strict mode: 'Test262Error: target[0] should remain unchanged (receiver: empty object) Expected SameValue(«2.3», «0») to be true (Testing with Float64Array.)'
-test/built-ins/Uint8Array/fromBase64/last-chunk-invalid.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/built-ins/Uint8Array/prototype/setFromBase64/last-chunk-handling.js:
-  default: 'Test262Error: Expected SameValue(«6», «4») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«6», «4») to be true'
-test/built-ins/Uint8Array/prototype/setFromBase64/target-size.js:
-  default: 'Test262Error: Expected SameValue(«7», «4») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«7», «4») to be true'
 test/intl402/DateTimeFormat/canonicalize-timezone.js:
   default: 'Test262Error: Time zone name Australia/Canberra should be preserved and not canonicalized to Australia/Sydney Expected SameValue(«"Australia/Sydney"», «"Australia/Canberra"») to be true'
   strict mode: 'Test262Error: Time zone name Australia/Canberra should be preserved and not canonicalized to Australia/Sydney Expected SameValue(«"Australia/Sydney"», «"Australia/Canberra"») to be true'

--- a/Source/WTF/wtf/simdutf/simdutf_impl.cpp.h
+++ b/Source/WTF/wtf/simdutf/simdutf_impl.cpp.h
@@ -1,4 +1,4 @@
-/* auto-generated on 2025-05-01 00:20:41 -0400. Do not edit! */
+/* auto-generated on 2025-07-13 10:46:57 -0400. Do not edit! */
 /* begin file src/simdutf.cpp */
 // #include "simdutf.h"
 
@@ -940,7 +940,7 @@ encoding_type check_bom(const uint8_t *byte, size_t length) {
   } else if (length >= 4 && byte[0] == 0x00 and byte[1] == 0x00 and
              byte[2] == 0xfe and byte[3] == 0xff) {
     return encoding_type::UTF32_BE;
-  } else if (length >= 4 && byte[0] == 0xef and byte[1] == 0xbb and
+  } else if (length >= 3 && byte[0] == 0xef and byte[1] == 0xbb and
              byte[2] == 0xbf) {
     return encoding_type::UTF8;
   }
@@ -2935,8 +2935,12 @@ public:
           last_chunk_handling_options::loose) const noexcept;
   size_t binary_to_base64(const char *input, size_t length, char *output,
                           base64_options options) const noexcept;
-#endif // SIMDUTF_FEATURE_BASE64
+  const char *find(const char *start, const char *end,
+                   char character) const noexcept;
+  const char16_t *find(const char16_t *start, const char16_t *end,
+                       char16_t character) const noexcept;
 };
+#endif // SIMDUTF_FEATURE_BASE64
 
 } // namespace arm64
 } // namespace simdutf
@@ -3075,6 +3079,7 @@ template <typename T, typename Mask = simd8<bool>> struct base_u8 {
   uint8x16_t value;
   static const int SIZE = sizeof(value);
   void dump() const {
+#ifdef SIMDUTF_LOGGING
     uint8_t temp[16];
     vst1q_u8(temp, *this);
     printf("[%04x, %04x, %04x, %04x, %04x, %04x, %04x, %04x,%04x, %04x, %04x, "
@@ -3082,6 +3087,7 @@ template <typename T, typename Mask = simd8<bool>> struct base_u8 {
            temp[0], temp[1], temp[2], temp[3], temp[4], temp[5], temp[6],
            temp[7], temp[8], temp[9], temp[10], temp[11], temp[12], temp[13],
            temp[14], temp[15]);
+#endif // SIMDUTF_LOGGING
   }
   // Conversion from/to SIMD register
   simdutf_really_inline base_u8(const uint8x16_t _value) : value(_value) {}
@@ -3586,10 +3592,12 @@ struct base16 : base_u16<T> {
 
   static const int SIZE = sizeof(base_u16<T>::value);
   void dump() const {
+#ifdef SIMDUTF_LOGGING
     uint16_t temp[8];
     vst1q_u16(temp, *this);
     printf("[%04x, %04x, %04x, %04x, %04x, %04x, %04x, %04x]\n", temp[0],
            temp[1], temp[2], temp[3], temp[4], temp[5], temp[6], temp[7]);
+#endif // SIMDUTF_LOGGING
   }
   template <int N = 1>
   simdutf_really_inline simd16<T> prev(const simd16<T> prev_chunk) const {
@@ -3939,9 +3947,11 @@ template <> struct simd32<uint32_t> {
   }
 
   void dump() const {
+#ifdef SIMDUTF_LOGGING
     uint32_t temp[4];
     vst1q_u32(temp, value);
     printf("[%08x, %08x, %08x, %08x]\n", temp[0], temp[1], temp[2], temp[3]);
+#endif // SIMDUTF_LOGGING
   }
 
   // operators
@@ -4592,6 +4602,10 @@ public:
           last_chunk_handling_options::loose) const noexcept;
   size_t binary_to_base64(const char *input, size_t length, char *output,
                           base64_options options) const noexcept;
+  const char *find(const char *start, const char *end,
+                   char character) const noexcept;
+  const char16_t *find(const char16_t *start, const char16_t *end,
+                       char16_t character) const noexcept;
 #endif // SIMDUTF_FEATURE_BASE64
 };
 
@@ -5176,6 +5190,10 @@ public:
           last_chunk_handling_options::loose) const noexcept;
   size_t binary_to_base64(const char *input, size_t length, char *output,
                           base64_options options) const noexcept;
+  const char *find(const char *start, const char *end,
+                   char character) const noexcept;
+  const char16_t *find(const char16_t *start, const char16_t *end,
+                       char16_t character) const noexcept;
 #endif // SIMDUTF_FEATURE_BASE64
 };
 
@@ -5648,7 +5666,11 @@ template <typename T> struct simd8x64 {
     return simd8x64<bool>(this->chunks[0] > mask, this->chunks[1] > mask)
         .to_bitmask();
   }
-
+  simdutf_really_inline uint64_t eq(const T m) const {
+    const simd8<T> mask = simd8<T>::splat(m);
+    return simd8x64<bool>(this->chunks[0] == mask, this->chunks[1] == mask)
+        .to_bitmask();
+  }
   simdutf_really_inline uint64_t gteq_unsigned(const uint8_t m) const {
     const simd8<uint8_t> mask = simd8<uint8_t>::splat(m);
     return simd8x64<bool>((simd8<uint8_t>(__m256i(this->chunks[0])) >= mask),
@@ -5896,7 +5918,11 @@ template <typename T> struct simd16x32 {
     return simd16x32<bool>(this->chunks[0] <= mask, this->chunks[1] <= mask)
         .to_bitmask();
   }
-
+  simdutf_really_inline uint64_t eq(const T m) const {
+    const simd16<T> mask = simd16<T>::splat(m);
+    return simd16x32<bool>(this->chunks[0] == mask, this->chunks[1] == mask)
+        .to_bitmask();
+  }
   simdutf_really_inline uint64_t not_in_range(const T low, const T high) const {
     const simd16<T> mask_low = simd16<T>::splat(static_cast<T>(low - 1));
     const simd16<T> mask_high = simd16<T>::splat(static_cast<T>(high + 1));
@@ -6430,6 +6456,10 @@ public:
           last_chunk_handling_options::loose) const noexcept;
   size_t binary_to_base64(const char *input, size_t length, char *output,
                           base64_options options) const noexcept;
+  const char *find(const char *start, const char *end,
+                   char character) const noexcept;
+  const char16_t *find(const char16_t *start, const char16_t *end,
+                       char16_t character) const noexcept;
 #endif // SIMDUTF_FEATURE_BASE64
 };
 
@@ -6873,6 +6903,14 @@ template <typename T> struct simd8x64 {
                           this->chunks[2] > mask, this->chunks[3] > mask)
         .to_bitmask();
   }
+
+  simdutf_really_inline uint64_t eq(const T m) const {
+    const simd8<T> mask = simd8<T>::splat(m);
+    return simd8x64<bool>(this->chunks[0] == mask, this->chunks[1] == mask,
+                          this->chunks[2] == mask, this->chunks[3] == mask)
+        .to_bitmask();
+  }
+
   simdutf_really_inline uint64_t gteq_unsigned(const uint8_t m) const {
     const simd8<uint8_t> mask = simd8<uint8_t>::splat(m);
     return simd8x64<bool>(simd8<uint8_t>(__m128i(this->chunks[0])) >= mask,
@@ -7098,6 +7136,13 @@ template <typename T> struct simd16x32 {
         .to_bitmask();
   }
 
+  simdutf_really_inline uint64_t eq(const T m) const {
+    const simd16<T> mask = simd16<T>::splat(m);
+    return simd16x32<bool>(this->chunks[0] == mask, this->chunks[1] == mask,
+                           this->chunks[2] == mask, this->chunks[3] == mask)
+        .to_bitmask();
+  }
+
   simdutf_really_inline uint64_t not_in_range(const T low, const T high) const {
     const simd16<T> mask_low = simd16<T>::splat(static_cast<T>(low - 1));
     const simd16<T> mask_high = simd16<T>::splat(static_cast<T>(high + 1));
@@ -7150,12 +7195,13 @@ template <> struct simd32<uint32_t> {
   template <int N> simdutf_really_inline simd32<uint32_t> shl() const {
     return _mm_slli_epi32(value, N);
   }
-
   void dump() const {
+#ifdef SIMDUTF_LOGGING
     printf("[%08x, %08x, %08x, %08x]\n", uint32_t(_mm_extract_epi32(value, 0)),
            uint32_t(_mm_extract_epi32(value, 1)),
            uint32_t(_mm_extract_epi32(value, 2)),
            uint32_t(_mm_extract_epi32(value, 3)));
+#endif // SIMDUTF_LOGGING
   }
 
   // operators
@@ -7651,15 +7697,24 @@ public:
           last_chunk_handling_options::loose) const noexcept;
   size_t binary_to_base64(const char *input, size_t length, char *output,
                           base64_options options) const noexcept;
+
+  const char *find(const char *start, const char *end,
+                   char character) const noexcept;
+
+  const char16_t *find(const char16_t *start, const char16_t *end,
+                       char16_t character) const noexcept;
 #endif // SIMDUTF_FEATURE_BASE64
 
 #ifdef SIMDUTF_INTERNAL_TESTS
   virtual std::vector<TestProcedure> internal_tests() const override;
 #endif
+#if SIMDUTF_FEATURE_UTF16
+
   void to_well_formed_utf16be(const char16_t *input, size_t len,
                               char16_t *output) const noexcept final;
   void to_well_formed_utf16le(const char16_t *input, size_t len,
                               char16_t *output) const noexcept final;
+#endif // SIMDUTF_FEATURE_UTF16
 };
 
 } // namespace ppc64
@@ -8175,8 +8230,8 @@ template <> struct simd8<uint8_t> : base8_numeric<uint8_t> {
     return simd8<uint8_t>(
         (vector_type)vec_sl(this->value, (vector_type)vec_splat_u8(N)));
   }
-
   void dump() const {
+#ifdef SIMDUTF_LOGGING
     uint8_t tmp[16];
     store(tmp);
     for (int i = 0; i < 16; i++) {
@@ -8189,9 +8244,11 @@ template <> struct simd8<uint8_t> : base8_numeric<uint8_t> {
       }
     }
     putchar('\n');
+#endif // SIMDUTF_LOGGING
   }
 
   void dump_ascii() const {
+#ifdef SIMDUTF_LOGGING
     uint8_t tmp[16];
     store(tmp);
     for (int i = 0; i < 16; i++) {
@@ -8204,6 +8261,7 @@ template <> struct simd8<uint8_t> : base8_numeric<uint8_t> {
       }
     }
     putchar('\n');
+#endif // SIMDUTF_LOGGING
   }
 };
 
@@ -8390,7 +8448,12 @@ template <typename T> struct simd8x64 {
                           this->chunks[2] > mask, this->chunks[3] > mask)
         .to_bitmask();
   }
-
+  simdutf_really_inline uint64_t eq(const T m) const {
+    const simd8<T> mask = simd8<T>::splat(m);
+    return simd8x64<bool>(this->chunks[0] == mask, this->chunks[1] == mask,
+                          this->chunks[2] == mask, this->chunks[3] == mask)
+        .to_bitmask();
+  }
   simdutf_really_inline uint64_t gteq_unsigned(const uint8_t m) const {
     const simd8<uint8_t> mask = simd8<uint8_t>::splat(m);
     return simd8x64<bool>(simd8<uint8_t>(this->chunks[0]) >= mask,
@@ -8431,8 +8494,8 @@ template <typename T> struct base16 {
 
   // Conversion from SIMD register
   simdutf_really_inline base16(const vector_type _value) : value{_value} {}
-
   void dump() const {
+#ifdef SIMDUTF_LOGGING
     uint16_t tmp[8];
     vec_xst(value, 0, reinterpret_cast<vector_type *>(tmp));
     for (int i = 0; i < 8; i++) {
@@ -8445,6 +8508,7 @@ template <typename T> struct base16 {
       }
     }
     putchar('\n');
+#endif // SIMDUTF_LOGGING
   }
 };
 
@@ -8716,6 +8780,13 @@ template <typename T> struct simd16x32 {
         .to_bitmask();
   }
 
+  simdutf_really_inline uint64_t eq(const T m) const {
+    const simd16<T> mask = simd16<T>::splat(m);
+    return simd16x32<bool>(this->chunks[0] == mask, this->chunks[1] == mask,
+                           this->chunks[2] == mask, this->chunks[3] == mask)
+        .to_bitmask();
+  }
+
   simdutf_really_inline uint64_t not_in_range(const T low, const T high) const {
     const simd16<T> mask_low = simd16<T>::splat(static_cast<T>(low - 1));
     const simd16<T> mask_high = simd16<T>::splat(static_cast<T>(high + 1));
@@ -8761,8 +8832,8 @@ template <typename T> struct base32 {
     return vec_xst(this->value, 0, reinterpret_cast<vector_type *>(dst));
 #endif // defined(__clang__)
   }
-
   void dump(const char *name = nullptr) const {
+#ifdef SIMDUTF_LOGGING
     if (name != nullptr) {
       printf("%-10s = ", name);
     }
@@ -8779,6 +8850,7 @@ template <typename T> struct base32 {
       }
     }
     putchar('\n');
+#endif // SIMDUTF_LOGGING
   }
 };
 
@@ -9384,6 +9456,11 @@ public:
           last_chunk_handling_options::loose) const noexcept;
   size_t binary_to_base64(const char *input, size_t length, char *output,
                           base64_options options) const noexcept;
+
+  const char *find(const char *start, const char *end,
+                   char character) const noexcept;
+  const char16_t *find(const char16_t *start, const char16_t *end,
+                       char16_t character) const noexcept;
 #endif // SIMDUTF_FEATURE_BASE64
 private:
   const bool _supports_zvbb;
@@ -9850,6 +9927,10 @@ public:
           last_chunk_handling_options::loose) const noexcept;
   size_t binary_to_base64(const char *input, size_t length, char *output,
                           base64_options options) const noexcept;
+  const char *find(const char *start, const char *end,
+                   char character) const noexcept;
+  const char16_t *find(const char16_t *start, const char16_t *end,
+                       char16_t character) const noexcept;
 #endif // SIMDUTF_FEATURE_BASE64
 };
 
@@ -10076,9 +10157,9 @@ simdutf_really_inline int count_ones(uint64_t input_num) {
 }
 
 #if SIMDUTF_NEED_TRAILING_ZEROES
-// simdutf_really_inline int trailing_zeroes(uint64_t input_num) {
-//   return __builtin_ctzll(input_num);
-// }
+simdutf_really_inline int trailing_zeroes(uint64_t input_num) {
+  return __builtin_ctzll(input_num);
+}
 #endif
 
 } // unnamed namespace
@@ -11122,6 +11203,10 @@ public:
           last_chunk_handling_options::loose) const noexcept;
   size_t binary_to_base64(const char *input, size_t length, char *output,
                           base64_options options) const noexcept;
+  const char *find(const char *start, const char *end,
+                   char character) const noexcept;
+  const char16_t *find(const char16_t *start, const char16_t *end,
+                       char16_t character) const noexcept;
 #endif // SIMDUTF_FEATURE_BASE64
 };
 
@@ -11440,9 +11525,9 @@ simdutf_really_inline int count_ones(uint64_t input_num) {
 }
 
 #if SIMDUTF_NEED_TRAILING_ZEROES
-// simdutf_really_inline int trailing_zeroes(uint64_t input_num) {
-//   return __builtin_ctzll(input_num);
-// }
+simdutf_really_inline int trailing_zeroes(uint64_t input_num) {
+  return __builtin_ctzll(input_num);
+}
 #endif
 
 } // unnamed namespace
@@ -12652,6 +12737,11 @@ public:
           last_chunk_handling_options::loose) const noexcept;
   size_t binary_to_base64(const char *input, size_t length, char *output,
                           base64_options options) const noexcept;
+  const char *find(const char *start, const char *end,
+                   char character) const noexcept;
+  const char16_t *find(const char16_t *start, const char16_t *end,
+                       char16_t character) const noexcept;
+
 #endif // SIMDUTF_FEATURE_BASE64
 };
 } // namespace fallback
@@ -13223,6 +13313,14 @@ template <endianness big_endian> bool is_low_surrogate(char16_t c) {
   return (0xdc00 <= c && c <= 0xdfff);
 }
 
+simdutf_really_inline bool high_surrogate(char16_t c) {
+  return (0xd800 <= c && c <= 0xdbff);
+}
+
+simdutf_really_inline bool low_surrogate(char16_t c) {
+  return (0xdc00 <= c && c <= 0xdfff);
+}
+
 // variable templates are a C++14 extension
 template <endianness big_endian> char16_t replacement() {
   return !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
@@ -13371,6 +13469,7 @@ simdutf_really_inline size_t utf8_length_from_latin1(const char *buf,
 #ifndef SIMDUTF_BASE64_H
 #define SIMDUTF_BASE64_H
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -13382,13 +13481,9 @@ namespace {
 namespace base64 {
 
 // This function is not expected to be fast. Do not use in long loops.
+// In most instances you should be using is_ignorable.
 template <class char_type> bool is_ascii_white_space(char_type c) {
   return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f';
-}
-
-template <class char_type> bool is_ascii_white_space_or_padding(char_type c) {
-  return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' ||
-         c == '=';
 }
 
 template <class char_type> bool is_eight_byte(char_type c) {
@@ -13398,16 +13493,143 @@ template <class char_type> bool is_eight_byte(char_type c) {
   return uint8_t(c) == c;
 }
 
+template <class char_type>
+bool is_ignorable(char_type c, simdutf::base64_options options) {
+  const uint8_t *to_base64 =
+      (options & base64_default_or_url)
+          ? tables::base64::to_base64_default_or_url_value
+          : ((options & base64_url) ? tables::base64::to_base64_url_value
+                                    : tables::base64::to_base64_value);
+  const bool ignore_garbage =
+      (options == base64_options::base64_url_accept_garbage) ||
+      (options == base64_options::base64_default_accept_garbage) ||
+      (options == base64_options::base64_default_or_url_accept_garbage);
+  uint8_t code = to_base64[uint8_t(c)];
+  if (is_eight_byte(c) && code <= 63) {
+    return false;
+  }
+  if (is_eight_byte(c) && code == 64) {
+    return true;
+  }
+  return ignore_garbage;
+}
+template <class char_type>
+bool is_base64(char_type c, simdutf::base64_options options) {
+  const uint8_t *to_base64 =
+      (options & base64_default_or_url)
+          ? tables::base64::to_base64_default_or_url_value
+          : ((options & base64_url) ? tables::base64::to_base64_url_value
+                                    : tables::base64::to_base64_value);
+  uint8_t code = to_base64[uint8_t(c)];
+  if (is_eight_byte(c) && code <= 63) {
+    return true;
+  }
+  return false;
+}
+
+template <class char_type>
+bool is_base64_or_padding(char_type c, simdutf::base64_options options) {
+  const uint8_t *to_base64 =
+      (options & base64_default_or_url)
+          ? tables::base64::to_base64_default_or_url_value
+          : ((options & base64_url) ? tables::base64::to_base64_url_value
+                                    : tables::base64::to_base64_value);
+  if (c == '=') {
+    return true;
+  }
+  uint8_t code = to_base64[uint8_t(c)];
+  if (is_eight_byte(c) && code <= 63) {
+    return true;
+  }
+  return false;
+}
+
+template <class char_type>
+bool is_ignorable_or_padding(char_type c, simdutf::base64_options options) {
+  return is_ignorable(c, options) || c == '=';
+}
+
+struct reduced_input {
+  size_t equalsigns;    // number of padding characters '=', typically 0, 1, 2.
+  size_t equallocation; // location of the first padding character if any
+  size_t srclen;        // length of the input buffer before padding
+  size_t full_input_length; // length of the input buffer with padding but
+                            // without ignorable characters
+};
+
+// find the end of the base64 input buffer
+// It returns the number of padding characters, the location of the first
+// padding character if any, the length of the input buffer before padding
+// and the length of the input buffer with padding but without ignorable
+// characters. The input buffer is not modified.
+// The function assumes that there are at most two padding characters.
+template <class char_type>
+reduced_input find_end(const char_type *src, size_t srclen,
+                       simdutf::base64_options options) {
+  const uint8_t *to_base64 =
+      (options & base64_default_or_url)
+          ? tables::base64::to_base64_default_or_url_value
+          : ((options & base64_url) ? tables::base64::to_base64_url_value
+                                    : tables::base64::to_base64_value);
+  const bool ignore_garbage =
+      (options == base64_options::base64_url_accept_garbage) ||
+      (options == base64_options::base64_default_accept_garbage) ||
+      (options == base64_options::base64_default_or_url_accept_garbage);
+
+  size_t equalsigns = 0;
+  // skip trailing spaces
+  while (!ignore_garbage && srclen > 0 &&
+         scalar::base64::is_eight_byte(src[srclen - 1]) &&
+         to_base64[uint8_t(src[srclen - 1])] == 64) {
+    srclen--;
+  }
+  size_t full_input_length = srclen;
+  size_t equallocation =
+      srclen; // location of the first padding character if any
+  if (ignore_garbage) {
+    // Technically, we don't need to find the first padding character, we can
+    // just change our algorithms, but it adds substantial complexity.
+    auto it = simdutf::find(src, src + srclen, '=');
+    if (it != src + srclen) {
+      equallocation = it - src;
+      equalsigns = 1;
+      srclen = equallocation;
+      full_input_length = equallocation + 1;
+    }
+    return {equalsigns, equallocation, srclen, full_input_length};
+  }
+  if (!ignore_garbage && srclen > 0 && src[srclen - 1] == '=') {
+    // This is the last '=' sign.
+    equallocation = srclen - 1;
+    srclen--;
+    equalsigns = 1;
+    // skip trailing spaces
+    while (srclen > 0 && scalar::base64::is_eight_byte(src[srclen - 1]) &&
+           to_base64[uint8_t(src[srclen - 1])] == 64) {
+      srclen--;
+    }
+    if (srclen > 0 && src[srclen - 1] == '=') {
+      // This is the second '=' sign.
+      equallocation = srclen - 1;
+      srclen--;
+      equalsigns = 2;
+    }
+  }
+  return {equalsigns, equallocation, srclen, full_input_length};
+}
+
 // Returns true upon success. The destination buffer must be large enough.
 // This functions assumes that the padding (=) has been removed.
-template <class char_type>
-full_result
-base64_tail_decode(char *dst, const char_type *src, size_t length,
-                   size_t padded_characters, // number of padding characters
-                                             // '=', typically 0, 1, 2.
-                   base64_options options,
-                   last_chunk_handling_options last_chunk_options) {
-
+// if check_capacity is true, it will check that the destination buffer is
+// large enough. If it is not, it will return OUTPUT_BUFFER_TOO_SMALL.
+template <bool check_capacity, class char_type>
+full_result base64_tail_decode_impl(
+    char *dst, size_t outlen, const char_type *src, size_t length,
+    size_t padding_characters, // number of padding characters
+                               // '=', typically 0, 1, 2.
+    base64_options options, last_chunk_handling_options last_chunk_options) {
+  char *dstend = dst + outlen;
+  (void)dstend;
   // This looks like 10 branches, but we expect the compiler to resolve this to
   // two branches (easily predicted):
   const uint8_t *to_base64 =
@@ -13456,10 +13678,15 @@ base64_tail_decode(char *dst, const char_type *src, size_t length,
       if (match_system(endianness::BIG)) {
         x = scalar::u32_swap_bytes(x);
       }
+      if (check_capacity && dstend - dst < 3) {
+        return {OUTPUT_BUFFER_TOO_SMALL, size_t(src - srcinit),
+                size_t(dst - dstinit)};
+      }
       std::memcpy(dst, &x, 3); // optimization opportunity: copy 4 bytes
       dst += 3;
       src += 4;
     }
+    const char_type *srccur = src;
     idx = 0;
     // we need at least four characters.
 #ifdef __clang__
@@ -13469,10 +13696,12 @@ base64_tail_decode(char *dst, const char_type *src, size_t length,
       char_type c1 = src[1];
       char_type c2 = src[2];
       char_type c3 = src[3];
+
       uint8_t code0 = to_base64[uint8_t(c0)];
       uint8_t code1 = to_base64[uint8_t(c1)];
       uint8_t code2 = to_base64[uint8_t(c2)];
       uint8_t code3 = to_base64[uint8_t(c3)];
+
       buffer[idx] = code0;
       idx += (is_eight_byte(c0) && code0 <= 63);
       buffer[idx] = code1;
@@ -13486,6 +13715,7 @@ base64_tail_decode(char *dst, const char_type *src, size_t length,
 #endif
     while ((idx < 4) && (src < srcend)) {
       char_type c = *src;
+
       uint8_t code = to_base64[uint8_t(c)];
       buffer[idx] = uint8_t(code);
       if (is_eight_byte(c) && code <= 63) {
@@ -13500,65 +13730,123 @@ base64_tail_decode(char *dst, const char_type *src, size_t length,
       src++;
     }
     if (idx != 4) {
-      if (!ignore_garbage &&
-          last_chunk_options == last_chunk_handling_options::strict &&
-          (idx != 1) && ((idx + padded_characters) & 3) != 0) {
-        // The partial chunk was at src - idx
-        return {BASE64_INPUT_REMAINDER, size_t(src - srcinit),
-                size_t(dst - dstinit)};
-      } else if (!ignore_garbage &&
-                 last_chunk_options ==
-                     last_chunk_handling_options::stop_before_partial &&
-                 (idx != 1) && ((idx + padded_characters) & 3) != 0) {
-        // Rewind src to before partial chunk
-        src -= idx;
-        return {SUCCESS, size_t(src - srcinit), size_t(dst - dstinit)};
-      } else {
-        if (idx == 2) {
-          uint32_t triple =
-              (uint32_t(buffer[0]) << 3 * 6) + (uint32_t(buffer[1]) << 2 * 6);
-          if (!ignore_garbage &&
-              (last_chunk_options == last_chunk_handling_options::strict) &&
-              (triple & 0xffff)) {
-            return {BASE64_EXTRA_BITS, size_t(src - srcinit),
-                    size_t(dst - dstinit)};
-          }
-          if (match_system(endianness::BIG)) {
-            triple <<= 8;
-            std::memcpy(dst, &triple, 1);
-          } else {
-            triple = scalar::u32_swap_bytes(triple);
-            triple >>= 8;
-            std::memcpy(dst, &triple, 1);
-          }
-          dst += 1;
-        } else if (idx == 3) {
-          uint32_t triple = (uint32_t(buffer[0]) << 3 * 6) +
-                            (uint32_t(buffer[1]) << 2 * 6) +
-                            (uint32_t(buffer[2]) << 1 * 6);
-          if (!ignore_garbage &&
-              (last_chunk_options == last_chunk_handling_options::strict) &&
-              (triple & 0xff)) {
-            return {BASE64_EXTRA_BITS, size_t(src - srcinit),
-                    size_t(dst - dstinit)};
-          }
-          if (match_system(endianness::BIG)) {
-            triple <<= 8;
-            std::memcpy(dst, &triple, 2);
-          } else {
-            triple = scalar::u32_swap_bytes(triple);
-            triple >>= 8;
-            std::memcpy(dst, &triple, 2);
-          }
-          dst += 2;
-        } else if (!ignore_garbage && idx == 1) {
-          return {BASE64_INPUT_REMAINDER, size_t(src - srcinit),
-                  size_t(dst - dstinit)};
-        }
-        return {SUCCESS, size_t(src - srcinit), size_t(dst - dstinit)};
+      simdutf_log_assert(idx < 4, "idx should be less than 4");
+      // We never should have that the number of base64 characters + the
+      // number of padding characters is more than 4.
+      if (!ignore_garbage && (idx + padding_characters > 4)) {
+        return {INVALID_BASE64_CHARACTER, size_t(src - srcinit),
+                size_t(dst - dstinit), true};
       }
-    }
 
+      // The idea here is that in loose mode,
+      // if there is padding at all, it must be used
+      // to form 4-wise chunk. However, in loose mode,
+      // we do accept no padding at all.
+      if (!ignore_garbage &&
+          last_chunk_options == last_chunk_handling_options::loose &&
+          (idx >= 2) && padding_characters > 0 &&
+          ((idx + padding_characters) & 3) != 0) {
+        return {INVALID_BASE64_CHARACTER, size_t(src - srcinit),
+                size_t(dst - dstinit), true};
+      } else
+
+        // The idea here is that in strict mode, we do not want to accept
+        // incomplete base64 chunks. So if the chunk was otherwise valid, we
+        // return BASE64_INPUT_REMAINDER.
+        if (!ignore_garbage &&
+            last_chunk_options == last_chunk_handling_options::strict &&
+            (idx >= 2) && ((idx + padding_characters) & 3) != 0) {
+          // The partial chunk was at src - idx
+          return {BASE64_INPUT_REMAINDER, size_t(src - srcinit),
+                  size_t(dst - dstinit), true};
+        } else
+          // If there is a partial chunk with insufficient padding, with
+          // stop_before_partial, we need to just ignore it. In "only full"
+          // mode, skip the minute there are padding characters.
+          if ((last_chunk_options ==
+                   last_chunk_handling_options::stop_before_partial &&
+               (padding_characters + idx < 4) &&
+               (idx >= 2 || padding_characters == 0)) ||
+              (last_chunk_options ==
+                   last_chunk_handling_options::only_full_chunks &&
+               (idx >= 2 || padding_characters == 0))) {
+            // Rewind src to before partial chunk
+
+            // partial means that we are *not* going to consume the read
+            // characters. We need to rewind the src pointer.
+            src = srccur;
+            // adjust, skipping ignorable characters
+            for (; src < srcend; src++) {
+              char_type c = *src;
+              uint8_t code = to_base64[uint8_t(c)];
+              if (is_eight_byte(c) && code <= 63) {
+                break;
+              }
+            }
+            return {SUCCESS, size_t(src - srcinit), size_t(dst - dstinit)};
+          } else {
+            if (idx == 2) {
+              uint32_t triple = (uint32_t(buffer[0]) << 3 * 6) +
+                                (uint32_t(buffer[1]) << 2 * 6);
+              if (!ignore_garbage &&
+                  (last_chunk_options == last_chunk_handling_options::strict) &&
+                  (triple & 0xffff)) {
+                return {BASE64_EXTRA_BITS, size_t(src - srcinit),
+                        size_t(dst - dstinit)};
+              }
+              if (check_capacity && dstend - dst < 1) {
+                return {OUTPUT_BUFFER_TOO_SMALL, size_t(srccur - srcinit),
+                        size_t(dst - dstinit)};
+              }
+              if (match_system(endianness::BIG)) {
+                triple <<= 8;
+                std::memcpy(dst, &triple, 1);
+              } else {
+                triple = scalar::u32_swap_bytes(triple);
+                triple >>= 8;
+                std::memcpy(dst, &triple, 1);
+              }
+              dst += 1;
+            } else if (idx == 3) {
+              uint32_t triple = (uint32_t(buffer[0]) << 3 * 6) +
+                                (uint32_t(buffer[1]) << 2 * 6) +
+                                (uint32_t(buffer[2]) << 1 * 6);
+              if (!ignore_garbage &&
+                  (last_chunk_options == last_chunk_handling_options::strict) &&
+                  (triple & 0xff)) {
+                return {BASE64_EXTRA_BITS, size_t(src - srcinit),
+                        size_t(dst - dstinit)};
+              }
+              if (check_capacity && dstend - dst < 2) {
+                return {OUTPUT_BUFFER_TOO_SMALL, size_t(srccur - srcinit),
+                        size_t(dst - dstinit)};
+              }
+              if (match_system(endianness::BIG)) {
+                triple <<= 8;
+                std::memcpy(dst, &triple, 2);
+              } else {
+                triple = scalar::u32_swap_bytes(triple);
+                triple >>= 8;
+                std::memcpy(dst, &triple, 2);
+              }
+              dst += 2;
+            } else if (!ignore_garbage && idx == 1 &&
+                       (!is_partial(last_chunk_options) ||
+                        (is_partial(last_chunk_options) &&
+                         padding_characters > 0))) {
+              return {BASE64_INPUT_REMAINDER, size_t(src - srcinit),
+                      size_t(dst - dstinit)};
+            } else if (!ignore_garbage && idx == 0 && padding_characters > 0) {
+              return {INVALID_BASE64_CHARACTER, size_t(src - srcinit),
+                      size_t(dst - dstinit), true};
+            }
+            return {SUCCESS, size_t(src - srcinit), size_t(dst - dstinit)};
+          }
+    }
+    if (check_capacity && dstend - dst < 3) {
+      return {OUTPUT_BUFFER_TOO_SMALL, size_t(srccur - srcinit),
+              size_t(dst - dstinit)};
+    }
     uint32_t triple =
         (uint32_t(buffer[0]) << 3 * 6) + (uint32_t(buffer[1]) << 2 * 6) +
         (uint32_t(buffer[2]) << 1 * 6) + (uint32_t(buffer[3]) << 0 * 6);
@@ -13574,207 +13862,52 @@ base64_tail_decode(char *dst, const char_type *src, size_t length,
   }
 }
 
+template <class char_type>
+full_result
+base64_tail_decode(char *dst, const char_type *src, size_t length,
+                   size_t padding_characters, // number of padding characters
+                                              // '=', typically 0, 1, 2.
+                   base64_options options,
+                   last_chunk_handling_options last_chunk_options) {
+  return base64_tail_decode_impl<false>(dst, 0, src, length, padding_characters,
+                                        options, last_chunk_options);
+}
+
 // like base64_tail_decode, but it will not write past the end of the output
 // buffer. The outlen parameter is modified to reflect the number of bytes
 // written. This functions assumes that the padding (=) has been removed.
+//
 template <class char_type>
-result base64_tail_decode_safe(
-    char *dst, size_t &outlen, const char_type *&srcr, size_t length,
-    size_t padded_characters, // number of padding characters '=', typically 0,
-                              // 1, 2.
+full_result base64_tail_decode_safe(
+    char *dst, size_t outlen, const char_type *src, size_t length,
+    size_t padding_characters, // number of padding characters
+                               // '=', typically 0, 1, 2.
     base64_options options, last_chunk_handling_options last_chunk_options) {
-  const char_type *src = srcr;
-  if (length == 0) {
-    outlen = 0;
-    return {SUCCESS, 0};
+  return base64_tail_decode_impl<true>(dst, outlen, src, length,
+                                       padding_characters, options,
+                                       last_chunk_options);
+}
+
+inline full_result
+patch_tail_result(full_result r, size_t previous_input, size_t previous_output,
+                  size_t equallocation, size_t full_input_length,
+                  last_chunk_handling_options last_chunk_options) {
+  r.input_count += previous_input;
+  r.output_count += previous_output;
+  if (r.padding_error) {
+    r.input_count = equallocation;
   }
-  // This looks like 10 branches, but we expect the compiler to resolve this to
-  // two branches (easily predicted):
-  const uint8_t *to_base64 =
-      (options & base64_default_or_url)
-          ? tables::base64::to_base64_default_or_url_value
-          : ((options & base64_url) ? tables::base64::to_base64_url_value
-                                    : tables::base64::to_base64_value);
-  const uint32_t *d0 =
-      (options & base64_default_or_url)
-          ? tables::base64::base64_default_or_url::d0
-          : ((options & base64_url) ? tables::base64::base64_url::d0
-                                    : tables::base64::base64_default::d0);
-  const uint32_t *d1 =
-      (options & base64_default_or_url)
-          ? tables::base64::base64_default_or_url::d1
-          : ((options & base64_url) ? tables::base64::base64_url::d1
-                                    : tables::base64::base64_default::d1);
-  const uint32_t *d2 =
-      (options & base64_default_or_url)
-          ? tables::base64::base64_default_or_url::d2
-          : ((options & base64_url) ? tables::base64::base64_url::d2
-                                    : tables::base64::base64_default::d2);
-  const uint32_t *d3 =
-      (options & base64_default_or_url)
-          ? tables::base64::base64_default_or_url::d3
-          : ((options & base64_url) ? tables::base64::base64_url::d3
-                                    : tables::base64::base64_default::d3);
-  const bool ignore_garbage =
-      (options == base64_options::base64_url_accept_garbage) ||
-      (options == base64_options::base64_default_accept_garbage) ||
-      (options == base64_options::base64_default_or_url_accept_garbage);
 
-  const char_type *srcend = src + length;
-  const char_type *srcinit = src;
-  const char *dstinit = dst;
-  const char *dstend = dst + outlen;
-
-  uint32_t x;
-  size_t idx;
-  uint8_t buffer[4];
-  while (true) {
-    while (src + 4 <= srcend && is_eight_byte(src[0]) &&
-           is_eight_byte(src[1]) && is_eight_byte(src[2]) &&
-           is_eight_byte(src[3]) &&
-           (x = d0[uint8_t(src[0])] | d1[uint8_t(src[1])] |
-                d2[uint8_t(src[2])] | d3[uint8_t(src[3])]) < 0x01FFFFFF) {
-      if (dstend - dst < 3) {
-        outlen = size_t(dst - dstinit);
-        srcr = src;
-        return {OUTPUT_BUFFER_TOO_SMALL, size_t(src - srcinit)};
-      }
-      if (match_system(endianness::BIG)) {
-        x = scalar::u32_swap_bytes(x);
-      }
-      std::memcpy(dst, &x, 3); // optimization opportunity: copy 4 bytes
-      dst += 3;
-      src += 4;
+  if (r.error == error_code::SUCCESS) {
+    if (!is_partial(last_chunk_options)) {
+      // A success when we are not in stop_before_partial mode.
+      // means that we have consumed the whole input buffer.
+      r.input_count = full_input_length;
+    } else if (r.output_count % 3 != 0) {
+      r.input_count = full_input_length;
     }
-    idx = 0;
-    const char_type *srccur = src;
-    // We need at least four characters.
-#ifdef __clang__
-    // If possible, we read four characters at a time. (It is an optimization.)
-    if (ignore_garbage && src + 4 <= srcend) {
-      char_type c0 = src[0];
-      char_type c1 = src[1];
-      char_type c2 = src[2];
-      char_type c3 = src[3];
-      uint8_t code0 = to_base64[uint8_t(c0)];
-      uint8_t code1 = to_base64[uint8_t(c1)];
-      uint8_t code2 = to_base64[uint8_t(c2)];
-      uint8_t code3 = to_base64[uint8_t(c3)];
-      buffer[idx] = code0;
-      idx += (is_eight_byte(c0) && code0 <= 63);
-      buffer[idx] = code1;
-      idx += (is_eight_byte(c1) && code1 <= 63);
-      buffer[idx] = code2;
-      idx += (is_eight_byte(c2) && code2 <= 63);
-      buffer[idx] = code3;
-      idx += (is_eight_byte(c3) && code3 <= 63);
-      src += 4;
-    }
-#endif
-    while (idx < 4 && src < srcend) {
-      char_type c = *src;
-      uint8_t code = to_base64[uint8_t(c)];
-
-      buffer[idx] = uint8_t(code);
-      if (is_eight_byte(c) && code <= 63) {
-        idx++;
-      } else if (!ignore_garbage &&
-                 (code > 64 || !scalar::base64::is_eight_byte(c))) {
-        outlen = size_t(dst - dstinit);
-        srcr = src;
-        return {INVALID_BASE64_CHARACTER, size_t(src - srcinit)};
-      } else {
-        // We have a space or a newline or garbage. We ignore it.
-      }
-      src++;
-    }
-    if (idx != 4) {
-      if (!ignore_garbage &&
-          last_chunk_options == last_chunk_handling_options::strict &&
-          ((idx + padded_characters) & 3) != 0) {
-        outlen = size_t(dst - dstinit);
-        srcr = src;
-        return {BASE64_INPUT_REMAINDER, size_t(src - srcinit)};
-      } else if (!ignore_garbage &&
-                 last_chunk_options ==
-                     last_chunk_handling_options::stop_before_partial &&
-                 ((idx + padded_characters) & 3) != 0) {
-        // Rewind src to before partial chunk
-        srcr = srccur;
-        outlen = size_t(dst - dstinit);
-        return {SUCCESS, size_t(dst - dstinit)};
-      } else { // loose mode
-        if (idx == 0) {
-          // No data left; return success
-          outlen = size_t(dst - dstinit);
-          srcr = src;
-          return {SUCCESS, size_t(dst - dstinit)};
-        } else if (!ignore_garbage && idx == 1) {
-          // Error: Incomplete chunk of length 1 is invalid in loose mode
-          outlen = size_t(dst - dstinit);
-          srcr = src;
-          return {BASE64_INPUT_REMAINDER, size_t(src - srcinit)};
-        } else if (idx == 2 || idx == 3) {
-          // Check if there's enough space in the destination buffer
-          size_t required_space = (idx == 2) ? 1 : 2;
-          if (size_t(dstend - dst) < required_space) {
-            outlen = size_t(dst - dstinit);
-            srcr = src;
-            return {OUTPUT_BUFFER_TOO_SMALL, size_t(srccur - srcinit)};
-          }
-          uint32_t triple = 0;
-          if (idx == 2) {
-            triple = (uint32_t(buffer[0]) << 18) + (uint32_t(buffer[1]) << 12);
-            if (!ignore_garbage &&
-                (last_chunk_options == last_chunk_handling_options::strict) &&
-                (triple & 0xffff)) {
-              srcr = src;
-              return {BASE64_EXTRA_BITS, size_t(src - srcinit)};
-            }
-            // Extract the first byte
-            triple >>= 16;
-            dst[0] = static_cast<char>(triple & 0xFF);
-            dst += 1;
-          } else if (idx == 3) {
-            triple = (uint32_t(buffer[0]) << 18) + (uint32_t(buffer[1]) << 12) +
-                     (uint32_t(buffer[2]) << 6);
-            if (!ignore_garbage &&
-                (last_chunk_options == last_chunk_handling_options::strict) &&
-                (triple & 0xff)) {
-              srcr = src;
-              return {BASE64_EXTRA_BITS, size_t(src - srcinit)};
-            }
-            // Extract the first two bytes
-            triple >>= 8;
-            dst[0] = static_cast<char>((triple >> 8) & 0xFF);
-            dst[1] = static_cast<char>(triple & 0xFF);
-            dst += 2;
-          }
-          outlen = size_t(dst - dstinit);
-          srcr = src;
-          return {SUCCESS, size_t(dst - dstinit)};
-        }
-      }
-    }
-
-    if (dstend - dst < 3) {
-      outlen = size_t(dst - dstinit);
-      srcr = src;
-      return {OUTPUT_BUFFER_TOO_SMALL, size_t(srccur - srcinit)};
-    }
-    uint32_t triple = (uint32_t(buffer[0]) << 18) +
-                      (uint32_t(buffer[1]) << 12) + (uint32_t(buffer[2]) << 6) +
-                      (uint32_t(buffer[3]));
-    if (match_system(endianness::BIG)) {
-      triple <<= 8;
-      std::memcpy(dst, &triple, 3);
-    } else {
-      triple = scalar::u32_swap_bytes(triple);
-      triple >>= 8;
-      std::memcpy(dst, &triple, 3);
-    }
-    dst += 3;
   }
+  return r;
 }
 
 // Returns the number of bytes written. The destination buffer must be large
@@ -13859,6 +13992,77 @@ simdutf_warn_unused size_t maximal_binary_length_from_base64(
   return actual_length / 4 * 3 + (actual_length % 4) - 1;
 }
 
+template <typename char_type>
+simdutf_warn_unused full_result base64_to_binary_details_impl(
+    const char_type *input, size_t length, char *output, base64_options options,
+    last_chunk_handling_options last_chunk_options) noexcept {
+  const bool ignore_garbage =
+      (options == base64_options::base64_url_accept_garbage) ||
+      (options == base64_options::base64_default_accept_garbage) ||
+      (options == base64_options::base64_default_or_url_accept_garbage);
+  auto ri = simdutf::scalar::base64::find_end(input, length, options);
+  size_t equallocation = ri.equallocation;
+  size_t equalsigns = ri.equalsigns;
+  length = ri.srclen;
+  size_t full_input_length = ri.full_input_length;
+  (void)full_input_length;
+  if (length == 0) {
+    if (!ignore_garbage && equalsigns > 0) {
+      return {INVALID_BASE64_CHARACTER, equallocation, 0};
+    }
+    return {SUCCESS, 0, 0};
+  }
+  full_result r = scalar::base64::base64_tail_decode(
+      output, input, length, equalsigns, options, last_chunk_options);
+  r = scalar::base64::patch_tail_result(r, 0, 0, equallocation,
+                                        full_input_length, last_chunk_options);
+  if (!is_partial(last_chunk_options) && r.error == error_code::SUCCESS &&
+      equalsigns > 0 && !ignore_garbage) {
+    // additional checks
+    if ((r.output_count % 3 == 0) ||
+        ((r.output_count % 3) + 1 + equalsigns != 4)) {
+      return {INVALID_BASE64_CHARACTER, equallocation, r.output_count};
+    }
+  }
+  return r;
+}
+
+template <typename char_type>
+simdutf_warn_unused full_result base64_to_binary_details_safe_impl(
+    const char_type *input, size_t length, char *output, size_t outlen,
+    base64_options options,
+    last_chunk_handling_options last_chunk_options) noexcept {
+  const bool ignore_garbage =
+      (options == base64_options::base64_url_accept_garbage) ||
+      (options == base64_options::base64_default_accept_garbage) ||
+      (options == base64_options::base64_default_or_url_accept_garbage);
+  auto ri = simdutf::scalar::base64::find_end(input, length, options);
+  size_t equallocation = ri.equallocation;
+  size_t equalsigns = ri.equalsigns;
+  length = ri.srclen;
+  size_t full_input_length = ri.full_input_length;
+  (void)full_input_length;
+  if (length == 0) {
+    if (!ignore_garbage && equalsigns > 0) {
+      return {INVALID_BASE64_CHARACTER, equallocation, 0};
+    }
+    return {SUCCESS, 0, 0};
+  }
+  full_result r = scalar::base64::base64_tail_decode_safe(
+      output, outlen, input, length, equalsigns, options, last_chunk_options);
+  r = scalar::base64::patch_tail_result(r, 0, 0, equallocation,
+                                        full_input_length, last_chunk_options);
+  if (!is_partial(last_chunk_options) && r.error == error_code::SUCCESS &&
+      equalsigns > 0 && !ignore_garbage) {
+    // additional checks
+    if ((r.output_count % 3 == 0) ||
+        ((r.output_count % 3) + 1 + equalsigns != 4)) {
+      return {INVALID_BASE64_CHARACTER, equallocation, r.output_count};
+    }
+  }
+  return r;
+}
+
 simdutf_warn_unused size_t
 base64_length_from_binary(size_t length, base64_options options) noexcept {
   // By default, we use padding if we are not using the URL variant.
@@ -13877,6 +14081,38 @@ base64_length_from_binary(size_t length, base64_options options) noexcept {
   }
   return (length + 2) / 3 *
          4; // We use padding to make the length a multiple of 4.
+}
+
+// Return the length of the prefix that contains count base64 characters.
+// Thus, if count is 3, the function returns the length of the prefix
+// that contains 3 base64 characters.
+// The function returns (size_t)-1 if there is not enough base64 characters in
+// the input.
+template <typename char_type>
+simdutf_warn_unused size_t prefix_length(size_t count,
+                                         simdutf::base64_options options,
+                                         const char_type *input,
+                                         size_t length) noexcept {
+  size_t i = 0;
+  while (i < length && is_ignorable(input[i], options)) {
+    i++;
+  }
+  if (count == 0) {
+    return i; // duh!
+  }
+  for (; i < length; i++) {
+    if (is_ignorable(input[i], options)) {
+      continue;
+    }
+    // We have a base64 character or a padding character.
+    count--;
+    if (count == 0) {
+      return i + 1;
+    }
+  }
+  simdutf_log_assert(false, "You never get here");
+
+  return -1; // should never happen
 }
 
 } // namespace base64
@@ -14389,12 +14625,18 @@ inline size_t convert(const char16_t *buf, size_t len, char *utf8_output) {
   return utf8_output - start;
 }
 
-template <endianness big_endian>
-inline result convert_with_errors(const char16_t *buf, size_t len,
-                                  char *utf8_output) {
+template <endianness big_endian, bool check_output = false>
+inline full_result convert_with_errors(const char16_t *buf, size_t len,
+                                       char *utf8_output, size_t utf8_len = 0) {
   const uint16_t *data = reinterpret_cast<const uint16_t *>(buf);
+  if (check_output && utf8_len == 0) {
+    return full_result(error_code::OUTPUT_BUFFER_TOO_SMALL, 0, 0);
+  }
+
   size_t pos = 0;
   char *start{utf8_output};
+  char *end{utf8_output + utf8_len};
+
   while (pos < len) {
     // try to convert the next block of 8 bytes
     if (pos + 4 <=
@@ -14410,6 +14652,10 @@ inline result convert_with_errors(const char16_t *buf, size_t len,
                                ? char(u16_swap_bytes(buf[pos]))
                                : char(buf[pos]);
           pos++;
+          if (check_output && size_t(end - utf8_output) == 0) {
+            return full_result(error_code::OUTPUT_BUFFER_TOO_SMALL, pos,
+                               utf8_output - start);
+          }
         }
         continue;
       }
@@ -14420,34 +14666,52 @@ inline result convert_with_errors(const char16_t *buf, size_t len,
       // will generate one UTF-8 bytes
       *utf8_output++ = char(word);
       pos++;
+      if (check_output && size_t(end - utf8_output) == 0) {
+        return full_result(error_code::OUTPUT_BUFFER_TOO_SMALL, pos,
+                           utf8_output - start);
+      }
     } else if ((word & 0xF800) == 0) {
       // will generate two UTF-8 bytes
       // we have 0b110XXXXX 0b10XXXXXX
+      if (check_output && size_t(end - utf8_output) < 2) {
+        return full_result(error_code::OUTPUT_BUFFER_TOO_SMALL, pos,
+                           utf8_output - start);
+      }
       *utf8_output++ = char((word >> 6) | 0b11000000);
       *utf8_output++ = char((word & 0b111111) | 0b10000000);
       pos++;
+
     } else if ((word & 0xF800) != 0xD800) {
       // will generate three UTF-8 bytes
       // we have 0b1110XXXX 0b10XXXXXX 0b10XXXXXX
+      if (check_output && size_t(end - utf8_output) < 3) {
+        return full_result(error_code::OUTPUT_BUFFER_TOO_SMALL, pos,
+                           utf8_output - start);
+      }
       *utf8_output++ = char((word >> 12) | 0b11100000);
       *utf8_output++ = char(((word >> 6) & 0b111111) | 0b10000000);
       *utf8_output++ = char((word & 0b111111) | 0b10000000);
       pos++;
     } else {
+
+      if (check_output && size_t(end - utf8_output) < 4) {
+        return full_result(error_code::OUTPUT_BUFFER_TOO_SMALL, pos,
+                           utf8_output - start);
+      }
       // must be a surrogate pair
       if (pos + 1 >= len) {
-        return result(error_code::SURROGATE, pos);
+        return full_result(error_code::SURROGATE, pos, utf8_output - start);
       }
       uint16_t diff = uint16_t(word - 0xD800);
       if (diff > 0x3FF) {
-        return result(error_code::SURROGATE, pos);
+        return full_result(error_code::SURROGATE, pos, utf8_output - start);
       }
       uint16_t next_word = !match_system(big_endian)
                                ? u16_swap_bytes(data[pos + 1])
                                : data[pos + 1];
       uint16_t diff2 = uint16_t(next_word - 0xDC00);
       if (diff2 > 0x3FF) {
-        return result(error_code::SURROGATE, pos);
+        return full_result(error_code::SURROGATE, pos, utf8_output - start);
       }
       uint32_t value = (diff << 10) + diff2 + 0x10000;
       // will generate four UTF-8 bytes
@@ -14459,7 +14723,13 @@ inline result convert_with_errors(const char16_t *buf, size_t len,
       pos += 2;
     }
   }
-  return result(error_code::SUCCESS, utf8_output - start);
+  return full_result(error_code::SUCCESS, pos, utf8_output - start);
+}
+
+template <endianness big_endian>
+inline result simple_convert_with_errors(const char16_t *buf, size_t len,
+                                         char *utf8_output) {
+  return convert_with_errors<big_endian, false>(buf, len, utf8_output, 0);
 }
 
 } // namespace utf16_to_utf8
@@ -16987,6 +17257,16 @@ public:
                           base64_options options) const noexcept override {
     return set_best()->binary_to_base64(input, length, output, options);
   }
+
+  const char *find(const char *start, const char *end,
+                   char character) const noexcept override {
+    return set_best()->find(start, end, character);
+  }
+
+  const char16_t *find(const char16_t *start, const char16_t *end,
+                       char16_t character) const noexcept override {
+    return set_best()->find(start, end, character);
+  }
 #endif // SIMDUTF_FEATURE_BASE64
 
   simdutf_really_inline
@@ -17497,6 +17777,13 @@ public:
                           base64_options) const noexcept override {
     return 0;
   }
+  const char *find(const char *, const char *, char) const noexcept override {
+    return nullptr;
+  }
+  const char16_t *find(const char16_t *, const char16_t *,
+                       char16_t) const noexcept override {
+    return nullptr;
+  }
 #endif // SIMDUTF_FEATURE_BASE64
 
   unsupported_implementation()
@@ -17780,31 +18067,49 @@ simdutf_warn_unused result atomic_base64_to_binary_safe_impl(
   constexpr size_t buffer_size = 4096;
     #endif
   std::array<char, buffer_size> temp_buffer;
-  const char_type *input_init = input;
+  const char_type *const input_init = input;
   size_t actual_out = 0;
-  while (true) {
-    const bool last_chunk = (temp_buffer.size() >= outlen - actual_out);
+  bool last_chunk = false;
+  result r;
+  while (!last_chunk) {
+    last_chunk |= (temp_buffer.size() >= outlen - actual_out);
     size_t temp_outlen = (std::min)(temp_buffer.size(), outlen - actual_out);
-    result r = base64_to_binary_safe(
-        input, length, temp_buffer.data(), temp_outlen, options,
-        last_chunk_handling_options, decode_up_to_bad_char);
+    r = base64_to_binary_safe(input, length, temp_buffer.data(), temp_outlen,
+                              options, last_chunk_handling_options,
+                              decode_up_to_bad_char);
+    // We processed r.count characters of input.
+    // We wrote temp_outlen bytes to temp_buffer.
+    // If there is no ignorable characters,
+    // we should expect that values/4.0*3 == temp_outlen,
+    // except maybe at the tail end of the string.
+
+    //
+    // We are assuming that when r.error == error_code::OUTPUT_BUFFER_TOO_SMALL,
+    // we truncate the results so that a number of base64 characters divisible
+    // by four is processed.
+    //
+
+    //
     // We wrote temp_outlen bytes to temp_buffer.
     // We need to copy them to output.
     // Copy with relaxed atomic operations to the output
+    simdutf_log_assert(temp_outlen <= outlen - actual_out,
+                       "Output buffer is too small");
+    simdutf_log_assert(temp_outlen <= temp_buffer.size(),
+                       "Output buffer is too small");
+
     simdutf::scalar::memcpy_atomic_write(output + actual_out,
                                          temp_buffer.data(), temp_outlen);
     actual_out += temp_outlen;
     length -= r.count;
     input += r.count;
 
-    // If we are done, return the result, the only case where
-    // we are not done is when we ran out of space in output.
-    if (last_chunk || r.error != error_code::OUTPUT_BUFFER_TOO_SMALL) {
-      outlen = actual_out;
-      r.count = size_t(input - input_init);
-      return r;
+    if (r.error != error_code::OUTPUT_BUFFER_TOO_SMALL) {
+      break;
     }
   }
+  outlen = actual_out;
+  return {r.error, size_t(input - input_init)};
 }
 
 simdutf_warn_unused result atomic_base64_to_binary_safe(
@@ -17901,6 +18206,62 @@ simdutf_warn_unused size_t convert_utf16_to_utf8(const char16_t *buf,
   #else
   return convert_utf16le_to_utf8(buf, len, utf8_buffer);
   #endif
+}
+
+simdutf_warn_unused size_t
+convert_utf16_to_utf8_safe(const char16_t *buf, size_t len, char *utf8_output,
+                           size_t utf8_len) noexcept {
+  const auto start{utf8_output};
+  // We might be able to go faster by first scanning the input buffer to
+  // determine how many char16_t characters we can read without exceeding the
+  // utf8_len. This is a one-pass algorithm that has the benefit of not
+  // requiring a first pass to determine the length.
+  while (true) {
+    // The worst case for convert_utf16_to_utf8 is when you go from 1 char16_t
+    // to 3 characters of UTF-8. So we can read at most utf8_len / 3 char16_t
+    // characters.
+    auto read_len = std::min(len, utf8_len / 3);
+    if (read_len <= 16) {
+      break;
+    }
+    if (read_len < len) {
+      //  If we have a high surrogate at the end of the buffer, we need to
+      //  either read one more char16_t or backtrack.
+      if (scalar::utf16::high_surrogate(buf[read_len - 1])) {
+        read_len--;
+      }
+    }
+    if (read_len == 0) {
+      // If we cannot read anything, we are done.
+      break;
+    }
+    const auto write_len =
+        simdutf::convert_utf16_to_utf8(buf, read_len, utf8_output);
+    if (write_len == 0) {
+      // There was an error in the conversion, we cannot continue.
+      return 0; // indicating failure
+    }
+
+    utf8_output += write_len;
+    utf8_len -= write_len;
+    buf += read_len;
+    len -= read_len;
+  }
+  #if SIMDUTF_IS_BIG_ENDIAN
+  full_result r =
+      scalar::utf16_to_utf8::convert_with_errors<endianness::BIG, true>(
+          buf, len, utf8_output, utf8_len);
+  #else
+  full_result r =
+      scalar::utf16_to_utf8::convert_with_errors<endianness::LITTLE, true>(
+          buf, len, utf8_output, utf8_len);
+  #endif
+  if (r.error != error_code::SUCCESS &&
+      r.error != error_code::OUTPUT_BUFFER_TOO_SMALL) {
+    // If there was an error, we return 0 to indicate failure.
+    return 0; // indicating failure
+  }
+  return r.output_count + (utf8_output - start);
 }
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
@@ -18300,6 +18661,15 @@ simdutf_warn_unused size_t utf32_length_from_utf8(const char *input,
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
 
 #if SIMDUTF_FEATURE_BASE64
+simdutf_warn_unused const char *find(const char *start, const char *end,
+                                     char character) noexcept {
+  return get_default_implementation()->find(start, end, character);
+}
+simdutf_warn_unused const char16_t *
+find(const char16_t *start, const char16_t *end, char16_t character) noexcept {
+  return get_default_implementation()->find(start, end, character);
+}
+
 simdutf_warn_unused size_t
 maximal_binary_length_from_base64(const char *input, size_t length) noexcept {
   return get_default_implementation()->maximal_binary_length_from_base64(
@@ -18332,36 +18702,15 @@ simdutf_warn_unused result slow_base64_to_binary_safe_impl(
     base64_options options,
     last_chunk_handling_options last_chunk_options) noexcept {
   const bool ignore_garbage = (options & base64_default_accept_garbage) != 0;
-  while (length > 0 &&
-         scalar::base64::is_ascii_white_space(input[length - 1])) {
-    length--;
-  }
-  size_t equallocation =
-      length; // location of the first padding character if any
-  size_t equalsigns = 0;
-  if (length > 0 && input[length - 1] == '=') {
-    equallocation = length - 1;
-    length -= 1;
-    equalsigns++;
-    while (length > 0 &&
-           scalar::base64::is_ascii_white_space(input[length - 1])) {
-      length--;
-    }
-    if (length > 0 && input[length - 1] == '=') {
-      equallocation = length - 1;
-      equalsigns++;
-      length -= 1;
-    }
-  }
+  auto ri = simdutf::scalar::base64::find_end(input, length, options);
+  size_t equallocation = ri.equallocation;
+  size_t equalsigns = ri.equalsigns;
+  length = ri.srclen;
+  size_t full_input_length = ri.full_input_length;
+  (void)full_input_length;
   if (length == 0) {
     outlen = 0;
     if (!ignore_garbage && equalsigns > 0) {
-      if (last_chunk_options == last_chunk_handling_options::strict) {
-        return {BASE64_INPUT_REMAINDER, 0};
-      } else if (last_chunk_options ==
-                 last_chunk_handling_options::stop_before_partial) {
-        return {SUCCESS, 0};
-      }
       return {INVALID_BASE64_CHARACTER, equallocation};
     }
     return {SUCCESS, 0};
@@ -18369,8 +18718,7 @@ simdutf_warn_unused result slow_base64_to_binary_safe_impl(
 
   // The parameters of base64_tail_decode_safe are:
   // - dst: the output buffer
-  // - outlen: the size of the output buffer, modified to the number of
-  //   bytes written to the output buffer
+  // - outlen: the size of the output buffer
   // - srcr: the input buffer
   // - length: the size of the input buffer
   // - padded_characters: the number of padding characters
@@ -18380,16 +18728,44 @@ simdutf_warn_unused result slow_base64_to_binary_safe_impl(
   // and the number of bytes read from the input buffer.
   // The function will also return an error code if the input buffer is not
   // valid base64.
-  result r = scalar::base64::base64_tail_decode_safe(
+  full_result r = scalar::base64::base64_tail_decode_safe(
       output, outlen, input, length, equalsigns, options, last_chunk_options);
-  if (last_chunk_options != stop_before_partial &&
-      r.error == error_code::SUCCESS && equalsigns > 0) {
+  r = scalar::base64::patch_tail_result(r, 0, 0, equallocation,
+                                        full_input_length, last_chunk_options);
+  outlen = r.output_count;
+  if (!is_partial(last_chunk_options) && r.error == error_code::SUCCESS &&
+      equalsigns > 0) {
     // additional checks
     if ((outlen % 3 == 0) || ((outlen % 3) + 1 + equalsigns != 4)) {
       r.error = error_code::INVALID_BASE64_CHARACTER;
     }
   }
-  return r;
+  return {r.error, r.input_count}; // we cannot return r itself because it gets
+                                   // converted to error/output_count
+}
+simdutf_warn_unused bool base64_ignorable(char input,
+                                          base64_options options) noexcept {
+  return scalar::base64::is_ignorable(input, options);
+}
+simdutf_warn_unused bool base64_ignorable(char16_t input,
+                                          base64_options options) noexcept {
+  return scalar::base64::is_ignorable(input, options);
+}
+simdutf_warn_unused bool base64_valid(char input,
+                                      base64_options options) noexcept {
+  return scalar::base64::is_base64(input, options);
+}
+simdutf_warn_unused bool base64_valid(char16_t input,
+                                      base64_options options) noexcept {
+  return scalar::base64::is_base64(input, options);
+}
+simdutf_warn_unused bool
+base64_valid_or_padding(char input, base64_options options) noexcept {
+  return scalar::base64::is_base64_or_padding(input, options);
+}
+simdutf_warn_unused bool
+base64_valid_or_padding(char16_t input, base64_options options) noexcept {
+  return scalar::base64::is_base64_or_padding(input, options);
 }
 
 template <typename chartype>
@@ -18401,124 +18777,70 @@ simdutf_warn_unused result base64_to_binary_safe_impl(
   static_assert(std::is_same<chartype, char>::value ||
                     std::is_same<chartype, char16_t>::value,
                 "Only char and char16_t are supported.");
-  // The implementation could be nicer, but we expect that most times, the user
-  // will provide us with a buffer that is large enough.
-  size_t max_length = maximal_binary_length_from_base64(input, length);
-  if (outlen >= max_length) {
-    // fast path
-    full_result r = get_default_implementation()->base64_to_binary_details(
-        input, length, output, options, last_chunk_handling_options);
+  size_t remaining_input_length = length;
+  size_t remaining_output_length = outlen;
+  size_t input_position = 0;
+  size_t output_position = 0;
+
+  // We also do a first pass using the fast path to decode as much as possible
+  size_t safe_input = (std::min)(
+      remaining_input_length,
+      base64_length_from_binary(remaining_output_length / 3 * 3, options));
+  bool done_with_partial = (safe_input == remaining_input_length);
+  simdutf::full_result r =
+      get_default_implementation()->base64_to_binary_details(
+          input + input_position, safe_input, output + output_position, options,
+          done_with_partial
+              ? last_chunk_handling_options
+              : simdutf::last_chunk_handling_options::only_full_chunks);
+  simdutf_log_assert(r.input_count <= safe_input,
+                     "You should not read more than safe_input");
+  simdutf_log_assert(r.output_count <= remaining_output_length,
+                     "You should not write more than remaining_output_length");
+  // Technically redundant, but we want to be explicit about it.
+  input_position += r.input_count;
+  output_position += r.output_count;
+  remaining_input_length -= r.input_count;
+  remaining_output_length -= r.output_count;
+  if (r.error != simdutf::error_code::SUCCESS) {
+    // There is an error. We return.
     if (decode_up_to_bad_char &&
         r.error == error_code::INVALID_BASE64_CHARACTER) {
-      // We need to use the slow path because we want to make sure that
-      // we write as much data as possible to the output buffer to meet
-      // the requirements of the JavaScript standard.
       return slow_base64_to_binary_safe_impl(
           input, length, output, outlen, options, last_chunk_handling_options);
     }
-    if (r.error != error_code::INVALID_BASE64_CHARACTER &&
-        r.error != error_code::BASE64_EXTRA_BITS) {
-      outlen = r.output_count;
-      if (last_chunk_handling_options == stop_before_partial) {
-        if ((r.output_count % 3) != 0) {
-          bool empty_trail = true;
-          for (size_t i = r.input_count; i < length; i++) {
-            if (!scalar::base64::is_ascii_white_space_or_padding(input[i])) {
-              empty_trail = false;
-              break;
-            }
-          }
-          if (empty_trail) {
-            r.input_count = length;
-          }
-        }
-        return {r.error, r.input_count};
-      }
-      return {r.error, length};
-    }
-    return r;
+    outlen = output_position;
+    return {r.error, input_position};
   }
-  // The output buffer is maybe too small. We will decode a truncated version of
-  // the input.
-  size_t outlen3 = outlen / 3 * 3; // round down to multiple of 3
-  size_t safe_input = base64_length_from_binary(outlen3, options);
-  full_result r = get_default_implementation()->base64_to_binary_details(
-      input, safe_input, output, options, last_chunk_handling_options);
-  if (r.error == error_code::INVALID_BASE64_CHARACTER) {
-    if (decode_up_to_bad_char) { // We need to use the slow path because we want
-                                 // to make sure that
-      // we write as much data as possible to the output buffer to meet
-      // the requirements of the JavaScript standard.
+  if (done_with_partial) {
+    // We are done. We have decoded everything.
+    outlen = output_position;
+    return {simdutf::error_code::SUCCESS, input_position};
+  }
+
+  // We have decoded some data, but we still have some data to decode.
+  // We need to decode the rest of the input buffer.
+  r = simdutf::scalar::base64::base64_to_binary_details_safe_impl(
+      input + input_position, remaining_input_length, output + output_position,
+      remaining_output_length, options, last_chunk_handling_options);
+
+  input_position += r.input_count;
+  output_position += r.output_count;
+  remaining_input_length -= r.input_count;
+  remaining_output_length -= r.output_count;
+
+  if (r.error != simdutf::error_code::SUCCESS) {
+    // There is an error. We return.
+    if (decode_up_to_bad_char &&
+        r.error == error_code::INVALID_BASE64_CHARACTER) {
       return slow_base64_to_binary_safe_impl(
           input, length, output, outlen, options, last_chunk_handling_options);
     }
-    return r;
+    outlen = output_position;
+    return {r.error, input_position};
   }
-  size_t offset =
-      (r.error == error_code::BASE64_INPUT_REMAINDER)
-          ? 1
-          : ((r.output_count % 3) == 0 ? 0 : (r.output_count % 3) + 1);
-  size_t output_index = r.output_count - (r.output_count % 3);
-  size_t input_index = safe_input;
-  // offset is a value that is no larger than 3. We backtrack
-  // by up to offset characters + an undetermined number of
-  // white space characters. It is expected that the next loop
-  // runs at most 3 times + the number of white space characters
-  // in between them, so we are not worried about performance.
-  while (offset > 0 && input_index > 0) {
-    chartype c = input[--input_index];
-    if (scalar::base64::is_ascii_white_space(c)) {
-      // skipping
-    } else {
-      offset--;
-    }
-  }
-  size_t remaining_out = outlen - output_index;
-  const chartype *tail_input = input + input_index;
-  size_t tail_length = length - input_index;
-  while (tail_length > 0 &&
-         scalar::base64::is_ascii_white_space(tail_input[tail_length - 1])) {
-    tail_length--;
-  }
-  size_t padding_characts = 0;
-  if (tail_length > 0 && tail_input[tail_length - 1] == '=') {
-    tail_length--;
-    padding_characts++;
-    while (tail_length > 0 &&
-           scalar::base64::is_ascii_white_space(tail_input[tail_length - 1])) {
-      tail_length--;
-    }
-    if (tail_length > 0 && tail_input[tail_length - 1] == '=') {
-      tail_length--;
-      padding_characts++;
-    }
-  }
-  // this will advance tail_input and tail_length
-  result rr = scalar::base64::base64_tail_decode_safe(
-      output + output_index, remaining_out, tail_input, tail_length,
-      padding_characts, options, last_chunk_handling_options);
-  outlen = output_index + remaining_out;
-  if (last_chunk_handling_options != stop_before_partial &&
-      rr.error == error_code::SUCCESS && padding_characts > 0) {
-    // additional checks
-    if ((outlen % 3 == 0) || ((outlen % 3) + 1 + padding_characts != 4)) {
-      rr.error = error_code::INVALID_BASE64_CHARACTER;
-    }
-  }
-  if (rr.error == error_code::SUCCESS) {
-    if (last_chunk_handling_options == stop_before_partial) {
-      if (tail_input > input + input_index) {
-        rr.count = tail_input - input;
-      } else if (r.input_count > 0) {
-        rr.count = r.input_count + rr.count;
-      }
-      return rr;
-    }
-    rr.count = length;
-  } else {
-    rr.count += input_index;
-  }
-  return rr;
+  outlen = output_position;
+  return {simdutf::error_code::SUCCESS, input_position};
 }
 
   #if SIMDUTF_ATOMIC_REF
@@ -20949,27 +21271,27 @@ uint64_t to_base64_mask(block64 *b, bool *error) {
 #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
   if (default_or_url) {
     lut_lo =
-        simdutf_make_uint8x16_t(0x15, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c,
-                                0x1c, 0x1d, 0x19, 0x12, 0x11, 0x13, 0x10, 0x32);
+        simdutf_make_uint8x16_t(0xa9, 0xf8, 0xf8, 0xf8, 0xf8, 0xf8, 0xf8, 0xf8,
+                                0xf8, 0xf9, 0xf1, 0xa2, 0xa1, 0xa5, 0xa0, 0xa6);
   } else if (base64_url) {
     lut_lo =
-        simdutf_make_uint8x16_t(0x15, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c,
-                                0x1c, 0x1d, 0x19, 0x10, 0x11, 0x13, 0x10, 0x30);
+        simdutf_make_uint8x16_t(0xa9, 0xf8, 0xf8, 0xf8, 0xf8, 0xf8, 0xf8, 0xf8,
+                                0xf8, 0xf9, 0xf1, 0xa0, 0xa1, 0xa5, 0xa0, 0xa2);
   } else {
     lut_lo =
-        simdutf_make_uint8x16_t(0x15, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c,
-                                0x1c, 0x1d, 0x19, 0x12, 0x11, 0x11, 0x10, 0x12);
+        simdutf_make_uint8x16_t(0xa9, 0xf8, 0xf8, 0xf8, 0xf8, 0xf8, 0xf8, 0xf8,
+                                0xf8, 0xf9, 0xf1, 0xa2, 0xa1, 0xa1, 0xa0, 0xa4);
   }
 #else
   if (default_or_url) {
-    lut_lo = uint8x16_t{0x15, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c,
-                        0x1c, 0x1d, 0x19, 0x12, 0x11, 0x13, 0x10, 0x32};
+    lut_lo = uint8x16_t{0xa9, 0xf8, 0xf8, 0xf8, 0xf8, 0xf8, 0xf8, 0xf8,
+                        0xf8, 0xf9, 0xf1, 0xa2, 0xa1, 0xa5, 0xa0, 0xa6};
   } else if (base64_url) {
-    lut_lo = uint8x16_t{0x15, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c,
-                        0x1c, 0x1d, 0x19, 0x10, 0x11, 0x13, 0x10, 0x30};
+    lut_lo = uint8x16_t{0xa9, 0xf8, 0xf8, 0xf8, 0xf8, 0xf8, 0xf8, 0xf8,
+                        0xf8, 0xf9, 0xf1, 0xa0, 0xa1, 0xa5, 0xa0, 0xa2};
   } else {
-    lut_lo = uint8x16_t{0x15, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c,
-                        0x1c, 0x1d, 0x19, 0x12, 0x11, 0x11, 0x10, 0x12};
+    lut_lo = uint8x16_t{0xa9, 0xf8, 0xf8, 0xf8, 0xf8, 0xf8, 0xf8, 0xf8,
+                        0xf8, 0xf9, 0xf1, 0xa2, 0xa1, 0xa1, 0xa0, 0xa4};
   }
 #endif
   uint8x16_t lo0 = vqtbl1q_u8(lut_lo, lo_nibbles0);
@@ -20980,27 +21302,27 @@ uint64_t to_base64_mask(block64 *b, bool *error) {
 #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
   if (default_or_url) {
     lut_hi =
-        simdutf_make_uint8x16_t(0x0, 0x1, 0x0, 0x0, 0x1, 0x2, 0x4, 0x4, 0x8,
-                                0x10, 0x10, 0x28, 0x8, 0x10, 0x10, 0x8);
+        simdutf_make_uint8x16_t(0x0, 0x1, 0x0, 0x0, 0x1, 0x6, 0x8, 0x8, 0x10,
+                                0x20, 0x20, 0x12, 0x40, 0x80, 0x80, 0x40);
   } else if (base64_url) {
     lut_hi =
-        simdutf_make_uint8x16_t(0x0, 0x1, 0x0, 0x0, 0x1, 0x2, 0x4, 0x4, 0x8,
-                                0x10, 0x10, 0x28, 0x8, 0x10, 0x10, 0x8);
+        simdutf_make_uint8x16_t(0x0, 0x1, 0x0, 0x0, 0x1, 0x6, 0x8, 0x8, 0x10,
+                                0x20, 0x20, 0x12, 0x40, 0x80, 0x80, 0x40);
   } else {
     lut_hi =
-        simdutf_make_uint8x16_t(0x0, 0x1, 0x0, 0x0, 0x1, 0x2, 0x4, 0x4, 0x8,
-                                0x10, 0x10, 0x8, 0x8, 0x10, 0x10, 0x8);
+        simdutf_make_uint8x16_t(0x0, 0x1, 0x0, 0x0, 0x1, 0x6, 0x8, 0x8, 0x10,
+                                0x20, 0x20, 0x10, 0x40, 0x80, 0x80, 0x40);
   }
 #else
   if (default_or_url) {
-    lut_hi = uint8x16_t{0x0, 0x1,  0x0,  0x0,  0x1, 0x2,  0x4,  0x4,
-                        0x8, 0x10, 0x10, 0x28, 0x8, 0x10, 0x10, 0x8};
+    lut_hi = uint8x16_t{0x0,  0x1,  0x0,  0x0,  0x1,  0x6,  0x8,  0x8,
+                        0x10, 0x20, 0x20, 0x12, 0x40, 0x80, 0x80, 0x40};
   } else if (base64_url) {
-    lut_hi = uint8x16_t{0x0, 0x1,  0x0,  0x0,  0x1, 0x2,  0x4,  0x4,
-                        0x8, 0x10, 0x10, 0x28, 0x8, 0x10, 0x10, 0x8};
+    lut_hi = uint8x16_t{0x0,  0x1,  0x0,  0x0,  0x1,  0x4,  0x8,  0x8,
+                        0x10, 0x20, 0x20, 0x12, 0x40, 0x80, 0x80, 0x40};
   } else {
-    lut_hi = uint8x16_t{0x0, 0x1,  0x0,  0x0, 0x1, 0x2,  0x4,  0x4,
-                        0x8, 0x10, 0x10, 0x8, 0x8, 0x10, 0x10, 0x8};
+    lut_hi = uint8x16_t{0x0,  0x1,  0x0,  0x0,  0x1,  0x6,  0x8,  0x8,
+                        0x10, 0x20, 0x20, 0x10, 0x40, 0x80, 0x80, 0x40};
   }
 #endif
   uint8x16_t hi0 = vqtbl1q_u8(lut_hi, hi_bits0);
@@ -21044,7 +21366,6 @@ uint64_t to_base64_mask(block64 *b, bool *error) {
   // This is the transformation step that can be done while we are waiting for
   // sum0
   uint8x16_t roll_lut;
-  uint8x16_t delta_asso;
 #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
   if (default_or_url) {
     roll_lut =
@@ -21052,59 +21373,55 @@ uint64_t to_base64_mask(block64 *b, bool *error) {
                                 0xB9, 0x00, 0xFF, 0x11, 0xFF, 0xBF, 0x10, 0xB9);
   } else if (base64_url) {
     roll_lut =
-        simdutf_make_uint8x16_t(0x00, 0x00, 0x00, 0x13, 0x04, 0xBF, 0xBF, 0xB9,
-                                0xB9, 0x00, 0x11, 0xC3, 0xBF, 0xE0, 0xB9, 0xB9);
+        simdutf_make_uint8x16_t(0xB9, 0xB9, 0xBF, 0xBF, 0x04, 0x11, 0xE0, 0x00,
+                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
   } else {
     roll_lut =
-        simdutf_make_uint8x16_t(0x00, 0x00, 0x00, 0x13, 0x04, 0xBF, 0xBF, 0xB9,
-                                0xB9, 0x00, 0x10, 0xC3, 0xBF, 0xBF, 0xB9, 0xB9);
-  }
-  if (default_or_url) {
-    delta_asso =
-        simdutf_make_uint8x16_t(0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
-                                0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x00, 0x16);
-  } else {
-    delta_asso =
-        simdutf_make_uint8x16_t(0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
-                                0x00, 0x00, 0x00, 0x00, 0x00, 0x0F, 0x00, 0x0F);
+        simdutf_make_uint8x16_t(0xB9, 0xB9, 0xBF, 0xBF, 0x04, 0x10, 0x13, 0x00,
+                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
   }
 #else
   if (default_or_url) {
     roll_lut = uint8x16_t{0xBF, 0xE0, 0xB9, 0x13, 0x04, 0xBF, 0xBF, 0xB9,
                           0xB9, 0x00, 0xFF, 0x11, 0xFF, 0xBF, 0x10, 0xB9};
   } else if (base64_url) {
-    roll_lut = uint8x16_t{0x00, 0x00, 0x00, 0x13, 0x04, 0xBF, 0xBF, 0xB9,
-                          0xB9, 0x00, 0x11, 0xC3, 0xBF, 0xE0, 0xB9, 0xB9};
+    roll_lut = uint8x16_t{0xB9, 0xB9, 0xBF, 0xBF, 0x04, 0x11, 0xE0, 0x00,
+                          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
   } else {
-    roll_lut = uint8x16_t{0x00, 0x00, 0x00, 0x13, 0x04, 0xBF, 0xBF, 0xB9,
-                          0xB9, 0x00, 0x10, 0xC3, 0xBF, 0xBF, 0xB9, 0xB9};
-  }
-  if (default_or_url) {
-    delta_asso = uint8x16_t{0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
-                            0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x00, 0x16};
-  } else {
-    delta_asso = uint8x16_t{0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
-                            0x00, 0x00, 0x00, 0x00, 0x00, 0x0F, 0x00, 0x0F};
+    roll_lut = uint8x16_t{0xB9, 0xB9, 0xBF, 0xBF, 0x04, 0x10, 0x13, 0x00,
+                          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
   }
 #endif
-  // the logic of translating is based on westmere
-  uint8x16_t delta_hash0 =
-      vrhaddq_u8(vqtbl1q_u8(delta_asso, lo_nibbles0), hi_bits0);
-  uint8x16_t delta_hash1 =
-      vrhaddq_u8(vqtbl1q_u8(delta_asso, lo_nibbles1), hi_bits1);
-  uint8x16_t delta_hash2 =
-      vrhaddq_u8(vqtbl1q_u8(delta_asso, lo_nibbles2), hi_bits2);
-  uint8x16_t delta_hash3 =
-      vrhaddq_u8(vqtbl1q_u8(delta_asso, lo_nibbles3), hi_bits3);
-
   uint8x16_t roll0, roll1, roll2, roll3;
   if (default_or_url) {
+#ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
+    const uint8x16_t delta_asso =
+        simdutf_make_uint8x16_t(0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+                                0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x00, 0x16);
+#else
+    const uint8x16_t delta_asso =
+        uint8x16_t{0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+                   0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x00, 0x16};
+#endif
+    // the logic of translating is based on westmere
+    uint8x16_t delta_hash0 =
+        vrhaddq_u8(vqtbl1q_u8(delta_asso, lo_nibbles0), hi_bits0);
+    uint8x16_t delta_hash1 =
+        vrhaddq_u8(vqtbl1q_u8(delta_asso, lo_nibbles1), hi_bits1);
+    uint8x16_t delta_hash2 =
+        vrhaddq_u8(vqtbl1q_u8(delta_asso, lo_nibbles2), hi_bits2);
+    uint8x16_t delta_hash3 =
+        vrhaddq_u8(vqtbl1q_u8(delta_asso, lo_nibbles3), hi_bits3);
     const uint8x16x2_t roll_lut_2 = {roll_lut, roll_lut};
     roll0 = vqtbl2q_u8(roll_lut_2, delta_hash0);
     roll1 = vqtbl2q_u8(roll_lut_2, delta_hash1);
     roll2 = vqtbl2q_u8(roll_lut_2, delta_hash2);
     roll3 = vqtbl2q_u8(roll_lut_2, delta_hash3);
   } else {
+    uint8x16_t delta_hash0 = vclzq_u8(res0);
+    uint8x16_t delta_hash1 = vclzq_u8(res1);
+    uint8x16_t delta_hash2 = vclzq_u8(res2);
+    uint8x16_t delta_hash3 = vclzq_u8(res3);
     roll0 = vqtbl1q_u8(roll_lut, delta_hash0);
     roll1 = vqtbl1q_u8(roll_lut, delta_hash1);
     roll2 = vqtbl1q_u8(roll_lut, delta_hash2);
@@ -21258,37 +21575,14 @@ compress_decode_base64(char *dst, const char_type *src, size_t srclen,
       default_or_url ? tables::base64::to_base64_default_or_url_value
                      : (base64_url ? tables::base64::to_base64_url_value
                                    : tables::base64::to_base64_value);
-  size_t equallocation =
-      srclen; // location of the first padding character if any
-  // skip trailing spaces
-  while (srclen > 0 && scalar::base64::is_eight_byte(src[srclen - 1]) &&
-         to_base64[uint8_t(src[srclen - 1])] == 64) {
-    srclen--;
-  }
-  size_t equalsigns = 0;
-  if (srclen > 0 && src[srclen - 1] == '=') {
-    equallocation = srclen - 1;
-    srclen--;
-    equalsigns = 1;
-    // skip trailing spaces
-    while (srclen > 0 && scalar::base64::is_eight_byte(src[srclen - 1]) &&
-           to_base64[uint8_t(src[srclen - 1])] == 64) {
-      srclen--;
-    }
-    if (srclen > 0 && src[srclen - 1] == '=') {
-      equallocation = srclen - 1;
-      srclen--;
-      equalsigns = 2;
-    }
-  }
+  auto ri = simdutf::scalar::base64::find_end(src, srclen, options);
+  size_t equallocation = ri.equallocation;
+  size_t equalsigns = ri.equalsigns;
+  srclen = ri.srclen;
+  size_t full_input_length = ri.full_input_length;
+  (void)full_input_length;
   if (srclen == 0) {
     if (!ignore_garbage && equalsigns > 0) {
-      if (last_chunk_options == last_chunk_handling_options::strict) {
-        return {BASE64_INPUT_REMAINDER, 0, 0};
-      } else if (last_chunk_options ==
-                 last_chunk_handling_options::stop_before_partial) {
-        return {SUCCESS, 0, 0};
-      }
       return {INVALID_BASE64_CHARACTER, equallocation, 0};
     }
     return {SUCCESS, 0, 0};
@@ -21417,22 +21711,9 @@ compress_decode_base64(char *dst, const char_type *src, size_t srclen,
   if (src < srcend + equalsigns) {
     full_result r = scalar::base64::base64_tail_decode(
         dst, src, srcend - src, equalsigns, options, last_chunk_options);
-    r.input_count += size_t(src - srcinit);
-    if (r.error == error_code::INVALID_BASE64_CHARACTER ||
-        r.error == error_code::BASE64_EXTRA_BITS) {
-      return r;
-    } else {
-      r.output_count += size_t(dst - dstinit);
-    }
-    if (last_chunk_options != stop_before_partial &&
-        r.error == error_code::SUCCESS && equalsigns > 0 && !ignore_garbage) {
-      // additional checks
-      if ((r.output_count % 3 == 0) ||
-          ((r.output_count % 3) + 1 + equalsigns != 4)) {
-        r.error = error_code::INVALID_BASE64_CHARACTER;
-        r.input_count = equallocation;
-      }
-    }
+    r = scalar::base64::patch_tail_result(
+        r, size_t(src - srcinit), size_t(dst - dstinit), equallocation,
+        full_input_length, last_chunk_options);
     return r;
   }
   if (equalsigns > 0 && !ignore_garbage) {
@@ -21444,6 +21725,81 @@ compress_decode_base64(char *dst, const char_type *src, size_t srclen,
   return {SUCCESS, srclen, size_t(dst - dstinit)};
 }
 /* end file src/arm64/arm_base64.cpp */
+/* begin file src/arm64/arm_find.cpp */
+
+simdutf_really_inline const char *util_find(const char *start, const char *end,
+                                            char character) noexcept {
+  // Handle empty or invalid range
+  if (start >= end)
+    return end;
+
+  // Process 16 bytes (128 bits) at a time with NEON
+  const size_t step = 16;
+  uint8x16_t char_vec = vdupq_n_u8(static_cast<uint8_t>(character));
+
+  // Main loop for full 16-byte chunks
+  while (size_t(end - start) >= step) {
+    uint8x16_t data = vld1q_u8(reinterpret_cast<const uint8_t *>(start));
+    uint8x16_t cmp = vceqq_u8(data, char_vec);
+    uint64_t mask = vget_lane_u64(
+        vreinterpret_u64_u8(vshrn_n_u16(vreinterpretq_u16_u8(cmp), 4)), 0);
+
+    if (mask != 0) {
+      // Found a match, return the first one
+      int index = trailing_zeroes(mask) / 4; // Each character maps to 4 bits
+      return start + index;
+    }
+
+    start += step;
+  }
+
+  // Handle remaining bytes with scalar loop
+  for (; start < end; ++start) {
+    if (*start == character) {
+      return start;
+    }
+  }
+
+  return end;
+}
+
+simdutf_really_inline const char16_t *util_find(const char16_t *start,
+                                                const char16_t *end,
+                                                char16_t character) noexcept {
+  // Handle empty or invalid range
+  if (start >= end)
+    return end;
+
+  // Process 8 char16_t (16 bytes, 128 bits) at a time with NEON
+  const size_t step = 8;
+  uint16x8_t char_vec = vdupq_n_u16(character);
+
+  // Main loop for full 8-element chunks
+  while (size_t(end - start) >= step) {
+    uint16x8_t data = vld1q_u16(reinterpret_cast<const uint16_t *>(start));
+    uint16x8_t cmp = vceqq_u16(data, char_vec);
+    uint64_t mask = vget_lane_u64(
+        vreinterpret_u64_u16(vshrn_n_u32(vreinterpretq_u32_u16(cmp), 4)), 0);
+
+    if (mask != 0) {
+      // Found a match, return the first one
+      int index = trailing_zeroes(mask) / 8; // Each character maps to 8 bits
+      return start + index;
+    }
+
+    start += step;
+  }
+
+  // Handle remaining elements with scalar loop
+  for (; start < end; ++start) {
+    if (*start == character) {
+      return start;
+    }
+  }
+
+  return end;
+}
+/* end file src/arm64/arm_find.cpp */
 #endif // SIMDUTF_FEATURE_BASE64
 #if SIMDUTF_FEATURE_UTF32 && SIMDUTF_FEATURE_LATIN1
 /* begin file src/arm64/arm_convert_utf32_to_latin1.cpp */
@@ -25217,6 +25573,16 @@ size_t implementation::binary_to_base64(const char *input, size_t length,
                                         base64_options options) const noexcept {
   return encode_base64(output, input, length, options);
 }
+
+const char *implementation::find(const char *start, const char *end,
+                                 char character) const noexcept {
+  return util_find(start, end, character);
+}
+
+const char16_t *implementation::find(const char16_t *start, const char16_t *end,
+                                     char16_t character) const noexcept {
+  return util_find(start, end, character);
+}
 #endif // SIMDUTF_FEATURE_BASE64
 
 } // namespace arm64
@@ -25749,219 +26115,49 @@ simdutf_warn_unused size_t implementation::utf32_length_from_utf8(
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
 
 #if SIMDUTF_FEATURE_BASE64
+
 simdutf_warn_unused result implementation::base64_to_binary(
     const char *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  const bool ignore_garbage =
-      (options == base64_options::base64_url_accept_garbage) ||
-      (options == base64_options::base64_default_accept_garbage) ||
-      (options == base64_options::base64_default_or_url_accept_garbage);
-  while (length > 0 &&
-         scalar::base64::is_ascii_white_space(input[length - 1])) {
-    length--;
-  }
-  size_t equallocation =
-      length; // location of the first padding character if any
-  size_t equalsigns = 0;
-  if (length > 0 && input[length - 1] == '=') {
-    equallocation = length - 1;
-    length -= 1;
-    equalsigns++;
-    while (length > 0 &&
-           scalar::base64::is_ascii_white_space(input[length - 1])) {
-      length--;
-    }
-    if (length > 0 && input[length - 1] == '=') {
-      equallocation = length - 1;
-      equalsigns++;
-      length -= 1;
-    }
-  }
-  if (length == 0) {
-    if (!ignore_garbage && equalsigns > 0) {
-      if (last_chunk_options == last_chunk_handling_options::strict) {
-        return {BASE64_INPUT_REMAINDER, 0};
-      } else if (last_chunk_options ==
-                 last_chunk_handling_options::stop_before_partial) {
-        return {SUCCESS, 0};
-      }
-      return {INVALID_BASE64_CHARACTER, equallocation};
-    }
-    return {SUCCESS, 0};
-  }
-  result r = scalar::base64::base64_tail_decode(
-      output, input, length, equalsigns, options, last_chunk_options);
-  if (last_chunk_options != stop_before_partial &&
-      r.error == error_code::SUCCESS && equalsigns > 0 && !ignore_garbage) {
-    // additional checks
-    if ((r.count % 3 == 0) || ((r.count % 3) + 1 + equalsigns != 4)) {
-      return {INVALID_BASE64_CHARACTER, equallocation};
-    }
-  }
-  return r;
-}
-
-simdutf_warn_unused full_result implementation::base64_to_binary_details(
-    const char *input, size_t length, char *output, base64_options options,
-    last_chunk_handling_options last_chunk_options) const noexcept {
-  const bool ignore_garbage =
-      (options == base64_options::base64_url_accept_garbage) ||
-      (options == base64_options::base64_default_accept_garbage) ||
-      (options == base64_options::base64_default_or_url_accept_garbage);
-  while (length > 0 &&
-         scalar::base64::is_ascii_white_space(input[length - 1])) {
-    length--;
-  }
-  size_t equallocation =
-      length; // location of the first padding character if any
-  size_t equalsigns = 0;
-  if (length > 0 && input[length - 1] == '=') {
-    equallocation = length - 1;
-    length -= 1;
-    equalsigns++;
-    while (length > 0 &&
-           scalar::base64::is_ascii_white_space(input[length - 1])) {
-      length--;
-    }
-    if (length > 0 && input[length - 1] == '=') {
-      equallocation = length - 1;
-      equalsigns++;
-      length -= 1;
-    }
-  }
-  if (length == 0) {
-    if (!ignore_garbage && equalsigns > 0) {
-      if (last_chunk_options == last_chunk_handling_options::strict) {
-        return {BASE64_INPUT_REMAINDER, 0, 0};
-      } else if (last_chunk_options ==
-                 last_chunk_handling_options::stop_before_partial) {
-        return {SUCCESS, 0, 0};
-      }
-      return {INVALID_BASE64_CHARACTER, equallocation, 0};
-    }
-    return {SUCCESS, 0, 0};
-  }
-  full_result r = scalar::base64::base64_tail_decode(
-      output, input, length, equalsigns, options, last_chunk_options);
-  if (last_chunk_options != stop_before_partial &&
-      r.error == error_code::SUCCESS && equalsigns > 0 && !ignore_garbage) {
-    // additional checks
-    if ((r.output_count % 3 == 0) ||
-        ((r.output_count % 3) + 1 + equalsigns != 4)) {
-      return {INVALID_BASE64_CHARACTER, equallocation, r.output_count};
-    }
-  }
-  return r;
+  return simdutf::scalar::base64::base64_to_binary_details_impl(
+      input, length, output, options, last_chunk_options);
 }
 
 simdutf_warn_unused result implementation::base64_to_binary(
     const char16_t *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  const bool ignore_garbage =
-      (options == base64_options::base64_url_accept_garbage) ||
-      (options == base64_options::base64_default_accept_garbage) ||
-      (options == base64_options::base64_default_or_url_accept_garbage);
-  while (length > 0 &&
-         scalar::base64::is_ascii_white_space(input[length - 1])) {
-    length--;
-  }
-  size_t equallocation =
-      length; // location of the first padding character if any
-  size_t equalsigns = 0;
-  if (length > 0 && input[length - 1] == '=') {
-    equallocation = length - 1;
-    length -= 1;
-    equalsigns++;
-    while (length > 0 &&
-           scalar::base64::is_ascii_white_space(input[length - 1])) {
-      length--;
-    }
-    if (length > 0 && input[length - 1] == '=') {
-      equallocation = length - 1;
-      equalsigns++;
-      length -= 1;
-    }
-  }
-  if (length == 0) {
-    if (!ignore_garbage && equalsigns > 0) {
-      if (last_chunk_options == last_chunk_handling_options::strict) {
-        return {BASE64_INPUT_REMAINDER, 0};
-      } else if (last_chunk_options ==
-                 last_chunk_handling_options::stop_before_partial) {
-        return {SUCCESS, 0};
-      }
-      return {INVALID_BASE64_CHARACTER, equallocation};
-    }
-    return {SUCCESS, 0};
-  }
-  result r = scalar::base64::base64_tail_decode(
-      output, input, length, equalsigns, options, last_chunk_options);
-  if (last_chunk_options != stop_before_partial &&
-      r.error == error_code::SUCCESS && equalsigns > 0 && !ignore_garbage) {
-    // additional checks
-    if ((r.count % 3 == 0) || ((r.count % 3) + 1 + equalsigns != 4)) {
-      return {INVALID_BASE64_CHARACTER, equallocation};
-    }
-  }
-  return r;
+  return simdutf::scalar::base64::base64_to_binary_details_impl(
+      input, length, output, options, last_chunk_options);
+}
+
+simdutf_warn_unused full_result implementation::base64_to_binary_details(
+    const char *input, size_t length, char *output, base64_options options,
+    last_chunk_handling_options last_chunk_options) const noexcept {
+  return simdutf::scalar::base64::base64_to_binary_details_impl(
+      input, length, output, options, last_chunk_options);
 }
 
 simdutf_warn_unused full_result implementation::base64_to_binary_details(
     const char16_t *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  const bool ignore_garbage =
-      (options == base64_options::base64_url_accept_garbage) ||
-      (options == base64_options::base64_default_accept_garbage);
-  while (length > 0 &&
-         scalar::base64::is_ascii_white_space(input[length - 1])) {
-    length--;
-  }
-  size_t equallocation =
-      length; // location of the first padding character if any
-  size_t equalsigns = 0;
-  if (length > 0 && input[length - 1] == '=') {
-    equallocation = length - 1;
-    length -= 1;
-    equalsigns++;
-    while (length > 0 &&
-           scalar::base64::is_ascii_white_space(input[length - 1])) {
-      length--;
-    }
-    if (length > 0 && input[length - 1] == '=') {
-      equallocation = length - 1;
-      equalsigns++;
-      length -= 1;
-    }
-  }
-  if (length == 0) {
-    if (!ignore_garbage && equalsigns > 0) {
-      if (last_chunk_options == last_chunk_handling_options::strict) {
-        return {BASE64_INPUT_REMAINDER, 0, 0};
-      } else if (last_chunk_options ==
-                 last_chunk_handling_options::stop_before_partial) {
-        return {SUCCESS, 0, 0};
-      }
-      return {INVALID_BASE64_CHARACTER, equallocation, 0};
-    }
-    return {SUCCESS, 0, 0};
-  }
-  full_result r = scalar::base64::base64_tail_decode(
-      output, input, length, equalsigns, options, last_chunk_options);
-  if (last_chunk_options != stop_before_partial &&
-      r.error == error_code::SUCCESS && equalsigns > 0 && !ignore_garbage) {
-    // additional checks
-    if ((r.output_count % 3 == 0) ||
-        ((r.output_count % 3) + 1 + equalsigns != 4)) {
-      return {INVALID_BASE64_CHARACTER, equallocation, r.output_count};
-    }
-  }
-  return r;
+  return simdutf::scalar::base64::base64_to_binary_details_impl(
+      input, length, output, options, last_chunk_options);
 }
 
 size_t implementation::binary_to_base64(const char *input, size_t length,
                                         char *output,
                                         base64_options options) const noexcept {
   return scalar::base64::tail_encode_base64(output, input, length, options);
+}
+
+const char *implementation::find(const char *start, const char *end,
+                                 char character) const noexcept {
+  return std::find(start, end, character);
+}
+
+const char16_t *implementation::find(const char16_t *start, const char16_t *end,
+                                     char16_t character) const noexcept {
+  return std::find(start, end, character);
 }
 #endif // SIMDUTF_FEATURE_BASE64
 
@@ -29900,43 +30096,20 @@ full_result
 compress_decode_base64(char *dst, const chartype *src, size_t srclen,
                        base64_options options,
                        last_chunk_handling_options last_chunk_options) {
+
   (void)options;
   const uint8_t *to_base64 =
       default_or_url ? tables::base64::to_base64_default_or_url_value
                      : (base64_url ? tables::base64::to_base64_url_value
                                    : tables::base64::to_base64_value);
-  size_t equallocation =
-      srclen; // location of the first padding character if any
-  size_t equalsigns = 0;
-  // skip trailing spaces
-  while (!ignore_garbage && srclen > 0 &&
-         scalar::base64::is_eight_byte(src[srclen - 1]) &&
-         to_base64[uint8_t(src[srclen - 1])] == 64) {
-    srclen--;
-  }
-  if (!ignore_garbage && srclen > 0 && src[srclen - 1] == '=') {
-    equallocation = srclen - 1;
-    srclen--;
-    equalsigns = 1;
-    // skip trailing spaces
-    while (srclen > 0 && scalar::base64::is_eight_byte(src[srclen - 1]) &&
-           to_base64[uint8_t(src[srclen - 1])] == 64) {
-      srclen--;
-    }
-    if (srclen > 0 && src[srclen - 1] == '=') {
-      equallocation = srclen - 1;
-      srclen--;
-      equalsigns = 2;
-    }
-  }
+  auto ri = simdutf::scalar::base64::find_end(src, srclen, options);
+  size_t equallocation = ri.equallocation;
+  size_t padding_characters = ri.equalsigns;
+  srclen = ri.srclen;
+  size_t full_input_length = ri.full_input_length;
+  (void)full_input_length;
   if (srclen == 0) {
-    if (!ignore_garbage && equalsigns > 0) {
-      if (last_chunk_options == last_chunk_handling_options::strict) {
-        return {BASE64_INPUT_REMAINDER, 0, 0};
-      } else if (last_chunk_options ==
-                 last_chunk_handling_options::stop_before_partial) {
-        return {SUCCESS, 0, 0};
-      }
+    if (!ignore_garbage && padding_characters > 0) {
       return {INVALID_BASE64_CHARACTER, equallocation, 0};
     }
     return {SUCCESS, 0, 0};
@@ -30014,6 +30187,9 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
   }
 
   if ((bufferptr - buffer_start) != 0) {
+    // For efficiency reasons, we end up reproducing much of the code
+    // in base64_tail_decode_impl. Better engineering would be to
+    // refactor the code so that we can call it without a performance hit.
     size_t rem = (bufferptr - buffer_start);
     int idx = rem % 4;
     __mmask64 mask = ((__mmask64)1 << rem) - 1;
@@ -30030,97 +30206,226 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
         28, 29, 30, 24, 25, 26, 20, 21, 22, 16, 17, 18, 12, 13, 14, 8, 9, 10, 4,
         5, 6, 0, 1, 2);
     const __m512i shuffled = _mm512_permutexvar_epi8(pack, merged);
-
-    if (!ignore_garbage &&
-        last_chunk_options == last_chunk_handling_options::strict &&
-        (idx != 1) && ((idx + equalsigns) & 3) != 0) {
-      // The partial chunk was at src - idx
-      _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
-      dst += output_len;
-      return {BASE64_INPUT_REMAINDER, size_t(src - srcinit),
-              size_t(dst - dstinit)};
-    } else if (!ignore_garbage &&
-               last_chunk_options ==
-                   last_chunk_handling_options::stop_before_partial &&
-               (idx != 1) && ((idx + equalsigns) & 3) != 0) {
-      // Rewind src to before partial chunk
-      _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
-      dst += output_len;
-      src -= idx;
-    } else {
-      if (idx == 2) {
-        if (!ignore_garbage &&
-            last_chunk_options == last_chunk_handling_options::strict) {
-          uint32_t triple = (uint32_t(bufferptr[-2]) << 3 * 6) +
-                            (uint32_t(bufferptr[-1]) << 2 * 6);
-          if (triple & 0xffff) {
-            _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
-            dst += output_len;
-            return {BASE64_EXTRA_BITS, size_t(src - srcinit),
-                    size_t(dst - dstinit)};
-          }
-        }
-        output_mask = (output_mask << 1) | 1;
-        output_len += 1;
-        _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
-        dst += output_len;
-      } else if (idx == 3) {
-        if (!ignore_garbage &&
-            last_chunk_options == last_chunk_handling_options::strict) {
-          uint32_t triple = (uint32_t(bufferptr[-3]) << 3 * 6) +
-                            (uint32_t(bufferptr[-2]) << 2 * 6) +
-                            (uint32_t(bufferptr[-1]) << 1 * 6);
-          if (triple & 0xff) {
-            _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
-            dst += output_len;
-            return {BASE64_EXTRA_BITS, size_t(src - srcinit),
-                    size_t(dst - dstinit)};
-          }
-        }
-        output_mask = (output_mask << 2) | 3;
-        output_len += 2;
-        _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
-        dst += output_len;
-      } else if (!ignore_garbage && idx == 1) {
-        _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
-        dst += output_len;
-        return {BASE64_INPUT_REMAINDER, size_t(src - srcinit),
-                size_t(dst - dstinit)};
-      } else {
-        _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
-        dst += output_len;
-      }
+    // We never should have that the number of base64 characters + the
+    // number of padding characters is more than 4.
+    if (!ignore_garbage && (idx + padding_characters > 4)) {
+      return {INVALID_BASE64_CHARACTER, size_t(src - srcinit),
+              size_t(dst - dstinit), true};
     }
+    // The idea here is that in loose mode,
+    // if there is padding at all, it must be used
+    // to form 4-wise chunk. However, in loose mode,
+    // we do accept no padding at all.
+    if (!ignore_garbage &&
+        last_chunk_options == last_chunk_handling_options::loose &&
+        (idx >= 2) && padding_characters > 0 &&
+        ((idx + padding_characters) & 3) != 0) {
+      return {INVALID_BASE64_CHARACTER, size_t(src - srcinit),
+              size_t(dst - dstinit), true};
+    } else
 
-    if (!ignore_garbage && last_chunk_options != stop_before_partial &&
-        equalsigns > 0) {
+      // The idea here is that in strict mode, we do not want to accept
+      // incomplete base64 chunks. So if the chunk was otherwise valid, we
+      // return BASE64_INPUT_REMAINDER.
+      if (!ignore_garbage &&
+          last_chunk_options == last_chunk_handling_options::strict &&
+          (idx >= 2) && ((idx + padding_characters) & 3) != 0) {
+        // The partial chunk was at src - idx
+        _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
+        dst += output_len;
+        return {BASE64_INPUT_REMAINDER, equallocation, size_t(dst - dstinit)};
+      } else
+        // If there is a partial chunk with insufficient padding, with
+        // stop_before_partial, we need to just ignore it. In "only full" mode,
+        // skip the minute there are padding characters.
+        if ((last_chunk_options ==
+                 last_chunk_handling_options::stop_before_partial &&
+             (padding_characters + idx < 4) &&
+             (idx >= 2 || padding_characters == 0)) ||
+            (last_chunk_options ==
+                 last_chunk_handling_options::only_full_chunks &&
+             (idx >= 2 || padding_characters == 0))) {
+          _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
+          dst += output_len;
+          // we need to rewind src to before the partial chunk
+          size_t characters_to_skip = idx;
+          while (characters_to_skip > 0) {
+            src--;
+            auto c = *src;
+            uint8_t code = to_base64[uint8_t(c)];
+            if (simdutf::scalar::base64::is_eight_byte(c) && code <= 63) {
+              characters_to_skip--;
+            }
+          }
+          return {SUCCESS, size_t(src - srcinit), size_t(dst - dstinit)};
+        } else {
+          if (idx == 2) {
+            if (!ignore_garbage &&
+                last_chunk_options == last_chunk_handling_options::strict) {
+              uint32_t triple = (uint32_t(bufferptr[-2]) << 3 * 6) +
+                                (uint32_t(bufferptr[-1]) << 2 * 6);
+              if (triple & 0xffff) {
+                _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
+                dst += output_len;
+                return {BASE64_EXTRA_BITS, size_t(src - srcinit),
+                        size_t(dst - dstinit)};
+              }
+            }
+            output_mask = (output_mask << 1) | 1;
+            output_len += 1;
+            _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
+            dst += output_len;
+          } else if (idx == 3) {
+            if (!ignore_garbage &&
+                last_chunk_options == last_chunk_handling_options::strict) {
+              uint32_t triple = (uint32_t(bufferptr[-3]) << 3 * 6) +
+                                (uint32_t(bufferptr[-2]) << 2 * 6) +
+                                (uint32_t(bufferptr[-1]) << 1 * 6);
+              if (triple & 0xff) {
+                _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
+                dst += output_len;
+                return {BASE64_EXTRA_BITS, size_t(src - srcinit),
+                        size_t(dst - dstinit)};
+              }
+            }
+            output_mask = (output_mask << 2) | 3;
+            output_len += 2;
+            _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
+            dst += output_len;
+          } else if (!ignore_garbage && idx == 1 &&
+                     (!is_partial(last_chunk_options) ||
+                      (is_partial(last_chunk_options) &&
+                       padding_characters > 0))) {
+            _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
+            dst += output_len;
+            return {BASE64_INPUT_REMAINDER, size_t(src - srcinit),
+                    size_t(dst - dstinit)};
+          } else if (!ignore_garbage && idx == 0 && padding_characters > 0) {
+            _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
+            dst += output_len;
+            return {INVALID_BASE64_CHARACTER, equallocation,
+                    size_t(dst - dstinit)};
+          } else {
+            _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
+            dst += output_len;
+          }
+        }
+
+    if (!ignore_garbage && !is_partial(last_chunk_options) &&
+        padding_characters > 0) {
       size_t output_count = size_t(dst - dstinit);
       if ((output_count % 3 == 0) ||
-          ((output_count % 3) + 1 + equalsigns != 4)) {
+          ((output_count % 3) + 1 + padding_characters != 4)) {
         return {INVALID_BASE64_CHARACTER, equallocation, output_count};
       }
     }
-
-    return {SUCCESS, srclen, size_t(dst - dstinit)};
+    return {SUCCESS, full_input_length, size_t(dst - dstinit)};
   }
 
-  if (!ignore_garbage && equalsigns > 0) {
-    if (last_chunk_options == last_chunk_handling_options::strict) {
-      return {BASE64_INPUT_REMAINDER, size_t(src - srcinit),
-              size_t(dst - dstinit)};
-    }
-    if (last_chunk_options ==
-        last_chunk_handling_options::stop_before_partial) {
-      return {SUCCESS, size_t(src - srcinit), size_t(dst - dstinit)};
-    }
+  if (!ignore_garbage && padding_characters > 0) {
     if ((size_t(dst - dstinit) % 3 == 0) ||
-        ((size_t(dst - dstinit) % 3) + 1 + equalsigns != 4)) {
+        ((size_t(dst - dstinit) % 3) + 1 + padding_characters != 4)) {
       return {INVALID_BASE64_CHARACTER, equallocation, size_t(dst - dstinit)};
     }
   }
   return {SUCCESS, srclen, size_t(dst - dstinit)};
 }
 /* end file src/icelake/icelake_base64.inl.cpp */
+/* begin file src/icelake/icelake_find.inl.cpp */
+
+simdutf_really_inline const char *util_find(const char *start, const char *end,
+                                            char character) noexcept {
+  // Handle empty or invalid range
+  if (start >= end)
+    return end;
+
+  // Process 64 bytes (512 bits) at a time with AVX-512
+  const size_t step = 64;
+  __m512i char_vec = _mm512_set1_epi8(character);
+
+  // Main loop for full 64-byte chunks
+  while (size_t(end - start) >= step) {
+    __m512i data = _mm512_loadu_si512(reinterpret_cast<const __m512i *>(start));
+    __mmask64 mask = _mm512_cmpeq_epi8_mask(data, char_vec);
+
+    if (mask != 0) {
+      // Found a match, return the first one
+      size_t index = _tzcnt_u64(mask);
+      return start + index;
+    }
+
+    start += step;
+  }
+
+  // Handle remaining bytes with masked load
+  size_t remaining = end - start;
+  if (remaining > 0) {
+    // Create a mask for the remaining bytes using shifted 0xFFFFFFFFFFFFFFFF
+    __mmask64 load_mask = 0xFFFFFFFFFFFFFFFF >> (64 - remaining);
+    __m512i data = _mm512_maskz_loadu_epi8(
+        load_mask, reinterpret_cast<const __m512i *>(start));
+    __mmask64 match_mask = _mm512_cmpeq_epi8_mask(data, char_vec);
+
+    // Apply load mask to avoid false positives
+    match_mask &= load_mask;
+
+    if (match_mask != 0) {
+      // Found a match in the remaining bytes
+      size_t index = _tzcnt_u64(match_mask);
+      return start + index;
+    }
+  }
+
+  return end;
+}
+
+simdutf_really_inline const char16_t *util_find(const char16_t *start,
+                                                const char16_t *end,
+                                                char16_t character) noexcept {
+  // Handle empty or invalid range
+  if (start >= end)
+    return end;
+
+  // Process 32 char16_t (64 bytes, 512 bits) at a time with AVX-512
+  const size_t step = 32;
+  __m512i char_vec = _mm512_set1_epi16(character);
+
+  // Main loop for full 32-element chunks
+  while (size_t(end - start) >= step) {
+    __m512i data = _mm512_loadu_si512(reinterpret_cast<const __m512i *>(start));
+    __mmask32 mask = _mm512_cmpeq_epi16_mask(data, char_vec);
+
+    if (mask != 0) {
+      // Found a match, return the first one
+      size_t index = _tzcnt_u64(mask);
+      return start + index;
+    }
+
+    start += step;
+  }
+
+  // Handle remaining elements with masked load
+  size_t remaining = end - start;
+  if (remaining > 0) {
+    // Create a mask for the remaining elements using shifted 0xFFFFFFFF
+    __mmask32 load_mask = 0xFFFFFFFF >> (32 - remaining);
+    __m512i data = _mm512_maskz_loadu_epi16(
+        load_mask, reinterpret_cast<const __m512i *>(start));
+    __mmask32 match_mask = _mm512_cmpeq_epi16_mask(data, char_vec);
+
+    // Apply load mask to avoid false positives
+    match_mask &= load_mask;
+
+    if (match_mask != 0) {
+      // Found a match in the remaining elements
+      size_t index = _tzcnt_u64(match_mask);
+      return start + index;
+    }
+  }
+
+  return end;
+}
+/* end file src/icelake/icelake_find.inl.cpp */
 #endif // SIMDUTF_FEATURE_BASE64
 
 #include <cstdint>
@@ -30509,13 +30814,9 @@ simdutf_warn_unused bool
 implementation::validate_utf16be(const char16_t *buf,
                                  size_t len) const noexcept {
   const char16_t *end = buf + len;
-  const __m512i byteflip = _mm512_setr_epi64(
-      0x0607040502030001, 0x0e0f0c0d0a0b0809, 0x0607040502030001,
-      0x0e0f0c0d0a0b0809, 0x0607040502030001, 0x0e0f0c0d0a0b0809,
-      0x0607040502030001, 0x0e0f0c0d0a0b0809);
+
   for (; end - buf >= 32;) {
-    __m512i in =
-        _mm512_shuffle_epi8(_mm512_loadu_si512((__m512i *)buf), byteflip);
+    __m512i in = _mm512_slli_epi32(_mm512_loadu_si512((__m512i *)buf), 8);
     __m512i diff = _mm512_sub_epi16(in, _mm512_set1_epi16(uint16_t(0xD800)));
     __mmask32 surrogates =
         _mm512_cmplt_epu16_mask(diff, _mm512_set1_epi16(uint16_t(0x0800)));
@@ -30539,9 +30840,8 @@ implementation::validate_utf16be(const char16_t *buf,
     }
   }
   if (buf < end) {
-    __m512i in = _mm512_shuffle_epi8(
-        _mm512_maskz_loadu_epi16((1U << (end - buf)) - 1, (__m512i *)buf),
-        byteflip);
+    __m512i in = _mm512_slli_epi16(
+        _mm512_maskz_loadu_epi16((1U << (end - buf)) - 1, (__m512i *)buf), 8);
     __m512i diff = _mm512_sub_epi16(in, _mm512_set1_epi16(uint16_t(0xD800)));
     __mmask32 surrogates =
         _mm512_cmplt_epu16_mask(diff, _mm512_set1_epi16(uint16_t(0x0800)));
@@ -30619,13 +30919,9 @@ simdutf_warn_unused result implementation::validate_utf16be_with_errors(
     const char16_t *buf, size_t len) const noexcept {
   const char16_t *start_buf = buf;
   const char16_t *end = buf + len;
-  const __m512i byteflip = _mm512_setr_epi64(
-      0x0607040502030001, 0x0e0f0c0d0a0b0809, 0x0607040502030001,
-      0x0e0f0c0d0a0b0809, 0x0607040502030001, 0x0e0f0c0d0a0b0809,
-      0x0607040502030001, 0x0e0f0c0d0a0b0809);
+
   for (; end - buf >= 32;) {
-    __m512i in =
-        _mm512_shuffle_epi8(_mm512_loadu_si512((__m512i *)buf), byteflip);
+    __m512i in = _mm512_slli_epi16(_mm512_loadu_si512((__m512i *)buf), 8);
     __m512i diff = _mm512_sub_epi16(in, _mm512_set1_epi16(uint16_t(0xD800)));
     __mmask32 surrogates =
         _mm512_cmplt_epu16_mask(diff, _mm512_set1_epi16(uint16_t(0x0800)));
@@ -30654,9 +30950,8 @@ simdutf_warn_unused result implementation::validate_utf16be_with_errors(
     }
   }
   if (buf < end) {
-    __m512i in = _mm512_shuffle_epi8(
-        _mm512_maskz_loadu_epi16((1U << (end - buf)) - 1, (__m512i *)buf),
-        byteflip);
+    __m512i in = _mm512_slli_epi16(
+        _mm512_maskz_loadu_epi16((1U << (end - buf)) - 1, (__m512i *)buf), 8);
     __m512i diff = _mm512_sub_epi16(in, _mm512_set1_epi16(uint16_t(0xD800)));
     __mmask32 surrogates =
         _mm512_cmplt_epu16_mask(diff, _mm512_set1_epi16(uint16_t(0x0800)));
@@ -31918,6 +32213,16 @@ size_t implementation::binary_to_base64(const char *input, size_t length,
     return encode_base64<false>(output, input, length, options);
   }
 }
+
+const char *implementation::find(const char *start, const char *end,
+                                 char character) const noexcept {
+  return util_find(start, end, character);
+}
+const char16_t *implementation::find(const char16_t *start, const char16_t *end,
+                                     char16_t character) const noexcept {
+  return util_find(start, end, character);
+}
+
 #endif // SIMDUTF_FEATURE_BASE64
 
 } // namespace icelake
@@ -37445,44 +37750,23 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
       default_or_url ? tables::base64::to_base64_default_or_url_value
                      : (base64_url ? tables::base64::to_base64_url_value
                                    : tables::base64::to_base64_value);
-  size_t equallocation =
-      srclen; // location of the first padding character if any
-  // skip trailing spaces
-  while (!ignore_garbage && srclen > 0 &&
-         scalar::base64::is_eight_byte(src[srclen - 1]) &&
-         to_base64[uint8_t(src[srclen - 1])] == 64) {
-    srclen--;
-  }
-  size_t equalsigns = 0;
-  if (!ignore_garbage && srclen > 0 && src[srclen - 1] == '=') {
-    equallocation = srclen - 1;
-    srclen--;
-    equalsigns = 1;
-    // skip trailing spaces
-    while (srclen > 0 && scalar::base64::is_eight_byte(src[srclen - 1]) &&
-           to_base64[uint8_t(src[srclen - 1])] == 64) {
-      srclen--;
-    }
-    if (srclen > 0 && src[srclen - 1] == '=') {
-      equallocation = srclen - 1;
-      srclen--;
-      equalsigns = 2;
-    }
-  }
+  auto ri = simdutf::scalar::base64::find_end(src, srclen, options);
+  size_t equallocation = ri.equallocation;
+  size_t equalsigns = ri.equalsigns;
+  srclen = ri.srclen;
+  size_t full_input_length = ri.full_input_length;
+  (void)full_input_length;
   if (srclen == 0) {
     if (!ignore_garbage && equalsigns > 0) {
-      if (last_chunk_options == last_chunk_handling_options::strict) {
-        return {BASE64_INPUT_REMAINDER, 0, 0};
-      } else if (last_chunk_options ==
-                 last_chunk_handling_options::stop_before_partial) {
-        return {SUCCESS, 0, 0};
-      }
       return {INVALID_BASE64_CHARACTER, equallocation, 0};
     }
     return {SUCCESS, 0, 0};
   }
   char *end_of_safe_64byte_zone =
-      (srclen + 3) / 4 * 3 >= 63 ? dst + (srclen + 3) / 4 * 3 - 63 : dst;
+      dst == nullptr
+          ? nullptr
+          : ((srclen + 3) / 4 * 3 >= 63 ? dst + (srclen + 3) / 4 * 3 - 63
+                                        : dst);
 
   const chartype *const srcinit = src;
   const char *const dstinit = dst;
@@ -37613,22 +37897,9 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
   if (src < srcend + equalsigns) {
     full_result r = scalar::base64::base64_tail_decode(
         dst, src, srcend - src, equalsigns, options, last_chunk_options);
-    r.input_count += size_t(src - srcinit);
-    if (r.error == error_code::INVALID_BASE64_CHARACTER ||
-        r.error == error_code::BASE64_EXTRA_BITS) {
-      return r;
-    } else {
-      r.output_count += size_t(dst - dstinit);
-    }
-    if (!ignore_garbage && last_chunk_options != stop_before_partial &&
-        r.error == error_code::SUCCESS && equalsigns > 0) {
-      // additional checks
-      if ((r.output_count % 3 == 0) ||
-          ((r.output_count % 3) + 1 + equalsigns != 4)) {
-        r.error = error_code::INVALID_BASE64_CHARACTER;
-        r.input_count = equallocation;
-      }
-    }
+    r = scalar::base64::patch_tail_result(
+        r, size_t(src - srcinit), size_t(dst - dstinit), equallocation,
+        full_input_length, last_chunk_options);
     return r;
   }
   if (!ignore_garbage && equalsigns > 0) {
@@ -37645,6 +37916,45 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
 } // namespace haswell
 } // namespace simdutf
 /* end file src/generic/base64.h */
+/* begin file src/generic/find.h */
+
+namespace simdutf {
+namespace haswell {
+namespace {
+namespace util {
+
+simdutf_really_inline const char *find(const char *start, const char *end,
+                                       char character) noexcept {
+  for (; std::distance(start, end) >= 64; start += 64) {
+    simd8x64<uint8_t> input(reinterpret_cast<const uint8_t *>(start));
+    uint64_t matches = input.eq(uint8_t(character));
+    if (matches != 0) {
+      // Found a match, return the first one
+      int index = trailing_zeroes(matches);
+      return start + index;
+    }
+  }
+  return std::find(start, end, character);
+}
+
+simdutf_really_inline const char16_t *
+find(const char16_t *start, const char16_t *end, char16_t character) noexcept {
+  for (; std::distance(start, end) >= 32; start += 32) {
+    simd16x32<uint16_t> input(reinterpret_cast<const uint16_t *>(start));
+    uint64_t matches = input.eq(uint16_t(character));
+    if (matches != 0) {
+      // Found a match, return the first one
+      int index = trailing_zeroes(matches) / 2;
+      return start + index;
+    }
+  }
+  return std::find(start, end, character);
+}
+} // namespace util
+} // namespace
+} // namespace haswell
+} // namespace simdutf
+/* end file src/generic/find.h */
 #endif // SIMDUTF_FEATURE_BASE64
 
 namespace simdutf {
@@ -38863,7 +39173,18 @@ size_t implementation::binary_to_base64(const char *input, size_t length,
     return encode_base64<false>(output, input, length, options);
   }
 }
+
+const char *implementation::find(const char *start, const char *end,
+                                 char character) const noexcept {
+  return util::find(start, end, character);
+}
+
+const char16_t *implementation::find(const char16_t *start, const char16_t *end,
+                                     char16_t character) const noexcept {
+  return util::find(start, end, character);
+}
 #endif // SIMDUTF_FEATURE_BASE64
+
 } // namespace haswell
 } // namespace simdutf
 
@@ -44225,44 +44546,23 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
       default_or_url ? tables::base64::to_base64_default_or_url_value
                      : (base64_url ? tables::base64::to_base64_url_value
                                    : tables::base64::to_base64_value);
-  size_t equallocation =
-      srclen; // location of the first padding character if any
-  // skip trailing spaces
-  while (!ignore_garbage && srclen > 0 &&
-         scalar::base64::is_eight_byte(src[srclen - 1]) &&
-         to_base64[uint8_t(src[srclen - 1])] == 64) {
-    srclen--;
-  }
-  size_t equalsigns = 0;
-  if (!ignore_garbage && srclen > 0 && src[srclen - 1] == '=') {
-    equallocation = srclen - 1;
-    srclen--;
-    equalsigns = 1;
-    // skip trailing spaces
-    while (srclen > 0 && scalar::base64::is_eight_byte(src[srclen - 1]) &&
-           to_base64[uint8_t(src[srclen - 1])] == 64) {
-      srclen--;
-    }
-    if (srclen > 0 && src[srclen - 1] == '=') {
-      equallocation = srclen - 1;
-      srclen--;
-      equalsigns = 2;
-    }
-  }
+  auto ri = simdutf::scalar::base64::find_end(src, srclen, options);
+  size_t equallocation = ri.equallocation;
+  size_t equalsigns = ri.equalsigns;
+  srclen = ri.srclen;
+  size_t full_input_length = ri.full_input_length;
+  (void)full_input_length;
   if (srclen == 0) {
     if (!ignore_garbage && equalsigns > 0) {
-      if (last_chunk_options == last_chunk_handling_options::strict) {
-        return {BASE64_INPUT_REMAINDER, 0, 0};
-      } else if (last_chunk_options ==
-                 last_chunk_handling_options::stop_before_partial) {
-        return {SUCCESS, 0, 0};
-      }
       return {INVALID_BASE64_CHARACTER, equallocation, 0};
     }
     return {SUCCESS, 0, 0};
   }
   char *end_of_safe_64byte_zone =
-      (srclen + 3) / 4 * 3 >= 63 ? dst + (srclen + 3) / 4 * 3 - 63 : dst;
+      dst == nullptr
+          ? nullptr
+          : ((srclen + 3) / 4 * 3 >= 63 ? dst + (srclen + 3) / 4 * 3 - 63
+                                        : dst);
 
   const chartype *const srcinit = src;
   const char *const dstinit = dst;
@@ -44393,22 +44693,9 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
   if (src < srcend + equalsigns) {
     full_result r = scalar::base64::base64_tail_decode(
         dst, src, srcend - src, equalsigns, options, last_chunk_options);
-    r.input_count += size_t(src - srcinit);
-    if (r.error == error_code::INVALID_BASE64_CHARACTER ||
-        r.error == error_code::BASE64_EXTRA_BITS) {
-      return r;
-    } else {
-      r.output_count += size_t(dst - dstinit);
-    }
-    if (!ignore_garbage && last_chunk_options != stop_before_partial &&
-        r.error == error_code::SUCCESS && equalsigns > 0) {
-      // additional checks
-      if ((r.output_count % 3 == 0) ||
-          ((r.output_count % 3) + 1 + equalsigns != 4)) {
-        r.error = error_code::INVALID_BASE64_CHARACTER;
-        r.input_count = equallocation;
-      }
-    }
+    r = scalar::base64::patch_tail_result(
+        r, size_t(src - srcinit), size_t(dst - dstinit), equallocation,
+        full_input_length, last_chunk_options);
     return r;
   }
   if (!ignore_garbage && equalsigns > 0) {
@@ -44425,6 +44712,45 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
 } // namespace ppc64
 } // namespace simdutf
 /* end file src/generic/base64.h */
+/* begin file src/generic/find.h */
+
+namespace simdutf {
+namespace ppc64 {
+namespace {
+namespace util {
+
+simdutf_really_inline const char *find(const char *start, const char *end,
+                                       char character) noexcept {
+  for (; std::distance(start, end) >= 64; start += 64) {
+    simd8x64<uint8_t> input(reinterpret_cast<const uint8_t *>(start));
+    uint64_t matches = input.eq(uint8_t(character));
+    if (matches != 0) {
+      // Found a match, return the first one
+      int index = trailing_zeroes(matches);
+      return start + index;
+    }
+  }
+  return std::find(start, end, character);
+}
+
+simdutf_really_inline const char16_t *
+find(const char16_t *start, const char16_t *end, char16_t character) noexcept {
+  for (; std::distance(start, end) >= 32; start += 32) {
+    simd16x32<uint16_t> input(reinterpret_cast<const uint16_t *>(start));
+    uint64_t matches = input.eq(uint16_t(character));
+    if (matches != 0) {
+      // Found a match, return the first one
+      int index = trailing_zeroes(matches) / 2;
+      return start + index;
+    }
+  }
+  return std::find(start, end, character);
+}
+} // namespace util
+} // namespace
+} // namespace ppc64
+} // namespace simdutf
+/* end file src/generic/find.h */
 #endif // SIMDUTF_FEATURE_BASE64
 
 /* begin file src/ppc64/templates.cpp */
@@ -44871,8 +45197,8 @@ simdutf_warn_unused result implementation::convert_utf16le_to_utf8_with_errors(
 
   return convert_with_errors_impl(
       ppc64_convert_utf16_to_utf8<endianness::LITTLE>,
-      scalar::utf16_to_utf8::convert_with_errors<endianness::LITTLE>, buf, len,
-      utf8_output);
+      scalar::utf16_to_utf8::simple_convert_with_errors<endianness::LITTLE>,
+      buf, len, utf8_output);
 }
 
 simdutf_warn_unused result implementation::convert_utf16be_to_utf8_with_errors(
@@ -44880,8 +45206,8 @@ simdutf_warn_unused result implementation::convert_utf16be_to_utf8_with_errors(
 
   return convert_with_errors_impl(
       ppc64_convert_utf16_to_utf8<endianness::BIG>,
-      scalar::utf16_to_utf8::convert_with_errors<endianness::BIG>, buf, len,
-      utf8_output);
+      scalar::utf16_to_utf8::simple_convert_with_errors<endianness::BIG>, buf,
+      len, utf8_output);
 }
 
 simdutf_warn_unused size_t implementation::convert_valid_utf16le_to_utf8(
@@ -45268,6 +45594,15 @@ size_t implementation::binary_to_base64(const char *input, size_t length,
     return encode_base64<false>(output, input, length, options);
   }
 }
+const char *implementation::find(const char *start, const char *end,
+                                 char character) const noexcept {
+  return util::find(start, end, character);
+}
+
+const char16_t *implementation::find(const char16_t *start, const char16_t *end,
+                                     char16_t character) const noexcept {
+  return util::find(start, end, character);
+}
 #endif // SIMDUTF_FEATURE_BASE64
 
 #ifdef SIMDUTF_INTERNAL_TESTS
@@ -45594,11 +45929,14 @@ simdutf_really_inline static size_t rvv_count_valid_utf8(const char *src,
      * https://arxiv.org/abs/2010.03090 */
     vuint8m4_t v1 = __riscv_vslide1down_vx_u8m4(v0, next0, vl);
     vuint8m4_t v2 = __riscv_vslide1down_vx_u8m4(v1, next1, vl);
-    vuint8m4_t v3 = __riscv_vslide1down_vx_u8m4(v2, next2, vl);
+
+    vuint8m4_t v2_hi_nibble = __riscv_vsrl_vx_u8m4(v2, 4, vl);
+    vuint8m4_t v3_hi_nibble =
+        __riscv_vslide1down_vx_u8m4(v2_hi_nibble, next2 >> 4, vl);
 
     vuint8m4_t idx2 = __riscv_vand_vx_u8m4(v2, 0xF, vl);
-    vuint8m4_t idx1 = __riscv_vsrl_vx_u8m4(v2, 4, vl);
-    vuint8m4_t idx3 = __riscv_vsrl_vx_u8m4(v3, 4, vl);
+    vuint8m4_t idx1 = v2_hi_nibble;
+    vuint8m4_t idx3 = v3_hi_nibble;
 
     vuint8m4_t err1 = simdutf_vrgather_u8m1x4(err1tbl, idx1);
     vuint8m4_t err2 = simdutf_vrgather_u8m1x4(err2tbl, idx2);
@@ -45644,28 +45982,31 @@ template <simdutf_ByteFlip bflip>
 simdutf_really_inline static result
 rvv_validate_utf16_with_errors(const char16_t *src, size_t len) {
   const char16_t *beg = src;
+
+  const uint16_t mask = simdutf_byteflip<bflip>(0xfc00);
+  const uint16_t hi_surrogate = simdutf_byteflip<bflip>(0xd800);
+  const uint16_t lo_surrogate = simdutf_byteflip<bflip>(0xdc00);
+
   uint16_t last = 0;
-  for (size_t vl; len > 0;
-       len -= vl, src += vl, last = simdutf_byteflip<bflip>(src[-1])) {
+  for (size_t vl; len > 0; len -= vl, src += vl, last = src[-1]) {
     vl = __riscv_vsetvl_e16m8(len);
     vuint16m8_t v1 = __riscv_vle16_v_u16m8((const uint16_t *)src, vl);
-    v1 = simdutf_byteflip<bflip>(v1, vl);
     vuint16m8_t v0 = __riscv_vslide1up_vx_u16m8(v1, last, vl);
 
     vbool2_t surhi = __riscv_vmseq_vx_u16m8_b2(
-        __riscv_vand_vx_u16m8(v0, 0xFC00, vl), 0xD800, vl);
+        __riscv_vand_vx_u16m8(v0, mask, vl), hi_surrogate, vl);
     vbool2_t surlo = __riscv_vmseq_vx_u16m8_b2(
-        __riscv_vand_vx_u16m8(v1, 0xFC00, vl), 0xDC00, vl);
+        __riscv_vand_vx_u16m8(v1, mask, vl), lo_surrogate, vl);
 
     long idx = __riscv_vfirst_m_b2(__riscv_vmxor_mm_b2(surhi, surlo, vl), vl);
     if (idx >= 0) {
-      last = idx > 0 ? simdutf_byteflip<bflip>(src[idx - 1]) : last;
+      last = simdutf_byteflip<bflip>(idx > 0 ? src[idx - 1] : last);
       return result(error_code::SURROGATE,
                     src - beg + idx - (last - 0xD800u < 0x400u));
       break;
     }
   }
-  if (last - 0xD800u < 0x400u) {
+  if (simdutf_byteflip<bflip>(last) - 0xD800u < 0x400u) {
     return result(error_code::SURROGATE,
                   src - beg - 1); /* end on high surrogate */
   } else {
@@ -46442,27 +46783,33 @@ rvv_convert_utf32_to_utf16_with_errors(const char32_t *src, size_t len,
     vl = __riscv_vsetvl_e32m4(len);
     vuint32m4_t v = __riscv_vle32_v_u32m4((uint32_t *)src, vl);
     vuint32m4_t off = __riscv_vadd_vx_u32m4(v, 0xFFFF2000, vl);
-    const long idx1 =
-        __riscv_vfirst_m_b8(__riscv_vmsgtu_vx_u32m4_b8(v, 0x10FFFF, vl), vl);
-    const long idx2 = __riscv_vfirst_m_b8(
+    const long err_surrogate_idx = __riscv_vfirst_m_b8(
         __riscv_vmsgtu_vx_u32m4_b8(off, 0xFFFFF7FF, vl), vl);
-    if (idx1 >= 0 || idx2 >= 0) {
-      if (static_cast<unsigned long>(idx1) <=
-          static_cast<unsigned long>(idx2)) {
-        return result(error_code::TOO_LARGE, src - srcBeg + idx1);
-      } else {
-        return result(error_code::SURROGATE, src - srcBeg + idx2);
-      }
-    }
     const long idx =
         __riscv_vfirst_m_b8(__riscv_vmsgtu_vx_u32m4_b8(v, 0xFFFF, vl), vl);
     if (idx < 0) {
+      if (err_surrogate_idx >= 0) {
+        return result(error_code::SURROGATE, src - srcBeg + err_surrogate_idx);
+      }
+
       vlOut = vl;
       vuint16m2_t n =
           simdutf_byteflip<bflip>(__riscv_vncvt_x_x_w_u16m2(v, vlOut), vlOut);
       __riscv_vse16_v_u16m2((uint16_t *)dst, n, vlOut);
       continue;
     }
+
+    const long err_too_big_idx =
+        __riscv_vfirst_m_b8(__riscv_vmsgtu_vx_u32m4_b8(v, 0x10FFFF, vl), vl);
+    if (err_too_big_idx >= 0 || err_surrogate_idx >= 0) {
+      if (static_cast<unsigned long>(err_too_big_idx) <=
+          static_cast<unsigned long>(err_surrogate_idx)) {
+        return result(error_code::TOO_LARGE, src - srcBeg + err_too_big_idx);
+      } else {
+        return result(error_code::SURROGATE, src - srcBeg + err_surrogate_idx);
+      }
+    }
+
     vlOut = rvv_utf32_store_utf16_m4<bflip>((uint16_t *)dst, v, vl, m4even);
   }
   return result(error_code::SUCCESS, dst - dstBeg);
@@ -46974,6 +47321,39 @@ simdutf_warn_unused size_t implementation::convert_valid_utf8_to_utf32(
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
 /* end file src/rvv/rvv_utf8_to.inl.cpp */
 
+#if SIMDUTF_FEATURE_BASE64
+/* begin file src/rvv/rvv_find.cpp */
+simdutf_really_inline const char *util_find(const char *start, const char *end,
+                                            char character) noexcept {
+  const char *src = start;
+  for (size_t len = end - start, vl; len > 0; len -= vl, src += vl) {
+    vl = __riscv_vsetvl_e8m8(len);
+    vuint8m8_t v = __riscv_vle8_v_u8m8((uint8_t *)src, vl);
+    long idx =
+        __riscv_vfirst_m_b1(__riscv_vmseq_vx_u8m8_b1(v, character, vl), vl);
+    if (idx >= 0)
+      return src + idx;
+  }
+  return end;
+}
+
+simdutf_really_inline const char16_t *util_find(const char16_t *start,
+                                                const char16_t *end,
+                                                char16_t character) noexcept {
+  const char16_t *src = start;
+  for (size_t len = end - start, vl; len > 0; len -= vl, src += vl) {
+    vl = __riscv_vsetvl_e16m8(len);
+    vuint16m8_t v = __riscv_vle16_v_u16m8((uint16_t *)src, vl);
+    long idx =
+        __riscv_vfirst_m_b2(__riscv_vmseq_vx_u16m8_b2(v, character, vl), vl);
+    if (idx >= 0)
+      return src + idx;
+  }
+  return end;
+}
+/* end file src/rvv/rvv_find.cpp */
+#endif // SIMDUTF_FEATURE_BASE64
+
 #if SIMDUTF_FEATURE_DETECT_ENCODING
 simdutf_warn_unused int
 implementation::detect_encodings(const char *input,
@@ -47036,213 +47416,45 @@ void implementation::change_endianness_utf16(const char16_t *src, size_t len,
 simdutf_warn_unused result implementation::base64_to_binary(
     const char *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  const bool ignore_garbage =
-      (options == base64_options::base64_url_accept_garbage) ||
-      (options == base64_options::base64_default_accept_garbage);
-  while (length > 0 &&
-         scalar::base64::is_ascii_white_space(input[length - 1])) {
-    length--;
-  }
-  size_t equallocation =
-      length; // location of the first padding character if any
-  size_t equalsigns = 0;
-  if (length > 0 && input[length - 1] == '=') {
-    equallocation = length - 1;
-    length -= 1;
-    equalsigns++;
-    while (length > 0 &&
-           scalar::base64::is_ascii_white_space(input[length - 1])) {
-      length--;
-    }
-    if (length > 0 && input[length - 1] == '=') {
-      equallocation = length - 1;
-      equalsigns++;
-      length -= 1;
-    }
-  }
-  if (length == 0) {
-    if (!ignore_garbage && equalsigns > 0) {
-      if (last_chunk_options == last_chunk_handling_options::strict) {
-        return {BASE64_INPUT_REMAINDER, 0};
-      } else if (last_chunk_options ==
-                 last_chunk_handling_options::stop_before_partial) {
-        return {SUCCESS, 0};
-      }
-      return {INVALID_BASE64_CHARACTER, equallocation};
-    }
-    return {SUCCESS, 0};
-  }
-  result r = scalar::base64::base64_tail_decode(
-      output, input, length, equalsigns, options, last_chunk_options);
-  if (last_chunk_options != stop_before_partial &&
-      r.error == error_code::SUCCESS && equalsigns > 0 && !ignore_garbage) {
-    // additional checks
-    if ((r.count % 3 == 0) || ((r.count % 3) + 1 + equalsigns != 4)) {
-      return {INVALID_BASE64_CHARACTER, equallocation};
-    }
-  }
-  return r;
-}
-
-simdutf_warn_unused full_result implementation::base64_to_binary_details(
-    const char *input, size_t length, char *output, base64_options options,
-    last_chunk_handling_options last_chunk_options) const noexcept {
-  const bool ignore_garbage =
-      (options == base64_options::base64_url_accept_garbage) ||
-      (options == base64_options::base64_default_accept_garbage);
-  while (length > 0 &&
-         scalar::base64::is_ascii_white_space(input[length - 1])) {
-    length--;
-  }
-  size_t equallocation =
-      length; // location of the first padding character if any
-  size_t equalsigns = 0;
-  if (length > 0 && input[length - 1] == '=') {
-    equallocation = length - 1;
-    length -= 1;
-    equalsigns++;
-    while (length > 0 &&
-           scalar::base64::is_ascii_white_space(input[length - 1])) {
-      length--;
-    }
-    if (length > 0 && input[length - 1] == '=') {
-      equallocation = length - 1;
-      equalsigns++;
-      length -= 1;
-    }
-  }
-  if (length == 0) {
-    if (!ignore_garbage && equalsigns > 0) {
-      if (last_chunk_options == last_chunk_handling_options::strict) {
-        return {BASE64_INPUT_REMAINDER, 0, 0};
-      } else if (last_chunk_options ==
-                 last_chunk_handling_options::stop_before_partial) {
-        return {SUCCESS, 0, 0};
-      }
-      return {INVALID_BASE64_CHARACTER, equallocation, 0};
-    }
-    return {SUCCESS, 0, 0};
-  }
-  full_result r = scalar::base64::base64_tail_decode(
-      output, input, length, equalsigns, options, last_chunk_options);
-  if (last_chunk_options != stop_before_partial &&
-      r.error == error_code::SUCCESS && equalsigns > 0 && !ignore_garbage) {
-    // additional checks
-    if ((r.output_count % 3 == 0) ||
-        ((r.output_count % 3) + 1 + equalsigns != 4)) {
-      return {INVALID_BASE64_CHARACTER, equallocation, r.output_count};
-    }
-  }
-  return r;
+  return simdutf::scalar::base64::base64_to_binary_details_impl(
+      input, length, output, options, last_chunk_options);
 }
 
 simdutf_warn_unused result implementation::base64_to_binary(
     const char16_t *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  const bool ignore_garbage =
-      (options == base64_options::base64_url_accept_garbage) ||
-      (options == base64_options::base64_default_accept_garbage);
-  while (length > 0 &&
-         scalar::base64::is_ascii_white_space(input[length - 1])) {
-    length--;
-  }
-  size_t equallocation =
-      length; // location of the first padding character if any
-  auto equalsigns = 0;
-  if (length > 0 && input[length - 1] == '=') {
-    equallocation = length - 1;
-    length -= 1;
-    equalsigns++;
-    while (length > 0 &&
-           scalar::base64::is_ascii_white_space(input[length - 1])) {
-      length--;
-    }
-    if (length > 0 && input[length - 1] == '=') {
-      equallocation = length - 1;
-      equalsigns++;
-      length -= 1;
-    }
-  }
-  if (length == 0) {
-    if (!ignore_garbage && equalsigns > 0) {
-      if (last_chunk_options == last_chunk_handling_options::strict) {
-        return {BASE64_INPUT_REMAINDER, 0};
-      } else if (last_chunk_options ==
-                 last_chunk_handling_options::stop_before_partial) {
-        return {SUCCESS, 0};
-      }
-      return {INVALID_BASE64_CHARACTER, equallocation};
-    }
-    return {SUCCESS, 0};
-  }
-  result r = scalar::base64::base64_tail_decode(
-      output, input, length, equalsigns, options, last_chunk_options);
-  if (last_chunk_options != stop_before_partial &&
-      r.error == error_code::SUCCESS && equalsigns > 0 && !ignore_garbage) {
-    // additional checks
-    if ((r.count % 3 == 0) || ((r.count % 3) + 1 + equalsigns != 4)) {
-      return {INVALID_BASE64_CHARACTER, equallocation};
-    }
-  }
-  return r;
+  return simdutf::scalar::base64::base64_to_binary_details_impl(
+      input, length, output, options, last_chunk_options);
+}
+
+simdutf_warn_unused full_result implementation::base64_to_binary_details(
+    const char *input, size_t length, char *output, base64_options options,
+    last_chunk_handling_options last_chunk_options) const noexcept {
+  return simdutf::scalar::base64::base64_to_binary_details_impl(
+      input, length, output, options, last_chunk_options);
 }
 
 simdutf_warn_unused full_result implementation::base64_to_binary_details(
     const char16_t *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  const bool ignore_garbage =
-      (options == base64_options::base64_url_accept_garbage) ||
-      (options == base64_options::base64_default_accept_garbage);
-  while (length > 0 &&
-         scalar::base64::is_ascii_white_space(input[length - 1])) {
-    length--;
-  }
-  size_t equallocation =
-      length; // location of the first padding character if any
-  size_t equalsigns = 0;
-  if (length > 0 && input[length - 1] == '=') {
-    equallocation = length - 1;
-    length -= 1;
-    equalsigns++;
-    while (length > 0 &&
-           scalar::base64::is_ascii_white_space(input[length - 1])) {
-      length--;
-    }
-    if (length > 0 && input[length - 1] == '=') {
-      equallocation = length - 1;
-      equalsigns++;
-      length -= 1;
-    }
-  }
-  if (length == 0) {
-    if (!ignore_garbage && equalsigns > 0) {
-      if (last_chunk_options == last_chunk_handling_options::strict) {
-        return {BASE64_INPUT_REMAINDER, 0, 0};
-      } else if (last_chunk_options ==
-                 last_chunk_handling_options::stop_before_partial) {
-        return {SUCCESS, 0, 0};
-      }
-      return {INVALID_BASE64_CHARACTER, equallocation, 0};
-    }
-    return {SUCCESS, 0, 0};
-  }
-  full_result r = scalar::base64::base64_tail_decode(
-      output, input, length, equalsigns, options, last_chunk_options);
-  if (last_chunk_options != stop_before_partial &&
-      r.error == error_code::SUCCESS && equalsigns > 0 && !ignore_garbage) {
-    // additional checks
-    if ((r.output_count % 3 == 0) ||
-        ((r.output_count % 3) + 1 + equalsigns != 4)) {
-      return {INVALID_BASE64_CHARACTER, equallocation, r.output_count};
-    }
-  }
-  return r;
+  return simdutf::scalar::base64::base64_to_binary_details_impl(
+      input, length, output, options, last_chunk_options);
 }
 
 size_t implementation::binary_to_base64(const char *input, size_t length,
                                         char *output,
                                         base64_options options) const noexcept {
   return scalar::base64::tail_encode_base64(output, input, length, options);
+}
+
+const char *implementation::find(const char *start, const char *end,
+                                 char character) const noexcept {
+  return util_find(start, end, character);
+}
+
+const char16_t *implementation::find(const char16_t *start, const char16_t *end,
+                                     char16_t character) const noexcept {
+  return util_find(start, end, character);
 }
 #endif // SIMDUTF_FEATURE_BASE64
 
@@ -52664,44 +52876,23 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
       default_or_url ? tables::base64::to_base64_default_or_url_value
                      : (base64_url ? tables::base64::to_base64_url_value
                                    : tables::base64::to_base64_value);
-  size_t equallocation =
-      srclen; // location of the first padding character if any
-  // skip trailing spaces
-  while (!ignore_garbage && srclen > 0 &&
-         scalar::base64::is_eight_byte(src[srclen - 1]) &&
-         to_base64[uint8_t(src[srclen - 1])] == 64) {
-    srclen--;
-  }
-  size_t equalsigns = 0;
-  if (!ignore_garbage && srclen > 0 && src[srclen - 1] == '=') {
-    equallocation = srclen - 1;
-    srclen--;
-    equalsigns = 1;
-    // skip trailing spaces
-    while (srclen > 0 && scalar::base64::is_eight_byte(src[srclen - 1]) &&
-           to_base64[uint8_t(src[srclen - 1])] == 64) {
-      srclen--;
-    }
-    if (srclen > 0 && src[srclen - 1] == '=') {
-      equallocation = srclen - 1;
-      srclen--;
-      equalsigns = 2;
-    }
-  }
+  auto ri = simdutf::scalar::base64::find_end(src, srclen, options);
+  size_t equallocation = ri.equallocation;
+  size_t equalsigns = ri.equalsigns;
+  srclen = ri.srclen;
+  size_t full_input_length = ri.full_input_length;
+  (void)full_input_length;
   if (srclen == 0) {
     if (!ignore_garbage && equalsigns > 0) {
-      if (last_chunk_options == last_chunk_handling_options::strict) {
-        return {BASE64_INPUT_REMAINDER, 0, 0};
-      } else if (last_chunk_options ==
-                 last_chunk_handling_options::stop_before_partial) {
-        return {SUCCESS, 0, 0};
-      }
       return {INVALID_BASE64_CHARACTER, equallocation, 0};
     }
     return {SUCCESS, 0, 0};
   }
   char *end_of_safe_64byte_zone =
-      (srclen + 3) / 4 * 3 >= 63 ? dst + (srclen + 3) / 4 * 3 - 63 : dst;
+      dst == nullptr
+          ? nullptr
+          : ((srclen + 3) / 4 * 3 >= 63 ? dst + (srclen + 3) / 4 * 3 - 63
+                                        : dst);
 
   const chartype *const srcinit = src;
   const char *const dstinit = dst;
@@ -52832,22 +53023,9 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
   if (src < srcend + equalsigns) {
     full_result r = scalar::base64::base64_tail_decode(
         dst, src, srcend - src, equalsigns, options, last_chunk_options);
-    r.input_count += size_t(src - srcinit);
-    if (r.error == error_code::INVALID_BASE64_CHARACTER ||
-        r.error == error_code::BASE64_EXTRA_BITS) {
-      return r;
-    } else {
-      r.output_count += size_t(dst - dstinit);
-    }
-    if (!ignore_garbage && last_chunk_options != stop_before_partial &&
-        r.error == error_code::SUCCESS && equalsigns > 0) {
-      // additional checks
-      if ((r.output_count % 3 == 0) ||
-          ((r.output_count % 3) + 1 + equalsigns != 4)) {
-        r.error = error_code::INVALID_BASE64_CHARACTER;
-        r.input_count = equallocation;
-      }
-    }
+    r = scalar::base64::patch_tail_result(
+        r, size_t(src - srcinit), size_t(dst - dstinit), equallocation,
+        full_input_length, last_chunk_options);
     return r;
   }
   if (!ignore_garbage && equalsigns > 0) {
@@ -52864,6 +53042,45 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
 } // namespace westmere
 } // namespace simdutf
 /* end file src/generic/base64.h */
+/* begin file src/generic/find.h */
+
+namespace simdutf {
+namespace westmere {
+namespace {
+namespace util {
+
+simdutf_really_inline const char *find(const char *start, const char *end,
+                                       char character) noexcept {
+  for (; std::distance(start, end) >= 64; start += 64) {
+    simd8x64<uint8_t> input(reinterpret_cast<const uint8_t *>(start));
+    uint64_t matches = input.eq(uint8_t(character));
+    if (matches != 0) {
+      // Found a match, return the first one
+      int index = trailing_zeroes(matches);
+      return start + index;
+    }
+  }
+  return std::find(start, end, character);
+}
+
+simdutf_really_inline const char16_t *
+find(const char16_t *start, const char16_t *end, char16_t character) noexcept {
+  for (; std::distance(start, end) >= 32; start += 32) {
+    simd16x32<uint16_t> input(reinterpret_cast<const uint16_t *>(start));
+    uint64_t matches = input.eq(uint16_t(character));
+    if (matches != 0) {
+      // Found a match, return the first one
+      int index = trailing_zeroes(matches) / 2;
+      return start + index;
+    }
+  }
+  return std::find(start, end, character);
+}
+} // namespace util
+} // namespace
+} // namespace westmere
+} // namespace simdutf
+/* end file src/generic/find.h */
 #endif // SIMDUTF_FEATURE_BASE64
 
 //
@@ -54117,6 +54334,16 @@ size_t implementation::binary_to_base64(const char *input, size_t length,
   } else {
     return encode_base64<false>(output, input, length, options);
   }
+}
+
+const char *implementation::find(const char *start, const char *end,
+                                 char character) const noexcept {
+  return util::find(start, end, character);
+}
+
+const char16_t *implementation::find(const char16_t *start, const char16_t *end,
+                                     char16_t character) const noexcept {
+  return util::find(start, end, character);
 }
 #endif // SIMDUTF_FEATURE_BASE64
 
@@ -56912,37 +57139,14 @@ compress_decode_base64(char *dst, const char_type *src, size_t srclen,
       default_or_url ? tables::base64::to_base64_default_or_url_value
                      : (base64_url ? tables::base64::to_base64_url_value
                                    : tables::base64::to_base64_value);
-  size_t equallocation =
-      srclen; // location of the first padding character if any
-  // skip trailing spaces
-  while (srclen > 0 && scalar::base64::is_eight_byte(src[srclen - 1]) &&
-         to_base64[uint8_t(src[srclen - 1])] == 64) {
-    srclen--;
-  }
-  size_t equalsigns = 0;
-  if (srclen > 0 && src[srclen - 1] == '=') {
-    equallocation = srclen - 1;
-    srclen--;
-    equalsigns = 1;
-    // skip trailing spaces
-    while (srclen > 0 && scalar::base64::is_eight_byte(src[srclen - 1]) &&
-           to_base64[uint8_t(src[srclen - 1])] == 64) {
-      srclen--;
-    }
-    if (srclen > 0 && src[srclen - 1] == '=') {
-      equallocation = srclen - 1;
-      srclen--;
-      equalsigns = 2;
-    }
-  }
+  auto ri = simdutf::scalar::base64::find_end(src, srclen, options);
+  size_t equallocation = ri.equallocation;
+  size_t equalsigns = ri.equalsigns;
+  srclen = ri.srclen;
+  size_t full_input_length = ri.full_input_length;
+  (void)full_input_length;
   if (srclen == 0) {
     if (!ignore_garbage && equalsigns > 0) {
-      if (last_chunk_options == last_chunk_handling_options::strict) {
-        return {BASE64_INPUT_REMAINDER, 0, 0};
-      } else if (last_chunk_options ==
-                 last_chunk_handling_options::stop_before_partial) {
-        return {SUCCESS, 0, 0};
-      }
       return {INVALID_BASE64_CHARACTER, equallocation, 0};
     }
     return {SUCCESS, 0, 0};
@@ -57067,22 +57271,9 @@ compress_decode_base64(char *dst, const char_type *src, size_t srclen,
   if (src < srcend + equalsigns) {
     full_result r = scalar::base64::base64_tail_decode(
         dst, src, srcend - src, equalsigns, options, last_chunk_options);
-    r.input_count += size_t(src - srcinit);
-    if (r.error == error_code::INVALID_BASE64_CHARACTER ||
-        r.error == error_code::BASE64_EXTRA_BITS) {
-      return r;
-    } else {
-      r.output_count += size_t(dst - dstinit);
-    }
-    if (last_chunk_options != stop_before_partial &&
-        r.error == error_code::SUCCESS && equalsigns > 0 && !ignore_garbage) {
-      // additional checks
-      if ((r.output_count % 3 == 0) ||
-          ((r.output_count % 3) + 1 + equalsigns != 4)) {
-        r.error = error_code::INVALID_BASE64_CHARACTER;
-        r.input_count = equallocation;
-      }
-    }
+    r = scalar::base64::patch_tail_result(
+        r, size_t(src - srcinit), size_t(dst - dstinit), equallocation,
+        full_input_length, last_chunk_options);
     return r;
   }
   if (equalsigns > 0 && !ignore_garbage) {
@@ -57094,6 +57285,68 @@ compress_decode_base64(char *dst, const char_type *src, size_t srclen,
   return {SUCCESS, srclen, size_t(dst - dstinit)};
 }
 /* end file src/lsx/lsx_base64.cpp */
+/* begin file src/lsx/lsx_find.cpp */
+simdutf_really_inline const char *util_find(const char *start, const char *end,
+                                            char character) noexcept {
+  if (start >= end)
+    return end;
+
+  const int step = 16;
+  __m128i char_vec = __lsx_vreplgr2vr_b(static_cast<uint8_t>(character));
+
+  while (end - start >= step) {
+    __m128i data = __lsx_vld(reinterpret_cast<const __m128i *>(start), 0);
+    __m128i cmp = __lsx_vseq_b(data, char_vec);
+    if (__lsx_bnz_v(cmp)) {
+      uint16_t mask =
+          static_cast<uint16_t>(__lsx_vpickve2gr_hu(__lsx_vmsknz_b(cmp), 0));
+      return start + trailing_zeroes(mask);
+    }
+
+    start += step;
+  }
+
+  // Handle remaining bytes with scalar loop
+  for (; start < end; ++start) {
+    if (*start == character) {
+      return start;
+    }
+  }
+
+  return end;
+}
+
+simdutf_really_inline const char16_t *util_find(const char16_t *start,
+                                                const char16_t *end,
+                                                char16_t character) noexcept {
+  if (start >= end)
+    return end;
+
+  const int step = 8;
+  __m128i char_vec = __lsx_vreplgr2vr_h(static_cast<uint16_t>(character));
+
+  while (end - start >= step) {
+    __m128i data = __lsx_vld(reinterpret_cast<const __m128i *>(start), 0);
+    __m128i cmp = __lsx_vseq_h(data, char_vec);
+    if (__lsx_bnz_v(cmp)) {
+      uint16_t mask =
+          static_cast<uint16_t>(__lsx_vpickve2gr_hu(__lsx_vmsknz_b(cmp), 0));
+      return start + trailing_zeroes(mask) / 2;
+    }
+
+    start += step;
+  }
+
+  // Handle remaining elements with scalar loop
+  for (; start < end; ++start) {
+    if (*start == character) {
+      return start;
+    }
+  }
+
+  return end;
+}
+/* end file src/lsx/lsx_find.cpp */
 #endif // SIMDUTF_FEATURE_BASE64
 
 } // namespace
@@ -60603,7 +60856,17 @@ size_t implementation::binary_to_base64(const char *input, size_t length,
     return encode_base64<false>(output, input, length, options);
   }
 }
+const char *implementation::find(const char *start, const char *end,
+                                 char character) const noexcept {
+  return util_find(start, end, character);
+}
+
+const char16_t *implementation::find(const char16_t *start, const char16_t *end,
+                                     char16_t character) const noexcept {
+  return util_find(start, end, character);
+}
 #endif // SIMDUTF_FEATURE_BASE64
+
 } // namespace lsx
 } // namespace simdutf
 
@@ -63785,37 +64048,14 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
       default_or_url ? tables::base64::to_base64_default_or_url_value
                      : (base64_url ? tables::base64::to_base64_url_value
                                    : tables::base64::to_base64_value);
-  size_t equallocation =
-      srclen; // location of the first padding character if any
-  // skip trailing spaces
-  while (srclen > 0 && scalar::base64::is_eight_byte(src[srclen - 1]) &&
-         to_base64[uint8_t(src[srclen - 1])] == 64) {
-    srclen--;
-  }
-  size_t equalsigns = 0;
-  if (srclen > 0 && src[srclen - 1] == '=') {
-    equallocation = srclen - 1;
-    srclen--;
-    equalsigns = 1;
-    // skip trailing spaces
-    while (srclen > 0 && scalar::base64::is_eight_byte(src[srclen - 1]) &&
-           to_base64[uint8_t(src[srclen - 1])] == 64) {
-      srclen--;
-    }
-    if (srclen > 0 && src[srclen - 1] == '=') {
-      equallocation = srclen - 1;
-      srclen--;
-      equalsigns = 2;
-    }
-  }
+  auto ri = simdutf::scalar::base64::find_end(src, srclen, options);
+  size_t equallocation = ri.equallocation;
+  size_t equalsigns = ri.equalsigns;
+  srclen = ri.srclen;
+  size_t full_input_length = ri.full_input_length;
+  (void)full_input_length;
   if (srclen == 0) {
     if (!ignore_garbage && equalsigns > 0) {
-      if (last_chunk_options == last_chunk_handling_options::strict) {
-        return {BASE64_INPUT_REMAINDER, 0, 0};
-      } else if (last_chunk_options ==
-                 last_chunk_handling_options::stop_before_partial) {
-        return {SUCCESS, 0, 0};
-      }
       return {INVALID_BASE64_CHARACTER, equallocation, 0};
     }
     return {SUCCESS, 0, 0};
@@ -63955,22 +64195,9 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
   if (src < srcend + equalsigns) {
     full_result r = scalar::base64::base64_tail_decode(
         dst, src, srcend - src, equalsigns, options, last_chunk_options);
-    r.input_count += size_t(src - srcinit);
-    if (r.error == error_code::INVALID_BASE64_CHARACTER ||
-        r.error == error_code::BASE64_EXTRA_BITS) {
-      return r;
-    } else {
-      r.output_count += size_t(dst - dstinit);
-    }
-    if (last_chunk_options != stop_before_partial &&
-        r.error == error_code::SUCCESS && equalsigns > 0 && !ignore_garbage) {
-      // additional checks
-      if ((r.output_count % 3 == 0) ||
-          ((r.output_count % 3) + 1 + equalsigns != 4)) {
-        r.error = error_code::INVALID_BASE64_CHARACTER;
-        r.input_count = equallocation;
-      }
-    }
+    r = scalar::base64::patch_tail_result(
+        r, size_t(src - srcinit), size_t(dst - dstinit), equallocation,
+        full_input_length, last_chunk_options);
     return r;
   }
   if (equalsigns > 0 && !ignore_garbage) {
@@ -63982,6 +64209,72 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
   return {SUCCESS, srclen, size_t(dst - dstinit)};
 }
 /* end file src/lasx/lasx_base64.cpp */
+/* begin file src/lasx/lasx_find.cpp */
+simdutf_really_inline const char *util_find(const char *start, const char *end,
+                                            char character) noexcept {
+  if (start >= end)
+    return end;
+
+  const int step = 32;
+  __m256i char_vec = __lasx_xvreplgr2vr_b(static_cast<uint16_t>(character));
+
+  while (end - start >= step) {
+    __m256i data = __lasx_xvld(reinterpret_cast<const __m256i *>(start), 0);
+    __m256i cmp = __lasx_xvseq_b(data, char_vec);
+    if (__lasx_xbnz_v(cmp)) {
+      __m256i res = __lasx_xvmsknz_b(cmp);
+      uint32_t mask0 = __lasx_xvpickve2gr_wu(res, 0);
+      uint32_t mask1 = __lasx_xvpickve2gr_wu(res, 4);
+      uint32_t mask = (mask0 | (mask1 << 16));
+      return start + trailing_zeroes(mask);
+    }
+
+    start += step;
+  }
+
+  // Handle remaining bytes with scalar loop
+  for (; start < end; ++start) {
+    if (*start == character) {
+      return start;
+    }
+  }
+
+  return end;
+}
+
+simdutf_really_inline const char16_t *util_find(const char16_t *start,
+                                                const char16_t *end,
+                                                char16_t character) noexcept {
+  if (start >= end)
+    return end;
+
+  const int step = 16;
+  __m256i char_vec = __lasx_xvreplgr2vr_h(static_cast<uint16_t>(character));
+
+  while (end - start >= step) {
+    __m256i data = __lasx_xvld(reinterpret_cast<const __m256i *>(start), 0);
+    __m256i cmp = __lasx_xvseq_h(data, char_vec);
+    if (__lasx_xbnz_v(cmp)) {
+      __m256i res = __lasx_xvmsknz_b(cmp);
+      uint32_t mask0 = __lasx_xvpickve2gr_wu(res, 0);
+      uint32_t mask1 = __lasx_xvpickve2gr_wu(res, 4);
+      uint32_t mask = (mask0 | (mask1 << 16));
+      return start + trailing_zeroes(mask) / 2;
+    }
+
+    start += step;
+  }
+
+  // Handle remaining elements with scalar loop
+  for (; start < end; ++start) {
+    if (*start == character) {
+      return start;
+    }
+  }
+
+  return end;
+}
+/* end file src/lasx/lasx_find.cpp */
 #endif // SIMDUTF_FEATURE_BASE64
 
 } // namespace
@@ -67602,7 +67895,18 @@ size_t implementation::binary_to_base64(const char *input, size_t length,
     return encode_base64<false>(output, input, length, options);
   }
 }
+
+const char *implementation::find(const char *start, const char *end,
+                                 char character) const noexcept {
+  return util_find(start, end, character);
+}
+
+const char16_t *implementation::find(const char16_t *start, const char16_t *end,
+                                     char16_t character) const noexcept {
+  return util_find(start, end, character);
+}
 #endif // SIMDUTF_FEATURE_BASE64
+
 } // namespace lasx
 } // namespace simdutf
 

--- a/Source/WTF/wtf/simdutf/simdutf_impl.h
+++ b/Source/WTF/wtf/simdutf/simdutf_impl.h
@@ -1,4 +1,4 @@
-/* auto-generated on 2025-05-01 00:20:41 -0400. Do not edit! */
+/* auto-generated on 2025-07-13 10:46:57 -0400. Do not edit! */
 /* begin file include/simdutf.h */
 #ifndef SIMDUTF_H
 #define SIMDUTF_H
@@ -401,6 +401,26 @@
 #endif // SIMDUTF_AVX512_H_
 /* end file include/simdutf/avx512.h */
 
+// Sometimes logging is useful, but we want it disabled by default
+// and free of any logging code in release builds.
+#ifdef SIMDUTF_LOGGING
+  #include <iostream>
+  #define simdutf_log(msg)                                                     \
+    std::cout << "[" << __FUNCTION__ << "]: " << msg << std::endl              \
+              << "\t" << __FILE__ << ":" << __LINE__ << std::endl;
+  #define simdutf_log_assert(cond, msg)                                        \
+    do {                                                                       \
+      if (!(cond)) {                                                           \
+        std::cerr << "[" << __FUNCTION__ << "]: " << msg << std::endl          \
+                  << "\t" << __FILE__ << ":" << __LINE__ << std::endl;         \
+        std::abort();                                                          \
+      }                                                                        \
+    } while (0)
+#else
+  #define simdutf_log(msg)
+  #define simdutf_log_assert(cond, msg)
+#endif
+
 #if defined(SIMDUTF_REGULAR_VISUAL_STUDIO)
   #define SIMDUTF_DEPRECATED __declspec(deprecated)
 
@@ -600,12 +620,43 @@ enum error_code {
                             // base64 string. This may include a misplaced
                             // padding character ('=').
   BASE64_INPUT_REMAINDER,   // The base64 input terminates with a single
-                            // character, excluding padding (=).
+                            // character, excluding padding (=). It is also used
+                            // in strict mode when padding is not adequate.
   BASE64_EXTRA_BITS,        // The base64 input terminates with non-zero
                             // padding bits.
   OUTPUT_BUFFER_TOO_SMALL,  // The provided buffer is too small.
   OTHER                     // Not related to validation/transcoding.
 };
+#if SIMDUTF_CPLUSPLUS17
+inline std::string_view error_to_string(error_code code) noexcept {
+  switch (code) {
+  case SUCCESS:
+    return "SUCCESS";
+  case HEADER_BITS:
+    return "HEADER_BITS";
+  case TOO_SHORT:
+    return "TOO_SHORT";
+  case TOO_LONG:
+    return "TOO_LONG";
+  case OVERLONG:
+    return "OVERLONG";
+  case TOO_LARGE:
+    return "TOO_LARGE";
+  case SURROGATE:
+    return "SURROGATE";
+  case INVALID_BASE64_CHARACTER:
+    return "INVALID_BASE64_CHARACTER";
+  case BASE64_INPUT_REMAINDER:
+    return "BASE64_INPUT_REMAINDER";
+  case BASE64_EXTRA_BITS:
+    return "BASE64_EXTRA_BITS";
+  case OUTPUT_BUFFER_TOO_SMALL:
+    return "OUTPUT_BUFFER_TOO_SMALL";
+  default:
+    return "OTHER";
+  }
+}
+#endif
 
 struct result {
   error_code error;
@@ -613,16 +664,17 @@ struct result {
                 // case of success, indicates the number of code units
                 // validated/written.
 
-  simdutf_really_inline result() : error{error_code::SUCCESS}, count{0} {}
+  simdutf_really_inline result() noexcept
+      : error{error_code::SUCCESS}, count{0} {}
 
-  simdutf_really_inline result(error_code err, size_t pos)
+  simdutf_really_inline result(error_code err, size_t pos) noexcept
       : error{err}, count{pos} {}
 
-  simdutf_really_inline bool is_ok() const {
+  simdutf_really_inline bool is_ok() const noexcept {
     return error == error_code::SUCCESS;
   }
 
-  simdutf_really_inline bool is_err() const {
+  simdutf_really_inline bool is_err() const noexcept {
     return error != error_code::SUCCESS;
   }
 };
@@ -631,17 +683,22 @@ struct full_result {
   error_code error;
   size_t input_count;
   size_t output_count;
+  bool padding_error = false; // true if the error is due to padding, only
+                              // meaningful when error is not SUCCESS
 
-  simdutf_really_inline full_result()
+  simdutf_really_inline full_result() noexcept
       : error{error_code::SUCCESS}, input_count{0}, output_count{0} {}
 
   simdutf_really_inline full_result(error_code err, size_t pos_in,
-                                    size_t pos_out)
+                                    size_t pos_out) noexcept
       : error{err}, input_count{pos_in}, output_count{pos_out} {}
+  simdutf_really_inline full_result(error_code err, size_t pos_in,
+                                    size_t pos_out, bool padding_err) noexcept
+      : error{err}, input_count{pos_in}, output_count{pos_out},
+        padding_error{padding_err} {}
 
   simdutf_really_inline operator result() const noexcept {
-    if (error == error_code::SUCCESS ||
-        error == error_code::BASE64_INPUT_REMAINDER) {
+    if (error == error_code::SUCCESS) {
       return result{error, output_count};
     } else {
       return result{error, input_count};
@@ -664,7 +721,7 @@ SIMDUTF_DISABLE_UNDESIRED_WARNINGS
 #define SIMDUTF_SIMDUTF_VERSION_H
 
 /** The version of simdutf being used (major.minor.revision) */
-#define SIMDUTF_VERSION "7.0.0"
+#define SIMDUTF_VERSION "7.3.3"
 
 namespace simdutf {
 enum {
@@ -675,11 +732,11 @@ enum {
   /**
    * The minor version (major.MINOR.revision) of simdutf being used.
    */
-  SIMDUTF_VERSION_MINOR = 0,
+  SIMDUTF_VERSION_MINOR = 3,
   /**
    * The revision (major.minor.REVISION) of simdutf being used.
    */
-  SIMDUTF_VERSION_REVISION = 0
+  SIMDUTF_VERSION_REVISION = 3
 };
 } // namespace simdutf
 
@@ -1028,7 +1085,9 @@ static inline uint32_t detect_supported_architectures() {
   #include <span>
   #include <tuple>
 #endif
-
+#if SIMDUTF_CPLUSPLUS17
+  #include <string_view>
+#endif
 // The following defines are conditionally enabled/disabled during amalgamation.
 // By default all features are enabled, regular code shouldn't check them. Only
 // when user code really relies of a selected subset, it's good to verify these
@@ -1519,7 +1578,7 @@ validate_utf32_with_errors(std::span<const char32_t> input) noexcept {
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
 /**
- * Convert Latin1 string into UTF8 string.
+ * Convert Latin1 string into UTF-8 string.
  *
  * This function is suitable to work with inputs from untrusted sources.
  *
@@ -1542,9 +1601,11 @@ simdutf_really_inline simdutf_warn_unused size_t convert_latin1_to_utf8(
   #endif // SIMDUTF_SPAN
 
 /**
- * Convert Latin1 string into UTF8 string with output limit.
+ * Convert Latin1 string into UTF-8 string with output limit.
  *
  * This function is suitable to work with inputs from untrusted sources.
+ *
+ * We write as many characters as possible.
  *
  * @param input         the Latin1 string to convert
  * @param length        the length of the string in bytes
@@ -1578,7 +1639,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_latin1_to_utf8_safe(
  *
  * This function is suitable to work with inputs from untrusted sources.
  *
- * @param input         the Latin1  string to convert
+ * @param input         the Latin1 string to convert
  * @param length        the length of the string in bytes
  * @param utf16_buffer  the pointer to buffer that can hold conversion result
  * @return the number of written char16_t; 0 if conversion is not possible
@@ -1717,7 +1778,7 @@ convert_utf8_to_utf16(const detail::input_span_of_byte_like auto &input,
 /**
  * Using native endianness, convert a Latin1 string into a UTF-16 string.
  *
- * @param input         the UTF-8 string to convert
+ * @param input         the Latin1 string to convert
  * @param length        the length of the string in bytes
  * @param utf16_buffer  the pointer to buffer that can hold conversion result
  * @return the number of written char16_t.
@@ -2202,6 +2263,44 @@ simdutf_really_inline simdutf_warn_unused size_t convert_utf16_to_utf8(
     detail::output_span_of_byte_like auto &&utf8_output) noexcept {
   return convert_utf16_to_utf8(utf16_input.data(), utf16_input.size(),
                                reinterpret_cast<char *>(utf8_output.data()));
+}
+  #endif // SIMDUTF_SPAN
+
+/**
+ * Using native endianness, convert possibly broken UTF-16 string into UTF-8
+ * string with output limit.
+ *
+ * We write as many characters as possible into the output buffer,
+ *
+ * During the conversion also validation of the input string is done.
+ * This function is suitable to work with inputs from untrusted sources.
+ *
+ * This function is not BOM-aware.
+ *
+ *
+ * @param input         the UTF-16 string to convert
+ * @param length        the length of the string in 16-bit code units (char16_t)
+ * @param utf8_output  	the pointer to buffer that can hold conversion result
+ * @param utf8_len      the maximum output length
+ * @return the number of written char; 0 if conversion is not possible
+ */
+simdutf_warn_unused size_t convert_utf16_to_utf8_safe(const char16_t *input,
+                                                      size_t length,
+                                                      char *utf8_output,
+                                                      size_t utf8_len) noexcept;
+  #if SIMDUTF_SPAN
+simdutf_really_inline simdutf_warn_unused size_t convert_utf16_to_utf8_safe(
+    std::span<const char16_t> utf16_input,
+    detail::output_span_of_byte_like auto &&utf8_output) noexcept {
+  // implementation note: outputspan is a forwarding ref to avoid copying and
+  // allow both lvalues and rvalues. std::span can be copied without problems,
+  // but std::vector should not, and this function should accept both. it will
+  // allow using an owning rvalue ref (example: passing a temporary std::string)
+  // as output, but the user will quickly find out that he has no way of getting
+  // the data out of the object in that case.
+  return convert_utf16_to_utf8_safe(
+      utf16_input.data(), utf16_input.size(),
+      reinterpret_cast<char *>(utf8_output.data()), utf8_output.size());
 }
   #endif // SIMDUTF_SPAN
 #endif   // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
@@ -3788,25 +3887,53 @@ trim_partial_utf16(std::span<const char16_t> valid_utf16_input) noexcept {
 // ASCII spaces are ' ', '\t', '\n', '\r', '\f'
 // garbage characters are characters that are not part of the base64 alphabet
 // nor ASCII spaces.
+constexpr uint64_t base64_reverse_padding =
+    2; /* modifier for base64_default and base64_url */
 enum base64_options : uint64_t {
-  base64_default = 0,         /* standard base64 format (with padding) */
-  base64_url = 1,             /* base64url format (no padding) */
-  base64_reverse_padding = 2, /* modifier for base64_default and base64_url */
+  base64_default = 0, /* standard base64 format (with padding) */
+  base64_url = 1,     /* base64url format (no padding) */
   base64_default_no_padding =
       base64_default |
       base64_reverse_padding, /* standard base64 format without padding */
   base64_url_with_padding =
       base64_url | base64_reverse_padding, /* base64url with padding */
   base64_default_accept_garbage =
-      4, /* standard base64 format accepting garbage characters */
+      4, /* standard base64 format accepting garbage characters, the input stops
+            with the first '=' if any */
   base64_url_accept_garbage =
-      5, /* base64url format accepting garbage characters */
+      5, /* base64url format accepting garbage characters, the input stops with
+            the first '=' if any */
   base64_default_or_url =
       8, /* standard/base64url hybrid format (only meaningful for decoding!) */
   base64_default_or_url_accept_garbage =
       12, /* standard/base64url hybrid format accepting garbage characters
-             (only meaningful for decoding!) */
+             (only meaningful for decoding!), the input stops with the first '='
+             if any */
 };
+
+  #if SIMDUTF_CPLUSPLUS17
+inline std::string_view to_string(base64_options options) {
+  switch (options) {
+  case base64_default:
+    return "base64_default";
+  case base64_url:
+    return "base64_url";
+  case base64_reverse_padding:
+    return "base64_reverse_padding";
+  case base64_url_with_padding:
+    return "base64_url_with_padding";
+  case base64_default_accept_garbage:
+    return "base64_default_accept_garbage";
+  case base64_url_accept_garbage:
+    return "base64_url_accept_garbage";
+  case base64_default_or_url:
+    return "base64_default_or_url";
+  case base64_default_or_url_accept_garbage:
+    return "base64_default_or_url_accept_garbage";
+  }
+  return "<unknown>";
+}
+  #endif // SIMDUTF_CPLUSPLUS17
 
 // last_chunk_handling_options are used to specify the handling of the last
 // chunk in base64 decoding.
@@ -3816,8 +3943,30 @@ enum last_chunk_handling_options : uint64_t {
   strict = 1, /* error when the last chunk is partial, 2 or 3 chars, and
                  unpadded, or non-zero bit padding */
   stop_before_partial =
-      2, /* if the last chunk is partial (2 or 3 chars), ignore it (no error) */
+      2, /* if the last chunk is partial, ignore it (no error) */
+  only_full_chunks =
+      3 /* only decode full blocks (4 base64 characters, no padding) */
 };
+
+inline bool is_partial(last_chunk_handling_options options) {
+  return (options == stop_before_partial) || (options == only_full_chunks);
+}
+
+  #if SIMDUTF_CPLUSPLUS17
+inline std::string_view to_string(last_chunk_handling_options options) {
+  switch (options) {
+  case loose:
+    return "loose";
+  case strict:
+    return "strict";
+  case stop_before_partial:
+    return "stop_before_partial";
+  case only_full_chunks:
+    return "only_full_chunks";
+  }
+  return "<unknown>";
+}
+  #endif
 
 /**
  * Provide the maximal binary length in bytes given the base64 input.
@@ -3891,7 +4040,7 @@ maximal_binary_length_from_base64(std::span<const char16_t> input) noexcept {
  * maximal_binary_length_from_base64(input, length) bytes long. If you fail to
  * provide that much space, the function may cause a buffer overflow.
  *
- * Advanced users may want to taylor how the last chunk is handled. By default,
+ * Advanced users may want to tailor how the last chunk is handled. By default,
  * we use a loose (forgiving) approach but we also support a strict approach
  * as well as a stop_before_partial approach, as per the following proposal:
  *
@@ -3998,6 +4147,12 @@ binary_to_base64(const detail::input_span_of_byte_like auto &input,
  *
  * This function always succeeds.
  *
+ * This function is considered experimental. It is not tested by default
+ * (see the CMake option SIMDUTF_ATOMIC_BASE64_TESTS) nor is it fuzz tested.
+ * It is not documented in the public API documentation (README). It is
+ * offered on a best effort basis. We rely on the community for further
+ * testing and feedback.
+ *
  * @brief atomic_binary_to_base64
  * @param input         the binary to process
  * @param length        the length of the input in bytes
@@ -4056,7 +4211,7 @@ atomic_binary_to_base64(const detail::input_span_of_byte_like auto &input,
  * maximal_binary_length_from_base64(input, length) bytes long. If you fail
  * to provide that much space, the function may cause a buffer overflow.
  *
- * Advanced users may want to taylor how the last chunk is handled. By default,
+ * Advanced users may want to tailor how the last chunk is handled. By default,
  * we use a loose (forgiving) approach but we also support a strict approach
  * as well as a stop_before_partial approach, as per the following proposal:
  *
@@ -4097,6 +4252,54 @@ simdutf_really_inline simdutf_warn_unused result base64_to_binary(
   #endif // SIMDUTF_SPAN
 
 /**
+ * Check if a character is an ignorabl base64 character.
+ * Checking a large input, character by character, is not computationally
+ * efficient.
+ *
+ * @param input         the character to check
+ * @param options       the base64 options to use, is base64_default by default.
+ * @return true if the character is an ignorablee base64 character, false
+ * otherwise.
+ */
+simdutf_warn_unused bool
+base64_ignorable(char input, base64_options options = base64_default) noexcept;
+simdutf_warn_unused bool
+base64_ignorable(char16_t input,
+                 base64_options options = base64_default) noexcept;
+
+/**
+ * Check if a character is a valid base64 character.
+ * Checking a large input, character by character, is not computationally
+ * efficient.
+ * Note that padding characters are not considered valid base64 characters in
+ * this context, nor are spaces.
+ *
+ * @param input         the character to check
+ * @param options       the base64 options to use, is base64_default by default.
+ * @return true if the character is a base64 character, false otherwise.
+ */
+simdutf_warn_unused bool
+base64_valid(char input, base64_options options = base64_default) noexcept;
+simdutf_warn_unused bool
+base64_valid(char16_t input, base64_options options = base64_default) noexcept;
+
+/**
+ * Check if a character is a valid base64 character or the padding character
+ * ('='). Checking a large input, character by character, is not computationally
+ * efficient.
+ *
+ * @param input         the character to check
+ * @param options       the base64 options to use, is base64_default by default.
+ * @return true if the character is a base64 character, false otherwise.
+ */
+simdutf_warn_unused bool
+base64_valid_or_padding(char input,
+                        base64_options options = base64_default) noexcept;
+simdutf_warn_unused bool
+base64_valid_or_padding(char16_t input,
+                        base64_options options = base64_default) noexcept;
+
+/**
  * Convert a base64 input to a binary output.
  *
  * This function follows the WHATWG forgiving-base64 format, which means that it
@@ -4135,7 +4338,7 @@ simdutf_really_inline simdutf_warn_unused result base64_to_binary(
  * true. In that case, the function will decode up to the first invalid
  * character. Extra padding characters ('=') are considered invalid characters.
  *
- * Advanced users may want to taylor how the last chunk is handled. By default,
+ * Advanced users may want to tailor how the last chunk is handled. By default,
  * we use a loose (forgiving) approach but we also support a strict approach
  * as well as a stop_before_partial approach, as per the following proposal:
  *
@@ -4156,7 +4359,8 @@ simdutf_really_inline simdutf_warn_unused result base64_to_binary(
  * last_chunk_handling_options::stop_before_partial.
  * @param decode_up_to_bad_char if true, the function will decode up to the
  * first invalid character. By default (false), it is assumed that the output
- * buffer is to be discarded.
+ * buffer is to be discarded. When there are multiple errors in the input,
+ * using decode_up_to_bad_char might trigger a different error.
  * @return a result pair struct (of type simdutf::result containing the two
  * fields error and count) with an error code and position of the
  * INVALID_BASE64_CHARACTER error (in the input in units) if any, or the number
@@ -4232,6 +4436,12 @@ base64_to_binary_safe(std::span<const char16_t> input,
  * the availability of this function by checking the macro
  * SIMDUTF_ATOMIC_REF.
  *
+ * This function is considered experimental. It is not tested by default
+ * (see the CMake option SIMDUTF_ATOMIC_BASE64_TESTS) nor is it fuzz tested.
+ * It is not documented in the public API documentation (README). It is
+ * offered on a best effort basis. We rely on the community for further
+ * testing and feedback.
+ *
  * @param input         the base64 input to decode
  * @param length        the length of the input in bytes
  * @param output        the pointer to buffer that can hold the conversion
@@ -4243,7 +4453,8 @@ base64_to_binary_safe(std::span<const char16_t> input,
  * stop_before_partial)
  * @param decode_up_to_bad_char if true, the function will decode up to the
  * first invalid character. By default (false), it is assumed that the output
- * buffer is to be discarded.
+ * buffer is to be discarded. When there are multiple errors in the input,
+ * using decode_up_to_bad_char might trigger a different error.
  * @return a result struct with an error code and count indicating error
  * position or success
  */
@@ -4299,6 +4510,20 @@ atomic_base64_to_binary_safe(
     #endif // SIMDUTF_SPAN
   #endif   // SIMDUTF_ATOMIC_REF
 
+/**
+ * Find the first occurrence of a character in a string. If the character is
+ * not found, return a pointer to the end of the string.
+ * @param start        the start of the string
+ * @param end          the end of the string
+ * @param character    the character to find
+ * @return a pointer to the first occurrence of the character in the string,
+ * or a pointer to the end of the string if the character is not found.
+ *
+ */
+simdutf_warn_unused const char *find(const char *start, const char *end,
+                                     char character) noexcept;
+simdutf_warn_unused const char16_t *
+find(const char16_t *start, const char16_t *end, char16_t character) noexcept;
 #endif // SIMDUTF_FEATURE_BASE64
 
 /**
@@ -4580,7 +4805,7 @@ public:
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
   /**
-   * Convert Latin1 string into UTF8 string.
+   * Convert Latin1 string into UTF-8 string.
    *
    * This function is suitable to work with inputs from untrusted sources.
    *
@@ -6023,6 +6248,20 @@ public:
   virtual size_t
   binary_to_base64(const char *input, size_t length, char *output,
                    base64_options options = base64_default) const noexcept = 0;
+  /**
+   * Find the first occurrence of a character in a string. If the character is
+   * not found, return a pointer to the end of the string.
+   * @param start        the start of the string
+   * @param end          the end of the string
+   * @param character    the character to find
+   * @return a pointer to the first occurrence of the character in the string,
+   * or a pointer to the end of the string if the character is not found.
+   *
+   */
+  virtual const char *find(const char *start, const char *end,
+                           char character) const noexcept = 0;
+  virtual const char16_t *find(const char16_t *start, const char16_t *end,
+                               char16_t character) const noexcept = 0;
 #endif // SIMDUTF_FEATURE_BASE64
 
 #ifdef SIMDUTF_INTERNAL_TESTS

--- a/Source/WTF/wtf/text/Base64.cpp
+++ b/Source/WTF/wtf/text/Base64.cpp
@@ -97,7 +97,7 @@ static constexpr std::array<char, decodeMapSize> base64URLDecMap {
     0x31, 0x32, 0x33, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet
 };
 
-static inline simdutf::base64_options toSIMDUTFOptions(OptionSet<Base64EncodeOption> options)
+static inline simdutf::base64_options toSIMDUTFEncodeOptions(OptionSet<Base64EncodeOption> options)
 {
     if (options.contains(Base64EncodeOption::URL)) {
         if (options.contains(Base64EncodeOption::OmitPadding))
@@ -115,7 +115,7 @@ template<typename CharacterType> static void base64EncodeInternal(std::span<cons
     ASSERT(calculateBase64EncodedSize(inputDataBuffer.size(), options) == destinationDataBuffer.size());
 
     if constexpr (sizeof(CharacterType) == 1) {
-        size_t bytesWritten = simdutf::binary_to_base64(std::bit_cast<const char*>(inputDataBuffer.data()), inputDataBuffer.size(), std::bit_cast<char*>(destinationDataBuffer.data()), toSIMDUTFOptions(options));
+        size_t bytesWritten = simdutf::binary_to_base64(std::bit_cast<const char*>(inputDataBuffer.data()), inputDataBuffer.size(), std::bit_cast<char*>(destinationDataBuffer.data()), toSIMDUTFEncodeOptions(options));
         ASSERT_UNUSED(bytesWritten, bytesWritten == destinationDataBuffer.size());
         return;
     }
@@ -202,7 +202,7 @@ unsigned calculateBase64EncodedSize(unsigned inputLength, OptionSet<Base64Encode
     if (inputLength > maximumBase64EncoderInputBufferSize)
         return 0;
 
-    return simdutf::base64_length_from_binary(inputLength, toSIMDUTFOptions(options));
+    return simdutf::base64_length_from_binary(inputLength, toSIMDUTFEncodeOptions(options));
 }
 
 template<typename T, typename Malloc = VectorBufferMalloc>
@@ -313,162 +313,73 @@ String base64DecodeToString(StringView input, OptionSet<Base64DecodeOption> opti
     return toString(base64DecodeInternal<char16_t, StringImplMalloc>(input.span16(), options));
 }
 
-template<typename CharacterType>
-static std::tuple<FromBase64ShouldThrowError, size_t, size_t> fromBase64SlowImpl(std::span<const CharacterType> span, std::span<uint8_t> output, Alphabet alphabet, LastChunkHandling lastChunkHandling)
+static inline simdutf::base64_options toSIMDUTFDecodeOptions(Alphabet alphabet)
 {
-    size_t read = 0;
-    size_t write = 0;
-    size_t length = span.size();
-
-    if (!output.size())
-        return { FromBase64ShouldThrowError::No, 0, 0 };
-
-    std::array<char16_t, 4> chunk { 0, 0, 0, 0 };
-    size_t chunkLength = 0;
-
-    for (size_t i = 0; i < length;) {
-        char16_t c = span[i++];
-
-        if (isASCIIWhitespace(c))
-            continue;
-
-        if (c == '=') {
-            if (chunkLength < 2)
-                return { FromBase64ShouldThrowError::Yes, read, write };
-
-            while (i < length && isASCIIWhitespace(span[i]))
-                ++i;
-
-            if (chunkLength == 2) {
-                if (i == length) {
-                    if (lastChunkHandling == LastChunkHandling::StopBeforePartial)
-                        return { FromBase64ShouldThrowError::No, read, write };
-
-                    return { FromBase64ShouldThrowError::Yes, read, write };
-                }
-
-                if (span[i] == '=') {
-                    do {
-                        ++i;
-                    } while (i < length && isASCIIWhitespace(span[i]));
-                }
-            }
-
-            if (i < length)
-                return { FromBase64ShouldThrowError::Yes, read, write };
-
-            for (size_t j = chunkLength; j < 4; ++j)
-                chunk[j] = 'A';
-
-            auto decodedVector = base64Decode(StringView(std::span { chunk }));
-            if (!decodedVector)
-                return { FromBase64ShouldThrowError::Yes, read, write };
-            auto decoded = decodedVector->span();
-
-            ASSERT(chunkLength >= 2);
-            ASSERT(chunkLength <= 4);
-            if (chunkLength == 2 || chunkLength == 3) {
-                if (lastChunkHandling == LastChunkHandling::Strict && decoded[chunkLength - 1])
-                    return { FromBase64ShouldThrowError::Yes, read, write };
-
-                decoded = decoded.first(chunkLength - 1);
-            }
-
-            memcpySpan(output.subspan(write), decoded);
-            write += decoded.size();
-            return { FromBase64ShouldThrowError::No, length, write };
-        }
-
-        if (alphabet == Alphabet::Base64URL) {
-            if (c == '+' || c == '/')
-                return { FromBase64ShouldThrowError::Yes, read, write };
-
-            if (c == '-')
-                c = '+';
-            else if (c == '_')
-                c = '/';
-        }
-
-        if (!StringView("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"_s).contains(c))
-            return { FromBase64ShouldThrowError::Yes, read, write };
-
-        auto remaining = output.size() - write;
-        if ((remaining == 1 && chunkLength == 2) || (remaining == 2 && chunkLength == 3))
-            return { FromBase64ShouldThrowError::No, read, write };
-
-        chunk[chunkLength++] = c;
-        if (chunkLength != 4)
-            continue;
-
-        auto decodedVector = base64Decode(StringView(std::span { chunk }));
-        ASSERT(decodedVector);
-        if (!decodedVector)
-            return { FromBase64ShouldThrowError::Yes, read, write };
-        auto decoded = decodedVector->span();
-
-        read = i;
-        memcpySpan(output.subspan(write), decoded);
-        write += decoded.size();
-        if (write == output.size())
-            return { FromBase64ShouldThrowError::No, read, write };
-
-        for (size_t j = 0; j < 4; ++j)
-            chunk[j] = 0;
-        chunkLength = 0;
+    switch (alphabet) {
+    case Alphabet::Base64:
+        return simdutf::base64_default;
+    case Alphabet::Base64URL:
+        return simdutf::base64_url;
     }
+    RELEASE_ASSERT_NOT_REACHED();
+}
 
-    if (chunkLength) {
-        if (lastChunkHandling == LastChunkHandling::StopBeforePartial)
-            return { FromBase64ShouldThrowError::No, read, write };
-
-        if (lastChunkHandling == LastChunkHandling::Strict || chunkLength == 1)
-            return { FromBase64ShouldThrowError::Yes, read, write };
-
-        for (size_t j = chunkLength; j < 4; ++j)
-            chunk[j] = 'A';
-
-        auto decodedVector = base64Decode(StringView(std::span { chunk }.first(chunkLength)));
-        ASSERT(decodedVector);
-        if (!decodedVector)
-            return { FromBase64ShouldThrowError::Yes, read, write };
-        auto decoded = decodedVector->span();
-
-        if (chunkLength == 2 || chunkLength == 3)
-            decoded = decoded.first(chunkLength - 1);
-
-        memcpySpan(output.subspan(write), decoded);
-        write += decoded.size();
+static inline simdutf::last_chunk_handling_options toSIMDUTFLastChunkHandling(LastChunkHandling lastChunkHandling)
+{
+    switch (lastChunkHandling) {
+    case LastChunkHandling::Loose:
+        return simdutf::last_chunk_handling_options::loose;
+    case LastChunkHandling::Strict:
+        return simdutf::last_chunk_handling_options::strict;
+    case LastChunkHandling::StopBeforePartial:
+        return simdutf::last_chunk_handling_options::stop_before_partial;
     }
+    RELEASE_ASSERT_NOT_REACHED();
+}
 
-    return { FromBase64ShouldThrowError::No, length, write };
+template<typename CharacterType>
+static inline size_t fixSIMDUTFStopBeforePartialReadLength(std::span<const CharacterType> span, size_t readLengthFromSIMDUTF)
+{
+    // Work around simdutf bug for stop-before-partial read length.
+    // FIXME: Remove once fixed in simdutf.
+
+    // First go backwards to find the last non-whitespace character read.
+    size_t idx = readLengthFromSIMDUTF;
+    while (idx && isASCIIWhitespace(span[idx - 1]))
+        idx--;
+
+    // This is the correct read length if the input doesn't end in trailing whitespace.
+    size_t fixedReadLength = idx;
+
+    // If the input ends in trailing whitespace, the correct read length is the input size.
+    while (idx < span.size() && isASCIIWhitespace(span[idx]))
+        idx++;
+    if (idx == span.size())
+        fixedReadLength = span.size();
+
+    return fixedReadLength;
 }
 
 template<typename CharacterType>
 static std::tuple<FromBase64ShouldThrowError, size_t, size_t> fromBase64Impl(std::span<const CharacterType> span, std::span<uint8_t> output, Alphabet alphabet, LastChunkHandling lastChunkHandling)
 {
-    if (lastChunkHandling != LastChunkHandling::Loose)
-        return fromBase64SlowImpl(span, output, alphabet, lastChunkHandling);
-
     using UTFType = std::conditional_t<sizeof(CharacterType) == 1, char, char16_t>;
-    auto options = alphabet == Alphabet::Base64URL ? simdutf::base64_url : simdutf::base64_default;
-    if (!output.size())
-        return { FromBase64ShouldThrowError::No, 0, 0 };
 
     size_t outputLength = output.size();
     constexpr bool decodeUpToBadChar = true;
-    auto result = simdutf::base64_to_binary_safe(std::bit_cast<const UTFType*>(span.data()), span.size(), std::bit_cast<char*>(output.data()), outputLength, options, simdutf::last_chunk_handling_options::loose, decodeUpToBadChar);
+    auto result = simdutf::base64_to_binary_safe(std::bit_cast<const UTFType*>(span.data()), span.size(), std::bit_cast<char*>(output.data()), outputLength, toSIMDUTFDecodeOptions(alphabet), toSIMDUTFLastChunkHandling(lastChunkHandling), decodeUpToBadChar);
     switch (result.error) {
-    case simdutf::error_code::INVALID_BASE64_CHARACTER:
-        return { FromBase64ShouldThrowError::Yes, result.count, outputLength };
-
-    case simdutf::error_code::BASE64_INPUT_REMAINDER:
-        return { FromBase64ShouldThrowError::No, result.count, outputLength };
-
     case simdutf::error_code::OUTPUT_BUFFER_TOO_SMALL:
         return { FromBase64ShouldThrowError::No, result.count, outputLength };
 
-    case simdutf::error_code::SUCCESS:
-        return { FromBase64ShouldThrowError::No, span.size(), outputLength };
+    case simdutf::error_code::SUCCESS: {
+        size_t read;
+        if (lastChunkHandling == LastChunkHandling::StopBeforePartial) [[unlikely]]
+            read = fixSIMDUTFStopBeforePartialReadLength(span, result.count);
+        else
+            read = span.size();
+        return { FromBase64ShouldThrowError::No, read, outputLength };
+    }
 
     default:
         return { FromBase64ShouldThrowError::Yes, result.count, outputLength };


### PR DESCRIPTION
#### c5b50b5798c546487e961aa2984082c729c80b0b
<pre>
[JSC] Fix Uint8Array fromBase64 and setFromBase64 for invalid 1-chunk input
<a href="https://bugs.webkit.org/show_bug.cgi?id=295578">https://bugs.webkit.org/show_bug.cgi?id=295578</a>
<a href="https://rdar.apple.com/155346981">rdar://155346981</a>

Reviewed by Yusuke Suzuki.

This PR updates simdutf to 7.3.3, fixes handling of invalid 1-chunk input in
base64 decoding, and removes the slow fallback.

First, base64 input is changed to unconditionally decode even when the expected
decoded binary size is 0. Previously, there was a fast path in fromBase64 input
to an empty Uint8Array when the expected decoded binary size is 0. This is
incorrect when the input contains a single invalid chunk, as it skips decoding
entirely when it should attempt to and report the error.

Second, use simdutf to decode base64 for all values of lastChunkHandling.
Previously, simdutf was only used for &apos;loose&apos;, and a slow fallback was used for
&apos;strict&apos; and &apos;stop-before-partial&apos;. Now simdutf has support for all 3, so use
it and remove the fallback.

Note that simdutf currently has a bug for the read count when lastChunkHandling
is &apos;stop-before-partial&apos;, which this patch works around.

Canonical link: <a href="https://commits.webkit.org/297335@main">https://commits.webkit.org/297335@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33e2abc0d9655f71aad61a127313af16aca0e3b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111396 "1280 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21527 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117428 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61664 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39644 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84662 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25343 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100280 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65109 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24689 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18417 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61248 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/103889 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94729 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18483 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120630 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109950 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38445 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28569 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93586 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38821 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96550 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93410 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38517 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16290 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/34470 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17955 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38334 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43811 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/134225 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37999 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36182 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41332 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39701 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->