### PR TITLE
[iPadOS 26] Web content crash after zooming in, scrolling down and to the right, and opening sidebar in Safari

### DIFF
--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -1074,6 +1074,18 @@ LayoutPoint LocalFrameView::scrollPositionRespectingCustomFixedPosition() const
     return scrollPositionForFixedPosition();
 }
 
+void LocalFrameView::clearObscuredInsetsAdjustmentsIfNeeded()
+{
+    if (CheckedPtr tiledBacking = this->tiledBacking())
+        tiledBacking->clearObscuredInsetsAdjustments();
+}
+
+void LocalFrameView::obscuredInsetsWillChange(FloatBoxExtent&& obscuredInsetsDelta)
+{
+    if (CheckedPtr tiledBacking = this->tiledBacking())
+        tiledBacking->obscuredInsetsWillChange(WTFMove(obscuredInsetsDelta));
+}
+
 void LocalFrameView::obscuredContentInsetsDidChange(const FloatBoxExtent& newObscuredContentInsets)
 {
     RenderView* renderView = this->renderView();

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -636,6 +636,8 @@ public:
 
     LayoutPoint scrollPositionRespectingCustomFixedPosition() const;
 
+    WEBCORE_EXPORT void clearObscuredInsetsAdjustmentsIfNeeded();
+    void obscuredInsetsWillChange(FloatBoxExtent&& delta);
     void obscuredContentInsetsDidChange(const FloatBoxExtent&);
 
     void topContentDirectionDidChange();

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5305,9 +5305,17 @@ void Page::setSceneIdentifier(String&& sceneIdentifier)
 
 void Page::setObscuredInsets(const FloatBoxExtent& insets)
 {
-    if (m_obscuredInsets == insets)
-        return;
+    RefPtr localMainFrame = this->localMainFrame();
+    RefPtr view = localMainFrame ? localMainFrame->view() : nullptr;
 
+    if (m_obscuredInsets == insets) {
+        if (view)
+            view->clearObscuredInsetsAdjustmentsIfNeeded();
+        return;
+    }
+
+    if (view)
+        view->obscuredInsetsWillChange(insets - m_obscuredInsets);
     m_obscuredInsets = insets;
     m_chrome->client().setNeedsFixedContainerEdgesUpdate();
 }

--- a/Source/WebCore/platform/RectEdges.h
+++ b/Source/WebCore/platform/RectEdges.h
@@ -174,6 +174,25 @@ inline RectEdges<T>& operator+=(RectEdges<T>& a, const RectEdges<T>& b)
     return a;
 }
 
+template<typename T>
+constexpr RectEdges<T> operator-(const RectEdges<T>& a, const RectEdges<T>& b)
+{
+    return {
+        a.top() - b.top(),
+        a.right() - b.right(),
+        a.bottom() - b.bottom(),
+        a.left() - b.left()
+    };
+}
+
+template<typename T>
+inline RectEdges<T>& operator-=(RectEdges<T>& a, const RectEdges<T>& b)
+{
+    a = a - b;
+    return a;
+}
+
+
 template<typename T, typename F>
 inline RectEdges<T> blend(const RectEdges<T>& a, const RectEdges<T>& b, F&& functor)
 {

--- a/Source/WebCore/platform/graphics/TiledBacking.h
+++ b/Source/WebCore/platform/graphics/TiledBacking.h
@@ -202,6 +202,10 @@ public:
 #if USE(CA)
     virtual PlatformCALayer* tiledScrollingIndicatorLayer() = 0;
 #endif
+
+    virtual void clearObscuredInsetsAdjustments() = 0;
+    virtual void obscuredInsetsWillChange(FloatBoxExtent&&) = 0;
+    virtual FloatRect adjustedTileClipRectForObscuredInsets(const FloatRect&) const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -1763,7 +1763,10 @@ GraphicsLayerCA::VisibleAndCoverageRects GraphicsLayerCA::computeVisibleAndCover
     bool mapWasClamped;
     auto clipRectFromParent = state.mappedQuad(&mapWasClamped).boundingBox();
 
-    auto clipRectForSelf = FloatRect { { }, m_size };
+    FloatRect clipRectForSelf { { }, m_size };
+    if (CheckedPtr backing = this->tiledBacking())
+        clipRectForSelf = backing->adjustedTileClipRectForObscuredInsets(clipRectForSelf);
+
     if (!applyWasClamped && !mapWasClamped)
         clipRectForSelf.intersect(clipRectFromParent);
 

--- a/Source/WebCore/platform/graphics/ca/TileController.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileController.cpp
@@ -931,6 +931,15 @@ std::optional<DynamicContentScalingDisplayList> TileController::dynamicContentSc
 }
 #endif
 
