### PR TITLE
[WebIDL] Add WebIDL support for [Enumerated] extended attribute and related attributes [MissingValueDefault],[InvalidValueDefault]

### DIFF
--- a/Source/WebCore/bindings/scripts/CodeGenerator.pm
+++ b/Source/WebCore/bindings/scripts/CodeGenerator.pm
@@ -404,6 +404,13 @@ sub ProcessInterfaceSupplementalDependencies
         foreach my $interface (@{$document->interfaces}) {
             next unless $object->IsValidSupplementalInterface($interface, $targetInterface, \%includesMap);
 
+            # Ensure the root IDLDocument has access to all relevant enums (e.g., such as those defined in a mixin interface).
+            foreach my $enumeration (@{$document->enumerations}) {
+                my $enumName = $enumeration->type->name;
+                next if grep { $_->type->name eq $enumName } @{$targetDocument->enumerations};
+                push @{$targetDocument->enumerations}, $enumeration;
+            }
+
             if ($interface->isMixin && !$interface->isPartial) {
                 # Recursively process any supplemental dependencies for each valid mixin. This
                 # allows partial partial interface mixins to be merged into the mixin.

--- a/Source/WebCore/bindings/scripts/IDLAttributes.json
+++ b/Source/WebCore/bindings/scripts/IDLAttributes.json
@@ -202,6 +202,14 @@
                 "url": "https://webidl.spec.whatwg.org/#EnforceRange"
             }
         },
+        "Enumerated": {
+            "contextsAllowed": ["attribute"],
+            "values": ["*"],
+            "notes": "Specifies that an attribute is limited to known values, e.g., [Reflect, Enumerated=AttributeValues] where AttributeValues is an enum",
+            "standard": {
+                "url": "https://html.spec.whatwg.org/#keywords-and-enumerated-attributes"
+            }
+        },
         "Exception": {
             "contextsAllowed": ["interface"]
         },
@@ -263,6 +271,13 @@
         "InterfaceName": {
             "contextsAllowed": ["interface", "namespace"],
             "values": ["*"]
+        },
+        "InvalidValueDefault": {
+            "contextsAllowed": ["enum"],
+            "values": ["*"],
+            "standard": {
+                "url": "https://html.spec.whatwg.org/#keywords-and-enumerated-attributes"
+            }
         },
         "IsImmutablePrototypeExoticObject": {
             "contextsAllowed": ["interface"]
@@ -377,6 +392,13 @@
         },
         "MasqueradesAsUndefined": {
             "contextsAllowed": ["interface"]
+        },
+        "MissingValueDefault": {
+            "contextsAllowed": ["enum"],
+            "values": ["*"],
+            "standard": {
+                "url": "https://html.spec.whatwg.org/#keywords-and-enumerated-attributes"
+            }
         },
         "NewImpurePropertyFiresWatchpoints": {
             "contextsAllowed": ["interface"]

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
@@ -539,6 +539,282 @@ template<> ASCIILiteral expectedEnumerationValues<TestObj::Confidence>()
     return "\"high\", \"kinda-low\""_s;
 }
 
