### PR TITLE
[Style] Convert grid-auto-columns/grid-auto-rows to use strong style types

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2785,6 +2785,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/grid/StyleGridTemplateList.h
     style/values/grid/StyleGridTrackBreadth.h
     style/values/grid/StyleGridTrackSize.h
+    style/values/grid/StyleGridTrackSizes.h
 
     style/values/images/StyleGradient.h
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3183,6 +3183,7 @@ style/values/grid/StyleGridTemplateAreas.cpp
 style/values/grid/StyleGridTemplateList.cpp
 style/values/grid/StyleGridTrackBreadth.cpp
 style/values/grid/StyleGridTrackSize.cpp
+style/values/grid/StyleGridTrackSizes.cpp
 style/values/images/StyleGradient.cpp
 style/values/masking/StyleClip.cpp
 style/values/masking/StyleClipPath.cpp

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -9956,8 +9956,8 @@
             "animation-type-comment": "Current spec animation type is 'by computed value'",
             "initial": "auto",
             "codegen-properties": {
-                "style-converter": "GridTrackSizeList",
                 "separator": " ",
+                "style-converter": "StyleType<GridTrackSizes>",
                 "parser-function": "consumeGridTrackList",
                 "parser-grammar-unused": "<track-size>+",
                 "parser-grammar-unused-reason": "Needs investigation."
@@ -9972,8 +9972,8 @@
             "animation-type-comment": "Current spec animation type is 'by computed value'",
             "initial": "auto",
             "codegen-properties": {
-                "style-converter": "GridTrackSizeList",
                 "separator": " ",
+                "style-converter": "StyleType<GridTrackSizes>",
                 "parser-function": "consumeGridTrackList",
                 "parser-grammar-unused": "<track-size>+",
                 "parser-grammar-unused-reason": "Needs investigation."

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -184,6 +184,7 @@ private:
     };
 
     std::optional<LayoutUnit> availableSpace() const;
+    bool isRelativeGridTrackBreadthAsAuto(const Style::GridTrackFitContentLength&, GridTrackSizingDirection) const;
     bool isRelativeGridTrackBreadthAsAuto(const Style::GridTrackBreadth&, GridTrackSizingDirection) const;
     Style::GridTrackSize calculateGridTrackSize(GridTrackSizingDirection, unsigned translatedIndex) const;
     const Style::GridTrackSize& rawGridTrackSize(GridTrackSizingDirection, unsigned translatedIndex) const;

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -298,6 +298,7 @@ struct GridOrderedNamedLinesMap;
 struct GridTemplateAreas;
 struct GridTemplateList;
 struct GridTrackSize;
+struct GridTrackSizes;
 struct InsetEdge;
 struct MarginEdge;
 struct MaximumSize;
@@ -885,9 +886,9 @@ public:
     inline bool isGridAutoFlowDirectionColumn() const;
     inline bool isGridAutoFlowAlgorithmSparse() const;
     inline bool isGridAutoFlowAlgorithmDense() const;
-    inline const Vector<Style::GridTrackSize>& gridAutoColumns() const;
-    inline const Vector<Style::GridTrackSize>& gridAutoRows() const;
-    inline const Vector<Style::GridTrackSize>& gridAutoList(GridTrackSizingDirection) const;
+    inline const Style::GridTrackSizes& gridAutoColumns() const;
+    inline const Style::GridTrackSizes& gridAutoRows() const;
+    inline const Style::GridTrackSizes& gridAutoList(GridTrackSizingDirection) const;
     inline const Style::GridTemplateAreas& gridTemplateAreas() const;
     inline const Style::GridTemplateList& gridTemplateColumns() const;
     inline const Style::GridTemplateList& gridTemplateRows() const;
@@ -1547,8 +1548,8 @@ public:
     inline void setBoxDecorationBreak(BoxDecorationBreak);
 
     inline void setGridAutoFlow(GridAutoFlow);
-    inline void setGridAutoColumns(Vector<Style::GridTrackSize>&&);
-    inline void setGridAutoRows(Vector<Style::GridTrackSize>&&);
+    inline void setGridAutoColumns(Style::GridTrackSizes&&);
+    inline void setGridAutoRows(Style::GridTrackSizes&&);
     inline void setGridTemplateAreas(Style::GridTemplateAreas&&);
     inline void setGridTemplateColumns(Style::GridTemplateList&&);
     inline void setGridTemplateRows(Style::GridTemplateList&&);
@@ -2175,8 +2176,8 @@ public:
 #endif
 
     static constexpr GridAutoFlow initialGridAutoFlow();
-    static inline Vector<Style::GridTrackSize> initialGridAutoColumns();
-    static inline Vector<Style::GridTrackSize> initialGridAutoRows();
+    static inline Style::GridTrackSizes initialGridAutoColumns();
+    static inline Style::GridTrackSizes initialGridAutoRows();
     static inline Style::GridTemplateAreas initialGridTemplateAreas();
     static inline Style::GridTemplateList initialGridTemplateColumns();
     static inline Style::GridTemplateList initialGridTemplateRows();

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -231,7 +231,7 @@ inline FontSelectionValue RenderStyle::fontWidth() const { return fontDescriptio
 inline FontOpticalSizing RenderStyle::fontOpticalSizing() const { return fontDescription().opticalSizing(); }
 inline FontVariationSettings RenderStyle::fontVariationSettings() const { return fontDescription().variationSettings(); }
 inline FontSelectionValue RenderStyle::fontWeight() const { return fontDescription().weight(); }
-inline const Vector<Style::GridTrackSize>& RenderStyle::gridAutoColumns() const { return m_nonInheritedData->rareData->grid->m_gridAutoColumns; }
+inline const Style::GridTrackSizes& RenderStyle::gridAutoColumns() const { return m_nonInheritedData->rareData->grid->m_gridAutoColumns; }
 inline GridAutoFlow RenderStyle::gridAutoFlow() const { return static_cast<GridAutoFlow>(m_nonInheritedData->rareData->grid->m_gridAutoFlow); }
 inline const Vector<Style::GridTrackSize>& RenderStyle::gridAutoRepeatColumns() const { return m_nonInheritedData->rareData->grid->gridAutoRepeatColumns(); }
 inline unsigned RenderStyle::gridAutoRepeatColumnsInsertionPoint() const { return m_nonInheritedData->rareData->grid->autoRepeatColumnsInsertionPoint(); }
@@ -239,8 +239,8 @@ inline AutoRepeatType RenderStyle::gridAutoRepeatColumnsType() const  { return m
 inline const Vector<Style::GridTrackSize>& RenderStyle::gridAutoRepeatRows() const { return m_nonInheritedData->rareData->grid->gridAutoRepeatRows(); }
 inline unsigned RenderStyle::gridAutoRepeatRowsInsertionPoint() const { return m_nonInheritedData->rareData->grid->autoRepeatRowsInsertionPoint(); }
 inline AutoRepeatType RenderStyle::gridAutoRepeatRowsType() const  { return m_nonInheritedData->rareData->grid->autoRepeatRowsType(); }
-inline const Vector<Style::GridTrackSize>& RenderStyle::gridAutoRows() const { return m_nonInheritedData->rareData->grid->m_gridAutoRows; }
-inline const Vector<Style::GridTrackSize>& RenderStyle::gridAutoList(GridTrackSizingDirection direction) const { return direction == GridTrackSizingDirection::ForColumns ? gridAutoColumns() : gridAutoRows(); }
+inline const Style::GridTrackSizes& RenderStyle::gridAutoRows() const { return m_nonInheritedData->rareData->grid->m_gridAutoRows; }
+inline const Style::GridTrackSizes& RenderStyle::gridAutoList(GridTrackSizingDirection direction) const { return direction == GridTrackSizingDirection::ForColumns ? gridAutoColumns() : gridAutoRows(); }
 inline const Style::GridTemplateList& RenderStyle::gridTemplateColumns() const { return m_nonInheritedData->rareData->grid->m_gridTemplateColumns; }
 inline const Vector<Style::GridTrackSize>& RenderStyle::gridColumnTrackSizes() const { return m_nonInheritedData->rareData->grid->gridColumnTrackSizes(); }
 inline const GridPosition& RenderStyle::gridItemColumnEnd() const { return m_nonInheritedData->rareData->gridItem->gridColumnEnd; }
@@ -404,9 +404,9 @@ inline Style::FlexBasis RenderStyle::initialFlexBasis() { return CSS::Keyword::A
 constexpr FlexDirection RenderStyle::initialFlexDirection() { return FlexDirection::Row; }
 constexpr FlexWrap RenderStyle::initialFlexWrap() { return FlexWrap::NoWrap; }
 constexpr Float RenderStyle::initialFloating() { return Float::None; }
-inline Vector<Style::GridTrackSize> RenderStyle::initialGridAutoColumns() { return { Style::GridTrackSize { CSS::Keyword::Auto { } } }; }
+inline Style::GridTrackSizes RenderStyle::initialGridAutoColumns() { return CSS::Keyword::Auto { }; }
 constexpr GridAutoFlow RenderStyle::initialGridAutoFlow() { return AutoFlowRow; }
-inline Vector<Style::GridTrackSize> RenderStyle::initialGridAutoRows() { return { Style::GridTrackSize { CSS::Keyword::Auto { } } }; }
+inline Style::GridTrackSizes RenderStyle::initialGridAutoRows() { return CSS::Keyword::Auto { }; }
 inline GridPosition RenderStyle::initialGridItemColumnEnd() { return { }; }
 inline GridPosition RenderStyle::initialGridItemColumnStart() { return { }; }
 inline GridPosition RenderStyle::initialGridItemRowEnd() { return { }; }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -154,9 +154,9 @@ inline void RenderStyle::setFilter(FilterOperations&& ops) { SET_DOUBLY_NESTED(m
 inline void RenderStyle::setFlexBasis(Style::FlexBasis&& basis) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, flexibleBox, flexBasis, WTFMove(basis)); }
 inline void RenderStyle::setFlexDirection(FlexDirection direction) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, flexibleBox, flexDirection, static_cast<unsigned>(direction)); }
 inline void RenderStyle::setFlexWrap(FlexWrap wrap) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, flexibleBox, flexWrap, static_cast<unsigned>(wrap)); }
