### PR TITLE
Infinite recursion in XMLMalloc::free()

### DIFF
--- a/LayoutTests/fast/parser/resources/xhtml-parser-pending-callbacks-crash.js
+++ b/LayoutTests/fast/parser/resources/xhtml-parser-pending-callbacks-crash.js
@@ -1,0 +1,2 @@
+if (window.testRunner)
+    testRunner.dumpAsText();

--- a/LayoutTests/fast/parser/xhtml-parser-pending-callbacks-crash-expected.txt
+++ b/LayoutTests/fast/parser/xhtml-parser-pending-callbacks-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/parser/xhtml-parser-pending-callbacks-crash.xhtml
+++ b/LayoutTests/fast/parser/xhtml-parser-pending-callbacks-crash.xhtml
@@ -1,0 +1,6 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+<body>
+  <script src="resources/xhtml-parser-pending-callbacks-crash.js" />
+  <p>This test passes if it does not crash.</p>
+</body>
+</html>

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -109,19 +109,23 @@ static inline bool shouldRenderInXMLTreeViewerMode(Document& document)
 
 #endif
 
-// xmlMalloc() is a macro that calls malloc() and thus cannot be called directly from
-// XMLMalloc::malloc() or it would cause infinite recusion.
+// xmlMalloc() and xmlFree() are macros that call malloc() and free(), respectively. Thus, they
+// cannot be called directly from XMLMalloc::malloc() and XMLMalloc::free() or they would cause
+// infinite recusion.
+
 static void* xmlMallocHelper(size_t size)
 {
     return xmlMalloc(size);
 }
 
+static void xmlFreeHelper(void* p)
+{
+    xmlFree(p);
+}
+
 struct XMLMalloc {
     static void* malloc(size_t size) { return xmlMallocHelper(size); }
-    static void free(void* p)
-    {
-        xmlFree(p);
-    }
+    static void free(void* p) { xmlFreeHelper(p); }
 };
 
 static std::span<xmlChar> unsafeSpanIncludingNullTerminator(xmlChar* string)


### PR DESCRIPTION
#### 1d1b9f7f23d2cf622b698a01af3a995e260f13fd
<pre>
Infinite recursion in XMLMalloc::free()
<a href="https://bugs.webkit.org/show_bug.cgi?id=295946">https://bugs.webkit.org/show_bug.cgi?id=295946</a>
<a href="https://rdar.apple.com/155829627">rdar://155829627</a>

Reviewed by Chris Dumez.

XMLMalloc::free() calls xmlFree(), which in libxml2 is #defined to free(). This leads to infinite
recursion, since in this context XMLMalloc::free is resolved before ::free. Fixed this by doing
what we already do for XMLMalloc::malloc(): created a helper function named xmlFreeHelper() that
calls xmlFree().

Added a layout test.

* LayoutTests/fast/parser/resources/xhtml-parser-pending-callbacks-crash.js: Added.
* LayoutTests/fast/parser/xhtml-parser-pending-callbacks-crash-expected.txt: Added.
* LayoutTests/fast/parser/xhtml-parser-pending-callbacks-crash.xhtml: Added.
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::xmlFreeHelper):
(WebCore::XMLMalloc::free):

Canonical link: <a href="https://commits.webkit.org/297376@main">https://commits.webkit.org/297376@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96509eb9f8336fdbe6837ba69b78a833108ee570

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31258 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21732 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117626 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/61862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113553 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39843 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/84786 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/61862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114538 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25495 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100434 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65227 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/24835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18569 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61457 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/94881 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18638 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/120871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38644 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/28708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/120871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39021 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/96695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/120871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23831 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38646 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16437 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/34680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38533 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44017 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/38196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/41532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39898 "Build is in progress. Recent messages:") | | | 
<!--EWS-Status-Bubble-End-->