### PR TITLE
[JSC] Cache computed IntRange in ReduceStrength::rangeFor

### DIFF
--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -3547,69 +3547,93 @@ private:
     {
         if (!timeToLive)
             DUMP_INT_RANGE_AND_RETURN(IntRange::top(value->type()));
+
+        auto it = m_rangeCache.find(value);
+        if (it != m_rangeCache.end())
+            DUMP_INT_RANGE_AND_RETURN(it->value);
         
+        IntRange result;
         switch (value->opcode()) {
         case Const32:
         case Const64: {
             int64_t intValue = value->asInt();
-            DUMP_INT_RANGE_AND_RETURN(IntRange(intValue, intValue));
+            result = IntRange(intValue, intValue);
+            break;
         }
 
         case BitAnd:
-            if (value->child(1)->hasInt())
-                DUMP_INT_RANGE_AND_RETURN(IntRange::rangeForMask(value->child(1)->asInt(), value->type()));
+            if (value->child(1)->hasInt()) {
+                result = IntRange::rangeForMask(value->child(1)->asInt(), value->type());
+                break;
+            }
+            result = IntRange::top(value->type());
             break;
 
         case SShr:
             if (value->child(1)->hasInt32()) {
-                DUMP_INT_RANGE_AND_RETURN(rangeFor(value->child(0), timeToLive - 1).sShr(
-                    value->child(1)->asInt32(), value->type()));
+                result = rangeFor(value->child(0), timeToLive - 1).sShr(
+                    value->child(1)->asInt32(), value->type());
+                break;
             }
+            result = IntRange::top(value->type());
             break;
 
         case ZShr:
             if (value->child(1)->hasInt32()) {
-                DUMP_INT_RANGE_AND_RETURN(rangeFor(value->child(0), timeToLive - 1).zShr(
-                    value->child(1)->asInt32(), value->type()));
+                result = rangeFor(value->child(0), timeToLive - 1).zShr(
+                    value->child(1)->asInt32(), value->type());
+                break;
             }
+            result = IntRange::top(value->type());
             break;
 
         case Shl:
             if (value->child(1)->hasInt32()) {
-                DUMP_INT_RANGE_AND_RETURN(rangeFor(value->child(0), timeToLive - 1).shl(
-                    value->child(1)->asInt32(), value->type()));
+                result = rangeFor(value->child(0), timeToLive - 1).shl(
+                    value->child(1)->asInt32(), value->type());
+                break;
             }
+            result = IntRange::top(value->type());
             break;
 
         case Add:
-            DUMP_INT_RANGE_AND_RETURN(rangeFor(value->child(0), timeToLive - 1).add(
-                rangeFor(value->child(1), timeToLive - 1), value->type()));
+            result = rangeFor(value->child(0), timeToLive - 1).add(
+                rangeFor(value->child(1), timeToLive - 1), value->type());
+            break;
 
         case Sub:
-            DUMP_INT_RANGE_AND_RETURN(rangeFor(value->child(0), timeToLive - 1).sub(
-                rangeFor(value->child(1), timeToLive - 1), value->type()));
+            result = rangeFor(value->child(0), timeToLive - 1).sub(
+                rangeFor(value->child(1), timeToLive - 1), value->type());
+            break;
 
         case Mul:
-            DUMP_INT_RANGE_AND_RETURN(rangeFor(value->child(0), timeToLive - 1).mul(
-                rangeFor(value->child(1), timeToLive - 1), value->type()));
+            result = rangeFor(value->child(0), timeToLive - 1).mul(
+                rangeFor(value->child(1), timeToLive - 1), value->type());
+            break;
 
         case SExt8:
         case SExt8To64:
-            DUMP_INT_RANGE_AND_RETURN(rangeFor(value->child(0), timeToLive - 1).sExt<int8_t>());
+            result = rangeFor(value->child(0), timeToLive - 1).sExt<int8_t>();
+            break;
         case SExt16:
         case SExt16To64:
-            DUMP_INT_RANGE_AND_RETURN(rangeFor(value->child(0), timeToLive - 1).sExt<int16_t>());
+            result = rangeFor(value->child(0), timeToLive - 1).sExt<int16_t>();
+            break;
         case SExt32:
-            DUMP_INT_RANGE_AND_RETURN(rangeFor(value->child(0), timeToLive - 1).sExt<int32_t>());
+            result = rangeFor(value->child(0), timeToLive - 1).sExt<int32_t>();
+            break;
 
         case ZExt32:
-            DUMP_INT_RANGE_AND_RETURN(rangeFor(value->child(0), timeToLive - 1).zExt32());
+            result = rangeFor(value->child(0), timeToLive - 1).zExt32();
+            break;
 
         default:
+            result = IntRange::top(value->type());
             break;
         }
 
-        DUMP_INT_RANGE_AND_RETURN(IntRange::top(value->type()));
+        m_rangeCache.add(value, result);
+        DUMP_INT_RANGE_AND_RETURN(result);
     }
 
     template<typename ValueType, typename... Arguments>
@@ -3875,6 +3899,7 @@ private:
     InsertionSet m_insertionSet;
     BlockInsertionSet m_blockInsertionSet;
     UncheckedKeyHashMap<ValueKey, Value*> m_valueForConstant;
+    UncheckedKeyHashMap<Value*, IntRange> m_rangeCache;
     BasicBlock* m_root { nullptr };
     BasicBlock* m_block { nullptr };
     unsigned m_index { 0 };


### PR DESCRIPTION
#### 1ce772661afd5114430645641ad7799e844d543f
<pre>
[JSC] Cache computed IntRange in ReduceStrength::rangeFor
<a href="https://bugs.webkit.org/show_bug.cgi?id=295850">https://bugs.webkit.org/show_bug.cgi?id=295850</a>
<a href="https://rdar.apple.com/155714460">rdar://155714460</a>

Reviewed by NOBODY (OOPS!).

This patch introduces a cache to store previously computed IntRange results in
B3ReduceStrength::rangeFor. Since IntRange computation can be recursive and expensive,
caching avoids redundant recomputation for the same value.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ce772661afd5114430645641ad7799e844d543f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111330 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30996 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21461 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117362 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61598 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31677 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39578 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84614 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114277 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25292 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100226 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65062 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24635 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18365 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61182 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/103823 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94675 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18432 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120531 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109884 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38379 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28515 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93541 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38755 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96499 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93365 "Found 2 new API test failures: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38466 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16237 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34383 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38268 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43745 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/134159 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37933 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36167 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41266 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39635 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->