### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in WTF::ConcurrentBuffer

### DIFF
--- a/Source/WTF/wtf/ConcurrentBuffer.h
+++ b/Source/WTF/wtf/ConcurrentBuffer.h
@@ -29,11 +29,10 @@
 #include <wtf/FastMalloc.h>
 #include <wtf/HashFunctions.h>
 #include <wtf/Lock.h>
+#include <wtf/MallocPtr.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WTF {
 
@@ -47,37 +46,33 @@ class ConcurrentBuffer final {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     
-    ConcurrentBuffer()
-    {
-    }
+    ConcurrentBuffer() = default;
     
     ~ConcurrentBuffer()
     {
-        if (Array* array = m_array) {
-            for (size_t i = 0; i < array->size; ++i)
-                array->data[i].~T();
+        if (auto* array = m_array) {
+            for (auto& item : array->span())
+                item.~T();
         }
-        for (Array* array : m_allArrays)
-            ConcurrentBufferMalloc::free(array);
     }
 
     // Growing is not concurrent. This assumes you are holding some other lock before you do this.
     void growExact(size_t newSize)
     {
-        Array* array = m_array;
+        auto* array = m_array;
         if (array && newSize <= array->size)
             return;
-        Array* newArray = createArray(newSize);
+        auto newArray = createArray(newSize);
         // This allows us to do ConcurrentBuffer<std::unique_ptr<>>.
         // asMutableByteSpan() avoids triggering -Wclass-memaccess.
         if (array)
             memcpySpan(asMutableByteSpan(newArray->span()), asByteSpan(array->span()));
-        for (size_t i = array ? array->size : 0; i < newSize; ++i)
-            new (newArray->data + i) T();
+        for (auto& item : newArray->span().subspan(array ? array->size : 0))
+            new (&item) T();
         WTF::storeStoreFence();
-        m_array = newArray;
+        m_array = newArray.get();
         WTF::storeStoreFence();
-        m_allArrays.append(newArray);
+        m_allArrays.append(WTFMove(newArray));
     }
     
     void grow(size_t newSize)
@@ -98,24 +93,22 @@ public:
     
     Array* array() const { return m_array; }
     
-    T& operator[](size_t index) { return m_array->data[index]; }
-    const T& operator[](size_t index) const { return m_array->data[index]; }
+    T& operator[](size_t index) { return m_array->span()[index]; }
+    const T& operator[](size_t index) const { return m_array->span()[index]; }
     
 private:
-    Array* createArray(size_t size)
+    MallocPtr<Array, ConcurrentBufferMalloc> createArray(size_t size)
     {
         Checked<size_t> objectSize = sizeof(T);
         objectSize *= size;
         objectSize += static_cast<size_t>(OBJECT_OFFSETOF(Array, data));
-        Array* result = static_cast<Array*>(ConcurrentBufferMalloc::malloc(objectSize));
+        auto result = MallocPtr<Array, ConcurrentBufferMalloc>::malloc(objectSize);
         result->size = size;
         return result;
     }
     
     Array* m_array { nullptr };
-    Vector<Array*> m_allArrays;
+    Vector<MallocPtr<Array, ConcurrentBufferMalloc>> m_allArrays;
 };
 
 } // namespace WTF
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### 0bbdfbb65d4e4adf989efb7e93509bc154e514b6
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in WTF::ConcurrentBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=295921">https://bugs.webkit.org/show_bug.cgi?id=295921</a>

Reviewed by Darin Adler.

This tested as performance neutral on Speedometer and JetStream.

* Source/WTF/wtf/ConcurrentBuffer.h:

Canonical link: <a href="https://commits.webkit.org/297481@main">https://commits.webkit.org/297481@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff6427f4816eb9b9c4eef73c6055cf4d2c1c0dd1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111515 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31181 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117547 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61788 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31862 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39763 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84738 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35531 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114462 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25439 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100376 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65186 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24786 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18512 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61371 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/104008 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94823 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18577 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120776 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/110069 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38564 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28655 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93665 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38940 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96644 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93487 "Found 1 new API test failure: /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23919 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38602 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16384 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34601 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38453 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43930 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/134344 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38118 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36201 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41451 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39820 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->