### PR TITLE
Reduce unsafeness in webtransport module

### DIFF
--- a/Source/WebCore/Modules/webtransport/WebTransport.h
+++ b/Source/WebCore/Modules/webtransport/WebTransport.h
@@ -104,6 +104,8 @@ private:
     void streamReceiveBytes(WebTransportStreamIdentifier, std::span<const uint8_t>, bool, std::optional<Exception>&&) final;
     void networkProcessCrashed() final;
 
+    RefPtr<WebTransportSession> protectedSession();
+
     ListHashSet<Ref<WritableStream>> m_sendStreams;
     ListHashSet<Ref<ReadableStream>> m_receiveStreams;
     const Ref<ReadableStream> m_incomingBidirectionalStreams;
@@ -119,12 +121,12 @@ private:
     };
     State m_state { State::Connecting };
 
-    using PromiseAndWrapper = std::pair<Ref<DOMPromise>, Ref<DeferredPromise>>;
-    PromiseAndWrapper m_ready;
+    using PromiseAndWrapper = const std::pair<const Ref<DOMPromise>, const Ref<DeferredPromise>>;
+    const PromiseAndWrapper m_ready;
     WebTransportReliabilityMode m_reliability { WebTransportReliabilityMode::Pending };
     WebTransportCongestionControl m_congestionControl;
-    PromiseAndWrapper m_closed;
-    PromiseAndWrapper m_draining;
+    const PromiseAndWrapper m_closed;
+    const PromiseAndWrapper m_draining;
     const Ref<WebTransportDatagramDuplexStream> m_datagrams;
     RefPtr<WebTransportSession> m_session;
     const Ref<DatagramSource> m_datagramSource;

--- a/Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.cpp
@@ -46,41 +46,6 @@ WebTransportDatagramDuplexStream::WebTransportDatagramDuplexStream(Ref<ReadableS
 
 WebTransportDatagramDuplexStream::~WebTransportDatagramDuplexStream() = default;
 
-ReadableStream& WebTransportDatagramDuplexStream::readable()
-{
-    return m_readable.get();
-}
-
-WritableStream& WebTransportDatagramDuplexStream::writable()
-{
-    return m_writable.get();
-}
-
-unsigned WebTransportDatagramDuplexStream::maxDatagramSize()
-{
-    return m_outgoingMaxDatagramSize;
-}
-
-double WebTransportDatagramDuplexStream::incomingMaxAge()
-{
-    return m_incomingDatagramsExpirationDuration;
-}
-
-double WebTransportDatagramDuplexStream::outgoingMaxAge()
-{
-    return m_outgoingDatagramsExpirationDuration;
-}
-
-double WebTransportDatagramDuplexStream::incomingHighWaterMark()
-{
-    return m_incomingDatagramsHighWaterMark;
-}
-
-double WebTransportDatagramDuplexStream::outgoingHighWaterMark()
-{
-    return m_outgoingDatagramsHighWaterMark;
-}
-
 ExceptionOr<void> WebTransportDatagramDuplexStream::setIncomingMaxAge(double maxAge)
 {
     // https://www.w3.org/TR/webtransport/#dom-webtransportdatagramduplexstream-incomingmaxage

--- a/Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.h
@@ -44,13 +44,13 @@ public:
     static Ref<WebTransportDatagramDuplexStream> create(Ref<ReadableStream>&&, Ref<WritableStream>&&);
     ~WebTransportDatagramDuplexStream();
 
-    ReadableStream& readable();
-    WritableStream& writable();
-    unsigned maxDatagramSize();
-    double incomingMaxAge();
-    double outgoingMaxAge();
-    double incomingHighWaterMark();
-    double outgoingHighWaterMark();
+    ReadableStream& readable() { return m_readable; }
+    WritableStream& writable() { return m_writable; }
+    unsigned maxDatagramSize() { return m_outgoingMaxDatagramSize; }
+    double incomingMaxAge() { return m_incomingDatagramsExpirationDuration; }
+    double outgoingMaxAge() { return m_outgoingDatagramsExpirationDuration; }
+    double incomingHighWaterMark() { return m_incomingDatagramsHighWaterMark; }
+    double outgoingHighWaterMark() { return m_outgoingDatagramsHighWaterMark; }
     ExceptionOr<void> setIncomingMaxAge(double);
     ExceptionOr<void> setOutgoingMaxAge(double);
     ExceptionOr<void> setIncomingHighWaterMark(double);


### PR DESCRIPTION
#### 68af28fb7f43baa3c0ea69b5e699e72364568feb
<pre>
Reduce unsafeness in webtransport module
<a href="https://bugs.webkit.org/show_bug.cgi?id=295852">https://bugs.webkit.org/show_bug.cgi?id=295852</a>

Reviewed by Alex Christensen.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/297444@main">https://commits.webkit.org/297444@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67c966eb2405f153410074362747defa880c4bfc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111634 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31301 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21775 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117669 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62011 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113596 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31989 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39886 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84814 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35603 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114581 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25531 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100468 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65256 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24867 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18602 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61501 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94915 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18671 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120917 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38687 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28739 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93714 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39065 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96725 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93540 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38677 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16467 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34723 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18017 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38576 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44061 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38239 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41575 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39941 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->