### PR TITLE
Putting HashMap in a heap block hurts memory use, speed, code size (WebCore databases)

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h
@@ -62,7 +62,7 @@ public:
     void addExistingObjectStore(MemoryObjectStore&);
 
     void objectStoreDeleted(Ref<MemoryObjectStore>&&);
-    void objectStoreCleared(MemoryObjectStore&, std::unique_ptr<KeyValueMap>&&, std::unique_ptr<IDBKeyDataSet>&&);
+    void objectStoreCleared(MemoryObjectStore&, KeyValueMap&&, std::unique_ptr<IDBKeyDataSet>&&);
     void objectStoreRenamed(MemoryObjectStore&, const String& oldName);
     void indexRenamed(MemoryIndex&, const String& oldName);
 

--- a/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h
@@ -128,7 +128,7 @@ private:
     uint64_t m_keyGeneratorValue { 1 };
 
     KeyValueMap m_transactionModifiedRecords;
-    std::unique_ptr<KeyValueMap> m_keyValueStore;
+    KeyValueMap m_keyValueStore;
     std::unique_ptr<IDBKeyDataSet> m_orderedKeys;
 
     HashMap<IDBIndexIdentifier, RefPtr<MemoryIndex>> m_indexesByIdentifier;

--- a/Source/WebCore/Modules/webdatabase/DatabaseTracker.cpp
+++ b/Source/WebCore/Modules/webdatabase/DatabaseTracker.cpp
@@ -524,12 +524,10 @@ Vector<Ref<Database>> DatabaseTracker::openDatabases()
     {
         Locker openDatabaseMapLock { m_openDatabaseMapGuard };
 
-        if (m_openDatabaseMap) {
-            for (auto& nameMap : m_openDatabaseMap->values()) {
-                for (auto& set : nameMap->values()) {
-                    for (auto& database : *set)
-                        openDatabases.append(*database);
-                }
+        for (auto& nameMap : m_openDatabaseMap.values()) {
+            for (auto& set : nameMap.values()) {
+                for (auto& database : set)
+                    openDatabases.append(*database);
             }
         }
     }
@@ -540,65 +538,43 @@ void DatabaseTracker::addOpenDatabase(Database& database)
 {
     Locker openDatabaseMapLock { m_openDatabaseMapGuard };
 
-    if (!m_openDatabaseMap)
-        m_openDatabaseMap = makeUnique<DatabaseOriginMap>();
+    auto name = database.stringIdentifierIsolatedCopy();
+    m_openDatabaseMap.add(database.securityOrigin().isolatedCopy(), DatabaseNameMap { }).iterator->value
+        .add(name, DatabaseSet { }).iterator->value
+        .add(&database);
 
-    auto origin = database.securityOrigin();
-    auto* nameMap = m_openDatabaseMap->get(origin);
-    if (!nameMap) {
-        nameMap = new DatabaseNameMap;
-        m_openDatabaseMap->add(WTFMove(origin).isolatedCopy(), nameMap);
-    }
-
-    String name = database.stringIdentifierIsolatedCopy();
-    auto* databaseSet = nameMap->get(name);
-    if (!databaseSet) {
-        databaseSet = new DatabaseSet;
-        nameMap->set(WTFMove(name).isolatedCopy(), databaseSet);
-    }
-
-    databaseSet->add(&database);
-
-    LOG(StorageAPI, "Added open Database %s (%p)\n", database.stringIdentifierIsolatedCopy().utf8().data(), &database);
+    LOG(StorageAPI, "Added open Database %s (%p)\n", name.utf8().data(), &database);
 }
 
 void DatabaseTracker::removeOpenDatabase(Database& database)
 {
     Locker openDatabaseMapLock { m_openDatabaseMapGuard };
 
-    if (!m_openDatabaseMap) {
+    auto iterator = m_openDatabaseMap.find(database.securityOrigin());
+    if (iterator == m_openDatabaseMap.end()) {
         ASSERT_NOT_REACHED();
         return;
     }
 
-    DatabaseNameMap* nameMap = m_openDatabaseMap->get(database.securityOrigin());
-    if (!nameMap) {
+    auto name = database.stringIdentifierIsolatedCopy();
+    auto innerIterator = iterator->value.find(name);
+    if (innerIterator == iterator->value.end()) {
         ASSERT_NOT_REACHED();
         return;
     }
 
-    String name = database.stringIdentifierIsolatedCopy();
-    auto* databaseSet = nameMap->get(name);
-    if (!databaseSet) {
-        ASSERT_NOT_REACHED();
-        return;
-    }
+    innerIterator->value.remove(&database);
 
-    databaseSet->remove(&database);
+    LOG(StorageAPI, "Removed open Database %s (%p)\n", name.utf8().data(), &database);
 
-    LOG(StorageAPI, "Removed open Database %s (%p)\n", database.stringIdentifierIsolatedCopy().utf8().data(), &database);
-
-    if (!databaseSet->isEmpty())
+    if (!innerIterator->value.isEmpty())
         return;
 
-    nameMap->remove(name);
-    delete databaseSet;
-
-    if (!nameMap->isEmpty())
+    iterator->value.remove(innerIterator);
+    if (!iterator->value.isEmpty())
         return;
 
-    m_openDatabaseMap->remove(database.securityOrigin());
-    delete nameMap;
+    m_openDatabaseMap.remove(iterator);
 }
 
 Ref<OriginLock> DatabaseTracker::originLockFor(const SecurityOriginData& origin)
@@ -1112,12 +1088,10 @@ bool DatabaseTracker::deleteDatabaseFile(const SecurityOriginData& origin, const
     // during the synchronous DatabaseThread call it triggers.
     {
         Locker openDatabaseMapLock { m_openDatabaseMapGuard };
-        if (m_openDatabaseMap) {
-            if (auto* nameMap = m_openDatabaseMap->get(origin)) {
-                if (auto* databaseSet = nameMap->get(name)) {
-                    for (auto& database : *databaseSet)
-                        deletedDatabases.append(*database);
-                }
+        if (auto iterator = m_openDatabaseMap.find(origin); iterator != m_openDatabaseMap.end()) {
+            if (auto innerIterator = iterator->value.find(name); innerIterator != iterator->value.end()) {
+                for (auto& database : innerIterator->value)
+                    deletedDatabases.append(*database);
             }
         }
     }
@@ -1170,45 +1144,43 @@ void DatabaseTracker::removeDeletedOpenedDatabases() WTF_IGNORES_THREAD_SAFETY_A
     // during the synchronous DatabaseThread call it triggers.
     {
         Locker openDatabaseMapLock { m_openDatabaseMapGuard };
-        if (m_openDatabaseMap) {
-            for (auto& openDatabase : *m_openDatabaseMap) {
-                auto& origin = openDatabase.key;
-                DatabaseNameMap* databaseNameMap = openDatabase.value;
-                Vector<String> deletedDatabaseNamesForThisOrigin;
+        for (auto& openDatabase : m_openDatabaseMap) {
+            auto& origin = openDatabase.key;
+            Vector<String> deletedDatabaseNamesForThisOrigin;
 
-                // Loop through all opened databases in this origin.  Get the current database file path of each database and see if
-                // it still matches the path stored in the opened database object.
-                for (auto& databases : *databaseNameMap) {
-                    String databaseName = databases.key;
-                    String databaseFileName;
-                    if (auto statement = m_database.prepareStatement("SELECT path FROM Databases WHERE origin=? AND name=?;"_s)) {
-                        statement->bindText(1, origin.databaseIdentifier());
-                        statement->bindText(2, databaseName);
-                        if (statement->step() == SQLITE_ROW)
-                            databaseFileName = statement->columnText(0);
-                    }
-                    
-                    bool foundDeletedDatabase = false;
-                    for (auto& db : *databases.value) {
-                        // We are done if this database has already been marked as deleted.
-                        if (db->deleted())
-                            continue;
-                        
-                        // If this database has been deleted or if its database file no longer matches the current version, this database is no longer valid and it should be marked as deleted.
-                        if (databaseFileName.isNull() || databaseFileName != FileSystem::pathFileName(db->fileNameIsolatedCopy())) {
-                            deletedDatabases.append(db);
-                            foundDeletedDatabase = true;
-                        }
-                    }
-                    
-                    // If the database no longer exists, we should remember to send that information to the client later.
-                    if (m_client && foundDeletedDatabase && databaseFileName.isNull())
-                        deletedDatabaseNamesForThisOrigin.append(databaseName);
+            // Loop through all opened databases in this origin.
+            // Get the current database file path of each database and see if
+            // it still matches the path stored in the opened database object.
+            for (auto& databases : openDatabase.value) {
+                String databaseName = databases.key;
+                String databaseFileName;
+                if (auto statement = m_database.prepareStatement("SELECT path FROM Databases WHERE origin=? AND name=?;"_s)) {
+                    statement->bindText(1, origin.databaseIdentifier());
+                    statement->bindText(2, databaseName);
+                    if (statement->step() == SQLITE_ROW)
+                        databaseFileName = statement->columnText(0);
                 }
-                
-                if (!deletedDatabaseNamesForThisOrigin.isEmpty())
-                    deletedDatabaseNames.append({ origin, WTFMove(deletedDatabaseNamesForThisOrigin) });
+
+                bool foundDeletedDatabase = false;
+                for (auto& db : databases.value) {
+                    // We are done if this database has already been marked as deleted.
+                    if (db->deleted())
+                        continue;
+
+                    // If this database has been deleted or if its database file no longer matches the current version, this database is no longer valid and it should be marked as deleted.
+                    if (databaseFileName.isNull() || databaseFileName != FileSystem::pathFileName(db->fileNameIsolatedCopy())) {
+                        deletedDatabases.append(db);
+                        foundDeletedDatabase = true;
+                    }
+                }
+
+                // If the database no longer exists, we should remember to send that information to the client later.
+                if (m_client && foundDeletedDatabase && databaseFileName.isNull())
+                    deletedDatabaseNamesForThisOrigin.append(databaseName);
             }
+
+            if (!deletedDatabaseNamesForThisOrigin.isEmpty())
+                deletedDatabaseNames.append({ origin, WTFMove(deletedDatabaseNamesForThisOrigin) });
         }
     }
     

--- a/Source/WebCore/Modules/webdatabase/DatabaseTracker.h
+++ b/Source/WebCore/Modules/webdatabase/DatabaseTracker.h
@@ -162,11 +162,11 @@ private:
     void deleteOriginLockFor(const SecurityOriginData&) WTF_REQUIRES_LOCK(m_databaseGuard);
 
     using DatabaseSet = HashSet<Database*>;
-    using DatabaseNameMap = HashMap<String, DatabaseSet*>;
-    using DatabaseOriginMap = HashMap<SecurityOriginData, DatabaseNameMap*>;
+    using DatabaseNameMap = HashMap<String, DatabaseSet>;
+    using DatabaseOriginMap = HashMap<SecurityOriginData, DatabaseNameMap>;
 
     Lock m_openDatabaseMapGuard;
-    mutable std::unique_ptr<DatabaseOriginMap> m_openDatabaseMap WTF_GUARDED_BY_LOCK(m_openDatabaseMapGuard);
+    mutable DatabaseOriginMap m_openDatabaseMap WTF_GUARDED_BY_LOCK(m_openDatabaseMapGuard);
 
     // This lock protects m_database, m_originLockMap, m_databaseDirectoryPath, m_originsBeingDeleted, m_beingCreated, and m_beingDeleted.
     Lock m_databaseGuard;


### PR DESCRIPTION
#### d73b4b3064358261cd1f0ee3585e2b103db6b8db
<pre>
Putting HashMap in a heap block hurts memory use, speed, code size (WebCore databases)
<a href="https://bugs.webkit.org/show_bug.cgi?id=295861">https://bugs.webkit.org/show_bug.cgi?id=295861</a>
<a href="https://rdar.apple.com/155734983">rdar://155734983</a>

Reviewed by Sihui Liu and Sam Weinig.

HashMap and related class templates already are pointers to a hash table in
production builds, so there is no reason to wrap them in heap block with
unique_ptr and add another level of indirection. Fix this in a few places
in WebCore database modules.

* Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h:
Revise objectStoreCleared to take a map instead of a pointer to a map.

* Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.cpp:
(WebCore::IDBServer::MemoryObjectStore::forEachRecord): Update since
m_keyValueStore is now a map rather than a pointer to a map.
(WebCore::IDBServer::MemoryObjectStore::containsRecord): Ditto.
(WebCore::IDBServer::MemoryObjectStore::clear): Ditto.
(WebCore::IDBServer::MemoryObjectStore::deleteRecord): Ditto.
(WebCore::IDBServer::MemoryObjectStore::addRecordWithoutUpdatingIndexes): Ditto.
(WebCore::IDBServer::MemoryObjectStore::addRecord): Ditto.
(WebCore::IDBServer::MemoryObjectStore::countForKeyRange const): Ditto.
(WebCore::IDBServer::MemoryObjectStore::valueForKey const): Ditto.
(WebCore::IDBServer::MemoryObjectStore::valueForKeyRange const): Ditto.
(WebCore::IDBServer::MemoryObjectStore::lowestKeyWithRecordInRange const): Ditto.
(WebCore::IDBServer::MemoryObjectStore::registerIndex): Ditto.
(WebCore::IDBServer::MemoryObjectStore::renameIndex): Ditto.
* Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h: Ditto.

* Source/WebCore/Modules/webdatabase/DatabaseTracker.cpp:
(WebCore::DatabaseTracker::openDatabases): Update since m_openDatabaseMap is now a
map containing maps rather than a pointer to a map containing pointers to maps.
(WebCore::DatabaseTracker::addOpenDatabase): Ditto.
(WebCore::DatabaseTracker::removeOpenDatabase): Ditto.
(WebCore::DatabaseTracker::deleteDatabaseFile): Ditto.
* Source/WebCore/Modules/webdatabase/DatabaseTracker.h: Ditto.

Canonical link: <a href="https://commits.webkit.org/297507@main">https://commits.webkit.org/297507@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c017a5a5efe44f1bbf951dac76e17c366b3acff7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111374 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31040 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21505 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117406 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61642 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113336 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31721 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39622 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84647 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114321 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25329 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100263 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65094 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24672 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18400 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61226 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94714 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18467 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120596 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38423 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28553 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93571 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/fractional-translation-from-position.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38799 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96534 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93395 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23929 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38502 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16274 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34439 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38312 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43789 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37977 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41310 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39679 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->