### PR TITLE
[Form Control Refresh] Author-level padding is not applying correctly for native textareas.

### DIFF
--- a/LayoutTests/platform/mac-wk2/fast/forms/placeholder-position-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/forms/placeholder-position-expected.txt
@@ -24,27 +24,27 @@ layer at (0,0) size 800x600
           RenderBlock {DIV} at (130,1) size 12x11
       RenderBR {BR} at (155,64) size 1x18
       RenderBR {BR} at (167,102) size 0x18
-      RenderTextControl {INPUT} at (0,116) size 156x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+      RenderTextControl {INPUT} at (0,116) size 156x34 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
       RenderBR {BR} at (155,117) size 1x18
-      RenderBR {BR} at (167,155) size 0x18
-      RenderTextControl {INPUT} at (5,174) size 199x30 [bgcolor=#FFFFFF] [border: (5px solid #000000)]
-      RenderBR {BR} at (208,181) size 1x18
-      RenderTextControl {INPUT} at (0,209) size 156x33 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
-      RenderText {#text} at (155,216) size 5x18
-        text run at (155,216) width 5: " "
-      RenderTextControl {INPUT} at (159,209) size 157x33 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+      RenderBR {BR} at (167,181) size 0x18
+      RenderTextControl {INPUT} at (5,200) size 199x30 [bgcolor=#FFFFFF] [border: (5px solid #000000)]
+      RenderBR {BR} at (208,207) size 1x18
+      RenderTextControl {INPUT} at (0,235) size 156x33 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+      RenderText {#text} at (155,242) size 5x18
+        text run at (155,242) width 5: " "
+      RenderTextControl {INPUT} at (159,235) size 157x33 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
       RenderText {#text} at (0,0) size 0x0
-      RenderBR {BR} at (315,216) size 1x18
-      RenderTextControl {INPUT} at (0,242) size 156x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
-      RenderText {#text} at (155,243) size 5x18
-        text run at (155,243) width 5: " "
-      RenderTextControl {INPUT} at (159,242) size 157x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
-      RenderText {#text} at (315,243) size 5x18
-        text run at (315,243) width 5: " "
-      RenderTextControl {INPUT} at (319,242) size 157x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+      RenderBR {BR} at (315,242) size 1x18
+      RenderTextControl {INPUT} at (0,268) size 156x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+      RenderText {#text} at (155,269) size 5x18
+        text run at (155,269) width 5: " "
+      RenderTextControl {INPUT} at (159,268) size 157x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+      RenderText {#text} at (315,269) size 5x18
+        text run at (315,269) width 5: " "
+      RenderTextControl {INPUT} at (319,268) size 157x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
       RenderText {#text} at (0,0) size 0x0
-      RenderBR {BR} at (475,243) size 1x18
-      RenderBR {BR} at (155,264) size 1x18
+      RenderBR {BR} at (475,269) size 1x18
+      RenderBR {BR} at (155,303) size 1x18
 layer at (30,12) size 116x13
   RenderBlock {DIV} at (21,4) size 117x13 [color=#A9A9A9]
     RenderText {#text} at (0,0) size 62x13
@@ -81,49 +81,49 @@ layer at (15,128) size 142x13
       text run at (0,0) width 62: "placeholder"
 layer at (15,128) size 142x13
   RenderBlock {DIV} at (7,4) size 142x13
-layer at (8,145) size 167x32 clip at (9,146) size 165x30
-  RenderTextControl {TEXTAREA} at (0,137) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (6,3) size 155x13
-    RenderBlock {DIV} at (6,3) size 155x13 [color=#A9A9A9]
+layer at (8,158) size 167x45 clip at (9,159) size 165x43
+  RenderTextControl {TEXTAREA} at (0,150) size 167x45 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+    RenderBlock {DIV} at (6,16) size 155x13
+    RenderBlock {DIV} at (6,16) size 155x13 [color=#A9A9A9]
       RenderText {#text} at (0,0) size 62x13
         text run at (0,0) width 62: "placeholder"
-layer at (19,188) size 186x18
+layer at (19,214) size 186x18
   RenderBlock {DIV} at (6,6) size 187x18 [color=#A9A9A9]
     RenderText {#text} at (0,0) size 81x18
       text run at (0,0) width 81: "placeholder"
-layer at (19,188) size 186x18
+layer at (19,214) size 186x18
   RenderBlock {DIV} at (6,6) size 187x18
-layer at (15,221) size 142x25
+layer at (15,247) size 142x25
   RenderBlock {DIV} at (7,4) size 142x25
     RenderText {#text} at (0,6) size 29x13
       text run at (0,6) width 29: "Value"
-layer at (175,227) size 142x13
+layer at (175,253) size 142x13
   RenderBlock {DIV} at (7,10) size 142x13 [color=#A9A9A9]
     RenderText {#text} at (0,0) size 62x13
       text run at (0,0) width 62: "placeholder"
-layer at (175,221) size 142x25
+layer at (175,247) size 142x25
   RenderBlock {DIV} at (7,4) size 142x25
-layer at (15,254) size 142x13
+layer at (15,280) size 142x13
   RenderBlock {DIV} at (7,4) size 142x13
     RenderText {#text} at (56,0) size 30x13
       text run at (56,0) width 30: "Value"
-layer at (175,254) size 142x13
+layer at (175,280) size 142x13
   RenderBlock {DIV} at (7,4) size 142x13 [color=#A9A9A9]
     RenderText {#text} at (40,0) size 62x13
       text run at (40,0) width 62: "placeholder"
-layer at (175,254) size 142x13
+layer at (175,280) size 142x13
   RenderBlock {DIV} at (7,4) size 142x13
-layer at (335,254) size 142x13
+layer at (335,280) size 142x13
   RenderBlock {DIV} at (7,4) size 142x13 [color=#A9A9A9]
     RenderText {#text} at (40,0) size 62x13
       text run at (40,0) width 62: "placeholder"
-layer at (335,254) size 142x13
+layer at (335,280) size 142x13
   RenderBlock {DIV} at (7,4) size 142x13
-layer at (8,271) size 156x21
-  RenderTextControl {INPUT} at (0,263) size 156x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
-layer at (15,275) size 142x13
-  RenderBlock {DIV} at (7,4) size 142x13 [color=#A9A9A9]
+layer at (8,297) size 156x34
+  RenderTextControl {INPUT} at (0,289) size 156x34 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+layer at (15,314) size 142x13
+  RenderBlock {DIV} at (7,17) size 142x13 [color=#A9A9A9]
     RenderText {#text} at (0,0) size 62x13
       text run at (0,0) width 62: "placeholder"
-layer at (15,275) size 142x13
-  RenderBlock {DIV} at (7,4) size 142x13
+layer at (15,314) size 142x13
+  RenderBlock {DIV} at (7,17) size 142x13

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -1667,7 +1667,8 @@ static void applyEmPadding(RenderStyle& style, const Element* element, float pad
     const auto horizontalPadding = isVertical ? paddingBlockPixels : paddingInlinePixels;
     const auto verticalPadding = isVertical ? paddingInlinePixels : paddingBlockPixels;
 
-    style.setPaddingBox({ verticalPadding, horizontalPadding, verticalPadding, horizontalPadding });
+    Style::PaddingBox paddingBox { verticalPadding, horizontalPadding, verticalPadding, horizontalPadding };
+    applyPaddingIfNotExplicitlySet(style, paddingBox);
 }
 
 #if PLATFORM(MAC)


### PR DESCRIPTION
#### 5c30fec00330dc6fd6ad5eb9f02dae03e2867795
<pre>
[Form Control Refresh] Author-level padding is not applying correctly for native textareas.
<a href="https://bugs.webkit.org/show_bug.cgi?id=295903">https://bugs.webkit.org/show_bug.cgi?id=295903</a>
<a href="https://rdar.apple.com/155803154">rdar://155803154</a>

Reviewed by Abrar Rahman Protyasha.

Check if the author explicitly set padding before applying adjusted padding values
for native textareas.

Tested by fast/forms/placeholder-position.html.

* LayoutTests/platform/mac-wk2/fast/forms/placeholder-position-expected.txt:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::applyEmPadding):

Canonical link: <a href="https://commits.webkit.org/297379@main">https://commits.webkit.org/297379@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aeaa3975922d6e8f8a083bb31927b5d536ea65f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111478 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31144 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117510 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61746 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113440 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31825 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39726 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84720 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/35523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114425 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25408 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100341 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65168 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24756 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18476 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61333 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94794 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18542 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120735 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38527 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28630 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93642 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38903 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96609 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93468 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23837 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38581 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; Skipped layout-tests; Passed layout tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16349 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34564 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38416 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43893 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38081 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41414 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39783 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->