### PR TITLE
[Form Control Refresh] Checkboxes and radio buttons in checked state with mismatched background/color-scheme disappear when window inactive

### DIFF
--- a/LayoutTests/fast/forms/form-control-refresh/checkbox-radio-inactive-appearance-dark-bg-light-color-scheme-expected-mismatch.html
+++ b/LayoutTests/fast/forms/form-control-refresh/checkbox-radio-inactive-appearance-dark-bg-light-color-scheme-expected-mismatch.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body style="background: black;">
+    <p style="color: white;">This tests that a checked checkbox or radio button with light color-scheme does not disappear on a black background when the window is inactive.</p>
+</body>
+</html>

--- a/LayoutTests/fast/forms/form-control-refresh/checkbox-radio-inactive-appearance-dark-bg-light-color-scheme.html
+++ b/LayoutTests/fast/forms/form-control-refresh/checkbox-radio-inactive-appearance-dark-bg-light-color-scheme.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<body style="background: black;">
+    <p style="color: white;">This tests that a checked checkbox or radio button with light color-scheme does not disappear on a black background when the window is inactive.</p>
+    <input type="checkbox" checked>
+    <input type="radio" checked>
+</body>
+<script>
+if (window.testRunner)
+    window.testRunner.setWindowIsKey(false);
+</script>
+</html>

--- a/LayoutTests/fast/forms/form-control-refresh/checkbox-radio-inactive-appearance-light-bg-dark-color-scheme-expected-mismatch.html
+++ b/LayoutTests/fast/forms/form-control-refresh/checkbox-radio-inactive-appearance-light-bg-dark-color-scheme-expected-mismatch.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <p>This tests that a checked checkbox or radio button with dark color-scheme does not disappear on a white background when the window is inactive.</p>
+</body>
+</html>

--- a/LayoutTests/fast/forms/form-control-refresh/checkbox-radio-inactive-appearance-light-bg-dark-color-scheme.html
+++ b/LayoutTests/fast/forms/form-control-refresh/checkbox-radio-inactive-appearance-light-bg-dark-color-scheme.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="color-scheme" content="dark" />
+</head>
+<body style="background: white;">
+    <p style="color: black;">This tests that a checked checkbox or radio button with dark color-scheme does not disappear on a white background when the window is inactive.</p>
+    <input type="checkbox" checked>
+    <input type="radio" checked>
+</body>
+<script>
+if (window.testRunner)
+    window.testRunner.setWindowIsKey(false);
+</script>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7954,6 +7954,10 @@ fast/forms/datalist/datalist-fallback-content.html [ ImageOnlyFailure ]
 fast/forms/form-control-refresh [ Pass ]
 imported/w3c/web-platform-tests/css/css-ui/button-author-level-padding-applies.html [ Pass ]
 
+# Window inactive appearance is only used on macOS.
+fast/forms/form-control-refresh/checkbox-radio-inactive-appearance-dark-bg-light-color-scheme.html [ Skip ]
+fast/forms/form-control-refresh/checkbox-radio-inactive-appearance-light-bg-dark-color-scheme.html [ Skip ]
+
 # rdar://155348715 (REGRESSION (Liquid Glass): [ iOS 26 ] 72 WPT/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-select-*.html tests are constantly failing (IMAGE).)
 # Explicit pass expectations for many of these tests are set above. Uncomment that block once this is resolved.
 imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-select-dropdown-box-background-attachment-001.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/visionos/TestExpectations
+++ b/LayoutTests/platform/visionos/TestExpectations
@@ -166,6 +166,10 @@ http/tests/security/model-element [ Pass ]
 # Tests which pass only with form control refresh enabled (visionOS 26)
 fast/forms/form-control-refresh [ Pass ]
 
+# Window inactive appearance is only used on macOS.
+fast/forms/form-control-refresh/checkbox-radio-inactive-appearance-dark-bg-light-color-scheme.html [ Skip ]
+fast/forms/form-control-refresh/checkbox-radio-inactive-appearance-light-bg-dark-color-scheme.html [ Skip ]
+
 ### END OF Triaged failures
 ###################################################################################################
 


### PR DESCRIPTION
#### 227d518593d44efa337d2f12e1220ffd183213b2
<pre>
[Form Control Refresh] Checkboxes and radio buttons in checked state with mismatched background/color-scheme disappear when window inactive
<a href="https://bugs.webkit.org/show_bug.cgi?id=295893">https://bugs.webkit.org/show_bug.cgi?id=295893</a>
<a href="https://rdar.apple.com/155794915">rdar://155794915</a>

Reviewed by Abrar Rahman Protyasha.

Checkbox/radio background colors are now composited over the canvas color.

* LayoutTests/fast/forms/form-control-refresh/checkbox-radio-inactive-appearance-dark-bg-light-color-scheme-expected-mismatch.html: Added.
* LayoutTests/fast/forms/form-control-refresh/checkbox-radio-inactive-appearance-dark-bg-light-color-scheme.html: Added.
* LayoutTests/fast/forms/form-control-refresh/checkbox-radio-inactive-appearance-light-bg-dark-color-scheme-expected-mismatch.html: Added.
* LayoutTests/fast/forms/form-control-refresh/checkbox-radio-inactive-appearance-light-bg-dark-color-scheme.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/visionos/TestExpectations:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::colorCompositedOverCanvasColor):
(WebCore::RenderThemeCocoa::checkboxRadioBackgroundColorForVectorBasedControls const):

Canonical link: <a href="https://commits.webkit.org/297380@main">https://commits.webkit.org/297380@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e109787e20dd57341495a7cdcb67de45c56eb8ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111482 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31148 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21613 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117514 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61750 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113444 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31829 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39730 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84721 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/35525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114429 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25413 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100352 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65169 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24761 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18487 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61337 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94799 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18553 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120739 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38531 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28632 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93644 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38907 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96620 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93470 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23838 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38588 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16360 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34568 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38420 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43897 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38085 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41418 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39787 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->