### PR TITLE
Fix non-unified builds part 1: Exception/ExceptionOr includes

### DIFF
--- a/Source/WebCore/Modules/compression/DecompressionStreamDecoder.cpp
+++ b/Source/WebCore/Modules/compression/DecompressionStreamDecoder.cpp
@@ -26,6 +26,7 @@
 #include "DecompressionStreamDecoder.h"
 
 #include "BufferSource.h"
+#include "ExceptionOr.h"
 #include <JavaScriptCore/GenericTypedArrayViewInlines.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSGenericTypedArrayViewInlines.h>

--- a/Source/WebCore/Modules/compression/DecompressionStreamDecoder.h
+++ b/Source/WebCore/Modules/compression/DecompressionStreamDecoder.h
@@ -26,6 +26,7 @@
 
 #include "BufferSource.h"
 #include "CompressionStream.h"
+#include "ExceptionOr.h"
 #include "Formats.h"
 #include "SharedBuffer.h"
 #include "ZStream.h"

--- a/Source/WebCore/Modules/entriesapi/DOMFileSystem.h
+++ b/Source/WebCore/Modules/entriesapi/DOMFileSystem.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "ExceptionOr.h"
 #include "FileSystemDirectoryEntry.h"
 #include "ScriptWrappable.h"
 #include <wtf/RefCounted.h>
@@ -37,7 +38,6 @@ class File;
 class FileSystemFileEntry;
 class FileSystemEntry;
 class ScriptExecutionContext;
-template<typename> class ExceptionOr;
 
 class DOMFileSystem final : public ScriptWrappable, public RefCounted<DOMFileSystem> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(DOMFileSystem);

--- a/Source/WebCore/Modules/fetch/FetchHeaders.cpp
+++ b/Source/WebCore/Modules/fetch/FetchHeaders.cpp
@@ -29,6 +29,7 @@
 #include "config.h"
 #include "FetchHeaders.h"
 
+#include "ExceptionOr.h"
 #include "HTTPParsers.h"
 #include <ranges>
 #include <wtf/text/MakeString.h>

--- a/Source/WebCore/Modules/fetch/FormDataConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FormDataConsumer.cpp
@@ -27,6 +27,7 @@
 #include "FormDataConsumer.h"
 
 #include "BlobLoader.h"
+#include "ExceptionOr.h"
 #include "FormData.h"
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/WorkQueue.h>

