### PR TITLE
Reduce unsafeness in WakeLock.cpp and WakeLockManager.cpp

### DIFF
--- a/Source/WebCore/Modules/permissions/MainThreadPermissionObserver.cpp
+++ b/Source/WebCore/Modules/permissions/MainThreadPermissionObserver.cpp
@@ -47,13 +47,13 @@ MainThreadPermissionObserver::MainThreadPermissionObserver(ThreadSafeWeakPtr<Per
     , m_origin(WTFMove(origin))
 {
     ASSERT(isMainThread());
-    PermissionController::protectedShared()->addObserver(*this);
+    PermissionController::singleton().addObserver(*this);
 }
 
 MainThreadPermissionObserver::~MainThreadPermissionObserver()
 {
     ASSERT(isMainThread());
-    PermissionController::protectedShared()->removeObserver(*this);
+    PermissionController::singleton().removeObserver(*this);
 }
 
 void MainThreadPermissionObserver::stateChanged(PermissionState newPermissionState)

--- a/Source/WebCore/Modules/permissions/PermissionController.cpp
+++ b/Source/WebCore/Modules/permissions/PermissionController.cpp
@@ -36,17 +36,12 @@ static RefPtr<PermissionController>& sharedController()
     return controller;
 }
 
-PermissionController& PermissionController::shared()
+PermissionController& PermissionController::singleton()
 {
     auto& controller = sharedController();
     if (!controller)
         controller = DummyPermissionController::create();
     return *controller;
-}
-
-Ref<PermissionController> PermissionController::protectedShared()
-{
-    return shared();
 }
 
 void PermissionController::setSharedController(Ref<PermissionController>&& controller)