-inline void RenderStyle::setGridAutoColumns(Vector<Style::GridTrackSize>&& trackSizeList) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, grid, m_gridAutoColumns, WTFMove(trackSizeList)); }
+inline void RenderStyle::setGridAutoColumns(Style::GridTrackSizes&& trackSizeList) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, grid, m_gridAutoColumns, WTFMove(trackSizeList)); }
 inline void RenderStyle::setGridAutoFlow(GridAutoFlow flow) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, grid, m_gridAutoFlow, flow); }
-inline void RenderStyle::setGridAutoRows(Vector<Style::GridTrackSize>&& trackSizeList) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, grid, m_gridAutoRows, WTFMove(trackSizeList)); }
+inline void RenderStyle::setGridAutoRows(Style::GridTrackSizes&& trackSizeList) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, grid, m_gridAutoRows, WTFMove(trackSizeList)); }
 inline void RenderStyle::setGridItemColumnEnd(const GridPosition& columnEndPosition) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, gridItem, gridColumnEnd, columnEndPosition); }
 inline void RenderStyle::setGridItemColumnStart(const GridPosition& columnStartPosition) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, gridItem, gridColumnStart, columnStartPosition); }
 inline void RenderStyle::setGridItemRowEnd(const GridPosition& rowEndPosition) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, gridItem, gridRowEnd, rowEndPosition); }