+String convertEnumerationToString(TestObj::EnumWithMissingValueDefault enumerationValue)
+{
+    static const std::array<NeverDestroyed<String>, 4> values {
+        MAKE_STATIC_STRING_IMPL("value1"),
+        MAKE_STATIC_STRING_IMPL("value2"),
+        MAKE_STATIC_STRING_IMPL("value3"),
+        emptyString(),
+    };
+    static_assert(static_cast<size_t>(TestObj::EnumWithMissingValueDefault::Value1) == 0, "TestObj::EnumWithMissingValueDefault::Value1 is not 0 as expected");
+    static_assert(static_cast<size_t>(TestObj::EnumWithMissingValueDefault::Value2) == 1, "TestObj::EnumWithMissingValueDefault::Value2 is not 1 as expected");
+    static_assert(static_cast<size_t>(TestObj::EnumWithMissingValueDefault::Value3) == 2, "TestObj::EnumWithMissingValueDefault::Value3 is not 2 as expected");
+    static_assert(static_cast<size_t>(TestObj::EnumWithMissingValueDefault::EmptyString) == 3, "TestObj::EnumWithMissingValueDefault::EmptyString is not 3 as expected");
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
+    return values[static_cast<size_t>(enumerationValue)];
+}
+
+template<> JSString* convertEnumerationToJS(VM& vm, TestObj::EnumWithMissingValueDefault enumerationValue)
+{
+    return jsStringWithCache(vm, convertEnumerationToString(enumerationValue));
+}
+
+template<> std::optional<TestObj::EnumWithMissingValueDefault> parseEnumerationFromString<TestObj::EnumWithMissingValueDefault>(const String& stringValue)
+{
+    if (stringValue.isEmpty())
+        return TestObj::EnumWithMissingValueDefault::EmptyString;
+    static constexpr std::array<std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefault>, 3> mappings {
+        std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefault> { "value1"_s, TestObj::EnumWithMissingValueDefault::Value1 },
+        std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefault> { "value2"_s, TestObj::EnumWithMissingValueDefault::Value2 },
+        std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefault> { "value3"_s, TestObj::EnumWithMissingValueDefault::Value3 },
+    };
+    static constexpr SortedArrayMap enumerationMapping { mappings };
+    if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]
+        return *enumerationValue;
+    return std::nullopt;
+}
+
+template<> std::optional<TestObj::EnumWithMissingValueDefault> parseEnumeration<TestObj::EnumWithMissingValueDefault>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+{
+    return parseEnumerationFromString<TestObj::EnumWithMissingValueDefault>(value.toWTFString(&lexicalGlobalObject));
+}
+
+template<> ASCIILiteral expectedEnumerationValues<TestObj::EnumWithMissingValueDefault>()
+{
+    return "\"value1\", \"value2\", \"value3\", \"\""_s;
+}
+
+String convertEnumerationToString(TestObj::EnumWithInvalidValueDefault enumerationValue)
+{
+    static const std::array<NeverDestroyed<String>, 4> values {
+        MAKE_STATIC_STRING_IMPL("value1"),
+        MAKE_STATIC_STRING_IMPL("value2"),
+        MAKE_STATIC_STRING_IMPL("value3"),
+        emptyString(),
+    };
+    static_assert(static_cast<size_t>(TestObj::EnumWithInvalidValueDefault::Value1) == 0, "TestObj::EnumWithInvalidValueDefault::Value1 is not 0 as expected");
+    static_assert(static_cast<size_t>(TestObj::EnumWithInvalidValueDefault::Value2) == 1, "TestObj::EnumWithInvalidValueDefault::Value2 is not 1 as expected");
+    static_assert(static_cast<size_t>(TestObj::EnumWithInvalidValueDefault::Value3) == 2, "TestObj::EnumWithInvalidValueDefault::Value3 is not 2 as expected");
+    static_assert(static_cast<size_t>(TestObj::EnumWithInvalidValueDefault::EmptyString) == 3, "TestObj::EnumWithInvalidValueDefault::EmptyString is not 3 as expected");
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
+    return values[static_cast<size_t>(enumerationValue)];
+}
+
+template<> JSString* convertEnumerationToJS(VM& vm, TestObj::EnumWithInvalidValueDefault enumerationValue)
+{
+    return jsStringWithCache(vm, convertEnumerationToString(enumerationValue));
+}
+
+template<> std::optional<TestObj::EnumWithInvalidValueDefault> parseEnumerationFromString<TestObj::EnumWithInvalidValueDefault>(const String& stringValue)
+{
+    if (stringValue.isEmpty())
+        return TestObj::EnumWithInvalidValueDefault::EmptyString;
+    static constexpr std::array<std::pair<ComparableASCIILiteral, TestObj::EnumWithInvalidValueDefault>, 3> mappings {
+        std::pair<ComparableASCIILiteral, TestObj::EnumWithInvalidValueDefault> { "value1"_s, TestObj::EnumWithInvalidValueDefault::Value1 },
+        std::pair<ComparableASCIILiteral, TestObj::EnumWithInvalidValueDefault> { "value2"_s, TestObj::EnumWithInvalidValueDefault::Value2 },
+        std::pair<ComparableASCIILiteral, TestObj::EnumWithInvalidValueDefault> { "value3"_s, TestObj::EnumWithInvalidValueDefault::Value3 },
+    };
+    static constexpr SortedArrayMap enumerationMapping { mappings };
+    if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]
+        return *enumerationValue;
+    return std::nullopt;
+}
+
+template<> std::optional<TestObj::EnumWithInvalidValueDefault> parseEnumeration<TestObj::EnumWithInvalidValueDefault>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+{
+    return parseEnumerationFromString<TestObj::EnumWithInvalidValueDefault>(value.toWTFString(&lexicalGlobalObject));
+}
+
+template<> ASCIILiteral expectedEnumerationValues<TestObj::EnumWithInvalidValueDefault>()
+{
+    return "\"value1\", \"value2\", \"value3\", \"\""_s;
+}
+
+String convertEnumerationToString(TestObj::EnumWithMissingAndInvalidValueDefault enumerationValue)
+{
+    static const std::array<NeverDestroyed<String>, 4> values {
+        MAKE_STATIC_STRING_IMPL("value1"),
+        MAKE_STATIC_STRING_IMPL("value2"),
+        MAKE_STATIC_STRING_IMPL("value3"),
+        emptyString(),
+    };
+    static_assert(static_cast<size_t>(TestObj::EnumWithMissingAndInvalidValueDefault::Value1) == 0, "TestObj::EnumWithMissingAndInvalidValueDefault::Value1 is not 0 as expected");
+    static_assert(static_cast<size_t>(TestObj::EnumWithMissingAndInvalidValueDefault::Value2) == 1, "TestObj::EnumWithMissingAndInvalidValueDefault::Value2 is not 1 as expected");
+    static_assert(static_cast<size_t>(TestObj::EnumWithMissingAndInvalidValueDefault::Value3) == 2, "TestObj::EnumWithMissingAndInvalidValueDefault::Value3 is not 2 as expected");
+    static_assert(static_cast<size_t>(TestObj::EnumWithMissingAndInvalidValueDefault::EmptyString) == 3, "TestObj::EnumWithMissingAndInvalidValueDefault::EmptyString is not 3 as expected");
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
+    return values[static_cast<size_t>(enumerationValue)];
+}
+
+template<> JSString* convertEnumerationToJS(VM& vm, TestObj::EnumWithMissingAndInvalidValueDefault enumerationValue)
+{
+    return jsStringWithCache(vm, convertEnumerationToString(enumerationValue));
+}
+
+template<> std::optional<TestObj::EnumWithMissingAndInvalidValueDefault> parseEnumerationFromString<TestObj::EnumWithMissingAndInvalidValueDefault>(const String& stringValue)
+{
+    if (stringValue.isEmpty())
+        return TestObj::EnumWithMissingAndInvalidValueDefault::EmptyString;
+    static constexpr std::array<std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingAndInvalidValueDefault>, 3> mappings {
+        std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingAndInvalidValueDefault> { "value1"_s, TestObj::EnumWithMissingAndInvalidValueDefault::Value1 },
+        std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingAndInvalidValueDefault> { "value2"_s, TestObj::EnumWithMissingAndInvalidValueDefault::Value2 },
+        std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingAndInvalidValueDefault> { "value3"_s, TestObj::EnumWithMissingAndInvalidValueDefault::Value3 },
+    };
+    static constexpr SortedArrayMap enumerationMapping { mappings };
+    if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]
+        return *enumerationValue;
+    return std::nullopt;
+}
+
+template<> std::optional<TestObj::EnumWithMissingAndInvalidValueDefault> parseEnumeration<TestObj::EnumWithMissingAndInvalidValueDefault>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+{
+    return parseEnumerationFromString<TestObj::EnumWithMissingAndInvalidValueDefault>(value.toWTFString(&lexicalGlobalObject));
+}
+
+template<> ASCIILiteral expectedEnumerationValues<TestObj::EnumWithMissingAndInvalidValueDefault>()
+{
+    return "\"value1\", \"value2\", \"value3\", \"\""_s;
+}
+
+String convertEnumerationToString(TestObj::EnumWithMissingValueDefaultNoQuotes enumerationValue)
+{
+    static const std::array<NeverDestroyed<String>, 4> values {
+        MAKE_STATIC_STRING_IMPL("value1"),
+        MAKE_STATIC_STRING_IMPL("value2"),
+        MAKE_STATIC_STRING_IMPL("value3"),
+        emptyString(),
+    };
+    static_assert(static_cast<size_t>(TestObj::EnumWithMissingValueDefaultNoQuotes::Value1) == 0, "TestObj::EnumWithMissingValueDefaultNoQuotes::Value1 is not 0 as expected");
+    static_assert(static_cast<size_t>(TestObj::EnumWithMissingValueDefaultNoQuotes::Value2) == 1, "TestObj::EnumWithMissingValueDefaultNoQuotes::Value2 is not 1 as expected");
+    static_assert(static_cast<size_t>(TestObj::EnumWithMissingValueDefaultNoQuotes::Value3) == 2, "TestObj::EnumWithMissingValueDefaultNoQuotes::Value3 is not 2 as expected");
+    static_assert(static_cast<size_t>(TestObj::EnumWithMissingValueDefaultNoQuotes::EmptyString) == 3, "TestObj::EnumWithMissingValueDefaultNoQuotes::EmptyString is not 3 as expected");
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
+    return values[static_cast<size_t>(enumerationValue)];
+}
+
+template<> JSString* convertEnumerationToJS(VM& vm, TestObj::EnumWithMissingValueDefaultNoQuotes enumerationValue)
+{
+    return jsStringWithCache(vm, convertEnumerationToString(enumerationValue));
+}
+
+template<> std::optional<TestObj::EnumWithMissingValueDefaultNoQuotes> parseEnumerationFromString<TestObj::EnumWithMissingValueDefaultNoQuotes>(const String& stringValue)
+{
+    if (stringValue.isEmpty())
+        return TestObj::EnumWithMissingValueDefaultNoQuotes::EmptyString;
+    static constexpr std::array<std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultNoQuotes>, 3> mappings {
+        std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultNoQuotes> { "value1"_s, TestObj::EnumWithMissingValueDefaultNoQuotes::Value1 },
+        std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultNoQuotes> { "value2"_s, TestObj::EnumWithMissingValueDefaultNoQuotes::Value2 },
+        std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultNoQuotes> { "value3"_s, TestObj::EnumWithMissingValueDefaultNoQuotes::Value3 },
+    };
+    static constexpr SortedArrayMap enumerationMapping { mappings };
+    if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]
+        return *enumerationValue;
+    return std::nullopt;
+}
+
+template<> std::optional<TestObj::EnumWithMissingValueDefaultNoQuotes> parseEnumeration<TestObj::EnumWithMissingValueDefaultNoQuotes>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+{
+    return parseEnumerationFromString<TestObj::EnumWithMissingValueDefaultNoQuotes>(value.toWTFString(&lexicalGlobalObject));
+}
+
+template<> ASCIILiteral expectedEnumerationValues<TestObj::EnumWithMissingValueDefaultNoQuotes>()
+{
+    return "\"value1\", \"value2\", \"value3\", \"\""_s;
+}
+
+String convertEnumerationToString(TestObj::EnumWithMissingValueDefaultAsEmptyValue enumerationValue)
+{
+    static const std::array<NeverDestroyed<String>, 4> values {
+        MAKE_STATIC_STRING_IMPL("value1"),
+        MAKE_STATIC_STRING_IMPL("value2"),
+        MAKE_STATIC_STRING_IMPL("value3"),
+        emptyString(),
+    };
+    static_assert(static_cast<size_t>(TestObj::EnumWithMissingValueDefaultAsEmptyValue::Value1) == 0, "TestObj::EnumWithMissingValueDefaultAsEmptyValue::Value1 is not 0 as expected");
+    static_assert(static_cast<size_t>(TestObj::EnumWithMissingValueDefaultAsEmptyValue::Value2) == 1, "TestObj::EnumWithMissingValueDefaultAsEmptyValue::Value2 is not 1 as expected");
+    static_assert(static_cast<size_t>(TestObj::EnumWithMissingValueDefaultAsEmptyValue::Value3) == 2, "TestObj::EnumWithMissingValueDefaultAsEmptyValue::Value3 is not 2 as expected");
+    static_assert(static_cast<size_t>(TestObj::EnumWithMissingValueDefaultAsEmptyValue::EmptyString) == 3, "TestObj::EnumWithMissingValueDefaultAsEmptyValue::EmptyString is not 3 as expected");
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
+    return values[static_cast<size_t>(enumerationValue)];
+}
+
+template<> JSString* convertEnumerationToJS(VM& vm, TestObj::EnumWithMissingValueDefaultAsEmptyValue enumerationValue)
+{
+    return jsStringWithCache(vm, convertEnumerationToString(enumerationValue));
+}
+
+template<> std::optional<TestObj::EnumWithMissingValueDefaultAsEmptyValue> parseEnumerationFromString<TestObj::EnumWithMissingValueDefaultAsEmptyValue>(const String& stringValue)
+{
+    if (stringValue.isEmpty())
+        return TestObj::EnumWithMissingValueDefaultAsEmptyValue::EmptyString;
+    static constexpr std::array<std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultAsEmptyValue>, 3> mappings {
+        std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultAsEmptyValue> { "value1"_s, TestObj::EnumWithMissingValueDefaultAsEmptyValue::Value1 },
+        std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultAsEmptyValue> { "value2"_s, TestObj::EnumWithMissingValueDefaultAsEmptyValue::Value2 },
+        std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultAsEmptyValue> { "value3"_s, TestObj::EnumWithMissingValueDefaultAsEmptyValue::Value3 },
+    };
+    static constexpr SortedArrayMap enumerationMapping { mappings };
+    if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]
+        return *enumerationValue;
+    return std::nullopt;
+}
+
+template<> std::optional<TestObj::EnumWithMissingValueDefaultAsEmptyValue> parseEnumeration<TestObj::EnumWithMissingValueDefaultAsEmptyValue>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+{
+    return parseEnumerationFromString<TestObj::EnumWithMissingValueDefaultAsEmptyValue>(value.toWTFString(&lexicalGlobalObject));
+}
+
+template<> ASCIILiteral expectedEnumerationValues<TestObj::EnumWithMissingValueDefaultAsEmptyValue>()
+{
+    return "\"value1\", \"value2\", \"value3\", \"\""_s;
+}
+
+String convertEnumerationToString(TestObj::EnumWithMissingValueDefaultNotInEnumValues enumerationValue)
+{
+    static const std::array<NeverDestroyed<String>, 4> values {
+        MAKE_STATIC_STRING_IMPL("value1"),
+        MAKE_STATIC_STRING_IMPL("value2"),
+        MAKE_STATIC_STRING_IMPL("value3"),
+        emptyString(),
+    };
+    static_assert(static_cast<size_t>(TestObj::EnumWithMissingValueDefaultNotInEnumValues::Value1) == 0, "TestObj::EnumWithMissingValueDefaultNotInEnumValues::Value1 is not 0 as expected");
+    static_assert(static_cast<size_t>(TestObj::EnumWithMissingValueDefaultNotInEnumValues::Value2) == 1, "TestObj::EnumWithMissingValueDefaultNotInEnumValues::Value2 is not 1 as expected");
+    static_assert(static_cast<size_t>(TestObj::EnumWithMissingValueDefaultNotInEnumValues::Value3) == 2, "TestObj::EnumWithMissingValueDefaultNotInEnumValues::Value3 is not 2 as expected");
+    static_assert(static_cast<size_t>(TestObj::EnumWithMissingValueDefaultNotInEnumValues::EmptyString) == 3, "TestObj::EnumWithMissingValueDefaultNotInEnumValues::EmptyString is not 3 as expected");
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
+    return values[static_cast<size_t>(enumerationValue)];
+}
+
+template<> JSString* convertEnumerationToJS(VM& vm, TestObj::EnumWithMissingValueDefaultNotInEnumValues enumerationValue)
+{
+    return jsStringWithCache(vm, convertEnumerationToString(enumerationValue));
+}
+
+template<> std::optional<TestObj::EnumWithMissingValueDefaultNotInEnumValues> parseEnumerationFromString<TestObj::EnumWithMissingValueDefaultNotInEnumValues>(const String& stringValue)
+{
+    if (stringValue.isEmpty())
+        return TestObj::EnumWithMissingValueDefaultNotInEnumValues::EmptyString;
+    static constexpr std::array<std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultNotInEnumValues>, 3> mappings {
+        std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultNotInEnumValues> { "value1"_s, TestObj::EnumWithMissingValueDefaultNotInEnumValues::Value1 },
+        std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultNotInEnumValues> { "value2"_s, TestObj::EnumWithMissingValueDefaultNotInEnumValues::Value2 },
+        std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultNotInEnumValues> { "value3"_s, TestObj::EnumWithMissingValueDefaultNotInEnumValues::Value3 },
+    };
+    static constexpr SortedArrayMap enumerationMapping { mappings };
+    if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]
+        return *enumerationValue;
+    return std::nullopt;
+}
+
+template<> std::optional<TestObj::EnumWithMissingValueDefaultNotInEnumValues> parseEnumeration<TestObj::EnumWithMissingValueDefaultNotInEnumValues>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+{
+    return parseEnumerationFromString<TestObj::EnumWithMissingValueDefaultNotInEnumValues>(value.toWTFString(&lexicalGlobalObject));
+}
+
+template<> ASCIILiteral expectedEnumerationValues<TestObj::EnumWithMissingValueDefaultNotInEnumValues>()
+{
+    return "\"value1\", \"value2\", \"value3\", \"\""_s;
+}
+
 template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionary<TestObj::Dictionary>(JSGlobalObject& lexicalGlobalObject, JSValue value)
 {
     SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
@@ -1977,6 +2253,24 @@ static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_create);
 static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_create);
 static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedStringAttr);
 static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedStringAttr);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedEnumWithMissingValueDefaultStringAttr);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedEnumWithMissingValueDefaultStringAttr);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedEnumWithInvalidValueDefaultStringAttr);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedEnumWithInvalidValueDefaultStringAttr);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedEnumWithInvalidAndMissingValueDefaultStringAttr);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedEnumWithInvalidAndMissingValueDefaultStringAttr);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedEnumWithMissingValueDefaultNoQuotesStringAttr);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedEnumWithMissingValueDefaultNoQuotesStringAttr);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedEnumWithNoEnumerationSpecified);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedEnumWithNoEnumerationSpecified);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedEnumWithInvalidEnumSpecified);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedEnumWithInvalidEnumSpecified);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedEnumWithMissingValueDefaultAsEmptyValue);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedEnumWithMissingValueDefaultAsEmptyValue);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedEnumWithMissingValueDefaultNotInEnumValues);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedEnumWithMissingValueDefaultNotInEnumValues);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_fauxEnumReflectedStringMissingReflectAttribute);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_fauxEnumReflectedStringMissingReflectAttribute);
 static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedUSVStringAttr);
 static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedUSVStringAttr);
 static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedIntegralAttr);
