### PR TITLE
Putting HashMap in a heap block hurts memory use, speed, code size (part 1)

### DIFF
--- a/Source/JavaScriptCore/API/JSBase.cpp
+++ b/Source/JavaScriptCore/API/JSBase.cpp
@@ -206,7 +206,7 @@ JSObjectRef JSGetMemoryUsageStatistics(JSContextRef ctx)
 
     auto typeCounts = vm.heap.objectTypeCounts();
     JSObject* objectTypeCounts = constructEmptyObject(globalObject);
-    for (auto& it : *typeCounts)
+    for (auto& it : typeCounts)
         objectTypeCounts->putDirect(vm, Identifier::fromString(vm, it.key), jsNumber(it.value));
 
     JSObject* object = constructEmptyObject(globalObject);

--- a/Source/JavaScriptCore/API/JSClassRef.cpp
+++ b/Source/JavaScriptCore/API/JSClassRef.cpp
@@ -56,21 +56,19 @@ OpaqueJSClass::OpaqueJSClass(const JSClassDefinition* definition, OpaqueJSClass*
     JSC::initialize();
 
     if (const JSStaticValue* staticValue = definition->staticValues) {
-        m_staticValues = makeUnique<OpaqueJSClassStaticValuesTable>();
         while (staticValue->name) {
             String valueName = String::fromUTF8(staticValue->name);
             if (!valueName.isNull())
-                m_staticValues->set(valueName.impl(), makeUnique<StaticValueEntry>(staticValue->getProperty, staticValue->setProperty, staticValue->attributes, valueName));
+                m_staticValues.add(valueName.impl(), makeUnique<StaticValueEntry>(staticValue->getProperty, staticValue->setProperty, staticValue->attributes, valueName));
             ++staticValue;
         }
     }
 
     if (const JSStaticFunction* staticFunction = definition->staticFunctions) {
-        m_staticFunctions = makeUnique<OpaqueJSClassStaticFunctionsTable>();
         while (staticFunction->name) {
             String functionName = String::fromUTF8(staticFunction->name);
             if (!functionName.isNull())
-                m_staticFunctions->set(functionName.impl(), makeUnique<StaticFunctionEntry>(staticFunction->callAsFunction, staticFunction->attributes));
+                m_staticFunctions.add(functionName.impl(), makeUnique<StaticFunctionEntry>(staticFunction->callAsFunction, staticFunction->attributes));
             ++staticFunction;
         }
     }
@@ -84,20 +82,13 @@ OpaqueJSClass::~OpaqueJSClass()
     // The empty string is shared across threads & is an identifier, in all other cases we should have done a deep copy in className(), below. 
     ASSERT(!m_className.length() || !m_className.impl()->isAtom());
 
-#ifndef NDEBUG
-    if (m_staticValues) {
-        OpaqueJSClassStaticValuesTable::const_iterator end = m_staticValues->end();
-        for (OpaqueJSClassStaticValuesTable::const_iterator it = m_staticValues->begin(); it != end; ++it)
-            ASSERT(!it->key->isAtom());
-    }
-
-    if (m_staticFunctions) {
-        OpaqueJSClassStaticFunctionsTable::const_iterator end = m_staticFunctions->end();
-        for (OpaqueJSClassStaticFunctionsTable::const_iterator it = m_staticFunctions->begin(); it != end; ++it)
-            ASSERT(!it->key->isAtom());
-    }
+#if ASSERT_ENABLED
+    for (auto& key : m_staticValues.keys())
+        ASSERT(!key->isAtom());
+    for (auto& key : m_staticFunctions.keys())
+        ASSERT(!key->isAtom());
 #endif
-    
+
     if (prototypeClass)
         JSClassRelease(prototypeClass);
 }
