### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in wtf/ListDump.h

### DIFF
--- a/Source/WTF/wtf/ListDump.h
+++ b/Source/WTF/wtf/ListDump.h
@@ -30,8 +30,6 @@
 #include <wtf/PrintStream.h>
 #include <wtf/StringPrintStream.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 template<typename T>
@@ -45,8 +43,8 @@ public:
     
     void dump(PrintStream& out) const
     {
-        for (auto iter = m_list.begin(); iter != m_list.end(); ++iter)
-            out.print(m_comma, *iter);
+        for (auto& item : m_list)
+            out.print(m_comma, item);
     }
 
 private:
@@ -65,8 +63,8 @@ public:
     
     void dump(PrintStream& out) const
     {
-        for (auto iter = m_list.begin(); iter != m_list.end(); ++iter)
-            out.print(m_comma, pointerDump(*iter));
+        for (auto* item : m_list)
+            out.print(m_comma, pointerDump(item));
     }
 
 private:
@@ -159,8 +157,8 @@ public:
     
     void dump(PrintStream& out) const
     {
-        for (auto iter = m_list.begin(); iter != m_list.end(); ++iter)
-            out.print(m_comma, inContext(*iter, m_context));
+        for (auto& item : m_list)
+            out.print(m_comma, inContext(item, m_context));
     }
 
 private:
@@ -184,5 +182,3 @@ using WTF::mapDump;
 using WTF::pointerListDump;
 using WTF::sortedListDump;
 using WTF::sortedMapDump;
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### d1b5bcd6d2a561f297ce909a3e91b56c61334c48
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in wtf/ListDump.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=295944">https://bugs.webkit.org/show_bug.cgi?id=295944</a>

Reviewed by Ryosuke Niwa.

* Source/WTF/wtf/ListDump.h:
(WTF::ListDump::dump const):
(WTF::PointerListDump::dump const):
(WTF::ListDumpInContext::dump const):

Canonical link: <a href="https://commits.webkit.org/297408@main">https://commits.webkit.org/297408@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5d1fe195c1f25247df51f96b7a6dbe0f0f89b71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111572 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117607 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61843 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31919 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39824 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84773 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35548 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114519 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25481 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100423 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65214 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24822 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18558 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61436 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/104069 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94867 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18627 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120870 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/110130 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38625 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28695 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93691 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39002 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96685 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93516 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38633 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16426 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34661 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17989 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38514 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43998 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/134401 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38177 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36215 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41513 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39879 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->