### PR TITLE
AX: Building AXObjectCache::{m_sortedLiveRegionIDs, m_sortedLiveRegionIDs} does `n - 1` unnecessary full-tree walks when processing `n` objects that need sorting at the same time

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -109,7 +109,7 @@ enum class ClickHandlerFilter : bool {
     IncludeBody,
 };
 
-enum class PreSortedObjectType : bool { LiveRegion, WebArea };
+enum class PreSortedObjectType : uint8_t { LiveRegion, WebArea };
 
 enum class DateComponentsType : uint8_t;
 

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -673,7 +673,9 @@ public:
 #if PLATFORM(MAC)
     AXCoreObject::AccessibilityChildrenVector sortedLiveRegions();
     AXCoreObject::AccessibilityChildrenVector sortedNonRootWebAreas();
-    void addSortedObject(AccessibilityObject&, PreSortedObjectType);
+    void deferSortForNewLiveRegion(Ref<AccessibilityObject>&&);
+    void queueUnsortedObject(Ref<AccessibilityObject>&&, PreSortedObjectType);
+    void addSortedObjects(Vector<Ref<AccessibilityObject>>&&, PreSortedObjectType);
     void removeLiveRegion(AccessibilityObject&);
     void initializeSortedIDLists();
 
@@ -943,7 +945,7 @@ private:
     std::optional<std::pair<WeakPtr<Element, WeakPtrImplWithEventTargetData>, WeakPtr<Element, WeakPtrImplWithEventTargetData>>> m_deferredFocusedNodeChange;
     WeakHashSet<AccessibilityObject> m_deferredUnconnectedObjects;
 #if PLATFORM(MAC)
-    WeakHashSet<Document, WeakPtrImplWithEventTargetData> m_deferredDocumentAddedList;
+    HashMap<PreSortedObjectType, Vector<Ref<AccessibilityObject>>, IntHash<PreSortedObjectType>, WTF::StrongEnumHashTraits<PreSortedObjectType>> m_deferredUnsortedObjects;
 #endif
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)

--- a/Source/WebCore/accessibility/AXSearchManager.cpp
+++ b/Source/WebCore/accessibility/AXSearchManager.cpp
@@ -284,7 +284,7 @@ AXCoreObject::AccessibilityChildrenVector AXSearchManager::findMatchingObjectsIn
         return { };
 
 #if PLATFORM(MAC)