+FloatRect TileController::adjustedTileClipRectForObscuredInsets(const FloatRect& clipRect) const
+{
+    auto delta = m_obscuredInsetsDelta;
+    if (!delta)
+        return clipRect;
+    FloatSize sizeAdjustment { delta->left() + delta->right(), delta->top() + delta->bottom() };
+    return { clipRect.location(), clipRect.size() + sizeAdjustment.expandedTo({ }) };
+}
+
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/ca/TileController.h
+++ b/Source/WebCore/platform/graphics/ca/TileController.h
@@ -231,6 +231,10 @@ private:
 
     PlatformCALayerClient* owningGraphicsLayer() const { return m_tileCacheLayer->owner(); }
 
+    void clearObscuredInsetsAdjustments() final { m_obscuredInsetsDelta = std::nullopt; }
+    void obscuredInsetsWillChange(FloatBoxExtent&& obscuredInsetsDelta) final { m_obscuredInsetsDelta = WTFMove(obscuredInsetsDelta); }
+    FloatRect adjustedTileClipRectForObscuredInsets(const FloatRect&) const;
+
     PlatformCALayer* m_tileCacheLayer;
 
     WeakPtr<TiledBackingClient> m_client;
@@ -288,6 +292,7 @@ private:
     float m_tileDebugBorderWidth { 0 };
     ScrollingModeIndication m_indicatorMode { SynchronousScrollingBecauseOfLackOfScrollingCoordinatorIndication };
     FloatBoxExtent m_obscuredContentInsets;
+    std::optional<FloatBoxExtent> m_obscuredInsetsDelta;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -250,6 +250,8 @@ struct PerWebProcessState {
     Markable<WebCore::PlatformLayerIdentifier> committedFindLayerID;
 
     std::optional<LiveResizeParameters> liveResizeParameters;
+
+    std::optional<WebKit::TransactionID> firstTransactionIDAfterObscuredInsetChange;
 };
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -5182,6 +5182,7 @@ void WebPage::updateVisibleContentRects(const VisibleContentRectUpdateInfo& visi
     if (m_viewportConfiguration.setMinimumEffectiveDeviceWidthWhenIgnoringScalingConstraints(minimumEffectiveDeviceWidthWhenIgnoringScalingConstraints))
         viewportConfigurationChanged();
 
+    frameView.clearObscuredInsetsAdjustmentsIfNeeded();
     frameView.setUnobscuredContentSize(unobscuredContentRect.size());
     m_page->setContentInsets(visibleContentRectUpdateInfo.contentInsets());
     m_page->setObscuredInsets(visibleContentRectUpdateInfo.obscuredInsets());

--- a/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
@@ -142,6 +142,9 @@ public:
     float tilingScaleFactor() const final { return 1; }
     IntRect bounds() const final { return { { }, IntSize(m_owner.size()) }; };
     IntRect boundsWithoutMargin() const final { return bounds(); };
+    void clearObscuredInsetsAdjustments() final { }
+    void obscuredInsetsWillChange(FloatBoxExtent&&) final { }
+    FloatRect adjustedTileClipRectForObscuredInsets(const FloatRect&) const final { return { }; }
 
 private:
     bool m_isInWindow { false };


### PR DESCRIPTION
#### 33f6aaf56f343a936a38ee4fedd09a82a210b0fe
<pre>
[iPadOS 26] Web content crash after zooming in, scrolling down and to the right, and opening sidebar in Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=295898">https://bugs.webkit.org/show_bug.cgi?id=295898</a>
<a href="https://rdar.apple.com/153348208">rdar://153348208</a>

Reviewed by Simon Fraser and Wenson Hsieh.

The combination of _overrideLayoutParametersWithMinimumLayoutSize:...
and _setObscuredInsets, say, to present a sidebar UI that lays out web
content in a new (narrower) viewport configuration, can exhibit extreme
page demands under certain conditions.

To understand this bad behavior, let&apos;s mark two time periods:
pre-sidebar presentation (A), and post-sidebar presentation (B).

When a client overrides layout parameters, it triggers layout in the web
content process and leads to resizing of the graphics layers. In some
future layer change commit, the visible rect from the root layer&apos;s
compositing state flush corresponds to the frame&apos;s exposed content rect
in (A). However, the clip rect for child layers, which is zero origin
and layer sized, uses a layer size from (B) -- i.e. narrower by the inset
amount. When zoomed in and far enough to the right, there is no longer
an intersection between these two rects, and so a zero sized visible
rect and layer sized coverage rect is computed. When scrolled down
sufficiently, this coverage rect has a huge height, which means we end
up preparing an enormous number of backing stores, exhibiting jetsams
because of the sheer amount of IOSurfaces we need.

There are a few issues:
1 Both layout parameter override and obscured inset assignment kicks off
  UI process driven update cycles in the web process. The former
  triggers layout and the latter a visible content rect update. Hence,
  whether or not a compositing flush happens with a layer size from (A)
  or (B) is racy. This is not directly fixable because overriding a
  layout parameter leads to multiple layer tree transactions, and we
  cannot reliably block scheduling visible rect updates in the UI
  process while those are done.
2 The frame&apos;s exposed content rect cannot be in (B) until the web
  process performs a layout round. This necessarily resizes layers.
  Which means that there will always be at least one layer change commit
  where we use the outdated exposed content rect from (A) to compute
  coverage rects.

(2) is more damning here, though, because it implies clients using these
APIs in their current shape will necessarily be prone to this bug under
certain conditions.

In this patch, we make an effort to work around the issue highlighted
above. On obscured inset changes, we introduce a fence against layout
size change dispatches until the first layer tree transaction round trip.
We use this round trip to relay the new obscured inset to the web content
process, where the local frame view is informed of changes in the
obscured inset amount across successive visible rect updates. The tile
controller holds on to these deltas to adjust child clip rects as
necessary to avoid the unfounded disjointness of clip rects. More
details inline.

Note that no API test could be added here. The layer change commit with
pre-sidebar exposed content rect still ends up with a correct reconciled
scroll position, so the only behavior to test would be page demand,
which is not meaningfully observed.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::clearObscuredInsetsAdjustmentsIfNeeded):
  This provides an explicit path to clear these adjustments to avoid
  an implicit dependency on Page::setObscuredInsets being called
  consecutively with the same values.