@@ -2001,6 +2295,16 @@ static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedCustomBooleanAttr);
 static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedCustomBooleanAttr);
 static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedCustomURLAttr);
 static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedCustomURLAttr);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedNullableStringAttr);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedNullableStringAttr);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedNullableEnumWithMissingValueDefaultStringAttr);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedNullableEnumWithMissingValueDefaultStringAttr);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedNullableEnumWithInvalidValueDefaultStringAttr);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedNullableEnumWithInvalidValueDefaultStringAttr);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedNullableEnumWithInvalidAndMissingValueDefaultStringAttr);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedNullableEnumWithInvalidAndMissingValueDefaultStringAttr);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedNullableEnumWithMissingValueDefaultNoQuotesStringAttr);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedNullableEnumWithMissingValueDefaultNoQuotesStringAttr);
 static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedSetterStringAttr);
 static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedSetterStringAttr);
 static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedSetterUSVStringAttr);
@@ -2340,7 +2644,7 @@ template<> void JSTestObjDOMConstructor::initializeProperties(VM& vm, JSDOMGloba
 
 /* Hash table for prototype */
 
-static const std::array<HashTableValue, 282> JSTestObjPrototypeTableValues {
+static const std::array<HashTableValue, 296> JSTestObjPrototypeTableValues {
     HashTableValue { "constructor"_s, static_cast<unsigned>(PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObjConstructor, 0 } },
     HashTableValue { "readOnlyLongAttr"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_readOnlyLongAttr, 0 } },
     HashTableValue { "readOnlyStringAttr"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_readOnlyStringAttr, 0 } },
@@ -2380,6 +2684,15 @@ static const std::array<HashTableValue, 282> JSTestObjPrototypeTableValues {
     HashTableValue { "XMLObjAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_XMLObjAttr, setJSTestObj_XMLObjAttr } },
     HashTableValue { "create"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_create, setJSTestObj_create } },
     HashTableValue { "reflectedStringAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedStringAttr, setJSTestObj_reflectedStringAttr } },
+    HashTableValue { "reflectedEnumWithMissingValueDefaultStringAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedEnumWithMissingValueDefaultStringAttr, setJSTestObj_reflectedEnumWithMissingValueDefaultStringAttr } },
+    HashTableValue { "reflectedEnumWithInvalidValueDefaultStringAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedEnumWithInvalidValueDefaultStringAttr, setJSTestObj_reflectedEnumWithInvalidValueDefaultStringAttr } },
+    HashTableValue { "reflectedEnumWithInvalidAndMissingValueDefaultStringAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedEnumWithInvalidAndMissingValueDefaultStringAttr, setJSTestObj_reflectedEnumWithInvalidAndMissingValueDefaultStringAttr } },
+    HashTableValue { "reflectedEnumWithMissingValueDefaultNoQuotesStringAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedEnumWithMissingValueDefaultNoQuotesStringAttr, setJSTestObj_reflectedEnumWithMissingValueDefaultNoQuotesStringAttr } },
+    HashTableValue { "reflectedEnumWithNoEnumerationSpecified"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedEnumWithNoEnumerationSpecified, setJSTestObj_reflectedEnumWithNoEnumerationSpecified } },
+    HashTableValue { "reflectedEnumWithInvalidEnumSpecified"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedEnumWithInvalidEnumSpecified, setJSTestObj_reflectedEnumWithInvalidEnumSpecified } },
+    HashTableValue { "reflectedEnumWithMissingValueDefaultAsEmptyValue"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedEnumWithMissingValueDefaultAsEmptyValue, setJSTestObj_reflectedEnumWithMissingValueDefaultAsEmptyValue } },
+    HashTableValue { "reflectedEnumWithMissingValueDefaultNotInEnumValues"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedEnumWithMissingValueDefaultNotInEnumValues, setJSTestObj_reflectedEnumWithMissingValueDefaultNotInEnumValues } },
+    HashTableValue { "fauxEnumReflectedStringMissingReflectAttribute"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_fauxEnumReflectedStringMissingReflectAttribute, setJSTestObj_fauxEnumReflectedStringMissingReflectAttribute } },
     HashTableValue { "reflectedUSVStringAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedUSVStringAttr, setJSTestObj_reflectedUSVStringAttr } },
     HashTableValue { "reflectedIntegralAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedIntegralAttr, setJSTestObj_reflectedIntegralAttr } },
     HashTableValue { "reflectedUnsignedIntegralAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedUnsignedIntegralAttr, setJSTestObj_reflectedUnsignedIntegralAttr } },
@@ -2392,6 +2705,11 @@ static const std::array<HashTableValue, 282> JSTestObjPrototypeTableValues {
     HashTableValue { "reflectedCustomIntegralAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedCustomIntegralAttr, setJSTestObj_reflectedCustomIntegralAttr } },
     HashTableValue { "reflectedCustomBooleanAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedCustomBooleanAttr, setJSTestObj_reflectedCustomBooleanAttr } },
     HashTableValue { "reflectedCustomURLAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedCustomURLAttr, setJSTestObj_reflectedCustomURLAttr } },
+    HashTableValue { "reflectedNullableStringAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedNullableStringAttr, setJSTestObj_reflectedNullableStringAttr } },
+    HashTableValue { "reflectedNullableEnumWithMissingValueDefaultStringAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedNullableEnumWithMissingValueDefaultStringAttr, setJSTestObj_reflectedNullableEnumWithMissingValueDefaultStringAttr } },
+    HashTableValue { "reflectedNullableEnumWithInvalidValueDefaultStringAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedNullableEnumWithInvalidValueDefaultStringAttr, setJSTestObj_reflectedNullableEnumWithInvalidValueDefaultStringAttr } },
+    HashTableValue { "reflectedNullableEnumWithInvalidAndMissingValueDefaultStringAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedNullableEnumWithInvalidAndMissingValueDefaultStringAttr, setJSTestObj_reflectedNullableEnumWithInvalidAndMissingValueDefaultStringAttr } },
+    HashTableValue { "reflectedNullableEnumWithMissingValueDefaultNoQuotesStringAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedNullableEnumWithMissingValueDefaultNoQuotesStringAttr, setJSTestObj_reflectedNullableEnumWithMissingValueDefaultNoQuotesStringAttr } },
     HashTableValue { "reflectedSetterStringAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedSetterStringAttr, setJSTestObj_reflectedSetterStringAttr } },
     HashTableValue { "reflectedSetterUSVStringAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedSetterUSVStringAttr, setJSTestObj_reflectedSetterUSVStringAttr } },
     HashTableValue { "reflectedSetterIntegralAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedSetterIntegralAttr, setJSTestObj_reflectedSetterIntegralAttr } },
@@ -4252,6 +4570,351 @@ JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedStringAttr, (JSGlobalObject* lexi
     return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedStringAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
 }
 
+static inline JSValue jsTestObj_reflectedEnumWithMissingValueDefaultStringAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    const AtomString& contentAttributeValue = impl.attributeWithoutSynchronization(WebCore::HTMLNames::reflectedEnumWithMissingValueDefaultStringAttrAttr);
+    AtomString result;
+    if (contentAttributeValue.isNull())
+        result = AtomString("value1"_s);
+    else if (auto value = parseEnumerationFromString<TestObj::EnumWithMissingValueDefault>(contentAttributeValue.convertToASCIILowercase()); value) [[likely]]
+        result = AtomString(convertEnumerationToString(*value));
+    else
+        { }
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, throwScope, result)));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedEnumWithMissingValueDefaultStringAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedEnumWithMissingValueDefaultStringAttrGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_reflectedEnumWithMissingValueDefaultStringAttrSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto nativeValueConversionResult = convert<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, value);
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return false;
+    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+        return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectedenumwithmissingvaluedefaultstringattrAttr, nativeValueConversionResult.releaseReturnValue());
+    });
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedEnumWithMissingValueDefaultStringAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedEnumWithMissingValueDefaultStringAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
+static inline JSValue jsTestObj_reflectedEnumWithInvalidValueDefaultStringAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    const AtomString& contentAttributeValue = impl.attributeWithoutSynchronization(WebCore::HTMLNames::reflectedEnumWithInvalidValueDefaultStringAttrAttr);
+    AtomString result;
+    if (contentAttributeValue.isNull())
+        { }
+    else if (auto value = parseEnumerationFromString<TestObj::EnumWithInvalidValueDefault>(contentAttributeValue.convertToASCIILowercase()); value) [[likely]]
+        result = AtomString(convertEnumerationToString(*value));
+    else
+        result = AtomString("value2"_s);
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, throwScope, result)));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedEnumWithInvalidValueDefaultStringAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedEnumWithInvalidValueDefaultStringAttrGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_reflectedEnumWithInvalidValueDefaultStringAttrSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto nativeValueConversionResult = convert<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, value);
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return false;
+    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+        return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectedenumwithinvalidvaluedefaultstringattrAttr, nativeValueConversionResult.releaseReturnValue());
+    });
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedEnumWithInvalidValueDefaultStringAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedEnumWithInvalidValueDefaultStringAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
+static inline JSValue jsTestObj_reflectedEnumWithInvalidAndMissingValueDefaultStringAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    const AtomString& contentAttributeValue = impl.attributeWithoutSynchronization(WebCore::HTMLNames::reflectedEnumWithInvalidAndMissingValueDefaultStringAttrAttr);
+    AtomString result;
+    if (contentAttributeValue.isNull())
+        result = AtomString("value1"_s);
+    else if (auto value = parseEnumerationFromString<TestObj::EnumWithMissingAndInvalidValueDefault>(contentAttributeValue.convertToASCIILowercase()); value) [[likely]]
+        result = AtomString(convertEnumerationToString(*value));
+    else
+        result = AtomString("value2"_s);
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, throwScope, result)));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedEnumWithInvalidAndMissingValueDefaultStringAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedEnumWithInvalidAndMissingValueDefaultStringAttrGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_reflectedEnumWithInvalidAndMissingValueDefaultStringAttrSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto nativeValueConversionResult = convert<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, value);
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return false;
+    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+        return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectedenumwithinvalidandmissingvaluedefaultstringattrAttr, nativeValueConversionResult.releaseReturnValue());
+    });
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedEnumWithInvalidAndMissingValueDefaultStringAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedEnumWithInvalidAndMissingValueDefaultStringAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
+static inline JSValue jsTestObj_reflectedEnumWithMissingValueDefaultNoQuotesStringAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    const AtomString& contentAttributeValue = impl.attributeWithoutSynchronization(WebCore::HTMLNames::reflectedEnumWithMissingValueDefaultNoQuotesStringAttrAttr);
+    AtomString result;
+    if (contentAttributeValue.isNull())
+        result = AtomString("value1"_s);
+    else if (auto value = parseEnumerationFromString<TestObj::EnumWithMissingValueDefaultNoQuotes>(contentAttributeValue.convertToASCIILowercase()); value) [[likely]]
+        result = AtomString(convertEnumerationToString(*value));
+    else
+        { }
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, throwScope, result)));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedEnumWithMissingValueDefaultNoQuotesStringAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedEnumWithMissingValueDefaultNoQuotesStringAttrGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_reflectedEnumWithMissingValueDefaultNoQuotesStringAttrSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto nativeValueConversionResult = convert<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, value);
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return false;
+    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+        return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectedenumwithmissingvaluedefaultnoquotesstringattrAttr, nativeValueConversionResult.releaseReturnValue());
+    });
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedEnumWithMissingValueDefaultNoQuotesStringAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedEnumWithMissingValueDefaultNoQuotesStringAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
+static inline JSValue jsTestObj_reflectedEnumWithNoEnumerationSpecifiedGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, throwScope, impl.attributeWithoutSynchronization(WebCore::HTMLNames::reflectedenumwithnoenumerationspecifiedAttr))));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedEnumWithNoEnumerationSpecified, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedEnumWithNoEnumerationSpecifiedGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_reflectedEnumWithNoEnumerationSpecifiedSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto nativeValueConversionResult = convert<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, value);
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return false;
+    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+        return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectedenumwithnoenumerationspecifiedAttr, nativeValueConversionResult.releaseReturnValue());
+    });
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedEnumWithNoEnumerationSpecified, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedEnumWithNoEnumerationSpecifiedSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
+static inline JSValue jsTestObj_reflectedEnumWithInvalidEnumSpecifiedGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, throwScope, impl.attributeWithoutSynchronization(WebCore::HTMLNames::reflectedenumwithinvalidenumspecifiedAttr))));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedEnumWithInvalidEnumSpecified, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedEnumWithInvalidEnumSpecifiedGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_reflectedEnumWithInvalidEnumSpecifiedSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto nativeValueConversionResult = convert<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, value);
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return false;
+    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+        return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectedenumwithinvalidenumspecifiedAttr, nativeValueConversionResult.releaseReturnValue());
+    });
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedEnumWithInvalidEnumSpecified, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedEnumWithInvalidEnumSpecifiedSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
+static inline JSValue jsTestObj_reflectedEnumWithMissingValueDefaultAsEmptyValueGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    const AtomString& contentAttributeValue = impl.attributeWithoutSynchronization(WebCore::HTMLNames::reflectedEnumWithMissingValueDefaultAsEmptyValueAttr);
+    AtomString result;
+    if (contentAttributeValue.isNull())
+        { }
+    else if (auto value = parseEnumerationFromString<TestObj::EnumWithMissingValueDefaultAsEmptyValue>(contentAttributeValue.convertToASCIILowercase()); value) [[likely]]
+        result = AtomString(convertEnumerationToString(*value));
+    else
+        { }
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, throwScope, result)));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedEnumWithMissingValueDefaultAsEmptyValue, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedEnumWithMissingValueDefaultAsEmptyValueGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_reflectedEnumWithMissingValueDefaultAsEmptyValueSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto nativeValueConversionResult = convert<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, value);
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return false;
+    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+        return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectedenumwithmissingvaluedefaultasemptyvalueAttr, nativeValueConversionResult.releaseReturnValue());
+    });
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedEnumWithMissingValueDefaultAsEmptyValue, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedEnumWithMissingValueDefaultAsEmptyValueSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
+static inline JSValue jsTestObj_reflectedEnumWithMissingValueDefaultNotInEnumValuesGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    const AtomString& contentAttributeValue = impl.attributeWithoutSynchronization(WebCore::HTMLNames::reflectedEnumWithMissingValueDefaultNotInEnumValuesAttr);
+    AtomString result;
+    if (contentAttributeValue.isNull())
+        result = AtomString("foo"_s);
+    else if (auto value = parseEnumerationFromString<TestObj::EnumWithMissingValueDefaultNotInEnumValues>(contentAttributeValue.convertToASCIILowercase()); value) [[likely]]
+        result = AtomString(convertEnumerationToString(*value));
+    else
+        { }
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, throwScope, result)));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedEnumWithMissingValueDefaultNotInEnumValues, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedEnumWithMissingValueDefaultNotInEnumValuesGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_reflectedEnumWithMissingValueDefaultNotInEnumValuesSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto nativeValueConversionResult = convert<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, value);
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return false;
+    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+        return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectedenumwithmissingvaluedefaultnotinenumvaluesAttr, nativeValueConversionResult.releaseReturnValue());
+    });
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedEnumWithMissingValueDefaultNotInEnumValues, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedEnumWithMissingValueDefaultNotInEnumValuesSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
+static inline JSValue jsTestObj_fauxEnumReflectedStringMissingReflectAttributeGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLDOMString>(lexicalGlobalObject, throwScope, impl.fauxEnumReflectedStringMissingReflectAttribute())));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_fauxEnumReflectedStringMissingReflectAttribute, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_fauxEnumReflectedStringMissingReflectAttributeGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_fauxEnumReflectedStringMissingReflectAttributeSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto nativeValueConversionResult = convert<IDLDOMString>(lexicalGlobalObject, value);
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return false;
+    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+        return impl.setFauxEnumReflectedStringMissingReflectAttribute(nativeValueConversionResult.releaseReturnValue());
+    });
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_fauxEnumReflectedStringMissingReflectAttribute, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_fauxEnumReflectedStringMissingReflectAttributeSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
 static inline JSValue jsTestObj_reflectedUSVStringAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
 {
     SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
@@ -4646,6 +5309,203 @@ static inline bool setJSTestObj_reflectedCustomURLAttrSetter(JSGlobalObject& lex
 JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedCustomURLAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
 {
     return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedCustomURLAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
+static inline JSValue jsTestObj_reflectedNullableStringAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLNullable<IDLAtomStringAdaptor<IDLDOMString>>>(lexicalGlobalObject, throwScope, impl.attributeWithoutSynchronization(WebCore::HTMLNames::reflectednullablestringattrAttr))));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedNullableStringAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedNullableStringAttrGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_reflectedNullableStringAttrSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto nativeValueConversionResult = convert<IDLNullable<IDLAtomStringAdaptor<IDLDOMString>>>(lexicalGlobalObject, value);
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return false;
+    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+        return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectednullablestringattrAttr, nativeValueConversionResult.releaseReturnValue());
+    });
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedNullableStringAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedNullableStringAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
+static inline JSValue jsTestObj_reflectedNullableEnumWithMissingValueDefaultStringAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    const AtomString& contentAttributeValue = impl.attributeWithoutSynchronization(WebCore::HTMLNames::reflectedNullableEnumWithMissingValueDefaultStringAttrAttr);
+    AtomString result;
+    if (contentAttributeValue.isNull())
+        result = AtomString("value1"_s);
+    else if (auto value = parseEnumerationFromString<TestObj::EnumWithMissingValueDefault>(contentAttributeValue.convertToASCIILowercase()); value) [[likely]]
+        result = AtomString(convertEnumerationToString(*value));
+    else
+        { }
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLNullable<IDLAtomStringAdaptor<IDLDOMString>>>(lexicalGlobalObject, throwScope, result)));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedNullableEnumWithMissingValueDefaultStringAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedNullableEnumWithMissingValueDefaultStringAttrGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_reflectedNullableEnumWithMissingValueDefaultStringAttrSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto nativeValueConversionResult = convert<IDLNullable<IDLAtomStringAdaptor<IDLDOMString>>>(lexicalGlobalObject, value);
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return false;
+    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+        return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectednullableenumwithmissingvaluedefaultstringattrAttr, nativeValueConversionResult.releaseReturnValue());
+    });
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedNullableEnumWithMissingValueDefaultStringAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedNullableEnumWithMissingValueDefaultStringAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
+static inline JSValue jsTestObj_reflectedNullableEnumWithInvalidValueDefaultStringAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    const AtomString& contentAttributeValue = impl.attributeWithoutSynchronization(WebCore::HTMLNames::reflectedNullableEnumWithInvalidValueDefaultStringAttrAttr);
+    AtomString result;
+    if (contentAttributeValue.isNull())
+        { }
+    else if (auto value = parseEnumerationFromString<TestObj::EnumWithInvalidValueDefault>(contentAttributeValue.convertToASCIILowercase()); value) [[likely]]
+        result = AtomString(convertEnumerationToString(*value));
+    else
+        result = AtomString("value2"_s);
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLNullable<IDLAtomStringAdaptor<IDLDOMString>>>(lexicalGlobalObject, throwScope, result)));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedNullableEnumWithInvalidValueDefaultStringAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedNullableEnumWithInvalidValueDefaultStringAttrGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_reflectedNullableEnumWithInvalidValueDefaultStringAttrSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto nativeValueConversionResult = convert<IDLNullable<IDLAtomStringAdaptor<IDLDOMString>>>(lexicalGlobalObject, value);
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return false;
+    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+        return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectednullableenumwithinvalidvaluedefaultstringattrAttr, nativeValueConversionResult.releaseReturnValue());
+    });
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedNullableEnumWithInvalidValueDefaultStringAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedNullableEnumWithInvalidValueDefaultStringAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
+static inline JSValue jsTestObj_reflectedNullableEnumWithInvalidAndMissingValueDefaultStringAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    const AtomString& contentAttributeValue = impl.attributeWithoutSynchronization(WebCore::HTMLNames::reflectedNullableEnumWithInvalidAndMissingValueDefaultStringAttrAttr);
+    AtomString result;
+    if (contentAttributeValue.isNull())
+        result = AtomString("value1"_s);
+    else if (auto value = parseEnumerationFromString<TestObj::EnumWithMissingAndInvalidValueDefault>(contentAttributeValue.convertToASCIILowercase()); value) [[likely]]
+        result = AtomString(convertEnumerationToString(*value));
+    else
+        result = AtomString("value2"_s);
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLNullable<IDLAtomStringAdaptor<IDLDOMString>>>(lexicalGlobalObject, throwScope, result)));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedNullableEnumWithInvalidAndMissingValueDefaultStringAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedNullableEnumWithInvalidAndMissingValueDefaultStringAttrGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_reflectedNullableEnumWithInvalidAndMissingValueDefaultStringAttrSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto nativeValueConversionResult = convert<IDLNullable<IDLAtomStringAdaptor<IDLDOMString>>>(lexicalGlobalObject, value);
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return false;
+    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+        return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectednullableenumwithinvalidandmissingvaluedefaultstringattrAttr, nativeValueConversionResult.releaseReturnValue());
+    });
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedNullableEnumWithInvalidAndMissingValueDefaultStringAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedNullableEnumWithInvalidAndMissingValueDefaultStringAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
+static inline JSValue jsTestObj_reflectedNullableEnumWithMissingValueDefaultNoQuotesStringAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    const AtomString& contentAttributeValue = impl.attributeWithoutSynchronization(WebCore::HTMLNames::reflectedNullableEnumWithMissingValueDefaultNoQuotesStringAttrAttr);
+    AtomString result;
+    if (contentAttributeValue.isNull())
+        result = AtomString("value1"_s);
+    else if (auto value = parseEnumerationFromString<TestObj::EnumWithMissingValueDefaultNoQuotes>(contentAttributeValue.convertToASCIILowercase()); value) [[likely]]
+        result = AtomString(convertEnumerationToString(*value));
+    else
+        { }
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLNullable<IDLAtomStringAdaptor<IDLDOMString>>>(lexicalGlobalObject, throwScope, result)));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedNullableEnumWithMissingValueDefaultNoQuotesStringAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedNullableEnumWithMissingValueDefaultNoQuotesStringAttrGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_reflectedNullableEnumWithMissingValueDefaultNoQuotesStringAttrSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto nativeValueConversionResult = convert<IDLNullable<IDLAtomStringAdaptor<IDLDOMString>>>(lexicalGlobalObject, value);
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return false;
+    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+        return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectednullableenumwithmissingvaluedefaultnoquotesstringattrAttr, nativeValueConversionResult.releaseReturnValue());
+    });
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedNullableEnumWithMissingValueDefaultNoQuotesStringAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedNullableEnumWithMissingValueDefaultNoQuotesStringAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
 }
 
 static inline JSValue jsTestObj_reflectedSetterStringAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.h
