### PR TITLE
[JSC] Add Compare profile

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -620,6 +620,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     bytecode/CodeBlockHash.h
     bytecode/CodeOrigin.h
     bytecode/CodeType.h
+    bytecode/CompareProfile.h
     bytecode/DFGExitProfile.h
     bytecode/DataFormat.h
     bytecode/DirectEvalCodeCache.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1930,6 +1930,7 @@
 		E30E8A5626DE2E4800DA4915 /* TemporalTimeZone.h in Headers */ = {isa = PBXBuildFile; fileRef = E30E8A5026DE2E4800DA4915 /* TemporalTimeZone.h */; };
 		E30E8A5726DE2E4800DA4915 /* TemporalTimeZoneConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = E30E8A5126DE2E4800DA4915 /* TemporalTimeZoneConstructor.h */; };
 		E31179AA2288386100514B2C /* SymbolTableOrScopeDepth.h in Headers */ = {isa = PBXBuildFile; fileRef = E31179A92288385D00514B2C /* SymbolTableOrScopeDepth.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E311F2972E04C70E00C12AAC /* CompareProfile.h in Headers */ = {isa = PBXBuildFile; fileRef = E311F2942E04C70E00C12AAC /* CompareProfile.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E31618131EC5FE170006A218 /* DOMAnnotation.h in Headers */ = {isa = PBXBuildFile; fileRef = E31618101EC5FE080006A218 /* DOMAnnotation.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E31618151EC5FE270006A218 /* DOMAttributeGetterSetter.h in Headers */ = {isa = PBXBuildFile; fileRef = E31618121EC5FE080006A218 /* DOMAttributeGetterSetter.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E318CA6B254406B6004DC129 /* IntlListFormatConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = E318CA65254406B4004DC129 /* IntlListFormatConstructor.h */; };
@@ -5605,6 +5606,8 @@
 		E30E8A5026DE2E4800DA4915 /* TemporalTimeZone.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TemporalTimeZone.h; sourceTree = "<group>"; };
 		E30E8A5126DE2E4800DA4915 /* TemporalTimeZoneConstructor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TemporalTimeZoneConstructor.h; sourceTree = "<group>"; };
 		E31179A92288385D00514B2C /* SymbolTableOrScopeDepth.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SymbolTableOrScopeDepth.h; sourceTree = "<group>"; };
+		E311F2942E04C70E00C12AAC /* CompareProfile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CompareProfile.h; sourceTree = "<group>"; };
+		E311F2952E04C70E00C12AAC /* CompareProfile.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CompareProfile.cpp; sourceTree = "<group>"; };
 		E31618101EC5FE080006A218 /* DOMAnnotation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DOMAnnotation.h; sourceTree = "<group>"; };
 		E31618111EC5FE080006A218 /* DOMAttributeGetterSetter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DOMAttributeGetterSetter.cpp; sourceTree = "<group>"; };
 		E31618121EC5FE080006A218 /* DOMAttributeGetterSetter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DOMAttributeGetterSetter.h; sourceTree = "<group>"; };
@@ -9615,6 +9618,8 @@
 				0FBD7E671447998F00481315 /* CodeOrigin.h */,
 				0F8F943F1667632D00D61971 /* CodeType.cpp */,
 				0F0B83A514BCF50400885B4F /* CodeType.h */,
+				E311F2952E04C70E00C12AAC /* CompareProfile.cpp */,
+				E311F2942E04C70E00C12AAC /* CompareProfile.h */,
 				0F6FC74E196110A800E1D02D /* ComplexGetStatus.cpp */,
 				0F6FC74F196110A800E1D02D /* ComplexGetStatus.h */,
 				62E3D5EF1B8D0B7300B868BB /* DataFormat.cpp */,
@@ -10626,6 +10631,7 @@
 				BC18C3F30E16F5CD00B34460 /* CommonIdentifiers.h in Headers */,
 				0F15F15F14B7A73E005DE37D /* CommonSlowPaths.h in Headers */,
 				33A920BD23DA2C6D000EBAF0 /* CommonSlowPathsInlines.h in Headers */,
+				E311F2972E04C70E00C12AAC /* CompareProfile.h in Headers */,
 				A7E5A3A81797432D00E893C0 /* CompilationResult.h in Headers */,
 				0F4F11E8209BCDAB00709654 /* CompilerTimingScope.h in Headers */,
 				0FDCE12A1FAFA85F006F3901 /* CompleteSubspace.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -224,6 +224,7 @@ bytecode/CodeBlockHash.cpp
 bytecode/CodeBlockJettisoningWatchpoint.cpp
 bytecode/CodeOrigin.cpp
 bytecode/CodeType.cpp
+bytecode/CompareProfile.cpp
 bytecode/ComplexGetStatus.cpp
 bytecode/DFGExitProfile.cpp
 bytecode/DataFormat.cpp

--- a/Source/JavaScriptCore/bytecode/BytecodeList.rb
+++ b/Source/JavaScriptCore/bytecode/BytecodeList.rb
@@ -26,6 +26,7 @@ types [
 
     :BasicBlockLocation,
     :BoundLabel,
+    :CompareProfile,
     :DataOnlyCallLinkInfo,
     :DebugHookType,
     :ECMAMode,
@@ -772,6 +773,51 @@ op :try_get_by_id,
     }
 
 # Alignment: 1
+
+op_group :CompareJmp,
+    [
+        :jeq,
+        :jstricteq,
+        :jneq,
+        :jnstricteq,
+        :jless,
+        :jlesseq,
+        :jgreater,
+        :jgreatereq,
+        :jnless,
+        :jnlesseq,
+        :jngreater,
+        :jngreatereq,
+    ],
+    args: {
+        lhs: VirtualRegister,
+        rhs: VirtualRegister,
+        targetLabel: BoundLabel,
+    },
+    metadata: {
+        profile: CompareProfile,
+    }
+
+op_group :CompareOp,
+    [
+        :eq,
+        :neq,
+        :stricteq,
+        :nstricteq,
+        :less,
+        :lesseq,
+        :greater,
+        :greatereq,
+    ],
+    args: {
+        dst: VirtualRegister,
+        lhs: VirtualRegister,
+        rhs: VirtualRegister,
+    },
+    metadata: {
+        profile: CompareProfile,
+    }
+
 op :jneq_ptr,
     args: {
         value: VirtualRegister,
@@ -783,6 +829,32 @@ op :jneq_ptr,
     }
 
 # Opcodes without metadata are last
+
+op_group :BinaryJmp,
+    [
+        :jbelow,
+        :jbeloweq,
+    ],
+    args: {
+        lhs: VirtualRegister,
+        rhs: VirtualRegister,
+        targetLabel: BoundLabel,
+    }
+
+op_group :BinaryOp,
+    [
+        :below,
+        :beloweq,
+        :mod,
+        :pow,
+        :urshift,
+    ],
+    args: {
+        dst: VirtualRegister,
+        lhs: VirtualRegister,
+        rhs: VirtualRegister,
+    }
+
 op :get_argument,
     args: {
         dst: VirtualRegister,
@@ -988,29 +1060,6 @@ op :jeq_ptr,
     args: {
         value: VirtualRegister,
         specialPointer: VirtualRegister,
-        targetLabel: BoundLabel,
-    }
-
-op_group :BinaryJmp,
-    [
-        :jeq,
-        :jstricteq,
-        :jneq,
-        :jnstricteq,
-        :jless,
-        :jlesseq,
-        :jgreater,
-        :jgreatereq,
-        :jnless,
-        :jnlesseq,
-        :jngreater,
-        :jngreatereq,
-        :jbelow,
-        :jbeloweq,
-    ],
-    args: {
-        lhs: VirtualRegister,
-        rhs: VirtualRegister,
         targetLabel: BoundLabel,
     }
 
@@ -1270,28 +1319,6 @@ op :mov,
     args: {
         dst: VirtualRegister,
         src: VirtualRegister,
-    }
-
-op_group :BinaryOp,
-    [
-        :eq,
-        :neq,
-        :stricteq,
-        :nstricteq,
-        :less,
-        :lesseq,
-        :greater,
-        :greatereq,
-        :below,
-        :beloweq,
-        :mod,
-        :pow,
-        :urshift,
-    ],
-    args: {
-        dst: VirtualRegister,
-        lhs: VirtualRegister,
-        rhs: VirtualRegister,
     }
 
 op_group :ProfiledBinaryOpWithOperandTypes,

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -2823,7 +2823,7 @@ bool CodeBlock::shouldReoptimizeFromLoopNow()
 }
 #endif
 
-ArrayProfile* CodeBlock::getArrayProfile(const ConcurrentJSLocker&, BytecodeIndex bytecodeIndex)
+ArrayProfile* CodeBlock::getArrayProfile(BytecodeIndex bytecodeIndex)
 {
     auto instruction = instructions().at(bytecodeIndex);
 
@@ -2845,6 +2845,27 @@ ArrayProfile* CodeBlock::getArrayProfile(const ConcurrentJSLocker&, BytecodeInde
 
     return nullptr;
 }
+
+CompareProfile* CodeBlock::getCompareProfile(BytecodeIndex bytecodeIndex)
+{
+    auto instruction = instructions().at(bytecodeIndex);
+
+    switch (instruction->opcodeID()) {
+#define CASE(Op) \
+    case Op::opcodeID: \
+        return &instruction->as<Op>().metadata(this).m_profile;
+
+    FOR_EACH_OPCODE_WITH_SIMPLE_COMPARE_PROFILE(CASE)
+
+#undef CASE
+
+    default:
+        break;
+    }
+
+    return nullptr;
+}
+
 
 #if ENABLE(DFG_JIT)
 DFG::CodeOriginPool& CodeBlock::codeOrigins()

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -35,6 +35,7 @@
 #include "CodeBlockHash.h"
 #include "CodeOrigin.h"
 #include "CodeType.h"
+#include "CompareProfile.h"
 #include "CompilationResult.h"
 #include "ConcurrentJSLock.h"
 #include "DFGCodeOriginPool.h"
@@ -474,7 +475,8 @@ public:
 
     bool couldTakeSpecialArithFastCase(BytecodeIndex bytecodeOffset);
 
-    ArrayProfile* getArrayProfile(const ConcurrentJSLocker&, BytecodeIndex);
+    ArrayProfile* getArrayProfile(BytecodeIndex);
+    CompareProfile* getCompareProfile(BytecodeIndex);
 
     // Exception handling support
 

--- a/Source/JavaScriptCore/bytecode/CompareProfile.cpp
+++ b/Source/JavaScriptCore/bytecode/CompareProfile.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CompareProfile.h"
+
+namespace WTF {
+
+void printInternal(PrintStream& out, const JSC::CompareProfile& profile)
+{
+    out.print(" LHS ObservedType:<");
+    out.print(profile.lhsObservedType());
+    out.print("> RHS ObservedType:<");
+    out.print(profile.rhsObservedType());
+    out.print(">");
+}
+
+} // namespace WTF

--- a/Source/JavaScriptCore/bytecode/CompareProfile.h
+++ b/Source/JavaScriptCore/bytecode/CompareProfile.h
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ArithProfile.h"
+
+namespace JSC {
+
+/* This class stores the following components in 16 bits:
+ * - ObservedType for right-hand-side
+ * - ObservedType for left-hand-side
+ * - a bit used by division to indicate whether a special fast path was taken
+ */
+using CompareProfileBase = uint16_t;
+class CompareProfile {
+    static constexpr uint32_t rhsObservedTypeShift = 0;
+    static constexpr uint32_t lhsObservedTypeShift = rhsObservedTypeShift + ObservedType::numBitsNeeded;
+
+    static_assert(ObservedType::numBitsNeeded == 3, "We make a hard assumption about that here.");
+    static constexpr CompareProfileBase clearRhsObservedTypeBitMask = static_cast<CompareProfileBase>(~(0b111 << rhsObservedTypeShift));
+    static constexpr CompareProfileBase clearLhsObservedTypeBitMask = static_cast<CompareProfileBase>(~(0b111 << lhsObservedTypeShift));
+
+    static constexpr CompareProfileBase observedTypeMask = (1 << ObservedType::numBitsNeeded) - 1;
+
+public:
+    CompareProfile()
+    {
+        ASSERT(lhsObservedType().isEmpty());
+        ASSERT(rhsObservedType().isEmpty());
+    }
+
+    static constexpr BinaryArithProfileBase observedIntIntBits()
+    {
+        constexpr ObservedType observedInt32 { ObservedType().withInt32() };
+        constexpr BinaryArithProfileBase bits = (observedInt32.bits() << lhsObservedTypeShift) | (observedInt32.bits() << rhsObservedTypeShift);
+        return bits;
+    }
+    static constexpr BinaryArithProfileBase observedNumberIntBits()
+    {
+        constexpr ObservedType observedNumber { ObservedType().withNumber() };
+        constexpr ObservedType observedInt32 { ObservedType().withInt32() };
+        constexpr BinaryArithProfileBase bits = (observedNumber.bits() << lhsObservedTypeShift) | (observedInt32.bits() << rhsObservedTypeShift);
+        return bits;
+    }
+    static constexpr BinaryArithProfileBase observedIntNumberBits()
+    {
+        constexpr ObservedType observedNumber { ObservedType().withNumber() };
+        constexpr ObservedType observedInt32 { ObservedType().withInt32() };
+        constexpr BinaryArithProfileBase bits = (observedInt32.bits() << lhsObservedTypeShift) | (observedNumber.bits() << rhsObservedTypeShift);
+        return bits;
+    }
+    static constexpr BinaryArithProfileBase observedNumberNumberBits()
+    {
+        constexpr ObservedType observedNumber { ObservedType().withNumber() };
+        constexpr BinaryArithProfileBase bits = (observedNumber.bits() << lhsObservedTypeShift) | (observedNumber.bits() << rhsObservedTypeShift);
+        return bits;
+    }
+
+    constexpr ObservedType lhsObservedType() const { return ObservedType((m_bits >> lhsObservedTypeShift) & observedTypeMask); }
+    constexpr ObservedType rhsObservedType() const { return ObservedType((m_bits >> rhsObservedTypeShift) & observedTypeMask); }
+    void setLhsObservedType(ObservedType type)
+    {
+        BinaryArithProfileBase bits = m_bits;
+        bits &= clearLhsObservedTypeBitMask;
+        bits |= type.bits() << lhsObservedTypeShift;
+        m_bits = bits;
+        ASSERT(lhsObservedType() == type);
+    }
+
+    void setRhsObservedType(ObservedType type)
+    {
+        BinaryArithProfileBase bits = m_bits;
+        bits &= clearRhsObservedTypeBitMask;
+        bits |= type.bits() << rhsObservedTypeShift;
+        m_bits = bits;
+        ASSERT(rhsObservedType() == type);
+    }
+
+    void lhsSawInt32() { setLhsObservedType(lhsObservedType().withInt32()); }
+    void lhsSawNumber() { setLhsObservedType(lhsObservedType().withNumber()); }
+    void lhsSawNonNumber() { setLhsObservedType(lhsObservedType().withNonNumber()); }
+    void rhsSawInt32() { setRhsObservedType(rhsObservedType().withInt32()); }
+    void rhsSawNumber() { setRhsObservedType(rhsObservedType().withNumber()); }
+    void rhsSawNonNumber() { setRhsObservedType(rhsObservedType().withNonNumber()); }
+
+    void observeLHS(JSValue lhs)
+    {
+        auto newProfile = *this;
+        if (lhs.isNumber()) {
+            if (lhs.isInt32())
+                newProfile.lhsSawInt32();
+            else
+                newProfile.lhsSawNumber();
+        } else
+            newProfile.lhsSawNonNumber();
+
+        m_bits = newProfile.bits();
+    }
+
+    void observeLHSAndRHS(JSValue lhs, JSValue rhs)
+    {
+        observeLHS(lhs);
+
+        auto newProfile = *this;
+        if (rhs.isNumber()) {
+            if (rhs.isInt32())
+                newProfile.rhsSawInt32();
+            else
+                newProfile.rhsSawNumber();
+        } else
+            newProfile.rhsSawNonNumber();
+
+        m_bits = newProfile.bits();
+    }
+
+    bool isObservedTypeEmpty()
+    {
+        return lhsObservedType().isEmpty() && rhsObservedType().isEmpty();
+    }
+
+    friend class JSC::LLIntOffsetsExtractor;
+
+    constexpr CompareProfileBase bits() const { return m_bits; }
+
+    CompareProfileBase m_bits { };
+};
+
+} // namespace JSC
+
+namespace WTF {
+
+void printInternal(PrintStream&, const JSC::CompareProfile&);
+
+} // namespace WTF

--- a/Source/JavaScriptCore/bytecode/Opcode.h
+++ b/Source/JavaScriptCore/bytecode/Opcode.h
@@ -157,6 +157,28 @@ static constexpr unsigned bitWidthForMaxBytecodeStructLength = WTF::getMSBSetCon
     macro(OpTailCall) \
     macro(OpIteratorOpen) \
 
+#define FOR_EACH_OPCODE_WITH_SIMPLE_COMPARE_PROFILE(macro) \
+    macro(OpEq) \
+    macro(OpNeq) \
+    macro(OpStricteq) \
+    macro(OpNstricteq) \
+    macro(OpLess) \
+    macro(OpLesseq) \
+    macro(OpGreater) \
+    macro(OpGreatereq) \
+    macro(OpJeq) \
+    macro(OpJneq) \
+    macro(OpJstricteq) \
+    macro(OpJnstricteq) \
+    macro(OpJless) \
+    macro(OpJlesseq) \
+    macro(OpJgreater) \
+    macro(OpJgreatereq) \
+    macro(OpJnless) \
+    macro(OpJnlesseq) \
+    macro(OpJngreater) \
+    macro(OpJngreatereq) \
+
 #define FOR_EACH_OPCODE_WITH_ARRAY_ALLOCATION_PROFILE(macro) \
     macro(OpNewArray) \
     macro(OpNewArrayWithSize) \

--- a/Source/JavaScriptCore/bytecode/SpeculatedType.h
+++ b/Source/JavaScriptCore/bytecode/SpeculatedType.h
@@ -454,6 +454,11 @@ inline bool isFullNumberOrBooleanSpeculationExpectingDefined(SpeculatedType valu
     return isFullNumberOrBooleanSpeculation(value & ~SpecOther);
 }
 
+inline bool isFullNumberOrOtherSpeculation(SpeculatedType value)
+{
+    return !!(value & (SpecFullNumber | SpecOther)) && !(value & ~(SpecFullNumber | SpecOther));
+}
+
 inline bool isBooleanSpeculation(SpeculatedType value)
 {
     return value == SpecBoolean;

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -1043,10 +1043,10 @@ private:
     ArrayMode getArrayMode(Array::Action action)
     {
         CodeBlock* codeBlock = m_inlineStackTop->m_profiledBlock;
-        ConcurrentJSLocker locker(codeBlock->m_lock);
-        ArrayProfile* profile = codeBlock->getArrayProfile(locker, codeBlock->bytecodeIndex(m_currentInstruction));
+        ArrayProfile* profile = codeBlock->getArrayProfile(codeBlock->bytecodeIndex(m_currentInstruction));
         if (!profile)
             return { };
+        ConcurrentJSLocker locker(codeBlock->m_lock);
         return getArrayMode(locker, *profile, action);
     }
 

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -981,6 +981,34 @@ private:
                 fixDoubleOrBooleanEdge(node->child2());
             }
 
+            if (!m_graph.hasExitSite(node->origin.semantic, BadType)) {
+                if (node->child1()->shouldSpeculateInt32OrOther() && node->child2()->shouldSpeculateInt32OrOther()) {
+                    CodeBlock* profiledBlock = m_graph.baselineCodeBlockFor(node->origin.semantic);
+                    if (auto* profile = profiledBlock->getCompareProfile(node->origin.semantic.bytecodeIndex())) {
+                        if (!profile->lhsObservedType().sawNonNumber() && !profile->rhsObservedType().sawNonNumber()) {
+                            // Likely polluted with undefined due to control flow, but it is only getting Int32 at runtime.
+                            fixIntOrBooleanEdge(node->child1());
+                            fixIntOrBooleanEdge(node->child2());
+                            node->clearFlags(NodeMustGenerate);
+                            break;
+                        }
+                    }
+                }
+
+                if (node->child1()->shouldSpeculateNumberOrOther() && node->child2()->shouldSpeculateNumberOrOther()) {
+                    CodeBlock* profiledBlock = m_graph.baselineCodeBlockFor(node->origin.semantic);
+                    if (auto* profile = profiledBlock->getCompareProfile(node->origin.semantic.bytecodeIndex())) {
+                        if (!profile->lhsObservedType().sawNonNumber() && !profile->rhsObservedType().sawNonNumber()) {
+                            // Likely polluted with undefined due to control flow, but it is only getting Int32 at runtime.
+                            fixEdge<DoubleRepUse>(node->child1());
+                            fixEdge<DoubleRepUse>(node->child2());
+                            node->clearFlags(NodeMustGenerate);
+                            break;
+                        }
+                    }
+                }
+            }
+
             // FIXME: We can convert BigInt32 to Double in Compare nodes since they do not require ToNumber semantics.
             // https://bugs.webkit.org/show_bug.cgi?id=211407
             if (node->op() != CompareEq
@@ -1245,9 +1273,10 @@ private:
                             ArrayModes arrayModes = 0;
                             {
                                 CodeBlock* profiledBlock = m_graph.baselineCodeBlockFor(node->origin.semantic);
-                                ConcurrentJSLocker locker(profiledBlock->m_lock);
-                                if (ArrayProfile* arrayProfile = profiledBlock->getArrayProfile(locker, node->origin.semantic.bytecodeIndex()))
+                                if (ArrayProfile* arrayProfile = profiledBlock->getArrayProfile(node->origin.semantic.bytecodeIndex())) {
+                                    ConcurrentJSLocker locker(profiledBlock->m_lock);
                                     arrayModes = arrayProfile->observedArrayModes(locker);
+                                }
                             }
                             auto info = refineArrayModesForMultiGetByVal(node, arrayModes);
                             if (!info)
@@ -1433,9 +1462,10 @@ private:
                             ArrayModes arrayModes = 0;
                             {
                                 CodeBlock* profiledBlock = m_graph.baselineCodeBlockFor(node->origin.semantic);
-                                ConcurrentJSLocker locker(profiledBlock->m_lock);
-                                if (ArrayProfile* arrayProfile = profiledBlock->getArrayProfile(locker, node->origin.semantic.bytecodeIndex()))
+                                if (ArrayProfile* arrayProfile = profiledBlock->getArrayProfile(node->origin.semantic.bytecodeIndex())) {
+                                    ConcurrentJSLocker locker(profiledBlock->m_lock);
                                     arrayModes = arrayProfile->observedArrayModes(locker);
+                                }
                             }
                             if (auto result = refineArrayModesForMultiPutByVal(node, arrayModes)) {
                                 if (m_graph.hasExitSite(node->origin.semantic, OutOfBounds)) {
@@ -4895,9 +4925,8 @@ private:
         ArrayMode arrayMode = ArrayMode(Array::SelectUsingPredictions, Array::Read);
         {
             CodeBlock* profiledBlock = m_graph.baselineCodeBlockFor(node->origin.semantic);
-            ConcurrentJSLocker locker(profiledBlock->m_lock);
-            ArrayProfile* arrayProfile = profiledBlock->getArrayProfile(locker, node->origin.semantic.bytecodeIndex());
-            if (arrayProfile) {
+            if (ArrayProfile* arrayProfile = profiledBlock->getArrayProfile(node->origin.semantic.bytecodeIndex())) {
+                ConcurrentJSLocker locker(profiledBlock->m_lock);
                 arrayProfile->computeUpdatedPrediction(profiledBlock);
                 arrayMode = ArrayMode::fromObserved(locker, arrayProfile, Array::Read, false);
                 if (arrayMode.type() == Array::Unprofiled) {

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -3146,7 +3146,12 @@ public:
     {
         return isFullNumberOrBooleanSpeculationExpectingDefined(prediction());
     }
-    
+
+    bool shouldSpeculateNumberOrOther()
+    {
+        return isFullNumberOrOtherSpeculation(prediction());
+    }
+
     bool shouldSpeculateBoolean()
     {
         return isBooleanSpeculation(prediction());

--- a/Source/JavaScriptCore/dfg/DFGOSRExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSRExit.cpp
@@ -333,7 +333,7 @@ void OSRExit::compileExit(CCallHelpers& jit, VM& vm, const OSRExit& exit, const 
 
             CodeOrigin codeOrigin = exit.m_codeOriginForExitProfile;
             CodeBlock* codeBlock = jit.baselineCodeBlockFor(codeOrigin);
-            if (ArrayProfile* arrayProfile = codeBlock->getArrayProfile(ConcurrentJSLocker(codeBlock->m_lock), codeOrigin.bytecodeIndex())) {
+            if (ArrayProfile* arrayProfile = codeBlock->getArrayProfile(codeOrigin.bytecodeIndex())) {
 #if USE(JSVALUE64)
                 GPRReg usedRegister;
                 if (exit.m_jsValueSource.isAddress())

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -1873,13 +1873,95 @@ JSC_DEFINE_JIT_OPERATION(operationBitXorHeapBigInt, EncodedJSValue, (JSGlobalObj
     OPERATION_RETURN(scope, JSValue::encode(JSBigInt::bitwiseXor(globalObject, leftOperand, rightOperand)));
 }
 
+JSC_DEFINE_JIT_OPERATION(operationCompareLess, size_t, (JSGlobalObject* globalObject, EncodedJSValue encodedOp1, EncodedJSValue encodedOp2))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    OPERATION_RETURN(scope, jsLess<true>(globalObject, JSValue::decode(encodedOp1), JSValue::decode(encodedOp2)));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationCompareLessEq, size_t, (JSGlobalObject* globalObject, EncodedJSValue encodedOp1, EncodedJSValue encodedOp2))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    OPERATION_RETURN(scope, jsLessEq<true>(globalObject, JSValue::decode(encodedOp1), JSValue::decode(encodedOp2)));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationCompareGreater, size_t, (JSGlobalObject* globalObject, EncodedJSValue encodedOp1, EncodedJSValue encodedOp2))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    OPERATION_RETURN(scope, jsLess<false>(globalObject, JSValue::decode(encodedOp2), JSValue::decode(encodedOp1)));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationCompareGreaterEq, size_t, (JSGlobalObject* globalObject, EncodedJSValue encodedOp1, EncodedJSValue encodedOp2))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    OPERATION_RETURN(scope, jsLessEq<false>(globalObject, JSValue::decode(encodedOp2), JSValue::decode(encodedOp1)));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationCompareEq, size_t, (JSGlobalObject* globalObject, EncodedJSValue encodedOp1, EncodedJSValue encodedOp2))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    OPERATION_RETURN(scope, JSValue::equalSlowCaseInline(globalObject, JSValue::decode(encodedOp1), JSValue::decode(encodedOp2)));
+}
+
+#if USE(JSVALUE64)
+JSC_DEFINE_JIT_OPERATION(operationCompareStringEq, EncodedJSValue, (JSGlobalObject* globalObject, JSCell* left, JSCell* right))
+#else
+JSC_DEFINE_JIT_OPERATION(operationCompareStringEq, size_t, (JSGlobalObject* globalObject, JSCell* left, JSCell* right))
+#endif
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    bool result = asString(left)->equalInline(globalObject, asString(right));
+#if USE(JSVALUE64)
+    OPERATION_RETURN(scope, JSValue::encode(jsBoolean(result)));
+#else
+    OPERATION_RETURN(scope, result);
+#endif
+}
+
+JSC_DEFINE_JIT_OPERATION(operationCompareStrictEq, size_t, (JSGlobalObject* globalObject, EncodedJSValue encodedOp1, EncodedJSValue encodedOp2))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue src1 = JSValue::decode(encodedOp1);
+    JSValue src2 = JSValue::decode(encodedOp2);
+
+    OPERATION_RETURN(scope, JSValue::strictEqual(globalObject, src1, src2));
+}
+
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationCompareStrictEqCell, size_t, (JSGlobalObject* globalObject, JSCell* op1, JSCell* op2))
 {
     VM& vm = globalObject->vm();
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    
+
     OPERATION_RETURN(scope, JSValue::strictEqualForCells(globalObject, op1, op2));
 }
 

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -224,6 +224,17 @@ JSC_DECLARE_JIT_OPERATION(operationRegExpTest, size_t, (JSGlobalObject*, RegExpO
 JSC_DECLARE_JIT_OPERATION(operationRegExpTestGeneric, size_t, (JSGlobalObject*, EncodedJSValue, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationRegExpSearchString, UCPUStrictInt32, (JSGlobalObject*, RegExpObject*, JSString*));
 JSC_DECLARE_JIT_OPERATION(operationRegExpSearch, UCPUStrictInt32, (JSGlobalObject*, RegExpObject*, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationCompareLess, size_t, (JSGlobalObject*, EncodedJSValue, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationCompareLessEq, size_t, (JSGlobalObject*, EncodedJSValue, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationCompareGreater, size_t, (JSGlobalObject*, EncodedJSValue, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationCompareGreaterEq, size_t, (JSGlobalObject*, EncodedJSValue, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationCompareEq, size_t, (JSGlobalObject*, EncodedJSValue, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationCompareStrictEq, size_t, (JSGlobalObject*, EncodedJSValue, EncodedJSValue));
+#if USE(JSVALUE64)
+JSC_DECLARE_JIT_OPERATION(operationCompareStringEq, EncodedJSValue, (JSGlobalObject*, JSCell* left, JSCell* right));
+#else
+JSC_DECLARE_JIT_OPERATION(operationCompareStringEq, size_t, (JSGlobalObject*, JSCell* left, JSCell* right));
+#endif
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationCompareStrictEqCell, size_t, (JSGlobalObject*, JSCell* op1, JSCell* op2));
 JSC_DECLARE_JIT_OPERATION(operationSubHeapBigInt, EncodedJSValue, (JSGlobalObject*, JSCell* op1, JSCell* op2));
 JSC_DECLARE_JIT_OPERATION(operationMulHeapBigInt, EncodedJSValue, (JSGlobalObject*, JSCell* op1, JSCell* op2));

--- a/Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp
@@ -265,7 +265,7 @@ static void compileStub(VM& vm, unsigned exitID, JITCode* jitCode, OSRExit& exit
         if (exit.m_kind == BadCache || exit.m_kind == BadIndexingType) {
             CodeOrigin codeOrigin = exit.m_codeOriginForExitProfile;
             CodeBlock* codeBlock = jit.baselineCodeBlockFor(codeOrigin);
-            if (ArrayProfile* arrayProfile = codeBlock->getArrayProfile(ConcurrentJSLocker(codeBlock->m_lock), codeOrigin.bytecodeIndex())) {
+            if (ArrayProfile* arrayProfile = codeBlock->getArrayProfile(codeOrigin.bytecodeIndex())) {
                 jit.move(CCallHelpers::TrustedImmPtr(arrayProfile), GPRInfo::regT3);
                 jit.load32(MacroAssembler::Address(GPRInfo::regT0, JSCell::structureIDOffset()), GPRInfo::regT1);
                 jit.store32(GPRInfo::regT1, CCallHelpers::Address(GPRInfo::regT3, ArrayProfile::offsetOfSpeculationFailureStructureID()));

--- a/Source/JavaScriptCore/generator/DSL.rb
+++ b/Source/JavaScriptCore/generator/DSL.rb
@@ -215,6 +215,7 @@ module DSL
 #include "ArithProfile.h"
 #include "ArrayAllocationProfile.h"
 #include "BytecodeDumper.h"
+#include "CompareProfile.h"
 #include "Fits.h"
 #include "GetByIdMetadata.h"
 #include "Instruction.h"

--- a/Source/JavaScriptCore/jit/JIT.h
+++ b/Source/JavaScriptCore/jit/JIT.h
@@ -354,8 +354,8 @@ namespace JSC {
         void emit_compareUnsignedAndJumpImpl(VirtualRegister op1, VirtualRegister op2, unsigned target, RelationalCondition);
         template<typename Op, typename SlowOperation>
         void emit_compareSlow(const JSInstruction*, DoubleCondition, SlowOperation, Vector<SlowCaseEntry>::iterator&);
-        template<typename SlowOperation, typename HanldeReturnValueGPRFunctor, typename EmitDoubleCompareFunctor>
-        void emit_compareSlowImpl(VirtualRegister op1, VirtualRegister op2, size_t instructionSize, SlowOperation, Vector<SlowCaseEntry>::iterator&, const HanldeReturnValueGPRFunctor&, const EmitDoubleCompareFunctor&);
+        template<typename Op, typename Bytecode, typename SlowOperation, typename HanldeReturnValueGPRFunctor, typename EmitDoubleCompareFunctor>
+        void emit_compareSlowImpl(Bytecode&, VirtualRegister op1, VirtualRegister op2, size_t instructionSize, SlowOperation, Vector<SlowCaseEntry>::iterator&, const HanldeReturnValueGPRFunctor&, const EmitDoubleCompareFunctor&);
         template<typename Op, typename SlowOperation>
         void emit_compareAndJumpSlow(const JSInstruction*, DoubleCondition, SlowOperation, bool invert, Vector<SlowCaseEntry>::iterator&);
 

--- a/Source/JavaScriptCore/jit/JITArithmetic.cpp
+++ b/Source/JavaScriptCore/jit/JITArithmetic.cpp
@@ -106,62 +106,62 @@ void JIT::emit_op_jngreatereq(const JSInstruction* currentInstruction)
 
 void JIT::emitSlow_op_less(const JSInstruction* currentInstruction, Vector<SlowCaseEntry>::iterator& iter)
 {
-    emit_compareSlow<OpLess>(currentInstruction, DoubleLessThanAndOrdered, operationCompareLess, iter);
+    emit_compareSlow<OpLess>(currentInstruction, DoubleLessThanAndOrdered, operationCompareLessWithProfile, iter);
 }
 
 void JIT::emitSlow_op_lesseq(const JSInstruction* currentInstruction, Vector<SlowCaseEntry>::iterator& iter)
 {
-    emit_compareSlow<OpLesseq>(currentInstruction, DoubleLessThanOrEqualAndOrdered, operationCompareLessEq, iter);
+    emit_compareSlow<OpLesseq>(currentInstruction, DoubleLessThanOrEqualAndOrdered, operationCompareLessEqWithProfile, iter);
 }
 
 void JIT::emitSlow_op_greater(const JSInstruction* currentInstruction, Vector<SlowCaseEntry>::iterator& iter)
 {
-    emit_compareSlow<OpGreater>(currentInstruction, DoubleGreaterThanAndOrdered, operationCompareGreater, iter);
+    emit_compareSlow<OpGreater>(currentInstruction, DoubleGreaterThanAndOrdered, operationCompareGreaterWithProfile, iter);
 }
 
 void JIT::emitSlow_op_greatereq(const JSInstruction* currentInstruction, Vector<SlowCaseEntry>::iterator& iter)
 {
-    emit_compareSlow<OpGreatereq>(currentInstruction, DoubleGreaterThanOrEqualAndOrdered, operationCompareGreaterEq, iter);
+    emit_compareSlow<OpGreatereq>(currentInstruction, DoubleGreaterThanOrEqualAndOrdered, operationCompareGreaterEqWithProfile, iter);
 }
 
 void JIT::emitSlow_op_jless(const JSInstruction* currentInstruction, Vector<SlowCaseEntry>::iterator& iter)
 {
-    emit_compareAndJumpSlow<OpJless>(currentInstruction, DoubleLessThanAndOrdered, operationCompareLess, false, iter);
+    emit_compareAndJumpSlow<OpJless>(currentInstruction, DoubleLessThanAndOrdered, operationCompareLessWithProfile, false, iter);
 }
 
 void JIT::emitSlow_op_jlesseq(const JSInstruction* currentInstruction, Vector<SlowCaseEntry>::iterator& iter)
 {
-    emit_compareAndJumpSlow<OpJlesseq>(currentInstruction, DoubleLessThanOrEqualAndOrdered, operationCompareLessEq, false, iter);
+    emit_compareAndJumpSlow<OpJlesseq>(currentInstruction, DoubleLessThanOrEqualAndOrdered, operationCompareLessEqWithProfile, false, iter);
 }
 
 void JIT::emitSlow_op_jgreater(const JSInstruction* currentInstruction, Vector<SlowCaseEntry>::iterator& iter)
 {
-    emit_compareAndJumpSlow<OpJgreater>(currentInstruction, DoubleGreaterThanAndOrdered, operationCompareGreater, false, iter);
+    emit_compareAndJumpSlow<OpJgreater>(currentInstruction, DoubleGreaterThanAndOrdered, operationCompareGreaterWithProfile, false, iter);
 }
 
 void JIT::emitSlow_op_jgreatereq(const JSInstruction* currentInstruction, Vector<SlowCaseEntry>::iterator& iter)
 {
-    emit_compareAndJumpSlow<OpJgreatereq>(currentInstruction, DoubleGreaterThanOrEqualAndOrdered, operationCompareGreaterEq, false, iter);
+    emit_compareAndJumpSlow<OpJgreatereq>(currentInstruction, DoubleGreaterThanOrEqualAndOrdered, operationCompareGreaterEqWithProfile, false, iter);
 }
 
 void JIT::emitSlow_op_jnless(const JSInstruction* currentInstruction, Vector<SlowCaseEntry>::iterator& iter)
 {
-    emit_compareAndJumpSlow<OpJnless>(currentInstruction, DoubleGreaterThanOrEqualOrUnordered, operationCompareLess, true, iter);
+    emit_compareAndJumpSlow<OpJnless>(currentInstruction, DoubleGreaterThanOrEqualOrUnordered, operationCompareLessWithProfile, true, iter);
 }
 
 void JIT::emitSlow_op_jnlesseq(const JSInstruction* currentInstruction, Vector<SlowCaseEntry>::iterator& iter)
 {
-    emit_compareAndJumpSlow<OpJnlesseq>(currentInstruction, DoubleGreaterThanOrUnordered, operationCompareLessEq, true, iter);
+    emit_compareAndJumpSlow<OpJnlesseq>(currentInstruction, DoubleGreaterThanOrUnordered, operationCompareLessEqWithProfile, true, iter);
 }
 
 void JIT::emitSlow_op_jngreater(const JSInstruction* currentInstruction, Vector<SlowCaseEntry>::iterator& iter)
 {
-    emit_compareAndJumpSlow<OpJngreater>(currentInstruction, DoubleLessThanOrEqualOrUnordered, operationCompareGreater, true, iter);
+    emit_compareAndJumpSlow<OpJngreater>(currentInstruction, DoubleLessThanOrEqualOrUnordered, operationCompareGreaterWithProfile, true, iter);
 }
 
 void JIT::emitSlow_op_jngreatereq(const JSInstruction* currentInstruction, Vector<SlowCaseEntry>::iterator& iter)
 {
-    emit_compareAndJumpSlow<OpJngreatereq>(currentInstruction, DoubleLessThanOrUnordered, operationCompareGreaterEq, true, iter);
+    emit_compareAndJumpSlow<OpJngreatereq>(currentInstruction, DoubleLessThanOrUnordered, operationCompareGreaterEqWithProfile, true, iter);
 }
 
 void JIT::emit_op_below(const JSInstruction* currentInstruction)
@@ -348,7 +348,7 @@ void JIT::emit_compareSlow(const JSInstruction* instruction, DoubleCondition con
         boxBoolean(regT0, jsRegT10);
         emitPutVirtualRegister(dst, jsRegT10);
     };
-    emit_compareSlowImpl(op1, op2, instruction->size(), operation, iter, handleReturnValueGPR, emitDoubleCompare);
+    emit_compareSlowImpl<Op>(bytecode, op1, op2, instruction->size(), operation, iter, handleReturnValueGPR, emitDoubleCompare);
 }
 
 template<typename Op, typename SlowOperation>
@@ -364,11 +364,11 @@ void JIT::emit_compareAndJumpSlow(const JSInstruction* instruction, DoubleCondit
     auto emitCompareAndJump = [&](FPRReg left, FPRReg right) {
         emitJumpSlowToHot(branchDouble(condition, left, right), target);
     };
-    emit_compareSlowImpl(op1, op2, instruction->size(), operation, iter, handleReturnValueGPR, emitCompareAndJump);
+    emit_compareSlowImpl<Op>(bytecode, op1, op2, instruction->size(), operation, iter, handleReturnValueGPR, emitCompareAndJump);
 }
 
-template<typename SlowOperation, typename HanldeReturnValueGPRFunctor, typename EmitDoubleCompareFunctor>
-void JIT::emit_compareSlowImpl(VirtualRegister op1, VirtualRegister op2, size_t instructionSize, SlowOperation operation, Vector<SlowCaseEntry>::iterator& iter, const HanldeReturnValueGPRFunctor& handleReturnValueGPR, const EmitDoubleCompareFunctor& emitDoubleCompare)
+template<typename Op, typename Bytecode, typename SlowOperation, typename HanldeReturnValueGPRFunctor, typename EmitDoubleCompareFunctor>
+void JIT::emit_compareSlowImpl(Bytecode& bytecode, VirtualRegister op1, VirtualRegister op2, size_t instructionSize, SlowOperation operation, Vector<SlowCaseEntry>::iterator& iter, const HanldeReturnValueGPRFunctor& handleReturnValueGPR, const EmitDoubleCompareFunctor& emitDoubleCompare)
 {
 
     // We generate inline code for the following cases in the slow path:
@@ -379,13 +379,15 @@ void JIT::emit_compareSlowImpl(VirtualRegister op1, VirtualRegister op2, size_t 
         linkAllSlowCases(iter);
 
         constexpr GPRReg globalObjectGPR = preferredArgumentGPR<SlowOperation, 0>();
-        constexpr JSValueRegs arg1JSR = preferredArgumentJSR<SlowOperation, 1>();
-        constexpr JSValueRegs arg2JSR = preferredArgumentJSR<SlowOperation, 2>();
+        constexpr GPRReg profileGPR = preferredArgumentGPR<SlowOperation, 1>();
+        constexpr JSValueRegs arg1JSR = preferredArgumentJSR<SlowOperation, 2>();
+        constexpr JSValueRegs arg2JSR = preferredArgumentJSR<SlowOperation, 3>();
 
         emitGetVirtualRegister(op1, arg1JSR);
         emitGetVirtualRegister(op2, arg2JSR);
         loadGlobalObject(globalObjectGPR);
-        callOperation(operation, globalObjectGPR, arg1JSR, arg2JSR);
+        materializePointerIntoMetadata(bytecode, Op::Metadata::offsetOfProfile(), profileGPR);
+        callOperation(operation, globalObjectGPR, profileGPR, arg1JSR, arg2JSR);
         handleReturnValueGPR();
         return;
     }
@@ -419,7 +421,8 @@ void JIT::emit_compareSlowImpl(VirtualRegister op1, VirtualRegister op2, size_t 
 
         emitGetVirtualRegister(op, jsReg1);
         loadGlobalObject(regT4);
-        callOperation(operation, regT4, jsRegT10, jsRegT32);
+        materializePointerIntoMetadata(bytecode, Op::Metadata::offsetOfProfile(), regT5);
+        callOperation(operation, regT4, regT5, jsRegT10, jsRegT32);
         handleReturnValueGPR();
         return true;
     };
@@ -449,7 +452,8 @@ void JIT::emit_compareSlowImpl(VirtualRegister op1, VirtualRegister op2, size_t 
 
     linkSlowCase(iter); // RHS is not Int.
     loadGlobalObject(regT4);
-    callOperation(operation, regT4, jsRegT10, jsRegT32);
+    materializePointerIntoMetadata(bytecode, Op::Metadata::offsetOfProfile(), regT5);
+    callOperation(operation, regT4, regT5, jsRegT10, jsRegT32);
     handleReturnValueGPR();
 }
 

--- a/Source/JavaScriptCore/jit/JITOpcodes.cpp
+++ b/Source/JavaScriptCore/jit/JITOpcodes.cpp
@@ -1095,7 +1095,8 @@ void JIT::emitSlow_op_jstricteq(const JSInstruction* currentInstruction, Vector<
     auto bytecode = currentInstruction->as<OpJstricteq>();
     unsigned target = jumpTarget(currentInstruction, bytecode.m_targetLabel);
     loadGlobalObject(regT2);
-    callOperation(operationCompareStrictEq, regT2, regT0, regT1);
+    materializePointerIntoMetadata(bytecode, OpJstricteq::Metadata::offsetOfProfile(), regT5);
+    callOperation(operationCompareStrictEqWithProfile, regT2, regT5, regT0, regT1);
     emitJumpSlowToHot(branchTest32(NonZero, returnValueGPR), target);
 }
 
@@ -1106,7 +1107,8 @@ void JIT::emitSlow_op_jnstricteq(const JSInstruction* currentInstruction, Vector
     auto bytecode = currentInstruction->as<OpJnstricteq>();
     unsigned target = jumpTarget(currentInstruction, bytecode.m_targetLabel);
     loadGlobalObject(regT2);
-    callOperation(operationCompareStrictEq, regT2, regT0, regT1);
+    materializePointerIntoMetadata(bytecode, OpJnstricteq::Metadata::offsetOfProfile(), regT5);
+    callOperation(operationCompareStrictEqWithProfile, regT2, regT5, regT0, regT1);
     emitJumpSlowToHot(branchTest32(Zero, returnValueGPR), target);
 }
 
@@ -1681,7 +1683,8 @@ void JIT::emitSlow_op_eq(const JSInstruction* currentInstruction, Vector<SlowCas
 
     auto bytecode = currentInstruction->as<OpEq>();
     loadGlobalObject(regT2);
-    callOperation(operationCompareEq, regT2, regT0, regT1);
+    materializePointerIntoMetadata(bytecode, OpEq::Metadata::offsetOfProfile(), regT5);
+    callOperation(operationCompareEqWithProfile, regT2, regT5, regT0, regT1);
     boxBoolean(returnValueGPR, JSValueRegs { returnValueGPR });
     emitPutVirtualRegister(bytecode.m_dst, returnValueGPR);
 }
@@ -1692,7 +1695,8 @@ void JIT::emitSlow_op_neq(const JSInstruction* currentInstruction, Vector<SlowCa
 
     auto bytecode = currentInstruction->as<OpNeq>();
     loadGlobalObject(regT2);
-    callOperation(operationCompareEq, regT2, regT0, regT1);
+    materializePointerIntoMetadata(bytecode, OpNeq::Metadata::offsetOfProfile(), regT5);
+    callOperation(operationCompareEqWithProfile, regT2, regT5, regT0, regT1);
     xor32(TrustedImm32(0x1), regT0);
     boxBoolean(returnValueGPR, JSValueRegs { returnValueGPR });
     emitPutVirtualRegister(bytecode.m_dst, returnValueGPR);
@@ -1705,7 +1709,8 @@ void JIT::emitSlow_op_jeq(const JSInstruction* currentInstruction, Vector<SlowCa
     auto bytecode = currentInstruction->as<OpJeq>();
     unsigned target = jumpTarget(currentInstruction, bytecode.m_targetLabel);
     loadGlobalObject(regT2);
-    callOperation(operationCompareEq, regT2, regT0, regT1);
+    materializePointerIntoMetadata(bytecode, OpJeq::Metadata::offsetOfProfile(), regT5);
+    callOperation(operationCompareEqWithProfile, regT2, regT5, regT0, regT1);
     emitJumpSlowToHot(branchTest32(NonZero, returnValueGPR), target);
 }
 
@@ -1716,7 +1721,8 @@ void JIT::emitSlow_op_jneq(const JSInstruction* currentInstruction, Vector<SlowC
     auto bytecode = currentInstruction->as<OpJneq>();
     unsigned target = jumpTarget(currentInstruction, bytecode.m_targetLabel);
     loadGlobalObject(regT2);
-    callOperation(operationCompareEq, regT2, regT0, regT1);
+    materializePointerIntoMetadata(bytecode, OpJneq::Metadata::offsetOfProfile(), regT5);
+    callOperation(operationCompareEqWithProfile, regT2, regT5, regT0, regT1);
     emitJumpSlowToHot(branchTest32(Zero, returnValueGPR), target);
 }
 

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -2532,66 +2532,91 @@ JSC_DEFINE_JIT_OPERATION(operationDefaultCall, UCPURegister, (CallFrame* calleeF
     OPERATION_RETURN(scope, std::bit_cast<UCPURegister>(std::bit_cast<uintptr_t>(callTarget)));
 }
 
-JSC_DEFINE_JIT_OPERATION(operationCompareLess, size_t, (JSGlobalObject* globalObject, EncodedJSValue encodedOp1, EncodedJSValue encodedOp2))
+JSC_DEFINE_JIT_OPERATION(operationCompareLessWithProfile, size_t, (JSGlobalObject* globalObject, CompareProfile* profile, EncodedJSValue encodedOp1, EncodedJSValue encodedOp2))
 {
     VM& vm = globalObject->vm();
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    
-    OPERATION_RETURN(scope, jsLess<true>(globalObject, JSValue::decode(encodedOp1), JSValue::decode(encodedOp2)));
+
+    JSValue src1 = JSValue::decode(encodedOp1);
+    JSValue src2 = JSValue::decode(encodedOp2);
+    profile->observeLHSAndRHS(src1, src2);
+
+    OPERATION_RETURN(scope, jsLess<true>(globalObject, src1, src2));
 }
 
-JSC_DEFINE_JIT_OPERATION(operationCompareLessEq, size_t, (JSGlobalObject* globalObject, EncodedJSValue encodedOp1, EncodedJSValue encodedOp2))
+JSC_DEFINE_JIT_OPERATION(operationCompareLessEqWithProfile, size_t, (JSGlobalObject* globalObject, CompareProfile* profile, EncodedJSValue encodedOp1, EncodedJSValue encodedOp2))
 {
     VM& vm = globalObject->vm();
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    OPERATION_RETURN(scope, jsLessEq<true>(globalObject, JSValue::decode(encodedOp1), JSValue::decode(encodedOp2)));
+    JSValue src1 = JSValue::decode(encodedOp1);
+    JSValue src2 = JSValue::decode(encodedOp2);
+    profile->observeLHSAndRHS(src1, src2);
+
+    OPERATION_RETURN(scope, jsLessEq<true>(globalObject, src1, src2));
 }
 
-JSC_DEFINE_JIT_OPERATION(operationCompareGreater, size_t, (JSGlobalObject* globalObject, EncodedJSValue encodedOp1, EncodedJSValue encodedOp2))
+JSC_DEFINE_JIT_OPERATION(operationCompareGreaterWithProfile, size_t, (JSGlobalObject* globalObject, CompareProfile* profile, EncodedJSValue encodedOp1, EncodedJSValue encodedOp2))
 {
     VM& vm = globalObject->vm();
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    OPERATION_RETURN(scope, jsLess<false>(globalObject, JSValue::decode(encodedOp2), JSValue::decode(encodedOp1)));
+    JSValue src1 = JSValue::decode(encodedOp1);
+    JSValue src2 = JSValue::decode(encodedOp2);
+    profile->observeLHSAndRHS(src1, src2);
+
+    OPERATION_RETURN(scope, jsLess<false>(globalObject, src2, src1));
 }
 
-JSC_DEFINE_JIT_OPERATION(operationCompareGreaterEq, size_t, (JSGlobalObject* globalObject, EncodedJSValue encodedOp1, EncodedJSValue encodedOp2))
+JSC_DEFINE_JIT_OPERATION(operationCompareGreaterEqWithProfile, size_t, (JSGlobalObject* globalObject, CompareProfile* profile, EncodedJSValue encodedOp1, EncodedJSValue encodedOp2))
 {
     VM& vm = globalObject->vm();
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    OPERATION_RETURN(scope, jsLessEq<false>(globalObject, JSValue::decode(encodedOp2), JSValue::decode(encodedOp1)));
+    JSValue src1 = JSValue::decode(encodedOp1);
+    JSValue src2 = JSValue::decode(encodedOp2);
+    profile->observeLHSAndRHS(src1, src2);
+
+    OPERATION_RETURN(scope, jsLessEq<false>(globalObject, src2, src1));
 }
 
-JSC_DEFINE_JIT_OPERATION(operationCompareEq, size_t, (JSGlobalObject* globalObject, EncodedJSValue encodedOp1, EncodedJSValue encodedOp2))
+JSC_DEFINE_JIT_OPERATION(operationCompareEqWithProfile, size_t, (JSGlobalObject* globalObject, CompareProfile* profile, EncodedJSValue encodedOp1, EncodedJSValue encodedOp2))
 {
     VM& vm = globalObject->vm();
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    OPERATION_RETURN(scope, JSValue::equalSlowCaseInline(globalObject, JSValue::decode(encodedOp1), JSValue::decode(encodedOp2)));
+    JSValue src1 = JSValue::decode(encodedOp1);
+    JSValue src2 = JSValue::decode(encodedOp2);
+    profile->observeLHSAndRHS(src1, src2);
+
+    OPERATION_RETURN(scope, JSValue::equalSlowCaseInline(globalObject, src1, src2));
 }
 
 #if USE(JSVALUE64)
-JSC_DEFINE_JIT_OPERATION(operationCompareStringEq, EncodedJSValue, (JSGlobalObject* globalObject, JSCell* left, JSCell* right))
+JSC_DEFINE_JIT_OPERATION(operationCompareStringEqWithProfile, EncodedJSValue, (JSGlobalObject* globalObject, CompareProfile* profile, JSCell* left, JSCell* right))
 #else
-JSC_DEFINE_JIT_OPERATION(operationCompareStringEq, size_t, (JSGlobalObject* globalObject, JSCell* left, JSCell* right))
+JSC_DEFINE_JIT_OPERATION(operationCompareStringEqWithProfile, size_t, (JSGlobalObject* globalObject, CompareProfile* profile, JSCell* left, JSCell* right))
 #endif
 {
     VM& vm = globalObject->vm();
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto newProfile = *profile;
+    newProfile.lhsSawNonNumber();
+    newProfile.rhsSawNonNumber();
+    *profile = newProfile;
 
     bool result = asString(left)->equalInline(globalObject, asString(right));
 #if USE(JSVALUE64)
@@ -2601,7 +2626,7 @@ JSC_DEFINE_JIT_OPERATION(operationCompareStringEq, size_t, (JSGlobalObject* glob
 #endif
 }
 
-JSC_DEFINE_JIT_OPERATION(operationCompareStrictEq, size_t, (JSGlobalObject* globalObject, EncodedJSValue encodedOp1, EncodedJSValue encodedOp2))
+JSC_DEFINE_JIT_OPERATION(operationCompareStrictEqWithProfile, size_t, (JSGlobalObject* globalObject, CompareProfile* profile, EncodedJSValue encodedOp1, EncodedJSValue encodedOp2))
 {
     VM& vm = globalObject->vm();
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
@@ -2610,6 +2635,7 @@ JSC_DEFINE_JIT_OPERATION(operationCompareStrictEq, size_t, (JSGlobalObject* glob
 
     JSValue src1 = JSValue::decode(encodedOp1);
     JSValue src2 = JSValue::decode(encodedOp2);
+    profile->observeLHSAndRHS(src1, src2);
 
     OPERATION_RETURN(scope, JSValue::strictEqual(globalObject, src1, src2));
 }

--- a/Source/JavaScriptCore/jit/JITOperations.h
+++ b/Source/JavaScriptCore/jit/JITOperations.h
@@ -50,6 +50,7 @@ class CallFrame;
 class CallLinkInfo;
 class ClonedArguments;
 class CodeBlock;
+class CompareProfile;
 class DirectArguments;
 class InlineCacheHandler;
 class JSArray;
@@ -326,17 +327,19 @@ JSC_DECLARE_JIT_OPERATION(operationPolymorphicCall, UCPURegister, (CallFrame*, C
 JSC_DECLARE_JIT_OPERATION(operationVirtualCall, UCPURegister, (CallFrame*, CallLinkInfo*));
 JSC_DECLARE_JIT_OPERATION(operationDefaultCall, UCPURegister, (CallFrame*, CallLinkInfo*));
 
-JSC_DECLARE_JIT_OPERATION(operationCompareLess, size_t, (JSGlobalObject*, EncodedJSValue, EncodedJSValue));
-JSC_DECLARE_JIT_OPERATION(operationCompareLessEq, size_t, (JSGlobalObject*, EncodedJSValue, EncodedJSValue));
-JSC_DECLARE_JIT_OPERATION(operationCompareGreater, size_t, (JSGlobalObject*, EncodedJSValue, EncodedJSValue));
-JSC_DECLARE_JIT_OPERATION(operationCompareGreaterEq, size_t, (JSGlobalObject*, EncodedJSValue, EncodedJSValue));
-JSC_DECLARE_JIT_OPERATION(operationCompareEq, size_t, (JSGlobalObject*, EncodedJSValue, EncodedJSValue));
-JSC_DECLARE_JIT_OPERATION(operationCompareStrictEq, size_t, (JSGlobalObject*, EncodedJSValue, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationCompareLessWithProfile, size_t, (JSGlobalObject*, CompareProfile*, EncodedJSValue, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationCompareLessEqWithProfile, size_t, (JSGlobalObject*, CompareProfile*, EncodedJSValue, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationCompareGreaterWithProfile, size_t, (JSGlobalObject*, CompareProfile*, EncodedJSValue, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationCompareGreaterEqWithProfile, size_t, (JSGlobalObject*, CompareProfile*, EncodedJSValue, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationCompareEqWithProfile, size_t, (JSGlobalObject*, CompareProfile*, EncodedJSValue, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationCompareStrictEqWithProfile, size_t, (JSGlobalObject*, CompareProfile*, EncodedJSValue, EncodedJSValue));
 #if USE(JSVALUE64)
-JSC_DECLARE_JIT_OPERATION(operationCompareStringEq, EncodedJSValue, (JSGlobalObject*, JSCell* left, JSCell* right));
-JSC_DECLARE_JIT_OPERATION(operationCompareEqHeapBigIntToInt32, size_t, (JSGlobalObject*, JSCell* heapBigInt, int32_t smallInt));
+JSC_DECLARE_JIT_OPERATION(operationCompareStringEqWithProfile, EncodedJSValue, (JSGlobalObject*, CompareProfile*, JSCell* left, JSCell* right));
 #else
-JSC_DECLARE_JIT_OPERATION(operationCompareStringEq, size_t, (JSGlobalObject*, JSCell* left, JSCell* right));
+JSC_DECLARE_JIT_OPERATION(operationCompareStringEqWithProfile, size_t, (JSGlobalObject*, CompareProfile*, JSCell* left, JSCell* right));
+#endif
+#if USE(JSVALUE64)
+JSC_DECLARE_JIT_OPERATION(operationCompareEqHeapBigIntToInt32, size_t, (JSGlobalObject*, JSCell* heapBigInt, int32_t smallInt));
 #endif
 JSC_DECLARE_JIT_OPERATION(operationNewArrayWithProfile, EncodedJSValue, (JSGlobalObject*, ArrayAllocationProfile*, const JSValue* values, int32_t size));
 JSC_DECLARE_JIT_OPERATION(operationNewArrayWithSizeAndProfile, EncodedJSValue, (JSGlobalObject*, ArrayAllocationProfile*, EncodedJSValue size));

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -1747,112 +1747,176 @@ LLINT_SLOW_PATH_DECL(slow_path_less)
 {
     LLINT_BEGIN();
     auto bytecode = pc->as<OpLess>();
-    LLINT_RETURN(jsBoolean(jsLess<true>(globalObject, getOperand(callFrame, bytecode.m_lhs), getOperand(callFrame, bytecode.m_rhs))));
+    auto& metadata = bytecode.metadata(codeBlock);
+    JSValue lhs = getOperand(callFrame, bytecode.m_lhs);
+    JSValue rhs = getOperand(callFrame, bytecode.m_rhs);
+    metadata.m_profile.observeLHSAndRHS(lhs, rhs);
+    LLINT_RETURN(jsBoolean(jsLess<true>(globalObject, lhs, rhs)));
 }
 
 LLINT_SLOW_PATH_DECL(slow_path_lesseq)
 {
     LLINT_BEGIN();
     auto bytecode = pc->as<OpLesseq>();
-    LLINT_RETURN(jsBoolean(jsLessEq<true>(globalObject, getOperand(callFrame, bytecode.m_lhs), getOperand(callFrame, bytecode.m_rhs))));
+    auto& metadata = bytecode.metadata(codeBlock);
+    JSValue lhs = getOperand(callFrame, bytecode.m_lhs);
+    JSValue rhs = getOperand(callFrame, bytecode.m_rhs);
+    metadata.m_profile.observeLHSAndRHS(lhs, rhs);
+    LLINT_RETURN(jsBoolean(jsLessEq<true>(globalObject, lhs, rhs)));
 }
 
 LLINT_SLOW_PATH_DECL(slow_path_greater)
 {
     LLINT_BEGIN();
     auto bytecode = pc->as<OpGreater>();
-    LLINT_RETURN(jsBoolean(jsLess<false>(globalObject, getOperand(callFrame, bytecode.m_rhs), getOperand(callFrame, bytecode.m_lhs))));
+    auto& metadata = bytecode.metadata(codeBlock);
+    JSValue lhs = getOperand(callFrame, bytecode.m_lhs);
+    JSValue rhs = getOperand(callFrame, bytecode.m_rhs);
+    metadata.m_profile.observeLHSAndRHS(lhs, rhs);
+    LLINT_RETURN(jsBoolean(jsLess<false>(globalObject, rhs, lhs)));
 }
 
 LLINT_SLOW_PATH_DECL(slow_path_greatereq)
 {
     LLINT_BEGIN();
     auto bytecode = pc->as<OpGreatereq>();
-    LLINT_RETURN(jsBoolean(jsLessEq<false>(globalObject, getOperand(callFrame, bytecode.m_rhs), getOperand(callFrame, bytecode.m_lhs))));
+    auto& metadata = bytecode.metadata(codeBlock);
+    JSValue lhs = getOperand(callFrame, bytecode.m_lhs);
+    JSValue rhs = getOperand(callFrame, bytecode.m_rhs);
+    metadata.m_profile.observeLHSAndRHS(lhs, rhs);
+    LLINT_RETURN(jsBoolean(jsLessEq<false>(globalObject, rhs, lhs)));
 }
 
 LLINT_SLOW_PATH_DECL(slow_path_jless)
 {
     LLINT_BEGIN();
     auto bytecode = pc->as<OpJless>();
-    LLINT_BRANCH(jsLess<true>(globalObject, getOperand(callFrame, bytecode.m_lhs), getOperand(callFrame, bytecode.m_rhs)));
+    auto& metadata = bytecode.metadata(codeBlock);
+    JSValue lhs = getOperand(callFrame, bytecode.m_lhs);
+    JSValue rhs = getOperand(callFrame, bytecode.m_rhs);
+    metadata.m_profile.observeLHSAndRHS(lhs, rhs);
+    LLINT_BRANCH(jsLess<true>(globalObject, lhs, rhs));
 }
 
 LLINT_SLOW_PATH_DECL(slow_path_jnless)
 {
     LLINT_BEGIN();
     auto bytecode = pc->as<OpJnless>();
-    LLINT_BRANCH(!jsLess<true>(globalObject, getOperand(callFrame, bytecode.m_lhs), getOperand(callFrame, bytecode.m_rhs)));
+    auto& metadata = bytecode.metadata(codeBlock);
+    JSValue lhs = getOperand(callFrame, bytecode.m_lhs);
+    JSValue rhs = getOperand(callFrame, bytecode.m_rhs);
+    metadata.m_profile.observeLHSAndRHS(lhs, rhs);
+    LLINT_BRANCH(!jsLess<true>(globalObject, lhs, rhs));
 }
 
 LLINT_SLOW_PATH_DECL(slow_path_jgreater)
 {
     LLINT_BEGIN();
     auto bytecode = pc->as<OpJgreater>();
-    LLINT_BRANCH(jsLess<false>(globalObject, getOperand(callFrame, bytecode.m_rhs), getOperand(callFrame, bytecode.m_lhs)));
+    auto& metadata = bytecode.metadata(codeBlock);
+    JSValue lhs = getOperand(callFrame, bytecode.m_lhs);
+    JSValue rhs = getOperand(callFrame, bytecode.m_rhs);
+    metadata.m_profile.observeLHSAndRHS(lhs, rhs);
+    LLINT_BRANCH(jsLess<false>(globalObject, rhs, lhs));
 }
 
 LLINT_SLOW_PATH_DECL(slow_path_jngreater)
 {
     LLINT_BEGIN();
     auto bytecode = pc->as<OpJngreater>();
-    LLINT_BRANCH(!jsLess<false>(globalObject, getOperand(callFrame, bytecode.m_rhs), getOperand(callFrame, bytecode.m_lhs)));
+    auto& metadata = bytecode.metadata(codeBlock);
+    JSValue lhs = getOperand(callFrame, bytecode.m_lhs);
+    JSValue rhs = getOperand(callFrame, bytecode.m_rhs);
+    metadata.m_profile.observeLHSAndRHS(lhs, rhs);
+    LLINT_BRANCH(!jsLess<false>(globalObject, rhs, lhs));
 }
 
 LLINT_SLOW_PATH_DECL(slow_path_jlesseq)
 {
     LLINT_BEGIN();
     auto bytecode = pc->as<OpJlesseq>();
-    LLINT_BRANCH(jsLessEq<true>(globalObject, getOperand(callFrame, bytecode.m_lhs), getOperand(callFrame, bytecode.m_rhs)));
+    auto& metadata = bytecode.metadata(codeBlock);
+    JSValue lhs = getOperand(callFrame, bytecode.m_lhs);
+    JSValue rhs = getOperand(callFrame, bytecode.m_rhs);
+    metadata.m_profile.observeLHSAndRHS(lhs, rhs);
+    LLINT_BRANCH(jsLessEq<true>(globalObject, lhs, rhs));
 }
 
 LLINT_SLOW_PATH_DECL(slow_path_jnlesseq)
 {
     LLINT_BEGIN();
     auto bytecode = pc->as<OpJnlesseq>();
-    LLINT_BRANCH(!jsLessEq<true>(globalObject, getOperand(callFrame, bytecode.m_lhs), getOperand(callFrame, bytecode.m_rhs)));
+    auto& metadata = bytecode.metadata(codeBlock);
+    JSValue lhs = getOperand(callFrame, bytecode.m_lhs);
+    JSValue rhs = getOperand(callFrame, bytecode.m_rhs);
+    metadata.m_profile.observeLHSAndRHS(lhs, rhs);
+    LLINT_BRANCH(!jsLessEq<true>(globalObject, lhs, rhs));
 }
 
 LLINT_SLOW_PATH_DECL(slow_path_jgreatereq)
 {
     LLINT_BEGIN();
     auto bytecode = pc->as<OpJgreatereq>();
-    LLINT_BRANCH(jsLessEq<false>(globalObject, getOperand(callFrame, bytecode.m_rhs), getOperand(callFrame, bytecode.m_lhs)));
+    auto& metadata = bytecode.metadata(codeBlock);
+    JSValue lhs = getOperand(callFrame, bytecode.m_lhs);
+    JSValue rhs = getOperand(callFrame, bytecode.m_rhs);
+    metadata.m_profile.observeLHSAndRHS(lhs, rhs);
+    LLINT_BRANCH(jsLessEq<false>(globalObject, rhs, lhs));
 }
 
 LLINT_SLOW_PATH_DECL(slow_path_jngreatereq)
 {
     LLINT_BEGIN();
     auto bytecode = pc->as<OpJngreatereq>();
-    LLINT_BRANCH(!jsLessEq<false>(globalObject, getOperand(callFrame, bytecode.m_rhs), getOperand(callFrame, bytecode.m_lhs)));
+    auto& metadata = bytecode.metadata(codeBlock);
+    JSValue lhs = getOperand(callFrame, bytecode.m_lhs);
+    JSValue rhs = getOperand(callFrame, bytecode.m_rhs);
+    metadata.m_profile.observeLHSAndRHS(lhs, rhs);
+    LLINT_BRANCH(!jsLessEq<false>(globalObject, rhs, lhs));
 }
 
 LLINT_SLOW_PATH_DECL(slow_path_jeq)
 {
     LLINT_BEGIN();
     auto bytecode = pc->as<OpJeq>();
-    LLINT_BRANCH(JSValue::equal(globalObject, getOperand(callFrame, bytecode.m_lhs), getOperand(callFrame, bytecode.m_rhs)));
+    auto& metadata = bytecode.metadata(codeBlock);
+    JSValue lhs = getOperand(callFrame, bytecode.m_lhs);
+    JSValue rhs = getOperand(callFrame, bytecode.m_rhs);
+    metadata.m_profile.observeLHSAndRHS(lhs, rhs);
+    LLINT_BRANCH(JSValue::equal(globalObject, lhs, rhs));
 }
 
 LLINT_SLOW_PATH_DECL(slow_path_jneq)
 {
     LLINT_BEGIN();
     auto bytecode = pc->as<OpJneq>();
-    LLINT_BRANCH(!JSValue::equal(globalObject, getOperand(callFrame, bytecode.m_lhs), getOperand(callFrame, bytecode.m_rhs)));
+    auto& metadata = bytecode.metadata(codeBlock);
+    JSValue lhs = getOperand(callFrame, bytecode.m_lhs);
+    JSValue rhs = getOperand(callFrame, bytecode.m_rhs);
+    metadata.m_profile.observeLHSAndRHS(lhs, rhs);
+    LLINT_BRANCH(!JSValue::equal(globalObject, lhs, rhs));
 }
 
 LLINT_SLOW_PATH_DECL(slow_path_jstricteq)
 {
     LLINT_BEGIN();
     auto bytecode = pc->as<OpJstricteq>();
-    LLINT_BRANCH(JSValue::strictEqual(globalObject, getOperand(callFrame, bytecode.m_lhs), getOperand(callFrame, bytecode.m_rhs)));
+    auto& metadata = bytecode.metadata(codeBlock);
+    JSValue lhs = getOperand(callFrame, bytecode.m_lhs);
+    JSValue rhs = getOperand(callFrame, bytecode.m_rhs);
+    metadata.m_profile.observeLHSAndRHS(lhs, rhs);
+    LLINT_BRANCH(JSValue::strictEqual(globalObject, lhs, rhs));
 }
 
 LLINT_SLOW_PATH_DECL(slow_path_jnstricteq)
 {
     LLINT_BEGIN();
     auto bytecode = pc->as<OpJnstricteq>();
-    LLINT_BRANCH(!JSValue::strictEqual(globalObject, getOperand(callFrame, bytecode.m_lhs), getOperand(callFrame, bytecode.m_rhs)));
+    auto& metadata = bytecode.metadata(codeBlock);
+    JSValue lhs = getOperand(callFrame, bytecode.m_lhs);
+    JSValue rhs = getOperand(callFrame, bytecode.m_rhs);
+    metadata.m_profile.observeLHSAndRHS(lhs, rhs);
+    LLINT_BRANCH(!JSValue::strictEqual(globalObject, lhs, rhs));
 }
 
 LLINT_SLOW_PATH_DECL(slow_path_switch_imm)

--- a/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
+++ b/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
@@ -327,28 +327,44 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_eq)
 {
     BEGIN();
     auto bytecode = pc->as<OpEq>();
-    RETURN(jsBoolean(JSValue::equal(globalObject, GET_C(bytecode.m_lhs).jsValue(), GET_C(bytecode.m_rhs).jsValue())));
+    auto& metadata = bytecode.metadata(codeBlock);
+    auto lhs = GET_C(bytecode.m_lhs).jsValue();
+    auto rhs = GET_C(bytecode.m_rhs).jsValue();
+    metadata.m_profile.observeLHSAndRHS(lhs, rhs);
+    RETURN(jsBoolean(JSValue::equal(globalObject, lhs, rhs)));
 }
 
 JSC_DEFINE_COMMON_SLOW_PATH(slow_path_neq)
 {
     BEGIN();
     auto bytecode = pc->as<OpNeq>();
-    RETURN(jsBoolean(!JSValue::equal(globalObject, GET_C(bytecode.m_lhs).jsValue(), GET_C(bytecode.m_rhs).jsValue())));
+    auto& metadata = bytecode.metadata(codeBlock);
+    auto lhs = GET_C(bytecode.m_lhs).jsValue();
+    auto rhs = GET_C(bytecode.m_rhs).jsValue();
+    metadata.m_profile.observeLHSAndRHS(lhs, rhs);
+    RETURN(jsBoolean(!JSValue::equal(globalObject, lhs, rhs)));
 }
 
 JSC_DEFINE_COMMON_SLOW_PATH(slow_path_stricteq)
 {
     BEGIN();
     auto bytecode = pc->as<OpStricteq>();
-    RETURN(jsBoolean(JSValue::strictEqual(globalObject, GET_C(bytecode.m_lhs).jsValue(), GET_C(bytecode.m_rhs).jsValue())));
+    auto& metadata = bytecode.metadata(codeBlock);
+    auto lhs = GET_C(bytecode.m_lhs).jsValue();
+    auto rhs = GET_C(bytecode.m_rhs).jsValue();
+    metadata.m_profile.observeLHSAndRHS(lhs, rhs);
+    RETURN(jsBoolean(JSValue::strictEqual(globalObject, lhs, rhs)));
 }
 
 JSC_DEFINE_COMMON_SLOW_PATH(slow_path_nstricteq)
 {
     BEGIN();
     auto bytecode = pc->as<OpNstricteq>();
-    RETURN(jsBoolean(!JSValue::strictEqual(globalObject, GET_C(bytecode.m_lhs).jsValue(), GET_C(bytecode.m_rhs).jsValue())));
+    auto& metadata = bytecode.metadata(codeBlock);
+    auto lhs = GET_C(bytecode.m_lhs).jsValue();
+    auto rhs = GET_C(bytecode.m_rhs).jsValue();
+    metadata.m_profile.observeLHSAndRHS(lhs, rhs);
+    RETURN(jsBoolean(!JSValue::strictEqual(globalObject, lhs, rhs)));
 }
 
 JSC_DEFINE_COMMON_SLOW_PATH(slow_path_inc)


### PR DESCRIPTION
#### 229eaaa2a6b2199941a53f23f8278b8819d38b5e
<pre>
[JSC] Add Compare profile
<a href="https://bugs.webkit.org/show_bug.cgi?id=295971">https://bugs.webkit.org/show_bug.cgi?id=295971</a>
<a href="https://rdar.apple.com/155864101">rdar://155864101</a>

Reviewed by NOBODY (OOPS!).

WIP

* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/bytecode/BytecodeList.rb:
* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::getArrayProfile):
(JSC::CodeBlock::getCompareProfile):
* Source/JavaScriptCore/bytecode/CodeBlock.h:
* Source/JavaScriptCore/bytecode/CompareProfile.cpp: Added.
(WTF::printInternal):
* Source/JavaScriptCore/bytecode/CompareProfile.h: Added.
(JSC::CompareProfile::CompareProfile):
(JSC::CompareProfile::observedIntIntBits):
(JSC::CompareProfile::observedNumberIntBits):
(JSC::CompareProfile::observedIntNumberBits):
(JSC::CompareProfile::observedNumberNumberBits):
(JSC::CompareProfile::lhsObservedType const):
(JSC::CompareProfile::rhsObservedType const):
(JSC::CompareProfile::setLhsObservedType):
(JSC::CompareProfile::setRhsObservedType):
(JSC::CompareProfile::lhsSawInt32):
(JSC::CompareProfile::lhsSawNumber):
(JSC::CompareProfile::lhsSawNonNumber):
(JSC::CompareProfile::rhsSawInt32):
(JSC::CompareProfile::rhsSawNumber):
(JSC::CompareProfile::rhsSawNonNumber):
(JSC::CompareProfile::observeLHS):
(JSC::CompareProfile::observeLHSAndRHS):
(JSC::CompareProfile::isObservedTypeEmpty):
(JSC::CompareProfile::bits const):
* Source/JavaScriptCore/bytecode/Opcode.h:
* Source/JavaScriptCore/bytecode/SpeculatedType.h:
(JSC::isFullNumberOrOtherSpeculation):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::getArrayMode):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
(JSC::DFG::FixupPhase::attemptToMakeGetArrayLength):
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::shouldSpeculateNumberOrOther):
* Source/JavaScriptCore/dfg/DFGOSRExit.cpp:
(JSC::DFG::OSRExit::compileExit):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
(JSC::DFG::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp:
(JSC::FTL::compileStub):
* Source/JavaScriptCore/generator/DSL.rb:
* Source/JavaScriptCore/jit/JIT.h:
* Source/JavaScriptCore/jit/JITArithmetic.cpp:
(JSC::JIT::emitSlow_op_less):
(JSC::JIT::emitSlow_op_lesseq):
(JSC::JIT::emitSlow_op_greater):
(JSC::JIT::emitSlow_op_greatereq):
(JSC::JIT::emitSlow_op_jless):
(JSC::JIT::emitSlow_op_jlesseq):
(JSC::JIT::emitSlow_op_jgreater):
(JSC::JIT::emitSlow_op_jgreatereq):
(JSC::JIT::emitSlow_op_jnless):
(JSC::JIT::emitSlow_op_jnlesseq):
(JSC::JIT::emitSlow_op_jngreater):
(JSC::JIT::emitSlow_op_jngreatereq):
(JSC::JIT::emit_compareSlow):
(JSC::JIT::emit_compareAndJumpSlow):
(JSC::JIT::emit_compareSlowImpl):
* Source/JavaScriptCore/jit/JITOpcodes.cpp:
(JSC::JIT::emitSlow_op_jstricteq):
(JSC::JIT::emitSlow_op_jnstricteq):
(JSC::JIT::emitSlow_op_eq):
(JSC::JIT::emitSlow_op_neq):
(JSC::JIT::emitSlow_op_jeq):
(JSC::JIT::emitSlow_op_jneq):
* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/jit/JITOperations.h:
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::LLINT_SLOW_PATH_DECL):
* Source/JavaScriptCore/runtime/CommonSlowPaths.cpp:
(JSC::JSC_DEFINE_COMMON_SLOW_PATH):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/229eaaa2a6b2199941a53f23f8278b8819d38b5e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111783 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21922 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117803 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62020 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32130 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40028 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84932 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35616 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114730 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25649 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100598 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65371 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24977 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18731 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61637 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/104271 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95032 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18803 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121056 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/110341 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38817 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28854 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93805 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39197 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96854 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93627 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38790 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16576 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34838 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38713 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44209 "Built successfully") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/134605 "Hash 229eaaa2 for PR 48042 does not build (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38357 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/134605 "Hash 229eaaa2 for PR 48042 does not build (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41682 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40070 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->