### PR TITLE
[JSC] Increase capacity of Double cache

### DIFF
--- a/Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h
@@ -294,7 +294,7 @@ inline bool canUseFastArrayJoin(const JSObject* thisObject)
 }
 
 // This is intentionally supporting non-JSArray as well.
-inline JSString* fastArrayJoin(JSGlobalObject* globalObject, JSObject* thisObject, StringView separator, unsigned length, bool& sawHoles, bool& genericCase)
+ALWAYS_INLINE JSString* fastArrayJoin(JSGlobalObject* globalObject, JSObject* thisObject, StringView separator, unsigned length, bool& sawHoles, bool& genericCase)
 {
     VM& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);

--- a/Source/JavaScriptCore/runtime/NumericStrings.h
+++ b/Source/JavaScriptCore/runtime/NumericStrings.h
@@ -37,6 +37,7 @@ class SmallStrings;
 class NumericStrings {
 public:
     static const size_t cacheSize = 1024;
+    static const size_t doubleCacheSize = 4096;
 
     template<typename T>
     struct CacheEntry {
@@ -58,8 +59,16 @@ public:
         static constexpr ptrdiff_t offsetOfJSString() { return OBJECT_OFFSETOF(StringWithJSString, jsString); }
     };
 
+    struct DoubleCache {
+        WTF_MAKE_TZONE_ALLOCATED(DoubleCache);
+    public:
+        std::array<CacheEntryWithJSString<double>, doubleCacheSize> m_doubleCache { };
+    };
+
     ALWAYS_INLINE const String& add(double d)
     {
+        if (!m_doubleCache) [[unlikely]]
+            initializeDoubleCache();
         auto& entry = lookup(d);
         if (d == entry.key && !entry.value.isNull())
             return entry.value;
@@ -101,8 +110,10 @@ public:
     {
         for (auto& entry : m_intCache)
             entry.jsString = nullptr;
-        for (auto& entry : m_doubleCache)
-            entry.jsString = nullptr;
+        if (m_doubleCache) {
+            for (auto& entry : m_doubleCache->m_doubleCache)
+                entry.jsString = nullptr;
+        }
         // 0-9 are managed by SmallStrings. They never die.
         for (unsigned i = 10; i < m_smallIntCache.size(); ++i)
             m_smallIntCache[i].jsString = nullptr;
@@ -113,8 +124,10 @@ public:
     {
         for (auto& entry : m_intCache)
             visitor.appendUnbarriered(entry.jsString);
-        for (auto& entry : m_doubleCache)
-            visitor.appendUnbarriered(entry.jsString);
+        if (m_doubleCache) {
+            for (auto& entry : m_doubleCache->m_doubleCache)
+                visitor.appendUnbarriered(entry.jsString);
+        }
         // 0-9 are managed by SmallStrings. They never die.
         for (unsigned i = 10; i < m_smallIntCache.size(); ++i)
             visitor.appendUnbarriered(m_smallIntCache[i].jsString);
@@ -125,7 +138,13 @@ public:
     void initializeSmallIntCache(VM&);
 
 private:
-    CacheEntryWithJSString<double>& lookup(double d) { return m_doubleCache[WTF::FloatHash<double>::hash(d) & (cacheSize - 1)]; }
+    CacheEntryWithJSString<double>& lookup(double d)
+    {
+        ASSERT(m_doubleCache);
+        uint64_t bits = std::bit_cast<uint64_t>(d);
+        uint32_t hash = static_cast<uint32_t>(bits) ^ static_cast<uint32_t>(bits >> 32);
+        return m_doubleCache->m_doubleCache[hash & (doubleCacheSize - 1)];
+    }
     CacheEntryWithJSString<int>& lookup(int i) { return m_intCache[WTF::IntHash<int>::hash(i) & (cacheSize - 1)]; }
     CacheEntry<unsigned>& lookup(unsigned i) { return m_unsignedCache[WTF::IntHash<unsigned>::hash(i) & (cacheSize - 1)]; }
     ALWAYS_INLINE StringWithJSString& lookupSmallString(unsigned i)
@@ -136,10 +155,12 @@ private:
         return m_smallIntCache[i];
     }
 
+    void initializeDoubleCache();
+
     std::array<StringWithJSString, cacheSize> m_smallIntCache { };
     std::array<CacheEntryWithJSString<int>, cacheSize> m_intCache { };
-    std::array<CacheEntryWithJSString<double>, cacheSize> m_doubleCache { };
     std::array<CacheEntry<unsigned>, cacheSize> m_unsignedCache { };
+    std::unique_ptr<DoubleCache> m_doubleCache;
 };
 
 } // namespace JSC


### PR DESCRIPTION
#### df26015612dd007e9f547c2044320adc6d2af220
<pre>
[JSC] Increase capacity of Double cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=295859">https://bugs.webkit.org/show_bug.cgi?id=295859</a>
<a href="https://rdar.apple.com/155731398">rdar://155731398</a>

Reviewed by Mark Lam.

This patch increases the capacity of double to string cache from 1024 to
4096 which is aligned to V8&apos;s size. We also move the cache out from VM.
We also simplify Double cache&apos;s hash function for quick look up.

* Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h:
(JSC::fastArrayJoin):
* Source/JavaScriptCore/runtime/NumberPrototype.cpp:
(JSC::NumericStrings::addJSString):
(JSC::NumericStrings::initializeDoubleCache):
* Source/JavaScriptCore/runtime/NumericStrings.h:
(JSC::NumericStrings::add):
(JSC::NumericStrings::clearOnGarbageCollection):
(JSC::NumericStrings::visitAggregate):
(JSC::NumericStrings::lookup):

Canonical link: <a href="https://commits.webkit.org/297318@main">https://commits.webkit.org/297318@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b48460e60f3218e1624f4a73580da6676e9f422

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111364 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31030 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21495 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117396 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61632 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39612 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/84643 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114311 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25322 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100253 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65090 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24665 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18391 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61216 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/103857 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94706 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18458 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120578 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/109918 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38413 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28544 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/93569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38789 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96525 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93393 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38491 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16265 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34428 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17945 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38302 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43779 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/134193 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37967 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36173 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41300 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39669 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->