@@ -205,6 +205,48 @@ template<> std::optional<TestObj::Confidence> parseEnumerationFromString<TestObj
 template<> std::optional<TestObj::Confidence> parseEnumeration<TestObj::Confidence>(JSC::JSGlobalObject&, JSC::JSValue);
 template<> ASCIILiteral expectedEnumerationValues<TestObj::Confidence>();
 
+String convertEnumerationToString(TestObj::EnumWithMissingValueDefault);
+template<> JSC::JSString* convertEnumerationToJS(JSC::VM&, TestObj::EnumWithMissingValueDefault);
+
+template<> std::optional<TestObj::EnumWithMissingValueDefault> parseEnumerationFromString<TestObj::EnumWithMissingValueDefault>(const String&);
+template<> std::optional<TestObj::EnumWithMissingValueDefault> parseEnumeration<TestObj::EnumWithMissingValueDefault>(JSC::JSGlobalObject&, JSC::JSValue);
+template<> ASCIILiteral expectedEnumerationValues<TestObj::EnumWithMissingValueDefault>();
+
+String convertEnumerationToString(TestObj::EnumWithInvalidValueDefault);
+template<> JSC::JSString* convertEnumerationToJS(JSC::VM&, TestObj::EnumWithInvalidValueDefault);
+
+template<> std::optional<TestObj::EnumWithInvalidValueDefault> parseEnumerationFromString<TestObj::EnumWithInvalidValueDefault>(const String&);
+template<> std::optional<TestObj::EnumWithInvalidValueDefault> parseEnumeration<TestObj::EnumWithInvalidValueDefault>(JSC::JSGlobalObject&, JSC::JSValue);
+template<> ASCIILiteral expectedEnumerationValues<TestObj::EnumWithInvalidValueDefault>();
+
+String convertEnumerationToString(TestObj::EnumWithMissingAndInvalidValueDefault);
+template<> JSC::JSString* convertEnumerationToJS(JSC::VM&, TestObj::EnumWithMissingAndInvalidValueDefault);
+
+template<> std::optional<TestObj::EnumWithMissingAndInvalidValueDefault> parseEnumerationFromString<TestObj::EnumWithMissingAndInvalidValueDefault>(const String&);
+template<> std::optional<TestObj::EnumWithMissingAndInvalidValueDefault> parseEnumeration<TestObj::EnumWithMissingAndInvalidValueDefault>(JSC::JSGlobalObject&, JSC::JSValue);
+template<> ASCIILiteral expectedEnumerationValues<TestObj::EnumWithMissingAndInvalidValueDefault>();
+
+String convertEnumerationToString(TestObj::EnumWithMissingValueDefaultNoQuotes);
+template<> JSC::JSString* convertEnumerationToJS(JSC::VM&, TestObj::EnumWithMissingValueDefaultNoQuotes);
+
+template<> std::optional<TestObj::EnumWithMissingValueDefaultNoQuotes> parseEnumerationFromString<TestObj::EnumWithMissingValueDefaultNoQuotes>(const String&);
+template<> std::optional<TestObj::EnumWithMissingValueDefaultNoQuotes> parseEnumeration<TestObj::EnumWithMissingValueDefaultNoQuotes>(JSC::JSGlobalObject&, JSC::JSValue);
+template<> ASCIILiteral expectedEnumerationValues<TestObj::EnumWithMissingValueDefaultNoQuotes>();
+
+String convertEnumerationToString(TestObj::EnumWithMissingValueDefaultAsEmptyValue);
+template<> JSC::JSString* convertEnumerationToJS(JSC::VM&, TestObj::EnumWithMissingValueDefaultAsEmptyValue);
+
+template<> std::optional<TestObj::EnumWithMissingValueDefaultAsEmptyValue> parseEnumerationFromString<TestObj::EnumWithMissingValueDefaultAsEmptyValue>(const String&);
+template<> std::optional<TestObj::EnumWithMissingValueDefaultAsEmptyValue> parseEnumeration<TestObj::EnumWithMissingValueDefaultAsEmptyValue>(JSC::JSGlobalObject&, JSC::JSValue);
+template<> ASCIILiteral expectedEnumerationValues<TestObj::EnumWithMissingValueDefaultAsEmptyValue>();
+
+String convertEnumerationToString(TestObj::EnumWithMissingValueDefaultNotInEnumValues);
+template<> JSC::JSString* convertEnumerationToJS(JSC::VM&, TestObj::EnumWithMissingValueDefaultNotInEnumValues);
+
+template<> std::optional<TestObj::EnumWithMissingValueDefaultNotInEnumValues> parseEnumerationFromString<TestObj::EnumWithMissingValueDefaultNotInEnumValues>(const String&);
+template<> std::optional<TestObj::EnumWithMissingValueDefaultNotInEnumValues> parseEnumeration<TestObj::EnumWithMissingValueDefaultNotInEnumValues>(JSC::JSGlobalObject&, JSC::JSValue);
+template<> ASCIILiteral expectedEnumerationValues<TestObj::EnumWithMissingValueDefaultNotInEnumValues>();
+
 template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionary<TestObj::Dictionary>(JSC::JSGlobalObject&, JSC::JSValue);
 
 JSC::JSObject* convertDictionaryToJS(JSC::JSGlobalObject&, JSDOMGlobalObject&, const TestObj::Dictionary&);

