### PR TITLE
Reduce unsafeness in async-clipboard module

### DIFF
--- a/Source/WebCore/Modules/async-clipboard/Clipboard.cpp
+++ b/Source/WebCore/Modules/async-clipboard/Clipboard.cpp
@@ -259,7 +259,7 @@ void Clipboard::getType(ClipboardItem& item, const String& type, Ref<DeferredPro
     if (RefPtr page = frame->page())
         resultAsString = page->applyLinkDecorationFiltering(resultAsString, LinkDecorationFilteringTrigger::Paste);
 
-    promise->resolve<IDLInterface<Blob>>(ClipboardItem::blobFromString(frame->document(), resultAsString, type));
+    promise->resolve<IDLInterface<Blob>>(ClipboardItem::blobFromString(frame->protectedDocument().get(), resultAsString, type));
 }
 
 Clipboard::SessionIsValid Clipboard::updateSessionValidity()
@@ -283,10 +283,11 @@ void Clipboard::write(const Vector<Ref<ClipboardItem>>& items, Ref<DeferredPromi
         return;
     }
 
-    if (auto existingWriter = std::exchange(m_activeItemWriter, ItemWriter::create(*this, WTFMove(promise))))
+    Ref newActiveItemWriter = ItemWriter::create(*this, WTFMove(promise));
+    if (RefPtr existingWriter = std::exchange(m_activeItemWriter, newActiveItemWriter.copyRef()))
         existingWriter->invalidate();
 
-    m_activeItemWriter->write(items);
+    newActiveItemWriter->write(items);
 }
 
 void Clipboard::didResolveOrReject(Clipboard::ItemWriter& writer)
