### PR TITLE
[JSC] Extend DoubleToStringCache

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -998,6 +998,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/DisposableStackConstructor.h
     runtime/DisposableStackPrototype.h
     runtime/DisposableStackPrototypeInlines.h
+    runtime/DoubleToStringCache.h
     runtime/DumpContext.h
     runtime/ECMAMode.h
     runtime/EnsureStillAliveHere.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2084,6 +2084,7 @@
 		E3C8ED4323A1DBCB00131958 /* IsoInlinedHeapCellType.h in Headers */ = {isa = PBXBuildFile; fileRef = E3C8ED4223A1DBC500131958 /* IsoInlinedHeapCellType.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3CA3A4E2527AB2F004802BF /* JITOperationList.h in Headers */ = {isa = PBXBuildFile; fileRef = E3CA3A4C2527AB2F004802BF /* JITOperationList.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3CDCFAF28DD065A00215350 /* ImportMap.h in Headers */ = {isa = PBXBuildFile; fileRef = E3CDCFAE28DD065A00215350 /* ImportMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E3CE33872DFFB4FD00E763AB /* DoubleToStringCache.h in Headers */ = {isa = PBXBuildFile; fileRef = E3CE33842DFFB4ED00E763AB /* DoubleToStringCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3D239C91B829C1C00BBEF67 /* JSModuleEnvironment.h in Headers */ = {isa = PBXBuildFile; fileRef = E3D239C71B829C1C00BBEF67 /* JSModuleEnvironment.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3D3515F241B89D7008DC16E /* MarkedJSValueRefArray.h in Headers */ = {isa = PBXBuildFile; fileRef = E3D3515D241B89CE008DC16E /* MarkedJSValueRefArray.h */; };
 		E3D4FFE22AF21D96004ED359 /* InlineAttribute.h in Headers */ = {isa = PBXBuildFile; fileRef = E3D4FFE12AF21D96004ED359 /* InlineAttribute.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5624,6 +5625,7 @@
 		E319A3EB28DA84EB00DF18C7 /* IntlDurationFormatPrototype.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IntlDurationFormatPrototype.h; sourceTree = "<group>"; };
 		E31C31302511AFD600E7A3A0 /* IntlCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IntlCache.h; sourceTree = "<group>"; };
 		E31C31312511AFD600E7A3A0 /* IntlCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IntlCache.cpp; sourceTree = "<group>"; };
+		E320796B2E2268F700332457 /* NumericStrings.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NumericStrings.cpp; sourceTree = "<group>"; };
 		E320B66A2912298000E87CDB /* MemoryMode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MemoryMode.h; sourceTree = "<group>"; };
 		E320B66B2912298000E87CDB /* MemoryMode.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MemoryMode.cpp; sourceTree = "<group>"; };
 		E322E5A01DA64435006E7709 /* DFGSnippetParams.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DFGSnippetParams.cpp; path = dfg/DFGSnippetParams.cpp; sourceTree = "<group>"; };
@@ -5841,6 +5843,8 @@
 		E3CA3A4B2527AB2E004802BF /* JITOperationList.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JITOperationList.cpp; sourceTree = "<group>"; };
 		E3CA3A4C2527AB2F004802BF /* JITOperationList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JITOperationList.h; sourceTree = "<group>"; };
 		E3CDCFAE28DD065A00215350 /* ImportMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ImportMap.h; sourceTree = "<group>"; };
+		E3CE33842DFFB4ED00E763AB /* DoubleToStringCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DoubleToStringCache.h; sourceTree = "<group>"; };
+		E3CE33852DFFB4ED00E763AB /* DoubleToStringCache.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DoubleToStringCache.cpp; sourceTree = "<group>"; };
 		E3D239C61B829C1C00BBEF67 /* JSModuleEnvironment.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSModuleEnvironment.cpp; sourceTree = "<group>"; };
 		E3D239C71B829C1C00BBEF67 /* JSModuleEnvironment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSModuleEnvironment.h; sourceTree = "<group>"; };
 		E3D264261D38C042000BE174 /* BytecodeGeneratorification.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BytecodeGeneratorification.cpp; sourceTree = "<group>"; };
@@ -8180,6 +8184,8 @@
 				278D26042A70CF20007F5BC3 /* DOMAttributeGetterSetterInlines.h */,
 				E3FC25102256ECF400583518 /* DoublePredictionFuzzerAgent.cpp */,
 				E3FC25112256ECF400583518 /* DoublePredictionFuzzerAgent.h */,
+				E3CE33852DFFB4ED00E763AB /* DoubleToStringCache.cpp */,
+				E3CE33842DFFB4ED00E763AB /* DoubleToStringCache.h */,
 				A70447EB17A0BD7000F5898E /* DumpContext.cpp */,
 				A70447EC17A0BD7000F5898E /* DumpContext.h */,
 				145FF2C6243BB99A00569E71 /* ECMAMode.cpp */,
@@ -8710,6 +8716,7 @@
 				BC2680C40E16D4E900A06E92 /* NumberPrototype.cpp */,
 				BC2680C50E16D4E900A06E92 /* NumberPrototype.h */,
 				276B39072A71D2B400252F4E /* NumberPrototypeInlines.h */,
+				E320796B2E2268F700332457 /* NumericStrings.cpp */,
 				142D3938103E4560007DCB52 /* NumericStrings.h */,
 				E38F0919288D35CF009FD386 /* ObjectAdaptiveStructureWatchpoint.h */,
 				BC2680C60E16D4E900A06E92 /* ObjectConstructor.cpp */,
@@ -10890,6 +10897,7 @@
 				E3FF75331D9CEA1800C7E16D /* DOMJITGetterSetter.h in Headers */,
 				E35CA1541DBC3A5C00F83516 /* DOMJITHeapRange.h in Headers */,
 				E350708A1DC49BBF0089BCD6 /* DOMJITSignature.h in Headers */,
+				E3CE33872DFFB4FD00E763AB /* DoubleToStringCache.h in Headers */,
 				A70447EE17A0BD7000F5898E /* DumpContext.h in Headers */,
 				145FF2C8243BB9D600569E71 /* ECMAMode.h in Headers */,
 				2A83638618D7D0EE0000EBCC /* EdenGCActivityCallback.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -795,6 +795,7 @@ runtime/DirectEvalExecutable.cpp
 runtime/DisposableStackConstructor.cpp
 runtime/DisposableStackPrototype.cpp
 runtime/DoublePredictionFuzzerAgent.cpp
+runtime/DoubleToStringCache.cpp
 runtime/DumpContext.cpp
 runtime/ECMAMode.cpp
 runtime/Error.cpp
@@ -992,6 +993,7 @@ runtime/NumberConstructor.cpp
 runtime/NumberObject.cpp
 runtime/NumberPredictionFuzzerAgent.cpp
 runtime/NumberPrototype.cpp
+runtime/NumericStrings.cpp
 runtime/ObjectConstructor.cpp
 runtime/ObjectInitializationScope.cpp
 runtime/ObjectPrototype.cpp

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -1709,6 +1709,7 @@ NEVER_INLINE bool Heap::runEndPhase(GCConductor conn)
         sweepArrayBuffers();
         snapshotUnswept();
         finalizeUnconditionalFinalizers(); // We rely on these unconditional finalizers running before clearCurrentlyExecuting since CodeBlock's finalizer relies on querying currently executing.
+        vm().numericStrings.finalizeUnconditionally(vm(), collectionScope().value_or(CollectionScope::Full));
         removeDeadCompilerWorklistEntries();
     }
 
@@ -2266,7 +2267,6 @@ void Heap::finalize()
 
     if (m_lastCollectionScope && m_lastCollectionScope.value() == CollectionScope::Full) {
         vm().jsonAtomStringCache.clear();
-        vm().numericStrings.clearOnGarbageCollection();
         vm().stringReplaceCache.clear();
     }
     vm().keyAtomStringCache.clear();

--- a/Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h
@@ -294,7 +294,7 @@ inline bool canUseFastArrayJoin(const JSObject* thisObject)
 }
 
 // This is intentionally supporting non-JSArray as well.
-inline JSString* fastArrayJoin(JSGlobalObject* globalObject, JSObject* thisObject, StringView separator, unsigned length, bool& sawHoles, bool& genericCase)
+ALWAYS_INLINE JSString* fastArrayJoin(JSGlobalObject* globalObject, JSObject* thisObject, StringView separator, unsigned length, bool& sawHoles, bool& genericCase)
 {
     VM& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);

--- a/Source/JavaScriptCore/runtime/DoubleToStringCache.cpp
+++ b/Source/JavaScriptCore/runtime/DoubleToStringCache.cpp
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DoubleToStringCache.h"
+
+#include "JSCInlines.h"
+#include <wtf/Assertions.h>
+#include <wtf/TZoneMallocInlines.h>
+#include <wtf/dragonbox/dragonbox_to_chars.h>
+#include <wtf/dtoa.h>
+#include <wtf/dtoa/double-conversion.h>
+#include <wtf/text/MakeString.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DoubleToStringCache);
+
+const String& DoubleToStringCache::add(VM& vm, double d)
+{
+    uint64_t bits = std::bit_cast<uint64_t>(d);
+    if (!bits)
+        return vm.numericStrings.add(0);
+
+    auto& entry = acquire(bits);
+    if (bits == entry.key)
+        return entry.value;
+    entry.key = bits;
+    entry.value = String::number(d);
+    entry.jsString = nullptr;
+    return entry.value;
+}
+
+JSString* DoubleToStringCache::addJSString(VM& vm, double value)
+{
+    uint64_t bits = std::bit_cast<uint64_t>(value);
+    if (!bits)
+        return vm.numericStrings.addJSString(vm, 0);
+
+    auto& entry = acquire(bits);
+    if (bits != entry.key) {
+        entry.key = bits;
+        entry.value = String::number(value);
+    } else {
+        if (entry.jsString)
+            return entry.jsString;
+    }
+    entry.jsString = jsNontrivialString(vm, entry.value);
+    return entry.jsString;
+}
+
+ALWAYS_INLINE unsigned DoubleToStringCache::primaryHash(uint64_t bits)
+{
+    return static_cast<uint32_t>(bits) ^ static_cast<uint32_t>(bits >> 32);
+}
+
+ALWAYS_INLINE unsigned DoubleToStringCache::secondaryHash(uint64_t bits)
+{
+    return WTF::IntHash<uint64_t>::hash(bits);
+}
+
+ALWAYS_INLINE DoubleToStringCache::CacheEntryWithJSString<uint64_t>& DoubleToStringCache::acquire(uint64_t bits)
+{
+    auto& entry0 = m_primaryCache[primaryHash(bits) & (m_primaryCache.size() - 1)];
+    if (entry0.key == bits)
+        return entry0;
+
+    auto& entry1 = m_secondaryCache[secondaryHash(bits) & (m_secondaryCache.size() - 1)];
+    if (entry1.key == bits)
+        return entry1;
+
+    if (entry0.key)
+        m_secondaryCache[secondaryHash(entry0.key) & (m_secondaryCache.size() - 1)] = std::exchange(entry0, { });
+    return entry0;
+}
+
+template<typename Visitor>
+void DoubleToStringCache::visitAggregateImpl(Visitor& visitor)
+{
+    // We do not keep them!
+#if 1
+    for (auto& entry : m_primaryCache)
+        visitor.appendUnbarriered(entry.jsString);
+    for (auto& entry : m_secondaryCache)
+        visitor.appendUnbarriered(entry.jsString);
+#else
+    UNUSED_PARAM(visitor);
+#endif
+}
+
+DEFINE_VISIT_AGGREGATE(DoubleToStringCache);
+
+void DoubleToStringCache::finalizeUnconditionally(VM& vm, CollectionScope collectionScope)
+{
+#if 1
+    UNUSED_PARAM(vm);
+    if (collectionScope == CollectionScope::Full) {
+        for (auto& entry : m_primaryCache)
+            entry.jsString = nullptr;
+        for (auto& entry : m_secondaryCache)
+            entry.jsString = nullptr;
+    }
+#else
+    UNUSED_PARAM(collectionScope);
+    for (auto& entry : m_primaryCache) {
+        if (entry.jsString && !vm.heap.isMarked(entry.jsString))
+            entry.jsString = nullptr;
+    }
+    for (auto& entry : m_secondaryCache) {
+        if (entry.jsString && !vm.heap.isMarked(entry.jsString))
+            entry.jsString = nullptr;
+    }
+#endif
+}
+
+} // namespace JSC
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/runtime/DoubleToStringCache.h
+++ b/Source/JavaScriptCore/runtime/DoubleToStringCache.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "SlotVisitorMacros.h"
+#include <array>
+#include <wtf/HashFunctions.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/text/WTFString.h>
+
+namespace JSC {
+
+class JSString;
+class VM;
+
+class DoubleToStringCache {
+    WTF_MAKE_TZONE_ALLOCATED(DoubleToStringCache);
+public:
+    static const size_t primaryCacheSize = 4096;
+    static const size_t secondaryCacheSize = 1024;
+
+    template<typename T>
+    struct CacheEntryWithJSString {
+        T key { };
+        String value { };
+        JSString* jsString { nullptr };
+    };
+
+    const String& add(VM&, double);
+    JSString* addJSString(VM&, double);
+
+    DoubleToStringCache() = default;
+
+    DECLARE_VISIT_AGGREGATE;
+    void finalizeUnconditionally(VM&, CollectionScope);
+
+private:
+    CacheEntryWithJSString<uint64_t>& acquire(uint64_t);
+
+    static unsigned primaryHash(uint64_t);
+    static unsigned secondaryHash(uint64_t);
+
+    std::array<CacheEntryWithJSString<uint64_t>, primaryCacheSize> m_primaryCache { };
+    std::array<CacheEntryWithJSString<uint64_t>, secondaryCacheSize> m_secondaryCache { };
+};
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/Identifier.cpp
+++ b/Source/JavaScriptCore/runtime/Identifier.cpp
@@ -52,7 +52,7 @@ Identifier Identifier::from(VM& vm, int value)
 
 Identifier Identifier::from(VM& vm, double value)
 {
-    return Identifier(vm, vm.numericStrings.add(value));
+    return Identifier(vm, vm.numericStrings.add(vm, value));
 }
 
 void Identifier::dump(PrintStream& out) const

--- a/Source/JavaScriptCore/runtime/JSCJSValue.cpp
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.cpp
@@ -413,7 +413,7 @@ String JSValue::toWTFStringSlowCase(JSGlobalObject* globalObject) const
     if (isInt32())
         return vm.numericStrings.add(asInt32());
     if (isDouble())
-        return vm.numericStrings.add(asDouble());
+        return vm.numericStrings.add(vm, asDouble());
     if (isTrue())
         return vm.propertyNames->trueKeyword.string();
     if (isFalse())

--- a/Source/JavaScriptCore/runtime/JSStringJoiner.h
+++ b/Source/JavaScriptCore/runtime/JSStringJoiner.h
@@ -218,7 +218,7 @@ ALWAYS_INLINE void JSStringJoiner::appendNumber(VM& vm, double value)
     if (canBeStrictInt32(value))
         appendNumber(vm, static_cast<int32_t>(value));
     else
-        append8Bit(vm.numericStrings.add(value));
+        append8Bit(vm.numericStrings.add(vm, value));
 }
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

--- a/Source/JavaScriptCore/runtime/NumberPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/NumberPrototype.cpp
@@ -486,52 +486,6 @@ JSC_DEFINE_HOST_FUNCTION(numberProtoFuncToPrecision, (JSGlobalObject* globalObje
     return JSValue::encode(jsString(vm, String::numberToStringFixedPrecision(x, significantFigures, TrailingZerosPolicy::Keep)));
 }
 
-JSString* NumericStrings::addJSString(VM& vm, int i)
-{
-    if (static_cast<unsigned>(i) < cacheSize) {
-        auto& entry = lookupSmallString(static_cast<unsigned>(i));
-        if (entry.jsString)
-            return entry.jsString;
-        entry.jsString = jsNontrivialString(vm, entry.value);
-        return entry.jsString;
-    }
-    auto& entry = lookup(i);
-    if (i != entry.key || entry.value.isNull()) {
-        entry.key = i;
-        entry.value = String::number(i);
-    } else {
-        if (entry.jsString)
-            return entry.jsString;
-    }
-    entry.jsString = jsNontrivialString(vm, entry.value);
-    return entry.jsString;
-}
-
-JSString* NumericStrings::addJSString(VM& vm, double value)
-{
-    auto& entry = lookup(value);
-    if (value != entry.key || entry.value.isNull()) {
-        entry.key = value;
-        entry.value = String::number(value);
-    } else {
-        if (entry.jsString)
-            return entry.jsString;
-    }
-    entry.jsString = jsNontrivialString(vm, entry.value);
-    return entry.jsString;
-}
-
-void NumericStrings::initializeSmallIntCache(VM& vm)
-{
-    for (int i = 0; i < 10; ++i) {
-        auto* string = vm.smallStrings.singleCharacterString(i + '0');
-        auto& entry = lookupSmallString(static_cast<unsigned>(i));
-        entry.jsString = string;
-        ASSERT(string->tryGetValueImpl());
-        entry.value = string->tryGetValue();
-    }
-}
-
 static ALWAYS_INLINE JSString* int32ToStringInternal(VM& vm, int32_t value, int32_t radix)
 {
     ASSERT(!(radix < 2 || radix > 36));
@@ -587,7 +541,7 @@ JSString* int52ToString(VM& vm, int64_t value, int32_t radix)
         return int32ToString(vm, static_cast<int32_t>(value), radix);
 
     if (radix == 10)
-        return jsNontrivialString(vm, vm.numericStrings.add(static_cast<double>(value)));
+        return jsNontrivialString(vm, vm.numericStrings.add(vm, static_cast<double>(value)));
 
     // Position the decimal point at the center of the string, set
     // the startOfResultString pointer to point at the decimal point.

--- a/Source/JavaScriptCore/runtime/NumericStrings.cpp
+++ b/Source/JavaScriptCore/runtime/NumericStrings.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "NumericStrings.h"
+
+#include "JSString.h"
+#include "VM.h"
+#include <wtf/Assertions.h>
+#include <wtf/text/MakeString.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+namespace JSC {
+
+template<typename Visitor>
+void NumericStrings::visitAggregateImpl(Visitor& visitor)
+{
+    for (auto& entry : m_intCache)
+        visitor.appendUnbarriered(entry.jsString);
+    // 0-9 are managed by SmallStrings. They never die.
+    for (unsigned i = 10; i < m_smallIntCache.size(); ++i)
+        visitor.appendUnbarriered(m_smallIntCache[i].jsString);
+    if (m_doubleCache)
+        m_doubleCache->visitAggregate(visitor);
+}
+
+DEFINE_VISIT_AGGREGATE(NumericStrings);
+
+void NumericStrings::finalizeUnconditionally(VM& vm, CollectionScope collectionScope)
+{
+    if (collectionScope == CollectionScope::Full) {
+        for (auto& entry : m_intCache)
+            entry.jsString = nullptr;
+        // 0-9 are managed by SmallStrings. They never die.
+        for (unsigned i = 10; i < m_smallIntCache.size(); ++i)
+            m_smallIntCache[i].jsString = nullptr;
+    }
+    if (m_doubleCache)
+        m_doubleCache->finalizeUnconditionally(vm, collectionScope);
+}
+
+void NumericStrings::doubleToStringCacheSlow()
+{
+    auto cache = makeUnique<DoubleToStringCache>();
+    WTF::storeStoreFence();
+    m_doubleCache = WTFMove(cache);
+}
+
+void NumericStrings::initializeSmallIntCache(VM& vm)
+{
+    for (int i = 0; i < 10; ++i) {
+        auto* string = vm.smallStrings.singleCharacterString(i + '0');
+        auto& entry = lookupSmallString(static_cast<unsigned>(i));
+        entry.jsString = string;
+        ASSERT(string->tryGetValueImpl());
+        entry.value = string->tryGetValue();
+    }
+}
+
+JSString* NumericStrings::addJSString(VM& vm, int i)
+{
+    if (static_cast<unsigned>(i) < cacheSize) {
+        auto& entry = lookupSmallString(static_cast<unsigned>(i));
+        if (entry.jsString)
+            return entry.jsString;
+        entry.jsString = jsNontrivialString(vm, entry.value);
+        return entry.jsString;
+    }
+    auto& entry = lookup(i);
+    if (i != entry.key || entry.value.isNull()) {
+        entry.key = i;
+        entry.value = String::number(i);
+    } else {
+        if (entry.jsString)
+            return entry.jsString;
+    }
+    entry.jsString = jsNontrivialString(vm, entry.value);
+    return entry.jsString;
+}
+
+JSString* NumericStrings::addJSString(VM& vm, double value)
+{
+    return doubleToStringCache().addJSString(vm, value);
+}
+
+} // namespace JSC
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/runtime/NumericStrings.h
+++ b/Source/JavaScriptCore/runtime/NumericStrings.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "DoubleToStringCache.h"
 #include <array>
 #include <wtf/HashFunctions.h>
 #include <wtf/text/WTFString.h>
@@ -40,13 +41,13 @@ public:
 
     template<typename T>
     struct CacheEntry {
-        T key;
+        T key { };
         String value;
     };
 
     template<typename T>
     struct CacheEntryWithJSString {
-        T key;
+        T key { };
         String value;
         JSString* jsString { nullptr };
     };
@@ -58,23 +59,18 @@ public:
         static constexpr ptrdiff_t offsetOfJSString() { return OBJECT_OFFSETOF(StringWithJSString, jsString); }
     };
 
-    ALWAYS_INLINE const String& add(double d)
+    ALWAYS_INLINE const String& add(VM& vm, double d)
     {
-        auto& entry = lookup(d);
-        if (d == entry.key && !entry.value.isNull())
-            return entry.value;
-        entry.key = d;
-        entry.value = String::number(d);
-        entry.jsString = nullptr;
-        return entry.value;
+        return doubleToStringCache().add(vm, d);
     }
 
     ALWAYS_INLINE const String& add(int i)
     {
         if (static_cast<unsigned>(i) < cacheSize)
             return lookupSmallString(static_cast<unsigned>(i)).value;
+        ASSERT(i);
         auto& entry = lookup(i);
-        if (i == entry.key && !entry.value.isNull())
+        if (i == entry.key)
             return entry.value;
         entry.key = i;
         entry.value = String::number(i);
@@ -86,8 +82,9 @@ public:
     {
         if (i < cacheSize)
             return lookupSmallString(static_cast<unsigned>(i)).value;
+        ASSERT(i);
         auto& entry = lookup(i);
-        if (i == entry.key && !entry.value.isNull())
+        if (i == entry.key)
             return entry.value;
         entry.key = i;
         entry.value = String::number(i);
@@ -97,35 +94,21 @@ public:
     JSString* addJSString(VM&, int);
     JSString* addJSString(VM&, double);
 
-    void clearOnGarbageCollection()
-    {
-        for (auto& entry : m_intCache)
-            entry.jsString = nullptr;
-        for (auto& entry : m_doubleCache)
-            entry.jsString = nullptr;
-        // 0-9 are managed by SmallStrings. They never die.
-        for (unsigned i = 10; i < m_smallIntCache.size(); ++i)
-            m_smallIntCache[i].jsString = nullptr;
-    }
-
-    template<typename Visitor>
-    void visitAggregate(Visitor& visitor)
-    {
-        for (auto& entry : m_intCache)
-            visitor.appendUnbarriered(entry.jsString);
-        for (auto& entry : m_doubleCache)
-            visitor.appendUnbarriered(entry.jsString);
-        // 0-9 are managed by SmallStrings. They never die.
-        for (unsigned i = 10; i < m_smallIntCache.size(); ++i)
-            visitor.appendUnbarriered(m_smallIntCache[i].jsString);
-    }
+    DECLARE_VISIT_AGGREGATE;
+    void finalizeUnconditionally(VM&, CollectionScope);
 
     const StringWithJSString* smallIntCache() { return m_smallIntCache.data(); }
 
     void initializeSmallIntCache(VM&);
 
+    ALWAYS_INLINE DoubleToStringCache& doubleToStringCache()
+    {
+        if (!m_doubleCache) [[unlikely]]
+            doubleToStringCacheSlow();
+        return *m_doubleCache;
+    }
+
 private:
-    CacheEntryWithJSString<double>& lookup(double d) { return m_doubleCache[WTF::FloatHash<double>::hash(d) & (cacheSize - 1)]; }
     CacheEntryWithJSString<int>& lookup(int i) { return m_intCache[WTF::IntHash<int>::hash(i) & (cacheSize - 1)]; }
     CacheEntry<unsigned>& lookup(unsigned i) { return m_unsignedCache[WTF::IntHash<unsigned>::hash(i) & (cacheSize - 1)]; }
     ALWAYS_INLINE StringWithJSString& lookupSmallString(unsigned i)
@@ -136,10 +119,12 @@ private:
         return m_smallIntCache[i];
     }
 
+    void doubleToStringCacheSlow();
+
     std::array<StringWithJSString, cacheSize> m_smallIntCache { };
     std::array<CacheEntryWithJSString<int>, cacheSize> m_intCache { };
-    std::array<CacheEntryWithJSString<double>, cacheSize> m_doubleCache { };
     std::array<CacheEntry<unsigned>, cacheSize> m_unsignedCache { };
+    std::unique_ptr<DoubleToStringCache> m_doubleCache;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/ScopedArguments.h
+++ b/Source/JavaScriptCore/runtime/ScopedArguments.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "CommonIdentifiers.h"
 #include "GenericArgumentsImpl.h"
 #include "JSLexicalEnvironment.h"
 #include "Watchpoint.h"

--- a/Source/WTF/wtf/CagedPtr.h
+++ b/Source/WTF/wtf/CagedPtr.h
@@ -36,6 +36,8 @@
 #include <mach/vm_param.h>
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WTF {
 
 template<Gigacage::Kind passedKind, typename T, typename PtrTraits = RawPtrTraits<T>>
@@ -128,3 +130,4 @@ protected:
 
 using WTF::CagedPtr;
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### ecbd9d8660987cca45b928716cbcc4d47cd54d56
<pre>
[JSC] Extend DoubleToStringCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=295834">https://bugs.webkit.org/show_bug.cgi?id=295834</a>
<a href="https://rdar.apple.com/155676946">rdar://155676946</a>

Reviewed by NOBODY (OOPS!).

WIP

* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::runEndPhase):
(JSC::Heap::finalize):
* Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h:
(JSC::fastArrayJoin):
* Source/JavaScriptCore/runtime/DoubleToStringCache.cpp: Added.
(JSC::DoubleToStringCache::add):
(JSC::DoubleToStringCache::addJSString):
(JSC::DoubleToStringCache::primaryHash):
(JSC::DoubleToStringCache::secondaryHash):
(JSC::DoubleToStringCache::acquire):
(JSC::DoubleToStringCache::visitAggregateImpl):
(JSC::DoubleToStringCache::finalizeUnconditionally):
* Source/JavaScriptCore/runtime/DoubleToStringCache.h: Added.
* Source/JavaScriptCore/runtime/Identifier.cpp:
(JSC::Identifier::from):
* Source/JavaScriptCore/runtime/JSCJSValue.cpp:
(JSC::JSValue::toWTFStringSlowCase const):
* Source/JavaScriptCore/runtime/JSStringJoiner.h:
(JSC::JSStringJoiner::appendNumber):
* Source/JavaScriptCore/runtime/NumberPrototype.cpp:
(JSC::int52ToString):
(JSC::NumericStrings::addJSString):
(JSC::NumericStrings::initializeSmallIntCache): Deleted.
* Source/JavaScriptCore/runtime/NumericStrings.cpp: Added.
(JSC::NumericStrings::visitAggregateImpl):
(JSC::NumericStrings::finalizeUnconditionally):
(JSC::NumericStrings::doubleToStringCacheSlow):
(JSC::NumericStrings::initializeSmallIntCache):
(JSC::NumericStrings::addJSString):
* Source/JavaScriptCore/runtime/NumericStrings.h:
(JSC::NumericStrings::add):
(JSC::NumericStrings::doubleToStringCache):
(JSC::NumericStrings::clearOnGarbageCollection): Deleted.
(JSC::NumericStrings::visitAggregate): Deleted.
* Source/JavaScriptCore/runtime/ScopedArguments.h:
* Source/WTF/wtf/CagedPtr.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecbd9d8660987cca45b928716cbcc4d47cd54d56

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111266 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21397 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117298 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61534 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31613 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39514 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84569 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114213 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25244 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100177 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65015 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24586 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18318 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61117 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/103758 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94624 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18386 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120426 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109819 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38315 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28470 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93498 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38691 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96453 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93323 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38417 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16193 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34304 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38204 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43681 "Found 1 new failure in runtime/DoubleToStringCache.h and found 1 fixed file: runtime/NumericStrings.h") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/134095 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37869 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36159 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41202 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39571 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->