--- a/Source/WebCore/bindings/scripts/test/TestObj.idl
+++ b/Source/WebCore/bindings/scripts/test/TestObj.idl
@@ -46,6 +46,13 @@ enum TestObjKind { "quick", "dead" };
 enum ObjSize { "small", "much-much-larger" };
 enum TestConfidence { "high", "kinda-low" };
 
+[MissingValueDefault="value1"] enum TestEnumWithMissingValueDefault { "value1", "value2", "value3", "" };
+[InvalidValueDefault="value2"] enum TestEnumWithInvalidValueDefault { "value1", "value2", "value3", "" };
+[MissingValueDefault="value1", InvalidValueDefault="value2"] enum TestEnumWithMissingAndInvalidValueDefault { "value1", "value2", "value3", "" };
+[MissingValueDefault=value1] enum TestEnumWithMissingValueDefaultNoQuotes { "value1", "value2", "value3", "" };
+[MissingValueDefault] enum TestEnumWithMissingValueDefaultAsEmptyValue { "value1", "value2", "value3", "" };
+[MissingValueDefault="foo"] enum TestEnumWithMissingValueDefaultNotInEnumValues { "value1", "value2", "value3", "" };
+
 [
     InterfaceName=TestObject,
     Exposed=(Window,Worker)
@@ -101,8 +108,17 @@ enum TestConfidence { "high", "kinda-low" };
     attribute TestObj                  XMLObjAttr;
     attribute boolean                  create;
 
-    // Reflected DOM attributes
+    // Reflected IDL attributes
     [Reflect] attribute DOMString reflectedStringAttr;
+    [Reflect, Enumerated=TestEnumWithMissingValueDefault] attribute DOMString reflectedEnumWithMissingValueDefaultStringAttr;
+    [Reflect, Enumerated=TestEnumWithInvalidValueDefault] attribute DOMString reflectedEnumWithInvalidValueDefaultStringAttr;
+    [Reflect, Enumerated=TestEnumWithMissingAndInvalidValueDefault] attribute DOMString reflectedEnumWithInvalidAndMissingValueDefaultStringAttr;
+    [Reflect, Enumerated=TestEnumWithMissingValueDefaultNoQuotes] attribute DOMString reflectedEnumWithMissingValueDefaultNoQuotesStringAttr; 
+    [Reflect, Enumerated] attribute DOMString reflectedEnumWithNoEnumerationSpecified;
+    [Reflect, Enumerated=foo] attribute DOMString reflectedEnumWithInvalidEnumSpecified; 
+    [Reflect, Enumerated=TestEnumWithMissingValueDefaultAsEmptyValue] attribute DOMString reflectedEnumWithMissingValueDefaultAsEmptyValue; 
+    [Reflect, Enumerated=TestEnumWithMissingValueDefaultNotInEnumValues] attribute DOMString reflectedEnumWithMissingValueDefaultNotInEnumValues;
+    [Enumerated=foo] attribute DOMString fauxEnumReflectedStringMissingReflectAttribute; 
     [Reflect] attribute USVString reflectedUSVStringAttr;
     [Reflect] attribute long reflectedIntegralAttr;
     [Reflect] attribute unsigned long reflectedUnsignedIntegralAttr;
@@ -116,7 +132,14 @@ enum TestConfidence { "high", "kinda-low" };
     [Reflect="custom-content-boolean"] attribute boolean reflectedCustomBooleanAttr;
     [ReflectURL="custom-conten-url"] attribute DOMString reflectedCustomURLAttr;
 
-    // Reflected for setter only DOM attributes
+    // Reflected nullable IDL attributes
+    [Reflect] attribute DOMString? reflectedNullableStringAttr;
+    [Reflect, Enumerated=TestEnumWithMissingValueDefault] attribute DOMString? reflectedNullableEnumWithMissingValueDefaultStringAttr;
+    [Reflect, Enumerated=TestEnumWithInvalidValueDefault] attribute DOMString? reflectedNullableEnumWithInvalidValueDefaultStringAttr;
+    [Reflect, Enumerated=TestEnumWithMissingAndInvalidValueDefault] attribute DOMString? reflectedNullableEnumWithInvalidAndMissingValueDefaultStringAttr;
+    [Reflect, Enumerated=TestEnumWithMissingValueDefaultNoQuotes] attribute DOMString? reflectedNullableEnumWithMissingValueDefaultNoQuotesStringAttr; 
+
+    // Reflected for setter only IDL attributes
     [ReflectSetter] attribute DOMString reflectedSetterStringAttr;
     [ReflectSetter] attribute USVString reflectedSetterUSVStringAttr;
     [ReflectSetter] attribute long reflectedSetterIntegralAttr;

--- a/Source/WebCore/html/HTMLIFrameElement.cpp
+++ b/Source/WebCore/html/HTMLIFrameElement.cpp
@@ -180,11 +180,6 @@ ReferrerPolicy HTMLIFrameElement::referrerPolicy() const
     return referrerPolicyFromAttribute();
 }
 
