### PR TITLE
Putting HashMap in a heap block hurts memory use, speed, code size (WebCore bindings)

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -38,7 +38,6 @@ bindings/js/JSDOMConvertBase.h
 bindings/js/JSLocationCustom.cpp
 bindings/js/JSPaintRenderingContext2DCustom.cpp
 bindings/js/WebCoreOpaqueRootInlines.h
-bindings/js/WindowProxy.h
 bridge/objc/objc_runtime.h
 crypto/cocoa/CryptoAlgorithmEd25519Cocoa.cpp
 crypto/cocoa/CryptoKeyOKPCocoa.cpp

--- a/Source/WebCore/bindings/js/WindowProxy.h
+++ b/Source/WebCore/bindings/js/WindowProxy.h
@@ -1,7 +1,7 @@
 /*
  *  Copyright (C) 1999-2001 Harri Porten (porten@kde.org)
  *  Copyright (C) 2001 Peter Kelly (pmk@post.com)
- *  Copyright (C) 2006-2018 Apple Inc. All rights reserved.
+ *  Copyright (C) 2006-2025 Apple Inc. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -23,8 +23,6 @@
 #include <JavaScriptCore/Strong.h>
 #include <wtf/HashMap.h>
 #include <wtf/RefCounted.h>
-#include <wtf/TZoneMalloc.h>
-#include <wtf/UniqueRef.h>
 #include <wtf/WeakPtr.h>
 
 namespace JSC {
@@ -42,13 +40,7 @@ class JSWindowProxy;
 class WindowProxy : public RefCounted<WindowProxy> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(WindowProxy, WEBCORE_EXPORT);
 public:
-    using ProxyMap = HashMap<RefPtr<DOMWrapperWorld>, JSC::Strong<JSWindowProxy>>;
-
-    static Ref<WindowProxy> create(Frame& frame)
-    {
-        return adoptRef(*new WindowProxy(frame));
-    }
-
+    static Ref<WindowProxy> create(Frame&);
     WEBCORE_EXPORT ~WindowProxy();
 
     WEBCORE_EXPORT Frame* frame() const;
@@ -59,31 +51,14 @@ public:
 
     Vector<JSC::Strong<JSWindowProxy>> jsWindowProxiesAsVector() const;
 
-    WEBCORE_EXPORT ProxyMap releaseJSWindowProxies();
-    WEBCORE_EXPORT void setJSWindowProxies(ProxyMap&&);
-
-    JSWindowProxy* jsWindowProxy(DOMWrapperWorld& world)
-    {
-        if (!m_frame)
-            return nullptr;
-
-        if (auto* existingProxy = existingJSWindowProxy(world))
-            return existingProxy;
-
-        return &createJSWindowProxyWithInitializedScript(world);
-    }
-
-    JSWindowProxy* existingJSWindowProxy(DOMWrapperWorld& world) const
-    {
-        auto it = m_jsWindowProxies->find(&world);
-        return (it != m_jsWindowProxies->end()) ? it->value.get() : nullptr;
-    }
+    JSWindowProxy* jsWindowProxy(DOMWrapperWorld&);
+    WEBCORE_EXPORT JSWindowProxy* existingJSWindowProxy(DOMWrapperWorld&) const;
 
     WEBCORE_EXPORT JSDOMGlobalObject* globalObject(DOMWrapperWorld&);
 
     void clearJSWindowProxiesNotMatchingDOMWindow(DOMWindow*, bool goingIntoBackForwardCache);
 
-    WEBCORE_EXPORT void setDOMWindow(DOMWindow*);
+    void setDOMWindow(DOMWindow*);
 
     // Debugger can be nullptr to detach any existing Debugger.
     void attachDebugger(JSC::Debugger*); // Attaches/detaches in all worlds/window proxies.
@@ -94,10 +69,10 @@ private:
     explicit WindowProxy(Frame&);
 
     JSWindowProxy& createJSWindowProxy(DOMWrapperWorld&);
-    WEBCORE_EXPORT JSWindowProxy& createJSWindowProxyWithInitializedScript(DOMWrapperWorld&);
+    JSWindowProxy& createJSWindowProxyWithInitializedScript(DOMWrapperWorld&);
 
     WeakPtr<Frame> m_frame;
-    UniqueRef<ProxyMap> m_jsWindowProxies;
+    HashMap<RefPtr<DOMWrapperWorld>, JSC::Strong<JSWindowProxy>> m_jsWindowProxies;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### c90f9757379af396dae841fd2ec8685977fbcce1
<pre>
Putting HashMap in a heap block hurts memory use, speed, code size (WebCore bindings)
<a href="https://bugs.webkit.org/show_bug.cgi?id=295862">https://bugs.webkit.org/show_bug.cgi?id=295862</a>
<a href="https://rdar.apple.com/155737405">rdar://155737405</a>

Reviewed by Sam Weinig.

HashMap and similar classes are already pointers to a hash table, so there is no reason
to wrap them in a unique_ptr in a heap block and add another level of indirection.

* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations: Removed WindowProxy.h.

* Source/WebCore/bindings/js/WindowProxy.cpp:
(WebCore::WindowProxy::WindowProxy): Removed unneeded initialization of m_jsWindowProxies.
(WebCore::WindowProxy::create): Moved from the header.
(WebCore::WindowProxy::~WindowProxy): Updated for change to type of m_jsWindowProxies.
(WebCore::WindowProxy::detachFromFrame): Ditto. Also use do/while loop.
(WebCore::WindowProxy::destroyJSWindowProxy): Ditto.
(WebCore::WindowProxy::createJSWindowProxy): Ditto.
(WebCore::WindowProxy::jsWindowProxiesAsVector const): Ditto.
(WebCore::WindowProxy::clearJSWindowProxiesNotMatchingDOMWindow): Ditto.
(WebCore::WindowProxy::setDOMWindow): Ditto.
(WebCore::WindowProxy::attachDebugger): Ditto.
(WebCore::WindowProxy::existingJSWindowProxy const): Moved from the header.
(WebCore::WindowProxy::jsWindowProxy): Moved from the header.
(WebCore::WindowProxy::releaseJSWindowProxies): Deleted. Unused.
(WebCore::WindowProxy::setJSWindowProxies): Deleted. Unused.

* Source/WebCore/bindings/js/WindowProxy.h: Cut down on includes.
Removed the unused type ProxyMap and unused functions releaseJSWindowProxies
and setJSWindowProxies. Moved create, jsWindowProxy, and existingJSWindowProxy
function out of the header into the .cpp file. Removed unnecessary exports of
createJSWindowProxyWithInitializedScript and setDOMWindow functions.
Use a map for m_jsWindowProxies, rather than a UniqueRef to a map.
(WebCore::WindowProxy::create): Deleted.
(WebCore::WindowProxy::jsWindowProxy): Deleted.
(WebCore::WindowProxy::existingJSWindowProxy const): Deleted.

Canonical link: <a href="https://commits.webkit.org/297707@main">https://commits.webkit.org/297707@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccabf6f713a864eba47c7f7355dfd439685601c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112567 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32299 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22777 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118766 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63025 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114529 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32951 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40862 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85677 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36299 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115514 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26299 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101271 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65979 "Found 141 new API test failures: /WPE/TestLoaderClient:/webkit/WebKitWebView/loading-status, /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification, /WPE/TestWebKitFindController:/webkit/WebKitFindController/options, /WPE/TestLoaderClient:/webkit/WebKitWebView/reload, /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/script-message-received, /WPE/TestWebKitWebView:/webkit/WebKitWebView/run-javascript, /WPE/TestWebKitWebView:/webkit/WebKitWebView/disable-web-security, /WPE/TestLoaderClient:/webkit/WebKitWebView/load-bytes, /WPE/TestLoaderClient:/webkit/WebKitWebView/load-plain-text, /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification-initial-permission-allowed ... (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25598 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19404 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62525 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95691 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19477 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121987 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39641 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29530 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94547 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40023 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97503 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94284 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24079 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39395 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17201 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35729 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39529 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45017 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39166 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42501 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40907 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->