### PR TITLE
[Style] Adopt direction taking functions to simplify grid rendering

### DIFF
--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -1484,12 +1484,13 @@ static Style::GridOrderedNamedLinesMap gridLineNames(const RenderStyle* renderSt
             result.iterator->value.appendVector(newNames);
     };
 
-    auto orderedGridLineNames = direction == Style::GridTrackSizingDirection::Columns ? renderStyle->gridTemplateColumns().orderedNamedLines : renderStyle->gridTemplateRows().orderedNamedLines;
-    for (auto& [i, names] : orderedGridLineNames.map)
+    auto& tracks = renderStyle->gridTemplateList(direction);
+
+    for (auto& [i, names] : tracks.orderedNamedLines.map)
         appendLineNames(i, names);
 
-    auto& autoRepeatOrderedGridLineNames = (direction == Style::GridTrackSizingDirection::Columns ? renderStyle->gridTemplateColumns().autoRepeatOrderedNamedLines : renderStyle->gridTemplateRows().autoRepeatOrderedNamedLines).map;
-    auto autoRepeatInsertionPoint = direction == Style::GridTrackSizingDirection::Columns ? renderStyle->gridTemplateColumns().autoRepeatInsertionPoint : renderStyle->gridTemplateRows().autoRepeatInsertionPoint;
+    auto& autoRepeatOrderedGridLineNames = tracks.autoRepeatOrderedNamedLines.map;
+    auto autoRepeatInsertionPoint = tracks.autoRepeatInsertionPoint;
     unsigned autoRepeatIndex = 0;
     while (autoRepeatOrderedGridLineNames.size() && autoRepeatIndex < expectedLineCount - autoRepeatInsertionPoint) {
         auto names = autoRepeatOrderedGridLineNames.get(autoRepeatIndex % autoRepeatOrderedGridLineNames.size());
@@ -1498,8 +1499,7 @@ static Style::GridOrderedNamedLinesMap gridLineNames(const RenderStyle* renderSt
         ++autoRepeatIndex;
     }
 
-    auto& implicitGridLineNames = direction == Style::GridTrackSizingDirection::Columns ? renderStyle->gridTemplateAreas().implicitNamedGridColumnLines : renderStyle->gridTemplateAreas().implicitNamedGridRowLines;
-    for (auto& [name, indexes] : implicitGridLineNames.map) {
+    for (auto& [name, indexes] : renderStyle->gridTemplateAreas().implicitNamedGridLines(direction).map) {
         for (auto i : indexes)
             appendLineNames(i, {name});
     }

--- a/Source/WebCore/rendering/Grid.cpp
+++ b/Source/WebCore/rendering/Grid.cpp
@@ -183,8 +183,7 @@ OrderedTrackIndexSet* Grid::autoRepeatEmptyTracks(Style::GridTrackSizingDirectio
 
 GridSpan Grid::gridItemSpan(const RenderBox& gridItem, Style::GridTrackSizingDirection direction) const
 {
-    GridArea area = gridItemArea(gridItem);
-    return direction == Style::GridTrackSizingDirection::Columns ? area.columns : area.rows;
+    return gridItemArea(gridItem).span(direction);
 }
 
 GridSpan Grid::gridItemSpanIgnoringCollapsedTracks(const RenderBox& gridItem, Style::GridTrackSizingDirection direction) const

--- a/Source/WebCore/rendering/GridLayoutFunctions.cpp
+++ b/Source/WebCore/rendering/GridLayoutFunctions.cpp
@@ -181,12 +181,12 @@ bool isGridItemInlineSizeDependentOnBlockConstraints(const RenderBox& gridItem, 
 
 Style::GridTrackSizingDirection flowAwareDirectionForGridItem(const RenderGrid& grid, const RenderBox& gridItem, Style::GridTrackSizingDirection direction)
 {
-    return !isOrthogonalGridItem(grid, gridItem) ? direction : (direction == Style::GridTrackSizingDirection::Columns ? Style::GridTrackSizingDirection::Rows : Style::GridTrackSizingDirection::Columns);
+    return !isOrthogonalGridItem(grid, gridItem) ? direction : orthogonalDirection(direction);
 }
 
 Style::GridTrackSizingDirection flowAwareDirectionForParent(const RenderGrid& grid, const RenderElement& parent, Style::GridTrackSizingDirection direction)
 {
-    return isOrthogonalParent(grid, parent) ? (direction == Style::GridTrackSizingDirection::Columns ? Style::GridTrackSizingDirection::Rows : Style::GridTrackSizingDirection::Columns) : direction;
+    return isOrthogonalParent(grid, parent) ? orthogonalDirection(direction) : direction;
 }
 
 std::optional<RenderBox::GridAreaSize> overridingContainingBlockContentSizeForGridItem(const RenderBox& gridItem, Style::GridTrackSizingDirection direction)

--- a/Source/WebCore/rendering/GridMasonryLayout.cpp
+++ b/Source/WebCore/rendering/GridMasonryLayout.cpp
@@ -108,10 +108,10 @@ LayoutUnit GridMasonryLayout::calculateMasonryIntrinsicLogicalWidth(RenderBox& g
 
 void GridMasonryLayout::setItemGridAxisContainingBlockToGridArea(const GridTrackSizingAlgorithm& algorithm, RenderBox& gridItem)
 {
-    if (gridAxisDirection() == Style::GridTrackSizingDirection::Columns)
-        gridItem.setGridAreaContentLogicalWidth(algorithm.gridAreaBreadthForGridItem(gridItem, Style::GridTrackSizingDirection::Columns));
+    if (auto direction = gridAxisDirection(); direction == Style::GridTrackSizingDirection::Columns)
+        gridItem.setGridAreaContentLogicalWidth(algorithm.gridAreaBreadthForGridItem(gridItem, direction));
     else
-        gridItem.setGridAreaContentLogicalHeight(algorithm.gridAreaBreadthForGridItem(gridItem, Style::GridTrackSizingDirection::Rows));
+        gridItem.setGridAreaContentLogicalHeight(algorithm.gridAreaBreadthForGridItem(gridItem, direction));
     
     // FIXME(249230): Try to cache masonry layout sizes
     gridItem.setChildNeedsLayout(MarkOnlyThis);
@@ -221,7 +221,7 @@ inline Style::GridTrackSizingDirection GridMasonryLayout::gridAxisDirection() co
 {
     // The masonry axis and grid axis can never be the same. 
     // They are always perpendicular to each other.
-    return m_masonryAxisDirection == Style::GridTrackSizingDirection::Rows ? Style::GridTrackSizingDirection::Columns : Style::GridTrackSizingDirection::Rows;
+    return orthogonalDirection(m_masonryAxisDirection);
 }
 
 bool GridMasonryLayout::hasDefiniteGridAxisPosition(const RenderBox& gridItem, Style::GridTrackSizingDirection gridAxisDirection) const
@@ -231,12 +231,14 @@ bool GridMasonryLayout::hasDefiniteGridAxisPosition(const RenderBox& gridItem, S
 
 GridSpan GridMasonryLayout::gridAxisSpanFromArea(const GridArea& gridArea) const
 {
-    return gridAxisDirection() == Style::GridTrackSizingDirection::Rows ? gridArea.rows : gridArea.columns;
+    return gridArea.span(gridAxisDirection());
 }
 
 GridArea GridMasonryLayout::masonryGridAreaFromGridAxisSpan(const GridSpan& gridAxisSpan) const
 {
-    return m_masonryAxisDirection == Style::GridTrackSizingDirection::Rows ? GridArea { m_masonryAxisSpan, gridAxisSpan } : GridArea { gridAxisSpan, m_masonryAxisSpan };
+    return m_masonryAxisDirection == Style::GridTrackSizingDirection::Rows
+        ? GridArea { m_masonryAxisSpan, gridAxisSpan }
+        : GridArea { gridAxisSpan, m_masonryAxisSpan };
 }
 
 bool GridMasonryLayout::hasEnoughSpaceAtPosition(unsigned startingPosition, unsigned spanLength) const

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -192,12 +192,12 @@ void GridTrackSizingAlgorithm::setAvailableSpace(Style::GridTrackSizingDirection
 
 const Style::GridTrackSize& GridTrackSizingAlgorithm::rawGridTrackSize(Style::GridTrackSizingDirection direction, unsigned translatedIndex) const
 {
-    bool isRowAxis = direction == Style::GridTrackSizingDirection::Columns;
     auto& renderStyle = m_renderGrid->style();
-    auto& trackStyles = isRowAxis ? renderStyle.gridTemplateColumns().sizes : renderStyle.gridTemplateRows().sizes;
-    auto& autoRepeatTrackStyles = isRowAxis ? renderStyle.gridTemplateColumns().autoRepeatSizes : renderStyle.gridTemplateRows().autoRepeatSizes;
-    auto& autoTrackStyles = isRowAxis ? renderStyle.gridAutoColumns() : renderStyle.gridAutoRows();
-    unsigned insertionPoint = isRowAxis ? renderStyle.gridTemplateColumns().autoRepeatInsertionPoint : renderStyle.gridTemplateRows().autoRepeatInsertionPoint;
+    auto& autoTrackStyles = renderStyle.gridAutoList(direction);
+    auto& tracks = renderStyle.gridTemplateList(direction);
+    auto& trackStyles = tracks.sizes;
+    auto& autoRepeatTrackStyles = tracks.autoRepeatSizes;
+    unsigned insertionPoint = tracks.autoRepeatInsertionPoint;
     unsigned autoRepeatTracksCount = m_grid.autoRepeatTracks(direction);
 
     // We should not use Style::GridPositionsResolver::explicitGridXXXCount() for this because the

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -413,12 +413,12 @@ void RenderBox::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle
 
 static bool hasEquivalentGridPositioningStyle(const RenderStyle& style, const RenderStyle& oldStyle)
 {
-    return (oldStyle.gridItemColumnStart() == style.gridItemColumnStart()
+    return oldStyle.gridItemColumnStart() == style.gridItemColumnStart()
         && oldStyle.gridItemColumnEnd() == style.gridItemColumnEnd()
         && oldStyle.gridItemRowStart() == style.gridItemRowStart()
         && oldStyle.gridItemRowEnd() == style.gridItemRowEnd()
         && oldStyle.order() == style.order()
-        && oldStyle.hasOutOfFlowPosition() == style.hasOutOfFlowPosition())
+        && oldStyle.hasOutOfFlowPosition() == style.hasOutOfFlowPosition()
         && (oldStyle.gridTemplateColumns().subgrid == style.gridTemplateColumns().subgrid || style.gridTemplateColumns().orderedNamedLines.map.isEmpty())
         && (oldStyle.gridTemplateRows().subgrid == style.gridTemplateRows().subgrid || style.gridTemplateRows().orderedNamedLines.map.isEmpty());
 }

--- a/Source/WebCore/rendering/style/GridArea.h
+++ b/Source/WebCore/rendering/style/GridArea.h
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "GridSpan.h"
+#include "StyleGridTrackSizingDirection.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -57,6 +58,11 @@ public:
 
     GridSpan columns;
     GridSpan rows;
+
+    const GridSpan& span(Style::GridTrackSizingDirection direction) const
+    {
+        return direction == Style::GridTrackSizingDirection::Columns ? columns : rows;
+    }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -940,13 +940,15 @@ public:
     inline bool hasAutoColumnCount() const;
     inline bool specifiesColumns() const;
     inline ColumnFill columnFill() const;
-    inline const Style::GapGutter& columnGap() const;
-    inline const Style::GapGutter& rowGap() const;
     inline BorderStyle columnRuleStyle() const;
     inline unsigned short columnRuleWidth() const;
     inline bool columnRuleIsTransparent() const;
     inline ColumnSpan columnSpan() const;
     inline bool columnSpanEqual(const RenderStyle&) const;
+
+    inline const Style::GapGutter& columnGap() const;
+    inline const Style::GapGutter& rowGap() const;
+    inline const Style::GapGutter& gap(Style::GridTrackSizingDirection) const;
 
     inline const TransformOperations& transform() const;
     inline bool hasTransform() const;

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -227,6 +227,7 @@ inline FontSelectionValue RenderStyle::fontWidth() const { return fontDescriptio
 inline FontOpticalSizing RenderStyle::fontOpticalSizing() const { return fontDescription().opticalSizing(); }
 inline FontVariationSettings RenderStyle::fontVariationSettings() const { return fontDescription().variationSettings(); }
 inline FontSelectionValue RenderStyle::fontWeight() const { return fontDescription().weight(); }
+inline const Style::GapGutter& RenderStyle::gap(Style::GridTrackSizingDirection direction) const { return direction == Style::GridTrackSizingDirection::Columns ? columnGap() : rowGap(); }
 inline const Style::GridTrackSizes& RenderStyle::gridAutoColumns() const { return m_nonInheritedData->rareData->grid->m_gridAutoColumns; }
 inline GridAutoFlow RenderStyle::gridAutoFlow() const { return static_cast<GridAutoFlow>(m_nonInheritedData->rareData->grid->m_gridAutoFlow); }
 inline const Style::GridTrackSizes& RenderStyle::gridAutoRows() const { return m_nonInheritedData->rareData->grid->m_gridAutoRows; }

--- a/Source/WebCore/style/StyleOrderedNamedLinesCollector.h
+++ b/Source/WebCore/style/StyleOrderedNamedLinesCollector.h
@@ -43,9 +43,9 @@ namespace Style {
 class OrderedNamedLinesCollector {
     WTF_MAKE_NONCOPYABLE(OrderedNamedLinesCollector);
 public:
-    OrderedNamedLinesCollector(ExtractorState& state, bool isRowAxis)
-        : m_orderedNamedGridLines(isRowAxis ? state.style.gridTemplateColumns().orderedNamedLines : state.style.gridTemplateRows().orderedNamedLines)
-        , m_orderedNamedAutoRepeatGridLines(isRowAxis ? state.style.gridTemplateColumns().autoRepeatOrderedNamedLines : state.style.gridTemplateRows().autoRepeatOrderedNamedLines)
+    OrderedNamedLinesCollector(ExtractorState&, const Style::GridTemplateList& tracks)
+        : m_orderedNamedGridLines(tracks.orderedNamedLines)
+        , m_orderedNamedAutoRepeatGridLines(tracks.autoRepeatOrderedNamedLines)
     {
     }
     virtual ~OrderedNamedLinesCollector() = default;
@@ -65,9 +65,9 @@ protected:
 
 class OrderedNamedLinesCollectorInGridLayout : public OrderedNamedLinesCollector {
 public:
-    OrderedNamedLinesCollectorInGridLayout(ExtractorState& state, bool isRowAxis, unsigned autoRepeatTracksCount, unsigned autoRepeatTrackListLength)
-        : OrderedNamedLinesCollector(state, isRowAxis)
-        , m_insertionPoint(isRowAxis ? state.style.gridTemplateColumns().autoRepeatInsertionPoint : state.style.gridTemplateRows().autoRepeatInsertionPoint)
+    OrderedNamedLinesCollectorInGridLayout(ExtractorState& state, const Style::GridTemplateList& tracks, unsigned autoRepeatTracksCount, unsigned autoRepeatTrackListLength)
+        : OrderedNamedLinesCollector(state, tracks)
+        , m_insertionPoint(tracks.autoRepeatInsertionPoint)
         , m_autoRepeatTotalTracks(autoRepeatTracksCount)
         , m_autoRepeatTrackListLength(autoRepeatTrackListLength)
     {
@@ -83,17 +83,17 @@ private:
 
 class OrderedNamedLinesCollectorInSubgridLayout : public OrderedNamedLinesCollector {
 public:
-    OrderedNamedLinesCollectorInSubgridLayout(ExtractorState& state, bool isRowAxis, unsigned totalTracksCount)
-        : OrderedNamedLinesCollector(state, isRowAxis)
-        , m_insertionPoint(isRowAxis ? state.style.gridTemplateColumns().autoRepeatInsertionPoint : state.style.gridTemplateRows().autoRepeatInsertionPoint)
-        , m_autoRepeatLineSetListLength((isRowAxis ? state.style.gridTemplateColumns().autoRepeatOrderedNamedLines : state.style.gridTemplateRows().autoRepeatOrderedNamedLines).map.size())
+    OrderedNamedLinesCollectorInSubgridLayout(ExtractorState& state, const Style::GridTemplateList& tracks, unsigned totalTracksCount)
+        : OrderedNamedLinesCollector(state, tracks)
+        , m_insertionPoint(tracks.autoRepeatInsertionPoint)
+        , m_autoRepeatLineSetListLength(tracks.autoRepeatOrderedNamedLines.map.size())
         , m_totalLines(totalTracksCount + 1)
     {
         if (!m_autoRepeatLineSetListLength) {
             m_autoRepeatTotalLineSets = 0;
             return;
         }
-        unsigned named = (isRowAxis ? state.style.gridTemplateColumns().orderedNamedLines : state.style.gridTemplateRows().orderedNamedLines).map.size();
+        unsigned named = tracks.orderedNamedLines.map.size();
         if (named >= m_totalLines) {
             m_autoRepeatTotalLineSets = 0;
             return;

--- a/Source/WebCore/style/values/grid/StyleGridPositionsResolver.h
+++ b/Source/WebCore/style/values/grid/StyleGridPositionsResolver.h
@@ -49,8 +49,7 @@ public:
     static GridPositionSide finalPositionSide(GridTrackSizingDirection);
     static unsigned spanSizeForAutoPlacedItem(const RenderBox&, GridTrackSizingDirection);
     static GridSpan resolveGridPositionsFromStyle(const RenderGrid&, const RenderBox&, GridTrackSizingDirection);
-    static unsigned explicitGridColumnCount(const RenderGrid&);
-    static unsigned explicitGridRowCount(const RenderGrid&);
+    static unsigned explicitGridCount(const RenderGrid&, GridTrackSizingDirection);
 };
 
 } // namespace Style

--- a/Source/WebCore/style/values/grid/StyleGridTemplateAreas.h
+++ b/Source/WebCore/style/values/grid/StyleGridTemplateAreas.h
@@ -27,6 +27,7 @@
 #include "CSSGridTemplateAreas.h"
 #include "StyleGridNamedAreaMap.h"
 #include "StyleGridNamedLinesMap.h"
+#include "StyleGridTrackSizingDirection.h"
 
 namespace WebCore {
 namespace Style {
@@ -51,6 +52,16 @@ struct GridTemplateAreas {
         if (isNone())
             return visitor(CSS::Keyword::None { });
         return visitor(map);
+    }
+
+    size_t count(GridTrackSizingDirection direction) const
+    {
+        return direction == GridTrackSizingDirection::Columns ? map.columnCount : map.rowCount;
+    }
+
+    const GridNamedLinesMap& implicitNamedGridLines(GridTrackSizingDirection direction) const
+    {
+        return direction == GridTrackSizingDirection::Columns ? implicitNamedGridColumnLines : implicitNamedGridRowLines;
     }
 
     bool operator==(const GridTemplateAreas& other) const

--- a/Source/WebCore/style/values/grid/StyleGridTrackSizingDirection.h
+++ b/Source/WebCore/style/values/grid/StyleGridTrackSizingDirection.h
@@ -29,5 +29,12 @@ namespace Style {
 
 enum class GridTrackSizingDirection : bool { Columns, Rows };
 
+constexpr GridTrackSizingDirection orthogonalDirection(GridTrackSizingDirection direction)
+{
+    return direction == GridTrackSizingDirection::Columns
+        ? GridTrackSizingDirection::Rows
+        : GridTrackSizingDirection::Columns;
+}
+
 } // namespace Style
 } // namespace WebCore


### PR DESCRIPTION
#### 4e093b140ae0d59e74d31c6739c2d303d7facad5
<pre>
[Style] Adopt direction taking functions to simplify grid rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=295995">https://bugs.webkit.org/show_bug.cgi?id=295995</a>

Reviewed by Alan Baradlay.

Adds and adopts grid track sizing direction taking functions to reduce
the number of places with explicit checks for columns vs. rows.

* Source/WebCore/inspector/InspectorOverlay.cpp:
* Source/WebCore/rendering/Grid.cpp:
* Source/WebCore/rendering/GridLayoutFunctions.cpp:
* Source/WebCore/rendering/GridMasonryLayout.cpp:
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
* Source/WebCore/rendering/RenderBox.cpp:
* Source/WebCore/rendering/RenderGrid.cpp:
* Source/WebCore/rendering/RenderGrid.h:
* Source/WebCore/rendering/style/GridArea.h:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/StyleOrderedNamedLinesCollector.h:
* Source/WebCore/style/values/grid/StyleGridPositionsResolver.cpp:
* Source/WebCore/style/values/grid/StyleGridPositionsResolver.h:
* Source/WebCore/style/values/grid/StyleGridTemplateAreas.h:
* Source/WebCore/style/values/grid/StyleGridTrackSizingDirection.h:

Canonical link: <a href="https://commits.webkit.org/297547@main">https://commits.webkit.org/297547@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d11d8a000a4eb95b827b1cba0018c5503c6fd498

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112090 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31763 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22246 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118113 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62387 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114052 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32437 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40338 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85164 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/35860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115037 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25919 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100867 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65592 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25229 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19001 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61969 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95306 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19079 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121454 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39123 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29130 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94000 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39504 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97106 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93823 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23955 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39029 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16818 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35165 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39017 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44542 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/134910 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38656 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/134910 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41989 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40372 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->