### PR TITLE
Adopt smart pointers in FlexFormattingContext.cpp and FlexFormattingUtils.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -76,13 +76,10 @@ inspector/UserGestureEmulationScope.h
 inspector/agents/InspectorDOMAgent.h
 inspector/agents/InspectorNetworkAgent.h
 inspector/agents/InspectorPageAgent.h
-layout/floats/FloatingContext.h
-layout/formattingContexts/FormattingContext.h
 layout/formattingContexts/inline/InlineFormattingContext.h
 layout/formattingContexts/inline/InlineItemsBuilder.cpp
 layout/formattingContexts/inline/InlineLine.h
 layout/formattingContexts/inline/text/TextUtil.cpp
-layout/integration/LayoutIntegrationUtils.h
 layout/integration/inline/LayoutIntegrationLineLayout.h
 layout/layouttree/LayoutElementBox.h
 loader/cache/CachedImageClient.h

--- a/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
@@ -19,7 +19,6 @@ inspector/InstrumentingAgents.h
 inspector/agents/InspectorCSSAgent.h
 inspector/agents/InspectorDOMAgent.cpp
 inspector/agents/WebHeapAgent.cpp
-layout/formattingContexts/flex/FlexFormattingContext.h
 layout/formattingContexts/inline/AbstractLineBuilder.h
 layout/formattingContexts/inline/InlineContentBreaker.h
 layout/formattingContexts/inline/InlineFormattingContext.h

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -339,14 +339,12 @@ inspector/agents/worker/WorkerDebuggerAgent.cpp
 inspector/agents/worker/WorkerRuntimeAgent.cpp
 layout/floats/FloatingContext.cpp
 layout/floats/PlacedFloats.cpp
-layout/formattingContexts/FormattingContext.h
 layout/formattingContexts/FormattingGeometry.cpp
 layout/formattingContexts/block/BlockFormattingContext.cpp
 layout/formattingContexts/block/BlockFormattingQuirks.cpp
 layout/formattingContexts/block/BlockMarginCollapse.cpp
 layout/formattingContexts/block/PrecomputedBlockMarginCollapse.cpp
 layout/formattingContexts/block/tablewrapper/TableWrapperBlockFormattingContext.cpp
-layout/formattingContexts/flex/FlexFormattingContext.cpp
 layout/formattingContexts/flex/FlexLayout.cpp
 layout/formattingContexts/inline/AbstractLineBuilder.cpp
 layout/formattingContexts/inline/InlineContentAligner.cpp
@@ -378,7 +376,6 @@ layout/formattingContexts/inline/ruby/RubyFormattingContext.cpp
 layout/formattingContexts/inline/text/TextUtil.cpp
 layout/formattingContexts/table/TableFormattingContext.cpp
 layout/formattingContexts/table/TableFormattingGeometry.cpp
-layout/formattingContexts/table/TableFormattingQuirks.cpp
 layout/formattingContexts/table/TableGrid.cpp
 layout/formattingContexts/table/TableLayout.cpp
 layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -225,8 +225,6 @@ layout/formattingContexts/block/BlockFormattingQuirks.cpp
 layout/formattingContexts/block/BlockMarginCollapse.cpp
 layout/formattingContexts/block/PrecomputedBlockMarginCollapse.cpp
 layout/formattingContexts/block/tablewrapper/TableWrapperBlockFormattingContext.cpp
-layout/formattingContexts/flex/FlexFormattingContext.cpp
-layout/formattingContexts/flex/FlexFormattingUtils.cpp
 layout/formattingContexts/inline/AbstractLineBuilder.cpp
 layout/formattingContexts/inline/InlineContentAligner.cpp
 layout/formattingContexts/inline/InlineContentBreaker.cpp

--- a/Source/WebCore/layout/FormattingState.cpp
+++ b/Source/WebCore/layout/FormattingState.cpp
@@ -48,7 +48,7 @@ FormattingState::~FormattingState()
 BoxGeometry& FormattingState::boxGeometry(const Box& layoutBox)
 {
     // FIXME: Remove this when all FormattingStates transtioned to a cache setup.
-    return layoutState().ensureGeometryForBox(layoutBox);
+    return m_layoutState->ensureGeometryForBox(layoutBox);
 }
 
 }

--- a/Source/WebCore/layout/FormattingState.h
+++ b/Source/WebCore/layout/FormattingState.h
@@ -61,7 +61,7 @@ protected:
     ~FormattingState();
 
 private:
-    LayoutState& m_layoutState;
+    const CheckedRef<LayoutState> m_layoutState;
     HashMap<const Box*, IntrinsicWidthConstraints> m_intrinsicWidthConstraintsForBoxes;
     std::optional<IntrinsicWidthConstraints> m_intrinsicWidthConstraints;
     Type m_type;
