### PR TITLE
[WPE][browserperfdash-benchmark] Allow to define browser flavors and to run specific list of plans with them

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_cog_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_cog_driver.py
@@ -36,8 +36,11 @@ class CogBrowserDriver(LinuxBrowserDriver):
     def launch_url(self, url, options, browser_build_path, browser_path):
         self._default_browser_arguments = []
         if self.process_name.endswith('run-minibrowser'):
-            self._default_browser_arguments.append('--wpe')
+            self._default_browser_arguments.extend(['--wpe', '--'])
         self._default_browser_arguments.append('--webprocess-failure=exit')
+        if self.browser_args:
+            self._default_browser_arguments.extend(self.browser_args)
+            self.browser_args = []
         self._default_browser_arguments.append(url)
         super(CogBrowserDriver, self).launch_url(url, options, browser_build_path, browser_path)
 

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_minibrowsergtk_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_minibrowsergtk_driver.py
@@ -34,8 +34,11 @@ class GTKMiniBrowserDriver(LinuxBrowserDriver):
     def launch_url(self, url, options, browser_build_path, browser_path):
         self._default_browser_arguments = []
         if self.process_name.endswith('run-minibrowser'):
-            self._default_browser_arguments.append('--gtk')
+            self._default_browser_arguments.extend(['--gtk', '--'])
         self._default_browser_arguments.append('--full-screen')
+        if self.browser_args:
+            self._default_browser_arguments.extend(self.browser_args)
+            self.browser_args = []
         self._default_browser_arguments.append(url)
         super(GTKMiniBrowserDriver, self).launch_url(url, options, browser_build_path, browser_path)
 

--- a/Tools/Scripts/webkitpy/browserperfdash/config-file-example.txt
+++ b/Tools/Scripts/webkitpy/browserperfdash/config-file-example.txt
@@ -17,39 +17,55 @@
 # 'bot_password' : The password of this bot on the server.
 # 'post_url'     : The POST URL (typically ${BASE_URI}/dash/bot-report)
 #
-# There is a special section named 'settings' where you can specify a
-# list of plans to be run when the flag '--plans-from-config' is passed,
-# or specify default values for different options.
-# The settings that can be configured in this section are:
-#   plan_list = (Optional) list of plans to run when the flag --plans-from-config is specified
+# There are special sections named 'settings' where it is possible to specify list of
+# plans to be run when the flag '--plans-from-config' is passed, or to specify default
+# values for different options, or even to define several browsers to run the tests.
+# This sections have to be named 'settings' (default one) or start with the string 'settings:'
+# The values for the settings sections that can be configured in this section are:
+#   plan_list = list of plans to run when the flag --plans-from-config is specified
 #   timeout = (Optional) default value that will be used if no parameter "--timeout" is specified
 #   count = (Optional) default value that will be used if no parameter "--count" is specified
 #   platform = (Optional) default value that will be used if no parameter "--platform" is specified
 #   browser = (Optional) default value that will be used if no parameter "--browser" is specified
 #   driver = (Optional) default value that will be used if no parameter "--driver" is specified
 #
+# Note: this [settings] sections are ignored unless the flag '--plans-from-config' is passed.
 
 #
 # Example of configuration file
 #
 
-## Configuration of plans to run and default settings values
-#[settings]
-#plan_list = ares6 dromaeo-cssquery dromaeo-dom dromaeo-jslib jetstream2 jsbench kraken motionmark octane speedometer stylebench sunspider
-#timeout = 900
-#count = 1
-#platform = linux
-#driver = webdriver
-#browser = cog
+# Configuration of plans to run and default settings values
+[settings]
+plan_list = ares6 dromaeo-cssquery dromaeo-dom dromaeo-jslib jetstream2 jsbench kraken motionmark octane speedometer stylebench sunspider
+timeout = 900
+count = 1
+platform = linux
+driver = webserver
+browser = minibrowser-wpe
 
-## Configuration for dashboard browserperfdash.igalia.org
-#[browserperfdash.igalia.org]
-#bot_id = gtk-linux-64-perf-tests
-#bot_password = r4nd0MP4ss
-#post_url = https://browserperfdash.igalia.com/dash/bot-report
+# the values not specified here (platform, driver, count) default to the values passed from the default [settings]
+[settings:skia-cpu]
+plan_list = motionmark
+timeout = 1200
+browser = minibrowser-wpe-skia-cpu
 
-## Configuration for dashboard localhost-test
-#[localhost-test]
-#bot_id = testlocalbot
-#bot_password = 123
-#post_url = http://localhost:8000/dash/bot-report
+# plan_list defaults to the value specified in the default [settings]
+[settings:old-api]
+browser = minibrowser-wpe-old-api
+
+# all the values but webdriver defaults to the values from the default [settings]
+[settings:webdriver]
+driver = webdriver
+
+# Configuration for dashboard browserperfdash.igalia.org
+[browserperfdash.igalia.org]
+bot_id = gtk-linux-64-perf-tests
+bot_password = r4nd0MP4ss
+post_url = https://browserperfdash.igalia.com/dash/bot-report
+
+# Configuration for dashboard localhost-test
+[localhost-test]
+bot_id = testlocalbot
+bot_password = 123
+post_url = http://localhost:8000/dash/bot-report

