### PR TITLE
[Liquid Glass] [iOS] Make it possible for clients to hide scroll edge effects without breaking fixed color extensions

### DIFF
--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -540,6 +540,7 @@ UIProcess/ios/WKTapHighlightView.mm
 UIProcess/ios/WKTextInteractionWrapper.mm
 UIProcess/ios/WKTouchActionGestureRecognizer.mm
 UIProcess/ios/WKTouchEventsGestureRecognizer.mm
+UIProcess/ios/WKUIScrollEdgeEffect.mm
 UIProcess/ios/WKUSDPreviewView.mm
 UIProcess/ios/WKVideoView.mm
 UIProcess/ios/WKVisibilityPropagationView.mm

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -99,6 +99,7 @@
 #import "WKTextExtractionUtilities.h"
 #import "WKUIDelegate.h"
 #import "WKUIDelegateInternal.h"
+#import "WKUIScrollEdgeEffect.h"
 #import "WKUserContentControllerInternal.h"
 #import "WKWebViewConfigurationInternal.h"
 #import "WKWebViewContentProvider.h"
@@ -3301,18 +3302,11 @@ static WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::Fixe
 - (void)_updateHiddenScrollPocketEdges
 {
 #if PLATFORM(IOS_FAMILY)
-    [_scrollView _setHiddenPocketEdgesInternal:[&] {
-        UIRectEdge edges = UIRectEdgeNone;
-        if ([self _shouldHideTopScrollPocket])
-            edges |= UIRectEdgeTop;
-        if ([self _hasVisibleColorExtensionView:WebCore::BoxSide::Right])
-            edges |= UIRectEdgeRight;
-        if ([self _hasVisibleColorExtensionView:WebCore::BoxSide::Bottom])
-            edges |= UIRectEdgeBottom;
-        if ([self _hasVisibleColorExtensionView:WebCore::BoxSide::Left])
-            edges |= UIRectEdgeLeft;
-        return edges;
-    }()];
+    RetainPtr scrollView = _scrollView;
+    [scrollView _wk_topEdgeEffect].internallyHidden = [self _shouldHideTopScrollPocket];
+    [scrollView _wk_rightEdgeEffect].internallyHidden = [self _hasVisibleColorExtensionView:WebCore::BoxSide::Right];
+    [scrollView _wk_leftEdgeEffect].internallyHidden = [self _hasVisibleColorExtensionView:WebCore::BoxSide::Left];
+    [scrollView _wk_bottomEdgeEffect].internallyHidden = [self _hasVisibleColorExtensionView:WebCore::BoxSide::Bottom];
 #else
     _impl->updateScrollPocket();
 #endif

--- a/Source/WebKit/UIProcess/ios/WKScrollView.h
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.h
@@ -28,6 +28,7 @@
 #import "UIKitSPI.h"
 #import "WKBaseScrollView.h"
 
+@class WKUIScrollEdgeEffect;
 @class WKWebView;
 
 @interface WKScrollView : WKBaseScrollView
@@ -43,10 +44,6 @@
 - (BOOL)_setContentScrollInsetInternal:(UIEdgeInsets)insets;
 - (void)_setDecelerationRateInternal:(UIScrollViewDecelerationRate)rate;
 
-#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
-- (void)_setHiddenPocketEdgesInternal:(UIRectEdge)edges;
-#endif
-
 - (void)_resetContentInset;
 @property (nonatomic, readonly) BOOL _contentInsetWasExternallyOverridden;
 
@@ -55,6 +52,13 @@
 @property (nonatomic, assign, readonly) BOOL _contentInsetAdjustmentBehaviorWasExternallyOverridden;
 - (void)_setContentInsetAdjustmentBehaviorInternal:(UIScrollViewContentInsetAdjustmentBehavior)insetAdjustmentBehavior;
 - (void)_resetContentInsetAdjustmentBehavior;
+#endif
+
+#if HAVE(LIQUID_GLASS)
+- (WKUIScrollEdgeEffect *)_wk_topEdgeEffect;
+- (WKUIScrollEdgeEffect *)_wk_leftEdgeEffect;
+- (WKUIScrollEdgeEffect *)_wk_rightEdgeEffect;
+- (WKUIScrollEdgeEffect *)_wk_bottomEdgeEffect;
 #endif
 
 @end

--- a/Source/WebKit/UIProcess/ios/WKUIScrollEdgeEffect.h
+++ b/Source/WebKit/UIProcess/ios/WKUIScrollEdgeEffect.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(IOS_FAMILY) && HAVE(LIQUID_GLASS)
+
+#import <Foundation/Foundation.h>
+#import <WebCore/BoxSides.h>
+
+@class UIScrollEdgeEffect;
+
+@interface WKUIScrollEdgeEffect : NSObject
+
+- (instancetype)initWithScrollEdgeEffect:(UIScrollEdgeEffect *)effect boxSide:(WebCore::BoxSide)side;
+
+@property (nonatomic, getter=isInternallyHidden) BOOL internallyHidden;
+
+@end
+
+#endif // PLATFORM(IOS_FAMILY) && HAVE(LIQUID_GLASS)

--- a/Source/WebKit/UIProcess/ios/WKUIScrollEdgeEffect.mm
+++ b/Source/WebKit/UIProcess/ios/WKUIScrollEdgeEffect.mm
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "WKUIScrollEdgeEffect.h"
+
+#if PLATFORM(IOS_FAMILY) && HAVE(LIQUID_GLASS)
+
+#import <UIKit/UIKit.h>
+#import <wtf/OptionSet.h>
+
+namespace WebKit {
+
+enum class HiddenScrollEdgeEffectSource : uint8_t {
+    Internal    = 1 << 0,
+    Client      = 1 << 1
+};
+
+} // namespace WebKit
+
+@implementation WKUIScrollEdgeEffect {
+    __weak UIScrollEdgeEffect *_effect;
+    OptionSet<WebKit::HiddenScrollEdgeEffectSource> _hiddenSources;
+    WebCore::BoxSide _boxSide;
+}
+
+- (instancetype)initWithScrollEdgeEffect:(UIScrollEdgeEffect *)effect boxSide:(WebCore::BoxSide)boxSide
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _boxSide = boxSide;
+    _effect = effect;
+    _hiddenSources = { };
+    return self;
+}
+
+- (id)forwardingTargetForSelector:(SEL)selector
+{
+    return _effect;
+}
+
+- (BOOL)respondsToSelector:(SEL)selector
+{
+    return [super respondsToSelector:selector] || [_effect respondsToSelector:selector];
+}
+
+- (BOOL)isKindOfClass:(Class)classToCheck
+{
+    return [super isKindOfClass:classToCheck] || [_effect isKindOfClass:classToCheck];
+}
+
+- (void)setInternallyHidden:(BOOL)hidden
+{
+    [self _setHidden:hidden fromSource:WebKit::HiddenScrollEdgeEffectSource::Internal];
+}
+
+- (BOOL)isInternallyHidden
+{
+    return _hiddenSources.contains(WebKit::HiddenScrollEdgeEffectSource::Internal);
+}
+
+- (void)setHidden:(BOOL)hidden
+{
+    [self _setHidden:hidden fromSource:WebKit::HiddenScrollEdgeEffectSource::Client];
+}
+
+- (void)_setHidden:(BOOL)hidden fromSource:(WebKit::HiddenScrollEdgeEffectSource)source
+{
+    bool oldVisible = !_hiddenSources;
+    if (hidden)
+        _hiddenSources.add(source);
+    else
+        _hiddenSources.remove(source);
+
+    bool newVisible = !_hiddenSources;
+    if (oldVisible == newVisible)
+        return;
+
+    _effect.hidden = !newVisible;
+}
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@: %p wrapping %@ (%s)>", self.class, self, _effect.description, [&] {
+        switch (_boxSide) {
+        case WebCore::BoxSide::Top:
+            return "Top";
+        case WebCore::BoxSide::Right:
+            return "Right";
+        case WebCore::BoxSide::Bottom:
+            return "Bottom";
+        case WebCore::BoxSide::Left:
+            return "Left";
+        }
+        ASSERT_NOT_REACHED();
+        return "?";
+    }()];
+}
+
+@end
+
+#endif // PLATFORM(IOS_FAMILY) && HAVE(LIQUID_GLASS)

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -29,6 +29,7 @@
 #if ENABLE(FULLSCREEN_API) && !PLATFORM(IOS_FAMILY)
 
 #import "AppKitSPI.h"
