### PR TITLE
DeferredWorkTimer should properly handle termination exceptions

### DIFF
--- a/JSTests/stress/watchdog-under-deferred-work-timer.js
+++ b/JSTests/stress/watchdog-under-deferred-work-timer.js
@@ -1,0 +1,9 @@
+//@ requireOptions("--watchdog=300", "--watchdog-exception-ok")
+
+function iterate() {
+    while (true) {
+        1 + 1;
+    }
+}
+
+setTimeout(iterate, 0);

--- a/Source/JavaScriptCore/runtime/DeferredWorkTimer.cpp
+++ b/Source/JavaScriptCore/runtime/DeferredWorkTimer.cpp
@@ -32,6 +32,7 @@
 #include "JSGlobalObject.h"
 #include "VM.h"
 #include <wtf/RunLoop.h>
+#include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
@@ -89,6 +90,21 @@ void DeferredWorkTimer::doWork(VM& vm)
     if (!m_runTasks)
         return;
 
+    SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE auto stopRunLoopIfNecessary = makeScopeExit([&] {
+        locker.assertIsHolding(m_taskLock);
+        if (vm.hasPendingTerminationException()) {
+            vm.setExecutionForbidden();
+            if (m_shouldStopRunLoopWhenAllTicketsFinish)
+                RunLoop::currentSingleton().stop();
+            return;
+        }
+
+        if (m_shouldStopRunLoopWhenAllTicketsFinish && m_pendingTickets.isEmpty()) {
+            ASSERT(m_tasks.isEmpty());
+            RunLoop::currentSingleton().stop();
+        }
+    });
+
     Vector<std::tuple<Ticket, Task>> suspendedTasks;
 
     while (!m_tasks.isEmpty()) {
@@ -124,9 +140,9 @@ void DeferredWorkTimer::doWork(VM& vm)
         // But we want to keep ticketData while running task since its globalObject ensures dependencies are strongly held.
         auto ticketData = m_pendingTickets.take(pendingTicket);
 
-        // Allow tasks we are about to run to schedule work.
-        m_currentlyRunningTask = true;
         {
+            // Allow tasks we are about to run to schedule work.
+            SetForScope<bool> runningTask(m_currentlyRunningTask, true);
             auto dropper = DropLockForScope(locker);
 
             // This is the start of a runloop turn, we can release any weakrefs here.
@@ -138,12 +154,16 @@ void DeferredWorkTimer::doWork(VM& vm)
             if (Exception* exception = scope.exception()) {
                 if (scope.clearExceptionExceptTermination())
                     globalObject->globalObjectMethodTable()->reportUncaughtExceptionAtEventLoop(globalObject, exception);
+                else if (vm.hasPendingTerminationException()) [[unlikely]]
+                    return;
             }
 
             vm.drainMicrotasks();
-            ASSERT(!vm.exceptionForInspection() || vm.hasPendingTerminationException());
+            if (vm.hasPendingTerminationException()) [[unlikely]]
+                return;
+
+            scope.assertNoException();
         }
-        m_currentlyRunningTask = false;
     }
 
     while (!suspendedTasks.isEmpty())
@@ -155,11 +175,6 @@ void DeferredWorkTimer::doWork(VM& vm)
     m_pendingTickets.removeIf([] (auto& ticket) {
         return ticket->isCancelled();
     });
-
-    if (m_pendingTickets.isEmpty() && m_shouldStopRunLoopWhenAllTicketsFinish) {
-        ASSERT(m_tasks.isEmpty());
-        RunLoop::currentSingleton().stop();
-    }
 }
 
 void DeferredWorkTimer::runRunLoop()


### PR DESCRIPTION
#### 465bd0e38e9921d67691b9827423583c454f54ca
<pre>
DeferredWorkTimer should properly handle termination exceptions
<a href="https://bugs.webkit.org/show_bug.cgi?id=295984">https://bugs.webkit.org/show_bug.cgi?id=295984</a>
<a href="https://rdar.apple.com/155784567">rdar://155784567</a>

Reviewed by Mark Lam and Yusuke Suzuki.

Right now if a termination exception is propagated to DeferredWorkTimer it won&apos;t properly bail out of the system.
Also made a few other code quality cleanups at the same time.

Canonical link: <a href="https://commits.webkit.org/297424@main">https://commits.webkit.org/297424@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd6a496590db5272fdaf21bd73c87121e77c5261

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111751 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31414 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21892 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117776 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/61995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32101 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39998 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/84903 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/61995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114698 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25631 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100573 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65341 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/24960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18706 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61606 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/104239 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/95014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18778 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121025 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/110309 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38791 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28835 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/93788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39171 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96829 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93610 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23864 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38769 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/16556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34815 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38686 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44179 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/134573 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/38334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36251 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/41660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40044 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->