@@ -70,7 +70,7 @@ private:
 inline void FormattingState::setIntrinsicWidthConstraintsForBox(const Box& layoutBox, IntrinsicWidthConstraints intrinsicWidthConstraints)
 {
     ASSERT(!m_intrinsicWidthConstraintsForBoxes.contains(&layoutBox));
-    ASSERT(&m_layoutState.formattingStateForFormattingContext(FormattingContext::formattingContextRoot(layoutBox)) == this);
+    ASSERT(&m_layoutState->formattingStateForFormattingContext(FormattingContext::formattingContextRoot(layoutBox)) == this);
     m_intrinsicWidthConstraintsForBoxes.set(&layoutBox, intrinsicWidthConstraints);
 }
 
@@ -82,7 +82,7 @@ inline void FormattingState::clearIntrinsicWidthConstraints(const Box& layoutBox
 
 inline std::optional<IntrinsicWidthConstraints> FormattingState::intrinsicWidthConstraintsForBox(const Box& layoutBox) const
 {
-    ASSERT(&m_layoutState.formattingStateForFormattingContext(FormattingContext::formattingContextRoot(layoutBox)) == this);
+    ASSERT(&m_layoutState->formattingStateForFormattingContext(FormattingContext::formattingContextRoot(layoutBox)) == this);
     auto iterator = m_intrinsicWidthConstraintsForBoxes.find(&layoutBox);
     if (iterator == m_intrinsicWidthConstraintsForBoxes.end())
         return { };

--- a/Source/WebCore/layout/LayoutContext.cpp
+++ b/Source/WebCore/layout/LayoutContext.cpp
@@ -58,7 +58,7 @@ void LayoutContext::layout(const LayoutSize& rootContentBoxSize)
     // Note that we never layout the root box. It has to have an already computed geometry (in case of ICB, it's the view geometry).
     // ICB establishes the initial BFC, but it does not live in a formatting context and while a non-ICB root(subtree layout) has to have a formatting context,
     // we could not lay it out even if we wanted to since it's outside of this LayoutContext.
-    auto& boxGeometry = layoutState().geometryForRootBox();
+    auto& boxGeometry = m_layoutState->geometryForRootBox();
     boxGeometry.setHorizontalMargin({ });
     boxGeometry.setVerticalMargin({ });
     boxGeometry.setBorder({ });
@@ -68,13 +68,18 @@ void LayoutContext::layout(const LayoutSize& rootContentBoxSize)
     boxGeometry.setContentBoxWidth(rootContentBoxSize.width());
 
     auto scope = PhaseScope { Phase::Type::Layout };
-    layoutFormattingContextSubtree(m_layoutState.root());
+    layoutFormattingContextSubtree(m_layoutState->root());
 }
 
 
 void LayoutContext::layoutFormattingContextSubtree(const ElementBox& formattingContextRoot)
 {
     UNUSED_PARAM(formattingContextRoot);
+}
+
+LayoutState& LayoutContext::layoutState()
+{
+    return m_layoutState.get();
 }
 
 std::unique_ptr<FormattingContext> LayoutContext::createFormattingContext(const ElementBox& formattingContextRoot, LayoutState& layoutState)

--- a/Source/WebCore/layout/LayoutContext.h
+++ b/Source/WebCore/layout/LayoutContext.h
@@ -62,9 +62,9 @@ public:
 
 private:
     void layoutFormattingContextSubtree(const ElementBox&);
-    LayoutState& layoutState() { return m_layoutState; }
+    LayoutState& layoutState();
 
-    LayoutState& m_layoutState;
+    const CheckedRef<LayoutState> m_layoutState;
 };
 
 }

--- a/Source/WebCore/layout/LayoutState.h
+++ b/Source/WebCore/layout/LayoutState.h
@@ -60,9 +60,10 @@ class FormattingState;
 class InlineContentCache;
 class TableFormattingState;
 