--- a/Source/WebCore/Modules/permissions/PermissionController.h
+++ b/Source/WebCore/Modules/permissions/PermissionController.h
@@ -43,8 +43,7 @@ class SecurityOriginData;
 
 class PermissionController : public ThreadSafeRefCounted<PermissionController> {
 public:
-    static PermissionController& shared();
-    static Ref<PermissionController> protectedShared();
+    static PermissionController& singleton();
     WEBCORE_EXPORT static void setSharedController(Ref<PermissionController>&&);
     
     virtual ~PermissionController() = default;

--- a/Source/WebCore/Modules/permissions/Permissions.cpp
+++ b/Source/WebCore/Modules/permissions/Permissions.cpp
@@ -165,7 +165,7 @@ void Permissions::query(JSC::Strong<JSC::JSObject> permissionDescriptorValue, DO
             return;
         }
 
-        PermissionController::protectedShared()->query(ClientOrigin { document->topOrigin().data(), WTFMove(originData) }, permissionDescriptor, *page, *source, [document = Ref { *document }, page, permissionDescriptor, promise = WTFMove(promise)](auto permissionState) mutable {
+        PermissionController::singleton().query(ClientOrigin { document->topOrigin().data(), WTFMove(originData) }, permissionDescriptor, *page, *source, [document = Ref { *document }, page, permissionDescriptor, promise = WTFMove(promise)](auto permissionState) mutable {
             if (!permissionState) {
                 promise.reject(Exception { ExceptionCode::NotSupportedError, "Permissions::query does not support this API"_s });
                 return;
@@ -201,7 +201,7 @@ void Permissions::query(JSC::Strong<JSC::JSObject> permissionDescriptorValue, DO
 
         auto page = source == PermissionQuerySource::DedicatedWorker ? WeakPtr { *document->page() } : nullptr;
 
-        PermissionController::protectedShared()->query(ClientOrigin { document->topOrigin().data(), WTFMove(originData) }, permissionDescriptor, page, source, [contextIdentifier, permissionDescriptor, promise = WTFMove(promise), source, page, document](auto permissionState) mutable {
+        PermissionController::singleton().query(ClientOrigin { document->topOrigin().data(), WTFMove(originData) }, permissionDescriptor, page, source, [contextIdentifier, permissionDescriptor, promise = WTFMove(promise), source, page, document](auto permissionState) mutable {
             ASSERT(isMainThread());
 
             if (!permissionState) {

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp
@@ -67,8 +67,8 @@ void WakeLock::request(WakeLockType lockType, Ref<DeferredPromise>&& promise)
 
     // FIXME: The permission check can likely be dropped once the specification gets updated to only
     // require transient activation (https://github.com/w3c/screen-wake-lock/pull/326).
-    bool hasTransientActivation = document->window() && document->window()->hasTransientActivation();
-    PermissionController::shared().query(document->clientOrigin(), PermissionDescriptor { PermissionName::ScreenWakeLock }, *document->page(), PermissionQuerySource::Window, [this, protectedThis = Ref { *this }, document = Ref { *document }, hasTransientActivation, promise = WTFMove(promise), lockType](std::optional<PermissionState> permission) mutable {
+    bool hasTransientActivation = document->window() && document->protectedWindow()->hasTransientActivation();
+    PermissionController::singleton().query(document->clientOrigin(), PermissionDescriptor { PermissionName::ScreenWakeLock }, *document->page(), PermissionQuerySource::Window, [this, protectedThis = Ref { *this }, document = Ref { *document }, hasTransientActivation, promise = WTFMove(promise), lockType](std::optional<PermissionState> permission) mutable {
         if (!permission || *permission == PermissionState::Prompt) {
             if (hasTransientActivation || m_wasPreviouslyAuthorizedDueToTransientActivation) {
                 m_wasPreviouslyAuthorizedDueToTransientActivation = true;
@@ -77,7 +77,7 @@ void WakeLock::request(WakeLockType lockType, Ref<DeferredPromise>&& promise)
                 permission = PermissionState::Denied;
         } else if (*permission == PermissionState::Denied)
             m_wasPreviouslyAuthorizedDueToTransientActivation = false;
-        document->eventLoop().queueTask(TaskSource::ScreenWakelock, [protectedThis = WTFMove(protectedThis), document = WTFMove(document), promise = WTFMove(promise), lockType, permission]() mutable {
+        document->checkedEventLoop()->queueTask(TaskSource::ScreenWakelock, [protectedThis = WTFMove(protectedThis), document = WTFMove(document), promise = WTFMove(promise), lockType, permission]() mutable {
             if (permission == PermissionState::Denied) {
                 promise->reject(Exception { ExceptionCode::NotAllowedError, "Permission was denied"_s });
                 return;
@@ -92,7 +92,7 @@ void WakeLock::request(WakeLockType lockType, Ref<DeferredPromise>&& promise)
             }
             auto lock = WakeLockSentinel::create(document, lockType);
             promise->resolve<IDLInterface<WakeLockSentinel>>(lock.get());
-            document->wakeLockManager().addWakeLock(WTFMove(lock), document->pageID());
+            document->protectedWakeLockManager()->addWakeLock(WTFMove(lock), document->pageID());
         });
     });
 }

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockManager.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockManager.cpp
@@ -39,22 +39,22 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WakeLockManager);
 WakeLockManager::WakeLockManager(Document& document)
     : m_document(document)
 {
-    m_document.registerForVisibilityStateChangedCallbacks(*this);
+    m_document->registerForVisibilityStateChangedCallbacks(*this);
 }
 
 WakeLockManager::~WakeLockManager()
 {
-    m_document.unregisterForVisibilityStateChangedCallbacks(*this);
+    m_document->unregisterForVisibilityStateChangedCallbacks(*this);
 }
 
 void WakeLockManager::ref() const
 {
-    m_document.ref();
+    m_document->ref();
 }
 
 void WakeLockManager::deref() const
 {
-    m_document.deref();
+    m_document->deref();
 }
 
 void WakeLockManager::addWakeLock(Ref<WakeLockSentinel>&& lock, std::optional<PageIdentifier> pageID)
@@ -97,7 +97,7 @@ void WakeLockManager::removeWakeLock(WakeLockSentinel& lock)
 // https://www.w3.org/TR/screen-wake-lock/#handling-document-loss-of-visibility
 void WakeLockManager::visibilityStateChanged()
 {
-    if (m_document.visibilityState() != VisibilityState::Hidden)
+    if (m_document->visibilityState() != VisibilityState::Hidden)
         return;
 
     releaseAllLocks(WakeLockType::Screen);

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockManager.h
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockManager.h
@@ -56,7 +56,7 @@ public:
 private:
     void visibilityStateChanged() final;
 
-    Document& m_document;
+    const CheckedRef<Document> m_document;
     HashMap<WakeLockType, Vector<RefPtr<WakeLockSentinel>>, WTF::IntHash<WakeLockType>, WTF::StrongEnumHashTraits<WakeLockType>> m_wakeLocks;
     std::unique_ptr<SleepDisabler> m_screenLockDisabler;
 };

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -25,8 +25,6 @@ Modules/push-api/PushDatabase.cpp
 Modules/push-api/PushManager.cpp
 Modules/push-api/PushSubscription.cpp
 Modules/remoteplayback/RemotePlayback.cpp
-Modules/screen-wake-lock/WakeLock.cpp
-Modules/screen-wake-lock/WakeLockManager.cpp
 Modules/storage/StorageManager.cpp
 Modules/webaudio/BiquadFilterNode.cpp
 Modules/webaudio/DefaultAudioDestinationNode.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -71,8 +71,6 @@ Modules/push-api/ServiceWorkerRegistrationPushAPI.cpp
 Modules/remoteplayback/RemotePlayback.cpp
 Modules/reporting/ReportingObserver.cpp
 Modules/reporting/ReportingScope.cpp
-Modules/screen-wake-lock/WakeLock.cpp
-Modules/screen-wake-lock/WakeLockManager.cpp
 Modules/speech/SpeechSynthesis.cpp
 Modules/storage/StorageManager.cpp
 Modules/storage/WorkerStorageConnection.cpp

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2675,6 +2675,11 @@ WakeLockManager& Document::wakeLockManager()
     return *m_wakeLockManager;
 }
 
+Ref<WakeLockManager> Document::protectedWakeLockManager()
+{
+    return wakeLockManager();
+}
+
 FormController& Document::formController()
 {
     if (!m_formController)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -618,6 +618,7 @@ public:
     WEBCORE_EXPORT Ref<NodeList> getElementsByName(const AtomString& elementName);
 
     WakeLockManager& wakeLockManager();
+    Ref<WakeLockManager> protectedWakeLockManager();
 
     // Other methods (not part of DOM)
     bool isSynthesized() const { return m_isSynthesized; }


### PR DESCRIPTION
#### c97aa796879a235964dbe932a7988ae432a7220f
<pre>
Reduce unsafeness in WakeLock.cpp and WakeLockManager.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=295877">https://bugs.webkit.org/show_bug.cgi?id=295877</a>
<a href="https://rdar.apple.com/155767745">rdar://155767745</a>

Reviewed by Chris Dumez.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

* Source/WebCore/Modules/permissions/MainThreadPermissionObserver.cpp:
(WebCore::MainThreadPermissionObserver::MainThreadPermissionObserver):
(WebCore::MainThreadPermissionObserver::~MainThreadPermissionObserver):
* Source/WebCore/Modules/permissions/PermissionController.cpp:
(WebCore::PermissionController::singleton):
(WebCore::PermissionController::shared): Deleted.
(WebCore::PermissionController::protectedShared): Deleted.
* Source/WebCore/Modules/permissions/PermissionController.h:
* Source/WebCore/Modules/permissions/Permissions.cpp:
(WebCore::Permissions::query):
* Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp:
(WebCore::WakeLock::request):
* Source/WebCore/Modules/screen-wake-lock/WakeLockManager.cpp:
(WebCore::WakeLockManager::WakeLockManager):
(WebCore::WakeLockManager::~WakeLockManager):
(WebCore::WakeLockManager::ref const):
(WebCore::WakeLockManager::deref const):
(WebCore::WakeLockManager::visibilityStateChanged):
* Source/WebCore/Modules/screen-wake-lock/WakeLockManager.h:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::protectedWakeLockManager):
* Source/WebCore/dom/Document.h:

Canonical link: <a href="https://commits.webkit.org/297404@main">https://commits.webkit.org/297404@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19edadc2f030b8bec8d8796b2ae76e8bf662e6b1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111580 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31247 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21721 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117615 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61851 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113542 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31935 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39832 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84778 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/35551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114527 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25487 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100427 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65219 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24827 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18562 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61445 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94873 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18631 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120856 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38633 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28701 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93686 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39010 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96689 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93510 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38641 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16430 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34669 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17987 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38522 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44006 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38185 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41521 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39887 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->