### PR TITLE
[CSS] Split up grid-template-areas row parsing and row updating

### DIFF
--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.h
@@ -36,8 +36,8 @@ class CSSValue;
 enum CSSValueID : uint16_t;
 
 namespace CSS {
-struct GridNamedAreaMap;
 struct PropertyParserState;
+using GridNamedAreaMapRow = Vector<String, 8>;
 }
 
 namespace CSSPropertyParserHelpers {
@@ -48,7 +48,10 @@ enum class AllowEmpty : bool { No, Yes };
 enum TrackListType : uint8_t { GridTemplate, GridTemplateNoRepeat, GridAuto };
 
 bool isGridBreadthIdent(CSSValueID);
-bool parseGridTemplateAreasRow(StringView gridRowNames, CSS::GridNamedAreaMap&);
+
+// Parses a single <string> token from a <'grid-template-areas'> production.
+std::optional<CSS::GridNamedAreaMapRow> consumeUnresolvedGridTemplateAreasRow(CSSParserTokenRange&, CSS::PropertyParserState&);
+
 RefPtr<CSSGridLineNamesValue> consumeGridLineNames(CSSParserTokenRange&, CSS::PropertyParserState&, AllowEmpty = AllowEmpty::No);
 RefPtr<CSSValue> consumeGridLine(CSSParserTokenRange&, CSS::PropertyParserState&);
 RefPtr<CSSValue> consumeGridTrackSize(CSSParserTokenRange&, CSS::PropertyParserState&);

--- a/Source/WebCore/css/parser/CSSPropertyParserCustom.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserCustom.h
@@ -1439,7 +1439,8 @@ inline bool PropertyParserCustom::consumeGridTemplateShorthand(CSSParserTokenRan
         }
 
         // Handle a template-area's row.
-        if (range.peek().type() != StringToken || !parseGridTemplateAreasRow(range.consumeIncludingWhitespace().value(), gridAreaMap))
+        auto row = consumeUnresolvedGridTemplateAreasRow(range, state);
+        if (!row || !CSS::addRow(gridAreaMap, *row))
             return false;
 
         // Handle template-rows's track-size.

--- a/Source/WebCore/css/values/grid/CSSGridNamedAreaMap.cpp
+++ b/Source/WebCore/css/values/grid/CSSGridNamedAreaMap.cpp
@@ -32,6 +32,61 @@
 namespace WebCore {
 namespace CSS {
 
+bool addRow(GridNamedAreaMap& gridAreaMap, const GridNamedAreaMapRow& row)
+{
+    if (!gridAreaMap.rowCount) {
+        gridAreaMap.columnCount = row.size();
+        if (!gridAreaMap.columnCount)
+            return false;
+    } else if (gridAreaMap.columnCount != row.size()) {
+        // The declaration is invalid if all the rows don't have the number of columns.
+        return false;
+    }
+
+    for (size_t currentColumn = 0; currentColumn < gridAreaMap.columnCount; ++currentColumn) {
+        auto& gridAreaName = row[currentColumn];
+
+        // Unnamed areas are always valid (we consider them to be 1x1).
+        if (gridAreaName == "."_s)
+            continue;
+
+        auto lookAheadColumn = currentColumn + 1;
+        while (lookAheadColumn < gridAreaMap.columnCount && row[lookAheadColumn] == gridAreaName)
+            lookAheadColumn++;
+
+        auto result = gridAreaMap.map.ensure(gridAreaName, [&] {
+            return GridArea {
+                GridSpan::translatedDefiniteGridSpan(gridAreaMap.rowCount, gridAreaMap.rowCount + 1),
+                GridSpan::translatedDefiniteGridSpan(currentColumn, lookAheadColumn)
+            };
+        });
+        if (!result.isNewEntry) {
+            auto& gridArea = result.iterator->value;
+
+            // The following checks test that the grid area is a single filled-in rectangle.
+            // 1. The new row is adjacent to the previously parsed row.
+            if (gridAreaMap.rowCount != gridArea.rows.endLine())
+                return false;
+
+            // 2. The new area starts at the same position as the previously parsed area.
+            if (currentColumn != gridArea.columns.startLine())
+                return false;
+
+            // 3. The new area ends at the same position as the previously parsed area.
+            if (lookAheadColumn != gridArea.columns.endLine())
+                return false;
+
+            gridArea.rows = GridSpan::translatedDefiniteGridSpan(gridArea.rows.startLine(), gridArea.rows.endLine() + 1);
+        }
+        currentColumn = lookAheadColumn - 1;
+    }
+
+    ++gridAreaMap.rowCount;
+    return true;
+}
+
+// MARK: - Serialization
+
 static void serializeGridNamedAreaMapPosition(StringBuilder& builder, const GridNamedAreaMap::Map& map, size_t row, size_t column)
 {
     HashSet<String> candidates;
@@ -62,6 +117,8 @@ void Serialize<GridNamedAreaMap>::operator()(StringBuilder& builder, const CSS::
             builder.append(' ');
     }
 }
+
+// MARK: - Logging
 
 TextStream& operator<<(TextStream& ts, const GridNamedAreaMap& value)
 {

--- a/Source/WebCore/css/values/grid/CSSGridNamedAreaMap.h
+++ b/Source/WebCore/css/values/grid/CSSGridNamedAreaMap.h
@@ -43,7 +43,17 @@ struct GridNamedAreaMap {
     bool operator==(const GridNamedAreaMap&) const = default;
 };
 
+// A single `<string>` of <'grid-template-areas'>.
+using GridNamedAreaMapRow = Vector<String, 8>;
+
+// Adds a row to a `GridNamedAreaMap`. Returns `true` on success, `false` on failure.
+bool addRow(GridNamedAreaMap&, const GridNamedAreaMapRow&);
+
+// MARK: - Serialization
+
 template<> struct Serialize<GridNamedAreaMap> { void operator()(StringBuilder&, const CSS::SerializationContext&, const GridNamedAreaMap&); };
+
+// MARK: - Logging
 
 WTF::TextStream& operator<<(WTF::TextStream&, const GridNamedAreaMap&);
 


### PR DESCRIPTION
#### f18affe1cb29fbeeaf0242ef3759da1dfb181105
<pre>
[CSS] Split up grid-template-areas row parsing and row updating
<a href="https://bugs.webkit.org/show_bug.cgi?id=295912">https://bugs.webkit.org/show_bug.cgi?id=295912</a>

Reviewed by Darin Adler.

Replaces `parseGridTemplateAreasColumnNames` with two new functions:
  - `consumeUnresolvedGridTemplateAreasRow` which performs the parsing,
    taking over from `parseGridTemplateAreasColumnNames`.
  - `CSS::addRow()` which performs the map update.

Also gives the parsed row&apos;s type an inline capacity as it only ever lives
on the stack.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.h:
* Source/WebCore/css/parser/CSSPropertyParserCustom.h:
* Source/WebCore/css/values/grid/CSSGridNamedAreaMap.cpp:
* Source/WebCore/css/values/grid/CSSGridNamedAreaMap.h:

Canonical link: <a href="https://commits.webkit.org/297387@main">https://commits.webkit.org/297387@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07a3e81140ed28896c54e1f2434ad3b5352817bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111584 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31251 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21725 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117619 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61855 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113546 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31939 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39836 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84783 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/35553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114531 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25493 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100431 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65224 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24833 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18566 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61450 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94879 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18635 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120860 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38637 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28704 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93685 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39014 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96693 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93509 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23841 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38645 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16434 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34673 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38526 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44010 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38189 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41525 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39891 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->