--- a/Source/WebCore/rendering/style/StyleGridData.h
+++ b/Source/WebCore/rendering/style/StyleGridData.h
@@ -28,6 +28,7 @@
 #include "RenderStyleConstants.h"
 #include "StyleGridTemplateAreas.h"
 #include "StyleGridTemplateList.h"
+#include "StyleGridTrackSizes.h"
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 #include <wtf/Vector.h>
@@ -50,8 +51,8 @@ public:
 #endif
 
     unsigned gridAutoFlow() const { return m_gridAutoFlow; }
-    const Vector<Style::GridTrackSize>& gridAutoColumns() const { return m_gridAutoColumns; }
-    const Vector<Style::GridTrackSize>& gridAutoRows() const { return m_gridAutoRows; }
+    const Style::GridTrackSizes& gridAutoColumns() const { return m_gridAutoColumns; }
+    const Style::GridTrackSizes& gridAutoRows() const { return m_gridAutoRows; }
     const Style::GridTemplateAreas& gridTemplateAreas() { return m_gridTemplateAreas; }
     const Style::GridTemplateList& gridTemplateColumns() const { return m_gridTemplateColumns; }
     const Style::GridTemplateList& gridTemplateRows() const { return m_gridTemplateRows; }
@@ -85,8 +86,8 @@ private:
     friend class RenderStyle;
 
     unsigned m_gridAutoFlow : GridAutoFlowBits;
