### PR TITLE
[WebXR][OpenXR] Fill in FrameData information

### DIFF
--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -79,7 +79,7 @@ enum class ReferenceSpaceType : uint8_t {
     Unbounded
 };
 
-enum class Eye {
+enum class Eye : uint8_t {
     None,
     Left,
     Right,

--- a/Source/WebKit/Shared/XR/PlatformXR.serialization.in
+++ b/Source/WebKit/Shared/XR/PlatformXR.serialization.in
@@ -202,4 +202,18 @@ header: <WebCore/PlatformXR.h>
     Vector<PlatformXR::FrameData::InputSource> inputSources;
 };
 
+#if USE(OPENXR)
+enum class PlatformXR::Eye : uint8_t {
+    None,
+    Left,
+    Right,
+};
+
+header: <WebCore/PlatformXR.h>
+[Nested] struct PlatformXR::Device::LayerView {
+    PlatformXR::Eye eye;
+    WebCore::IntRect viewport;
+};
+#endif
+
 #endif

--- a/Source/WebKit/Shared/XR/XRDeviceLayer.h
+++ b/Source/WebKit/Shared/XR/XRDeviceLayer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Igalia, S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -22,29 +22,22 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
- 
-#if ENABLE(WEBXR)
 
-[
-    DispatchedFrom=WebContent,
-    DispatchedTo=UI,
-    SharedPreferencesNeedsConnection,
-    EnabledBy=WebXREnabled
-]
-messages -> PlatformXRSystem {
-    EnumerateImmersiveXRDevices() -> (Vector<WebKit::XRDeviceInfo> devicesInfos)
-    RequestPermissionOnSessionFeatures(WebCore::SecurityOriginData origin, PlatformXR::SessionMode mode, Vector<PlatformXR::SessionFeature> granted, Vector<PlatformXR::SessionFeature> consentRequired, Vector<PlatformXR::SessionFeature> consentOptional, Vector<PlatformXR::SessionFeature> requiredFeaturesRequested, Vector<PlatformXR::SessionFeature> optionalFeaturesRequested) -> (std::optional<Vector<PlatformXR::SessionFeature>> userGranted)
-    InitializeTrackingAndRendering()
-    ShutDownTrackingAndRendering()
-    RequestFrame(struct std::optional<PlatformXR::RequestData> requestData) -> (struct PlatformXR::FrameData frameData)
-#if USE(OPENXR)
-    CreateLayerProjection(uint32_t width, uint32_t height, bool alpha)
-    SubmitFrame(Vector<WebKit::XRDeviceLayer> layers)
-#endif
-#if !USE(OPENXR)
-    SubmitFrame()
-#endif
-    DidCompleteShutdownTriggeredBySystem()
-}
+#pragma once
 
-#endif
+#if ENABLE(WEBXR) && USE(OPENXR)
+
+#include <WebCore/PlatformXR.h>
+
+namespace WebKit {
+
+struct XRDeviceLayer {
+    PlatformXR::LayerHandle handle;
+    bool visible;
+    Vector<PlatformXR::Device::LayerView> views;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBXR) && USE(OPENXR)
+

--- a/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
+++ b/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
@@ -89,7 +89,7 @@ void XRDeviceProxy::initializeTrackingAndRendering(const WebCore::SecurityOrigin
 
         if (trackingAndRenderingClient())
             trackingAndRenderingClient()->sessionDidInitializeInputSources({ });
-    });    
+    });
 }
 
 void XRDeviceProxy::shutDownTrackingAndRendering()
@@ -129,10 +129,16 @@ std::optional<PlatformXR::LayerHandle> XRDeviceProxy::createLayerProjection(uint
     return xrSystem ? xrSystem->createLayerProjection(width, height, alpha) : std::nullopt;
 }
 
