### PR TITLE
Adopt smart pointers in History.cpp, HistoryItem.cpp, ContentFilter.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -444,7 +444,6 @@ page/EventHandler.cpp
 page/FocusController.cpp
 page/Frame.cpp
 page/FrameSnapshotting.cpp
-page/History.cpp
 page/ImageOverlayController.cpp
 page/IntelligenceTextEffectsSupport.cpp
 page/InteractionRegion.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -273,7 +273,6 @@ layout/integration/inline/LineSelection.h
 layout/layouttree/LayoutBox.cpp
 layout/layouttree/LayoutElementBox.cpp
 layout/layouttree/LayoutTreeBuilder.cpp
-loader/ContentFilter.cpp
 loader/DocumentLoader.cpp
 loader/EmptyClients.cpp
 loader/FrameLoader.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -472,7 +472,6 @@ editing/markup.cpp
 history/BackForwardCache.cpp
 history/CachedFrame.cpp
 history/CachedPage.cpp
-history/HistoryItem.cpp
 html/AttachmentAssociatedElement.cpp
 html/CachedHTMLCollection.h
 html/CachedHTMLCollectionInlines.h
@@ -659,7 +658,6 @@ page/Frame.cpp
 page/FrameDestructionObserver.cpp
 page/FrameSnapshotting.cpp
 page/FrameTree.cpp
-page/History.cpp
 page/ImageAnalysisQueue.cpp
 page/ImageOverlayController.cpp
 page/InteractionRegion.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -230,7 +230,6 @@ editing/mac/EditorMac.mm
 editing/mac/FrameSelectionMac.mm
 history/CachedFrame.cpp
 history/CachedPage.cpp
-history/HistoryItem.cpp
 html/Autofill.cpp
 html/CachedHTMLCollectionInlines.h
 html/CanvasBase.cpp
@@ -324,7 +323,6 @@ page/Frame.cpp
 page/FrameSnapshotting.cpp
 page/FrameTree.cpp
 page/FrameView.cpp
-page/History.cpp
 page/ImageAnalysisQueue.cpp
 page/InteractionRegion.cpp
 page/IntersectionObserver.cpp

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -17,7 +17,6 @@ editing/cocoa/AlternativeTextUIController.mm
 editing/cocoa/AttributedString.mm
 editing/cocoa/DataDetection.mm
 editing/cocoa/HTMLConverter.mm
-loader/ContentFilter.cpp
 loader/archive/cf/LegacyWebArchive.cpp
 loader/archive/cf/LegacyWebArchiveMac.mm
 loader/cocoa/BundleResourceLoader.mm

--- a/Source/WebCore/history/HistoryItem.cpp
+++ b/Source/WebCore/history/HistoryItem.cpp
@@ -83,7 +83,7 @@ HistoryItem::HistoryItem(const HistoryItem& item)
     , m_isTargetItem(item.m_isTargetItem)
     , m_itemSequenceNumber(item.m_itemSequenceNumber)
     , m_documentSequenceNumber(item.m_documentSequenceNumber)
-    , m_formData(item.m_formData ? RefPtr<FormData> { item.m_formData->copy() } : nullptr)
+    , m_formData(item.m_formData ? RefPtr<FormData> { RefPtr { item.m_formData }->copy() } : nullptr)
     , m_formContentType(item.m_formContentType)
 #if PLATFORM(IOS_FAMILY)
     , m_obscuredInsets(item.m_obscuredInsets)
@@ -393,9 +393,9 @@ bool HistoryItem::hasSameDocumentTree(HistoryItem& otherItem) const
         return false;
 
     for (size_t i = 0; i < children().size(); i++) {
-        auto& child = children()[i].get();
-        auto* otherChild = otherItem.childItemWithDocumentSequenceNumber(child.documentSequenceNumber());
-        if (!otherChild || !child.hasSameDocumentTree(*otherChild))
+        Ref child = children()[i].get();
+        RefPtr otherChild = otherItem.childItemWithDocumentSequenceNumber(child->documentSequenceNumber());
+        if (!otherChild || !child->hasSameDocumentTree(*otherChild))
             return false;
     }
 