(WebCore::LocalFrameView::obscuredInsetsWillChange):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::setObscuredInsets):
  Compute the diff in the obscured insets from the last visible rect
  update cycle and inform the local frame view accordingly.
* Source/WebCore/platform/RectEdges.h:
(WebCore::operator-):
(WebCore::operator-=):
  Allows for more ergonomic FloatBoxExtent subtractions expression.
* Source/WebCore/platform/graphics/TiledBacking.h:
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::computeVisibleAndCoverageRect const):
  If we&apos;re using tiled layers, adjust the clip rect input used for
  coverage computation as appropriate.
* Source/WebCore/platform/graphics/ca/TileController.cpp:
(WebCore::TileController::adjustedTileClipRectForObscuredInsets const):
  The adjustment of the tile clip rect is simply to inflate it by a size
  accounting for the delta in obscured insets across visible rect
  updates. We do this by diffs rather than absolute obscured inset
  values so that the workaround is active and used only when necessary
  (e.g. a new obscured insets are set) .
* Source/WebCore/platform/graphics/ca/TileController.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
  Add a transaction ID `firstTransactionIDAfterObscuredInsetChange` in
  the web view&apos;s per process state. This allows us to hold off on view
  layout size change dispathces till later.
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _setObscuredInsetsInternal:]):
(-[WKWebView _didCommitLayerTree:]):
  If we&apos;ve committed the layer tree, check if we were waiting for a
  transaction post obscured insets application. If so, stop deferring
  geometry updates.
(-[WKWebView _overrideLayoutParametersWithMinimumLayoutSize:minimumUnobscuredSizeOverride:maximumUnobscuredSizeOverride:]):
(-[WKWebView _shouldDispatchOverridenLayoutParametersImmediately]):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::updateVisibleContentRects):
* Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp:

Canonical link: <a href="https://commits.webkit.org/297499@main">https://commits.webkit.org/297499@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1ea6fbd3d9fc4f3bf08e8e4beca95375fb6aabb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112022 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/31693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/22178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/118045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/62259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113984 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/32369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/40270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/118045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/62259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114969 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/32369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/22178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/118045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/32369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/22178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/61897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/32369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/22178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/121364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/39055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/40270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/121364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/39436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/22178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/121364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/22178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/35077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18052 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/38949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/44461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/38586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/41914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/40302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->