-void XRDeviceProxy::submitFrame(Vector<PlatformXR::Device::Layer>&&)
+void XRDeviceProxy::submitFrame(Vector<PlatformXR::Device::Layer>&& layers)
 {
-    if (RefPtr xrSystem = m_xrSystem.get())
+    if (RefPtr xrSystem = m_xrSystem.get()) {
+#if USE(OPENXR)
+        xrSystem->submitFrame(WTFMove(layers));
+#else
+        UNUSED_PARAM(layers);
         xrSystem->submitFrame();
+#endif
+    }
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/XR/XRSystem.serialization.in
+++ b/Source/WebKit/Shared/XR/XRSystem.serialization.in
@@ -32,4 +32,14 @@ struct WebKit::XRDeviceInfo {
     double minimumNearClipPlane;
 };
 
+#if USE(OPENXR)
+
+struct WebKit::XRDeviceLayer {
+    PlatformXR::LayerHandle handle;
+    bool visible;
+    Vector<PlatformXR::Device::LayerView> views;
+};
+
+#endif
+
 #endif

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -296,6 +296,8 @@ UIProcess/gtk/WebTextCheckerClient.cpp
 UIProcess/soup/WebProcessPoolSoup.cpp
 
 UIProcess/XR/openxr/OpenXRExtensions.cpp
+UIProcess/XR/openxr/OpenXRLayer.cpp
+UIProcess/XR/openxr/OpenXRSwapchain.cpp
 UIProcess/XR/openxr/PlatformXROpenXR.cpp
 UIProcess/XR/openxr/PlatformXRSystemOpenXR.cpp
 

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -267,6 +267,8 @@ UIProcess/wpe/WebPasteboardProxyWPE.cpp
 UIProcess/wpe/WebPreferencesWPE.cpp
 
 UIProcess/XR/openxr/OpenXRExtensions.cpp
+UIProcess/XR/openxr/OpenXRLayer.cpp
+UIProcess/XR/openxr/OpenXRSwapchain.cpp
 UIProcess/XR/openxr/PlatformXROpenXR.cpp
 UIProcess/XR/openxr/PlatformXRSystemOpenXR.cpp
 

--- a/Source/WebKit/UIProcess/XR/PlatformXRCoordinator.h
+++ b/Source/WebKit/UIProcess/XR/PlatformXRCoordinator.h
@@ -29,6 +29,9 @@
 
 #include "XRDeviceIdentifier.h"
 #include "XRDeviceInfo.h"
+#if USE(OPENXR)
+#include "XRDeviceLayer.h"
+#endif
 #include <WebCore/PlatformXR.h>
 #include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Function.h>
@@ -62,13 +65,21 @@ public:
     using FeatureListCallback = CompletionHandler<void(std::optional<PlatformXR::Device::FeatureList>&&)>;
     virtual void requestPermissionOnSessionFeatures(WebPageProxy&, const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList& granted, const PlatformXR::Device::FeatureList& /* consentRequired */, const PlatformXR::Device::FeatureList& /* consentOptional */, const PlatformXR::Device::FeatureList& /* requiredFeaturesRequested */, const PlatformXR::Device::FeatureList& /* optionalFeaturesRequested */, FeatureListCallback&& completionHandler) { completionHandler(granted); }
 
+#if USE(OPENXR)
+    virtual void createLayerProjection(uint32_t width, uint32_t height, bool alpha) = 0;
+#endif
+
     // Session creation/termination.
     virtual void startSession(WebPageProxy&, WeakPtr<PlatformXRCoordinatorSessionEventClient>&&, const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&) = 0;
     virtual void endSessionIfExists(WebPageProxy&) = 0;
 
     // Session display loop.
     virtual void scheduleAnimationFrame(WebPageProxy&, std::optional<PlatformXR::RequestData>&&, PlatformXR::Device::RequestFrameCallback&&) = 0;
+#if USE(OPENXR)
+    virtual void submitFrame(WebPageProxy&, Vector<XRDeviceLayer>&&) = 0;
+#else
     virtual void submitFrame(WebPageProxy&) { }
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
@@ -237,7 +237,11 @@ void PlatformXRSystem::requestFrame(IPC::Connection& connection, std::optional<P
         completionHandler({ });
 }
 
+#if USE(OPENXR)
+void PlatformXRSystem::submitFrame(IPC::Connection& connection, Vector<XRDeviceLayer>&& layers)
+#else
 void PlatformXRSystem::submitFrame(IPC::Connection& connection)
+#endif
 {
     ASSERT(RunLoop::isMain());
     MESSAGE_CHECK(m_immersiveSessionState == ImmersiveSessionState::SessionRunning || m_immersiveSessionState == ImmersiveSessionState::SessionEndingFromSystem, connection);
@@ -248,8 +252,13 @@ void PlatformXRSystem::submitFrame(IPC::Connection& connection)
     if (!page)
         return;
 
-    if (auto* xrCoordinator = PlatformXRSystem::xrCoordinator())
+    if (auto* xrCoordinator = PlatformXRSystem::xrCoordinator()) {
+#if USE(OPENXR)
+        xrCoordinator->submitFrame(*page, WTFMove(layers));
+#else
         xrCoordinator->submitFrame(*page);
+#endif
+    }
 }
 
 void PlatformXRSystem::didCompleteShutdownTriggeredBySystem(IPC::Connection& connection)

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
@@ -85,7 +85,12 @@ private:
     void initializeTrackingAndRendering(IPC::Connection&);
     void shutDownTrackingAndRendering(IPC::Connection&);
     void requestFrame(IPC::Connection&, std::optional<PlatformXR::RequestData>&&, CompletionHandler<void(PlatformXR::FrameData&&)>&&);
+#if USE(OPENXR)
+    void createLayerProjection(IPC::Connection&, uint32_t width, uint32_t height, bool alpha);
+    void submitFrame(IPC::Connection&, Vector<XRDeviceLayer>&&);
+#else
     void submitFrame(IPC::Connection&);
+#endif
     void didCompleteShutdownTriggeredBySystem(IPC::Connection&);
 
     // PlatformXRCoordinatorSessionEventClient

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2025 Igalia, S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "OpenXRLayer.h"
+
+#include "XRDeviceLayer.h"
+#include <wtf/TZoneMallocInlines.h>
+
+#if ENABLE(WEBXR) && USE(OPENXR)
+
+namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(OpenXRLayer);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(OpenXRLayerProjection);
+
+// OpenXRLayerProjection
+
+std::unique_ptr<OpenXRLayerProjection> OpenXRLayerProjection::create(XrInstance instance, XrSession session, uint32_t width, uint32_t height, int64_t format, uint32_t sampleCount)
+{
+    if (!width || !height || !sampleCount)
+        return nullptr;
+
+    auto info = createOpenXRStruct<XrSwapchainCreateInfo, XR_TYPE_SWAPCHAIN_CREATE_INFO>();
+    info.arraySize = 1;
+    info.format = format;
+    info.width = width;
+    info.height = height;
+    info.mipCount = 1;
+    info.faceCount = 1;
+    info.arraySize = 1;
+    info.sampleCount = sampleCount;
+    info.usageFlags = XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT;
+
+    auto swapchain = OpenXRSwapchain::create(instance, session, info);
+    if (!swapchain)
+        return nullptr;
+    LOG(XR, "created %ux%u swapchain with format %lu and sample count %u", width, height, format, sampleCount);
+
+    return std::unique_ptr<OpenXRLayerProjection>(new OpenXRLayerProjection(makeUniqueRefFromNonNullUniquePtr(WTFMove(swapchain))));
+}
+
+OpenXRLayerProjection::OpenXRLayerProjection(UniqueRef<OpenXRSwapchain>&& swapchain)
+    : m_swapchain(WTFMove(swapchain))
+    , m_layerProjection(createOpenXRStruct<XrCompositionLayerProjection, XR_TYPE_COMPOSITION_LAYER_PROJECTION>())
+{
+}
+
+std::optional<PlatformXR::FrameData::LayerData> OpenXRLayerProjection::startFrame()
+{
+    auto texture = m_swapchain->acquireImage();
+    if (!texture)
+        return std::nullopt;
+
+    // FIXME: export the texture to the WebProcess using DMABuf, etc...
+    return PlatformXR::FrameData::LayerData {
+        .framebufferSize = m_swapchain->size(),
+        .opaqueTexture = *texture
+    };
+}
+
+XrCompositionLayerBaseHeader* OpenXRLayerProjection::endFrame(const XRDeviceLayer& layer, XrSpace space, const Vector<XrView>& frameViews)
+{
+    auto viewCount = frameViews.size();
+    m_projectionViews.fill(createOpenXRStruct<XrCompositionLayerProjectionView, XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW>(), viewCount);
+    for (uint32_t i = 0; i < viewCount; ++i) {
+        m_projectionViews[i].pose = frameViews[i].pose;
+        m_projectionViews[i].fov = frameViews[i].fov;
+        m_projectionViews[i].subImage.swapchain = m_swapchain->swapchain();
+
+        auto& viewport = layer.views[i].viewport;
+
+        m_projectionViews[i].subImage.imageRect.offset = { viewport.x(), viewport.y() };
+        m_projectionViews[i].subImage.imageRect.extent = { viewport.width(), viewport.height() };
+    }
+
+    m_layerProjection.layerFlags = XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT;
+    m_layerProjection.space = space;
+    m_layerProjection.viewCount = m_projectionViews.size();
+    m_layerProjection.views = m_projectionViews.span().data();
+
+    m_swapchain->releaseImage();
+
+    return reinterpret_cast<XrCompositionLayerBaseHeader*>(&m_layerProjection);
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBXR) && USE(OPENXR)

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2025 Igalia, S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#if ENABLE(WEBXR) && USE(OPENXR)
+
+#include "OpenXRSwapchain.h"
+#include "OpenXRUtils.h"
+
+#include <WebCore/PlatformXR.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/UniqueRef.h>
+#include <wtf/Vector.h>
+
+namespace WebKit {
+
+class XRDeviceLayer;
+
+class OpenXRLayer {
+    WTF_MAKE_TZONE_ALLOCATED(OpenXRLayer);
+    WTF_MAKE_NONCOPYABLE(OpenXRLayer);
+public:
+    virtual ~OpenXRLayer() = default;
+
+    virtual std::optional<PlatformXR::FrameData::LayerData> startFrame() = 0;
+    virtual XrCompositionLayerBaseHeader* endFrame(const XRDeviceLayer&, XrSpace, const Vector<XrView>&) = 0;
+
+protected:
+    OpenXRLayer() = default;
+};
+
+class OpenXRLayerProjection final: public OpenXRLayer  {
+    WTF_MAKE_TZONE_ALLOCATED(OpenXRLayerProjection);
+    WTF_MAKE_NONCOPYABLE(OpenXRLayerProjection);
+public:
+    static std::unique_ptr<OpenXRLayerProjection> create(XrInstance, XrSession, uint32_t width, uint32_t height, int64_t format, uint32_t sampleCount);
+private:
+    explicit OpenXRLayerProjection(UniqueRef<OpenXRSwapchain>&&);
+
+    std::optional<PlatformXR::FrameData::LayerData> startFrame() final;
+    XrCompositionLayerBaseHeader* endFrame(const XRDeviceLayer&, XrSpace, const Vector<XrView>&) final;
+
+    UniqueRef<OpenXRSwapchain> m_swapchain;
+    XrCompositionLayerProjection m_layerProjection;
+    Vector<XrCompositionLayerProjectionView> m_projectionViews;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBXR) && USE(OPENXR)

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRSwapchain.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRSwapchain.cpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2025 Igalia, S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+
+#if ENABLE(WEBXR) && USE(OPENXR)
+#include "OpenXRSwapchain.h"
+
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(OpenXRSwapchain);
+
+std::unique_ptr<OpenXRSwapchain> OpenXRSwapchain::create(XrInstance instance, XrSession session, const XrSwapchainCreateInfo& info)
+{
+    ASSERT(session != XR_NULL_HANDLE);
+    ASSERT(info.faceCount == 1);
+
+    XrSwapchain swapchain { XR_NULL_HANDLE };
+    CHECK_XRCMD(xrCreateSwapchain(session, &info, &swapchain));
+    if (swapchain == XR_NULL_HANDLE) {
+        LOG(XR, "xrCreateSwapchain() failed: swapchain is null");
+        return nullptr;
+    }
+
+    uint32_t imageCount;
+    CHECK_XRCMD(xrEnumerateSwapchainImages(swapchain, 0, &imageCount, nullptr));
+    if (!imageCount) {
+        LOG(XR, "xrEnumerateSwapchainImages(): no images\n");
+        return nullptr;
+    }
+
+    Vector<XrSwapchainImageOpenGLESKHR> imageBuffers(imageCount, [] {
+        return createOpenXRStruct<XrSwapchainImageOpenGLESKHR, XR_TYPE_SWAPCHAIN_IMAGE_OPENGL_ES_KHR>();
+    }());
+
+    Vector<XrSwapchainImageBaseHeader*> imageHeaders = imageBuffers.map([](auto& image) {
+        return (XrSwapchainImageBaseHeader*) &image;
+    });
+
+    // Get images from an XrSwapchain
+    CHECK_XRCMD(xrEnumerateSwapchainImages(swapchain, imageCount, &imageCount, imageHeaders[0]));
+
+    return std::unique_ptr<OpenXRSwapchain>(new OpenXRSwapchain(instance, swapchain, info, WTFMove(imageBuffers)));
+}
+
+OpenXRSwapchain::OpenXRSwapchain(XrInstance instance, XrSwapchain swapchain, const XrSwapchainCreateInfo& info, Vector<XrSwapchainImageOpenGLESKHR>&& imageBuffers)
+    : m_instance(instance)
+    , m_swapchain(swapchain)
+    , m_createInfo(info)
+    , m_imageBuffers(WTFMove(imageBuffers))
+{
+}
+
+OpenXRSwapchain::~OpenXRSwapchain()
+{
+    if (m_acquiredTexture)
+        releaseImage();
+    if (m_swapchain != XR_NULL_HANDLE)
+        xrDestroySwapchain(m_swapchain);
+}
+
+std::optional<PlatformGLObject> OpenXRSwapchain::acquireImage()
+{
+    RELEASE_ASSERT_WITH_MESSAGE(!m_acquiredTexture , "Expected no acquired images. ReleaseImage not called?");
+
+    auto acquireInfo = createOpenXRStruct<XrSwapchainImageAcquireInfo, XR_TYPE_SWAPCHAIN_IMAGE_ACQUIRE_INFO>();
+    uint32_t swapchainImageIndex = 0;
+    CHECK_XRCMD(xrAcquireSwapchainImage(m_swapchain, &acquireInfo, &swapchainImageIndex));
+    ASSERT(swapchainImageIndex < m_imageBuffers.size());
+
+    auto waitInfo = createOpenXRStruct<XrSwapchainImageWaitInfo, XR_TYPE_SWAPCHAIN_IMAGE_WAIT_INFO>();
+    waitInfo.timeout = XR_INFINITE_DURATION;
+    CHECK_XRCMD(xrWaitSwapchainImage(m_swapchain, &waitInfo));
+
+    m_acquiredTexture = m_imageBuffers[swapchainImageIndex].image;
+
+    return m_acquiredTexture;
+}
+
+void OpenXRSwapchain::releaseImage()
+{
+    RELEASE_ASSERT_WITH_MESSAGE(m_acquiredTexture, "Expected a valid acquired image. AcquireImage not called?");
+
+    auto releaseInfo = createOpenXRStruct<XrSwapchainImageReleaseInfo, XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO>();
+    CHECK_XRCMD(xrReleaseSwapchainImage(m_swapchain, &releaseInfo));
+
+    m_acquiredTexture = 0;
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBXR) && USE(OPENXR)

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRSwapchain.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRSwapchain.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2025 Igalia, S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#if ENABLE(WEBXR) && USE(OPENXR)
+
+#include "OpenXRUtils.h"
+#include <WebCore/GraphicsTypesGL.h>
+#include <WebCore/IntSize.h>
+typedef void* EGLDisplay;
+typedef void* EGLContext;
+typedef void* EGLConfig;
+typedef unsigned EGLenum;
+#include <openxr/openxr_platform.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/Vector.h>
+
+namespace WebKit {
+
+class OpenXRSwapchain {
+    WTF_MAKE_TZONE_ALLOCATED(OpenXRSwapchain);
+    WTF_MAKE_NONCOPYABLE(OpenXRSwapchain);
+public:
+    static std::unique_ptr<OpenXRSwapchain> create(XrInstance, XrSession, const XrSwapchainCreateInfo&);
+    ~OpenXRSwapchain();
+
+    std::optional<PlatformGLObject> acquireImage();
+    void releaseImage();
+    XrSwapchain swapchain() const { return m_swapchain; }
+    int32_t width() const { return m_createInfo.width; }
+    int32_t height() const { return m_createInfo.height; }
+    WebCore::IntSize size() const { return WebCore::IntSize(width(), height()); }
+
+private:
+    OpenXRSwapchain(XrInstance, XrSwapchain, const XrSwapchainCreateInfo&, Vector<XrSwapchainImageOpenGLESKHR>&&);
+
+    XrInstance m_instance;
+    XrSwapchain m_swapchain;
+    XrSwapchainCreateInfo m_createInfo;
+    Vector<XrSwapchainImageOpenGLESKHR> m_imageBuffers;
+    PlatformGLObject m_acquiredTexture { 0 };
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBXR) && USE(OPENXR)

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRUtils.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRUtils.h
@@ -22,6 +22,7 @@
 #if ENABLE(WEBXR) && USE(OPENXR)
 
 #include "Logging.h"
+#include <WebCore/PlatformXR.h>
 #include <openxr/openxr.h>
 #include <openxr/openxr_reflection.h>
 #include <wtf/text/MakeString.h>
@@ -69,6 +70,21 @@ inline XrResult checkXrResult(XrResult res, const char* originator = nullptr, co
 }
 
 #define CHECK_XRCMD(cmd) checkXrResult(cmd, #cmd, FILE_AND_LINE);
+
+inline PlatformXR::FrameData::Pose XrIdentityPose()
+{
+    return { { 0.0f, 0.0f, 0.0f }, { 0.0f, 0.0f, 0.0f, 1.0f } };
+}
+
+inline PlatformXR::FrameData::Pose XrPosefToPose(XrPosef pose)
+{
+    return { { pose.position.x, pose.position.y, pose.position.z }, { pose.orientation.x, pose.orientation.y, pose.orientation.z, pose.orientation.w } };
+}
+
+inline PlatformXR::FrameData::View XrViewToView(XrView view)
+{
+    return { XrPosefToPose(view.pose), PlatformXR::FrameData::Fov { std::abs(view.fov.angleUp), std::abs(view.fov.angleDown), std::abs(view.fov.angleLeft), std::abs(view.fov.angleRight) } };
+}
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXRSystemOpenXR.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXRSystemOpenXR.cpp
@@ -43,6 +43,18 @@ PlatformXRCoordinator* PlatformXRSystem::xrCoordinator()
     return &xrCoordinator.get();
 }
 
+void PlatformXRSystem::createLayerProjection(IPC::Connection&, uint32_t width, uint32_t height, bool alpha)
+{
+    ASSERT(RunLoop::isMain());
+
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
+    if (auto* xrCoordinator = PlatformXRSystem::xrCoordinator())
+        xrCoordinator->createLayerProjection(width, height, alpha);
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(WEBXR) && USE(OPENXR)

--- a/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h
+++ b/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h
@@ -54,7 +54,11 @@ public:
     void didCompleteShutdownTriggeredBySystem();
     void requestFrame(std::optional<PlatformXR::RequestData>&&, PlatformXR::Device::RequestFrameCallback&&);
     std::optional<PlatformXR::LayerHandle> createLayerProjection(uint32_t, uint32_t, bool);
+#if USE(OPENXR)
+    void submitFrame(Vector<PlatformXR::Device::Layer>&&);
+#else
     void submitFrame();
+#endif
 
     void ref() const final;
     void deref() const final;


### PR DESCRIPTION
#### a57ebb1d227dc33791da87d0fa7546a88053c98a
<pre>
[WebXR][OpenXR] Fill in FrameData information
<a href="https://bugs.webkit.org/show_bug.cgi?id=295881">https://bugs.webkit.org/show_bug.cgi?id=295881</a>

Reviewed by Carlos Garcia Campos.

XR information coming from XR devices is retrieved in the UI process
using OpenXR API. That info is then later transferred to the Web
Process to be consumed by the WebXR API. A struct called FrameData
is used to carry that information.

In this commit we&apos;re among other things collecting &amp; sending:
- Views information: fov, pose
- Tracking information availability
- Floor location (transform from local space)
- Layer data (so far only 1 projection layer)

In the WebProcess the submitFrame() method receives a vector
of objects containing information about the layers. The WebXR
layers spec is still not available in WebKit but even without
that there is still at least one layer, the base layer.

That info was not passed to the UIProcess in submitFrame() because
it wasn&apos;t used by the ARKit implementation. However it&apos;s needed
for the OpenXR one because we get there the viewport information
that we need to create the stereo views (we use a single projection
layer that is split in as many parts as views we have, typically 2).

Serializing PlatformXR::Device::Layer proved to be really complex
as serializers do not deal well with having multiple nested namespaces
for a given type. That&apos;s why we had to &quot;clone&quot; that structure in
another one hanging directly from the WebKit namespace.

Also a new message had to be added as well to ask the UIProcess to
create the projection layer with the data coming from WebXR.

One of the most important pieces of information to send to the Web Process
is the texture were the WebGL rendering should happen to be later submitted
to the OpenXR compositor. This commit implements the required machinery
to acquire and release those textures coming from OpenXR. However that
cannot be directly used by WebGL, we need to eventually implement a similar
mechanism as the ExternalTexture used by Apple ports. That&apos;s why no
rendering is expected to actually happen in the texture provided by OpenXR.

Last but not least, when adding the swapchains code we detected 2 important
issues in the current implementation:
- OpenXR resources were not properly freed upon session exiting
- we were incorrectly running multiple sequences of xrBeginFrame-&gt;xrEndFrame
in parallel. The confusion arose from an incorrect interpretation of what
xrWaitFrame does. The current code assumed that xrWaitFrame would wait until the
previous xrEndFrame is finished. But that&apos;s wrong. As the specs say
&quot;A subsequent xrWaitFrame call must block until the previous frame has been begun
with xrBeginFrame and must unblock independently of the corresponding call
to xrEndFrame&quot;. That&apos;s why we had to add some additional synchronization
using binary semaphores, basically identical to what ARKit implementation does.

* Source/WebCore/platform/xr/PlatformXR.h:
* Source/WebKit/Shared/XR/PlatformXR.serialization.in:
* Source/WebKit/Shared/XR/XRDeviceLayer.h: Copied from Source/WebKit/UIProcess/XR/openxr/PlatformXRSystemOpenXR.cpp.
* Source/WebKit/Shared/XR/XRDeviceProxy.cpp:
(WebKit::XRDeviceProxy::initializeTrackingAndRendering):
(WebKit::XRDeviceProxy::submitFrame):
* Source/WebKit/Shared/XR/XRSystem.serialization.in:
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/UIProcess/XR/PlatformXRCoordinator.h:
* Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp:
(WebKit::PlatformXRSystem::submitFrame):
* Source/WebKit/UIProcess/XR/PlatformXRSystem.h:
* Source/WebKit/UIProcess/XR/PlatformXRSystem.messages.in:
* Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp: Added.
(WebKit::OpenXRLayerProjection::create):
(WebKit::OpenXRLayerProjection::OpenXRLayerProjection):
(WebKit::OpenXRLayerProjection::startFrame):
(WebKit::OpenXRLayerProjection::endFrame):
* Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.h: Added.
* Source/WebKit/UIProcess/XR/openxr/OpenXRSwapchain.cpp: Added.
(WebKit::OpenXRSwapchain::create):
(WebKit::OpenXRSwapchain::OpenXRSwapchain):
(WebKit::OpenXRSwapchain::~OpenXRSwapchain):
(WebKit::OpenXRSwapchain::acquireImage):
(WebKit::OpenXRSwapchain::releaseImage):
* Source/WebKit/UIProcess/XR/openxr/OpenXRSwapchain.h: Added.
(WebKit::OpenXRSwapchain::swapchain const):
(WebKit::OpenXRSwapchain::width const):
(WebKit::OpenXRSwapchain::height const):
(WebKit::OpenXRSwapchain::size const):
* Source/WebKit/UIProcess/XR/openxr/OpenXRUtils.h:
(WebKit::XrIdentityPose):
(WebKit::XrPosefToPose):
(WebKit::XrViewToView):
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp:
(WebKit::OpenXRCoordinator::~OpenXRCoordinator):
(WebKit::OpenXRCoordinator::getPrimaryDeviceInfo):
(WebKit::OpenXRCoordinator::createLayerProjection):
(WebKit::OpenXRCoordinator::endSessionIfExists):
(WebKit::OpenXRCoordinator::submitFrameInternal):
(WebKit::OpenXRCoordinator::submitFrame):
(WebKit::OpenXRCoordinator::collectViewConfigurations):
(WebKit::OpenXRCoordinator::initializeBlendModes):
(WebKit::OpenXRCoordinator::cleanupSessionAndAssociatedResources):
(WebKit::OpenXRCoordinator::handleSessionStateChange):
(WebKit::OpenXRCoordinator::populateFrameData):
(WebKit::OpenXRCoordinator::createReferenceSpacesIfNeeded):
(WebKit::OpenXRCoordinator::renderLoop):
(WebKit::OpenXRCoordinator::recommendedResolution const): Deleted.
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h:
* Source/WebKit/UIProcess/XR/openxr/PlatformXRSystemOpenXR.cpp:
(WebKit::PlatformXRSystem::createLayerProjection):
* Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp:
(WebKit::PlatformXRSystemProxy::createLayerProjection):
(WebKit::PlatformXRSystemProxy::submitFrame):
* Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h:

Canonical link: <a href="https://commits.webkit.org/297780@main">https://commits.webkit.org/297780@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb826bad3feefa40ec086fae9bc6bb18218b2bab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112814 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32549 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23027 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119017 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63344 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114776 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33201 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41112 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85855 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36511 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115761 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26497 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101485 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66161 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25786 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19616 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62776 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95890 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19691 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122238 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39892 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29738 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94716 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40275 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97705 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94454 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24116 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39581 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17395 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35995 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39778 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45276 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39417 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42751 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41156 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->