@@ -324,7 +325,7 @@ void Clipboard::ItemWriter::write(const Vector<Ref<ClipboardItem>>& items)
     m_dataToWrite.fill(std::nullopt, items.size());
     m_pendingItemCount = items.size();
     for (size_t index = 0; index < items.size(); ++index) {
-        items[index]->collectDataForWriting(*m_clipboard, [this, protectedThis = Ref { *this }, index] (auto data) {
+        Ref { items[index] }->collectDataForWriting(Ref { *m_clipboard }.get(), [this, protectedThis = Ref { *this }, index](auto data) {
             protectedThis->setData(WTFMove(data), index);
             if (!--m_pendingItemCount)
                 didSetAllData();
@@ -352,7 +353,8 @@ void Clipboard::ItemWriter::setData(std::optional<PasteboardCustomData>&& data, 
 
 void Clipboard::ItemWriter::didSetAllData()
 {
-    if (!m_promise)
+    RefPtr promise = m_promise;
+    if (!promise)
         return;
 
     auto newChangeCount = m_pasteboard->changeCount();
@@ -375,7 +377,7 @@ void Clipboard::ItemWriter::didSetAllData()
     }
 
     m_pasteboard->writeCustomData(WTFMove(customData));
-    m_promise->resolve();
+    promise->resolve();
     m_promise = nullptr;
 
     if (auto clipboard = std::exchange(m_clipboard, nullptr))
@@ -384,7 +386,7 @@ void Clipboard::ItemWriter::didSetAllData()
 
 void Clipboard::ItemWriter::reject()
 {
-    if (auto promise = std::exchange(m_promise, nullptr))
+    if (RefPtr promise = std::exchange(m_promise, nullptr))
         promise->reject(ExceptionCode::NotAllowedError);
 
     if (auto clipboard = std::exchange(m_clipboard, nullptr))

--- a/Source/WebCore/Modules/async-clipboard/NavigatorClipboard.cpp
+++ b/Source/WebCore/Modules/async-clipboard/NavigatorClipboard.cpp
@@ -50,13 +50,13 @@ RefPtr<Clipboard> NavigatorClipboard::clipboard(Navigator& navigator)
 RefPtr<Clipboard> NavigatorClipboard::clipboard()
 {
     if (!m_clipboard)
-        lazyInitialize(m_clipboard, Clipboard::create(Ref { m_navigator.get() }));
+        lazyInitialize(m_clipboard, Clipboard::create(m_navigator.get()));
     return m_clipboard;
 }
 
 NavigatorClipboard* NavigatorClipboard::from(Navigator& navigator)
 {
-    auto* supplement = static_cast<NavigatorClipboard*>(Supplement<Navigator>::from(&navigator, supplementName()));
+    auto* supplement = downcast<NavigatorClipboard>(Supplement<Navigator>::from(&navigator, supplementName()));
     if (!supplement) {
         auto newSupplement = makeUnique<NavigatorClipboard>(navigator);
         supplement = newSupplement.get();
@@ -65,9 +65,4 @@ NavigatorClipboard* NavigatorClipboard::from(Navigator& navigator)
     return supplement;
 }
 
-ASCIILiteral NavigatorClipboard::supplementName()
-{
-    return "NavigatorClipboard"_s;
-}
-
-}
+} // namespace WebCore

--- a/Source/WebCore/Modules/async-clipboard/NavigatorClipboard.h
+++ b/Source/WebCore/Modules/async-clipboard/NavigatorClipboard.h
@@ -46,10 +46,15 @@ public:
 
 private:
     static NavigatorClipboard* from(Navigator&);
-    static ASCIILiteral supplementName();
+    static ASCIILiteral supplementName() { return "NavigatorClipboard"_s; }
+    bool isNavigatorClipboard() const final { return true; }
 
     const RefPtr<Clipboard> m_clipboard;
     const CheckedRef<Navigator> m_navigator;
 };
 
-}
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::NavigatorClipboard)
+    static bool isType(const WebCore::SupplementBase& supplement) { return supplement.isNavigatorClipboard(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/Modules/async-clipboard/mac/ClipboardImageReaderMac.mm
+++ b/Source/WebCore/Modules/async-clipboard/mac/ClipboardImageReaderMac.mm
@@ -38,8 +38,8 @@ void ClipboardImageReader::readBuffer(const String&, const String&, Ref<SharedBu
 {
     if (m_mimeType == "image/png"_s) {
         auto image = adoptNS([[NSImage alloc] initWithData:buffer->createNSData().get()]);
-        if (auto cgImage = [image CGImageForProposedRect:nil context:nil hints:nil]) {
-            auto representation = adoptNS([[NSBitmapImageRep alloc] initWithCGImage:cgImage]);
+        if (RetainPtr cgImage = [image CGImageForProposedRect:nil context:nil hints:nil]) {
+            auto representation = adoptNS([[NSBitmapImageRep alloc] initWithCGImage:cgImage.get()]);
             NSData* nsData = [representation representationUsingType:NSBitmapImageFileTypePNG properties:@{ }];
             m_result = Blob::create(m_document.get(), makeVector(nsData), m_mimeType);
         }

--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -4,7 +4,6 @@ MathMLNames.cpp
 Modules/WebGPU/Implementation/WebGPUBindGroupImpl.cpp
 Modules/WebGPU/Implementation/WebGPUDowncastConvertToBackingContext.cpp
 Modules/WebGPU/Implementation/WebGPUXRBindingImpl.cpp
-Modules/async-clipboard/NavigatorClipboard.cpp
 Modules/audiosession/NavigatorAudioSession.cpp
 Modules/beacon/NavigatorBeacon.cpp
 Modules/cache/WindowOrWorkerGlobalScopeCaches.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -1,6 +1,5 @@
 Modules/airplay/WebMediaSessionManager.cpp
 Modules/applicationmanifest/ApplicationManifestParser.cpp
-Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
 Modules/credentialmanagement/CredentialsContainer.cpp
 Modules/gamepad/GamepadManager.cpp
 Modules/indexeddb/IDBCursor.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -6,8 +6,6 @@ Modules/airplay/WebMediaSessionManager.cpp
 Modules/applepay/ApplePaySession.cpp
 Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp
 Modules/applicationmanifest/ApplicationManifestParser.cpp
-Modules/async-clipboard/Clipboard.cpp
-Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
 Modules/audiosession/DOMAudioSession.cpp
 Modules/cache/DOMCache.cpp
 Modules/cache/DOMCacheStorage.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -1,5 +1,4 @@
 Modules/applicationmanifest/ApplicationManifestParser.cpp
-Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
 Modules/cache/DOMCache.cpp
 Modules/cache/DOMCacheStorage.cpp
 Modules/gamepad/GamepadHapticActuator.cpp

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -1,5 +1,4 @@
 Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.mm
-Modules/async-clipboard/mac/ClipboardImageReaderMac.mm
 accessibility/cocoa/AXCoreObjectCocoa.mm
 accessibility/cocoa/AccessibilityObjectCocoa.mm
 accessibility/mac/AXObjectCacheMac.mm

--- a/Source/WebCore/platform/Supplementable.h
+++ b/Source/WebCore/platform/Supplementable.h
@@ -80,6 +80,7 @@ public:
     // a TypeCastTraits specialization. The isBar() function needed for this
     // specialization can be implemented here and overridden in the base class.
 
+    virtual bool isNavigatorClipboard() const { return false; }
     virtual bool isNavigatorCookieConsent() const { return false; }
 };
 


### PR DESCRIPTION
#### 06dcef93927f73b078537a292e1d656f52437919
<pre>
Reduce unsafeness in async-clipboard module
<a href="https://bugs.webkit.org/show_bug.cgi?id=295832">https://bugs.webkit.org/show_bug.cgi?id=295832</a>

Reviewed by Ryosuke Niwa.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/297314@main">https://commits.webkit.org/297314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1b75264bb599e2f80f6ffcbf6ad7383c89f199a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111279 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30945 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21410 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117311 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61547 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31626 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39527 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84580 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114226 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25255 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100189 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65026 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24597 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18330 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61130 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94635 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18397 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120460 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38328 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28481 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93511 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38704 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96464 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93335 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38428 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16204 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34324 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17943 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38217 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43694 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37882 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41215 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39584 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->