### PR TITLE
Fix vertical writing-mode, zoom and rounding issues for SVG `foreignObject`

### DIFF
--- a/LayoutTests/svg/foreignObject/vertical-foreignObject-expected.html
+++ b/LayoutTests/svg/foreignObject/vertical-foreignObject-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<svg width="200" height="200">
+  <rect x="100" y="50" width="20" height="100" fill="green"/>
+</svg>

--- a/LayoutTests/svg/foreignObject/vertical-foreignObject.html
+++ b/LayoutTests/svg/foreignObject/vertical-foreignObject.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<svg width="200" height="200">
+  <rect x="100" y="50" width="20" height="100" fill="red"/>
+  <foreignObject x="100" y="50" width="20" height="100"
+      style="overflow: hidden; writing-mode: vertical-rl">
+    <div style="background: green; width: 100%; height: 100%"></div>
+    <div style="background: red">Should not show this</div>
+  </foreignObject>
+</svg>

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp
@@ -26,6 +26,7 @@
 #include "HitTestResult.h"
 #include "LayoutRepainter.h"
 #include "LegacyRenderSVGResource.h"
+#include "RenderBoxInlines.h"
 #include "RenderBoxModelObjectInlines.h"
 #include "RenderSVGBlockInlines.h"
 #include "RenderView.h"
@@ -106,17 +107,14 @@ const AffineTransform& LegacyRenderSVGForeignObject::localToParentTransform() co
 
 void LegacyRenderSVGForeignObject::updateLogicalWidth()
 {
-    // FIXME: Investigate in size rounding issues
-    // FIXME: Remove unnecessary rounding when layout is off ints: webkit.org/b/63656
-    setWidth(static_cast<int>(roundf(m_viewport.width())));
+    auto logicalWidth = style().writingMode().isHorizontal() ? m_viewport.width() : m_viewport.height();
+    setLogicalWidth(LayoutUnit { logicalWidth * style().usedZoom() });
 }
 
 RenderBox::LogicalExtentComputedValues LegacyRenderSVGForeignObject::computeLogicalHeight(LayoutUnit, LayoutUnit logicalTop) const
 {
-    // FIXME: Investigate in size rounding issues
-    // FIXME: Remove unnecessary rounding when layout is off ints: webkit.org/b/63656
-    // FIXME: Is this correct for vertical writing mode?
-    return { static_cast<int>(roundf(m_viewport.height())), logicalTop, ComputedMarginValues() };
+    auto logicalHeight = style().writingMode().isHorizontal() ? m_viewport.height() : m_viewport.width();
+    return { LayoutUnit { logicalHeight * style().usedZoom() }, logicalTop, ComputedMarginValues() };
 }
 
 void LegacyRenderSVGForeignObject::layout()


### PR DESCRIPTION
#### 20237c4e8a8150b9c985a37f1560af95f6336a8f
<pre>
Fix vertical writing-mode, zoom and rounding issues for SVG `foreignObject`
<a href="https://bugs.webkit.org/show_bug.cgi?id=295863">https://bugs.webkit.org/show_bug.cgi?id=295863</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

This patch updates &apos;updateLogicalWidth&apos; and &apos;computeLogicalHeight&apos; to address
all FIXME and ensure that we handle vertical writing-mode and &apos;zoom&apos; handling.
It also removes rounding and uses `LayoutUnit` now.

Merge (Test): <a href="https://source.chromium.org/chromium/chromium/src/+/82ac602161c3c94c1c7dc979339a2908f71e71ca">https://source.chromium.org/chromium/chromium/src/+/82ac602161c3c94c1c7dc979339a2908f71e71ca</a>

For SVG zoom, we have other bugs - webkit.org/b/279041 &amp; webkit.org/b/199236

Hence, there is no additional test added for it.

* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp:
(WebCore::LegacyRenderSVGForeignObject::updateLogicalWidth):
(WebCore::LegacyRenderSVGForeignObject::computeLogicalHeight const):
* LayoutTests/svg/foreignObject/vertical-foreignObject.html:
* LayoutTests/svg/foreignObject/vertical-foreignObject-expected.html:

Canonical link: <a href="https://commits.webkit.org/297395@main">https://commits.webkit.org/297395@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65481002df8908a41bd9db86d1b9ed8a505d6db2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111651 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31318 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21792 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117686 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/61933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113613 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32006 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39903 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84828 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/61933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114598 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25549 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100488 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65269 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24885 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18623 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61518 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94934 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18691 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120934 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38704 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28756 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93726 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39082 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96745 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93552 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23846 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38693 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16487 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34740 "Failed to checkout and rebase branch from PR 47961") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38593 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44078 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38256 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41592 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39958 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->