-    Vector<Style::GridTrackSize> m_gridAutoColumns;
-    Vector<Style::GridTrackSize> m_gridAutoRows;
+    Style::GridTrackSizes m_gridAutoColumns;
+    Style::GridTrackSizes m_gridAutoRows;
     Style::GridTemplateAreas m_gridTemplateAreas;
     Style::GridTemplateList m_gridTemplateColumns;
     Style::GridTemplateList m_gridTemplateRows;

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -180,7 +180,6 @@ public:
     static ScrollbarGutter convertScrollbarGutter(BuilderState&, const CSSValue&);
     // scrollbar-width converter is only needed for quirking.
     static ScrollbarWidth convertScrollbarWidth(BuilderState&, const CSSValue&);
-    static Vector<GridTrackSize> convertGridTrackSizeList(BuilderState&, const CSSValue&);
     static GridPosition convertGridPosition(BuilderState&, const CSSValue&);
     static GridAutoFlow convertGridAutoFlow(BuilderState&, const CSSValue&);
     static FilterOperations convertFilterOperations(BuilderState&, const CSSValue&);
@@ -1040,34 +1039,6 @@ inline ScrollbarWidth BuilderConverter::convertScrollbarWidth(BuilderState& buil
         return ScrollbarWidth::Auto;
 
     return scrollbarWidth;
-}
-
-inline Vector<GridTrackSize> BuilderConverter::convertGridTrackSizeList(BuilderState& builderState, const CSSValue& value)
-{
-    auto validateValue = [](const CSSValue& value) {
-        ASSERT_UNUSED(value, !value.isGridLineNamesValue());
-        ASSERT_UNUSED(value, !value.isGridAutoRepeatValue());
-        ASSERT_UNUSED(value, !value.isGridIntegerRepeatValue());
-    };
-
-    if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
-        if (primitiveValue->isValueID()) {
-            ASSERT(primitiveValue->valueID() == CSSValueAuto);
-            return RenderStyle::initialGridAutoRows();
-        }
-        // Values coming from CSS Typed OM may not have been converted to a CSSValueList yet.
-        validateValue(*primitiveValue);
-        return Vector<GridTrackSize>({ toStyleFromCSSValue<GridTrackSize>(builderState, *primitiveValue) });
-    }
-
-    if (auto* valueList = dynamicDowncast<CSSValueList>(value))  {
-        return WTF::map(*valueList, [&](auto& currentValue) {
-            validateValue(currentValue);
-            return toStyleFromCSSValue<GridTrackSize>(builderState, currentValue);
-        });
-    }
-    validateValue(value);
-    return Vector<GridTrackSize>({ toStyleFromCSSValue<GridTrackSize>(builderState, value) });
 }
 
 inline GridPosition BuilderConverter::convertGridPosition(BuilderState& builderState, const CSSValue& value)

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -106,6 +106,7 @@ inline ClipPath forwardInheritedValue(const ClipPath& value) { auto copy = value
 inline CornerShapeValue forwardInheritedValue(const CornerShapeValue& value) { auto copy = value; return copy; }
 inline GridTemplateAreas forwardInheritedValue(const GridTemplateAreas& value) { auto copy = value; return copy; }
 inline GridTemplateList forwardInheritedValue(const GridTemplateList& value) { auto copy = value; return copy; }
+inline GridTrackSizes forwardInheritedValue(const GridTrackSizes& value) { auto copy = value; return copy; }
 inline OffsetAnchor forwardInheritedValue(const OffsetAnchor& value) { auto copy = value; return copy; }
 inline OffsetDistance forwardInheritedValue(const OffsetDistance& value) { auto copy = value; return copy; }
 inline OffsetPath forwardInheritedValue(const OffsetPath& value) { auto copy = value; return copy; }

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -301,7 +301,6 @@ public:
 
     static Ref<CSSValue> convertGridAutoFlow(ExtractorState&, GridAutoFlow);
     static Ref<CSSValue> convertGridPosition(ExtractorState&, const GridPosition&);
-    static Ref<CSSValue> convertGridTrackSizeList(ExtractorState&, const Vector<GridTrackSize>&);
 };
 
 // MARK: - Strong value conversions
