### PR TITLE
[WIP] builtin profiling, DFG work for filter

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -950,6 +950,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/BooleanPrototype.h
     runtime/BrandedStructure.h
     runtime/BufferMemoryHandle.h
+    runtime/BuiltinProfiling.h
     runtime/Butterfly.h
     runtime/ButterflyInlines.h
     runtime/BytecodeCacheError.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -913,6 +913,7 @@
 		2AD2EDFB19799E38004D6478 /* EnumerationMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 2AD2EDFA19799E38004D6478 /* EnumerationMode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2AD8932B17E3868F00668276 /* HeapIterationScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 2AD8932917E3868F00668276 /* HeapIterationScope.h */; };
 		2BDF4F7129E9E8BB0056BF50 /* PASReportCrashPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BDF4F6F29E9E8BB0056BF50 /* PASReportCrashPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2CFA3D562DEA2E8300ABCC7C /* BuiltinProfiling.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CFA3D532DEA2E8300ABCC7C /* BuiltinProfiling.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2D342F36F7244096804ADB24 /* SourceOrigin.h in Headers */ = {isa = PBXBuildFile; fileRef = 425BA1337E4344E1B269A671 /* SourceOrigin.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		31770C5527B94CE600308091 /* TemporalPlainDateConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = 31770C4F27B94CE400308091 /* TemporalPlainDateConstructor.h */; };
 		31770C5727B94CE600308091 /* TemporalPlainDatePrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 31770C5127B94CE400308091 /* TemporalPlainDatePrototype.h */; };
@@ -3990,6 +3991,8 @@
 		2ADFA26218EF3540004F9FCC /* GCLogging.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GCLogging.cpp; sourceTree = "<group>"; };
 		2BDF4F6E29E9E8BB0056BF50 /* PASReportCrashPrivate.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PASReportCrashPrivate.cpp; sourceTree = "<group>"; };
 		2BDF4F6F29E9E8BB0056BF50 /* PASReportCrashPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PASReportCrashPrivate.h; sourceTree = "<group>"; };
+		2CFA3D532DEA2E8300ABCC7C /* BuiltinProfiling.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BuiltinProfiling.h; sourceTree = "<group>"; };
+		2CFA3D542DEA2E8300ABCC7C /* BuiltinProfiling.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BuiltinProfiling.cpp; sourceTree = "<group>"; };
 		2E3AF00D28171AC000371A25 /* ShadowRealmPrototype.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = ShadowRealmPrototype.js; sourceTree = "<group>"; };
 		3032175DF1AD47D8998B34E1 /* JSSourceCode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSSourceCode.h; sourceTree = "<group>"; };
 		30A5F403F11C4F599CD596D5 /* WasmTypeDefinitionInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmTypeDefinitionInlines.h; sourceTree = "<group>"; };
@@ -8075,6 +8078,8 @@
 				861AF60625D18C9D000B63E1 /* BrandedStructure.h */,
 				E3B24858291224530029C08A /* BufferMemoryHandle.cpp */,
 				E3B24857291224530029C08A /* BufferMemoryHandle.h */,
+				2CFA3D542DEA2E8300ABCC7C /* BuiltinProfiling.cpp */,
+				2CFA3D532DEA2E8300ABCC7C /* BuiltinProfiling.h */,
 				9E72940A190F0514001A91B5 /* BundlePath.h */,
 				9E729409190F0306001A91B5 /* BundlePath.mm */,
 				0FB7F38B15ED8E3800F167B2 /* Butterfly.h */,
@@ -10538,6 +10543,7 @@
 				DE26E9031CB5DD0500D2BE82 /* BuiltinExecutableCreator.h in Headers */,
 				A7D801A51880D66E0026C39B /* BuiltinExecutables.h in Headers */,
 				A75EE9B218AAB7E200AAD043 /* BuiltinNames.h in Headers */,
+				2CFA3D562DEA2E8300ABCC7C /* BuiltinProfiling.h in Headers */,
 				99DA00A71BD5993100F4575C /* builtins_generate_combined_header.py in Headers */,
 				99DA00A81BD5993100F4575C /* builtins_generate_combined_implementation.py in Headers */,
 				412952771D2CF6BC00E78B89 /* builtins_generate_internals_wrapper_header.py in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -757,6 +757,7 @@ runtime/BooleanObject.cpp
 runtime/BooleanPrototype.cpp
 runtime/BrandedStructure.cpp
 runtime/BufferMemoryHandle.cpp
+runtime/BuiltinProfiling.cpp
 runtime/BytecodeCacheError.cpp
 runtime/CallData.cpp
 runtime/CachePayload.cpp

--- a/Source/JavaScriptCore/builtins/ArrayPrototype.js
+++ b/Source/JavaScriptCore/builtins/ArrayPrototype.js
@@ -130,33 +130,6 @@ function forEach(callback /*, thisArg */)
     }
 }
 
