### PR TITLE
[JSC] Fix Compatibility Issues with `timezone` in `Intl.DateTimeFormat`

### DIFF
--- a/JSTests/stress/intl-canonical-gmt.js
+++ b/JSTests/stress/intl-canonical-gmt.js
@@ -3,4 +3,4 @@ function shouldBe(actual, expected) {
         throw new Error('bad value: ' + actual);
 }
 
-shouldBe(new Intl.DateTimeFormat('en', { timeZone: "GMT" }).resolvedOptions().timeZone, "UTC")
+shouldBe(new Intl.DateTimeFormat('en', { timeZone: "GMT" }).resolvedOptions().timeZone, "GMT")

--- a/JSTests/stress/intl-datetimeformat.js
+++ b/JSTests/stress/intl-datetimeformat.js
@@ -253,32 +253,32 @@ shouldBe(Intl.DateTimeFormat('en', { timeZone: 'AMERICA/LOS_ANGELES' }).resolved
 // Default time zone is a valid canonical time zone.
 shouldBe(Intl.DateTimeFormat('en', { timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone }).resolvedOptions().timeZone, Intl.DateTimeFormat().resolvedOptions().timeZone);
 
-// Time zone is canonicalized for obsolete links in IANA tz backward file.
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Australia/ACT' }).resolvedOptions().timeZone, 'Australia/Sydney');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Australia/North' }).resolvedOptions().timeZone, 'Australia/Darwin');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Australia/South' }).resolvedOptions().timeZone, 'Australia/Adelaide');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Australia/West' }).resolvedOptions().timeZone, 'Australia/Perth');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Brazil/East' }).resolvedOptions().timeZone, 'America/Sao_Paulo');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Brazil/West' }).resolvedOptions().timeZone, 'America/Manaus');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Canada/Atlantic' }).resolvedOptions().timeZone, 'America/Halifax');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Canada/Central' }).resolvedOptions().timeZone, 'America/Winnipeg');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Canada/Eastern' }).resolvedOptions().timeZone, 'America/Toronto');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Canada/Mountain' }).resolvedOptions().timeZone, 'America/Edmonton');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Canada/Pacific' }).resolvedOptions().timeZone, 'America/Vancouver');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'GB' }).resolvedOptions().timeZone, 'Europe/London');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'GMT+0' }).resolvedOptions().timeZone, 'UTC');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'GMT-0' }).resolvedOptions().timeZone, 'UTC');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'GMT0' }).resolvedOptions().timeZone, 'UTC');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Greenwich' }).resolvedOptions().timeZone, 'UTC');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'UCT' }).resolvedOptions().timeZone, 'UTC');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'US/Central' }).resolvedOptions().timeZone, 'America/Chicago');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'US/Eastern' }).resolvedOptions().timeZone, 'America/New_York');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'US/Michigan' }).resolvedOptions().timeZone, 'America/Detroit');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'US/Mountain' }).resolvedOptions().timeZone, 'America/Denver');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'US/Pacific' }).resolvedOptions().timeZone, 'America/Los_Angeles');
+// Time zone should be preserved and not canonicalized.
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Australia/ACT' }).resolvedOptions().timeZone, 'Australia/ACT');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Australia/North' }).resolvedOptions().timeZone, 'Australia/North');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Australia/South' }).resolvedOptions().timeZone, 'Australia/South');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Australia/West' }).resolvedOptions().timeZone, 'Australia/West');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Brazil/East' }).resolvedOptions().timeZone, 'Brazil/East');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Brazil/West' }).resolvedOptions().timeZone, 'Brazil/West');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Canada/Atlantic' }).resolvedOptions().timeZone, 'Canada/Atlantic');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Canada/Central' }).resolvedOptions().timeZone, 'Canada/Central');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Canada/Eastern' }).resolvedOptions().timeZone, 'Canada/Eastern');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Canada/Mountain' }).resolvedOptions().timeZone, 'Canada/Mountain');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Canada/Pacific' }).resolvedOptions().timeZone, 'Canada/Pacific');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'GB' }).resolvedOptions().timeZone, 'GB');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'GMT+0' }).resolvedOptions().timeZone, 'GMT+0');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'GMT-0' }).resolvedOptions().timeZone, 'GMT-0');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'GMT0' }).resolvedOptions().timeZone, 'GMT0');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Greenwich' }).resolvedOptions().timeZone, 'Greenwich');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'UCT' }).resolvedOptions().timeZone, 'UCT');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'US/Central' }).resolvedOptions().timeZone, 'US/Central');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'US/Eastern' }).resolvedOptions().timeZone, 'US/Eastern');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'US/Michigan' }).resolvedOptions().timeZone, 'US/Michigan');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'US/Mountain' }).resolvedOptions().timeZone, 'US/Mountain');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'US/Pacific' }).resolvedOptions().timeZone, 'US/Pacific');
 shouldBe(Intl.DateTimeFormat('en', { timeZone: 'UTC' }).resolvedOptions().timeZone, 'UTC');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Universal' }).resolvedOptions().timeZone, 'UTC');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Zulu' }).resolvedOptions().timeZone, 'UTC');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Universal' }).resolvedOptions().timeZone, 'Universal');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Zulu' }).resolvedOptions().timeZone, 'Zulu');
 
 // Timezone-sensitive format().
 shouldBe(Intl.DateTimeFormat('en', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '12/25/2015');

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1075,12 +1075,6 @@ test/built-ins/TypedArrayConstructors/internals/Set/key-is-valid-index-prototype
 test/built-ins/TypedArrayConstructors/internals/Set/key-is-valid-index-reflect-set.js:
   default: 'Test262Error: target[0] should remain unchanged (receiver: empty object) Expected SameValue(«2.3», «0») to be true (Testing with Float64Array.)'
   strict mode: 'Test262Error: target[0] should remain unchanged (receiver: empty object) Expected SameValue(«2.3», «0») to be true (Testing with Float64Array.)'
-test/intl402/DateTimeFormat/canonicalize-timezone.js:
-  default: 'Test262Error: Time zone name Australia/Canberra should be preserved and not canonicalized to Australia/Sydney Expected SameValue(«"Australia/Sydney"», «"Australia/Canberra"») to be true'
-  strict mode: 'Test262Error: Time zone name Australia/Canberra should be preserved and not canonicalized to Australia/Sydney Expected SameValue(«"Australia/Sydney"», «"Australia/Canberra"») to be true'
-test/intl402/DateTimeFormat/canonicalize-utc-timezone.js:
-  default: "Test262Error: Time zone name Etc/GMT should be preserved and not canonicalized to 'UTC' Expected SameValue(«\"UTC\"», «\"Etc/GMT\"») to be true"
-  strict mode: "Test262Error: Time zone name Etc/GMT should be preserved and not canonicalized to 'UTC' Expected SameValue(«\"UTC\"», «\"Etc/GMT\"») to be true"
 test/intl402/DateTimeFormat/prototype/format/temporal-objects-not-overlapping-options.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.PlainYearMonth(2024, 9)')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.PlainYearMonth(2024, 9)')"