@@ -124,23 +115,15 @@ Ref<OpaqueJSClass> OpaqueJSClass::create(const JSClassDefinition* clientDefiniti
 OpaqueJSClassContextData::OpaqueJSClassContextData(JSC::VM&, OpaqueJSClass* jsClass)
     : m_class(jsClass)
 {
-    if (jsClass->m_staticValues) {
-        staticValues = makeUnique<OpaqueJSClassStaticValuesTable>();
-        OpaqueJSClassStaticValuesTable::const_iterator end = jsClass->m_staticValues->end();
-        for (OpaqueJSClassStaticValuesTable::const_iterator it = jsClass->m_staticValues->begin(); it != end; ++it) {
-            ASSERT(!it->key->isAtom());
-            String valueName = it->key->isolatedCopy();
-            staticValues->add(valueName.impl(), makeUnique<StaticValueEntry>(it->value->getProperty, it->value->setProperty, it->value->attributes, valueName));
-        }
+    for (auto& it : jsClass->m_staticValues) {
+        ASSERT(!it.key->isAtom());
+        String valueName = it.key->isolatedCopy();
+        staticValues.add(valueName.impl(), makeUnique<StaticValueEntry>(it.value->getProperty, it.value->setProperty, it.value->attributes, valueName));
     }
 
-    if (jsClass->m_staticFunctions) {
-        staticFunctions = makeUnique<OpaqueJSClassStaticFunctionsTable>();
-        OpaqueJSClassStaticFunctionsTable::const_iterator end = jsClass->m_staticFunctions->end();
-        for (OpaqueJSClassStaticFunctionsTable::const_iterator it = jsClass->m_staticFunctions->begin(); it != end; ++it) {
-            ASSERT(!it->key->isAtom());
-            staticFunctions->add(it->key->isolatedCopy(), makeUnique<StaticFunctionEntry>(it->value->callAsFunction, it->value->attributes));
-        }
+    for (auto& it : jsClass->m_staticFunctions) {
+        ASSERT(!it.key->isAtom());
+        staticFunctions.add(it.key->isolatedCopy(), makeUnique<StaticFunctionEntry>(it.value->callAsFunction, it.value->attributes));
     }
 }
 
@@ -160,12 +143,12 @@ String OpaqueJSClass::className()
 
 OpaqueJSClassStaticValuesTable* OpaqueJSClass::staticValues(JSC::JSGlobalObject* globalObject)
 {
-    return contextData(globalObject).staticValues.get();
+    return &contextData(globalObject).staticValues;
 }
 
 OpaqueJSClassStaticFunctionsTable* OpaqueJSClass::staticFunctions(JSC::JSGlobalObject* globalObject)
 {
-    return contextData(globalObject).staticFunctions.get();
+    return &contextData(globalObject).staticFunctions;
 }
 
 JSObject* OpaqueJSClass::prototype(JSGlobalObject* globalObject)

--- a/Source/JavaScriptCore/API/JSClassRef.h
+++ b/Source/JavaScriptCore/API/JSClassRef.h
@@ -92,8 +92,8 @@ public:
     // 4. When it is used, the old context data is found in VM and used.
     RefPtr<OpaqueJSClass> m_class;
 
-    std::unique_ptr<OpaqueJSClassStaticValuesTable> staticValues;
-    std::unique_ptr<OpaqueJSClassStaticFunctionsTable> staticFunctions;
+    OpaqueJSClassStaticValuesTable staticValues;
+    OpaqueJSClassStaticFunctionsTable staticFunctions;
     JSC::Weak<JSC::JSObject> cachedPrototype;
 };
 
@@ -136,8 +136,8 @@ private:
 
     // Strings in these data members should not be put into any AtomStringTable.
     String m_className;
-    std::unique_ptr<OpaqueJSClassStaticValuesTable> m_staticValues;
-    std::unique_ptr<OpaqueJSClassStaticFunctionsTable> m_staticFunctions;
+    OpaqueJSClassStaticValuesTable m_staticValues;
+    OpaqueJSClassStaticFunctionsTable m_staticFunctions;
 };
 
 #undef OPAQUE_JSCLASS_METHOD

--- a/Source/JavaScriptCore/ftl/FTLAbstractHeap.cpp
+++ b/Source/JavaScriptCore/ftl/FTLAbstractHeap.cpp
@@ -158,10 +158,7 @@ const AbstractHeap& IndexedAbstractHeap::atSlow(ptrdiff_t index)
 {
     ASSERT(static_cast<size_t>(index) >= m_smallIndices.size());
     
-    if (!m_largeIndices) [[unlikely]]
-        m_largeIndices = makeUnique<MapType>();
-
-    std::unique_ptr<AbstractHeap>& field = m_largeIndices->add(index, nullptr).iterator->value;
+    auto& field = m_largeIndices.add(index, nullptr).iterator->value;
     if (!field) {
         field = makeUnique<AbstractHeap>();
         initialize(*field, index);

--- a/Source/JavaScriptCore/ftl/FTLAbstractHeap.h
+++ b/Source/JavaScriptCore/ftl/FTLAbstractHeap.h
@@ -160,8 +160,8 @@ private:
         static bool isDeletedValue(ptrdiff_t value) { return value == 1; }
     };
     typedef UncheckedKeyHashMap<ptrdiff_t, std::unique_ptr<AbstractHeap>, WTF::IntHash<ptrdiff_t>, WithoutZeroOrOneHashTraits> MapType;
-    
-    std::unique_ptr<MapType> m_largeIndices;
+
+    MapType m_largeIndices;
     Vector<CString, 16> m_largeIndexNames;
 };
 

--- a/Source/JavaScriptCore/heap/CompleteSubspace.cpp
+++ b/Source/JavaScriptCore/heap/CompleteSubspace.cpp
@@ -185,7 +185,7 @@ void* CompleteSubspace::reallocatePreciseAllocationNonVirtual(VM& vm, HeapCell* 
 
     // If reallocation changes the address, we should update HashSet.
     if (oldAllocation != allocation) {
-        if (auto* set = m_space.preciseAllocationSet()) {
+        if (auto& set = m_space.preciseAllocationSet()) {
             set->remove(oldAllocation->cell());
             set->add(allocation->cell());
         }

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -1071,25 +1071,25 @@ size_t Heap::protectedObjectCount()
     return result;
 }
 
-std::unique_ptr<TypeCountSet> Heap::protectedObjectTypeCounts()
+TypeCountSet Heap::protectedObjectTypeCounts()
 {
-    std::unique_ptr<TypeCountSet> result = makeUnique<TypeCountSet>();
+    TypeCountSet result;
     forEachProtectedCell(
         [&] (JSCell* cell) {
-            recordType(*result, cell);
+            recordType(result, cell);
         });
     return result;
 }
 
-std::unique_ptr<TypeCountSet> Heap::objectTypeCounts()
+TypeCountSet Heap::objectTypeCounts()
 {
-    std::unique_ptr<TypeCountSet> result = makeUnique<TypeCountSet>();
+    TypeCountSet result;
     HeapIterationScope iterationScope(*this);
     m_objectSpace.forEachLiveCell(
         iterationScope,
         [&] (HeapCell* cell, HeapCell::Kind kind) -> IterationStatus {
             if (isJSCellKind(kind))
-                recordType(*result, static_cast<JSCell*>(cell));
+                recordType(result, static_cast<JSCell*>(cell));
             return IterationStatus::Continue;
         });
     return result;

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -451,8 +451,8 @@ public:
     JS_EXPORT_PRIVATE size_t globalObjectCount();
     JS_EXPORT_PRIVATE size_t protectedObjectCount();
     JS_EXPORT_PRIVATE size_t protectedGlobalObjectCount();
-    JS_EXPORT_PRIVATE std::unique_ptr<TypeCountSet> protectedObjectTypeCounts();
-    JS_EXPORT_PRIVATE std::unique_ptr<TypeCountSet> objectTypeCounts();
+    JS_EXPORT_PRIVATE TypeCountSet protectedObjectTypeCounts();
+    JS_EXPORT_PRIVATE TypeCountSet objectTypeCounts();
 
     UncheckedKeyHashSet<MarkedVectorBase*>& markListSet();
     void addMarkedJSValueRefArray(MarkedJSValueRefArray*);

--- a/Source/JavaScriptCore/heap/HeapUtil.h
+++ b/Source/JavaScriptCore/heap/HeapUtil.h
@@ -46,13 +46,13 @@ public:
     {
         // It could point to a large allocation.
         if (pointer->isPreciseAllocation()) {
-            auto* set = heap.objectSpace().preciseAllocationSet();
+            auto& set = heap.objectSpace().preciseAllocationSet();
             ASSERT(set);
-            if (set->isEmpty())
-                return false;
 #if USE(JSVALUE32_64)
             // In 32bit systems a cell pointer can be 0xFFFFFFFF (an entries in the call frame), and this
             // value clashes with the deletedValue in a set<JSCell*>.
+            // FIXME: In this case, the ASSERT(set) above could fail too so this check is too late.
+            // FIXME: Why couldn't a cell pointer be 0xFFFFFFFFFFFFFFFF on 64-bit systems too?
             if (!set->isValidValue(pointer))
                 return false;
 #endif

--- a/Source/JavaScriptCore/heap/MarkedSpace.cpp
+++ b/Source/JavaScriptCore/heap/MarkedSpace.cpp
@@ -235,7 +235,7 @@ void MarkedSpace::registerPreciseAllocation(PreciseAllocation* allocation, bool 
     ASSERT(allocation->isNewlyAllocated());
     ASSERT(!allocation->isMarked());
     m_preciseAllocations.append(allocation);
-    if (auto* set = preciseAllocationSet())
+    if (auto& set = preciseAllocationSet())
         set->add(allocation->cell());
     if (isNewAllocation) {
         // Existing code's ordering is calling `didAllocate` and increasing capacity.
@@ -254,7 +254,7 @@ void MarkedSpace::sweepPreciseAllocations()
         PreciseAllocation* allocation = m_preciseAllocations[srcIndex++];
         allocation->sweep();
         if (allocation->isEmpty()) {
-            if (auto* set = preciseAllocationSet())
+            if (auto& set = preciseAllocationSet())
                 set->remove(allocation->cell());
             if (allocation->isLowerTierPrecise())
                 static_cast<IsoSubspace*>(allocation->subspace())->sweepLowerTierPreciseCell(allocation);
@@ -288,7 +288,7 @@ void MarkedSpace::prepareForAllocation()
 
 void MarkedSpace::enablePreciseAllocationTracking()
 {
-    m_preciseAllocationSet = makeUnique<UncheckedKeyHashSet<HeapCell*>>();
+    m_preciseAllocationSet = UncheckedKeyHashSet<HeapCell*> { };
     for (auto* allocation : m_preciseAllocations)
         m_preciseAllocationSet->add(allocation->cell());
 }

--- a/Source/JavaScriptCore/heap/MarkedSpace.h
+++ b/Source/JavaScriptCore/heap/MarkedSpace.h
@@ -163,7 +163,7 @@ public:
     const Vector<PreciseAllocation*>& preciseAllocations() const { return m_preciseAllocations; }
     unsigned preciseAllocationsNurseryOffset() const { return m_preciseAllocationsNurseryOffset; }
     unsigned preciseAllocationsOffsetForThisCollection() const { return m_preciseAllocationsOffsetForThisCollection; }
-    UncheckedKeyHashSet<HeapCell*>* preciseAllocationSet() const { return m_preciseAllocationSet.get(); }
+    std::optional<UncheckedKeyHashSet<HeapCell*>>& preciseAllocationSet() { return m_preciseAllocationSet; }
 
     void enablePreciseAllocationTracking();
     
@@ -207,7 +207,7 @@ private:
 
     Vector<Subspace*> m_subspaces;
 
-    std::unique_ptr<UncheckedKeyHashSet<HeapCell*>> m_preciseAllocationSet;
+    std::optional<UncheckedKeyHashSet<HeapCell*>> m_preciseAllocationSet;
     Vector<PreciseAllocation*> m_preciseAllocations;
     unsigned m_preciseAllocationsNurseryOffset { 0 };
     unsigned m_preciseAllocationsOffsetForThisCollection { 0 };

--- a/Source/WebCore/page/MemoryRelease.cpp
+++ b/Source/WebCore/page/MemoryRelease.cpp
@@ -270,8 +270,7 @@ void logMemoryStatistics(LogMemoryStatisticsReason reason)
     auto& vm = commonVM();
     JSC::JSLockHolder locker(vm);
     RELEASE_LOG(MemoryPressure, "Live JavaScript objects at time of %" PUBLIC_LOG_STRING ":", description.characters());
-    auto typeCounts = vm.heap.objectTypeCounts();
-    for (auto& it : *typeCounts)
+    for (auto& it : vm.heap.objectTypeCounts())
         RELEASE_LOG(MemoryPressure, "  %" PUBLIC_LOG_STRING ": %d", it.key.characters(), it.value);
 }
 #endif

--- a/Source/WebCore/page/PerformanceLogging.cpp
+++ b/Source/WebCore/page/PerformanceLogging.cpp
@@ -83,7 +83,7 @@ Vector<std::pair<ASCIILiteral, size_t>> PerformanceLogging::memoryUsageStatistic
 
 HashCountedSet<ASCIILiteral> PerformanceLogging::javaScriptObjectCounts()
 {
-    return WTFMove(*commonVM().heap.objectTypeCounts());
+    return commonVM().heap.objectTypeCounts();
 }
 
 PerformanceLogging::PerformanceLogging(Page& page)

--- a/Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm
@@ -93,13 +93,13 @@ static RetainPtr<NSCountedSet> createNSCountedSet(const HashCountedSet<ASCIILite
 + (NSCountedSet *)javaScriptProtectedObjectTypeCounts
 {
     JSLockHolder lock(commonVM());
-    return createNSCountedSet(*commonVM().heap.protectedObjectTypeCounts()).autorelease();
+    return createNSCountedSet(commonVM().heap.protectedObjectTypeCounts()).autorelease();
 }
 
 + (NSCountedSet *)javaScriptObjectTypeCounts
 {
     JSLockHolder lock(commonVM());
-    return createNSCountedSet(*commonVM().heap.objectTypeCounts()).autorelease();
+    return createNSCountedSet(commonVM().heap.objectTypeCounts()).autorelease();
 }
 
 + (void)garbageCollectJavaScriptObjects


### PR DESCRIPTION
#### 0c95ee27a86ea97629da9bc1dfe216be3317814c
<pre>
Putting HashMap in a heap block hurts memory use, speed, code size (part 1)
<a href="https://bugs.webkit.org/show_bug.cgi?id=226162">https://bugs.webkit.org/show_bug.cgi?id=226162</a>
<a href="https://rdar.apple.com/78675956">rdar://78675956</a>

Reviewed by Keith Miller.

HashMap, HashSet, and HashCountedSet are already pointers to a hash table,
so there is no reason to wrap them in a unique_ptr in a heap block and add
another level of indirection. Fix this in a few places in JavaScriptCore.

* Source/JavaScriptCore/API/JSBase.cpp:
(JSGetMemoryUsageStatistics): Removed pointer dereference.
* Source/JavaScriptCore/API/JSClassRef.cpp:
(OpaqueJSClass::~OpaqueJSClass): Use simpler for loops.
(OpaqueJSClassContextData::OpaqueJSClassContextData): Ditto.
(OpaqueJSClass::staticValues): No need to call unique_ptr::get().
(OpaqueJSClass::staticFunctions): Ditto.
* Source/JavaScriptCore/API/JSClassRef.h: Stop using unique_ptr for
the static values and functions tables.

* Source/JavaScriptCore/ftl/FTLAbstractHeap.cpp:
(JSC::FTL::IndexedAbstractHeap::atSlow): Removed code to allocate m_largeIndices.
* Source/JavaScriptCore/ftl/FTLAbstractHeap.h: Made m_largeIndices a map, not
a unique_ptr to a map.

* Source/JavaScriptCore/heap/CompleteSubspace.cpp:
(JSC::CompleteSubspace::reallocatePreciseAllocationNonVirtual): Update since
preciseAllocationSet is now an optional rather than a pointer to a heap block.

* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::protectedObjectTypeCounts): Return a set instead of a pointer holding one.
(JSC::Heap::objectTypeCounts): Ditto.
* Source/JavaScriptCore/heap/Heap.h: Ditto.

* Source/JavaScriptCore/heap/HeapUtil.h:
(JSC::HeapUtil::isPointerGCObjectJSCell): Update since preciseAllocationSet is now an
optional rather than a pointer to a heap block. Also remove an unneeded empty check
since the contains function already handles that case so it&apos;s just redundant.

* Source/JavaScriptCore/heap/MarkedSpace.cpp:
(JSC::MarkedSpace::registerPreciseAllocation): Update since preciseAllocationSet is
now an optional rather than a pointer to a heap block.
(JSC::MarkedSpace::sweepPreciseAllocations): Ditto.
(JSC::MarkedSpace::enablePreciseAllocationTracking): Ditto.

* Source/JavaScriptCore/heap/MarkedSpace.h:
(JSC::MarkedSpace::preciseAllocationSet): Use std::optional instead of std::unique_ptr.

* Source/WebCore/page/MemoryRelease.cpp:
(WebCore::logMemoryStatistics): Update since objectTypeCounts now returns a set
instead of a unique_ptr to a set.
* Source/WebCore/page/PerformanceLogging.cpp:
(WebCore::PerformanceLogging::javaScriptObjectCounts): Ditto.
* Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm:
(+[WebCoreStatistics javaScriptProtectedObjectTypeCounts]): Ditto.
(+[WebCoreStatistics javaScriptObjectTypeCounts]): Ditto.

Canonical link: <a href="https://commits.webkit.org/297725@main">https://commits.webkit.org/297725@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5612da79e061c3a99a00ae3d7d93f4b9dd4d8da6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111350 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31016 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21481 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117382 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61618 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113312 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31697 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39598 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84633 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114297 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25311 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100245 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65080 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24654 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18383 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61202 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/103843 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94695 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18450 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120558 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109904 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38399 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28534 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93559 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38775 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96517 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93383 "Found 2 new API test failures: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24086 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38484 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16257 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34413 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38288 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43765 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/134179 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37953 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36172 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41286 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39655 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->