### PR TITLE
[SwiftUI] An Objective-C exception may sometimes be thrown when using a URLSchemeHandler that is synchronous

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WKURLSchemeHandlerAdapter.swift
+++ b/Source/WebKit/UIProcess/Cocoa/WKURLSchemeHandlerAdapter.swift
@@ -39,6 +39,8 @@ final class WKURLSchemeHandlerAdapter: NSObject, WKURLSchemeHandler {
         let task = Task {
             do {
                 for try await result in wrapped.reply(for: urlSchemeTask.request) {
+                    try Task.checkCancellation()
+
                     switch result {
                     case .response(let response):
                         urlSchemeTask.didReceive(response)


### PR DESCRIPTION
#### d1ca764838e40607f9cac3c359c65c80a456fa76
<pre>
[SwiftUI] An Objective-C exception may sometimes be thrown when using a URLSchemeHandler that is synchronous
<a href="https://bugs.webkit.org/show_bug.cgi?id=295829">https://bugs.webkit.org/show_bug.cgi?id=295829</a>
<a href="https://rdar.apple.com/155647966">rdar://155647966</a>

Reviewed by Wenson Hsieh.

297220@main fixed the version of this bug that happens when using Swift concurrency in a URLSchemeHandler by
using asynchronous functions and Tasks. This fix worked in this case because cancelling the scheme task resulted
in the handler&apos;s continuation terminating and skipping the for-try-await loop.

However, in the case of a purely synchronous implementation of URLSchemeHandler, the issue may still happen if
there is any expensive computation. This happens because unlike the async version, doing sync work is blocking,
and so the continuation doesn&apos;t actually end up terminating, and therefore the loop body gets executed.

Fix by checking for Task cancellation inside the loop in addition to after it.

Tested by updating an existing test to test both sync and async versions.

* Source/WebKit/UIProcess/Cocoa/WKURLSchemeHandlerAdapter.swift:
(WKURLSchemeHandlerAdapter.webView(_:start:)):
* Tools/TestWebKitAPI/Tests/WebKit Swift/URLSchemeHandlerTests.swift:
(reply(for:)):

Canonical link: <a href="https://commits.webkit.org/297301@main">https://commits.webkit.org/297301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f278b2a8bc4bbb2011f670a38be6d3086c4325d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111258 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30924 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117289 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/61526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113220 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31605 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39506 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/84560 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/61526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114205 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25236 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100167 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65006 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24578 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/18308 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61109 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94615 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18377 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120405 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38307 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/28463 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/93486 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38683 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96444 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93311 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38409 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16184 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34292 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17937 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38196 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43673 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37861 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41194 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39563 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->