-    if (criteria.searchKeys.size() == 1 && criteria.usePreCachedResults) {
+    if (criteria.searchKeys.size() == 1) {
         // Only perform these optimizations if we aren't expected to start from somewhere mid-tree.
         // We could probably implement these optimizations when we do have a startObject and get
         // performance benefits, but no known assistive technology needs this right now.
@@ -411,37 +411,6 @@ std::optional<AXTextMarkerRange> AXSearchManager::findMatchingRange(Accessibilit
         return forward ? ranges[0] : ranges.last();
     }
     return std::nullopt;
-}
-
-AXCoreObject* AXSearchManager::findNextStartingFrom(AccessibilitySearchKey key, AXCoreObject* start, AXCoreObject& anchor)
-{
-    AccessibilitySearchCriteria criteria;
-    criteria.startObject = start;
-    criteria.anchorObject = &anchor;
-    criteria.searchDirection = AccessibilitySearchDirection::Next;
-    criteria.searchKeys = { key };
-    criteria.resultsLimit = 1;
-    criteria.visibleOnly = false;
-    criteria.immediateDescendantsOnly = false;
-    criteria.usePreCachedResults = false;
-
-    auto results = findMatchingObjectsInternal(criteria);
-    return results.size() ? results[0].ptr() : nullptr;
-}
-
-AXCoreObject::AccessibilityChildrenVector AXSearchManager::findAllMatchingObjectsIgnoringCache(Vector<AccessibilitySearchKey>&& keys, AXCoreObject& anchor)
-{
-    AccessibilitySearchCriteria criteria;
-    criteria.anchorObject = &anchor;
-    criteria.startObject = nullptr;
-    criteria.searchDirection = AccessibilitySearchDirection::Next;
-    criteria.searchKeys = WTFMove(keys);
-    criteria.resultsLimit = std::numeric_limits<unsigned>::max();
-    criteria.visibleOnly = false;
-    criteria.immediateDescendantsOnly = false;
-    criteria.usePreCachedResults = false;
-
-    return findMatchingObjectsInternal(criteria);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AXSearchManager.h
+++ b/Source/WebCore/accessibility/AXSearchManager.h
@@ -87,16 +87,11 @@ struct AccessibilitySearchCriteria {
     unsigned resultsLimit { 0 };
     bool visibleOnly { false };
     bool immediateDescendantsOnly { false };
-    // For some types of common searches (e.g. all the live regions on the page), we eagerly
-    // compute results. This flag determines whether to use these precached results or not.
-    bool usePreCachedResults { true };
 };
 
 class AXSearchManager {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(AXSearchManager);
 public:
-    AXCoreObject* findNextStartingFrom(AccessibilitySearchKey, AXCoreObject* start, AXCoreObject& anchor);
-    AXCoreObject::AccessibilityChildrenVector findAllMatchingObjectsIgnoringCache(Vector<AccessibilitySearchKey>&&, AXCoreObject& anchor);
     AXCoreObject::AccessibilityChildrenVector findMatchingObjects(AccessibilitySearchCriteria&&);
     std::optional<AXTextMarkerRange> findMatchingRange(AccessibilitySearchCriteria&&);
 private:

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -257,12 +257,6 @@ RefPtr<AXIsolatedTree> AXIsolatedTree::treeForPageID(PageIdentifier pageID)
     return nullptr;
 }
 
-AXIsolatedObject* AXIsolatedTree::objectForID(AXID axID) const
-{
-    ASSERT(!isMainThread());
-    return m_readerThreadNodeMap.get(axID);
-}
-
 void AXIsolatedTree::generateSubtree(AccessibilityObject& axObject)
 {
     AXTRACE("AXIsolatedTree::generateSubtree"_s);

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -418,7 +418,15 @@ public:
     std::optional<AXID> focusedNodeID();
     WEBCORE_EXPORT RefPtr<AXIsolatedObject> focusedNode();
 
-    AXIsolatedObject* objectForID(AXID) const;
+    inline AXIsolatedObject* objectForID(AXID axID) const
+    {
+        ASSERT(!isMainThread());
+
+        auto iterator = m_readerThreadNodeMap.find(axID);
+        if (iterator != m_readerThreadNodeMap.end())
+            return iterator->value.ptr();
+        return nullptr;
+    }
     inline AXIsolatedObject* objectForID(std::optional<AXID> axID) const
     {
         return axID ? objectForID(*axID) : nullptr;


### PR DESCRIPTION
#### 3d2e2734107105b8dba93097ebc61d00ad084868
<pre>
AX: Building AXObjectCache::{m_sortedLiveRegionIDs, m_sortedLiveRegionIDs} does `n - 1` unnecessary full-tree walks when processing `n` objects that need sorting at the same time
<a href="https://bugs.webkit.org/show_bug.cgi?id=295920">https://bugs.webkit.org/show_bug.cgi?id=295920</a>
<a href="https://rdar.apple.com/155817283">rdar://155817283</a>

Reviewed by Joshua Hoffman.

Some webpages will add many live regions all at once. When this happens, we&apos;ll call handleLiveRegionCreated in a loop,
with each iteration calling AXObjectCache::addSortedObject. This function then does what can be a full tree walk to try
to place this single object.

Optimize this in two ways:

  1. Group objects that need sorting, and process them all at once in a new AXObjectCache::addSortedObjects function.

  2. Use a pre-order tree traversal for sorting rather than AXSearchManager. AXSearchManager has a complicated searching
     algorithm that is essentially a pre-order traversal, but does a ton of probably unnecessary work. I&apos;ve tried to
     re-write AXSearchManager to do a simple pre-order traversal, but was unsuccessful at the time. In any case, the simple
     and much faster pre-order traversal is fine for sorting objects, so this commit does that.

This commit also inlines AXIsolatedTree::objectForID by using HashMap::find instead of HashMap::get. HashMap::get wouldn&apos;t
work because it would require including AXIsolatedObject.h in AXIsolatedTree.h, which would cause a circular dependency.
HashMap::find avoids this issue. objectForID is an extremely hot function, so increasing the chance it gets inlined
made a difference in samples taken while debugging the original object-sorting issue.

* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::handleMenuOpened):
(WebCore::AXObjectCache::handleLiveRegionCreated):
(WebCore::AXObjectCache::handleRoleChanged):
(WebCore::AXObjectCache::handleAttributeChange):
(WebCore::AXObjectCache::performDeferredCacheUpdate):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AXSearchManager.cpp:
(WebCore::AXSearchManager::findMatchingObjectsInternal):
(WebCore::AXSearchManager::findNextStartingFrom): Deleted.
(WebCore::AXSearchManager::findAllMatchingObjectsIgnoringCache): Deleted.
* Source/WebCore/accessibility/AXSearchManager.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::objectForID const): Deleted.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
(WebCore::AXIsolatedTree::objectForID const):
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::AXObjectCache::onDocumentRenderTreeCreation):
(WebCore::AXObjectCache::deferSortForLiveRegion):
(WebCore::AXObjectCache::queueUnsortedObject):
(WebCore::AXObjectCache::platformPerformDeferredCacheUpdate):
(WebCore::AXObjectCache::addSortedObjects):
(WebCore::AXObjectCache::initializeSortedIDLists):
(WebCore::AXObjectCache::addSortedObject): Deleted.

Canonical link: <a href="https://commits.webkit.org/297427@main">https://commits.webkit.org/297427@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c0cb6f78c7d9cf47fa5d45ce48f851e87806506

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111544 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31211 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21675 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117587 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61815 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113506 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31891 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39792 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84765 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35540 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114491 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25451 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100392 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65206 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24805 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18528 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61407 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94848 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18592 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120878 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38597 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28682 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93695 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39031 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96659 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93520 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23866 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38649 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16398 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34633 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38494 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43959 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38149 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41485 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39851 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->