-@alwaysInline
-function filter(callback /*, thisArg */)
-{
-    "use strict";
-
-    var array = @toObject(this, "Array.prototype.filter requires that |this| not be null or undefined");
-    var length = @toLength(array.length);
-
-    if (!@isCallable(callback))
-        @throwTypeError("Array.prototype.filter callback must be a function");
-    
-    var thisArg = @argument(1);
-    var result = @newArrayWithSpecies(0, array);
-
-    var nextIndex = 0;
-    for (var i = 0; i < length; i++) {
-        if (!(i in array))
-            continue;
-        var current = array[i]
-        if (callback.@call(thisArg, current, i, array)) {
-            @putByValDirect(result, nextIndex, current);
-            ++nextIndex;
-        }
-    }
-    return result;
-}
-
 function map(callback /*, thisArg */)
 {
     "use strict";

--- a/Source/JavaScriptCore/bytecode/InlineCallFrame.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCallFrame.cpp
@@ -88,45 +88,12 @@ namespace WTF {
 void printInternal(PrintStream& out, JSC::InlineCallFrame::Kind kind)
 {
     switch (kind) {
-    case JSC::InlineCallFrame::Call:
-        out.print("Call");
+#define X(k) case JSC::InlineCallFrame::k: \
+        out.print(#k); \
         return;
-    case JSC::InlineCallFrame::Construct:
-        out.print("Construct");
-        return;
-    case JSC::InlineCallFrame::TailCall:
-        out.print("TailCall");
-        return;
-    case JSC::InlineCallFrame::CallVarargs:
-        out.print("CallVarargs");
-        return;
-    case JSC::InlineCallFrame::ConstructVarargs:
-        out.print("ConstructVarargs");
-        return;
-    case JSC::InlineCallFrame::TailCallVarargs:
-        out.print("TailCallVarargs");
-        return;
-    case JSC::InlineCallFrame::GetterCall:
-        out.print("GetterCall");
-        return;
-    case JSC::InlineCallFrame::SetterCall:
-        out.print("SetterCall");
-        return;
-    case JSC::InlineCallFrame::ProxyObjectLoadCall:
-        out.print("ProxyObjectLoadCall");
-        return;
-    case JSC::InlineCallFrame::ProxyObjectStoreCall:
-        out.print("ProxyObjectStoreCall");
-        return;
-    case JSC::InlineCallFrame::ProxyObjectInCall:
-        out.print("ProxyObjectInCall");
-        return;
-    case JSC::InlineCallFrame::BoundFunctionCall:
-        out.print("BoundFunctionCall");
-        return;
-    case JSC::InlineCallFrame::BoundFunctionTailCall:
-        out.print("BoundFunctionTailCall");
-        return;
+
+        JSC_FOR_EACH_INLINECALLFRAME_KIND(X)
+#undef X
     }
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/Source/JavaScriptCore/bytecode/InlineCallFrame.h
+++ b/Source/JavaScriptCore/bytecode/InlineCallFrame.h
@@ -45,23 +45,27 @@ DECLARE_COMPACT_ALLOCATOR_WITH_HEAP_IDENTIFIER(InlineCallFrame);
 struct InlineCallFrame {
     WTF_MAKE_STRUCT_FAST_COMPACT_ALLOCATED_WITH_HEAP_IDENTIFIER(InlineCallFrame);
 
+/* For GetterCall-BoundFunctionTailCall, the stackOffset incorporates the argument count plus the true return PC slot. */ \
+#define JSC_FOR_EACH_INLINECALLFRAME_KIND(macro) \
+    macro(Call) \
+    macro(Construct) \
+    macro(TailCall) \
+    macro(CallVarargs) \
+    macro(ConstructVarargs) \
+    macro(TailCallVarargs) \
+    macro(GetterCall) \
+    macro(SetterCall) \
+    macro(ProxyObjectLoadCall) \
+    macro(ProxyObjectStoreCall) \
+    macro(ProxyObjectInCall) \
+    macro(BoundFunctionCall) \
+    macro(BoundFunctionTailCall) \
+    macro(NativeBuiltinCall)
+
     enum Kind {
-        Call,
-        Construct,
-        TailCall,
-        CallVarargs,
-        ConstructVarargs,
-        TailCallVarargs,
-        
-        // For these, the stackOffset incorporates the argument count plus the true return PC
-        // slot.
-        GetterCall,
-        SetterCall,
-        ProxyObjectLoadCall,
-        ProxyObjectStoreCall,
-        ProxyObjectInCall,
-        BoundFunctionCall,
-        BoundFunctionTailCall,
+#define X(kind) kind,
+        JSC_FOR_EACH_INLINECALLFRAME_KIND(X)
+#undef X
     };
     static constexpr unsigned bitWidthOfKind = 4;
 
@@ -84,6 +88,8 @@ struct InlineCallFrame {
         case Construct:
         case ConstructVarargs:
             return CallMode::Construct;
+        case NativeBuiltinCall:
+            break; // TODO: see if this is needed
         }
         RELEASE_ASSERT_NOT_REACHED();
     }
@@ -132,6 +138,8 @@ struct InlineCallFrame {
         case Construct:
         case ConstructVarargs:
             return CodeSpecializationKind::CodeForConstruct;
+        case NativeBuiltinCall:
+            break; // TODO: see if this is needed
         }
         RELEASE_ASSERT_NOT_REACHED();
     }

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -187,6 +187,7 @@ private:
     void makeBlockTargetable(BasicBlock*, BytecodeIndex);
     void addJumpTo(BasicBlock*);
     void addJumpTo(unsigned bytecodeIndex);
+    void addBranch(Node* condition, BasicBlock* trueBlock, BasicBlock* falseBlock);
     // Handle calls. This resolves issues surrounding inlining and intrinsics.
     enum Terminality { Terminal, NonTerminal };
     Terminality handleCall(
@@ -1419,6 +1420,15 @@ void ByteCodeParser::addJumpTo(unsigned bytecodeIndex)
     m_inlineStackTop->m_unlinkedBlocks.append(m_currentBlock);
 }
 
+void ByteCodeParser::addBranch(Node* condition, BasicBlock* taken, BasicBlock* notTaken)
+{
+    ASSERT(!m_currentBlock->terminal());
+    BranchData* branchData = m_graph.m_branchData.add();
+    branchData->taken = BranchTarget(taken);
+    branchData->notTaken = BranchTarget(notTaken);
+    addToGraph(Branch, OpInfo(branchData), condition);
+}
+
 template<typename CallOp>
 ByteCodeParser::Terminality ByteCodeParser::handleCall(const JSInstruction* pc, NodeType op, CallMode callMode, BytecodeIndex osrExitIndex, Node* newTarget)
 {
@@ -2649,7 +2659,308 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             setResult(iterator);
             return CallOptimizationResult::Inlined;
         }
-            
+
+        case ArrayFilterIntrinsic: {
+            if (argumentCountIncludingThis < 2)
+                return CallOptimizationResult::DidNothing;
+
+            JSFunction* function = variant.function();
+            if (!function || !function->rareData())
+                return CallOptimizationResult::DidNothing;
+
+            ArrayMode arrayMode = getArrayMode(Array::Action::Write);
+            if (!arrayMode.isJSArray())
+                return CallOptimizationResult::DidNothing;
+
+            FunctionRareData* rareData = function->rareData();
+            ASSERT(rareData);
+
+            auto* profile = rareData->tryGetBuiltinProfileOfKind<BuiltinProfiling::ArrayPrototypeFilterProfile>();
+            if (!profile)
+                return CallOptimizationResult::DidNothing;
+
+            profile->updateValueProfiles(m_codeBlock->m_lock);
+
+            JSGlobalObject* globalObject = m_graph.globalObjectFor(currentNodeOrigin().semantic);
+            if (globalObject->arraySpeciesWatchpointSet().state() != IsWatched
+                || !globalObject->havingABadTimeWatchpointSet().isStillValid()
+                || globalObject->arrayPrototypeChainIsSaneWatchpointSet().state() != IsWatched) {
+                return CallOptimizationResult::DidNothing;
+            }
+
+            m_graph.watchpoints().addLazily(globalObject->arraySpeciesWatchpointSet());
+            m_graph.watchpoints().addLazily(globalObject->havingABadTimeWatchpointSet());
+            m_graph.watchpoints().addLazily(globalObject->arrayPrototypeChainIsSaneWatchpointSet());
+
+            auto exitOK = [&] ALWAYS_INLINE_LAMBDA {
+                m_exitOK = true;
+                addToGraph(ExitOK);
+            };
+
+            BasicBlock* bbThrowTypeError = allocateUntargetableBlock();
+            BasicBlock* bbAllocations = allocateUntargetableBlock();
+            BasicBlock* bbLoopHeader = allocateUntargetableBlock();
+            BasicBlock* bbLoopExitReturnA = allocateUntargetableBlock();
+            BasicBlock* bbLoopBodyHasProp = allocateUntargetableBlock();
+            BasicBlock* bbLoopBodyIncK = allocateUntargetableBlock();
+            BasicBlock* bbLoopBodyCheck = allocateUntargetableBlock();
+            BasicBlock* bbLoopBodySetProp = allocateUntargetableBlock();
+            BasicBlock* continuation = allocateUntargetableBlock();
+
+            auto oldIndex = m_currentIndex;
+
+            dataLogLn("bforward - ArrayFilterIntrinsic #########################################################");
+
+            ensureTmps(10);
+            auto k = Operand::tmp(0);
+            auto to = Operand::tmp(1);
+            auto scratch = Operand::tmp(2);
+            auto obj = Operand::tmp(3);
+            auto len = Operand::tmp(4);
+            auto arr = Operand::tmp(5);
+            auto val = Operand::tmp(6);
+
+            auto argThis = Operand::tmp(7);
+            auto argCallback = Operand::tmp(8);
+            auto argThisArg = Operand::tmp(9);
+
+            exitOK();
+            dataLogLn("bforward - before insertChecks()");
+            insertChecks(true);
+            dataLogLn("bforward - after insertChecks()");
+
+            set(argThis, get(virtualRegisterForArgumentIncludingThis(0, registerOffset)), ImmediateSetWithFlush);
+            set(argCallback, get(virtualRegisterForArgumentIncludingThis(1, registerOffset)), ImmediateSetWithFlush);
+            set(argThisArg, (argumentCountIncludingThis >= 3) ? get(virtualRegisterForArgumentIncludingThis(2, registerOffset)) : jsConstant(jsUndefined()), ImmediateSetWithFlush);
+
+            {
+                dataLogLn("bforward - before ToThis/ToObject/ToLength/IsCallable");
+
+                exitOK();
+                Node* toThisResult = addToGraph(ToThis, OpInfo(ECMAMode::strict()), OpInfo(profile->m_thisValueProfile.m_prediction), get(argThis));
+                Node* toObjectResult = addToGraph(ToObject, OpInfo(UINT32_MAX /* TODO: errorStringIndex? */), OpInfo(profile->m_toObjectValueProfile.m_prediction), toThisResult);
+
+                exitOK();
+                set(obj, toObjectResult);
+
+                exitOK();
+                Node* toLengthResult = addToGraph(ToLength, OpInfo(0), OpInfo(profile->m_toLengthValueProfile.m_prediction), toObjectResult);
+                set(len, toLengthResult);
+
+                exitOK();
+                Node* callableResult = addToGraph(IsCallable, get(argCallback));
+
+                processSetLocalQueue();
+                addBranch(callableResult, bbAllocations, bbThrowTypeError);
+
+                dataLogLn("bforward - after ToThis/ToObject/ToLength/IsCallable");
+            }
+
+            {
+                dataLogLn("bforward - bbThrowTypeError BEGIN");
+                m_currentBlock = bbThrowTypeError;
+                clearCaches();
+
+                LazyJSValue errorString = LazyJSValue::newString(m_graph, "Array.prototype.filter callback must be a function"_s);
+                OpInfo info(m_graph.m_lazyJSValues.add(errorString));
+                Node* errorMessage = addToGraph(LazyJSConstant, info);
+                addToGraph(ThrowStaticError, OpInfo(ErrorType::TypeError), errorMessage);
+
+                processSetLocalQueue();
+                flushForTerminal();
+
+                dataLogLn("bforward - bbThrowTypeError END");
+            }
+
+            {
+                dataLogLn("bforward - bbAllocations BEGIN");
+                m_currentBlock = bbAllocations;
+                clearCaches();
+
+                Node* zero = jsConstant(jsNumber(0));
+
+                NewArrayWithSpeciesData data;
+                data.arrayMode = arrayMode.asWord();
+                data.indexingMode = profile->m_arrayAllocProfile.selectIndexingTypeConcurrently();
+                Node* newArray = addToGraph(NewArrayWithSpecies, OpInfo(data.asQuadWord()), OpInfo(ArrayUse), Edge(zero, KnownInt32Use), Edge(get(obj), KnownCellUse));
+
+                set(arr, newArray);
+
+                set(k, zero);
+                set(to, zero);
+
+                processSetLocalQueue();
+                addJumpTo(bbLoopHeader);
+
+                dataLogLn("bforward - bbAllocations END");
+            }
+
+
+            {
+                dataLogLn("bforward - bbLoopHeader BEGIN");
+                m_currentBlock = bbLoopHeader;
+                clearCaches();
+
+                exitOK();
+                Node* compareResult = addToGraph(CompareGreaterEq, get(k), get(len));
+
+                processSetLocalQueue();
+                addBranch(compareResult, bbLoopExitReturnA, bbLoopBodyHasProp);
+
+                dataLogLn("bforward - bbLoopHeader END");
+            }
+
+            {
+                dataLogLn("bforward - bbLoopExitReturnA BEGIN");
+                m_currentBlock = bbLoopExitReturnA;
+                clearCaches();
+
+                setResult(get(arr));
+
+                processSetLocalQueue();
+                addJumpTo(continuation);
+
+                dataLogLn("bforward - bbLoopExitReturnA END");
+            }
+
+            {
+                dataLogLn("bforward - bbLoopBodyHasProp BEGIN");
+                m_currentBlock = bbLoopBodyHasProp;
+                clearCaches();
+
+                ArrayMode arrayMode2 = getArrayMode(Array::Read); // TODO: from profile
+                exitOK();
+                set(scratch, addToGraph(InByVal, OpInfo(arrayMode2.asWord()), get(obj), get(k)));
+
+                processSetLocalQueue();
+                addBranch(get(scratch), bbLoopBodyCheck, bbLoopBodyIncK);
+
+                dataLogLn("bforward - bbLoopBodyHasProp END");
+            }
+
+            {
+                dataLogLn("bforward - bbLoopBodyCheck BEGIN");
+                m_currentBlock = bbLoopBodyCheck;
+                clearCaches();
+
+                ArrayMode arrayMode2 = getArrayMode(Array::Read); // TODO: from profile
+
+                exitOK();
+                addVarArgChild(Edge(get(obj), KnownCellUse));
+                addVarArgChild(Edge(get(k), KnownInt32Use));
+                addVarArgChild(nullptr);
+                Node* kValue = addToGraph(Node::VarArg, GetByVal,
+                    OpInfo(arrayMode2.asWord()),
+                    OpInfo(profile->m_getByValValueProfile.m_prediction));
+                exitOK();
+                set(val, kValue, ImmediateSetWithFlush);
+                Vector<Node*> arguments;
+                arguments.append(get(argThisArg));
+                arguments.append(kValue);
+                arguments.append(get(k));
+                arguments.append(get(obj));
+
+                int newRegisterOffset = virtualRegisterForLocal(m_inlineStackTop->m_profiledBlock->numCalleeLocals() - 1).offset();
+                newRegisterOffset -= (argumentCountIncludingThis + 4 + 1); // args + return pc
+                newRegisterOffset -= CallFrame::headerSizeInRegisters;
+                newRegisterOffset = -WTF::roundUpToMultipleOf(stackAlignmentRegisters(), -newRegisterOffset);
+
+                ensureLocals(m_inlineStackTop->remapOperand(VirtualRegister(newRegisterOffset)).toLocal());
+
+                unsigned currentArgumentIndex = 0;
+                for (Node* argument : arguments)
+                    set(virtualRegisterForArgumentIncludingThis(currentArgumentIndex++, newRegisterOffset), argument, ImmediateNakedSet);
+
+                dataLogLn("bforward - before handleCall");
+                Terminality callTerminality = handleCall(
+                    scratch,
+                    Call,
+                    InlineCallFrame::Call,
+                    osrExitIndex, // TODO
+                    get(argCallback),
+                    4,
+                    newRegisterOffset,
+                    CallLinkStatus(), // TODO: pull this in from CallLinkInfo in profile
+                    profile->m_callbackResValueProfile.m_prediction,
+                    nullptr);
+                dataLogLn("bforward - after handleCall");
+                RELEASE_ASSERT(callTerminality == NonTerminal);
+                exitOK();
+
+                processSetLocalQueue();
+
+                Node* toBoolResult = addToGraph(ToBoolean, get(scratch));
+
+                addBranch(toBoolResult, bbLoopBodySetProp, bbLoopBodyIncK);
+                dataLogLn("bforward - bbLoopBodyCheck END");
+            }
+
+            {
+                dataLogLn("bforward - bbLoopBodySetProp BEGIN");
+                m_currentBlock = bbLoopBodySetProp;
+                clearCaches();
+
+                exitOK();
+
+                ArrayMode writeArrayMode = getArrayMode(Array::Write);
+
+                addVarArgChild(get(arr));
+                addVarArgChild(get(to));
+                addVarArgChild(get(val));
+                addVarArgChild(nullptr); // Leave room for property storage.
+                addVarArgChild(nullptr); // Leave room for length.
+                // Node* putByVal = addToGraph(Node::VarArg, isDirect ? PutByValDirect : status.isMegamorphic() ? PutByValMegamorphic : PutByVal, OpInfo(arrayMode.asWord()), OpInfo(bytecode.m_ecmaMode));
+
+                exitOK();
+                Node* putByVal = addToGraph(Node::VarArg, PutByVal, OpInfo(writeArrayMode.asWord()), OpInfo(ECMAMode::StrictMode));
+                // m_exitOK = false;
+                UNUSED_VARIABLE(putByVal);
+
+                exitOK();
+
+                Node* one = jsConstant(jsNumber(1));
+                Node* inc = addToGraph(ArithAdd, get(to), one);
+                inc->child1() = Edge(inc->child1().node(), KnownInt32Use);
+                inc->child2() = Edge(inc->child2().node(), KnownInt32Use);
+                set(to, inc);
+
+                processSetLocalQueue();
+                addJumpTo(bbLoopBodyIncK);
+                dataLogLn("bforward - bbLoopBodySetProp END");
+            }
+
+            {
+                dataLogLn("bforward - bbLoopBodyIncK BEGIN");
+                m_currentBlock = bbLoopBodyIncK;
+                clearCaches();
+
+                exitOK();
+
+                Node* one = jsConstant(jsNumber(1));
+                Node* inc = addToGraph(ArithAdd, get(k), one);
+                inc->child1() = Edge(inc->child1().node(), KnownInt32Use);
+                inc->child2() = Edge(inc->child2().node(), KnownInt32Use);
+                set(k, inc);
+
+                processSetLocalQueue();
+                addJumpTo(bbLoopHeader);
+                dataLogLn("bforward - bbLoopBodyIncK END");
+            }
+
+            {
+                dataLogLn("bforward - continuation BEGIN");
+                m_currentBlock = continuation;
+                clearCaches();
+                m_currentIndex = oldIndex;
+                dataLogLn("bforward - continuation END");
+            }
+
+            dataLogLn("bforward - case end! return Inlined");
+
+
+            return CallOptimizationResult::Inlined;
+        }
+
         case ArrayPushIntrinsic: {
             if (static_cast<unsigned>(argumentCountIncludingThis) >= MIN_SPARSE_ARRAY_INDEX)
                 return CallOptimizationResult::DidNothing;

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -72,6 +72,8 @@ static JSC_DECLARE_HOST_FUNCTION(arrayProtoFuncIncludes);
 static JSC_DECLARE_HOST_FUNCTION(arrayProtoFuncCopyWithin);
 static JSC_DECLARE_HOST_FUNCTION(arrayProtoFuncToSpliced);
 
+static JSC_DECLARE_HOST_FUNCTION(arrayProtoFuncFilter);
+
 // ------------------------------ ArrayPrototype ----------------------------
 
 const ClassInfo ArrayPrototype::s_info = { "Array"_s, &JSArray::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(ArrayPrototype) };
@@ -116,7 +118,7 @@ void ArrayPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().somePublicName(), arrayPrototypeSomeCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().indexOfPublicName(), arrayProtoFuncIndexOf, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, ArrayIndexOfIntrinsic);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("lastIndexOf"_s, arrayProtoFuncLastIndexOf, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
-    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().filterPublicName(), arrayPrototypeFilterCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->filter, arrayProtoFuncFilter, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, ArrayFilterIntrinsic);
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().flatPublicName(), arrayPrototypeFlatCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().flatMapPublicName(), arrayPrototypeFlatMapCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().reducePublicName(), arrayPrototypeReduceCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
@@ -2173,6 +2175,196 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncToSpliced, (JSGlobalObject* globalObject,
     }
 
     return JSValue::encode(result);
+}
+
+ALWAYS_INLINE static JSValue fastArrayFilter(JSGlobalObject* globalObject, VM& vm, JSArray* array, JSObject* callback, JSValue thisArg, BuiltinProfiling::ArrayPrototypeFilterProfile* profile)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    unsigned length = array->length();
+
+    auto indexingType = array->indexingType();
+    // ArrayAllocationProfile arrayProfile(indexingType);
+    profile->m_arrayAllocProfile.initializeIndexingMode(indexingType);
+    JSArray* result = constructEmptyArray(globalObject, &profile->m_arrayAllocProfile);
+    if (!length)
+        return result;
+
+    const auto callData = getCallData(callback);
+    ASSERT(callData.type != CallData::Type::None);
+
+    auto doFilter = [&](auto callFunction) ALWAYS_INLINE_LAMBDA {
+        switch (indexingType) {
+        case ALL_INT32_INDEXING_TYPES:
+        case ALL_CONTIGUOUS_INDEXING_TYPES: {
+            auto& butterfly = *array->butterfly();
+            auto data = butterfly.contiguous().data();
+            // TODO: we could check for holes and fall-back to slow path if it is faster:
+            // if (containsHole(data, length)) return { false, {} }; ...
+            for (unsigned i = 0; i < length; ++i) {
+                if (JSValue value = data[i].get(); value) [[likely]] {
+                    profile->m_getByValValueProfile.m_buckets[0] = JSValue::encode(value);
+                    JSValue callbackRes = callFunction(thisArg, value, jsNumber(i), array);
+                    profile->m_callbackResValueProfile.m_buckets[0] = JSValue::encode(callbackRes);
+                    if (callbackRes.toBoolean(globalObject))
+                        result->pushInline(globalObject, value);
+                }
+            }
+            break;
+        }
+        case ALL_DOUBLE_INDEXING_TYPES: {
+            auto& butterfly = *array->butterfly();
+            auto data = butterfly.contiguousDouble().data();
+            // TODO: if containsHole...
+            for (unsigned i = 0; i < length; ++i) {
+                if (isHole(data[i])) [[unlikely]]
+                    continue;
+                JSValue value = jsNumber(data[i]);
+                profile->m_getByValValueProfile.m_buckets[0] = JSValue::encode(value);
+                JSValue callbackRes = callFunction(thisArg, value, jsNumber(i), array);
+                profile->m_callbackResValueProfile.m_buckets[0] = JSValue::encode(callbackRes);
+                if (callbackRes.toBoolean(globalObject))
+                    result->pushInline(globalObject, value);
+            }
+            break;
+        }
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+    };
+
+    if (callData.type == CallData::Type::JS) [[likely]] {
+        CachedCall cachedCall(globalObject, jsCast<JSFunction*>(callback), 3);
+        RETURN_IF_EXCEPTION(scope, { });
+        doFilter([&](JSValue thisVal, JSValue value, JSValue i, JSValue thisObj) -> JSValue {
+            return cachedCall.callWithArguments(globalObject, thisVal, value, i, thisObj);
+        });
+    } else {
+        MarkedArgumentBuffer args;
+        doFilter([&](JSValue thisVal, JSValue value, JSValue i, JSValue thisObj) -> JSValue {
+            args.clear();
+            args.append(value);
+            args.append(i);
+            args.append(thisObj);
+            if (args.hasOverflowed()) [[unlikely]] {
+                throwOutOfMemoryError(globalObject, scope);
+                return { };
+            }
+            return call(globalObject, callback, callData, thisVal, args);
+        });
+    }
+
+    RELEASE_AND_RETURN(scope, result);
+}
+
+JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncFilter, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSFunction* selfJsFunction = jsCast<JSFunction*>(callFrame->jsCallee());
+    FunctionRareData* rareData = selfJsFunction->ensureRareData(vm);
+    auto* profile = rareData->tryGetBuiltinProfileOfKind<BuiltinProfiling::ArrayPrototypeFilterProfile>();
+    if (!profile)
+        profile = rareData->allocateBuiltinProfile<BuiltinProfiling::ArrayPrototypeFilterProfile>();
+
+    auto thisValue = callFrame->thisValue().toThis(globalObject, ECMAMode::strict());
+    RETURN_IF_EXCEPTION(scope, { });
+    profile->m_thisValueProfile.m_buckets[0] = JSValue::encode(thisValue);
+
+    if (thisValue.isUndefinedOrNull()) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "Array.prototype.filter requires that |this| not be null or undefined"_s);
+
+    auto* thisObject = thisValue.toObject(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+    profile->m_toObjectValueProfile.m_buckets[0] = JSValue::encode(thisObject);
+
+    uint64_t length = toLength(globalObject, thisObject);
+    RETURN_IF_EXCEPTION(scope, { });
+    profile->m_toLengthValueProfile.m_buckets[0] = JSValue::encode(jsNumber(length));
+
+    JSValue argCallback = callFrame->argument(0);
+    if (!argCallback.isCallable())
+        return throwVMTypeError(globalObject, scope, "Array.prototype.filter callback must be a function"_s);
+
+    JSValue argThisArg = callFrame->argument(1);
+
+    if (isJSArray(thisObject) && !holesMustForwardToPrototype(thisObject)) [[likely]] {
+        JSArray* array = asArray(thisObject);
+        switch (array->indexingType()) {
+        case ALL_INT32_INDEXING_TYPES:
+        case ALL_CONTIGUOUS_INDEXING_TYPES:
+        case ALL_DOUBLE_INDEXING_TYPES: {
+            JSValue result = fastArrayFilter(globalObject, vm, array, argCallback.toObject(globalObject), argThisArg, profile);
+            RELEASE_AND_RETURN(scope, JSValue::encode(result));
+        }
+        default:
+            break;
+        }
+    }
+
+    std::pair<SpeciesConstructResult, JSObject*> speciesResult = speciesConstructArray(globalObject, thisObject, 0);
+    EXCEPTION_ASSERT(!!scope.exception() == (speciesResult.first == SpeciesConstructResult::Exception));
+    if (speciesResult.first == SpeciesConstructResult::Exception) [[unlikely]]
+        return { };
+
+    JSObject* result;
+    if (speciesResult.first == SpeciesConstructResult::CreatedObject)
+        result = speciesResult.second;
+    else {
+        result = constructEmptyArray(globalObject, nullptr);
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+
+    if (!result) [[unlikely]] {
+        throwOutOfMemoryError(globalObject, scope);
+        return { };
+    }
+
+    // CachedCall cachedCall(globalObject, jsCast<JSFunction*>(argCallback), 3);
+    auto doFilter = [&](auto callFunction) ALWAYS_INLINE_LAMBDA -> JSValue {
+        uint64_t nextIndex = 0;
+        for (uint64_t i = 0; i < length; i++) {
+            if (thisObject->hasProperty(globalObject, i)) [[likely]] {
+                // TODO: switch indexing type and use custom hole checking logic for each type
+                auto fromValue = thisObject->getIndex(globalObject, i);
+                RETURN_IF_EXCEPTION(scope, { });
+                JSValue callbackRes = callFunction(argThisArg, fromValue, jsNumber(i), thisObject);
+                if (callbackRes.toBoolean(globalObject)) {
+                    result->putDirectIndex(globalObject, nextIndex, fromValue, 0, PutDirectIndexShouldThrow);
+                    RETURN_IF_EXCEPTION(scope, { });
+                    ++nextIndex;
+                }
+            }
+        }
+        return result;
+    };
+
+    const auto callData = getCallData(argCallback);
+    ASSERT(callData.type != CallData::Type::None);
+    if (callData.type == CallData::Type::JS) [[likely]] {
+        CachedCall cachedCall(globalObject, jsCast<JSFunction*>(argCallback), 3);
+        RETURN_IF_EXCEPTION(scope, { });
+        doFilter([&](JSValue thisVal, JSValue value, JSValue i, JSValue thisObj) -> JSValue {
+            return cachedCall.callWithArguments(globalObject, thisVal, value, i, thisObj);
+        });
+    } else {
+        MarkedArgumentBuffer args;
+        doFilter([&](JSValue thisVal, JSValue value, JSValue i, JSValue thisObj) -> JSValue {
+            args.clear();
+            args.append(value);
+            args.append(i);
+            args.append(thisObj);
+            if (args.hasOverflowed()) [[unlikely]] {
+                throwOutOfMemoryError(globalObject, scope);
+                return { };
+            }
+            return call(globalObject, argCallback, callData, thisVal, args);
+        });
+    }
+    RETURN_IF_EXCEPTION(scope, { });
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(result));
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/BuiltinProfiling.cpp
+++ b/Source/JavaScriptCore/runtime/BuiltinProfiling.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#include "config.h"
+#include "BuiltinProfiling.h"
+
+namespace JSC::BuiltinProfiling {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BuiltinProfile);
+
+}
+

--- a/Source/JavaScriptCore/runtime/BuiltinProfiling.h
+++ b/Source/JavaScriptCore/runtime/BuiltinProfiling.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#pragma once
+
+#include "ArrayAllocationProfile.h"
+#include "ConcurrentJSLock.h"
+#include "ValueProfile.h"
+#include <variant>
+#include <wtf/TZoneMalloc.h>
+
+namespace JSC::BuiltinProfiling {
+
+class BuiltinProfileBase {
+public:
+    virtual ~BuiltinProfileBase() = default;
+
+    mutable ConcurrentJSLock m_lock;
+
+    virtual void updateValueProfiles(const ConcurrentJSLocker&) = 0;
+};
+
+class ArrayPrototypeFilterProfile : public BuiltinProfileBase {
+public:
+    ArrayPrototypeFilterProfile() = default;
+
+public:
+    ValueProfile m_thisValueProfile;
+    ValueProfile m_toObjectValueProfile;
+    ValueProfile m_toLengthValueProfile;
+    ValueProfile m_getByValValueProfile;
+    ValueProfile m_callbackResValueProfile;
+
+    ArrayAllocationProfile m_arrayAllocProfile;
+    // ValueProfile m_thisArgValueProfile;
+    // ValueProfile m_callbackReturnValueProfile;
+
+    void updateValueProfiles(const ConcurrentJSLocker& locker) override
+    {
+        m_thisValueProfile.computeUpdatedPrediction(locker);
+        m_toObjectValueProfile.computeUpdatedPrediction(locker);
+        m_toLengthValueProfile.computeUpdatedPrediction(locker);
+        m_getByValValueProfile.computeUpdatedPrediction(locker);
+        m_callbackResValueProfile.computeUpdatedPrediction(locker);
+    }
+};
+
+#define JSC_BUILTIN_PROFILE_TYPE_FOREACH(macro) \
+    macro(ArrayPrototypeFilterProfile)
+
+using BuiltinProfileInvalid = struct { };
+#define X(name) , name
+using BuiltinProfileVariant = std::variant<
+    BuiltinProfileInvalid
+    JSC_BUILTIN_PROFILE_TYPE_FOREACH(X)
+>;
+#undef X
+
+#define X(name) || std::is_same_v<T, name>
+template <typename T>
+concept IsBuiltinProfileType = false JSC_BUILTIN_PROFILE_TYPE_FOREACH(X);
+#undef X
+
+class BuiltinProfile {
+WTF_MAKE_TZONE_ALLOCATED(BuiltinProfile);
+private:
+    BuiltinProfileVariant m_variant;
+
+public:
+    template <IsBuiltinProfileType T, typename... Args>
+    inline explicit BuiltinProfile(std::in_place_type_t<T>, Args&&... args) : m_variant(std::in_place_type<T>, std::forward<Args>(args)...) { }
+
+    template <IsBuiltinProfileType T>
+    inline explicit BuiltinProfile(std::in_place_type_t<T>) : m_variant(std::in_place_type<T>) { }
+
+    inline BuiltinProfileVariant& variant() { return m_variant; }
+    inline const BuiltinProfileVariant& variant() const { return m_variant; }
+};
+
+
+
+} // namespace JSC::BuiltinProfiling
+

--- a/Source/JavaScriptCore/runtime/ClonedArguments.h
+++ b/Source/JavaScriptCore/runtime/ClonedArguments.h
@@ -28,6 +28,7 @@
 #include "ArgumentsMode.h"
 #include "CommonIdentifiers.h"
 #include "JSObject.h"
+#include "VM.h"
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.h
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.h
@@ -130,6 +130,7 @@
     macro(exports) \
     macro(fallback) \
     macro(fill) \
+    macro(filter) \
     macro(flags) \
     macro(firstDayOfWeek) \
     macro(forEach) \

--- a/Source/JavaScriptCore/runtime/FunctionRareData.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionRareData.cpp
@@ -74,6 +74,7 @@ FunctionRareData::FunctionRareData(VM& vm, ExecutableBase* executable)
     // function is unlikely to allocate a rare data until the first allocation anyway.
     , m_allocationProfileWatchpointSet(ClearWatchpoint)
     , m_executable(executable, WriteBarrierEarlyInit)
+    , m_builtinProfiling(nullptr)
     , m_hasReifiedLength(false)
     , m_hasReifiedName(false)
     , m_hasModifiedLengthForBoundOrNonHostFunction(false)

--- a/Source/JavaScriptCore/runtime/FunctionRareData.h
+++ b/Source/JavaScriptCore/runtime/FunctionRareData.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "BuiltinProfiling.h"
 #include "InternalFunctionAllocationProfile.h"
 #include "JSCast.h"
 #include "ObjectAllocationProfile.h"
@@ -132,6 +133,47 @@ public:
         m_hasModifiedNameForBoundOrNonHostFunction = true;
     }
 
