### PR TITLE
[css-anchor-position-1] Support safe with anchor-center

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-expected.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<title>Tests whether safe alignment works correctly on the anchor element.</title>
+<style>
+.anchor {
+  position: fixed; 
+  left: 0px;
+  top: 0px; 
+  height: 30px;
+  color: white;
+  background-color: green;
+}
+.infobox {
+  color: darkblue;
+  background-color: azure;
+  border: 1px solid #ddd;
+  padding: 10px;
+  position: fixed;
+  top: 35px;
+  left: 0px;
+}
+.anchor2 {
+  position: fixed; 
+  left: 340px;
+  top: 0px; 
+  height: 30px;
+  width: 100px;
+  color: white;
+  background-color: green;
+}
+.infobox2 {
+  color: darkblue;
+  background-color: azure;
+  border: 1px solid #ddd;
+  padding: 10px;
+  position: fixed;
+  top: 0px;
+  left: 445px; /* This value is calculated from the left position value of .anchor2 plus its width, plus an additional 5 px of padding */ 
+}
+</style>
+<div style="position: relative;">
+  <div class="anchor">Anchor</div>
+  <div class="infobox">
+    <p>Anchored element with justify-self</p>
+  </div>
+  <div class="anchor2">Anchor2</div>
+  <div class="infobox2">
+    <p>Anchored element with align-self</p>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-ref.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<title>Tests whether safe alignment works correctly on the anchor element.</title>
+<style>
+.anchor {
+  position: fixed; 
+  left: 0px;
+  top: 0px; 
+  height: 30px;
+  color: white;
+  background-color: green;
+}
+.infobox {
+  color: darkblue;
+  background-color: azure;
+  border: 1px solid #ddd;
+  padding: 10px;
+  position: fixed;
+  top: 35px;
+  left: 0px;
+}
+.anchor2 {
+  position: fixed; 
+  left: 340px;
+  top: 0px; 
+  height: 30px;
+  width: 100px;
+  color: white;
+  background-color: green;
+}
+.infobox2 {
+  color: darkblue;
+  background-color: azure;
+  border: 1px solid #ddd;
+  padding: 10px;
+  position: fixed;
+  top: 0px;
+  left: 445px; /* This value is calculated from the left position value of .anchor2 plus its width, plus an additional 5 px of padding */ 
+}
+</style>
+<div style="position: relative;">
+  <div class="anchor">Anchor</div>
+  <div class="infobox">
+    <p>Anchored element with justify-self</p>
+  </div>
+  <div class="anchor2">Anchor2</div>
+  <div class="infobox2">
+    <p>Anchored element with align-self</p>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-rtl-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-rtl-expected.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<title>Tests whether safe alignment works correctly on the anchor element.</title>
+<style>
+body {
+ direction: rtl; 
+ display: inline;
+}
+.anchor {
+  position: fixed; 
+  top: 0px; 
+  right: 0px;
+  height: 30px;
+  color: white;
+  background-color: green;
+}
+.infobox {
+  color: darkblue;
+  background-color: azure;
+  border: 1px solid #ddd;
+  padding: 10px;
+  position: fixed;
+  top: 35px;
+  right: 0px;
+}
+.anchor2 {
+  position: fixed; 
+  top: 0px; 
+  right: 390px;
+  width: 100px;
+  height: 30px;
+  color: white;
+  background-color: green;
+}
+.infobox2 {
+  color: darkblue;
+  background-color: azure;
+  border: 1px solid #ddd;
+  padding: 10px;
+  position: fixed;
+  top: 0px;
+  right: 495px; /* This value is calculated from the right position value of .anchor2 plus its width, plus an additional 5 px of padding */  
+}
+</style>
+<div style="position: relative;">
+  <div class="anchor">Anchor</div>
+  <div class="infobox">
+    <p>Anchored element with justify-self</p>
+  </div>
+  <div class="anchor2">Anchor</div>
+  <div class="infobox2">
+    <p>Anchored element with align-self</p>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-rtl-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-rtl-ref.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<title>Tests whether safe alignment works correctly on the anchor element.</title>
+<style>
+body {
+ direction: rtl; 
+ display: inline;
+}
+.anchor {
+  position: fixed; 
+  top: 0px; 
+  right: 0px;
+  height: 30px;
+  color: white;
+  background-color: green;
+}
+.infobox {
+  color: darkblue;
+  background-color: azure;
+  border: 1px solid #ddd;
+  padding: 10px;
+  position: fixed;
+  top: 35px;
+  right: 0px;
+}
+.anchor2 {
+  position: fixed; 
+  top: 0px; 
+  right: 390px;
+  width: 100px;
+  height: 30px;
+  color: white;
+  background-color: green;
+}
+.infobox2 {
+  color: darkblue;
+  background-color: azure;
+  border: 1px solid #ddd;
+  padding: 10px;
+  position: fixed;
+  top: 0px;
+  right: 495px; /* This value is calculated from the right position value of .anchor2 plus its width, plus an additional 5 px of padding */  
+}
+</style>
+<div style="position: relative;">
+  <div class="anchor">Anchor</div>
+  <div class="infobox">
+    <p>Anchored element with justify-self</p>
+  </div>
+  <div class="anchor2">Anchor</div>
+  <div class="infobox2">
+    <p>Anchored element with align-self</p>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-rtl.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-rtl.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<title>Tests whether safe alignment works correctly on the anchor element.</title>
+<link rel="match" href="anchor-center-safe-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#anchor-center">
+<style>
+body {
+ direction: rtl; 
+ display: inline;
+}
+.anchor {
+  position: fixed; 
+  top: 0px; 
+  right: 0px;
+  height: 30px;
+  color: white;
+  background-color: green;
+  anchor-name: --myAnchor;
+}
+.infobox {
+  color: darkblue;
+  background-color: azure;
+  border: 1px solid #ddd;
+  padding: 10px;
+  position: fixed;
+  position-anchor: --myAnchor;
+  top: calc(anchor(bottom) + 5px);
+  right: 0px;
+  justify-self: safe anchor-center;
+}
+.anchor2 {
+  position: fixed; 
+  top: 0px; 
+  right: 390px;
+  width: 100px;
+  height: 30px;
+  color: white;
+  background-color: green;
+  anchor-name: --myAnchor2;
+}
+.infobox2 {
+  color: darkblue;
+  background-color: azure;
+  border: 1px solid #ddd;
+  padding: 10px;
+  position: fixed;
+  position-anchor: --myAnchor2;
+  top: calc(anchor(right) + 5px);
+  right: calc(anchor(left) + 5px);
+  align-self: safe anchor-center;
+}
+</style>
+<div class="anchor">Anchor</div>
+<div class="infobox">
+  <p>Anchored element with justify-self</p>
+</div>
+<div class="anchor2">Anchor</div>
+<div class="infobox2">
+  <p>Anchored element with align-self</p>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<title>Tests whether safe alignment works correctly on the anchor element.</title>
+<link rel="match" href="anchor-center-safe-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#anchor-center">
+<style>
+.anchor {
+  position: fixed; 
+  left: 0px;
+  top: 0px; 
+  height: 30px;
+  color: white;
+  background-color: green;
+  anchor-name: --myAnchor;
+}
+.infobox {
+  color: darkblue;
+  background-color: azure;
+  border: 1px solid #ddd;
+  padding: 10px;
+  position: fixed;
+  position-anchor: --myAnchor;
+  top: calc(anchor(bottom) + 5px);
+  left: 0px;
+  justify-self: safe anchor-center;
+}
+
+.anchor2 {
+  position: fixed;
+  top: 0px;  
+  left: 340px;
+  height: 30px;
+  width: 100px;
+  color: white;
+  background-color: green;
+  anchor-name: --myAnchor2;
+}
+.infobox2 {
+  color: darkblue;
+  background-color: azure;
+  border: 1px solid #ddd;
+  padding: 10px;
+  position: fixed;
+  position-anchor: --myAnchor2;
+  left: calc(anchor(right) + 5px);
+  align-self: safe anchor-center;
+}
+</style>
+<div class="anchor">Anchor</div>
+<div class="infobox">
+  <p>Anchored element with justify-self</p>
+</div>
+<div class="anchor2">Anchor2</div>
+<div class="infobox2">
+  <p>Anchored element with align-self</p>
+</div>

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
@@ -450,6 +450,15 @@ LayoutUnit PositionedLayoutConstraints::resolveAlignmentShift(LayoutUnit unusedS
     if (ItemPosition::AnchorCenter == resolvedAlignment) {
         auto anchorCenterPosition = m_anchorArea.min() + (m_anchorArea.size() - itemSize) / 2;
         shift = anchorCenterPosition - m_insetModifiedContainingRange.min();
+        if (m_alignment.overflow() == OverflowAlignment::Safe) {
+            if (startIsBefore) {
+                if (shift < 0)
+                    shift = 0;
+            } else {
+                if (shift > unusedSpace)
+                    shift = unusedSpace;
+            }
+        }
         if (!isOverflowing && OverflowAlignment::Default == m_alignment.overflow()) {
             // Avoid introducing overflow of the IMCB.
             if (shift < 0)


### PR DESCRIPTION
#### dd8920b30dbe0afea4b5ce0be8a4133f5181091b
<pre>
[css-anchor-position-1] Support safe with anchor-center
<a href="https://bugs.webkit.org/show_bug.cgi?id=295503">https://bugs.webkit.org/show_bug.cgi?id=295503</a>

Reviewed by Elika Etemad.

Make safe keyword work with anchor-aligned element as specified in CSS Anchor Positioning spec:
<a href="https://drafts.csswg.org/css-anchor-position-1/#anchor-center">https://drafts.csswg.org/css-anchor-position-1/#anchor-center</a>

&quot;When using anchor-center, by default if the anchor is too close to the edge of the box’s original containing block,
it will &quot;shift&quot; from being purely centered, in order to remain within the original containing block.
See CSS Box Alignment 3 §4.4 Overflow Alignment:
the safe and unsafe keywords and scroll safety limits for more details.&quot;

* Source/WebCore/rendering/PositionedLayoutConstraints.cpp:
(WebCore::PositionedLayoutConstraints::resolveAlignmentShift const):
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-rtl.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-rtl-expected.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-rtl-ref.html

Canonical link: <a href="https://commits.webkit.org/301301@main">https://commits.webkit.org/301301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7d23eb175816348b6be2744d8ac1f97c6bdd659

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125483 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45148 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35891 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132342 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77422 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127357 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45835 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53710 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95562 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128434 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36628 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112219 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76085 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30399 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75816 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106410 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30619 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135019 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52289 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40059 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; Passed layout tests; Running layout-tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104067 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52726 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108435 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103781 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49144 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27477 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49493 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19661 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52181 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57967 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51532 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54888 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53227 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->