### PR TITLE
[JSC] Arrayify should not convert CoW to non-CoW on Read

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -4695,7 +4695,9 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         }
         ASSERT(node->arrayMode().conversion() == Array::Convert);
         clobberStructures();
-        filterArrayModes(node->child1(), node->arrayMode().arrayModesThatPassFiltering());
+        auto arrayModes = node->arrayMode().arrayModesThatPassFiltering();
+        filterArrayModes(node->child1(), arrayModes);
+        forNode(node->child1()).m_arrayModes = arrayModes;
         break;
     }
     case ArrayifyToStructure: {

--- a/Source/JavaScriptCore/dfg/DFGArrayMode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGArrayMode.cpp
@@ -470,7 +470,10 @@ bool ArrayMode::alreadyChecked(Graph& graph, Node* node, const AbstractValue& va
 
     switch (arrayClass()) {
     case Array::Array: {
-        if (arrayModesAlreadyChecked(value.m_arrayModes, asArrayModesIgnoringTypedArrays(shape | IsArray)))
+        ArrayModes expected = asArrayModesIgnoringTypedArrays(shape | IsArray);
+        if (action() == Array::Read)
+            expected |= asArrayModesIgnoringTypedArrays(shape | IsArray | CopyOnWrite);
+        if (arrayModesAlreadyChecked(value.m_arrayModes, expected))
             return true;
         if (!value.m_structure.isFinite())
             return false;

--- a/Source/JavaScriptCore/dfg/DFGArrayMode.h
+++ b/Source/JavaScriptCore/dfg/DFGArrayMode.h
@@ -265,12 +265,29 @@ public:
                 case Array::Double:
                 case Array::Contiguous: {
                     ArrayModes arrayModes = profile->observedArrayModes(locker);
-                    if (hasSeenCopyOnWriteArray(arrayModes) && !hasSeenWritableArray(arrayModes))
+                    if (hasSeenCopyOnWriteArray(arrayModes) && !hasSeenWritableArray(arrayModes)) {
                         myArrayClass = Array::OriginalCopyOnWriteArray;
-                    else if (!hasSeenCopyOnWriteArray(arrayModes) && hasSeenWritableArray(arrayModes))
+                        break;
+                    }
+
+                    if (!hasSeenCopyOnWriteArray(arrayModes) && hasSeenWritableArray(arrayModes)) {
                         myArrayClass = Array::OriginalNonCopyOnWriteArray;
-                    else
-                        myArrayClass = Array::OriginalArray;
+                        break;
+                    }
+
+                    if (action() == Array::Read && conversion() == Array::Convert) {
+                        if ((type() == Array::Int32 && arrayModes & CopyOnWriteArrayWithInt32ArrayMode)
+                            || (type() == Array::Double && arrayModes & CopyOnWriteArrayWithDoubleArrayMode)
+                            || (type() == Array::Contiguous && arrayModes & CopyOnWriteArrayWithContiguousArrayMode)) {
+                            // This site is observing both CoW and non-CoW arrays.
+                            // And we need some conversion if necessary, and there is a chance that CoW array can be used directly.
+                            // Then, instead of requiring original Array, we can just relax it to Array so that we can just use array mode
+                            // and do not need to convert CoW array to non-CoW array while they have the same array modes.
+                            myArrayClass = Array::Array;
+                            break;
+                        }
+                    }
+                    myArrayClass = Array::OriginalArray;
                     break;
                 }
                 case Array::Undecided:

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -394,6 +394,7 @@ private:
             case Arrayify: {
                 if (!node->arrayMode().alreadyChecked(m_graph, node, m_state.forNode(node->child1())))
                     break;
+                m_interpreter.execute(indexInBlock); // Catch the fact that we may filter on cell.
                 node->remove(m_graph);
                 eliminated = true;
                 break;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -1065,7 +1065,7 @@ JITCompiler::JumpList SpeculativeJIT::jumpSlowForUnwantedArrayMode(GPRReg tempGP
         case Array::OriginalArray:
         case Array::OriginalNonCopyOnWriteArray:
         case Array::OriginalCopyOnWriteArray:
-            RELEASE_ASSERT_NOT_REACHED();
+            DFG_CRASH(m_graph, m_currentNode, "Bad array mode");
             return result;
 
         case Array::Array:


### PR DESCRIPTION
#### e929d84ee61530b5919ce327f9227053590dcc6a
<pre>
[JSC] Arrayify should not convert CoW to non-CoW on Read
<a href="https://bugs.webkit.org/show_bug.cgi?id=295833">https://bugs.webkit.org/show_bug.cgi?id=295833</a>
<a href="https://rdar.apple.com/155674843">rdar://155674843</a>

Reviewed by NOBODY (OOPS!).

WIP

* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGArrayMode.cpp:
(JSC::DFG::ArrayMode::alreadyChecked const):
* Source/JavaScriptCore/dfg/DFGArrayMode.h:
(JSC::DFG::ArrayMode::withProfile const):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::jumpSlowForUnwantedArrayMode):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e929d84ee61530b5919ce327f9227053590dcc6a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111264 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30930 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21395 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117296 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61532 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31611 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39512 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84567 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114211 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25242 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100175 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65013 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24584 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18316 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61115 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/103756 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94621 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18384 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120413 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109817 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38313 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28468 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93493 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38689 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96451 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93318 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38415 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16191 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34300 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38202 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43679 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/134093 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37867 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36157 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41200 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39569 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->