+    inline bool hasBuiltinProfile() const { return !!m_builtinProfiling; }
+    inline BuiltinProfiling::BuiltinProfile* getBuiltinProfile() const
+    {
+        ASSERT(hasBuiltinProfile());
+        return m_builtinProfiling.get();
+    }
+    template <BuiltinProfiling::IsBuiltinProfileType T, typename... Args>
+    inline T* allocateBuiltinProfile(Args&&... args)
+    {
+        ASSERT(!hasBuiltinProfile());
+        m_builtinProfiling = makeUnique<BuiltinProfiling::BuiltinProfile, Args...>(
+            std::in_place_type<T>,
+            std::forward<Args>(args)...
+        );
+        T* result = std::get_if<T>(&m_builtinProfiling->variant());
+        ASSERT(result);
+        return result;
+    }
+
+    template <BuiltinProfiling::IsBuiltinProfileType T>
+    inline T* allocateBuiltinProfile()
+    {
+        ASSERT(!hasBuiltinProfile());
+        m_builtinProfiling = makeUnique<BuiltinProfiling::BuiltinProfile>(std::in_place_type<T>);
+        T* result = std::get_if<T>(&m_builtinProfiling->variant());
+        ASSERT(result);
+        return result;
+    }
+
+
+    template <BuiltinProfiling::IsBuiltinProfileType T>
+    inline T* tryGetBuiltinProfileOfKind() const
+    {
+        if (!m_builtinProfiling)
+            return nullptr;
+        BuiltinProfiling::BuiltinProfile* profile = getBuiltinProfile();
+        if (T* p = std::get_if<T>(&profile->variant()); p)
+            return p;
+        return nullptr;
+    }
+
     bool hasAllocationProfileClearingWatchpoint() const { return !!m_allocationProfileClearingWatchpoint; }
     Watchpoint* createAllocationProfileClearingWatchpoint();
     class AllocationProfileClearingWatchpoint;