+#import "GPUProcessProxy.h"
 #import "LayerTreeContext.h"
 #import "NativeWebMouseEvent.h"
 #import "VideoPresentationManagerProxy.h"
@@ -37,6 +38,7 @@
 #import "WKViewPrivate.h"
 #import "WebFullScreenManagerProxy.h"
 #import "WebPageProxy.h"
+#import "WebProcessProxy.h"
 #import <QuartzCore/QuartzCore.h>
 #import <WebCore/CGWindowUtilities.h>
 #import <WebCore/FloatRect.h>

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -134,6 +134,9 @@ namespace WritingTools {
 enum class ReplacementBehavior : uint8_t;
 }
 
+struct FrameIdentifierType;
+using FrameIdentifier = ObjectIdentifier<FrameIdentifierType>;
+
 } // namespace WebCore
 
 @protocol WebViewImplDelegate

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -42,6 +42,7 @@
 #import "NativeWebMouseEvent.h"
 #import "NativeWebWheelEvent.h"
 #import "NetworkProcessMessages.h"
+#import "PDFPluginIdentifier.h"
 #import "PageClient.h"
 #import "PageClientImplMac.h"
 #import "PasteboardTypes.h"
@@ -104,6 +105,7 @@
 #import <WebCore/FixedContainerEdges.h>
 #import <WebCore/FontAttributeChanges.h>
 #import <WebCore/FontAttributes.h>