-class LayoutState : public CanMakeWeakPtr<LayoutState> {
+class LayoutState : public CanMakeWeakPtr<LayoutState>, public CanMakeThreadSafeCheckedPtr<LayoutState> {
     WTF_MAKE_NONCOPYABLE(LayoutState);
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(LayoutState);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LayoutState);
 public:
     // Primary layout state has a direct geometry cache in layout boxes.
     enum class Type { Primary, Secondary };

--- a/Source/WebCore/layout/floats/FloatingContext.cpp
+++ b/Source/WebCore/layout/floats/FloatingContext.cpp
@@ -484,6 +484,11 @@ PlacedFloats::Item FloatingContext::makeFloatItem(const Box& floatBox, const Box
     return { floatBox, position, absoluteBoxGeometry, borderBoxTopLeft, line };
 }
 
+const LayoutState& FloatingContext::containingBlockGeometries() const
+{
+    return m_layoutState;
+}
+
 void FloatingContext::findPositionForFormattingContextRoot(FloatAvoider& floatAvoider, BoxGeometry::HorizontalEdges containingBlockContentBoxEdges) const
 {
     // A non-floating formatting root's initial vertical position is its static position.

--- a/Source/WebCore/layout/floats/FloatingContext.h
+++ b/Source/WebCore/layout/floats/FloatingContext.h
@@ -75,7 +75,7 @@ private:
 
     const ElementBox& root() const { return m_formattingContextRoot; }
     // FIXME: Turn this into an actual geometry cache.
-    const LayoutState& containingBlockGeometries() const { return m_layoutState; }
+    const LayoutState& containingBlockGeometries() const;
 
     void findPositionForFormattingContextRoot(FloatAvoider&, BoxGeometry::HorizontalEdges containingBlockContentBoxEdges) const;
 
@@ -85,7 +85,7 @@ private:
     Point mapPointFromFloatingContextRootToBlockFormattingContextRoot(Point) const;
 
     CheckedRef<const ElementBox> m_formattingContextRoot;
-    const LayoutState& m_layoutState;
+    const CheckedRef<const LayoutState> m_layoutState;
     const PlacedFloats& m_placedFloats;
 };
 

--- a/Source/WebCore/layout/formattingContexts/FormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/FormattingContext.cpp
@@ -72,7 +72,7 @@ LayoutState& FormattingContext::layoutState()
 
 BoxGeometry& FormattingContext::geometryForBox(const Box& layoutBox, std::optional<EscapeReason>)
 {
-    return layoutState().ensureGeometryForBox(layoutBox);
+    return m_layoutState->ensureGeometryForBox(layoutBox);
 }
 
 const BoxGeometry& FormattingContext::geometryForBox(const Box& layoutBox, std::optional<EscapeReason> escapeReason) const
@@ -156,8 +156,8 @@ const BoxGeometry& FormattingContext::geometryForBox(const Box& layoutBox, std::
     };
 #endif
     ASSERT(isOkToAccessBoxGeometry());
-    ASSERT(layoutState().hasBoxGeometry(layoutBox));
-    return layoutState().geometryForBox(layoutBox);
+    ASSERT(m_layoutState->hasBoxGeometry(layoutBox));
+    return m_layoutState->geometryForBox(layoutBox);
 }
 
 const InitialContainingBlock& FormattingContext::initialContainingBlock(const Box& layoutBox)

--- a/Source/WebCore/layout/formattingContexts/FormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/FormattingContext.h
@@ -91,8 +91,8 @@ protected:
 #endif
 
 private:
-    CheckedRef<const ElementBox> m_root;
-    LayoutState& m_layoutState;
+    const CheckedRef<const ElementBox> m_root;
+    const CheckedRef<LayoutState> m_layoutState;
 };
 
 }