@@ -161,6 +203,7 @@ private:
     WriteBarrierStructureID m_boundFunctionStructureID;
     WriteBarrier<ExecutableBase> m_executable;
     std::unique_ptr<AllocationProfileClearingWatchpoint> m_allocationProfileClearingWatchpoint;
+    std::unique_ptr<BuiltinProfiling::BuiltinProfile> m_builtinProfiling;
     bool m_hasReifiedLength : 1;
     bool m_hasReifiedName : 1;
     bool m_hasModifiedLengthForBoundOrNonHostFunction : 1;

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -61,6 +61,7 @@ namespace JSC {
     macro(ArrayValuesIntrinsic) \
     macro(ArrayKeysIntrinsic) \
     macro(ArrayEntriesIntrinsic) \
+    macro(ArrayFilterIntrinsic) \
     macro(AsyncIteratorIntrinsic) \
     macro(BooleanConstructorIntrinsic) \
     macro(CharCodeAtIntrinsic) \

--- a/Source/JavaScriptCore/runtime/JSTemplateObjectDescriptor.h
+++ b/Source/JavaScriptCore/runtime/JSTemplateObjectDescriptor.h
@@ -28,6 +28,7 @@
 
 #include "Structure.h"
 #include "TemplateObjectDescriptor.h"
+#include "VM.h"
 
 namespace JSC {
 


### PR DESCRIPTION
#### be354c9de1df055ea9ca0225d291878177f1be26
<pre>
[WIP] builtin profiling, DFG work for filter

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/builtins/ArrayPrototype.js:
(alwaysInline.filter): Deleted.
* Source/JavaScriptCore/bytecode/InlineCallFrame.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/bytecode/InlineCallFrame.h:
(JSC::InlineCallFrame::callModeFor):
(JSC::InlineCallFrame::specializationKindFor):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::addBranch):
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::ArrayPrototype::finishCreation):
(JSC::fastArrayFilter):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/BuiltinProfiling.cpp: Added.
* Source/JavaScriptCore/runtime/BuiltinProfiling.h: Added.
(JSC::BuiltinProfiling::BuiltinProfile::BuiltinProfile):
(JSC::BuiltinProfiling::BuiltinProfile::variant):
(JSC::BuiltinProfiling::BuiltinProfile::variant const):
* Source/JavaScriptCore/runtime/ClonedArguments.h:
* Source/JavaScriptCore/runtime/CommonIdentifiers.h:
* Source/JavaScriptCore/runtime/FunctionRareData.cpp:
(JSC::FunctionRareData::FunctionRareData):
* Source/JavaScriptCore/runtime/FunctionRareData.h:
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/JSTemplateObjectDescriptor.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be354c9de1df055ea9ca0225d291878177f1be26

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111554 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31221 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21685 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117589 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61825 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31901 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39802 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84763 "Found 88 new test failures: ietestcenter/Javascript/15.4.4.20-9-2.html ietestcenter/Javascript/15.4.4.20-9-3.html ietestcenter/Javascript/15.4.4.20-9-4.html imported/w3c/web-platform-tests/FileAPI/idlharness.any.html imported/w3c/web-platform-tests/FileAPI/idlharness.any.worker.html imported/w3c/web-platform-tests/FileAPI/idlharness.html imported/w3c/web-platform-tests/FileAPI/idlharness.worker.html imported/w3c/web-platform-tests/IndexedDB/idlharness.any.html imported/w3c/web-platform-tests/badging/idlharness.https.any.worker.html imported/w3c/web-platform-tests/beacon/idlharness.any.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35543 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114501 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25474 "Found 7 new test failures: http/wpt/identity/idl.https.html ietestcenter/Javascript/15.4.4.20-9-2.html ietestcenter/Javascript/15.4.4.20-9-3.html ietestcenter/Javascript/15.4.4.20-9-4.html js/dom/document-all-is-callable-builtins.html js/strict-callback-this.html media/modern-media-controls/ios-inline-media-controls/ios-inline-media-dropping-controls.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100410 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65204 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/110987 "Build is in progress. Recent messages:") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24815 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/idlharness.any.html imported/w3c/web-platform-tests/FileAPI/idlharness.any.worker.html imported/w3c/web-platform-tests/FileAPI/idlharness.html imported/w3c/web-platform-tests/FileAPI/idlharness.worker.html imported/w3c/web-platform-tests/IndexedDB/idlharness.any.html imported/w3c/web-platform-tests/IndexedDB/idlharness.any.serviceworker.html imported/w3c/web-platform-tests/IndexedDB/idlharness.any.sharedworker.html imported/w3c/web-platform-tests/IndexedDB/idlharness.any.worker.html imported/w3c/web-platform-tests/WebCryptoAPI/idlharness.https.any.html imported/w3c/web-platform-tests/WebCryptoAPI/idlharness.https.any.worker.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18549 "Found 60 new test failures: accessibility/text-marker/text-marker-bidi-element-arabic.html accessibility/text-marker/text-marker-bidi-element-hebrew.html fonts/monospace.html fonts/sans-serif.html fonts/serif.html fonts/unicode-character-font-crash.html fonts/use-typo-metrics-1.html http/tests/security/contentSecurityPolicy/report-status-code-zero-when-using-https.html http/tests/security/contentSecurityPolicy/script-src-parsing-implicit-and-explicit-port-number.html http/tests/security/contentSecurityPolicy/script-src-star-cross-scheme.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61538 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/104051 "Found 151 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/class-syntax-method-names.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/class-syntax-method-names.js.layout-ftl-eager-no-cjit, microbenchmarks/array-filter-boolean-constructor.js.bytecode-cache, microbenchmarks/array-filter-boolean-constructor.js.default, microbenchmarks/array-filter-boolean-constructor.js.dfg-eager, microbenchmarks/array-filter-boolean-constructor.js.dfg-eager-no-cjit-validate, microbenchmarks/array-filter-boolean-constructor.js.eager-jettison-no-cjit, microbenchmarks/array-filter-boolean-constructor.js.ftl-eager, microbenchmarks/array-filter-boolean-constructor.js.ftl-eager-no-cjit, microbenchmarks/array-filter-boolean-constructor.js.ftl-eager-no-cjit-b3o1 ... (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94858 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18616 "Found 60 new test failures: accessibility/text-marker/text-marker-bidi-element-arabic.html accessibility/text-marker/text-marker-bidi-element-hebrew.html http/tests/webgpu/webgpu/api/operation/buffers/map.html http/tests/webgpu/webgpu/api/operation/command_buffer/queries/occlusionQuery.html http/tests/webgpu/webgpu/api/validation/buffer/create.html http/tests/webgpu/webgpu/api/validation/capability_checks/features/texture_formats.html http/tests/webgpu/webgpu/shader/execution/shader_io/compute_builtins.html http/tests/webgpu/webgpu/shader/execution/shader_io/fragment_builtins.html http/tests/webgpu/webgpu/shader/execution/shader_io/workgroup_size.html http/wpt/identity/idl.https.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120824 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/110108 "Found 156 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/class-syntax-method-names.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/class-syntax-method-names.js.layout-ftl-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/strict-callback-this.js.layout, jsc-layout-tests.yaml/js/script-tests/strict-callback-this.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/strict-callback-this.js.layout-ftl-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/strict-callback-this.js.layout-ftl-no-cjit, jsc-layout-tests.yaml/js/script-tests/strict-callback-this.js.layout-no-cjit, jsc-layout-tests.yaml/js/script-tests/strict-callback-this.js.layout-no-ftl, jsc-layout-tests.yaml/js/script-tests/strict-callback-this.js.layout-no-llint, microbenchmarks/array-filter-boolean-constructor.js.bytecode-cache ... (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38607 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28687 "Found 60 new test failures: accessibility/text-marker/text-marker-bidi-element-arabic.html accessibility/text-marker/text-marker-bidi-element-hebrew.html fast/mediastream/MediaStream-video-element-displays-buffer.html fast/text/glyph-display-lists/glyph-display-list-color.html fast/text/glyph-display-lists/glyph-display-list-colr-unshared.html fast/text/glyph-display-lists/glyph-display-list-gpu-process-crash.html fast/text/glyph-display-lists/glyph-display-list-scaled-unshared.html fast/text/glyph-display-lists/glyph-display-list-shadow-unshared.html fast/text/glyph-display-lists/glyph-display-list-svg-unshared.html http/tests/cache/disk-cache/shattered-deduplication.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93675 "Found 72 new test failures: ietestcenter/Javascript/15.4.4.20-9-2.html ietestcenter/Javascript/15.4.4.20-9-3.html ietestcenter/Javascript/15.4.4.20-9-4.html imported/w3c/web-platform-tests/FileAPI/idlharness.any.html imported/w3c/web-platform-tests/FileAPI/idlharness.any.worker.html imported/w3c/web-platform-tests/FileAPI/idlharness.html imported/w3c/web-platform-tests/FileAPI/idlharness.worker.html imported/w3c/web-platform-tests/IndexedDB/idlharness.any.html imported/w3c/web-platform-tests/WebCryptoAPI/idlharness.https.any.worker.html imported/w3c/web-platform-tests/badging/idlharness.https.any.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38984 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96672 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93498 "Found 3 new API test failures: /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/default, /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach, /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/custom-container-destroyed (failure)") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38624 "Found 1 new test failure: imported/w3c/web-platform-tests/webxr/idlharness.https.window.html (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16414 "Found 60 new test failures: accessibility/text-marker/text-marker-bidi-element-arabic.html accessibility/text-marker/text-marker-bidi-element-hebrew.html compositing/shared-backing/update-backing-sharing-on-size-change.html css3/blending/background-blend-mode-background-attachement-fixed.html css3/flexbox/flex-item-text-background-not-interleaved.html css3/viewport-percentage-lengths/css3-viewport-percentage-lengths-vh-absolute.html fast/repaint/absolute-position-changed.html http/tests/webgpu/webgpu/api/operation/buffers/map.html http/tests/webgpu/webgpu/api/validation/buffer/create.html http/wpt/identity/idl.https.html ... (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/34643 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38496 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43969 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/134383 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38159 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36210 "Found 68 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/class-syntax-method-names.js.layout-dfg-eager-no-cjit, microbenchmarks/array-filter-boolean-constructor.js.bytecode-cache, microbenchmarks/array-filter-boolean-constructor.js.default, microbenchmarks/array-filter-boolean-constructor.js.dfg-eager, microbenchmarks/array-filter-boolean-constructor.js.eager-jettison-no-cjit, microbenchmarks/array-filter-boolean-constructor.js.mini-mode, microbenchmarks/array-filter-boolean-constructor.js.no-cjit-collect-continuously, microbenchmarks/array-filter-boolean-constructor.js.no-cjit-validate-phases, microbenchmarks/array-filter-boolean-constructor.js.no-llint, microbenchmarks/emscripten-cube2hash-resizable.js.dfg-eager ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41495 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39861 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->