+#import <WebCore/FrameIdentifier.h>
 #import <WebCore/ImageAdapter.h>
 #import <WebCore/LegacyNSPasteboardTypes.h>
 #import <WebCore/LoaderNSURLExtras.h>
@@ -145,6 +147,7 @@
 #import <pal/spi/mac/NSApplicationSPI.h>
 #import <pal/spi/mac/NSImmediateActionGestureRecognizerSPI.h>
 #import <pal/spi/mac/NSMenuSPI.h>
+#import <pal/spi/mac/NSPasteboardSPI.h>
 #import <pal/spi/mac/NSScrollerImpSPI.h>
 #import <pal/spi/mac/NSSpellCheckerSPI.h>
 #import <pal/spi/mac/NSTextFinderSPI.h>

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2605,6 +2605,7 @@
 		F4F12CB02C48B2C800BC1254 /* CoreIPCPlistDictionary.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4F12CAF2C48AEA400BC1254 /* CoreIPCPlistDictionary.mm */; };
 		F4F12CB32C48B8C100BC1254 /* CoreIPCPlistArray.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4F12CB22C48B8BB00BC1254 /* CoreIPCPlistArray.mm */; };
 		F4F475822A4F55A80004197B /* WKTouchEventsGestureRecognizer.h in Headers */ = {isa = PBXBuildFile; fileRef = F4F4757F2A4F3D6D0004197B /* WKTouchEventsGestureRecognizer.h */; };
+		F4F7A4042E22F99C0029BCF2 /* WKUIScrollEdgeEffect.h in Headers */ = {isa = PBXBuildFile; fileRef = F4F7A4022E22F99C0029BCF2 /* WKUIScrollEdgeEffect.h */; };
 		F4F94AD92D8E05DB0087FE6F /* DigitalCredentialsRequestValidatorBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = F4F94AD82D8E05DB0087FE6F /* DigitalCredentialsRequestValidatorBridge.h */; };
 		F4F94AE02D91B2A80087FE6F /* WKIdentityDocumentRawRequestValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = F4F94ADE2D91B2A80087FE6F /* WKIdentityDocumentRawRequestValidator.h */; };
 		F6113E25126CE1820057D0A7 /* APIUserContentURLPattern.h in Headers */ = {isa = PBXBuildFile; fileRef = F6113E24126CE1820057D0A7 /* APIUserContentURLPattern.h */; };
