### PR TITLE
Improve web platform test webvtt/rendering/cues-with-video/processing-model/enable_controls_reposition.html

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/enable_controls_reposition-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/enable_controls_reposition-expected.html
@@ -2,13 +2,6 @@
 <title>Reference for WebVTT rendering, cue reposition after enabling controls</title>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
-.video {
-    display: inline-block;
-    outline: solid;
-    width: 320px;
-    height: 240px;
-    position: relative
-}
 video {
     position: absolute;
     width:320px;
@@ -27,9 +20,31 @@ video {
     color: green;
     font-size: 50px;
 }
+
+.media-container {
+    display: inline-block;
+    position: relative;
+    border: solid black 1px;
+    border-box: content-box;
+    width: 320px;
+    height: 240px;
+}
 </style>
-<video controls>
-    <source src="/media/white.webm" type="video/webm">
-    <source src="/media/white.mp4" type="video/mp4">
-</video>
-<div class="video"><span class="cue"><span>Foo</span></span></div>
+<div class="media-container">
+    <span class="cue"><span>Foo</span></span>
+    <video controls autoplay onplaying="runTest()">
+        <source src="/media/sound_5.mp3" type="audio/mp3">
+        <source src="/media/sound_5.oga" type="audio/ogg">
+    </video>
+</div>
+<script src="/common/reftest-wait.js"></script>
+<script>
+    async function runTest() {
+        let media = document.getElementsByTagName("video")[0];
+        media.pause();
+        media.currentTime = 0;
+        media.addEventListener("seeked", (event) => {
+            takeScreenshot();
+        });
+    }
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/enable_controls_reposition-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/enable_controls_reposition-ref.html
@@ -2,13 +2,6 @@
 <title>Reference for WebVTT rendering, cue reposition after enabling controls</title>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
-.video {
-    display: inline-block;
-    outline: solid;
-    width: 320px;
-    height: 240px;
-    position: relative
-}
 video {
     position: absolute;
     width:320px;
@@ -27,9 +20,32 @@ video {
     color: green;
     font-size: 50px;
 }
+
+.media-container {
+    display: inline-block;
+    position: relative;
+    border: solid black 1px;
+    border-box: content-box;
+    width: 320px;
+    height: 240px;
+}
 </style>
-<video controls>
-    <source src="/media/white.webm" type="video/webm">
-    <source src="/media/white.mp4" type="video/mp4">
-</video>
-<div class="video"><span class="cue"><span>Foo</span></span></div>
+<div class="media-container">
+    <span class="cue"><span>Foo</span></span>
+    <video controls autoplay onplaying="runTest()">
+        <source src="/media/sound_5.mp3" type="audio/mp3">
+        <source src="/media/sound_5.oga" type="audio/ogg">
+    </video>
+</div>
+<script src="/common/reftest-wait.js"></script>
+<script>
+    async function runTest() {
+        let media = document.getElementsByTagName("video")[0];
+        media.pause();
+        media.currentTime = 0;
+        media.addEventListener("seeked", (event) => {
+            takeScreenshot();
+        });
+    }
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/enable_controls_reposition.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/enable_controls_reposition.html
@@ -5,7 +5,6 @@
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 video {
-  outline: solid;
   width: 320px;
   height: 240px;
 }
@@ -14,19 +13,31 @@ video {
   font-size: 50px;
   color: green;
 }
+.media-container {
+    display: inline-block;
+    position: relative;
+    border: solid black 1px;
+    border-box: content-box;
+    width: 320px;
+    height: 240px;
+}
 </style>
-<script src="/common/reftest-wait.js"></script>
-<video autoplay onplaying="this.onplaying = null;
-                           this.pause();
-                           this.currentTime = 0;
-                           setTimeout(function(video){
-                             video.controls = true;
-                           }, 100, this);
-                           takeScreenshotDelayed(1000);">
-    <source src="/media/white.webm" type="video/webm">
-    <source src="/media/white.mp4" type="video/mp4">
-    <track src=support/foo.vtt>
-    <script>
-    document.getElementsByTagName('track')[0].track.mode = 'showing';
-    </script>
+<div class="media-container">
+<video controls autoplay onplaying="runTest()">
+    <source src="/media/sound_5.mp3" type="audio/mp3">
+    <source src="/media/sound_5.oga" type="audio/ogg">
+    <track src="support/foo.vtt">
 </video>
+</div>
+<script src="/common/reftest-wait.js"></script>
+<script>
+async function runTest() {
+    document.getElementsByTagName("track")[0].track.mode = "showing";
+    let media = document.getElementsByTagName("video")[0];
+    media.pause();
+    media.currentTime = 0;
+    media.addEventListener("seeked", (event) => {
+        takeScreenshot();
+    });
+}
+</script>


### PR DESCRIPTION
#### ffc22d60f48ce0444dd276b40496c2728cfd6db0
<pre>
Improve web platform test webvtt/rendering/cues-with-video/processing-model/enable_controls_reposition.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=295996">https://bugs.webkit.org/show_bug.cgi?id=295996</a>
<a href="https://rdar.apple.com/155897096">rdar://155897096</a>

Reviewed by Jer Noble.

This patch fixes a few issues present in this test. First, I added the autoplay attribute to the expected
file to match the actual file.

In the expected file, I changed the cue box to be behind the video element, so that the transparent grey
background that WebKit places on top of the video when controls are showing shades the cue in the same way
in the expected and actual file.

I changed the source for the video from an mp4 to an mp3, and explicitly styled a border around the video
to ensure consistency between the files.

I added a call to takeScreenshot() in the expected file inside a seek event listener, to ensure the screenshot
is not taken until the test is complete. I did the same for the actual file, which previously called
takeScreenShotDelayed(1000). This should remove a bottleneck in testing speed.

With these changes, all browsers will still fail this test because the test assumes that the cue will move up
50px when the controls are showing, and each browser moves the cue a different number of pixels upward. I believe
50px is an arbitrary number that was chosen at an earlier time, and that the WebVTT spec does not specify an
offset. In the future, I think we should consider making a standard way for browsers to allow interacting with
the cue inside a test, so that we check that the cue is unobstructed by the controls in an nonarbitrary way.

* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/enable_controls_reposition-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/enable_controls_reposition-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/enable_controls_reposition.html:

Canonical link: <a href="https://commits.webkit.org/297425@main">https://commits.webkit.org/297425@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/496887e5dcb9e51543c2243d1d09fa20835889c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111727 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31393 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21868 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117758 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/61982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32081 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39978 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84890 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/61982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114674 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25618 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100557 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65328 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24949 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18689 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61589 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95003 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18761 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121008 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38772 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28823 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93780 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39152 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96812 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93602 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38753 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16545 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34800 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18001 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38666 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38318 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41646 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40026 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->