@@ -1132,15 +1126,9 @@ test/intl402/DateTimeFormat/prototype/formatToParts/temporal-objects-not-overlap
 test/intl402/DateTimeFormat/prototype/formatToParts/temporal-zoneddatetime-not-supported.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, timeZone)')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, timeZone)')"
-test/intl402/DateTimeFormat/timezone-case-insensitive.js:
-  default: 'Test262Error: Time zone created from string "America/Argentina/Buenos_Aires" Expected SameValue(«"America/Buenos_Aires"», «"America/Argentina/Buenos_Aires"») to be true'
-  strict mode: 'Test262Error: Time zone created from string "America/Argentina/Buenos_Aires" Expected SameValue(«"America/Buenos_Aires"», «"America/Argentina/Buenos_Aires"») to be true'
 test/intl402/DateTimeFormat/timezone-legacy-non-iana.js:
   default: 'Test262Error: Time zone: ACT Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Time zone: ACT Expected a RangeError to be thrown but no exception was thrown at all'
-test/intl402/DateTimeFormat/timezone-not-canonicalized.js:
-  default: 'Test262Error: Expected SameValue(«"Asia/Calcutta"», «"Asia/Kolkata"») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«"Asia/Calcutta"», «"Asia/Kolkata"») to be true'
 test/intl402/Intl/supportedValuesOf/calendars-accepted-by-DateTimeFormat.js:
   default: 'RangeError: calendar is not a well-formed calendar value'
   strict mode: 'RangeError: calendar is not a well-formed calendar value'


### PR DESCRIPTION
#### 1110ee18af6079baeb4144596c30d22b9d1c1625
<pre>
[JSC] Fix Compatibility Issues with `timezone` in `Intl.DateTimeFormat`
<a href="https://bugs.webkit.org/show_bug.cgi?id=295856">https://bugs.webkit.org/show_bug.cgi?id=295856</a>

Reviewed by Darin Adler.

The Intl.DateTimeFormat constructor [1] did not align with the current TC39 specification
regarding the handling of the timeZone option.
This patch implements GetAvailableNamedTimeZoneIdentifier [2] to bring the behavior
in line with the latest TC39 spec.

[1]: <a href="https://tc39.es/ecma402/#sec-createdatetimeformat">https://tc39.es/ecma402/#sec-createdatetimeformat</a>
[2]: <a href="https://tc39.es/ecma402/#sec-getavailablenamedtimezoneidentifier">https://tc39.es/ecma402/#sec-getavailablenamedtimezoneidentifier</a>

* JSTests/stress/intl-canonical-gmt.js:
* JSTests/stress/intl-datetimeformat.js:
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp:
(JSC::availableNamedTimeZoneIdentifier):
(JSC::IntlDateTimeFormat::initializeDateTimeFormat):
(JSC::canonicalizeTimeZoneName): Deleted.

Canonical link: <a href="https://commits.webkit.org/297594@main">https://commits.webkit.org/297594@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fd28e3349f3ddf878bf95cd5ed222c7f13bcf73

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111996 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31666 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22152 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118019 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62233 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32343 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40244 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85079 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/35971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114943 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25829 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100777 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65511 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25145 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18918 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61869 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/104484 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95214 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18994 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121336 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/110555 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39029 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29036 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93925 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39410 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97036 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93742 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24012 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38948 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16741 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/35051 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38923 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44435 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/134815 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38560 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36297 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41888 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40276 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->