--- a/Source/WebCore/Modules/fetch/FormDataConsumer.h
+++ b/Source/WebCore/Modules/fetch/FormDataConsumer.h
@@ -36,6 +36,7 @@
 namespace WebCore {
 
 class BlobLoader;
+class Exception;
 class FormData;
 class ScriptExecutionContext;
 template<typename> class ExceptionOr;

--- a/Source/WebCore/Modules/filesystem/FileSystemStorageConnection.cpp
+++ b/Source/WebCore/Modules/filesystem/FileSystemStorageConnection.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "FileSystemStorageConnection.h"
 
+#include "Exception.h"
 #include "FileSystemWritableFileStream.h"
 
 namespace WebCore {

--- a/Source/WebCore/Modules/filesystem/FileSystemWritableFileStreamSink.cpp
+++ b/Source/WebCore/Modules/filesystem/FileSystemWritableFileStreamSink.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "FileSystemWritableFileStreamSink.h"
 
+#include "Exception.h"
+#include "ExceptionOr.h"
 #include "FileSystemFileHandle.h"
 #include "FileSystemWritableFileStream.h"
 #include "FileSystemWriteCloseReason.h"

--- a/Source/WebCore/Modules/filesystem/WorkerFileSystemStorageConnection.cpp
+++ b/Source/WebCore/Modules/filesystem/WorkerFileSystemStorageConnection.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WorkerFileSystemStorageConnection.h"
 
+#include "ExceptionOr.h"
 #include "FileSystemHandleCloseScope.h"
 #include "FileSystemSyncAccessHandle.h"
 #include "WorkerGlobalScope.h"

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
@@ -29,6 +29,7 @@
 #include "DOMStringList.h"
 #include "EventNames.h"
 #include "EventTargetInlines.h"
+#include "ExceptionOr.h"
 #include "IDBConnectionProxy.h"
 #include "IDBConnectionToServer.h"
 #include "IDBIndex.h"

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -22,6 +22,7 @@
 #if ENABLE(WEB_RTC) && USE(GSTREAMER_WEBRTC)
 #include "GStreamerWebRTCUtils.h"
 
+#include "ExceptionOr.h"
 #include "GStreamerRegistryScanner.h"
 #include "OpenSSLCryptoUniquePtr.h"
 #include "RTCIceCandidate.h"

--- a/Source/WebCore/Modules/push-api/PushMessageData.cpp
+++ b/Source/WebCore/Modules/push-api/PushMessageData.cpp
@@ -27,6 +27,7 @@
 #include "PushMessageData.h"
 
 #include "Blob.h"
+#include "ExceptionOr.h"
 #include "JSDOMGlobalObject.h"
 #include "TextResourceDecoder.h"
 #include <JavaScriptCore/JSCJSValueInlines.h>

--- a/Source/WebCore/Modules/url-pattern/URLPatternConstructorStringParser.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternConstructorStringParser.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "URLPatternConstructorStringParser.h"
 
+#include "ExceptionOr.h"
 #include "URLPatternCanonical.h"
 #include "URLPatternComponent.h"
 #include "URLPatternInit.h"

--- a/Source/WebCore/Modules/url-pattern/URLPatternParser.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternParser.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "URLPatternParser.h"
 
+#include "ExceptionOr.h"
 #include "URLPatternCanonical.h"
 #include "URLPatternTokenizer.h"
 #include <ranges>

--- a/Source/WebCore/Modules/webaudio/AudioParam.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioParam.cpp
@@ -32,6 +32,7 @@
 #include "AudioNode.h"
 #include "AudioNodeOutput.h"
 #include "AudioUtilities.h"
+#include "ExceptionOr.h"
 #include "FloatConversion.h"
 #include "Logging.h"
 #include "VectorMath.h"

--- a/Source/WebCore/Modules/webaudio/ChannelMergerNode.cpp
+++ b/Source/WebCore/Modules/webaudio/ChannelMergerNode.cpp
@@ -35,6 +35,7 @@
 #include "AudioContext.h"
 #include "AudioNodeInput.h"
 #include "AudioNodeOutput.h"
+#include "ExceptionOr.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/webaudio/ChannelSplitterNode.cpp
+++ b/Source/WebCore/Modules/webaudio/ChannelSplitterNode.cpp
@@ -31,6 +31,7 @@
 #include "AudioContext.h"
 #include "AudioNodeInput.h"
 #include "AudioNodeOutput.h"
+#include "ExceptionOr.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/webaudio/ConstantSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/ConstantSourceNode.cpp
@@ -33,6 +33,7 @@
 #include "AudioParam.h"
 #include "AudioUtilities.h"
 #include "ConstantSourceOptions.h"
+#include "ExceptionOr.h"
 #include <algorithm>
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/Modules/webaudio/DynamicsCompressorNode.cpp
+++ b/Source/WebCore/Modules/webaudio/DynamicsCompressorNode.cpp
@@ -34,6 +34,7 @@
 #include "AudioNodeOutput.h"
 #include "AudioUtilities.h"
 #include "DynamicsCompressor.h"
+#include "ExceptionOr.h"
 #include <wtf/TZoneMallocInlines.h>
 
 // Set output to stereo by default.

--- a/Source/WebCore/Modules/webaudio/GainNode.cpp
+++ b/Source/WebCore/Modules/webaudio/GainNode.cpp
@@ -32,6 +32,7 @@
 #include "AudioNodeInput.h"
 #include "AudioNodeOutput.h"
 #include "AudioUtilities.h"
+#include "ExceptionOr.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/webaudio/ScriptProcessorNode.cpp
+++ b/Source/WebCore/Modules/webaudio/ScriptProcessorNode.cpp
@@ -38,6 +38,7 @@
 #include "Document.h"
 #include "EventNames.h"
 #include "EventTargetInlines.h"
+#include "ExceptionOr.h"
 #include <JavaScriptCore/Float32Array.h>
 #include <wtf/MainThread.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/Modules/webaudio/StereoPannerNode.cpp
+++ b/Source/WebCore/Modules/webaudio/StereoPannerNode.cpp
@@ -33,6 +33,7 @@
 #include "AudioNodeInput.h"
 #include "AudioNodeOutput.h"
 #include "AudioUtilities.h"
+#include "ExceptionOr.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
@@ -31,6 +31,7 @@
 
 #include "ContextDestructionObserverInlines.h"
 #include "DOMException.h"
+#include "ExceptionOr.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSWebCodecsAudioDecoderSupport.h"
 #include "ScriptExecutionContextInlines.h"

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h
@@ -42,6 +42,8 @@ namespace WebCore {
 class WebCodecsEncodedAudioChunk;
 class WebCodecsErrorCallback;
 class WebCodecsAudioDataOutputCallback;
+template<typename> class ExceptionOr;
+class Exception;
 
 class WebCodecsAudioDecoder : public WebCodecsBase {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WebCodecsAudioDecoder);

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
@@ -32,6 +32,7 @@
 #include "AacEncoderConfig.h"
 #include "ContextDestructionObserverInlines.h"
 #include "DOMException.h"
+#include "ExceptionOr.h"
 #include "FlacEncoderConfig.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSWebCodecsAudioEncoderSupport.h"

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h
@@ -37,6 +37,7 @@
 
 namespace WebCore {
 
+class Exception;
 class WebCodecsEncodedAudioChunk;
 class WebCodecsErrorCallback;
 class WebCodecsEncodedAudioChunkOutputCallback;

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunk.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunk.cpp
@@ -29,6 +29,7 @@
 
 #if ENABLE(WEB_CODECS)
 
+#include "ExceptionOr.h"
 #include <wtf/StdLibExtras.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/webdatabase/LocalDOMWindowWebDatabase.cpp
+++ b/Source/WebCore/Modules/webdatabase/LocalDOMWindowWebDatabase.cpp
@@ -30,6 +30,7 @@
 #include "Database.h"
 #include "DatabaseManager.h"
 #include "Document.h"
+#include "ExceptionOr.h"
 #include "LocalDOMWindow.h"
 #include "SecurityOrigin.h"
 #include <JavaScriptCore/ConsoleTypes.h>

--- a/Source/WebCore/Modules/webdatabase/SQLResultSet.cpp
+++ b/Source/WebCore/Modules/webdatabase/SQLResultSet.cpp
@@ -29,6 +29,8 @@
 #include "config.h"
 #include "SQLResultSet.h"
 
+#include "ExceptionOr.h"
+
 namespace WebCore {
 
 SQLResultSet::SQLResultSet()

--- a/Source/WebCore/Modules/webtransport/WebTransport.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransport.cpp
@@ -29,6 +29,7 @@
 #include "ContextDestructionObserverInlines.h"
 #include "DatagramSink.h"
 #include "DatagramSource.h"
+#include "ExceptionOr.h"
 #include "JSDOMPromise.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSWebTransportBidirectionalStream.h"

--- a/Source/WebCore/bindings/js/InternalWritableStream.h
+++ b/Source/WebCore/bindings/js/InternalWritableStream.h
@@ -30,6 +30,7 @@
 
 namespace WebCore {
 
+class Exception;
 template<typename> class ExceptionOr;
 
 class InternalWritableStream final : public DOMGuarded<JSC::JSObject> {

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCBC.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCBC.cpp
@@ -29,6 +29,7 @@
 #include "CryptoAlgorithmAesCbcCfbParams.h"
 #include "CryptoAlgorithmAesKeyParams.h"
 #include "CryptoKeyAES.h"
+#include "ExceptionOr.h"
 #include <wtf/CrossThreadCopier.h>
 
 namespace WebCore {

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDH.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDH.cpp
@@ -29,6 +29,7 @@
 #include "CryptoAlgorithmEcKeyParams.h"
 #include "CryptoAlgorithmEcdhKeyDeriveParams.h"
 #include "CryptoKeyEC.h"
+#include "ExceptionOr.h"
 #include "ScriptExecutionContext.h"
 #if HAVE(SWIFT_CPP_INTEROP)
 #include <pal/PALSwift.h>

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDSA.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDSA.cpp
@@ -29,6 +29,7 @@
 #include "CryptoAlgorithmEcKeyParams.h"
 #include "CryptoAlgorithmEcdsaParams.h"
 #include "CryptoKeyEC.h"
+#include "ExceptionOr.h"
 #include "ScriptExecutionContext.h"
 #include <JavaScriptCore/JSCJSValueInlines.h>
 #include <wtf/CrossThreadCopier.h>

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.cpp
@@ -27,6 +27,7 @@
 #include "CryptoAlgorithmEd25519.h"
 
 #include "CryptoKeyOKP.h"
+#include "ExceptionOr.h"
 #include "NotImplemented.h"
 #include "ScriptExecutionContext.h"
 #include <JavaScriptCore/JSCJSValueInlines.h>

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.cpp
@@ -28,6 +28,7 @@
 
 #include "CryptoAlgorithmHkdfParams.h"
 #include "CryptoKeyRaw.h"
+#include "ExceptionOr.h"
 #include "ScriptExecutionContext.h"
 #include <JavaScriptCore/JSCJSValueInlines.h>
 #include <wtf/CrossThreadCopier.h>

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_OAEP.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_OAEP.cpp
@@ -31,6 +31,7 @@
 #include "CryptoAlgorithmRsaOaepParams.h"
 #include "CryptoKeyPair.h"
 #include "CryptoKeyRSA.h"
+#include "ExceptionOr.h"
 #include <wtf/CrossThreadCopier.h>
 
 namespace WebCore {

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_PSS.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_PSS.cpp
@@ -33,6 +33,7 @@
 #include "CryptoAlgorithmRsaPssParams.h"
 #include "CryptoKeyPair.h"
 #include "CryptoKeyRSA.h"
+#include "ExceptionOr.h"
 #include <wtf/CrossThreadCopier.h>
 
 namespace WebCore {

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESCFBGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESCFBGCrypt.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "CryptoAlgorithmAESCFB.h"
 
+#include "ExceptionOr.h"
+
 namespace WebCore {
 
 ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESCFB::platformEncrypt(const CryptoAlgorithmAesCbcCfbParams&, const CryptoKeyAES&, const Vector<uint8_t>&)

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESCTRGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESCTRGCrypt.cpp
@@ -30,6 +30,7 @@
 
 #include "CryptoAlgorithmAesCtrParams.h"
 #include "CryptoKeyAES.h"
+#include "ExceptionOr.h"
 #include <pal/crypto/gcrypt/Handle.h>
 #include <pal/crypto/gcrypt/Utilities.h>
 

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESGCMGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESGCMGCrypt.cpp
@@ -30,6 +30,7 @@
 
 #include "CryptoAlgorithmAesGcmParams.h"
 #include "CryptoKeyAES.h"
+#include "ExceptionOr.h"
 #include "NotImplemented.h"
 #include <pal/crypto/gcrypt/Handle.h>
 #include <pal/crypto/gcrypt/Utilities.h>

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESKWGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESKWGCrypt.cpp
@@ -28,6 +28,7 @@
 #include "CryptoAlgorithmAESKW.h"
 
 #include "CryptoKeyAES.h"
+#include "ExceptionOr.h"
 #include <pal/crypto/gcrypt/Handle.h>
 #include <pal/crypto/gcrypt/Utilities.h>
 

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmECDSAGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmECDSAGCrypt.cpp
@@ -30,6 +30,7 @@
 
 #include "CryptoAlgorithmEcdsaParams.h"
 #include "CryptoKeyEC.h"
+#include "ExceptionOr.h"
 #include "GCryptUtilities.h"
 #include <pal/crypto/CryptoDigest.h>
 

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmPBKDF2GCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmPBKDF2GCrypt.cpp
@@ -30,6 +30,7 @@
 
 #include "CryptoAlgorithmPbkdf2Params.h"
 #include "CryptoKeyRaw.h"
+#include "ExceptionOr.h"
 #include "GCryptUtilities.h"
 
 namespace WebCore {

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmRSASSA_PKCS1_v1_5GCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmRSASSA_PKCS1_v1_5GCrypt.cpp
@@ -28,6 +28,7 @@
 #include "CryptoAlgorithmRSASSA_PKCS1_v1_5.h"
 
 #include "CryptoKeyRSA.h"
+#include "ExceptionOr.h"
 #include "GCryptUtilities.h"
 #include "NotImplemented.h"
 

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmRSA_OAEPGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmRSA_OAEPGCrypt.cpp
@@ -28,6 +28,7 @@
 
 #include "CryptoAlgorithmRsaOaepParams.h"
 #include "CryptoKeyRSA.h"
+#include "ExceptionOr.h"
 #include "GCryptUtilities.h"
 #include "NotImplemented.h"
 

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmRSA_PSSGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmRSA_PSSGCrypt.cpp
@@ -30,6 +30,7 @@
 
 #include "CryptoAlgorithmRsaPssParams.h"
 #include "CryptoKeyRSA.h"
+#include "ExceptionOr.h"
 #include "GCryptUtilities.h"
 
 namespace WebCore {

--- a/Source/WebCore/crypto/gcrypt/CryptoKeyRSAGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoKeyRSAGCrypt.cpp
@@ -29,6 +29,7 @@
 #include "CryptoAlgorithmRegistry.h"
 #include "CryptoKeyPair.h"
 #include "CryptoKeyRSAComponents.h"
+#include "ExceptionOr.h"
 #include "GCryptUtilities.h"
 #include "ScriptExecutionContext.h"
 #include <JavaScriptCore/GenericTypedArrayViewInlines.h>

--- a/Source/WebCore/crypto/keys/CryptoKeyOKP.cpp
+++ b/Source/WebCore/crypto/keys/CryptoKeyOKP.cpp
@@ -27,6 +27,7 @@
 #include "CryptoKeyOKP.h"
 
 #include "CryptoAlgorithmRegistry.h"
+#include "ExceptionOr.h"
 #include "JsonWebKey.h"
 #include <wtf/text/Base64.h>
 

--- a/Source/WebCore/css/CSSFontFaceDescriptors.cpp
+++ b/Source/WebCore/css/CSSFontFaceDescriptors.cpp
@@ -24,6 +24,7 @@
 
 #include "config.h"
 #include "CSSFontFaceDescriptors.h"
+#include "ExceptionOr.h"
 
 #include "CSSFontFaceRule.h"
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/css/CSSPageDescriptors.cpp
+++ b/Source/WebCore/css/CSSPageDescriptors.cpp
@@ -26,6 +26,7 @@
 #include "CSSPageDescriptors.h"
 
 #include "CSSPageRule.h"
+#include "ExceptionOr.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/CSSPositionTryDescriptors.cpp
+++ b/Source/WebCore/css/CSSPositionTryDescriptors.cpp
@@ -26,6 +26,7 @@
 #include "CSSPositionTryDescriptors.h"
 
 #include "CSSPositionTryRule.h"
+#include "ExceptionOr.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp
+++ b/Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp
@@ -33,6 +33,7 @@
 #include "CSSTokenizer.h"
 #include "DOMCSSNamespace.h"
 #include "Document.h"
+#include "ExceptionOr.h"
 #include "StyleBuilder.h"
 #include "StyleCustomPropertyRegistry.h"
 #include "StyleResolver.h"

--- a/Source/WebCore/css/typedom/CSSStyleValue.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValue.cpp
@@ -35,6 +35,7 @@
 #include "CSSSerializationContext.h"
 #include "CSSStyleValueFactory.h"
 #include "CSSUnitValue.h"
+#include "ExceptionOr.h"
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringView.h>

--- a/Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.cpp
@@ -36,6 +36,7 @@
 #include "CSSUnparsedValue.h"
 #include "CSSVariableData.h"
 #include "Document.h"
+#include "ExceptionOr.h"
 #include "PaintWorkletGlobalScope.h"
 #include "StylePropertyShorthand.h"
 #include <wtf/text/MakeString.h>

--- a/Source/WebCore/dom/DataTransferItemList.cpp
+++ b/Source/WebCore/dom/DataTransferItemList.cpp
@@ -30,6 +30,7 @@
 #include "DataTransferItem.h"
 #include "DeprecatedGlobalSettings.h"
 #include "Document.h"
+#include "ExceptionOr.h"
 #include "FileList.h"
 #include "Pasteboard.h"
 #include "Settings.h"

--- a/Source/WebCore/dom/MessagePort.cpp
+++ b/Source/WebCore/dom/MessagePort.cpp
@@ -30,6 +30,7 @@
 #include "Document.h"
 #include "EventNames.h"
 #include "EventTargetInlines.h"
+#include "ExceptionOr.h"
 #include "Logging.h"
 #include "MessageEvent.h"
 #include "MessagePortChannelProvider.h"

--- a/Source/WebCore/dom/TextDecoder.cpp
+++ b/Source/WebCore/dom/TextDecoder.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "TextDecoder.h"
 
+#include "ExceptionOr.h"
 #include <pal/text/TextCodec.h>
 #include <pal/text/TextEncodingRegistry.h>
 #include <wtf/text/MakeString.h>

--- a/Source/WebCore/dom/TextDecoderStreamDecoder.cpp
+++ b/Source/WebCore/dom/TextDecoderStreamDecoder.cpp
@@ -25,6 +25,8 @@
 #include "config.h"
 #include "TextDecoderStreamDecoder.h"
 
+#include "ExceptionOr.h"
+
 namespace WebCore {
 
 ExceptionOr<Ref<TextDecoderStreamDecoder>> TextDecoderStreamDecoder::create(const String& label, bool fatal, bool ignoreBOM)

--- a/Source/WebCore/dom/TrustedTypePolicy.cpp
+++ b/Source/WebCore/dom/TrustedTypePolicy.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "TrustedTypePolicy.h"
 
+#include "ExceptionOr.h"
 #include "TrustedHTML.h"
 #include "TrustedScript.h"
 #include "TrustedScriptURL.h"

--- a/Source/WebCore/fileapi/FileReader.cpp
+++ b/Source/WebCore/fileapi/FileReader.cpp
@@ -37,6 +37,7 @@
 #include "EventNames.h"
 #include "Exception.h"
 #include "ExceptionCode.h"
+#include "ExceptionOr.h"
 #include "File.h"
 #include "Logging.h"
 #include "ProgressEvent.h"

--- a/Source/WebCore/html/DOMFormData.cpp
+++ b/Source/WebCore/html/DOMFormData.cpp
@@ -32,6 +32,7 @@
 #include "DOMFormData.h"
 
 #include "Document.h"
+#include "ExceptionOr.h"
 #include "HTMLFormControlElement.h"
 #include "HTMLFormElement.h"
 

--- a/Source/WebCore/html/HTMLTableRowElement.cpp
+++ b/Source/WebCore/html/HTMLTableRowElement.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "HTMLTableRowElement.h"
 
+#include "ExceptionOr.h"
 #include "GenericCachedHTMLCollection.h"
 #include "HTMLNames.h"
 #include "HTMLTableCellElement.h"

--- a/Source/WebCore/html/ImageData.cpp
+++ b/Source/WebCore/html/ImageData.cpp
@@ -30,6 +30,7 @@
 #include "config.h"
 #include "ImageData.h"
 
+#include "ExceptionOr.h"
 #include <JavaScriptCore/GenericTypedArrayViewInlines.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <wtf/text/TextStream.h>

--- a/Source/WebCore/html/TimeRanges.cpp
+++ b/Source/WebCore/html/TimeRanges.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "TimeRanges.h"
 
+#include "ExceptionOr.h"
+
 namespace WebCore {
 
 Ref<TimeRanges> TimeRanges::create()

--- a/Source/WebCore/html/canvas/CanvasGradient.cpp
+++ b/Source/WebCore/html/canvas/CanvasGradient.cpp
@@ -28,6 +28,7 @@
 #include "CanvasGradient.h"
 
 #include "CanvasStyle.h"
+#include "ExceptionOr.h"
 #include "Gradient.h"
 
 namespace WebCore {

--- a/Source/WebCore/html/shadow/DateTimeEditElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeEditElement.cpp
@@ -34,6 +34,7 @@
 #include "DateTimeSymbolicFieldElement.h"
 #include "Document.h"
 #include "Event.h"
+#include "ExceptionOr.h"
 #include "HTMLNames.h"
 #include "PlatformLocale.h"
 #include "RenderElement.h"

--- a/Source/WebCore/html/track/InbandGenericTextTrack.cpp
+++ b/Source/WebCore/html/track/InbandGenericTextTrack.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(VIDEO)
 
+#include "ExceptionOr.h"
 #include "InbandTextTrackPrivate.h"
 #include "Logging.h"
 #include "ScriptExecutionContext.h"

--- a/Source/WebCore/html/track/TextTrack.cpp
+++ b/Source/WebCore/html/track/TextTrack.cpp
@@ -37,6 +37,7 @@
 #include "CommonAtomStrings.h"
 #include "DataCue.h"
 #include "Event.h"
+#include "ExceptionOr.h"
 #include "SourceBuffer.h"
 #include "TextTrackClient.h"
 #include "TextTrackCueList.h"

--- a/Source/WebCore/html/track/TextTrackCueGeneric.cpp
+++ b/Source/WebCore/html/track/TextTrackCueGeneric.cpp
@@ -33,6 +33,7 @@
 #include "CSSStyleDeclaration.h"
 #include "CSSValueKeywords.h"
 #include "ColorSerialization.h"
+#include "ExceptionOr.h"
 #include "HTMLSpanElement.h"
 #include "InbandTextTrackPrivateClient.h"
 #include "Logging.h"

--- a/Source/WebCore/inspector/InspectorAuditDOMObject.cpp
+++ b/Source/WebCore/inspector/InspectorAuditDOMObject.cpp
@@ -29,6 +29,7 @@
 
 #include "Document.h"
 #include "EventTargetInlines.h"
+#include "ExceptionOr.h"
 #include "Node.h"
 #include "UserGestureEmulationScope.h"
 #include "VoidCallback.h"

--- a/Source/WebCore/inspector/InspectorAuditResourcesObject.cpp
+++ b/Source/WebCore/inspector/InspectorAuditResourcesObject.cpp
@@ -33,6 +33,7 @@
 #include "CachedResource.h"
 #include "CachedSVGDocument.h"
 #include "Document.h"
+#include "ExceptionOr.h"
 #include "FrameDestructionObserverInlines.h"
 #include "InspectorPageAgent.h"
 #include <wtf/Vector.h>

--- a/Source/WebCore/inspector/InspectorHistory.cpp
+++ b/Source/WebCore/inspector/InspectorHistory.cpp
@@ -32,6 +32,7 @@
 #include "config.h"
 #include "InspectorHistory.h"
 
+#include "ExceptionOr.h"
 #include "Node.h"
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -30,6 +30,7 @@
 #include "CSSRuleList.h"
 #include "CSSStyleProperties.h"
 #include "Document.h"
+#include "ExceptionOr.h"
 #include "Frame.h"
 #include "FrameLoader.h"
 #include "HTTPParsers.h"

--- a/Source/WebCore/page/EventSource.cpp
+++ b/Source/WebCore/page/EventSource.cpp
@@ -37,6 +37,7 @@
 #include "ContentSecurityPolicy.h"
 #include "EventLoop.h"
 #include "EventNames.h"
+#include "ExceptionOr.h"
 #include "HTTPStatusCodes.h"
 #include "MessageEvent.h"
 #include "ResourceError.h"

--- a/Source/WebCore/page/LoginStatus.cpp
+++ b/Source/WebCore/page/LoginStatus.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "LoginStatus.h"
 
+#include "ExceptionOr.h"
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringCommon.h>

--- a/Source/WebCore/page/Performance.cpp
+++ b/Source/WebCore/page/Performance.cpp
@@ -38,6 +38,7 @@
 #include "Event.h"
 #include "EventLoop.h"
 #include "EventNames.h"
+#include "ExceptionOr.h"
 #include "LocalFrame.h"
 #include "PerformanceEntry.h"
 #include "PerformanceMarkOptions.h"

--- a/Source/WebCore/page/PerformanceMeasure.cpp
+++ b/Source/WebCore/page/PerformanceMeasure.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "PerformanceMeasure.h"
 
+#include "ExceptionOr.h"
 #include "SerializedScriptValue.h"
 
 namespace WebCore {

--- a/Source/WebCore/page/RemoteDOMWindow.cpp
+++ b/Source/WebCore/page/RemoteDOMWindow.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "RemoteDOMWindow.h"
 
+#include "Document.h"
+#include "ExceptionOr.h"
 #include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "LocalDOMWindow.h"

--- a/Source/WebCore/page/ShareDataReader.cpp
+++ b/Source/WebCore/page/ShareDataReader.cpp
@@ -28,6 +28,7 @@
 
 #include "BlobLoader.h"
 #include "Document.h"
+#include "ExceptionOr.h"
 #include "SharedBuffer.h"
 
 namespace WebCore {

--- a/Source/WebCore/svg/SVGAngleValue.cpp
+++ b/Source/WebCore/svg/SVGAngleValue.cpp
@@ -22,6 +22,7 @@
 #include "config.h"
 #include "SVGAngleValue.h"
 
+#include "ExceptionOr.h"
 #include "SVGParserUtilities.h"
 #include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/svg/SVGLength.h
+++ b/Source/WebCore/svg/SVGLength.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include "Exception.h"
+#include "ExceptionOr.h"
 #include "SVGLengthContext.h"
 #include "SVGValueProperty.h"
 

--- a/Source/WebCore/svg/SVGLengthValue.cpp
+++ b/Source/WebCore/svg/SVGLengthValue.cpp
@@ -23,6 +23,7 @@
 #include "SVGLengthValue.h"
 
 #include "AnimationUtilities.h"
+#include "ExceptionOr.h"
 #include "SVGElement.h"
 #include "SVGLengthContext.h"
 #include "SVGParserUtilities.h"

--- a/Source/WebCore/svg/SVGPreserveAspectRatio.h
+++ b/Source/WebCore/svg/SVGPreserveAspectRatio.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "ExceptionOr.h"
 #include "SVGPreserveAspectRatioValue.h"
 #include "SVGValueProperty.h"
 

--- a/Source/WebCore/svg/SVGPreserveAspectRatioValue.cpp
+++ b/Source/WebCore/svg/SVGPreserveAspectRatioValue.cpp
@@ -25,6 +25,7 @@
 #include "SVGPreserveAspectRatioValue.h"
 
 #include "AffineTransform.h"
+#include "ExceptionOr.h"
 #include "FloatRect.h"
 #include "SVGParserUtilities.h"
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/svg/SVGRect.h
+++ b/Source/WebCore/svg/SVGRect.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "ExceptionOr.h"
 #include "SVGPropertyTraits.h"
 #include "SVGValueProperty.h"
 

--- a/Source/WebCore/svg/SVGTransformList.cpp
+++ b/Source/WebCore/svg/SVGTransformList.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "SVGTransformList.h"
 
+#include "ExceptionOr.h"
 #include "SVGParserUtilities.h"
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringParsingBuffer.h>

--- a/Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.h
+++ b/Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "Color.h"
+#include "ExceptionOr.h"
 #include "FloatRect.h"
 #include "SVGAngleValue.h"
 #include "SVGAnimationAdditiveValueFunction.h"

--- a/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
@@ -36,6 +36,7 @@
 #include "DedicatedWorkerThread.h"
 #include "EventNames.h"
 #include "EventTargetInterfaces.h"
+#include "ExceptionOr.h"
 #include "JSRTCRtpScriptTransformer.h"
 #include "LocalDOMWindow.h"
 #include "MessageEvent.h"

--- a/Source/WebCore/workers/service/ExtendableEvent.cpp
+++ b/Source/WebCore/workers/service/ExtendableEvent.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "ExtendableEvent.h"
 
+#include "EventLoop.h"
+#include "ExceptionOr.h"
 #include "JSDOMGlobalObject.h"
 #include "JSDOMPromise.h"
 #include "ScriptExecutionContext.h"

--- a/Source/WebCore/workers/service/ServiceWorker.cpp
+++ b/Source/WebCore/workers/service/ServiceWorker.cpp
@@ -29,6 +29,7 @@
 #include "Document.h"
 #include "EventNames.h"
 #include "EventTargetInterfaces.h"
+#include "ExceptionOr.h"
 #include "Logging.h"
 #include "MessagePort.h"
 #include "SWClientConnection.h"

--- a/Source/WebCore/workers/service/ServiceWorkerClient.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerClient.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "ServiceWorkerClient.h"
 
+#include "ExceptionOr.h"
 #include "MessagePort.h"
 #include "SWContextManager.h"
 #include "ScriptExecutionContext.h"

--- a/Source/WebCore/workers/service/WorkerSWClientConnection.cpp
+++ b/Source/WebCore/workers/service/WorkerSWClientConnection.cpp
@@ -32,6 +32,7 @@
 #include "BackgroundFetchRequest.h"
 #include "CacheQueryOptions.h"
 #include "CookieChangeSubscription.h"
+#include "ExceptionOr.h"
 #include "NotificationData.h"
 #include "RetrieveRecordsOptions.h"
 #include "SecurityOrigin.h"

--- a/Source/WebCore/xml/XPathEvaluator.cpp
+++ b/Source/WebCore/xml/XPathEvaluator.cpp
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "XPathEvaluator.h"
 
+#include "ExceptionOr.h"
 #include "NativeXPathNSResolver.h"
 #include "XPathExpression.h"
 #include "XPathResult.h"

--- a/Source/WebCore/xml/XPathExpression.cpp
+++ b/Source/WebCore/xml/XPathExpression.cpp
@@ -28,6 +28,7 @@
 #include "XPathExpression.h"
 
 #include "Document.h"
+#include "ExceptionOr.h"
 #include "XPathNSResolver.h"
 #include "XPathParser.h"
 #include "XPathResult.h"

--- a/Source/WebCore/xml/XPathParser.cpp
+++ b/Source/WebCore/xml/XPathParser.cpp
@@ -29,6 +29,7 @@
 #include "config.h"
 #include "XPathParser.h"
 
+#include "ExceptionOr.h"
 #include "XPathEvaluator.h"
 #include "XPathNSResolver.h"
 #include "XPathPath.h"

--- a/Source/WebCore/xml/XPathResult.cpp
+++ b/Source/WebCore/xml/XPathResult.cpp
@@ -28,6 +28,7 @@
 #include "XPathResult.h"
 
 #include "Document.h"
+#include "ExceptionOr.h"
 #include "XPathEvaluator.h"
 
 namespace WebCore {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp
@@ -31,6 +31,7 @@
 #include "WebProcess.h"
 #include "WebScreenOrientationManagerMessages.h"
 #include "WebScreenOrientationManagerProxyMessages.h"
+#include <WebCore/Exception.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {


### PR DESCRIPTION
#### e504890aa9e8c03f20e60f520e4ff3d65a0b7363
<pre>
Fix non-unified builds part 1: Exception/ExceptionOr includes
<a href="https://bugs.webkit.org/show_bug.cgi?id=295883">https://bugs.webkit.org/show_bug.cgi?id=295883</a>

Unreviewed build fix.

Since the wide adoption of Exception and ExceptionOr in WebCore,
many compilation units are broken due to missing includes for the
headers where these are defined.

This is the first of a series of commits trying to fix non-unified
builds, which are severely broken for a while now.

* Source/WebCore/Modules/compression/DecompressionStreamDecoder.cpp:
* Source/WebCore/Modules/compression/DecompressionStreamDecoder.h:
* Source/WebCore/Modules/entriesapi/DOMFileSystem.h:
* Source/WebCore/Modules/fetch/FetchHeaders.cpp:
* Source/WebCore/Modules/fetch/FormDataConsumer.cpp:
* Source/WebCore/Modules/fetch/FormDataConsumer.h:
* Source/WebCore/Modules/filesystem/FileSystemStorageConnection.cpp:
* Source/WebCore/Modules/filesystem/FileSystemWritableFileStreamSink.cpp:
* Source/WebCore/Modules/filesystem/WorkerFileSystemStorageConnection.cpp:
* Source/WebCore/Modules/indexeddb/IDBDatabase.cpp:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
* Source/WebCore/Modules/push-api/PushMessageData.cpp:
* Source/WebCore/Modules/url-pattern/URLPatternConstructorStringParser.cpp:
* Source/WebCore/Modules/url-pattern/URLPatternParser.cpp:
* Source/WebCore/Modules/webaudio/AudioParam.cpp:
* Source/WebCore/Modules/webaudio/ChannelMergerNode.cpp:
* Source/WebCore/Modules/webaudio/ChannelSplitterNode.cpp:
* Source/WebCore/Modules/webaudio/ConstantSourceNode.cpp:
* Source/WebCore/Modules/webaudio/DynamicsCompressorNode.cpp:
* Source/WebCore/Modules/webaudio/GainNode.cpp:
* Source/WebCore/Modules/webaudio/ScriptProcessorNode.cpp:
* Source/WebCore/Modules/webaudio/StereoPannerNode.cpp:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunk.cpp:
* Source/WebCore/Modules/webdatabase/LocalDOMWindowWebDatabase.cpp:
* Source/WebCore/Modules/webdatabase/SQLResultSet.cpp:
* Source/WebCore/Modules/webtransport/WebTransport.cpp:
* Source/WebCore/bindings/js/InternalWritableStream.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCBC.cpp:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmECDH.cpp:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmECDSA.cpp:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.cpp:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.cpp:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_OAEP.cpp:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_PSS.cpp:
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESCFBGCrypt.cpp:
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESCTRGCrypt.cpp:
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESGCMGCrypt.cpp:
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESKWGCrypt.cpp:
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmECDSAGCrypt.cpp:
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmPBKDF2GCrypt.cpp:
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmRSASSA_PKCS1_v1_5GCrypt.cpp:
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmRSA_OAEPGCrypt.cpp:
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmRSA_PSSGCrypt.cpp:
* Source/WebCore/crypto/gcrypt/CryptoKeyRSAGCrypt.cpp:
* Source/WebCore/crypto/keys/CryptoKeyOKP.cpp:
* Source/WebCore/css/CSSFontFaceDescriptors.cpp:
* Source/WebCore/css/CSSPageDescriptors.cpp:
* Source/WebCore/css/CSSPositionTryDescriptors.cpp:
* Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp:
* Source/WebCore/css/typedom/CSSStyleValue.cpp:
* Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.cpp:
* Source/WebCore/dom/DataTransferItemList.cpp:
* Source/WebCore/dom/MessagePort.cpp:
* Source/WebCore/dom/TextDecoder.cpp:
* Source/WebCore/dom/TextDecoderStreamDecoder.cpp:
* Source/WebCore/dom/TrustedTypePolicy.cpp:
* Source/WebCore/fileapi/FileReader.cpp:
* Source/WebCore/html/DOMFormData.cpp:
* Source/WebCore/html/HTMLTableRowElement.cpp:
* Source/WebCore/html/ImageData.cpp:
* Source/WebCore/html/TimeRanges.cpp:
* Source/WebCore/html/canvas/CanvasGradient.cpp:
* Source/WebCore/html/shadow/DateTimeEditElement.cpp:
* Source/WebCore/html/track/InbandGenericTextTrack.cpp:
* Source/WebCore/html/track/TextTrack.cpp:
* Source/WebCore/html/track/TextTrackCueGeneric.cpp:
* Source/WebCore/inspector/InspectorAuditDOMObject.cpp:
* Source/WebCore/inspector/InspectorAuditResourcesObject.cpp:
* Source/WebCore/inspector/InspectorHistory.cpp:
* Source/WebCore/page/DOMWindow.cpp:
* Source/WebCore/page/EventSource.cpp:
* Source/WebCore/page/LoginStatus.cpp:
* Source/WebCore/page/Performance.cpp:
* Source/WebCore/page/PerformanceMeasure.cpp:
* Source/WebCore/page/RemoteDOMWindow.cpp:
* Source/WebCore/page/ShareDataReader.cpp:
* Source/WebCore/svg/SVGAngleValue.cpp:
* Source/WebCore/svg/SVGLength.h:
* Source/WebCore/svg/SVGLengthValue.cpp:
* Source/WebCore/svg/SVGPreserveAspectRatio.h:
* Source/WebCore/svg/SVGPreserveAspectRatioValue.cpp:
* Source/WebCore/svg/SVGRect.h:
* Source/WebCore/svg/SVGTransformList.cpp:
* Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.h:
* Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp:
* Source/WebCore/workers/service/ExtendableEvent.cpp:
* Source/WebCore/workers/service/ServiceWorker.cpp:
* Source/WebCore/workers/service/ServiceWorkerClient.cpp:
* Source/WebCore/workers/service/WorkerSWClientConnection.cpp:
* Source/WebCore/xml/XPathEvaluator.cpp:
* Source/WebCore/xml/XPathExpression.cpp:
* Source/WebCore/xml/XPathParser.cpp:
* Source/WebCore/xml/XPathResult.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp:

Canonical link: <a href="https://commits.webkit.org/297331@main">https://commits.webkit.org/297331@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/795a424c1a19fdc6d05dc031ef6cd2a0c8d35e66

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111423 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21554 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117455 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61691 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113385 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39671 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/84686 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114370 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25364 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100306 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65133 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24710 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/18442 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61275 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94751 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18508 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120677 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38472 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28589 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/93610 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38848 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96575 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/93436 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38537 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16315 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34506 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17952 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38361 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43838 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38026 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41359 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39728 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->