### PR TITLE
[JSC] Optimize constant deduplication with single HashMap lookup

### DIFF
--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -2828,18 +2828,18 @@ private:
         case ConstFloat:
         case ConstDouble: {
             ValueKey key = m_value->key();
-            if (Value* constInRoot = m_valueForConstant.get(key)) {
+            auto addResult = m_valueForConstant.add(key, m_value);
+            if (!addResult.isNewEntry) {
+                Value* constInRoot = addResult.iterator->value;
                 if (constInRoot != m_value) {
                     m_value->replaceWithIdentity(constInRoot);
                     m_changed = true;
                 }
-            } else if (m_block == m_root)
-                m_valueForConstant.add(key, m_value);
-            else {
+            } else if (m_block != m_root) {
                 Value* constInRoot = m_proc.clone(m_value);
                 ASSERT(m_root && m_root->size() >= 1);
                 m_root->appendNonTerminal(constInRoot);
-                m_valueForConstant.add(key, constInRoot);
+                addResult.iterator->value = constInRoot;
                 m_value->replaceWithIdentity(constInRoot);
                 m_changed = true;
             }


### PR DESCRIPTION
#### c9ff5f4a865ebd053875e5a2fb5216dc73423ece
<pre>
[JSC] Optimize constant deduplication with single HashMap lookup
<a href="https://bugs.webkit.org/show_bug.cgi?id=295848">https://bugs.webkit.org/show_bug.cgi?id=295848</a>
<a href="https://rdar.apple.com/155713217">rdar://155713217</a>

Reviewed by Yusuke Suzuki.

Replace HashMap::get() followed by HashMap::add() with a single HashMap::add()
call in constant value deduplication. This reduces HashMap lookups from two
to one operation per constant.

The optimization uses HashMap::add()&apos;s return value to determine if the constant
already exists, eliminating the need for a separate lookup operation while
maintaining the same constant deduplication and root block hoisting behavior.

Canonical link: <a href="https://commits.webkit.org/297337@main">https://commits.webkit.org/297337@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2be0d76ebe387c2c1dc7618a527d3234c334ea4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111329 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21460 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117361 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61597 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31676 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39577 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84613 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114276 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25291 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100224 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65061 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24634 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18363 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61181 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/103821 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94674 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18430 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120530 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109883 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38378 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28514 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93540 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38754 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96497 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93364 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38464 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16235 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34381 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17956 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38267 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43744 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/134158 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37932 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36165 "Found 1 jsc stress test failure: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention.js.default") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41265 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39634 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->