### PR TITLE
[GTK][WPE] Fix building on non-systemd setups with ENABLE_JOURNALD_LOG=ON

### DIFF
--- a/Source/WTF/wtf/PlatformGTK.cmake
+++ b/Source/WTF/wtf/PlatformGTK.cmake
@@ -85,6 +85,7 @@ list(APPEND WTF_LIBRARIES
 )
 
 if (ENABLE_JOURNALD_LOG)
+    list(APPEND WTF_INTERFACE_LIBRARIES Journald::Journald)
     list(APPEND WTF_LIBRARIES Journald::Journald)
 endif ()
 

--- a/Source/WTF/wtf/PlatformWPE.cmake
+++ b/Source/WTF/wtf/PlatformWPE.cmake
@@ -67,6 +67,7 @@ list(APPEND WTF_LIBRARIES
 )
 
 if (ENABLE_JOURNALD_LOG)
+    list(APPEND WTF_INTERFACE_LIBRARIES Journald::Journald)
     list(APPEND WTF_LIBRARIES Journald::Journald)
 endif ()
 

--- a/Source/WebKit/WPEPlatform/wpe/drm/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/wpe/drm/CMakeLists.txt
@@ -39,10 +39,6 @@ set(WPEPlatformDRM_LIBRARIES
     ${GIO_UNIX_LIBRARIES}
 )
 
-if (ENABLE_JOURNALD_LOG)
-    list(APPEND WPEPlatformDRM_LIBRARIES Journald::Journald)
-endif ()
-
 set(WPEPlatformDRM_SOURCES_FOR_INTROSPECTION
     ${WPEPlatformDRM_INSTALLED_HEADERS}
     ${WPEPlatformDRM_SOURCES}


### PR DESCRIPTION
#### 041c588d9d7a2bbc21ee90a2d283815c570e437b
<pre>
[GTK][WPE] Fix building on non-systemd setups with ENABLE_JOURNALD_LOG=ON
<a href="https://bugs.webkit.org/show_bug.cgi?id=295636">https://bugs.webkit.org/show_bug.cgi?id=295636</a>

Reviewed by NOBODY (OOPS!).

With ENABLE_JOURNALD_LOG=ON, using WTF for logging will try to
include &lt;systemd/logind.h&gt; from &lt;wtf/Assertions.h&gt;, which means
that compile options needed to use the headers must be propagated
to any other target that uses WTF. The way to do this with CMake
is declaring the link the Journald::Journald target as an INTERFACE
library.

* Source/WTF/wtf/PlatformGTK.cmake: List Journald::Journald as an
  INTERFACE library.
* Source/WTF/wtf/PlatformWPE.cmake: Ditto.
* Source/WebKit/WPEPlatform/wpe/drm/CMakeLists.txt: Unlist
  Journald::Journald, given that CMake will propagate the build
  flags from it being an interface library for WTF.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/041c588d9d7a2bbc21ee90a2d283815c570e437b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111534 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31200 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21665 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117566 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61805 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31881 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39782 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84754 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35535 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114481 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25449 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100386 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65194 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24803 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18522 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61392 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/104033 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94846 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18587 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120803 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/110088 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38583 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28672 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93667 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38959 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96654 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93490 "Found 2 new API test failures: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38614 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16393 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34623 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38472 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43949 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/134363 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38139 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36205 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41470 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39841 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->