### PR TITLE
Rename AudioSession::sharedSession to AudioSession::singleton

### DIFF
--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
@@ -77,12 +77,12 @@ Ref<DOMAudioSession> DOMAudioSession::create(ScriptExecutionContext* context)
 DOMAudioSession::DOMAudioSession(ScriptExecutionContext* context)
     : ActiveDOMObject(context)
 {
-    AudioSession::protectedSharedSession()->addInterruptionObserver(*this);
+    AudioSession::singleton().addInterruptionObserver(*this);
 }
 
 DOMAudioSession::~DOMAudioSession()
 {
-    AudioSession::protectedSharedSession()->removeInterruptionObserver(*this);
+    AudioSession::singleton().removeInterruptionObserver(*this);
 }
 
 ExceptionOr<void> DOMAudioSession::setType(Type type)
@@ -101,7 +101,7 @@ ExceptionOr<void> DOMAudioSession::setType(Type type)
     page->setAudioSessionType(type);
 
     auto categoryOverride = fromDOMAudioSessionType(type);
-    AudioSession::protectedSharedSession()->setCategoryOverride(categoryOverride);
+    AudioSession::singleton().setCategoryOverride(categoryOverride);
 
     if (categoryOverride == AudioSessionCategory::None)
         PlatformMediaSessionManager::updateAudioSessionCategoryIfNecessary();