@@ -8590,6 +8591,8 @@
 		F4F475812A4F3D860004197B /* WKTouchEventsGestureRecognizer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKTouchEventsGestureRecognizer.mm; path = ios/WKTouchEventsGestureRecognizer.mm; sourceTree = "<group>"; };
 		F4F59AD32065A5C9006CAA46 /* WKSelectMenuListViewController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WKSelectMenuListViewController.mm; path = ios/forms/WKSelectMenuListViewController.mm; sourceTree = "<group>"; };
 		F4F59AD42065A5CA006CAA46 /* WKSelectMenuListViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WKSelectMenuListViewController.h; path = ios/forms/WKSelectMenuListViewController.h; sourceTree = "<group>"; };
+		F4F7A4022E22F99C0029BCF2 /* WKUIScrollEdgeEffect.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKUIScrollEdgeEffect.h; path = ios/WKUIScrollEdgeEffect.h; sourceTree = "<group>"; };
+		F4F7A4032E22F99C0029BCF2 /* WKUIScrollEdgeEffect.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKUIScrollEdgeEffect.mm; path = ios/WKUIScrollEdgeEffect.mm; sourceTree = "<group>"; };
 		F4F94AD82D8E05DB0087FE6F /* DigitalCredentialsRequestValidatorBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DigitalCredentialsRequestValidatorBridge.h; sourceTree = "<group>"; };
 		F4F94ADD2D8E066A0087FE6F /* DigitalCredentialsRequestValidatorBridge.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DigitalCredentialsRequestValidatorBridge.mm; sourceTree = "<group>"; };
 		F4F94ADE2D91B2A80087FE6F /* WKIdentityDocumentRawRequestValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKIdentityDocumentRawRequestValidator.h; sourceTree = "<group>"; };
@@ -11852,6 +11855,8 @@
 				F4F4757F2A4F3D6D0004197B /* WKTouchEventsGestureRecognizer.h */,
 				F4F475812A4F3D860004197B /* WKTouchEventsGestureRecognizer.mm */,
 				F4E727222A547E2100CE34FD /* WKTouchEventsGestureRecognizerTypes.h */,
+				F4F7A4022E22F99C0029BCF2 /* WKUIScrollEdgeEffect.h */,
+				F4F7A4032E22F99C0029BCF2 /* WKUIScrollEdgeEffect.mm */,
 				316B8B622054B55800BD4A62 /* WKUSDPreviewView.h */,
 				316B8B612054B55800BD4A62 /* WKUSDPreviewView.mm */,
 				CDB96AD32AB379C9007A90D3 /* WKVideoView.h */,
@@ -18488,6 +18493,7 @@
 				1AD8790A18B6C38A006CAFD7 /* WKUIDelegate.h in Headers */,
 				07AF79E92D695195004E8D3A /* WKUIDelegateInternal.h in Headers */,
 				3743925818BC4C60001C8675 /* WKUIDelegatePrivate.h in Headers */,
+				F4F7A4042E22F99C0029BCF2 /* WKUIScrollEdgeEffect.h in Headers */,
 				BC40760A124FF0270068F20A /* WKURL.h in Headers */,
 				BC40761C124FF0370068F20A /* WKURLCF.h in Headers */,
 				BC40760C124FF0270068F20A /* WKURLRequest.h in Headers */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/top-fixed-element.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/top-fixed-element.html
@@ -9,6 +9,11 @@ html, body {
      width: 100%;
      height: 100%;
 }
+
+.tall {
+    height: 4000px;
+}
+
 header {
      position: fixed;
      top: 0;
@@ -19,5 +24,9 @@ header {
 }
 </style>
 </head>
-<body><header></header>Hello world</body>
+<body>
+    <header></header>
+    <p>Hello world</p>
+    <div class="tall"></div>
+</body>
 </html>


### PR DESCRIPTION
#### a55b899d0184fc7a610bd4e3de64f286f4feee4a
<pre>
[Liquid Glass] [iOS] Make it possible for clients to hide scroll edge effects without breaking fixed color extensions
<a href="https://bugs.webkit.org/show_bug.cgi?id=295843">https://bugs.webkit.org/show_bug.cgi?id=295843</a>
<a href="https://rdar.apple.com/155241107">rdar://155241107</a>

Reviewed by Richard Robinson.

Currently, it&apos;s not really possible for `WKWebView` clients to hide scroll edge effects on the main
scroll view (`webView.scrollView`) without causing bugs in element fullscreen or when there are
fixed color extensions along the scroll effect edges being hidden. This is because WebKit internally
sets `scrollView.{top|bottom|left|right}EdgeEffect.hidden = YES;` to hide scroll edge effects on all
sides with fixed edges, and sets it to `NO` once there&apos;s no longer a fixed container edge. Since
the WebKit client just uses this same API, it&apos;s possible for both WebKit to override the last client
value, or for the client to override the last internally-set value.

To prevent the engine and client from stomping over the value of `-[UIScrollEdgeEffect hidden]`, we
make `-[WKScrollView {top|bottom|left|right}EdgeEffect]` return a wrapper object instead of the real
`UIScrollEdgeEffect`; when calling `-setHidden:` on this wrapper, we then make a distinction between
calls coming from within the WebKit engine, and calls coming from the external client. The scroll
pocket is only hidden if both WebKit and the external client don&apos;t hide the pocket.

See below for more details.

* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _updateHiddenScrollPocketEdges]):
* Source/WebKit/UIProcess/ios/WKScrollView.h:
* Source/WebKit/UIProcess/ios/WKScrollView.mm:
(-[WKScrollView topEdgeEffect]):
(-[WKScrollView leftEdgeEffect]):
(-[WKScrollView bottomEdgeEffect]):
(-[WKScrollView rightEdgeEffect]):

