### PR TITLE
Adopt smart pointers in WebLockManager.cpp

### DIFF
--- a/Source/WebCore/Modules/web-locks/WebLockManager.h
+++ b/Source/WebCore/Modules/web-locks/WebLockManager.h
@@ -77,7 +77,7 @@ private:
     void suspend(ReasonForSuspension) final;
 
     class MainThreadBridge;
-    RefPtr<MainThreadBridge> m_mainThreadBridge;
+    const RefPtr<MainThreadBridge> m_mainThreadBridge;
 
     HashMap<WebLockIdentifier, RefPtr<DeferredPromise>> m_releasePromises;
 

--- a/Source/WebCore/Modules/web-locks/WebLockRegistry.cpp
+++ b/Source/WebCore/Modules/web-locks/WebLockRegistry.cpp
@@ -42,7 +42,7 @@ static RefPtr<WebLockRegistry>& sharedRegistry()
     return registry;
 }
 
-WebLockRegistry& WebLockRegistry::shared()
+WebLockRegistry& WebLockRegistry::singleton()
 {
     auto& registry = sharedRegistry();
     if (!registry)

--- a/Source/WebCore/Modules/web-locks/WebLockRegistry.h
+++ b/Source/WebCore/Modules/web-locks/WebLockRegistry.h
@@ -43,7 +43,7 @@ struct WebLockManagerSnapshot;
 
 class WebLockRegistry : public RefCounted<WebLockRegistry> {
 public:
-    static WebLockRegistry& shared();
+    static WebLockRegistry& singleton();
     WEBCORE_EXPORT static void setSharedRegistry(Ref<WebLockRegistry>&&);
 
     virtual ~WebLockRegistry() { }

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -74,7 +74,6 @@ Modules/reporting/ReportingScope.cpp
 Modules/speech/SpeechSynthesis.cpp
 Modules/storage/StorageManager.cpp
 Modules/storage/WorkerStorageConnection.cpp
-Modules/web-locks/WebLockManager.cpp
 Modules/webaudio/AnalyserNode.cpp
 Modules/webaudio/AudioBasicInspectorNode.cpp
 Modules/webaudio/AudioBasicProcessorNode.cpp


### PR DESCRIPTION
#### 302d6cf1b9173473100951e1717ab6f69a8266d3
<pre>
Adopt smart pointers in WebLockManager.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=295880">https://bugs.webkit.org/show_bug.cgi?id=295880</a>
<a href="https://rdar.apple.com/155773416">rdar://155773416</a>

Reviewed by Per Arne Vollan and Chris Dumez.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

* Source/WebCore/Modules/web-locks/WebLockManager.cpp:
(WebCore::WebLockManager::MainThreadBridge::requestLock):
(WebCore::WebLockManager::MainThreadBridge::releaseLock):
(WebCore::WebLockManager::MainThreadBridge::abortLockRequest):
(WebCore::WebLockManager::MainThreadBridge::query):
(WebCore::WebLockManager::MainThreadBridge::clientIsGoingAway):
(WebCore::WebLockManager::WebLockManager):
(WebCore::WebLockManager::request):
(WebCore::WebLockManager::clientIsGoingAway):
* Source/WebCore/Modules/web-locks/WebLockManager.h:
* Source/WebCore/Modules/web-locks/WebLockRegistry.cpp:
(WebCore::WebLockRegistry::singleton):
(WebCore::WebLockRegistry::shared): Deleted.
* Source/WebCore/Modules/web-locks/WebLockRegistry.h:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/297405@main">https://commits.webkit.org/297405@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/681ba2fd8fceef00244267bf1ad8d5b04e5aed7c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111540 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31207 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21671 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117572 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61811 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113502 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31887 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39788 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84758 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/35538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114487 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25454 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100387 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65198 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24808 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18523 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61403 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94851 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18588 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120810 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38589 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28675 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93673 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38970 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96655 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93514 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38619 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16394 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34629 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17988 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38478 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43955 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38145 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41481 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39847 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->