--- a/Tools/Scripts/webkitpy/browserperfdash/plans/browser_binary_size.py
+++ b/Tools/Scripts/webkitpy/browserperfdash/plans/browser_binary_size.py
@@ -58,6 +58,8 @@ def get_browser_relevant_objects_glib(browser_driver):
     browser_path = port_driver.get_browser_path('cog' if browser_driver.browser_name == 'cog' else 'MiniBrowser')
     browser_relevant_objects.append(browser_path)
     browser_env = port_driver.setup_environ_for_server()
+    if not os.path.isfile(browser_path):
+        raise ValueError(f"The browser path does not exist: {browser_path}")
     libraries, interpreter = SharedObjectResolver('ldd', browser_env).get_libs_and_interpreter(browser_path)
     browser_build_dir = port_driver._build_path()
     for library in libraries:
@@ -67,7 +69,7 @@ def get_browser_relevant_objects_glib(browser_driver):
 
 
 def run(browser_driver, results_file):
-    if browser_driver.platform == "linux" and browser_driver.browser_name in ['minibrowser-wpe', 'cog', 'minibrowser-gtk']:
+    if browser_driver.platform == "linux" and (browser_driver.browser_name.startswith('minibrowser-wpe') or browser_driver.browser_name in ['cog', 'minibrowser-gtk']):
         browser_relevant_objects = get_browser_relevant_objects_glib(browser_driver)
     else:
         raise NotImplementedError(f'Getting the browser size data for browser "{browser_driver.browser_name}" and platform "{browser_driver.platform}" is not implemented')


### PR DESCRIPTION
#### 4bd0148e73a6af13d812769846f88dd6df7f0a9f
<pre>
[WPE][browserperfdash-benchmark] Allow to define browser flavors and to run specific list of plans with them
<a href="https://bugs.webkit.org/show_bug.cgi?id=295976">https://bugs.webkit.org/show_bug.cgi?id=295976</a>

Reviewed by Nikolas Zimmermann.

This patch introduces a way of specifying on the config file for the browserperfdash-benchmark runner
several settings sections where it is possible to specify in each one of them a list of different plans
to run with different browsers (or with different configurations of the same browser).

It adds also 3 variants (or flavors) of minibrowser-wpe: &apos;minibrowser-wpe-skiacpu&apos;,
&apos;minibrowser-wpe-skiacpu-fullscreen&apos; and &apos;minibrowser-wpe-oldapi&apos;.

The goal is to be able to run on the RPi4 boards some benchmark plans (like MotionMark) with this flavors
of WPE, in order to track performance regressions as well as compare performance metrics.

* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_minibrowserwpe_driver.py:
(WPEMiniBrowserBaseDriver):
(WPEMiniBrowserBaseDriver._extra_wpe_minibrowser_args):
(WPEMiniBrowserBaseDriver.launch_url):
(WPEMiniBrowserBaseDriver.prepare_env):
(WPEMiniBrowserDriver):
(WPEMiniBrowserSkiaCPUDriver):
(WPEMiniBrowserSkiaCPUDriver.prepare_env):
(WPEMiniBrowserOldAPIDriver):
(WPEMiniBrowserOldAPIDriver._extra_browser_args):
(WPEMiniBrowserDriver.launch_url): Deleted.
(WPEMiniBrowserDriver.launch_driver): Deleted.
(WPEMiniBrowserDriver.prepare_env): Deleted.
* Tools/Scripts/webkitpy/browserperfdash/browserperfdash_runner.py:
(BrowserPerfDashRunner.__init__):
(BrowserPerfDashRunner._set_args_from_extra_setting_browser_entry):
(BrowserPerfDashRunner):
(BrowserPerfDashRunner._load_extra_settings_browsers_from_config_file):
(BrowserPerfDashRunner._parse_config_file):
(BrowserPerfDashRunner._upload_result):
(BrowserPerfDashRunner._run_and_upload_plans_for_browser):
(BrowserPerfDashRunner._log_results_and_calculate_retcode):
(BrowserPerfDashRunner.run):
* Tools/Scripts/webkitpy/browserperfdash/config-file-example.txt:
* Tools/Scripts/webkitpy/browserperfdash/plans/browser_binary_size.py:
(get_browser_relevant_objects_glib):
(run):

Canonical link: <a href="https://commits.webkit.org/297459@main">https://commits.webkit.org/297459@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb615c05c9b65e094e856228baee7a298b5ba14c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111882 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31545 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22022 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117900 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62110 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113845 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32226 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40126 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/84990 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35678 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114829 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25733 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/100681 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65429 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/111315 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/25054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18816 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61743 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/95112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/18888 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121177 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38909 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/28933 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/93859 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39290 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96939 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93683 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38869 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16654 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34920 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18027 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38807 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38444 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41769 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40159 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->