@@ -126,10 +126,10 @@ DOMAudioSession::Type DOMAudioSession::type() const
 
 static DOMAudioSession::State computeAudioSessionState()
 {
-    if (AudioSession::sharedSession().isInterrupted())
+    if (AudioSession::singleton().isInterrupted())
         return DOMAudioSession::State::Interrupted;
 
-    if (!AudioSession::sharedSession().isActive())
+    if (!AudioSession::singleton().isActive())
         return DOMAudioSession::State::Inactive;
 
     return DOMAudioSession::State::Active;

--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -162,7 +162,7 @@ void MediaDevices::getUserMedia(StreamConstraints&& constraints, Promise&& promi
 
 #if USE(AUDIO_SESSION)
     if (audioConstraints.isValid) {
-        auto categoryOverride = AudioSession::protectedSharedSession()->categoryOverride();
+        auto categoryOverride = AudioSession::singleton().categoryOverride();
         if (categoryOverride != AudioSessionCategory::None && categoryOverride != AudioSessionCategory::PlayAndRecord)  {
             promise.reject(Exception { ExceptionCode::InvalidStateError, "AudioSession category is not compatible with audio capture."_s });
             return;

--- a/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
+++ b/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
@@ -207,7 +207,7 @@ void UserMediaRequest::allow(CaptureDevice&& audioDevice, CaptureDevice&& videoD
 
             if (RefPtr audioTrack = stream->getFirstAudioTrack()) {
 #if USE(AUDIO_SESSION)
-                AudioSession::sharedSession().tryToSetActive(true);
+                AudioSession::singleton().tryToSetActive(true);
 #endif
                 if (std::holds_alternative<MediaTrackConstraints>(protectedThis->m_audioConstraints))
                     audioTrack->setConstraints(std::get<MediaTrackConstraints>(WTFMove(protectedThis->m_audioConstraints)));

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
@@ -362,7 +362,7 @@ ExceptionOr<Ref<ScriptProcessorNode>> BaseAudioContext::createScriptProcessor(si
     case 0:
 #if USE(AUDIO_SESSION)
         // Pick a value between 256 (2^8) and 16384 (2^14), based on the buffer size of the current AudioSession:
-        bufferSize = 1 << std::max<size_t>(8, std::min<size_t>(14, std::log2(AudioSession::sharedSession().bufferSize())));
+        bufferSize = 1 << std::max<size_t>(8, std::min<size_t>(14, std::log2(AudioSession::singleton().bufferSize())));
 #else
         bufferSize = 2048;
 #endif

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -6,7 +6,6 @@ Modules/airplay/WebMediaSessionManager.cpp
 Modules/applepay/ApplePaySession.cpp
 Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp
 Modules/applicationmanifest/ApplicationManifestParser.cpp
-Modules/audiosession/DOMAudioSession.cpp
 Modules/cache/DOMCache.cpp
 Modules/cache/DOMCacheStorage.cpp
 Modules/cache/RetrieveRecordsOptions.h
@@ -822,7 +821,6 @@ platform/mediastream/cocoa/AudioMediaStreamTrackRendererCocoa.cpp
 platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.cpp
 platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp
 platform/mediastream/mac/MediaStreamTrackAudioSourceProviderCocoa.cpp
-platform/mediastream/mac/MockAudioSharedUnit.mm
 platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.cpp
 platform/mediastream/mac/WebAudioSourceProviderCocoa.mm
 platform/mock/GeolocationClientMock.cpp

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -707,7 +707,7 @@ void HTMLMediaElement::initializeMediaSession()
     registerWithDocument(document);
 
 #if USE(AUDIO_SESSION) && PLATFORM(MAC)
-    AudioSession::sharedSession().addConfigurationChangeObserver(*this);
+    AudioSession::singleton().addConfigurationChangeObserver(*this);
 #endif
 
     m_mediaSession->clientWillBeginAutoplaying();
@@ -749,7 +749,7 @@ HTMLMediaElement::~HTMLMediaElement()
     unregisterWithDocument(Ref<Document> { document() });
 
 #if USE(AUDIO_SESSION) && PLATFORM(MAC)
-    AudioSession::sharedSession().removeConfigurationChangeObserver(*this);
+    AudioSession::singleton().removeConfigurationChangeObserver(*this);
 #endif
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
@@ -6522,8 +6522,8 @@ void HTMLMediaElement::playPlayer()
         return;
 
 #if USE(AUDIO_SESSION)
-    m_categoryAtMostRecentPlayback = AudioSession::sharedSession().category();
-    m_modeAtMostRecentPlayback = AudioSession::sharedSession().mode();
+    m_categoryAtMostRecentPlayback = AudioSession::singleton().category();
+    m_modeAtMostRecentPlayback = AudioSession::singleton().mode();
 #endif
 
 #if ENABLE(MEDIA_SESSION) && ENABLE(MEDIA_SESSION_COORDINATOR)

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -826,7 +826,7 @@ void MediaElementSession::showPlaybackTargetPicker()
     }
 #endif
 
-    auto& audioSession = AudioSession::sharedSession();
+    auto& audioSession = AudioSession::singleton();
     document->showPlaybackTargetPicker(*this, is<HTMLVideoElement>(m_element), audioSession.routeSharingPolicy(), audioSession.routingContextUID());
 }
 

--- a/Source/WebCore/page/DeprecatedGlobalSettings.cpp
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.cpp
@@ -95,12 +95,12 @@ void DeprecatedGlobalSettings::setTrackingPreventionEnabled(bool flag)
 #if PLATFORM(IOS_FAMILY)
 void DeprecatedGlobalSettings::setAudioSessionCategoryOverride(unsigned sessionCategory)
 {
-    AudioSession::sharedSession().setCategoryOverride(static_cast<AudioSession::CategoryType>(sessionCategory));
+    AudioSession::singleton().setCategoryOverride(static_cast<AudioSession::CategoryType>(sessionCategory));
 }
 
 unsigned DeprecatedGlobalSettings::audioSessionCategoryOverride()
 {
-    return static_cast<unsigned>(AudioSession::sharedSession().categoryOverride());
+    return static_cast<unsigned>(AudioSession::singleton().categoryOverride());
 }
 
 void DeprecatedGlobalSettings::setNetworkInterfaceName(const String& networkInterfaceName)

--- a/Source/WebCore/platform/audio/AudioSession.cpp
+++ b/Source/WebCore/platform/audio/AudioSession.cpp
@@ -100,7 +100,7 @@ Ref<AudioSession> AudioSession::create()
 AudioSession::AudioSession() = default;
 AudioSession::~AudioSession() = default;
 
-AudioSession& AudioSession::sharedSession()
+AudioSession& AudioSession::singleton()
 {
     if (!s_mediaPlaybackEnabled)
         return dummyAudioSession();
@@ -141,11 +141,10 @@ bool AudioSession::tryToSetActive(bool active)
     m_active = active;
     if (m_isInterrupted && m_active) {
         callOnMainThread([hasActiveChanged] {
-            Ref session = sharedSession();
-            if (session->m_isInterrupted && session->m_active)
-                session->endInterruption(MayResume::Yes);
+            if (singleton().m_isInterrupted && singleton().m_active)
+                singleton().endInterruption(MayResume::Yes);
             if (hasActiveChanged)
-                session->activeStateChanged();
+                singleton().activeStateChanged();
         });
     } else if (hasActiveChanged)
         activeStateChanged();

--- a/Source/WebCore/platform/audio/AudioSession.h
+++ b/Source/WebCore/platform/audio/AudioSession.h
@@ -110,8 +110,7 @@ class WEBCORE_EXPORT AudioSession : public ThreadSafeRefCountedAndCanMakeThreadS
 public:
     static Ref<AudioSession> create();
     static void setSharedSession(Ref<AudioSession>&&);
-    static AudioSession& sharedSession();
-    static Ref<AudioSession> protectedSharedSession() { return sharedSession(); }
+    static AudioSession& singleton();
 
     static bool enableMediaPlayback();
 

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
@@ -732,7 +732,7 @@ void PlatformMediaSessionManager::maybeDeactivateAudioSession()
         return;
 
     ALWAYS_LOG(LOGIDENTIFIER, "tried to set inactive AudioSession");
-    AudioSession::protectedSharedSession()->tryToSetActive(false);
+    AudioSession::singleton().tryToSetActive(false);
     m_becameActive = false;
 #endif
 }
@@ -745,7 +745,7 @@ bool PlatformMediaSessionManager::maybeActivateAudioSession()
         return true;
     }
 
-    m_becameActive = AudioSession::protectedSharedSession()->tryToSetActive(true);
+    m_becameActive = AudioSession::singleton().tryToSetActive(true);
     ALWAYS_LOG(LOGIDENTIFIER, m_becameActive ? "successfully activated" : "failed to activate", " AudioSession");
     return m_becameActive;
 #else

--- a/Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.cpp
@@ -53,7 +53,7 @@ Ref<AudioDestination> AudioDestination::create(const CreationOptions& options)
     if (options.numberOfInputChannels)
         RELEASE_LOG(Media, "AudioDestination::create(%u, %u, %f) - unhandled input channels", options.numberOfInputChannels, options.numberOfOutputChannels, options.sampleRate);
 
-    if (options.numberOfOutputChannels > AudioSession::sharedSession().maximumNumberOfOutputChannels())
+    if (options.numberOfOutputChannels > AudioSession::singleton().maximumNumberOfOutputChannels())
         RELEASE_LOG(Media, "AudioDestination::create(%u, %u, %f) - unhandled output channels", options.numberOfInputChannels, options.numberOfOutputChannels, options.sampleRate);
 
     if (AudioDestinationCocoa::createOverride)
@@ -66,12 +66,12 @@ Ref<AudioDestination> AudioDestination::create(const CreationOptions& options)
 
 float AudioDestination::hardwareSampleRate()
 {
-    return AudioSession::sharedSession().sampleRate();
+    return AudioSession::singleton().sampleRate();
 }
 
 unsigned long AudioDestination::maxChannelCount()
 {
-    return AudioSession::sharedSession().maximumNumberOfOutputChannels();
+    return AudioSession::singleton().maximumNumberOfOutputChannels();
 }
 
 AudioDestinationCocoa::AudioDestinationCocoa(const CreationOptions& options)
@@ -133,7 +133,7 @@ OSStatus AudioDestinationCocoa::render(double sampleTime, uint64_t hostTime, UIn
 
 MediaTime AudioDestinationCocoa::outputLatency() const
 {
-    return MediaTime { static_cast<int64_t>(m_audioOutputUnitAdaptor.outputLatency()), static_cast<uint32_t>(sampleRate()) } + MediaTime { static_cast<int64_t>(AudioSession::protectedSharedSession()->outputLatency()), static_cast<uint32_t>(AudioSession::protectedSharedSession()->sampleRate()) };
+    return MediaTime { static_cast<int64_t>(m_audioOutputUnitAdaptor.outputLatency()), static_cast<uint32_t>(sampleRate()) } + MediaTime { static_cast<int64_t>(AudioSession::singleton().outputLatency()), static_cast<uint32_t>(AudioSession::singleton().sampleRate()) };
 }
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/platform/audio/ios/AudioOutputUnitAdaptorIOS.cpp
+++ b/Source/WebCore/platform/audio/ios/AudioOutputUnitAdaptorIOS.cpp
@@ -96,7 +96,7 @@ void AudioOutputUnitAdaptor::configure(float hardwareSampleRate, unsigned number
     result = PAL::AudioUnitSetProperty(m_outputUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, (void*)&streamFormat, sizeof(AudioStreamBasicDescription));
     ASSERT_UNUSED(result, !result);
 
-    AudioSession::sharedSession().setPreferredBufferSize(kPreferredBufferSize);
+    AudioSession::singleton().setPreferredBufferSize(kPreferredBufferSize);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/audio/ios/AudioSessionIOS.mm
+++ b/Source/WebCore/platform/audio/ios/AudioSessionIOS.mm
@@ -111,7 +111,7 @@ static WeakHashSet<AudioSessionIOS::CategoryChangedObserver>& audioSessionCatego
 void AudioSessionIOS::addAudioSessionCategoryChangedObserver(const CategoryChangedObserver& observer)
 {
     audioSessionCategoryChangedObservers().add(observer);
-    observer(AudioSession::sharedSession(), AudioSession::sharedSession().category());
+    observer(AudioSession::singleton(), AudioSession::singleton().category());
 }
 
 Ref<AudioSessionIOS> AudioSessionIOS::create()

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
@@ -55,7 +55,7 @@ const std::unique_ptr<PlatformMediaSessionManager> PlatformMediaSessionManager::
 MediaSessionManageriOS::MediaSessionManageriOS()
     : MediaSessionManagerCocoa()
 {
-    AudioSession::sharedSession().addInterruptionObserver(*this);
+    AudioSession::singleton().addInterruptionObserver(*this);
 }
 
 MediaSessionManageriOS::~MediaSessionManageriOS()
@@ -63,7 +63,7 @@ MediaSessionManageriOS::~MediaSessionManageriOS()
     if (m_isMonitoringWirelessRoutes)
         MediaSessionHelper::sharedHelper().stopMonitoringWirelessRoutes();
     MediaSessionHelper::sharedHelper().removeClient(*this);
-    AudioSession::sharedSession().removeInterruptionObserver(*this);
+    AudioSession::singleton().removeInterruptionObserver(*this);
 }
 
 #if !PLATFORM(MACCATALYST)

--- a/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm
@@ -364,8 +364,7 @@ void VideoPresentationModelVideoElement::fullscreenModeChanged(HTMLMediaElementE
 
 void VideoPresentationModelVideoElement::requestRouteSharingPolicyAndContextUID(CompletionHandler<void(RouteSharingPolicy, String)>&& completionHandler)
 {
-    Ref session = AudioSession::sharedSession();
-    completionHandler(session->routeSharingPolicy(), session->routingContextUID());
+    completionHandler(AudioSession::singleton().routeSharingPolicy(), AudioSession::singleton().routingContextUID());
 }
 
 void VideoPresentationModelVideoElement::addClient(VideoPresentationModelClient& client)

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.cpp
@@ -227,7 +227,7 @@ void LocalAudioMediaStreamTrackRendererInternalUnit::createAudioUnitIfNeeded()
             return;
         }
 
-        outputDescription.mSampleRate = AudioSession::protectedSharedSession()->sampleRate();
+        outputDescription.mSampleRate = AudioSession::singleton().sampleRate();
         m_outputDescription = outputDescription;
     }
     error = PAL::AudioUnitSetProperty(remoteIOUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, &m_outputDescription->streamDescription(), sizeof(m_outputDescription->streamDescription()));

--- a/Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.mm
+++ b/Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.mm
@@ -187,7 +187,7 @@ void AVAudioSessionCaptureDeviceManager::setPreferredSpeakerID(const String& spe
     } else
         m_isReceiverPreferredSpeaker = false;
 
-    AudioSession::sharedSession().setCategory(AudioSession::sharedSession().category(), AudioSession::sharedSession().mode(), AudioSession::sharedSession().routeSharingPolicy());
+    AudioSession::singleton().setCategory(AudioSession::singleton().category(), AudioSession::singleton().mode(), AudioSession::singleton().routeSharingPolicy());
 }
 
 bool AVAudioSessionCaptureDeviceManager::setPreferredAudioSessionDeviceIDs()

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
@@ -41,7 +41,7 @@ namespace WebCore {
 constexpr Seconds voiceActivityThrottlingDuration = 5_s;
 
 BaseAudioSharedUnit::BaseAudioSharedUnit()
-    : m_sampleRate(AudioSession::protectedSharedSession()->sampleRate())
+    : m_sampleRate(AudioSession::singleton().sampleRate())
 {
     RealtimeMediaSourceCenter::singleton().addDevicesChangedObserver(*this);
 }
@@ -138,10 +138,10 @@ OSStatus BaseAudioSharedUnit::startUnit()
     forEachClient([](auto& client) {
         client.audioUnitWillStart();
     });
-    ASSERT(!DeprecatedGlobalSettings::shouldManageAudioSessionCategory() || AudioSession::sharedSession().category() == AudioSession::CategoryType::PlayAndRecord);
+    ASSERT(!DeprecatedGlobalSettings::shouldManageAudioSessionCategory() || AudioSession::singleton().category() == AudioSession::CategoryType::PlayAndRecord);
 
 #if PLATFORM(IOS_FAMILY)
-    if (AudioSession::sharedSession().category() != AudioSession::CategoryType::PlayAndRecord) {
+    if (AudioSession::singleton().category() != AudioSession::CategoryType::PlayAndRecord) {
         RELEASE_LOG_ERROR(WebRTC, "BaseAudioSharedUnit::startUnit cannot call startInternal if category is not set to PlayAndRecord");
         return lowPriorityError2;
     }

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
@@ -109,12 +109,12 @@ CaptureSourceOrError CoreAudioCaptureSource::createForTesting(String&& deviceID,
 
 CoreAudioCaptureSourceFactory::CoreAudioCaptureSourceFactory()
 {
-    AudioSession::protectedSharedSession()->addInterruptionObserver(*this);
+    AudioSession::singleton().addInterruptionObserver(*this);
 }
 
 CoreAudioCaptureSourceFactory::~CoreAudioCaptureSourceFactory()
 {
-    AudioSession::protectedSharedSession()->removeInterruptionObserver(*this);
+    AudioSession::singleton().removeInterruptionObserver(*this);
 }
 
 void CoreAudioCaptureSourceFactory::beginInterruption()

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
@@ -254,7 +254,7 @@ CoreAudioSharedUnit::StoredAudioUnit CoreAudioSharedUnit::takeStoredVPIOUnit()
 
 void CoreAudioSharedUnit::resetSampleRate()
 {
-    setSampleRate(m_getSampleRateCallback ? m_getSampleRateCallback() : AudioSession::protectedSharedSession()->sampleRate());
+    setSampleRate(m_getSampleRateCallback ? m_getSampleRateCallback() : AudioSession::singleton().sampleRate());
 }
 
 void CoreAudioSharedUnit::captureDeviceChanged()
@@ -269,7 +269,7 @@ void CoreAudioSharedUnit::captureDeviceChanged()
 
 size_t CoreAudioSharedUnit::preferredIOBufferSize()
 {
-    return AudioSession::protectedSharedSession()->bufferSize();
+    return AudioSession::singleton().bufferSize();
 }
 
 OSStatus CoreAudioSharedUnit::setupAudioUnit()

--- a/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
+++ b/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
@@ -353,7 +353,7 @@ void MockAudioSharedInternalUnit::generateSampleBuffers(MonotonicTime renderTime
         reconfigure();
 
     uint32_t totalFrameCount = alignTo16Bytes(delta.seconds() * sampleRate());
-    uint32_t frameCount = std::min(totalFrameCount, static_cast<uint32_t>(AudioSession::sharedSession().bufferSize()));
+    uint32_t frameCount = std::min(totalFrameCount, static_cast<uint32_t>(AudioSession::singleton().bufferSize()));
 
     while (frameCount) {
         uint32_t bipBopStart = m_samplesRendered % m_bipBopBuffer.size();
@@ -368,7 +368,7 @@ void MockAudioSharedInternalUnit::generateSampleBuffers(MonotonicTime renderTime
         emitSampleBuffers(bipBopCount);
         m_samplesRendered += bipBopCount;
         totalFrameCount -= bipBopCount;
-        frameCount = std::min(totalFrameCount, static_cast<uint32_t>(AudioSession::sharedSession().bufferSize()));
+        frameCount = std::min(totalFrameCount, static_cast<uint32_t>(AudioSession::singleton().bufferSize()));
     }
 }
 

--- a/Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp
@@ -149,8 +149,8 @@ void MockRealtimeAudioSource::startProducingData()
 {
 #if PLATFORM(IOS_FAMILY)
     PlatformMediaSessionManager::singleton().sessionCanProduceAudioChanged();
-    ASSERT(AudioSession::sharedSession().category() == AudioSession::CategoryType::PlayAndRecord);
-    ASSERT(AudioSession::sharedSession().mode() == AudioSession::Mode::VideoChat);
+    ASSERT(AudioSession::singleton().category() == AudioSession::CategoryType::PlayAndRecord);
+    ASSERT(AudioSession::singleton().mode() == AudioSession::Mode::VideoChat);
 #endif
 
     if (!sampleRate())

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -709,9 +709,9 @@ void Internals::resetToConsistentState(Page& page)
     TextPainter::setForceUseGlyphDisplayListForTesting(false);
 
 #if USE(AUDIO_SESSION)
-    AudioSession::sharedSession().setCategoryOverride(AudioSessionCategory::None);
-    AudioSession::sharedSession().tryToSetActive(false);
-    AudioSession::sharedSession().endInterruptionForTesting();
+    AudioSession::singleton().setCategoryOverride(AudioSessionCategory::None);
+    AudioSession::singleton().tryToSetActive(false);
+    AudioSession::singleton().endInterruptionForTesting();
 #endif
 
 #if ENABLE(DAMAGE_TRACKING)
@@ -5173,7 +5173,7 @@ void Internals::forceStereoDecoding(HTMLMediaElement& element)
 void Internals::beginAudioSessionInterruption()
 {
 #if USE(AUDIO_SESSION)
-    AudioSession::sharedSession().beginInterruptionForTesting();
+    AudioSession::singleton().beginInterruptionForTesting();
 #endif
 }
 
@@ -5181,14 +5181,14 @@ void Internals::beginAudioSessionInterruption()
 void Internals::endAudioSessionInterruption()
 {
 #if USE(AUDIO_SESSION)
-    AudioSession::sharedSession().endInterruptionForTesting();
+    AudioSession::singleton().endInterruptionForTesting();
 #endif
 }
 
 void Internals::clearAudioSessionInterruptionFlag()
 {
 #if USE(AUDIO_SESSION)
-    AudioSession::sharedSession().clearInterruptionFlagForTesting();
+    AudioSession::singleton().clearInterruptionFlagForTesting();
 #endif
 }
 
@@ -6022,7 +6022,7 @@ double Internals::elementEffectivePlaybackRate(const HTMLMediaElement& media)
 ExceptionOr<void> Internals::setIsPlayingToBluetoothOverride(std::optional<bool> isPlaying)
 {
 #if ENABLE(ROUTING_ARBITRATION)
-    AudioSession::sharedSession().setIsPlayingToBluetoothOverride(isPlaying);
+    AudioSession::singleton().setIsPlayingToBluetoothOverride(isPlaying);
     return { };
 #else
     UNUSED_PARAM(isPlaying);
@@ -6454,7 +6454,7 @@ bool Internals::supportsAudioSession() const
 auto Internals::audioSessionCategory() const -> AudioSessionCategory
 {
 #if USE(AUDIO_SESSION)
-    return AudioSession::sharedSession().category();
+    return AudioSession::singleton().category();
 #else
     return AudioSessionCategory::None;
 #endif
@@ -6463,7 +6463,7 @@ auto Internals::audioSessionCategory() const -> AudioSessionCategory
 auto Internals::audioSessionMode() const -> AudioSessionMode
 {
 #if USE(AUDIO_SESSION)
-    return AudioSession::sharedSession().mode();
+    return AudioSession::singleton().mode();
 #else
     return AudioSessionMode::Default;
 #endif
@@ -6472,7 +6472,7 @@ auto Internals::audioSessionMode() const -> AudioSessionMode
 auto Internals::routeSharingPolicy() const -> RouteSharingPolicy
 {
 #if USE(AUDIO_SESSION)
-    return AudioSession::sharedSession().routeSharingPolicy();
+    return AudioSession::singleton().routeSharingPolicy();
 #else
     return RouteSharingPolicy::Default;
 #endif
@@ -6504,7 +6504,7 @@ auto Internals::modeAtMostRecentPlayback(HTMLMediaElement& element) const -> Aud
 double Internals::preferredAudioBufferSize() const
 {
 #if USE(AUDIO_SESSION)
-    return AudioSession::sharedSession().preferredBufferSize();
+    return AudioSession::singleton().preferredBufferSize();
 #endif
     return 0;
 }
@@ -6512,7 +6512,7 @@ double Internals::preferredAudioBufferSize() const
 double Internals::currentAudioBufferSize() const
 {
 #if USE(AUDIO_SESSION)
-    return AudioSession::sharedSession().bufferSize();
+    return AudioSession::singleton().bufferSize();
 #endif
     return 0;
 }
@@ -6521,7 +6521,7 @@ double Internals::currentAudioBufferSize() const
 bool Internals::audioSessionActive() const
 {
 #if USE(AUDIO_SESSION)
-    return AudioSession::sharedSession().isActive();
+    return AudioSession::singleton().isActive();
 #endif
     return false;
 }

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
@@ -186,12 +186,12 @@ Ref<IPC::Connection> RemoteAudioSessionProxy::protectedConnection() const
 
 void RemoteAudioSessionProxy::triggerBeginInterruptionForTesting()
 {
-    AudioSession::protectedSharedSession()->beginInterruptionForTesting();
+    AudioSession::singleton().beginInterruptionForTesting();
 }
 
 void RemoteAudioSessionProxy::triggerEndInterruptionForTesting()
 {
-    AudioSession::protectedSharedSession()->endInterruptionForTesting();
+    AudioSession::singleton().endInterruptionForTesting();
 }
 
 std::optional<SharedPreferencesForWebProcess> RemoteAudioSessionProxy::sharedPreferencesForWebProcess() const

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
@@ -51,16 +51,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteAudioSessionProxyManager);
 RemoteAudioSessionProxyManager::RemoteAudioSessionProxyManager(GPUProcess& gpuProcess)
     : m_gpuProcess(gpuProcess)
 {
-    Ref session = AudioSession::sharedSession();
-    session->addInterruptionObserver(*this);
-    session->addConfigurationChangeObserver(*this);
+    AudioSession::singleton().addInterruptionObserver(*this);
+    AudioSession::singleton().addConfigurationChangeObserver(*this);
 }
 
 RemoteAudioSessionProxyManager::~RemoteAudioSessionProxyManager()
 {
-    Ref session = AudioSession::sharedSession();
-    session->removeInterruptionObserver(*this);
-    session->removeConfigurationChangeObserver(*this);
+    AudioSession::singleton().removeInterruptionObserver(*this);
+    AudioSession::singleton().removeConfigurationChangeObserver(*this);
 }
 
 void RemoteAudioSessionProxyManager::addProxy(RemoteAudioSessionProxy& proxy, std::optional<audit_token_t> auditToken)
@@ -70,7 +68,7 @@ void RemoteAudioSessionProxyManager::addProxy(RemoteAudioSessionProxy& proxy, st
     updateCategory();
 
     if (auditToken)
-        AudioSession::protectedSharedSession()->setHostProcessAttribution(*auditToken);
+        AudioSession::singleton().setHostProcessAttribution(*auditToken);
 }
 
 void RemoteAudioSessionProxyManager::removeProxy(RemoteAudioSessionProxy& proxy)
@@ -119,7 +117,7 @@ void RemoteAudioSessionProxyManager::updateCategory()
     else if (policyCounts.contains(RouteSharingPolicy::Independent))
         ASSERT_NOT_REACHED();
 
-    AudioSession::protectedSharedSession()->setCategory(category, mode, policy);
+    AudioSession::singleton().setCategory(category, mode, policy);
 }
 
 void RemoteAudioSessionProxyManager::updatePreferredBufferSizeForProcess()
@@ -131,7 +129,7 @@ void RemoteAudioSessionProxyManager::updatePreferredBufferSizeForProcess()
     }
 
     if (preferredBufferSize != std::numeric_limits<size_t>::max())
-        AudioSession::protectedSharedSession()->setPreferredBufferSize(preferredBufferSize);
+        AudioSession::singleton().setPreferredBufferSize(preferredBufferSize);
 }
 
 void RemoteAudioSessionProxyManager::updateSpatialExperience()
@@ -148,9 +146,8 @@ void RemoteAudioSessionProxyManager::updateSpatialExperience()
         }
     }
 
-    Ref session = AudioSession::sharedSession();
-    session->setSceneIdentifier(sceneIdentifier);
-    session->setSoundStageSize(maxSize.value_or(AudioSession::SoundStageSize::Automatic));
+    AudioSession::singleton().setSceneIdentifier(sceneIdentifier);
+    AudioSession::singleton().setSoundStageSize(maxSize.value_or(AudioSession::SoundStageSize::Automatic));
 }
 
 bool RemoteAudioSessionProxyManager::hasOtherActiveProxyThan(RemoteAudioSessionProxy& proxyToExclude)
@@ -185,13 +182,13 @@ bool RemoteAudioSessionProxyManager::tryToSetActiveForProcess(RemoteAudioSession
         // This proxy wants to de-activate, and is the last remaining active
         // proxy. Deactivate the session, and return whether that deactivation
         // was sucessful.
-        return AudioSession::protectedSharedSession()->tryToSetActive(false);
+        return AudioSession::singleton().tryToSetActive(false);
     }
 
     if (!hasActiveNotInterruptedProxy()) {
         // This proxy and only this proxy wants to become active. Activate
         // the session, and return whether that activation was successful.
-        return AudioSession::protectedSharedSession()->tryToSetActive(active);
+        return AudioSession::singleton().tryToSetActive(active);
     }
 
     // If this proxy is Ambient, and the session is already active, this
@@ -247,7 +244,7 @@ void RemoteAudioSessionProxyManager::updatePresentingProcesses()
         presentingProcesses.append(*token);
 
     if (!presentingProcesses.isEmpty())
-        AudioSession::protectedSharedSession()->setPresentingProcesses(WTFMove(presentingProcesses));
+        AudioSession::singleton().setPresentingProcesses(WTFMove(presentingProcesses));
 }
 
 void RemoteAudioSessionProxyManager::beginInterruptionRemote()

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h
@@ -63,10 +63,10 @@ public:
     void beginInterruptionRemote();
     void endInterruptionRemote(WebCore::AudioSession::MayResume);
 
-    WebCore::AudioSession& session() { return WebCore::AudioSession::sharedSession(); }
-    const WebCore::AudioSession& session() const { return WebCore::AudioSession::sharedSession(); }
-    Ref<WebCore::AudioSession> protectedSession() { return WebCore::AudioSession::sharedSession(); }
-    Ref<const WebCore::AudioSession> protectedSession() const { return WebCore::AudioSession::sharedSession(); }
+    WebCore::AudioSession& session() { return WebCore::AudioSession::singleton(); }
+    const WebCore::AudioSession& session() const { return WebCore::AudioSession::singleton(); }
+    Ref<WebCore::AudioSession> protectedSession() { return WebCore::AudioSession::singleton(); }
+    Ref<const WebCore::AudioSession> protectedSession() const { return WebCore::AudioSession::singleton(); }
 
     void updatePresentingProcesses();
 

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -190,7 +190,7 @@ RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::RemoteAudioMediaStre
     , m_localUnit(WebCore::AudioMediaStreamTrackRendererInternalUnit::create(deviceID, *this))
     , m_canUseCaptureUnit(deviceID == AudioMediaStreamTrackRenderer::defaultDeviceID())
 {
-    WebCore::AudioSession::protectedSharedSession()->addInterruptionObserver(*this);
+    WebCore::AudioSession::singleton().addInterruptionObserver(*this);
     protectedLocalUnit()->retrieveFormatDescription([weakThis = WeakPtr { *this }, this, callback = WTFMove(callback)](auto&& description) mutable {
         if (!weakThis || !description) {
             RELEASE_LOG_IF(!description, WebRTC, "RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit unable to get format description");
@@ -206,7 +206,7 @@ RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::RemoteAudioMediaStre
 
 RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::~RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit()
 {
-    WebCore::AudioSession::protectedSharedSession()->removeInterruptionObserver(*this);
+    WebCore::AudioSession::singleton().removeInterruptionObserver(*this);
     stop();
 }
 
@@ -262,7 +262,7 @@ void RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::start(ConsumerS
 
     if (m_shouldRegisterAsSpeakerSamplesProducer) {
         WebCore::CoreAudioCaptureSourceFactory::singleton().registerSpeakerSamplesProducer(*this);
-        bool shouldNotStartLocalUnit = WebCore::CoreAudioCaptureSourceFactory::singleton().shouldAudioCaptureUnitRenderAudio() || WebCore::AudioSession::sharedSession().isInterrupted();
+        bool shouldNotStartLocalUnit = WebCore::CoreAudioCaptureSourceFactory::singleton().shouldAudioCaptureUnitRenderAudio() || WebCore::AudioSession::singleton().isInterrupted();
         if (shouldNotStartLocalUnit)
             return;
     }

--- a/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp
@@ -125,7 +125,7 @@ public:
 
     void audioUnitWillStart() final
     {
-        Ref session = AudioSession::sharedSession();
+        Ref session = AudioSession::singleton();
         session->setCategory(AudioSession::CategoryType::PlayAndRecord, AudioSession::Mode::VideoChat, RouteSharingPolicy::Default);
         session->tryToSetActive(true);
     }
@@ -387,7 +387,7 @@ private:
             m_writeOffset = 0;
             m_remainingFrameCount = 0;
             m_startTime = time;
-            m_frameChunkSize = std::max(WebCore::AudioUtilities::renderQuantumSize, AudioSession::protectedSharedSession()->preferredBufferSize());
+            m_frameChunkSize = std::max(WebCore::AudioUtilities::renderQuantumSize, AudioSession::singleton().preferredBufferSize());
 
             ASSERT(descriptionChanged || m_audioHandle);
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
@@ -216,7 +216,7 @@ MediaTime RemoteAudioDestinationProxy::outputLatency() const
 {
     return (MediaTime { static_cast<int64_t>(m_audioUnitLatency), static_cast<uint32_t>(sampleRate()) }
 #if USE(AUDIO_SESSION)
-            + MediaTime { static_cast<int64_t>(AudioSession::protectedSharedSession()->outputLatency()), static_cast<uint32_t>(AudioSession::protectedSharedSession()->sampleRate()) }
+            + MediaTime { static_cast<int64_t>(AudioSession::singleton().outputLatency()), static_cast<uint32_t>(AudioSession::singleton().sampleRate()) }
 #endif
             );
 }

--- a/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
+++ b/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
@@ -133,10 +133,10 @@ private:
     void audioUnitWillStart() final
     {
 #if USE(AUDIO_SESSION)
-        auto bufferSize = AudioSession::sharedSession().sampleRate() / 50;
-        if (AudioSession::sharedSession().preferredBufferSize() > bufferSize)
-            AudioSession::sharedSession().setPreferredBufferSize(bufferSize);
-        AudioSession::sharedSession().setCategory(AudioSession::CategoryType::PlayAndRecord, AudioSession::Mode::Default, RouteSharingPolicy::Default);
+        auto bufferSize = AudioSession::singleton().sampleRate() / 50;
+        if (AudioSession::singleton().preferredBufferSize() > bufferSize)
+            AudioSession::singleton().setPreferredBufferSize(bufferSize);
+        AudioSession::singleton().setCategory(AudioSession::CategoryType::PlayAndRecord, AudioSession::Mode::Default, RouteSharingPolicy::Default);
 #endif
     }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5399,7 +5399,7 @@ void WebPage::startPlayingPredominantVideo(CompletionHandler<void(bool)>&& compl
 #if PLATFORM(IOS_FAMILY)
 void WebPage::setSceneIdentifier(String&& sceneIdentifier)
 {
-    AudioSession::sharedSession().setSceneIdentifier(sceneIdentifier);
+    AudioSession::singleton().setSceneIdentifier(sceneIdentifier);
     m_page->setSceneIdentifier(WTFMove(sceneIdentifier));
 }
 

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
@@ -703,7 +703,7 @@ void PlaybackSessionManager::setSoundStageSize(WebCore::HTMLMediaElementIdentifi
         if (model.soundStageSize() > maxSize)
             maxSize = model.soundStageSize();
     });
-    AudioSession::sharedSession().setSoundStageSize(maxSize);
+    AudioSession::singleton().setSoundStageSize(maxSize);
 }
 
 #if HAVE(SPATIAL_TRACKING_LABEL)


### PR DESCRIPTION
#### a3e5b202b5421e90082c7399709403bba8e47d8e
<pre>
Rename AudioSession::sharedSession to AudioSession::singleton
<a href="https://bugs.webkit.org/show_bug.cgi?id=295966">https://bugs.webkit.org/show_bug.cgi?id=295966</a>

Reviewed by Ryosuke Niwa.

As singleton is recognized by the Safer CPP static analyzer this allows
us to remove protectedSharedSession.

Canonical link: <a href="https://commits.webkit.org/297445@main">https://commits.webkit.org/297445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d0265de701b44a84bb2e1862d50854940ac2184

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111837 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21976 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117855 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62068 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113800 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40082 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84957 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/35646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114784 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25697 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100645 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65396 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/25022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18780 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61695 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/95077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18852 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121127 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38867 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28896 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/93831 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39247 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96903 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93653 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38831 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16620 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/34886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18018 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38764 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44259 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38405 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/41730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40119 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->