### PR TITLE
Partition web archive permissions by file path

### DIFF
--- a/Source/WebCore/Modules/permissions/PermissionName.h
+++ b/Source/WebCore/Modules/permissions/PermissionName.h
@@ -46,3 +46,13 @@ enum class PermissionName : uint8_t {
 };
 
 } // namespace WebCore
+
+namespace WTF {
+
+template <>
+struct DefaultHash<WebCore::PermissionName> {
+    static unsigned hash(const WebCore::PermissionName& name) { return computeHash(name); }
+    static bool equal(const WebCore::PermissionName& a, const WebCore::PermissionName& b) { return a == b; }
+    static constexpr bool safeToCompareToEmptyOrDeleted = true;
+};
+} // namespace WTF

--- a/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp
@@ -680,7 +680,7 @@ void WKWebsiteDataStoreSetPerOriginStorageQuota(WKWebsiteDataStoreRef, uint64_t)
 void WKWebsiteDataStoreClearAllDeviceOrientationPermissions(WKWebsiteDataStoreRef dataStoreRef)
 {
 #if ENABLE(DEVICE_ORIENTATION)
-    WebKit::toProtectedImpl(dataStoreRef)->protectedDeviceOrientationAndMotionAccessController()->clearPermissions();
+    WebKit::toProtectedImpl(dataStoreRef)->clearDeviceOrientationPermissions();
 #endif
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2525,6 +2525,12 @@ public:
     void setInteractionRegionsEnabled(bool);
 #endif
 
+#if ENABLE(WEB_ARCHIVE)
+    std::optional<WebCore::PermissionState> cachedPermissionForWebArchive(WebCore::PermissionName, const StringView url) const;
+    void setPermissionForWebArchive(WebCore::PermissionName, WebCore::PermissionState);
+    void clearAllPermissionForWebArchive(WebCore::PermissionName);
+#endif
+
     void queryPermission(const WebCore::ClientOrigin&, const WebCore::PermissionDescriptor&, CompletionHandler<void(std::optional<WebCore::PermissionState>)>&&);
 
     void generateTestReport(const String& message, const String& group);
@@ -3851,6 +3857,10 @@ private:
         
 #if PLATFORM(IOS_FAMILY) && ENABLE(DEVICE_ORIENTATION)
     RefPtr<WebDeviceOrientationUpdateProviderProxy> m_webDeviceOrientationUpdateProviderProxy;
+#endif
+
+#if ENABLE(WEB_ARCHIVE)
+    HashMap<std::pair<String, WebCore::PermissionName>, WebCore::PermissionState> m_permissionDecisionsByFilePathForWebArchive;
 #endif
 
     RefPtr<WebScreenOrientationManagerProxy> m_screenOrientationManager;

--- a/Source/WebKit/UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.h
@@ -48,8 +48,11 @@ public:
 
     void shouldAllowAccess(WebPageProxy&, WebFrameProxy&, FrameInfoData&&, bool mayPrompt, CompletionHandler<void(WebCore::DeviceOrientationOrMotionPermissionState)>&&);
     void clearPermissions() { m_deviceOrientationPermissionDecisions.clear(); }
+#if ENABLE(WEB_ARCHIVE)
+    void clearPermissionsForWebArchives(WebPageProxy&);
+#endif
 
-    WebCore::DeviceOrientationOrMotionPermissionState cachedDeviceOrientationPermission(const WebCore::SecurityOriginData&) const;
+    WebCore::DeviceOrientationOrMotionPermissionState cachedDeviceOrientationPermission(const WebCore::SecurityOriginData&, const URL&, WebPageProxy&) const;
     void setCachedDeviceOrientationPermission(const WebCore::SecurityOriginData&, WebCore::DeviceOrientationOrMotionPermissionState);
 
 private:

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -1073,6 +1073,17 @@ void WebsiteDataStore::removeData(OptionSet<WebsiteDataType> dataTypes, const Ve
 #endif
 }
 
+#if ENABLE(DEVICE_ORIENTATION)
+void WebsiteDataStore::clearDeviceOrientationPermissions()
+{
+    protectedDeviceOrientationAndMotionAccessController()->clearPermissions();
+#if ENABLE(WEB_ARCHIVE)
+    for (Ref page : m_pages)
+        protectedDeviceOrientationAndMotionAccessController()->clearPermissionsForWebArchives(page.get());
+#endif
+}
+#endif
+
 DeviceIdHashSaltStorage& WebsiteDataStore::ensureDeviceIdHashSaltStorage()
 {
     if (!m_deviceIdHashSaltStorage)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -294,6 +294,8 @@ public:
 #endif
     void allowTLSCertificateChainForLocalPCMTesting(const WebCore::CertificateInfo&);
 
+    void clearDeviceOrientationPermissions();
+
     DeviceIdHashSaltStorage& ensureDeviceIdHashSaltStorage();
     Ref<DeviceIdHashSaltStorage> ensureProtectedDeviceIdHashSaltStorage();
 


### PR DESCRIPTION
#### 224437a1b88dd85d0d74cf167b3a434b1e3168a5
<pre>
Partition web archive permissions by file path
<a href="https://bugs.webkit.org/show_bug.cgi?id=295941">https://bugs.webkit.org/show_bug.cgi?id=295941</a>
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

WIP

* Source/WebCore/Modules/permissions/PermissionName.h:
(WTF::DefaultHash&lt;WebCore::PermissionName&gt;::hash):
(WTF::DefaultHash&lt;WebCore::PermissionName&gt;::equal):
* Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp:
(WKWebsiteDataStoreClearAllDeviceOrientationPermissions):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
(WebKit::WebPageProxy::cachedPermissionForWebArchive const):
(WebKit::WebPageProxy::setPermissionForWebArchive):
(WebKit::WebPageProxy::clearAllPermissionForWebArchive):
(WebKit::WebPageProxy::queryPermission):
(WebKit::WebPageProxy::originHasDeviceOrientationAndMotionAccess):
(WebKit::WebPageProxy::requestNotificationPermission):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.cpp:
(WebKit::deviceOrientationAndMotionPermissions):
(WebKit::WebDeviceOrientationAndMotionAccessController::clearPermissionsForWebArchives):
(WebKit::WebDeviceOrientationAndMotionAccessController::shouldAllowAccess):
(WebKit::WebDeviceOrientationAndMotionAccessController::cachedDeviceOrientationPermission const):
* Source/WebKit/UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::clearDeviceOrientationPermissions):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/224437a1b88dd85d0d74cf167b3a434b1e3168a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111567 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31234 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21710 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117602 "Hash 224437a1 for PR 48016 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61838 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113529 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31914 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39819 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/117602 "Hash 224437a1 for PR 48016 does not build (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/35545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114514 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25479 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100418 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/117602 "Hash 224437a1 for PR 48016 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24820 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18553 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61430 "Hash 224437a1 for PR 48016 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94865 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18622 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120842 "Hash 224437a1 for PR 48016 does not build (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38620 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28693 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/120842 "Hash 224437a1 for PR 48016 does not build (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38997 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96680 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/120842 "Hash 224437a1 for PR 48016 does not build (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38630 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16421 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34656 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38509 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43996 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38172 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41508 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39874 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->