@@ -2263,14 +2262,6 @@ inline Ref<CSSValue> ExtractorConverter::convertGridPosition(ExtractorState&, co
 
     if (hasNamedGridLine)
         list.append(CSSPrimitiveValue::createCustomIdent(position.namedGridLine()));
-    return CSSValueList::createSpaceSeparated(WTFMove(list));
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertGridTrackSizeList(ExtractorState& state, const Vector<GridTrackSize>& gridTrackSizeList)
-{
-    CSSValueListBuilder list;
-    for (auto& gridTrackSize : gridTrackSizeList)
-        list.append(convertStyleType(state, gridTrackSize));
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 

--- a/Source/WebCore/style/StyleExtractorSerializer.h
+++ b/Source/WebCore/style/StyleExtractorSerializer.h
@@ -212,7 +212,6 @@ public:
 
     static void serializeGridAutoFlow(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, GridAutoFlow);
     static void serializeGridPosition(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const GridPosition&);
-    static void serializeGridTrackSizeList(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const Vector<GridTrackSize>&);
 };
 
 // MARK: - Strong value serializations
@@ -2571,13 +2570,6 @@ inline void ExtractorSerializer::serializeGridPosition(ExtractorState& state, St
         builder.append(' ');
         serializationForCSS(builder, context, state.style, CustomIdentifier { AtomString { position.namedGridLine() } });
     }
-}
-
-inline void ExtractorSerializer::serializeGridTrackSizeList(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const Vector<GridTrackSize>& gridTrackSizeList)
-{
-    builder.append(interleave(gridTrackSizeList, [&](auto& builder, auto& gridTrackSize) {
-        serializeStyleType(state, builder, context, gridTrackSize);
-    }, ' '));
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/grid/StyleGridTemplateList.cpp
+++ b/Source/WebCore/style/values/grid/StyleGridTemplateList.cpp
@@ -34,6 +34,7 @@
 #include "StylePrimitiveNumericTypes+Blending.h"
 #include "StylePrimitiveNumericTypes+CSSValueConversion.h"
 #include "StylePrimitiveNumericTypes+CSSValueCreation.h"
+#include "StylePrimitiveNumericTypes+Logging.h"
 #include "StylePrimitiveNumericTypes+Serialization.h"
 #include <wtf/text/TextStream.h>
 

--- a/Source/WebCore/style/values/grid/StyleGridTemplateList.h
+++ b/Source/WebCore/style/values/grid/StyleGridTemplateList.h
@@ -63,7 +63,6 @@ using GridTrackEntry = Variant<
     GridTrackEntryMasonry
 >;
 using GridTrackList = Vector<GridTrackEntry>;
-using GridTrackSizeList = Vector<GridTrackSize>;
 
 // <'grid-template-columns'/'grid-template-rows'> = none | <track-list> | <auto-track-list>
 struct GridTemplateList {
@@ -74,11 +73,11 @@ struct GridTemplateList {
 
     // Calculated from list.
 
-    GridTrackSizeList sizes { };
+    Vector<GridTrackSize> sizes { };
     GridNamedLinesMap namedLines { };
     GridOrderedNamedLinesMap orderedNamedLines { };
 
-    GridTrackSizeList autoRepeatSizes { };
+    Vector<GridTrackSize> autoRepeatSizes { };
     GridNamedLinesMap autoRepeatNamedLines { };
     GridOrderedNamedLinesMap autoRepeatOrderedNamedLines { };
 

--- a/Source/WebCore/style/values/grid/StyleGridTrackSizes.cpp
+++ b/Source/WebCore/style/values/grid/StyleGridTrackSizes.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2020 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleGridTrackSizes.h"
+
+#include <wtf/NeverDestroyed.h>
+
+namespace WebCore {
+namespace Style {
+
+auto GridTrackSizeDefaulter::operator()() const -> const GridTrackSize&
+{
+    static NeverDestroyed staticValue = GridTrackSize { CSS::Keyword::Auto { } };
+    return staticValue.get();
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/grid/StyleGridTrackSizes.h
+++ b/Source/WebCore/style/values/grid/StyleGridTrackSizes.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StyleGridTrackSize.h"
+#include "StyleValueTypes.h"
+
+namespace WebCore {
+namespace Style {
+
+using GridTrackSizeList = SpaceSeparatedFixedVector<GridTrackSize>;
+
+// Default values for <'grid-auto-columns'>/<'grid-auto-rows'> is 'auto'.
+struct GridTrackSizeDefaulter {
+    auto operator()() const -> const GridTrackSize&;
+    bool operator==(const GridTrackSizeDefaulter&) const = default;
+};
+
+// <'grid-auto-columns'>/<'grid-auto-rows'> = <track-size>+
+// https://www.w3.org/TR/css-grid-2/#propdef-grid-auto-rows
+struct GridTrackSizes : ListOrDefault<GridTrackSizeList, GridTrackSizeDefaulter> {
+    using ListOrDefault<GridTrackSizeList, GridTrackSizeDefaulter>::ListOrDefault;
+
+    // Special constructor for use constructing initial 'auto' value.
+    GridTrackSizes(CSS::Keyword::Auto)
+        : ListOrDefault { DefaultValue }
+    {
+    }
+};
+
+} // namespace Style
+} // namespace WebCore
+
+template<> inline constexpr auto WebCore::TreatAsRangeLike<WebCore::Style::GridTrackSizes> = true;
+template<> inline constexpr auto WebCore::SerializationSeparator<WebCore::Style::GridTrackSizes> = WebCore::SerializationSeparator<typename WebCore::Style::GridTrackSizes::List>;

--- a/Source/WebCore/style/values/scroll-animations/StyleViewTimelineInsets.cpp
+++ b/Source/WebCore/style/values/scroll-animations/StyleViewTimelineInsets.cpp
@@ -38,11 +38,7 @@ namespace Style {
 
 auto ViewTimelineInsetDefaulter::operator()() const -> const ViewTimelineInsetItem&
 {
-    static LazyNeverDestroyed<ViewTimelineInsetItem> staticValue;
-    static std::once_flag onceFlag;
-    std::call_once(onceFlag, [] {
-        staticValue.construct(ViewTimelineInsetItem { WebCore::Length(WebCore::LengthType::Auto), std::nullopt });
-    });
+    static NeverDestroyed staticValue = ViewTimelineInsetItem { WebCore::Length(WebCore::LengthType::Auto), std::nullopt };
     return staticValue.get();
 }
 


### PR DESCRIPTION
#### 3bc1b8c9336ae14879f83e0c9e2a8da048fe8621
<pre>
[Style] Convert grid-auto-columns/grid-auto-rows to use strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=295866">https://bugs.webkit.org/show_bug.cgi?id=295866</a>

Reviewed by Darin Adler.

Adds a new type, `Style::GridTrackSizes` to represent the `grid-auto-columns/grid-auto-rows`
properties. To make it work, `Style::GridTrackSize` was updated to work with
the style type system and given explicit types to represent the `fit-content`
and `min-max` states.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
* Source/WebCore/rendering/GridTrackSizingAlgorithm.h:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:
* Source/WebCore/rendering/style/StyleGridData.h:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleExtractorConverter.h:
* Source/WebCore/style/StyleExtractorSerializer.h:
* Source/WebCore/style/values/grid/StyleGridTemplateList.cpp:
* Source/WebCore/style/values/grid/StyleGridTemplateList.h:
* Source/WebCore/style/values/grid/StyleGridTrackSize.cpp:
* Source/WebCore/style/values/grid/StyleGridTrackSize.h:
* Source/WebCore/style/values/grid/StyleGridTrackSizes.cpp: Added.
* Source/WebCore/style/values/grid/StyleGridTrackSizes.h: Added.

Canonical link: <a href="https://commits.webkit.org/297352@main">https://commits.webkit.org/297352@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e028ac40207b761a280033936e5011540d963371

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111472 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31138 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21603 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117504 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/61740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113434 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31819 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39720 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/84717 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/61740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114419 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25411 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100346 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65165 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24759 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18481 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61326 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94797 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18547 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120727 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38521 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28628 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/93643 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38897 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96614 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93469 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23811 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38578 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16354 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34558 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38410 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43887 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38075 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41408 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39777 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->