### PR TITLE
Add momentum phase will begin to WebWheelEvent

### DIFF
--- a/Source/WebCore/PAL/pal/spi/mac/IOKitSPIMac.h
+++ b/Source/WebCore/PAL/pal/spi/mac/IOKitSPIMac.h
@@ -92,6 +92,7 @@ typedef uint64_t IOHIDEventSenderID;
 
 
 enum {
+    kIOHIDEventScrollMomentumWillBegin = (1 << 3),
     kIOHIDEventScrollMomentumInterrupted = (1 << 4),
 };
 typedef uint8_t IOHIDEventScrollMomentumBits;

--- a/Source/WebCore/page/WheelEventDeltaFilter.cpp
+++ b/Source/WebCore/page/WheelEventDeltaFilter.cpp
@@ -113,6 +113,7 @@ void BasicWheelEventDeltaFilter::updateFromEvent(const PlatformWheelEvent& event
         break;
 
     case PlatformWheelEventPhase::None:
+    case PlatformWheelEventPhase::WillBegin:
         break;
 
     case PlatformWheelEventPhase::Began:

--- a/Source/WebCore/page/mac/WheelEventDeltaFilterMac.mm
+++ b/Source/WebCore/page/mac/WheelEventDeltaFilterMac.mm
@@ -47,7 +47,7 @@ WheelEventDeltaFilterMac::WheelEventDeltaFilterMac()
 
 void WheelEventDeltaFilterMac::updateFromEvent(const PlatformWheelEvent& event)
 {
-    if (event.momentumPhase() != PlatformWheelEventPhase::None) {
+    if (event.isMomentumEvent()) {
         if (event.momentumPhase() == PlatformWheelEventPhase::Began)
             updateCurrentVelocityFromEvent(event);
         m_lastIOHIDEventTimestamp = event.ioHIDEventTimestamp();
@@ -55,6 +55,7 @@ void WheelEventDeltaFilterMac::updateFromEvent(const PlatformWheelEvent& event)
     }
 
     switch (event.phase()) {
+    case PlatformWheelEventPhase::WillBegin:
     case PlatformWheelEventPhase::None:
     case PlatformWheelEventPhase::Ended:
         break;

--- a/Source/WebCore/page/scrolling/ScrollingTreeGestureState.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeGestureState.cpp
@@ -82,6 +82,7 @@ void ScrollingTreeGestureState::nodeDidHandleEvent(ScrollingNodeID nodeID, const
     case PlatformWheelEventPhase::Changed:
     case PlatformWheelEventPhase::Stationary:
     case PlatformWheelEventPhase::None:
+    case PlatformWheelEventPhase::WillBegin:
         break;
     }
 
@@ -101,6 +102,7 @@ void ScrollingTreeGestureState::nodeDidHandleEvent(ScrollingNodeID nodeID, const
     case PlatformWheelEventPhase::Changed:
     case PlatformWheelEventPhase::Stationary:
     case PlatformWheelEventPhase::None:
+    case PlatformWheelEventPhase::WillBegin:
         break;
     }
 }

--- a/Source/WebCore/platform/PlatformWheelEvent.cpp
+++ b/Source/WebCore/platform/PlatformWheelEvent.cpp
@@ -96,6 +96,7 @@ TextStream& operator<<(TextStream& ts, PlatformWheelEventPhase phase)
     case PlatformWheelEventPhase::Ended: ts << "ended"_s; break;
     case PlatformWheelEventPhase::Cancelled: ts << "cancelled"_s; break;
     case PlatformWheelEventPhase::MayBegin: ts << "mayBegin"_s; break;
+    case PlatformWheelEventPhase::WillBegin: ts << "willBegin"_s; break;
 #endif
     }
     return ts;

--- a/Source/WebCore/platform/PlatformWheelEvent.h
+++ b/Source/WebCore/platform/PlatformWheelEvent.h
@@ -64,6 +64,7 @@ enum class PlatformWheelEventPhase : uint8_t {
     Ended       = 1 << 3,
     Cancelled   = 1 << 4,
     MayBegin    = 1 << 5,
+    WillBegin   = 1 << 6,
 #endif
 };
 
@@ -158,6 +159,7 @@ public:
     bool isGestureContinuation() const; // The fingers-down part of the gesture excluding momentum.
     bool shouldResetLatching() const;
     bool isEndOfMomentumScroll() const;
+    bool isMomentumEvent() const;
 #else
     bool useLatchedEventElement() const { return false; }
 #endif
@@ -234,6 +236,8 @@ inline bool PlatformWheelEvent::isEndOfMomentumScroll() const
 {
     return m_phase == PlatformWheelEventPhase::None && m_momentumPhase == PlatformWheelEventPhase::Ended;
 }
+
+inline bool PlatformWheelEvent::isMomentumEvent() const { return momentumPhase() != PlatformWheelEventPhase::None && momentumPhase() != PlatformWheelEventPhase::WillBegin; }
 
 #endif // ENABLE(ASYNC_SCROLLING)
 

--- a/Source/WebCore/platform/PlatformWheelEvent.serialization.in
+++ b/Source/WebCore/platform/PlatformWheelEvent.serialization.in
@@ -29,5 +29,6 @@ enum class WebCore::PlatformWheelEventPhase : uint8_t {
     Ended,
     Cancelled,
     MayBegin,
+    WillBegin,
 #endif
 };

--- a/Source/WebCore/platform/mac/ScrollingEffectsController.mm
+++ b/Source/WebCore/platform/mac/ScrollingEffectsController.mm
@@ -157,7 +157,7 @@ bool ScrollingEffectsController::handleWheelEvent(const PlatformWheelEvent& whee
         return true;
     }
 
-    bool isMomentumScrollEvent = (wheelEvent.momentumPhase() != PlatformWheelEventPhase::None);
+    bool isMomentumScrollEvent = wheelEvent.isMomentumEvent();
     if (m_ignoreMomentumScrolls && (isMomentumScrollEvent || m_isAnimatingRubberBand)) {
         if (wheelEvent.momentumPhase() == PlatformWheelEventPhase::Ended) {
             m_ignoreMomentumScrolls = false;

--- a/Source/WebKit/Shared/WebEvent.serialization.in
+++ b/Source/WebKit/Shared/WebEvent.serialization.in
@@ -215,6 +215,7 @@ class WebKit::WebGestureEvent : WebKit::WebEvent {
     PhaseEnded,
     PhaseCancelled,
     PhaseMayBegin,
+    PhaseWillBegin,
 };
 
 [Nested] enum class WebKit::WebWheelEvent::MomentumEndType : uint8_t {

--- a/Source/WebKit/Shared/WebWheelEvent.h
+++ b/Source/WebKit/Shared/WebWheelEvent.h
@@ -47,6 +47,7 @@ public:
         PhaseEnded       = 1 << 3,
         PhaseCancelled   = 1 << 4,
         PhaseMayBegin    = 1 << 5,
+        PhaseWillBegin   = 1 << 6,
     };
 
     enum class MomentumEndType : uint8_t {
@@ -81,6 +82,8 @@ public:
     uint32_t scrollCount() const { return m_scrollCount; }
     const WebCore::FloatSize& unacceleratedScrollingDelta() const { return m_unacceleratedScrollingDelta; }
 #endif
+
+    bool isMomentumEvent() const { return momentumPhase() != Phase::PhaseNone && momentumPhase() != Phase::PhaseWillBegin; }
 
     static bool isWheelEventType(WebEventType);
 

--- a/Source/WebKit/Shared/mac/WebEventFactory.mm
+++ b/Source/WebKit/Shared/mac/WebEventFactory.mm
@@ -190,6 +190,11 @@ WebWheelEvent WebEventFactory::createWebWheelEvent(NSEvent *event, NSView *windo
         
         rawPlatformDelta = { WebCore::FloatSize(-IOHIDEventGetFloatValue(ioHIDEvent.get(), kIOHIDEventFieldScrollX), -IOHIDEventGetFloatValue(ioHIDEvent.get(), kIOHIDEventFieldScrollY)) };
 
+        if (IOHIDEventGetScrollMomentum(ioHIDEvent.get()) & kIOHIDEventScrollMomentumWillBegin) {
+            ASSERT(momentumPhase == WebWheelEvent::Phase::PhaseNone && phase == WebWheelEvent::Phase::PhaseEnded);
+            momentumPhase = WebWheelEvent::Phase::PhaseWillBegin;
+        }
+
         bool momentumWasInterrupted = IOHIDEventGetScrollMomentum(ioHIDEvent.get()) & kIOHIDEventScrollMomentumInterrupted;
         momentumEndType = momentumWasInterrupted ? WebWheelEvent::MomentumEndType::Interrupted : WebWheelEvent::MomentumEndType::Natural;
     })();

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -1605,7 +1605,7 @@ bool PDFPlugin::handleWheelEvent(const WebWheelEvent& event)
     bool atScrollTop = !scrollPosition().y();
     bool atScrollBottom = scrollPosition().y() == maximumScrollPosition().y();
 
-    bool inMomentumScroll = event.momentumPhase() != WebWheelEvent::PhaseNone;
+    bool inMomentumScroll = event.isMomentumEvent();
 
     int scrollMagnitudeThresholdForPageFlip = defaultScrollMagnitudeThresholdForPageFlip;
 

--- a/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
+++ b/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
@@ -77,7 +77,7 @@ bool MomentumEventDispatcher::handleWheelEvent(WebCore::PageIdentifier pageIdent
     m_lastRubberBandableEdges = rubberBandableEdges;
     m_lastIncomingEvent = event;
 
-    bool isMomentumEvent = event.momentumPhase() != WebWheelEvent::PhaseNone;
+    bool isMomentumEvent = event.isMomentumEvent();
 
     if (m_currentGesture.active) {
         bool pageIdentifierChanged = pageIdentifier != m_currentGesture.pageIdentifier;

--- a/Source/WebKitLegacy/mac/DOM/WebDOMOperations.mm
+++ b/Source/WebKitLegacy/mac/DOM/WebDOMOperations.mm
@@ -273,6 +273,8 @@ static NSEventPhase toNSEventPhase(PlatformWheelEventPhase platformPhase)
         return NSEventPhaseCancelled;
     case PlatformWheelEventPhase::MayBegin:
         return NSEventPhaseMayBegin;
+    case PlatformWheelEventPhase::WillBegin:
+        return NSEventPhaseNone;
     }
 
     return NSEventPhaseNone;


### PR DESCRIPTION
#### b31973ed822b67cb44fce5b2c251a895c05c3db1
<pre>
Add momentum phase will begin to WebWheelEvent
<a href="https://bugs.webkit.org/show_bug.cgi?id=295945">https://bugs.webkit.org/show_bug.cgi?id=295945</a>
<a href="https://rdar.apple.com/155832880">rdar://155832880</a>

Reviewed by Simon Fraser.

To properly implement scrollend events, we need to know if a
phase ended wheel event will result in subsequent momentum events.
Although this has not been adopted by AppKit, we can look at the
underlying IOHIDEvent. This patch adds a WillBegin phase, which will
be consulted in an upcoming patch implemnting the scrollend event for
momentum scrolls.

* Source/WebCore/PAL/pal/spi/mac/IOKitSPIMac.h:
* Source/WebCore/page/WheelEventDeltaFilter.cpp:
(WebCore::BasicWheelEventDeltaFilter::updateFromEvent):
* Source/WebCore/page/mac/WheelEventDeltaFilterMac.mm:
(WebCore::WheelEventDeltaFilterMac::updateFromEvent):
* Source/WebCore/page/scrolling/ScrollingTreeGestureState.cpp:
(WebCore::ScrollingTreeGestureState::nodeDidHandleEvent):
* Source/WebCore/platform/PlatformWheelEvent.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/PlatformWheelEvent.h:
(WebCore::PlatformWheelEvent::isMomentumEvent const):
* Source/WebCore/platform/PlatformWheelEvent.serialization.in:
* Source/WebCore/platform/mac/ScrollingEffectsController.mm:
(WebCore::ScrollingEffectsController::handleWheelEvent):
* Source/WebKit/Shared/WebEvent.serialization.in:
* Source/WebKit/Shared/WebWheelEvent.h:
(WebKit::WebWheelEvent::isMomentumEvent const):
* Source/WebKit/Shared/mac/WebEventFactory.mm:
(WebKit::WebEventFactory::createWebWheelEvent):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::handleWheelEvent):
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp:
(WebKit::MomentumEventDispatcher::handleWheelEvent):
* Source/WebKitLegacy/mac/DOM/WebDOMOperations.mm:
(toNSEventPhase):

Canonical link: <a href="https://commits.webkit.org/297432@main">https://commits.webkit.org/297432@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/216296e66bd801e11005004897be2b88db235210

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111721 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31387 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21862 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117753 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61979 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113683 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32075 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39972 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84885 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35596 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114668 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25612 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100551 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65323 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24947 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18683 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61585 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94999 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18755 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121004 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38767 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28819 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93779 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39147 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96806 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93601 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38750 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16540 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34797 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18006 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38661 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44152 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38315 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41643 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40022 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->