### PR TITLE
[WPE][Qt6] WPE MiniBrowser use QUrl::fromUserInput for URL processing

### DIFF
--- a/Tools/MiniBrowser/wpe/qt6/main.cpp
+++ b/Tools/MiniBrowser/wpe/qt6/main.cpp
@@ -26,6 +26,14 @@
 #include <QQmlContext>
 #include <QUrl>
 
+class UrlHelper : public QObject {
+    Q_OBJECT
+public:
+    Q_INVOKABLE QUrl parseUserUrl(const QString &input) {
+        return QUrl::fromUserInput(input);
+    }
+};
+
 int main(int argc, char* argv[])
 {
 #if defined(WEBKIT_INJECTED_BUNDLE_PATH)
@@ -45,12 +53,16 @@ int main(int argc, char* argv[])
     parser.addPositionalArgument("initialUrl", "The URL to open.");
     QStringList arguments = app.arguments();
     parser.process(arguments);
-    const QString initialUrl = parser.positionalArguments().isEmpty() ?
+    const QString userInput = parser.positionalArguments().isEmpty() ?
         QStringLiteral("https://wpewebkit.org") : parser.positionalArguments().first();
 
     QQmlApplicationEngine engine;
     QQmlContext* context = engine.rootContext();
-    context->setContextProperty(QStringLiteral("initialUrl"), QUrl(initialUrl));
+    QUrl initialUrl = QUrl::fromUserInput(userInput);
+    context->setContextProperty(QStringLiteral("initialUrl"), initialUrl);
+
+    UrlHelper urlHelper;
+    context->setContextProperty(QStringLiteral("urlHelper"), &urlHelper);
 
     engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
     if (engine.rootObjects().isEmpty())
@@ -58,3 +70,5 @@ int main(int argc, char* argv[])
 
     return app.exec();
 }
+
+#include "main.moc"

--- a/Tools/MiniBrowser/wpe/qt6/main.qml
+++ b/Tools/MiniBrowser/wpe/qt6/main.qml
@@ -69,7 +69,8 @@ Window {
                 text: initialUrl
 
                 onAccepted: {
-                    web_view.url = url_bar.text;
+                    url_bar.text = urlHelper.parseUserUrl(url_bar.text)
+                    web_view.url = url_bar.text
                 }
             }
 
@@ -79,7 +80,10 @@ Window {
                 Layout.preferredHeight: 50
                 font.pointSize: 20
                 text: qsTr("↪")
-                onClicked: function() { web_view.url = url_bar.text; }
+                onClicked: function() {
+                    url_bar.text = urlHelper.parseUserUrl(url_bar.text)
+                    web_view.url = url_bar.text
+                }
             }
 
             Button {


### PR DESCRIPTION
#### 3475db04463b13defd77e477cb640bb7937b7920
<pre>
[WPE][Qt6] WPE MiniBrowser use QUrl::fromUserInput for URL processing

<a href="https://bugs.webkit.org/show_bug.cgi?id=295967">https://bugs.webkit.org/show_bug.cgi?id=295967</a>

Reviewed by Patrick Griffis.

The WPE Qt MiniBrowser currently processes user-entered URLs as-is, which doesn&apos;t
handle common user input patterns like domain names without protocols or local file
paths. This causes URLs like &quot;google.com&quot; or local files to fail loading.

Integrates QUrl::fromUserInput() for both command-line arguments and
QML user input, following the recommendation in WPEQtView::setUrl documentation.
This enables automatic protocol inference, local file handling,
and proper URL validation.

Signed-off-by: LI Qingwu &lt;Qing-wu.Li@leica-geosystems.com.cn&gt;
Canonical link: <a href="https://commits.webkit.org/297852@main">https://commits.webkit.org/297852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee04c719007916ac7447da4ef62529a209c0e6be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111811 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31473 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21950 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117830 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62044 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113774 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32156 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40056 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84939 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35626 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114758 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25673 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100612 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65378 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24999 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18747 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61664 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95054 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18819 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121093 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38842 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28875 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93818 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39222 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96870 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93640 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24165 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38813 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16588 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/34862 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38739 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38381 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41706 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40094 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->