### PR TITLE
Avoidable hangs in WebCore::defaultWebCryptoMasterKey

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -835,6 +835,7 @@ crypto/CryptoAlgorithm.cpp
 crypto/CryptoAlgorithmRegistry.cpp
 crypto/CryptoAlgorithmTZoneImpls.cpp
 crypto/CryptoKey.cpp
+crypto/SerializedCryptoKeyWrap.cpp
 crypto/SubtleCrypto.cpp
 crypto/algorithms/CryptoAlgorithmAESCBC.cpp
 crypto/algorithms/CryptoAlgorithmAESCFB.cpp

--- a/Source/WebCore/crypto/SerializedCryptoKeyWrap.cpp
+++ b/Source/WebCore/crypto/SerializedCryptoKeyWrap.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SerializedCryptoKeyWrap.h"
+
+#include <wtf/CompletionHandler.h>
+
+namespace WebCore {
+
+void getDefaultWebCryptoMasterKey(CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&& handler)
+{
+    static NeverDestroyed<Ref<WorkQueue>> queue { WorkQueue::create("org.WebKit.WebCryptoMasterKey"_s) };
+    queue.get().get().dispatch([handler = WTFMove(handler)] mutable {
+        auto key = defaultWebCryptoMasterKey();
+        WorkQueue::protectedMain()->dispatch([handler = WTFMove(handler), key = WTFMove(key)] mutable {
+            handler(WTFMove(key));
+        });
+    });
+}
+
+}

--- a/Source/WebCore/crypto/SerializedCryptoKeyWrap.h
+++ b/Source/WebCore/crypto/SerializedCryptoKeyWrap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,6 +40,7 @@ struct WrappedCryptoKey;
 // https://www.w3.org/TR/WebCryptoAPI/#security-developers
 
 WEBCORE_EXPORT std::optional<Vector<uint8_t>> defaultWebCryptoMasterKey();
