### PR TITLE
AX: AccessibilityRenderObject::updateAttachmentViewParents() has unnecessary calls to isIgnored and unignoredChildren

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -3040,9 +3040,17 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
         postNotification(element, AXNotification::RequiredStatusChanged);
     else if (attrName == tabindexAttr) {
         if (oldValue.isEmpty() || newValue.isEmpty()) {
+#if ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
+            // When ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE), we don't need to do issue any children-changed events,
+            // which is quite expensive — just re-compute is-ignored on this single object.
+            if (RefPtr object = get(*element))
+                object->recomputeIsIgnored();
+#else
             RefPtr parent = element->parentNode();
             if (auto* renderer = parent ? parent->renderer() : nullptr)
                 childrenChanged(*renderer);
+#endif // ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
+
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
             postNotification(element, AXNotification::FocusableStateChanged);
 #endif

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -713,7 +713,7 @@ public:
     bool isHidden() const { return isAXHidden() || isRenderHidden(); }
     bool isOnScreen() const final;
 
-#if PLATFORM(COCOA)
+#if PLATFORM(MAC)
     void overrideAttachmentParent(AccessibilityObject* parent);
 #else
     void overrideAttachmentParent(AccessibilityObject*) { }

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -2636,22 +2636,15 @@ void AccessibilityRenderObject::addNodeOnlyChildren()
 }
 #endif // USE(ATSPI)
 
-#if PLATFORM(COCOA)
+#if PLATFORM(MAC)
 void AccessibilityRenderObject::updateAttachmentViewParents()
 {
-    // Only the unignored parent should set the attachment parent, because that's
-    // what is reflected in the AX hierarchy to the client.
-    if (isIgnored())
-        return;
-
-    for (const auto& child : unignoredChildren(/* updateChildrenIfNeeded */ false)) {
-        if (child->isAttachment()) {
-            if (RefPtr liveChild = dynamicDowncast<AccessibilityObject>(child.get()))
-                liveChild->overrideAttachmentParent(this);
-        }
-    }
+    // updateChildrenIfNeeded == false because this is called right after we've added children, so we know
+    // they're clean and don't need updating.
+    for (const auto& child : children(/* updateChildrenIfNeeded */ false))
+        downcast<AccessibilityObject>(child)->overrideAttachmentParent(this);
 }
-#endif // PLATFORM(COCOA)
+#endif // PLATFORM(MAC)
 
 RenderObject* AccessibilityRenderObject::markerRenderer() const
 {
@@ -2788,7 +2781,7 @@ void AccessibilityRenderObject::addChildren()
     addImageMapChildren();
     addTextFieldChildren();
     addRemoteSVGChildren();
-#if PLATFORM(COCOA)
+#if PLATFORM(MAC)
     updateAttachmentViewParents();
 #endif
     updateOwnedChildren();

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.h
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.h
@@ -186,7 +186,7 @@ private:
     void addImageMapChildren();
     void addAttachmentChildren();
     void addRemoteSVGChildren();
-#if PLATFORM(COCOA)
+#if PLATFORM(MAC)
     void updateAttachmentViewParents();
 #endif
     String expandedTextValue() const override;

--- a/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
+++ b/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
@@ -100,10 +100,6 @@ bool AccessibilityObject::fileUploadButtonReturnsValueInTitle() const
     return false;
 }
 
-void AccessibilityObject::overrideAttachmentParent(AccessibilityObject*)
-{
-}
-    
 // In iPhone only code for now. It's debateable whether this is desired on all platforms.
 unsigned AccessibilityObject::accessibilitySecureFieldLength()
 {

--- a/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
+++ b/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
@@ -68,22 +68,21 @@ void AccessibilityObject::detachPlatformWrapper(AccessibilityDetachmentType)
 
 void AccessibilityObject::detachFromParent()
 {
-    if (isAttachment())
-        overrideAttachmentParent(nullptr);
+    overrideAttachmentParent(nullptr);
 }
 
 void AccessibilityObject::overrideAttachmentParent(AccessibilityObject* parent)
 {
-    if (!isAttachment())
+    if (!isAttachment()) [[likely]]
         return;
 
     RefPtr axParent = parent;
     id parentWrapper = nil;
-    if (axParent) {
-        if (axParent->isIgnored())
-            axParent = axParent->parentObjectUnignored();
+    if (axParent && axParent->isIgnored())
+        axParent = axParent->parentObjectUnignored();
+
+    if (axParent)
         parentWrapper = axParent->wrapper();
-    }
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     [[wrapper() attachmentView] accessibilitySetOverrideValue:parentWrapper forAttribute:NSAccessibilityParentAttribute];


### PR DESCRIPTION
#### c8f72741b5f618181490315f842817843c0fc106
<pre>
AX: AccessibilityRenderObject::updateAttachmentViewParents() has unnecessary calls to isIgnored and unignoredChildren
<a href="https://bugs.webkit.org/show_bug.cgi?id=295926">https://bugs.webkit.org/show_bug.cgi?id=295926</a>
<a href="https://rdar.apple.com/155824341">rdar://155824341</a>

Reviewed by Joshua Hoffman.

AccessibilityRenderObject::updateAttachmentViewParents early-returns for isIgnored(), but this isn&apos;t necessary, as
AccessibilityObject::overrideAttachmentParent already checks for and handles any ignored parents that come in. This
commit removes this isIgnored() call, which did show up on samples for large webpages.

AccessibilityRenderObject::updateAttachmentViewParents also calls unignoredChildren() where it could use children().
unignoredChildren() provides no advantage over using children() (which can include ignored objects) here, and unignoredChildren
can be very expensive.

* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::updateAttachmentViewParents):
* Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm:
(WebCore::AccessibilityObject::overrideAttachmentParent): Deleted.
* Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm:
(WebCore::AccessibilityObject::detachFromParent):
(WebCore::AccessibilityObject::overrideAttachmentParent):

Canonical link: <a href="https://commits.webkit.org/297468@main">https://commits.webkit.org/297468@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b75ed20ff80bb8fa0653b3213618faa2fc816e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111810 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31472 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21949 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117829 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62043 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113773 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32155 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40055 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84937 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35629 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114757 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25671 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100614 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65376 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24997 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18749 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61662 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95052 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18821 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121092 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38841 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28874 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93817 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39221 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96872 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93639 "Found 2 new API test failures: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23910 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38808 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16590 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34861 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38738 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44233 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38380 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41705 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40093 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->