--- a/Source/WebCore/layout/formattingContexts/block/BlockMarginCollapse.h
+++ b/Source/WebCore/layout/formattingContexts/block/BlockMarginCollapse.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "MarginTypes.h"
+#include <wtf/CheckedRef.h>
 
 namespace WebCore {
 namespace Layout {
@@ -78,7 +79,7 @@ private:
     const LayoutState& layoutState() const { return m_layoutState; }
     const BlockFormattingState& formattingState() const { return m_blockFormattingState; }
 
-    const LayoutState& m_layoutState;
+    const CheckedRef<const LayoutState> m_layoutState;
     const BlockFormattingState& m_blockFormattingState;
     bool m_inQuirksMode { false };
 };

--- a/Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.cpp
@@ -83,9 +83,9 @@ FlexLayout::LogicalFlexItems FlexFormattingContext::convertFlexItemsToLogicalSpa
         auto isMainAxisParallelWithInlineAxis = FlexFormattingUtils::isMainAxisParallelWithInlineAxis(root());
         auto isReversedInCrossAxis = FlexFormattingUtils::areFlexLinesReversedInCrossAxis(root());
 
-        for (auto* flexItem = root().firstInFlowChild(); flexItem; flexItem = flexItem->nextInFlowSibling()) {
-            auto& flexItemGeometry = m_globalLayoutState.geometryForBox(*flexItem);
-            auto& style = flexItem->style();
+        for (CheckedPtr flexItem = checkedRoot()->firstInFlowChild(); flexItem; flexItem = flexItem->nextInFlowSibling()) {
+            auto& flexItemGeometry = m_globalLayoutState->geometryForBox(*flexItem);
+            CheckedRef style = flexItem->style();
             auto mainAxis = LogicalFlexItem::MainAxisGeometry { };
             auto crossAxis = LogicalFlexItem::CrossAxisGeometry { };
 
@@ -100,32 +100,32 @@ FlexLayout::LogicalFlexItems FlexFormattingContext::convertFlexItemsToLogicalSpa
             auto setMainAxisValues = [&] {
                 auto flexContainerMainInnerSize = constraints.mainAxis().availableSize;
 
-                mainAxis.size = propertyValueForLength(isMainAxisParallelWithInlineAxis ? style.width() : style.height(), flexContainerMainInnerSize);
-                mainAxis.minimumSize = propertyValueForLength(isMainAxisParallelWithInlineAxis ? style.minWidth() : style.minHeight(), flexContainerMainInnerSize);
-                mainAxis.maximumSize = propertyValueForLength(isMainAxisParallelWithInlineAxis ? style.maxWidth() : style.maxHeight(), flexContainerMainInnerSize);
+                mainAxis.size = propertyValueForLength(isMainAxisParallelWithInlineAxis ? style->width() : style->height(), flexContainerMainInnerSize);
+                mainAxis.minimumSize = propertyValueForLength(isMainAxisParallelWithInlineAxis ? style->minWidth() : style->minHeight(), flexContainerMainInnerSize);
+                mainAxis.maximumSize = propertyValueForLength(isMainAxisParallelWithInlineAxis ? style->maxWidth() : style->maxHeight(), flexContainerMainInnerSize);
                 // Auto keyword retrieves the value of the main size property as the used flex-basis.
                 // If that value is itself auto, then the used value is content.
-                mainAxis.definiteFlexBasis = style.flexBasis().isAuto() ? mainAxis.size : propertyValueForLength(style.flexBasis(), flexContainerMainInnerSize);
+                mainAxis.definiteFlexBasis = style->flexBasis().isAuto() ? mainAxis.size : propertyValueForLength(style->flexBasis(), flexContainerMainInnerSize);
 
                 auto marginStart = [&]() -> std::optional<LayoutUnit> {
-                    if (direction == FlexDirection::Row && !style.marginStart().isAuto())
+                    if (direction == FlexDirection::Row && !style->marginStart().isAuto())
                         return flexItemGeometry.marginStart();
-                    if (direction == FlexDirection::RowReverse && !style.marginEnd().isAuto())
+                    if (direction == FlexDirection::RowReverse && !style->marginEnd().isAuto())
                         return flexItemGeometry.marginEnd();
-                    if (direction == FlexDirection::Column && !style.marginBefore().isAuto())
+                    if (direction == FlexDirection::Column && !style->marginBefore().isAuto())
                         return flexItemGeometry.marginBefore();
-                    if (direction == FlexDirection::ColumnReverse && !style.marginAfter().isAuto())
+                    if (direction == FlexDirection::ColumnReverse && !style->marginAfter().isAuto())
                         return flexItemGeometry.marginAfter();
                     return { };
                 };
                 auto marginEnd = [&]() -> std::optional<LayoutUnit> {
-                    if (direction == FlexDirection::Row && !style.marginEnd().isAuto())
+                    if (direction == FlexDirection::Row && !style->marginEnd().isAuto())
                         return flexItemGeometry.marginEnd();
-                    if (direction == FlexDirection::RowReverse && !style.marginStart().isAuto())
+                    if (direction == FlexDirection::RowReverse && !style->marginStart().isAuto())
                         return flexItemGeometry.marginStart();
-                    if (direction == FlexDirection::Column && !style.marginAfter().isAuto())
+                    if (direction == FlexDirection::Column && !style->marginAfter().isAuto())
                         return flexItemGeometry.marginAfter();
-                    if (direction == FlexDirection::ColumnReverse && !style.marginBefore().isAuto())
+                    if (direction == FlexDirection::ColumnReverse && !style->marginBefore().isAuto())
                         return flexItemGeometry.marginBefore();
                     return { };
                 };
@@ -139,52 +139,52 @@ FlexLayout::LogicalFlexItems FlexFormattingContext::convertFlexItemsToLogicalSpa
             auto setCrossAxisValues = [&] {
                 auto flexContainerCrossInnerSize = constraints.crossAxis().availableSize;
 
-                crossAxis.definiteSize = propertyValueForLength(isMainAxisParallelWithInlineAxis ? style.height() : style.width(), flexContainerCrossInnerSize);
-                crossAxis.minimumSize = propertyValueForLength(isMainAxisParallelWithInlineAxis ? style.minHeight() : style.minWidth(), flexContainerCrossInnerSize);
-                crossAxis.maximumSize = propertyValueForLength(isMainAxisParallelWithInlineAxis ? style.maxHeight() : style.maxWidth(), flexContainerCrossInnerSize);
+                crossAxis.definiteSize = propertyValueForLength(isMainAxisParallelWithInlineAxis ? style->height() : style->width(), flexContainerCrossInnerSize);
+                crossAxis.minimumSize = propertyValueForLength(isMainAxisParallelWithInlineAxis ? style->minHeight() : style->minWidth(), flexContainerCrossInnerSize);
+                crossAxis.maximumSize = propertyValueForLength(isMainAxisParallelWithInlineAxis ? style->maxHeight() : style->maxWidth(), flexContainerCrossInnerSize);
 
                 auto marginStart = [&]() -> std::optional<LayoutUnit> {
                     if (!isReversedInCrossAxis) {
                         if (direction == FlexDirection::Row || direction == FlexDirection::RowReverse)
-                            return !style.marginBefore().isAuto() ? std::make_optional(flexItemGeometry.marginBefore()) : std::nullopt;
+                            return !style->marginBefore().isAuto() ? std::make_optional(flexItemGeometry.marginBefore()) : std::nullopt;
                         if (direction == FlexDirection::Column || direction == FlexDirection::ColumnReverse)
-                            return !style.marginStart().isAuto() ? std::make_optional(flexItemGeometry.marginStart()) : std::nullopt;
+                            return !style->marginStart().isAuto() ? std::make_optional(flexItemGeometry.marginStart()) : std::nullopt;
                         return { };
                     }
                     if (direction == FlexDirection::Row || direction == FlexDirection::RowReverse)
-                        return !style.marginAfter().isAuto() ? std::make_optional(flexItemGeometry.marginAfter()) : std::nullopt;
+                        return !style->marginAfter().isAuto() ? std::make_optional(flexItemGeometry.marginAfter()) : std::nullopt;
                     if (direction == FlexDirection::Column || direction == FlexDirection::ColumnReverse)
-                        return !style.marginEnd().isAuto() ? std::make_optional(flexItemGeometry.marginEnd()) : std::nullopt;
+                        return !style->marginEnd().isAuto() ? std::make_optional(flexItemGeometry.marginEnd()) : std::nullopt;
                     return { };
                 };
                 auto marginEnd = [&]() -> std::optional<LayoutUnit> {
                     if (!isReversedInCrossAxis) {
                         if (direction == FlexDirection::Row || direction == FlexDirection::RowReverse)
-                            return !style.marginAfter().isAuto() ? std::make_optional(flexItemGeometry.marginAfter()) : std::nullopt;
+                            return !style->marginAfter().isAuto() ? std::make_optional(flexItemGeometry.marginAfter()) : std::nullopt;
                         if (direction == FlexDirection::Column || direction == FlexDirection::ColumnReverse)
-                            return !style.marginEnd().isAuto() ? std::make_optional(flexItemGeometry.marginEnd()) : std::nullopt;
+                            return !style->marginEnd().isAuto() ? std::make_optional(flexItemGeometry.marginEnd()) : std::nullopt;
                         return { };
                     }
                     if (direction == FlexDirection::Row || direction == FlexDirection::RowReverse)
-                        return !style.marginBefore().isAuto() ? std::make_optional(flexItemGeometry.marginBefore()) : std::nullopt;
+                        return !style->marginBefore().isAuto() ? std::make_optional(flexItemGeometry.marginBefore()) : std::nullopt;
                     if (direction == FlexDirection::Column || direction == FlexDirection::ColumnReverse)
-                        return !style.marginStart().isAuto() ? std::make_optional(flexItemGeometry.marginStart()) : std::nullopt;
+                        return !style->marginStart().isAuto() ? std::make_optional(flexItemGeometry.marginStart()) : std::nullopt;
                     return { };
                 };
                 auto shouldFlipMargins = !isMainAxisParallelWithInlineAxis && root().writingMode().isLineInverted();
                 crossAxis.marginStart = !shouldFlipMargins ? marginStart() : marginEnd();
                 crossAxis.marginEnd = !shouldFlipMargins ? marginEnd() : marginStart();
 
-                crossAxis.hasSizeAuto = isMainAxisParallelWithInlineAxis ? style.height().isAuto() : style.width().isAuto();
+                crossAxis.hasSizeAuto = isMainAxisParallelWithInlineAxis ? style->height().isAuto() : style->width().isAuto();
                 crossAxis.borderAndPadding = isMainAxisParallelWithInlineAxis ? flexItemGeometry.verticalBorderAndPadding() : flexItemGeometry.horizontalBorderAndPadding();
             };
             setCrossAxisValues();
 
-            auto flexItemOrder = style.order();
+            auto flexItemOrder = style->order();
             flexItemsNeedReordering = flexItemsNeedReordering || flexItemOrder != previousLogicalOrder.value_or(0);
             previousLogicalOrder = flexItemOrder;
 
-            flexItemList.append({ mainAxis, crossAxis, flexItemOrder, downcast<ElementBox>(flexItem) });
+            flexItemList.append({ mainAxis, crossAxis, flexItemOrder, downcast<ElementBox>(flexItem.get()) });
         }
     };
     convertVisualToLogical();
@@ -212,9 +212,9 @@ FlexLayout::LogicalFlexItems FlexFormattingContext::convertFlexItemsToLogicalSpa
 
 void FlexFormattingContext::setFlexItemsGeometry(const FlexLayout::LogicalFlexItems& logicalFlexItemList, const FlexLayout::LogicalFlexItemRects& logicalRects, const ConstraintsForFlexContent& constraints)
 {
-    auto& flexBoxStyle = root().style();
-    auto flexDirection = flexBoxStyle.flexDirection();
-    auto isLeftToRightDirection = flexBoxStyle.writingMode().isLogicalLeftInlineStart();
+    CheckedRef flexBoxStyle = root().style();
+    auto flexDirection = flexBoxStyle->flexDirection();
+    auto isLeftToRightDirection = flexBoxStyle->writingMode().isLogicalLeftInlineStart();
     auto isRowDirection = flexDirection == FlexDirection::Row || flexDirection == FlexDirection::RowReverse;
     auto flexContainerContentBoxPosition = LayoutPoint { isRowDirection ? constraints.mainAxis().startPosition : constraints.crossAxis().startPosition, isRowDirection ? constraints.crossAxis().startPosition : constraints.mainAxis().startPosition };
     auto flexContainerMainAxisSize = [&] {
@@ -223,7 +223,7 @@ void FlexFormattingContext::setFlexItemsGeometry(const FlexLayout::LogicalFlexIt
         // Let's use content size when available size is inf.
         auto& lastFlexItem = logicalFlexItemList.last();
         auto& lastRect = logicalRects.last();
-        return lastRect.right() + lastRect.marginRight() + (lastFlexItem.isContentBoxBased() ? geometryForFlexItem(lastFlexItem.layoutBox()).horizontalBorderAndPadding() : 0_lu);
+        return lastRect.right() + lastRect.marginRight() + (lastFlexItem.isContentBoxBased() ? geometryForFlexItem(lastFlexItem.checkedLayoutBox()).horizontalBorderAndPadding() : 0_lu);
     }();
     auto flexContainerCrossAxisSize = [&] {
         if (auto crossAxisSize = constraints.crossAxis().availableSize)
@@ -237,10 +237,10 @@ void FlexFormattingContext::setFlexItemsGeometry(const FlexLayout::LogicalFlexIt
 
     for (size_t index = 0; index < logicalFlexItemList.size(); ++index) {
         auto& logicalFlexItem = logicalFlexItemList[index];
-        auto& flexItemGeometry = geometryForFlexItem(logicalFlexItem.layoutBox());
+        auto& flexItemGeometry = geometryForFlexItem(logicalFlexItem.checkedLayoutBox());
         auto logicalRect = [&] {
             // Note that flex rects are inner size based.
-            if (flexBoxStyle.flexWrap() != FlexWrap::Reverse)
+            if (flexBoxStyle->flexWrap() != FlexWrap::Reverse)
                 return logicalRects[index];
             auto rect = logicalRects[index];
             auto adjustedLogicalBorderBoxTop = flexContainerCrossAxisSize - rect.bottom();
@@ -290,20 +290,20 @@ void FlexFormattingContext::setFlexItemsGeometry(const FlexLayout::LogicalFlexIt
 void FlexFormattingContext::positionOutOfFlowChildren()
 {
     // FIXME: Implement out-of-flow positioning.
-    for (auto* outOfFlowChild = root().firstOutOfFlowChild(); outOfFlowChild; outOfFlowChild = outOfFlowChild->nextOutOfFlowSibling())
-        m_globalLayoutState.ensureGeometryForBox(*outOfFlowChild).setTopLeft({ });
+    for (CheckedPtr outOfFlowChild = checkedRoot()->firstOutOfFlowChild(); outOfFlowChild; outOfFlowChild = outOfFlowChild->nextOutOfFlowSibling())
+        m_globalLayoutState->ensureGeometryForBox(*outOfFlowChild).setTopLeft({ });
 }
 
 const BoxGeometry& FlexFormattingContext::geometryForFlexItem(const Box& flexItem) const
 {
     ASSERT(flexItem.isFlexItem());
-    return m_globalLayoutState.geometryForBox(flexItem);
+    return m_globalLayoutState->geometryForBox(flexItem);
 }
 
 BoxGeometry& FlexFormattingContext::geometryForFlexItem(const Box& flexItem)
 {
     ASSERT(flexItem.isFlexItem());
-    return m_globalLayoutState.ensureGeometryForBox(flexItem);
+    return m_globalLayoutState->ensureGeometryForBox(flexItem);
 }
 
 

--- a/Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.h
@@ -46,6 +46,7 @@ public:
     IntrinsicWidthConstraints computedIntrinsicWidthConstraints();
 
     const ElementBox& root() const { return m_flexBox; }
+    CheckedRef<const ElementBox> checkedRoot() const { return m_flexBox; }
     const FlexFormattingUtils& formattingUtils() const { return m_flexFormattingUtils; }
 
     const BoxGeometry& geometryForFlexItem(const Box&) const;
@@ -61,8 +62,8 @@ private:
     std::optional<LayoutUnit> computedAutoMarginValueForFlexItems(const ConstraintsForFlexContent&);
 
 private:
-    const ElementBox& m_flexBox;
-    LayoutState& m_globalLayoutState;
+    const CheckedRef<const ElementBox> m_flexBox;
+    const CheckedRef<LayoutState> m_globalLayoutState;
     const FlexFormattingUtils m_flexFormattingUtils;
     const IntegrationUtils m_integrationUtils;
 };

--- a/Source/WebCore/layout/formattingContexts/flex/FlexFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/flex/FlexFormattingUtils.cpp
@@ -120,8 +120,8 @@ LayoutUnit FlexFormattingUtils::usedMinimumSizeInMainAxis(const LogicalFlexItem&
     if (auto mainAxisMinimumWidth = flexItem.mainAxis().minimumSize)
         return *mainAxisMinimumWidth;
 
-    auto& flexContainer = formattingContext().root();
-    auto& flexItemBox = downcast<ElementBox>(flexItem.layoutBox());
+    CheckedRef flexContainer = formattingContext().root();
+    CheckedRef flexItemBox = downcast<ElementBox>(flexItem.layoutBox());
     auto isMainAxisParallelWithInlineAxis = this->isMainAxisParallelWithInlineAxis(flexContainer);
 
     auto minimumContentSize = LayoutUnit { };
@@ -142,8 +142,8 @@ std::optional<LayoutUnit> FlexFormattingUtils::usedMaximumSizeInMainAxis(const L
 
 LayoutUnit FlexFormattingUtils::usedMaxContentSizeInMainAxis(const LogicalFlexItem& flexItem) const
 {
-    auto& flexContainer = formattingContext().root();
-    auto& flexItemBox = downcast<ElementBox>(flexItem.layoutBox());
+    CheckedRef flexContainer = formattingContext().root();
+    CheckedRef flexItemBox = downcast<ElementBox>(flexItem.layoutBox());
     auto isMainAxisParallelWithInlineAxis = this->isMainAxisParallelWithInlineAxis(flexContainer);
 
     auto contentSize = LayoutUnit { };
@@ -154,7 +154,7 @@ LayoutUnit FlexFormattingUtils::usedMaxContentSizeInMainAxis(const LogicalFlexIt
         contentSize = formattingContext().integrationUtils().maxContentWidth(flexItemBox);
     else {
         formattingContext().integrationUtils().layoutWithFormattingContextForBox(flexItemBox);
-        auto isOrthogonal = flexContainer.writingMode().isOrthogonal(flexItem.writingMode());
+        auto isOrthogonal = flexContainer->writingMode().isOrthogonal(flexItem.writingMode());
         contentSize = !isOrthogonal ? formattingContext().geometryForFlexItem(flexItemBox).contentBoxHeight() : formattingContext().geometryForFlexItem(flexItemBox).contentBoxWidth();
     }
 
@@ -168,8 +168,8 @@ LayoutUnit FlexFormattingUtils::usedSizeInCrossAxis(const LogicalFlexItem& flexI
     if (auto definiteSize = flexItem.crossAxis().definiteSize)
         return *definiteSize;
 
-    auto& flexContainer = formattingContext().root();
-    auto& flexItemBox = flexItem.layoutBox();
+    CheckedRef flexContainer = formattingContext().root();
+    CheckedRef flexItemBox = flexItem.layoutBox();
     auto isMainAxisParallelWithInlineAxis = this->isMainAxisParallelWithInlineAxis(flexContainer);
 
     auto widtConstraintForLayout = isMainAxisParallelWithInlineAxis ? std::make_optional(maxAxisConstraint) : std::nullopt;

--- a/Source/WebCore/layout/formattingContexts/flex/LogicalFlexItem.h
+++ b/Source/WebCore/layout/formattingContexts/flex/LogicalFlexItem.h
@@ -85,6 +85,7 @@ public:
     bool isContentBoxBased() const { return style().boxSizing() == BoxSizing::ContentBox; }
 
     const ElementBox& layoutBox() const { return *m_layoutBox; }
+    CheckedRef<const ElementBox> checkedLayoutBox() const { return *m_layoutBox; }
     const RenderStyle& style() const { return layoutBox().style(); }
     WritingMode writingMode() const { return style().writingMode(); }
 

--- a/Source/WebCore/layout/integration/LayoutIntegrationUtils.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationUtils.cpp
@@ -41,25 +41,25 @@ IntegrationUtils::IntegrationUtils(const LayoutState& globalLayoutState)
 
 void IntegrationUtils::layoutWithFormattingContextForBox(const ElementBox& box, std::optional<LayoutUnit> widthConstraint) const
 {
-    m_globalLayoutState.layoutWithFormattingContextForBox(box, widthConstraint);
+    m_globalLayoutState->layoutWithFormattingContextForBox(box, widthConstraint);
 }
 
 LayoutUnit IntegrationUtils::maxContentWidth(const ElementBox& box) const
 {
     ASSERT(box.isFlexItem());
-    return m_globalLayoutState.logicalWidthWithFormattingContextForBox(box, LayoutIntegration::LogicalWidthType::MaxContent);
+    return m_globalLayoutState->logicalWidthWithFormattingContextForBox(box, LayoutIntegration::LogicalWidthType::MaxContent);
 }
 
 LayoutUnit IntegrationUtils::minContentWidth(const ElementBox& box) const
 {
     ASSERT(box.isFlexItem());
-    return m_globalLayoutState.logicalWidthWithFormattingContextForBox(box, LayoutIntegration::LogicalWidthType::MinContent);
+    return m_globalLayoutState->logicalWidthWithFormattingContextForBox(box, LayoutIntegration::LogicalWidthType::MinContent);
 }
 
 LayoutUnit IntegrationUtils::minContentHeight(const ElementBox& box) const
 {
     ASSERT(box.isFlexItem());
-    return m_globalLayoutState.logicalHeightWithFormattingContextForBox(box, LayoutIntegration::LogicalHeightType::MinContent);
+    return m_globalLayoutState->logicalHeightWithFormattingContextForBox(box, LayoutIntegration::LogicalHeightType::MinContent);
 }
 
 }

--- a/Source/WebCore/layout/integration/LayoutIntegrationUtils.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationUtils.h
@@ -45,7 +45,7 @@ public:
     LayoutUnit minContentHeight(const ElementBox&) const;
 
 private:
-    const LayoutState& m_globalLayoutState;
+    const CheckedRef<const LayoutState> m_globalLayoutState;
 };
 
 }


### PR DESCRIPTION
#### 57d177ab3b237f81f7649aa2c894ede1ca645110
<pre>
Adopt smart pointers in FlexFormattingContext.cpp and FlexFormattingUtils.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=295968">https://bugs.webkit.org/show_bug.cgi?id=295968</a>
<a href="https://rdar.apple.com/155855347">rdar://155855347</a>

Reviewed by Ryosuke Niwa and Per Arne Vollan.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/layout/FormattingState.cpp:
(WebCore::Layout::FormattingState::boxGeometry):
* Source/WebCore/layout/FormattingState.h:
(WebCore::Layout::FormattingState::setIntrinsicWidthConstraintsForBox):
(WebCore::Layout::FormattingState::intrinsicWidthConstraintsForBox const):
* Source/WebCore/layout/LayoutContext.cpp:
(WebCore::Layout::LayoutContext::layout):
(WebCore::Layout::LayoutContext::layoutFormattingContextSubtree):
(WebCore::Layout::LayoutContext::layoutState):
* Source/WebCore/layout/LayoutContext.h:
(WebCore::Layout::LayoutContext::layoutState): Deleted.
* Source/WebCore/layout/LayoutState.h:
* Source/WebCore/layout/floats/FloatingContext.cpp:
(WebCore::Layout::FloatingContext::containingBlockGeometries const):
* Source/WebCore/layout/floats/FloatingContext.h:
(WebCore::Layout::FloatingContext::containingBlockGeometries const): Deleted.
* Source/WebCore/layout/formattingContexts/FormattingContext.cpp:
(WebCore::Layout::FormattingContext::geometryForBox):
(WebCore::Layout::FormattingContext::geometryForBox const):
* Source/WebCore/layout/formattingContexts/FormattingContext.h:
* Source/WebCore/layout/formattingContexts/block/BlockMarginCollapse.h:
* Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.cpp:
(WebCore::Layout::FlexFormattingContext::convertFlexItemsToLogicalSpace):
(WebCore::Layout::FlexFormattingContext::setFlexItemsGeometry):
(WebCore::Layout::FlexFormattingContext::positionOutOfFlowChildren):
(WebCore::Layout::FlexFormattingContext::geometryForFlexItem const):
(WebCore::Layout::FlexFormattingContext::geometryForFlexItem):
* Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.h:
(WebCore::Layout::FlexFormattingContext::checkedRoot const):
* Source/WebCore/layout/formattingContexts/flex/FlexFormattingUtils.cpp:
(WebCore::Layout::FlexFormattingUtils::usedMinimumSizeInMainAxis const):
(WebCore::Layout::FlexFormattingUtils::usedMaxContentSizeInMainAxis const):
(WebCore::Layout::FlexFormattingUtils::usedSizeInCrossAxis const):
* Source/WebCore/layout/formattingContexts/flex/LogicalFlexItem.h:
(WebCore::Layout::LogicalFlexItem::checkedLayoutBox const):
* Source/WebCore/layout/integration/LayoutIntegrationUtils.cpp:
(WebCore::Layout::IntegrationUtils::layoutWithFormattingContextForBox const):
(WebCore::Layout::IntegrationUtils::maxContentWidth const):
(WebCore::Layout::IntegrationUtils::minContentWidth const):
(WebCore::Layout::IntegrationUtils::minContentHeight const):
* Source/WebCore/layout/integration/LayoutIntegrationUtils.h:

Canonical link: <a href="https://commits.webkit.org/297493@main">https://commits.webkit.org/297493@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c69c7ebd560cd8adaf3853c86acf3906eff5cfd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111929 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22086 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117950 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62164 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113892 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32277 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40178 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85038 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35717 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114876 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25773 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100720 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65469 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25099 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18855 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61800 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95167 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18931 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121244 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38963 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28986 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93899 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39344 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96973 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93716 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38901 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16694 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34984 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18046 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38857 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44369 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38494 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41822 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40210 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->