-const AtomString& HTMLIFrameElement::loading() const
-{
-    return equalLettersIgnoringASCIICase(attributeWithoutSynchronization(HTMLNames::loadingAttr), "lazy"_s) ? lazyAtom() : eagerAtom();
-}
-
 String HTMLIFrameElement::srcdoc() const
 {
     return attributeWithoutSynchronization(srcdocAttr);

--- a/Source/WebCore/html/HTMLIFrameElement.h
+++ b/Source/WebCore/html/HTMLIFrameElement.h
@@ -46,9 +46,6 @@ public:
     String referrerPolicyForBindings() const;
     ReferrerPolicy referrerPolicy() const final;
 
-    const AtomString& loading() const;
-    void setLoading(const AtomString&);
-
     String srcdoc() const;
     ExceptionOr<void> setSrcdoc(Variant<RefPtr<TrustedHTML>, String>&&, SubstituteData::SessionHistoryVisibility = SubstituteData::SessionHistoryVisibility::Visible);
     SubstituteData::SessionHistoryVisibility srcdocSessionHistoryVisibility() const { return m_srcdocSessionHistoryVisibility; };
@@ -56,6 +53,8 @@ public:
     LazyLoadFrameObserver& lazyLoadFrameObserver();
 
     void loadDeferredFrame();
+
+    enum LoadingValues { Lazy, Eager };
 
 #if ENABLE(FULLSCREEN_API)
     bool hasIFrameFullscreenFlag() const { return m_IFrameFullscreenFlag; }

--- a/Source/WebCore/html/HTMLIFrameElement.idl
+++ b/Source/WebCore/html/HTMLIFrameElement.idl
@@ -33,7 +33,7 @@
     [Reflect, CEReactions=NotNeeded] attribute DOMString width;
     [Reflect, CEReactions=NotNeeded] attribute DOMString height;
     [CEReactions=NotNeeded, ImplementedAs=referrerPolicyForBindings, ReflectSetter] attribute [AtomString] DOMString referrerPolicy;
-    [CEReactions=NotNeeded, EnabledBySetting=LazyIframeLoadingEnabled, ReflectSetter] attribute [AtomString] DOMString loading;
+    [CEReactions=NotNeeded, EnabledBySetting=LazyIframeLoadingEnabled, Reflect, Enumerated=HTMLIFrameElementLoadingValues] attribute DOMString loading;
     [CheckSecurityForNode] readonly attribute Document? contentDocument;
     readonly attribute WindowProxy? contentWindow;
     [CheckSecurityForNode] Document? getSVGDocument();
@@ -49,3 +49,5 @@
     [Reflect, CEReactions=NotNeeded] attribute [LegacyNullToEmptyString] DOMString marginWidth;
 
 };