--- a/Source/WebCore/loader/ContentFilter.cpp
+++ b/Source/WebCore/loader/ContentFilter.cpp
@@ -315,15 +315,15 @@ URL ContentFilter::url()
 const URL& ContentFilter::blockedPageURL()
 {
     static NeverDestroyed blockedPageURL = [] () -> URL {
-        auto webCoreBundle = CFBundleGetBundleWithIdentifier(CFSTR("com.apple.WebCore"));
-        return adoptCF(CFBundleCopyResourceURL(webCoreBundle, CFSTR("ContentFilterBlockedPage"), CFSTR("html"), nullptr)).get();
+        RetainPtr webCoreBundle = CFBundleGetBundleWithIdentifier(CFSTR("com.apple.WebCore"));
+        return adoptCF(CFBundleCopyResourceURL(webCoreBundle.get(), CFSTR("ContentFilterBlockedPage"), CFSTR("html"), nullptr)).get();
     }();
     return blockedPageURL;
 }
 
 bool ContentFilter::continueAfterSubstituteDataRequest(const DocumentLoader& activeLoader, const SubstituteData& substituteData)
 {
-    if (auto contentFilter = activeLoader.contentFilter()) {
+    if (CheckedPtr contentFilter = activeLoader.contentFilter()) {
         if (contentFilter->m_state == State::Blocked && !contentFilter->m_isLoadingBlockedPage)
             return contentFilter->m_blockedError.failingURL() != substituteData.failingURL();
     }

--- a/Source/WebCore/page/History.cpp
+++ b/Source/WebCore/page/History.cpp
@@ -88,7 +88,7 @@ ExceptionOr<History::ScrollRestoration> History::scrollRestoration() const
     if (!isDocumentFullyActive(frame.get()))
         return documentNotFullyActive();
 
-    auto* historyItem = frame->loader().history().currentItem();
+    RefPtr historyItem = frame->loader().history().currentItem();
     if (!historyItem)
         return ScrollRestoration::Auto;
     
@@ -118,10 +118,10 @@ ExceptionOr<SerializedScriptValue*> History::state()
 
 SerializedScriptValue* History::stateInternal() const
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return nullptr;
-    auto* historyItem = frame->loader().history().currentItem();
+    RefPtr historyItem = frame->loader().history().currentItem();
     if (!historyItem)
         return nullptr;
     return historyItem->stateObject();
@@ -289,7 +289,7 @@ ExceptionOr<void> History::stateObjectAdded(RefPtr<SerializedScriptValue>&& data
             return createBlockedURLSecurityErrorWithMessageSuffix("Only differences in query and fragment are allowed for file: URLs."_s);
         }
 
-        Ref documentSecurityOrigin = frame->document()->securityOrigin();
+        Ref documentSecurityOrigin = document->securityOrigin();
         // We allow sandboxed documents, 'data:'/'file:' URLs, etc. to use 'pushState'/'replaceState' to modify the URL query and fragments.
         // See https://bugs.webkit.org/show_bug.cgi?id=183028 for the compatibility concerns.
         bool allowSandboxException = (documentSecurityOrigin->isLocal() || documentSecurityOrigin->isOpaque())
@@ -303,7 +303,7 @@ ExceptionOr<void> History::stateObjectAdded(RefPtr<SerializedScriptValue>&& data
         return result.releaseException();
 
     if (document->settings().navigationAPIEnabled()) {
-        Ref navigation = document->window()->navigation();
+        Ref navigation = document->protectedWindow()->navigation();
         if (!navigation->dispatchPushReplaceReloadNavigateEvent(fullURL, historyBehavior == NavigationHistoryBehavior::Push ? NavigationNavigationType::Push : NavigationNavigationType::Replace, true, nullptr, data.get()))
             return { };
     }


### PR DESCRIPTION
#### 7216c347187a85062a5b3e414951a5952a11a29b
<pre>
Adopt smart pointers in History.cpp, HistoryItem.cpp, ContentFilter.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=295957">https://bugs.webkit.org/show_bug.cgi?id=295957</a>
<a href="https://rdar.apple.com/155845650">rdar://155845650</a>

Reviewed by Rupin Mittal and Anne van Kesteren.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/WebCore/history/HistoryItem.cpp:
(WebCore::m_formData):
(WebCore::HistoryItem::hasSameDocumentTree const):
* Source/WebCore/loader/ContentFilter.cpp:
(WebCore::ContentFilter::blockedPageURL):
(WebCore::ContentFilter::continueAfterSubstituteDataRequest):
* Source/WebCore/page/History.cpp:
(WebCore::History::scrollRestoration const):
(WebCore::History::stateInternal const):
(WebCore::History::stateObjectAdded):

Canonical link: <a href="https://commits.webkit.org/297448@main">https://commits.webkit.org/297448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d079fb6db3971c10cded60f08e51e992752ed17e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111774 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31437 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117796 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62009 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113737 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32123 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40021 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84915 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35604 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114721 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25645 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100596 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65352 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24973 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18729 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61629 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95028 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18801 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121049 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38810 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28851 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93799 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39190 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96852 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93621 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38785 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16574 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34831 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18021 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38706 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44202 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38350 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41675 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40063 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->