Override these APIs return the scroll edge effect wrappers instead.

(-[WKScrollView _wk_topEdgeEffect]):
(-[WKScrollView _wk_leftEdgeEffect]):
(-[WKScrollView _wk_rightEdgeEffect]):
(-[WKScrollView _wk_bottomEdgeEffect]):
(-[WKScrollView _setHiddenPocketEdges:]): Deleted.
(-[WKScrollView _setHiddenPocketEdgesInternal:]): Deleted.

Replace the call to `-_setHiddenPocketEdgesInternal:` with `-setInternallyHidden:` on the wrapper
object.

* Source/WebKit/UIProcess/ios/WKUIScrollEdgeEffect.h: Added.
* Source/WebKit/UIProcess/ios/WKUIScrollEdgeEffect.mm: Added.

Introduce `WKUIScrollEdgeEffect`, which wraps the given `UIScrollEdgeEffect` and forwards all
selectors (except for `-setHidden:`) to the inner effect object.

(-[WKUIScrollEdgeEffect initWithScrollEdgeEffect:boxSide:]):
(-[WKUIScrollEdgeEffect forwardingTargetForSelector:]):
(-[WKUIScrollEdgeEffect respondsToSelector:]):
(-[WKUIScrollEdgeEffect isKindOfClass:]):
(-[WKUIScrollEdgeEffect setInternallyHidden:]):
(-[WKUIScrollEdgeEffect isInternallyHidden]):

Add support for `-setInternallyHidden:` on the pocket wrapper which is only used to hide or unhide
the scroll pocket from within WebKit code.

(-[WKUIScrollEdgeEffect setHidden:]):
(-[WKUIScrollEdgeEffect _setHidden:fromSource:]):

Add `OptionSet&lt;HiddenScrollEdgeEffectSource&gt;`, which tracks whether or not the pocket should be
hidden according to the client and WebKit internal state. The `OptionSet` must be empty for the
wrapped `UIScrollEdgeEffect` to be unhidden.

(-[WKUIScrollEdgeEffect description]):

Override `-description` to print the wrapped scroll edge effect as well.

* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/top-fixed-element.html:
* Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm:
(TestWebKitAPI::TEST(WKScrollViewTests, PositionFixedLayerAfterScrolling)):
(TestWebKitAPI::TEST(WKScrollViewTests, AllowsKeyboardScrolling)):
(TestWebKitAPI::TEST(WKScrollViewTests, ClientCanHideScrollEdgeEffects)):

Add an API test to exercise the change, by verifying that `topEdgeEffect.hidden` can be used without
forcing the pocket to show up over fixed color extensions.

(traverseLayerTree): Deleted.
(TEST(WKScrollViewTests, PositionFixedLayerAfterScrolling)): Deleted.
(TEST(WKScrollViewTests, AsynchronousWheelEventHandling)): Deleted.
(TEST(WKScrollViewTests, OverscrollBehaviorAndOverflowHiddenOnRootShouldNotPreventScrolling)): Deleted.
(TEST(WKScrollViewTests, WheelEventDispatchedToSubframe)): Deleted.
(TEST(WKScrollViewTests, IndicatorStyleSetByClient)): Deleted.
(TEST(WKScrollViewTests, BackgroundColorSetByClient)): Deleted.
(TEST(WKScrollViewTests, DecelerationSetByClient)): Deleted.
(TEST(WKScrollViewTests, AllowsKeyboardScrolling)): Deleted.

Canonical link: <a href="https://commits.webkit.org/297313@main">https://commits.webkit.org/297313@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/181bcefb69e237c88bf1bbf0b77f265e047f0606

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111324 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30990 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21455 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117356 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61592 "Failed to checkout and rebase branch from PR 47943") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113286 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31671 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39572 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84610 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/61592 "Failed to checkout and rebase branch from PR 47943") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114271 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25288 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100219 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/65056 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24631 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18359 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61176 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94671 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18426 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120523 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38373 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28511 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93534 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38749 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96493 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93358 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23788 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38461 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16231 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34375 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38262 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43739 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37927 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41260 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39629 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->