### PR TITLE
Add new WebDriver capability to control Site Isolation runtime enablement

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/RemoteInspector.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspector.h
@@ -105,6 +105,7 @@ public:
             std::optional<bool> allowInsecureMediaCapture;
             std::optional<bool> suppressICECandidateFiltering;
             std::optional<bool> alwaysAllowAutoplay;
+            std::optional<bool> siteIsolationEnabled;
 #endif
         };
 

--- a/Source/JavaScriptCore/inspector/remote/RemoteInspectorConstants.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspectorConstants.h
@@ -121,6 +121,7 @@
 #define WIRAcceptInsecureCertificatesKey               @"org.webkit.webdriver.accept-insecure-certificates"
 #define WIRAlwaysAllowAutoplay                         @"org.webkit.webdriver.always-allow-autoplay"
 #define WIRAllowInsecureMediaCaptureCapabilityKey      @"org.webkit.webdriver.webrtc.allow-insecure-media-capture"
+#define WIRSiteIsolationEnabled                        @"org.webkit.webdriver.site-isolation-enabled"
 #define WIRSuppressICECandidateFilteringCapabilityKey  @"org.webkit.webdriver.webrtc.suppress-ice-candidate-filtering"
 
 // These definitions are shared with a Simulator webinspectord and

--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
@@ -854,6 +854,11 @@ void RemoteInspector::receivedAutomationSessionRequestMessage(NSDictionary *user
             sessionCapabilities.alwaysAllowAutoplay = value.boolValue;
     }
 
+    if (NSNumber *value = forwardedCapabilities[WIRSiteIsolationEnabled]) {
+        if ([value isKindOfClass:NSNumber.class])
+            sessionCapabilities.siteIsolationEnabled = value.boolValue;
+    }
+
     if (!m_client)
         return;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionConfiguration.h
@@ -36,6 +36,7 @@ WK_CLASS_AVAILABLE(macos(10.13.4), ios(12.2))
 @property (nonatomic) BOOL allowsInsecureMediaCapture;
 @property (nonatomic) BOOL suppressesICECandidateFiltering;
 @property (nonatomic) BOOL alwaysAllowAutoplay;
+@property (nonatomic) BOOL siteIsolationEnabled;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionConfiguration.mm
@@ -37,6 +37,7 @@
     _allowsInsecureMediaCapture = YES;
     _suppressesICECandidateFiltering = NO;
     _alwaysAllowAutoplay = NO;
+    _siteIsolationEnabled = NO;
 
     return self;
 }
@@ -49,6 +50,7 @@
     configuration.allowsInsecureMediaCapture = self.allowsInsecureMediaCapture;
     configuration.suppressesICECandidateFiltering = self.suppressesICECandidateFiltering;
     configuration.alwaysAllowAutoplay = self.alwaysAllowAutoplay;
+    configuration.siteIsolationEnabled = self.siteIsolationEnabled;
 
     return configuration;
 }

--- a/Source/WebKit/UIProcess/Cocoa/AutomationClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/AutomationClient.mm
@@ -85,6 +85,8 @@ void AutomationClient::requestAutomationSession(const String& sessionIdentifier,
         [configuration setSuppressesICECandidateFiltering:sessionCapabilities.suppressICECandidateFiltering.value()];
     if (sessionCapabilities.alwaysAllowAutoplay)
         [configuration setAlwaysAllowAutoplay:sessionCapabilities.alwaysAllowAutoplay.value()];
+    if (sessionCapabilities.siteIsolationEnabled)
+        [configuration setSiteIsolationEnabled:sessionCapabilities.siteIsolationEnabled.value()];
 
     // Force clients to create and register a session asynchronously. Otherwise,
     // RemoteInspector will try to acquire its lock to register the new session and


### PR DESCRIPTION
#### 9dc4585e143ce284259f78bf47638c7b804799ce
<pre>
Add new WebDriver capability to control Site Isolation runtime enablement
<a href="https://rdar.apple.com/155249855">rdar://155249855</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=296394">https://bugs.webkit.org/show_bug.cgi?id=296394</a>

Reviewed by BJ Burg.

Introduce support of a new WebDriver capability, webkit:siteIsolationEnabled,
to allow testing of site isolation easier.

* Source/JavaScriptCore/inspector/remote/RemoteInspector.h:
* Source/JavaScriptCore/inspector/remote/RemoteInspectorConstants.h:
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm:
(Inspector::RemoteInspector::receivedAutomationSessionRequestMessage):
* Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionConfiguration.mm:
(-[_WKAutomationSessionConfiguration init]):
(-[_WKAutomationSessionConfiguration copyWithZone:]):
* Source/WebKit/UIProcess/Cocoa/AutomationClient.mm:
(WebKit::AutomationClient::requestAutomationSession):

Canonical link: <a href="https://commits.webkit.org/297993@main">https://commits.webkit.org/297993@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b06f4a82582320e8d3ae3b93ae8b66fddd31e4e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112914 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32649 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23127 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119118 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63629 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33301 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41212 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85930 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36698 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115861 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26577 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101572 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66237 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25863 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19705 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62876 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/105431 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95970 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19778 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122339 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/111530 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39992 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29819 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94793 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40376 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97792 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94531 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24264 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39660 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17479 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/36105 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39878 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45377 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/135760 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39519 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36465 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42852 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41256 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->