### PR TITLE
[JSC] `Intl.Local#language` should return `"und"` if language subtag is `"und"`

### DIFF
--- a/JSTests/stress/intl-locale-prototype-language-und.js
+++ b/JSTests/stress/intl-locale-prototype-language-und.js
@@ -1,0 +1,27 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+
+var loc = new Intl.Locale("und");
+
+shouldBe(loc.toString(), "und");
+shouldBe(loc.baseName, "und");
+shouldBe(loc.language, "und");
+shouldBe(loc.script, undefined);
+shouldBe(loc.region, undefined);
+shouldBe(loc.variants, undefined);
+
+var loc = new Intl.Locale("und-US-u-co-emoji");
+
+shouldBe(loc.toString(), "und-US-u-co-emoji");
+shouldBe(loc.baseName, "und-US");
+shouldBe(loc.language, "und");
+shouldBe(loc.script, undefined);
+shouldBe(loc.region, "US");
+shouldBe(loc.variants, undefined);
+if ("collation" in loc) {
+    shouldBe(loc.collation, "emoji");
+}
+

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1138,9 +1138,6 @@ test/intl402/Intl/supportedValuesOf/calendars.js:
 test/intl402/Locale/extensions-grandfathered.js:
   default: 'Test262Error: Expected SameValue(«"fr-Cyrl-FR-gaulish-u-nu-latn"», «"fr-Cyrl-FR-u-nu-latn"») to be true'
   strict mode: 'Test262Error: Expected SameValue(«"fr-Cyrl-FR-gaulish-u-nu-latn"», «"fr-Cyrl-FR-u-nu-latn"») to be true'
-test/intl402/Locale/getters.js:
-  default: 'Test262Error: Expected SameValue(«undefined», «"und"») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«undefined», «"und"») to be true'
 test/intl402/NumberFormat/currency-digits-nonstandard-notation.js:
   default: "Test262Error: Didn't get correct maximumFractionDigits for JPY in engineering notation. Expected SameValue(«0», «3») to be true"
   strict mode: "Test262Error: Didn't get correct maximumFractionDigits for JPY in engineering notation. Expected SameValue(«0», «3») to be true"

--- a/Source/JavaScriptCore/runtime/IntlLocale.cpp
+++ b/Source/JavaScriptCore/runtime/IntlLocale.cpp
@@ -535,7 +535,10 @@ const String& IntlLocale::language()
         Vector<char, 8> buffer;
         auto status = callBufferProducingFunction(uloc_getLanguage, m_localeID.data(), buffer);
         ASSERT_UNUSED(status, U_SUCCESS(status));
-        m_language = buffer.span();
+        if (!buffer.size())
+            m_language = "und"_s;
+        else
+            m_language = buffer.span();
     }
     return m_language;
 }


### PR DESCRIPTION
#### dabe534de31f6b4507c0484fafe12259c7a2df81
<pre>
[JSC] `Intl.Local#language` should return `&quot;und&quot;` if language subtag is `&quot;und&quot;`
<a href="https://bugs.webkit.org/show_bug.cgi?id=295853">https://bugs.webkit.org/show_bug.cgi?id=295853</a>

Reviewed by Yusuke Suzuki.

According to the spec, `Intl.Locale#lanauge` getter should return `&quot;und&quot;` if language
subtag is `&quot;und&quot;`. But current JSC returns `undefined`.

This patch changes to fix it in the same wasy as V8[2].

[1]: <a href="https://tc39.es/ecma402/#sec-getlocalelanguage">https://tc39.es/ecma402/#sec-getlocalelanguage</a>
[2]: <a href="https://github.com/v8/v8/blob/8d147aa1fbaebe7d85eeaf99b70a2593f5f7ac7c/src/objects/js-locale.cc#L801-L81">https://github.com/v8/v8/blob/8d147aa1fbaebe7d85eeaf99b70a2593f5f7ac7c/src/objects/js-locale.cc#L801-L81</a>

* JSTests/stress/intl-locale-prototype-language-und.js: Added.
(shouldBe):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/IntlLocale.cpp:
(JSC::IntlLocale::language):

Canonical link: <a href="https://commits.webkit.org/297858@main">https://commits.webkit.org/297858@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b47fdf3943654975b415ebcff43c64bfabdfbb5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111339 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31005 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21470 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117371 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61607 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31686 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39587 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84623 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114286 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25301 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100232 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65071 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24644 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18371 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61191 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/103832 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94684 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18438 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120544 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109893 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38388 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28522 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93550 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38764 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96505 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93374 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24168 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38473 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16243 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34396 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38277 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43754 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/134168 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37942 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36169 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41275 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39644 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->