+WEBCORE_EXPORT void getDefaultWebCryptoMasterKey(CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
 WEBCORE_EXPORT bool deleteDefaultWebCryptoMasterKey();
 
 WEBCORE_EXPORT bool wrapSerializedCryptoKey(const Vector<uint8_t>& masterKey, const Vector<uint8_t>& key, Vector<uint8_t>& result);

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCFB.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCFB.cpp
@@ -29,6 +29,7 @@
 #include "CryptoAlgorithmAesCbcCfbParams.h"
 #include "CryptoAlgorithmAesKeyParams.h"
 #include "CryptoKeyAES.h"
+#include "ExceptionOr.h"
 #include <wtf/CrossThreadCopier.h>
 
 namespace WebCore {

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmHMAC.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmHMAC.cpp
@@ -28,6 +28,7 @@
 
 #include "CryptoAlgorithmHmacKeyParams.h"
 #include "CryptoKeyHMAC.h"
+#include "ExceptionOr.h"
 #include "ScriptExecutionContext.h"
 
 namespace WebCore {

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmRSA_PSSMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmRSA_PSSMac.cpp
@@ -32,6 +32,7 @@
 #include "CryptoAlgorithmRsaPssParams.h"
 #include "CryptoDigestAlgorithm.h"
 #include "CryptoKeyRSA.h"
+#include "ExceptionOr.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmEd25519GCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmEd25519GCrypt.cpp
@@ -21,6 +21,7 @@
 #include "CryptoAlgorithmEd25519.h"
 
 #include "CryptoKeyOKP.h"
+#include "ExceptionOr.h"
 #include "GCryptUtilities.h"
 
 namespace WebCore {

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -2507,7 +2507,7 @@ void WKPageSetPageNavigationClient(WKPageRef pageRef, const WKPageNavigationClie
                 if (auto data = adoptRef(toImpl(m_client.copyWebCryptoMasterKey(toAPI(&page), m_client.base.clientInfo))))
                     return completionHandler(Vector(data->span()));
             }
-            return completionHandler(defaultWebCryptoMasterKey());
+            return WebCore::getDefaultWebCryptoMasterKey(WTFMove(completionHandler));
         }
 
         void navigationActionDidBecomeDownload(WebKit::WebPageProxy& page, API::NavigationAction& action, WebKit::DownloadProxy& download) override

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -1324,7 +1324,7 @@ void NavigationState::NavigationClient::legacyWebCryptoMasterKey(WebPageProxy&, 
     if (!navigationState)
         return completionHandler(std::nullopt);
     if (!(navigationState->m_navigationDelegateMethods.webCryptoMasterKeyForWebView || navigationState->m_navigationDelegateMethods.webCryptoMasterKeyForWebViewCompletionHandler))
-        return completionHandler(WebCore::defaultWebCryptoMasterKey());
+        return WebCore::getDefaultWebCryptoMasterKey(WTFMove(completionHandler));
     auto navigationDelegate = navigationState->navigationDelegate();
     if (!navigationDelegate)
         return completionHandler(std::nullopt);

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -2817,7 +2817,7 @@ void WebProcessProxy::getWebCryptoMasterKey(CompletionHandler<void(std::optional
     m_websiteDataStore->client().webCryptoMasterKey([completionHandler = WTFMove(completionHandler)](std::optional<Vector<uint8_t>>&& key) mutable {
         if (key)
             return completionHandler(WTFMove(key));
-        return completionHandler(WebCore::defaultWebCryptoMasterKey());
+        return WebCore::getDefaultWebCryptoMasterKey(WTFMove(completionHandler));
     });
 }
 


### PR DESCRIPTION
#### 4f8eecb565eb2344d6e27d89b207e299b7f7cdf8
<pre>
Avoidable hangs in WebCore::defaultWebCryptoMasterKey
<a href="https://bugs.webkit.org/show_bug.cgi?id=295844">https://bugs.webkit.org/show_bug.cgi?id=295844</a>
<a href="https://rdar.apple.com/151058747">rdar://151058747</a>

Reviewed by Sam Weinig.

The code in WebCore::defaultWebCryptoMasterKey does work that on typical platforms should
not be done in the main thread or work queue. And in fact, clients of WebKit like Safari
on iOS implement this asynchronously. But on platforms like Mac where the implementation
inside WebKit is used, we were doing the work synchronously. We&apos;ve seen hang reports from
Mac Safari that show us this is a problem for some users in practice. The fix is to use
a separate work queue for this, analogous to what clients were already doing.

* Source/WebCore/Sources.txt: Added SerializedCryptoKeyWrap.cpp.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj: Ditto.

* Source/WebCore/crypto/SerializedCryptoKeyWrap.cpp: Added.
(WebCore::getDefaultWebCryptoMasterKey): Added. Calls defaultWebCryptoMasterKey on
a dedicated work queue and then marshals the result back to the main work queue.
* Source/WebCore/crypto/SerializedCryptoKeyWrap.h: Added getDefaultWebCryptoMasterKey.

* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCFB.cpp: Added missing include,
needed due to unified source differences.
* Source/WebCore/crypto/algorithms/CryptoAlgorithmHMAC.cpp: Ditto.
* Source/WebCore/crypto/cocoa/CryptoAlgorithmRSA_PSSMac.cpp: Ditto.
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmEd25519GCrypt.cpp: Ditto.

* Source/WebCore/crypto/gcrypt/CryptoAlgorithmEd25519GCrypt.cpp:
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageSetPageNavigationClient): Use getDefaultWebCryptoMasterKey.
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::NavigationState::NavigationClient::legacyWebCryptoMasterKey): Ditto.
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::getWebCryptoMasterKey): Ditto.

Canonical link: <a href="https://commits.webkit.org/297317@main">https://commits.webkit.org/297317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc17a9dc263190443f1bf51682bc64260714ae4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111318 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30984 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21449 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117350 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61586 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113280 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31665 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39566 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84606 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114265 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25281 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100213 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65052 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24623 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18353 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61170 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94663 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18420 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120525 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38367 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28507 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93536 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38743 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96487 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93360 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23790 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38453 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16225 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34369 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38256 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43733 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37921 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41254 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39623 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->