### PR TITLE
AX: Stale value is served to assistive technologies for partially completed date inputs whose subfields change value

### DIFF
--- a/LayoutTests/accessibility/mac/stale-input-value-from-subfield-change-expected.txt
+++ b/LayoutTests/accessibility/mac/stale-input-value-from-subfield-change-expected.txt
@@ -1,0 +1,8 @@
+This test ensures that an input's accessibility value is reported correctly after a subfield changes.
+
+PASS: getMonth(date.dateValue) === '03'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/stale-input-value-from-subfield-change.html
+++ b/LayoutTests/accessibility/mac/stale-input-value-from-subfield-change.html
@@ -1,0 +1,63 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html lang="en">
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<input id="date" type="date" />
+<input id="datetime" type="datetime-local" />
+
+<script>
+var output = "This test ensures that an input's accessibility value is reported correctly after a subfield changes.\n\n";
+
+function getMonth(dateString) {
+    // Example of what dateString is expected to be like: AXDateValue: 2025-03-15 00:00:00 +0000
+    const spaceSplit = dateString.split(" ");
+    // spaceSplit[1] == 2025-03-15
+    return spaceSplit[1].split("-")[1];
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var date = accessibilityController.accessibleElementById("date");
+    var dateTime = accessibilityController.accessibleElementById("datetime");
+    var currentDateTimeValue, previousDateTimeValue;
+
+    document.getElementById("date").focus();
+    for (let i = 0; i < 3; i++)
+        eventSender.keyDown("upArrow");
+
+    setTimeout(async function() {
+        output += await expectAsync("getMonth(date.dateValue)", "'03'");
+
+        document.getElementById("datetime").focus();
+        for (let i = 0; i < 3; i++)
+            eventSender.keyDown("upArrow");
+
+        await waitFor(() => {
+            previousDateTimeValue = dateTime.dateValue;
+            return getMonth(dateTime.dateValue) === "03";
+        });
+
+        // Move focus to the meridiem field, and modify it. Testing specifically this field is important because it's
+        // non-numeric ("AM" or "PM" for lang="en"), which is represented by a different C++ class internally.
+        for (let i = 0; i < 5; i++)
+            eventSender.keyDown("rightArrow");
+        eventSender.keyDown("upArrow");
+
+        await waitFor(() => {
+            currentDateTimeValue = dateTime.dateValue;    
+            return currentDateTimeValue !== previousDateTimeValue;
+        });
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -909,6 +909,8 @@ accessibility/mac/clipped-radio-input-frame.html [ WontFix ]
 
 accessibility/range-input-increment-decrement-fires-input-event.html [ WontFix ]
 
+accessibility/mac/stale-input-value-from-subfield-change.html [ WontFix ]
+
 # Default ARIA for custom elements are not yet enabled
 accessibility/custom-elements/ [ Skip ]
 


### PR DESCRIPTION
#### 6f2d27d179bb9706f3a875bdd0210cd269b54c2e
<pre>
AX: Stale value is served to assistive technologies for partially completed date inputs whose subfields change value
<a href="https://bugs.webkit.org/show_bug.cgi?id=296011">https://bugs.webkit.org/show_bug.cgi?id=296011</a>
<a href="https://rdar.apple.com/155910722">rdar://155910722</a>

Reviewed by Joshua Hoffman.

Date inputs are made up of sub-elements, which themselves are controls (specifically, spinbuttons). Prior to this commit,
we were not updating the cached date-value of date inputs that are partially completed (only some of the subfields have
a non-placeholder value). This is because the DOM code only notified accesibility of the input changing value when its
actual DOM value changed, and the DOM value of a date input is empty string until all fields are filled out.

With this commit, a hook is added into BaseDateAndTimeInputType to notify accessibility when a subfield changes.

* LayoutTests/accessibility/mac/stale-input-value-from-subfield-change-expected.txt: Added.
* LayoutTests/accessibility/mac/stale-input-value-from-subfield-change.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations: Disable new test.
* Source/WebCore/html/BaseDateAndTimeInputType.cpp:
(WebCore::BaseDateAndTimeInputType::didChangeValueFromControl):

Canonical link: <a href="https://commits.webkit.org/297435@main">https://commits.webkit.org/297435@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe9ab0c9692b3ecfa28eb0fd412d37a06f578fd6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111772 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21913 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117795 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62008 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113735 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32122 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40019 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84912 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35601 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114719 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25643 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100588 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65349 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24971 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18720 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61628 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95026 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18792 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121048 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38809 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28845 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93796 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39189 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96843 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93618 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23876 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38779 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16566 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34830 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38705 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44200 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38349 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41674 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40062 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->