+
+[MissingValueDefault="eager", InvalidValueDefault="eager"] enum HTMLIFrameElementLoadingValues { "lazy", "eager" };

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -969,12 +969,6 @@ AtomString HTMLImageElement::srcsetForBindings() const
     return getAttributeForBindings(srcsetAttr);
 }
 
-const AtomString& HTMLImageElement::loadingForBindings() const
-{
-    auto& attributeValue = attributeWithoutSynchronization(HTMLNames::loadingAttr);
-    return hasLazyLoadableAttributeValue(attributeValue) ? lazyAtom() : eagerAtom();
-}
-
 bool HTMLImageElement::isDeferred() const
 {
     return m_imageLoader->isDeferred();

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -139,7 +139,7 @@ public:
 
     bool usesSrcsetOrPicture() const;
 
-    const AtomString& loadingForBindings() const;
+    enum LoadingValues { Lazy, Eager };
 
     bool isLazyLoadable() const;
     static bool hasLazyLoadableAttributeValue(StringView);

--- a/Source/WebCore/html/HTMLImageElement.idl
+++ b/Source/WebCore/html/HTMLImageElement.idl
@@ -43,7 +43,7 @@
     readonly attribute USVString currentSrc;
     [CEReactions=NotNeeded, ImplementedAs=referrerPolicyForBindings, ReflectSetter] attribute [AtomString] DOMString referrerPolicy;
     [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString decoding;
-    [CEReactions=NotNeeded, EnabledBySetting=LazyImageLoadingEnabled, ImplementedAs=loadingForBindings, ReflectSetter] attribute [AtomString] DOMString loading;
+    [CEReactions=NotNeeded, EnabledBySetting=LazyImageLoadingEnabled, Reflect, Enumerated=HTMLImageElementLoadingValues] attribute DOMString loading;
 
     Promise<undefined> decode();
 
@@ -63,3 +63,4 @@
     [Conditional=ATTACHMENT_ELEMENT, EnabledByDeprecatedGlobalSetting=AttachmentElementEnabled] readonly attribute DOMString attachmentIdentifier;
 };
 
+[MissingValueDefault="eager", InvalidValueDefault="eager"] enum HTMLImageElementLoadingValues { "lazy", "eager" };


### PR DESCRIPTION
#### 5c150f7a3b5880d65eb13e92222e2d177846693d
<pre>
[WebIDL] Add WebIDL support for [Enumerated] extended attribute and related attributes [MissingValueDefault],[InvalidValueDefault]
<a href="https://bugs.webkit.org/show_bug.cgi?id=295854">https://bugs.webkit.org/show_bug.cgi?id=295854</a>
<a href="https://rdar.apple.com/problem/156249490">rdar://problem/156249490</a>

Reviewed by Darin Adler.

To simplify .idl definitions of DOMString/DOMString? reflected enumerated attributes (<a href="https://html.spec.whatwg.org/#keywords-and-enumerated-attributes)">https://html.spec.whatwg.org/#keywords-and-enumerated-attributes)</a>,
and reduce manual generation of bindings code, this PR adds 3 new WebKitIDL extended attributes:
- [Enumerated]
- [MissingValueDefault]
- [InvalidValueDefault]

These attributes provide bindings codegen for C++ getters/setters using the specified enum. For example,
given a nullable enumerated attr that is limited to known values, its IDL definition would look like:

enum AttrEnum { &quot;value1&quot;, &quot;value2&quot;,...&quot;valueN&quot; }

[Reflect, Enumerated=AttrEnum] attribute DOMString? attr;

Optionally, a missing and/or invalid value default can be supplied to the enum definition, e.g.,:

[MissingValueDefault=&quot;value1&quot;, InvalidValueDefault=&quot;value2&quot;] enum AttrEnum { &quot;value1&quot;, &quot;value2&quot;...&quot;valueN&quot; }

In addition to adding TestObj.idl tests, the loading attribute for HTMLImageElement and HTMLIFrameElement now use these new extended attributes.

* Source/WebCore/bindings/scripts/IDLAttributes.json
* Source/WebCore/bindings/scripts/CodeGenerator.pm
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
* Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
* Source/WebCore/bindings/scripts/test/JS/JSTestObj.h
* Source/WebCore/bindings/scripts/test/TestObj.idl
* Source/WebCore/html/HTMLImageElement.cpp
* Source/WebCore/html/HTMLImageElement.h
* Source/WebCore/html/HTMLImageElement.idl
* Source/WebCore/html/HTMLIFrameElement.cpp
* Source/WebCore/html/HTMLIFrameElement.h
* Source/WebCore/html/HTMLIFrameElement.idl

Canonical link: <a href="https://commits.webkit.org/298172@main">https://commits.webkit.org/298172@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/515458bf7c7f35d24df38a7ba4540679ac2c1639

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114504 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34250 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120668 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65224 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116393 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34879 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42810 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87023 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41931 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117452 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27790 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102831 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67414 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26975 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20958 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64350 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97167 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21072 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123875 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41517 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30981 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95841 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41894 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99022 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95625 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24365 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40790 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18628 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37553 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41396 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46906 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40982 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44289 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42732 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->