### PR TITLE
Reviewed-by validator fails intermittently with long commit messages

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -6683,9 +6683,9 @@ class ValidateCommitMessage(steps.ShellSequence, ShellMixin, AddToLogMixin):
         self.commands = []
         commands = [
             f"git log {head_ref} ^{base_ref} | grep -q '{self.OOPS_RE}' && echo 'Commit message contains (OOPS!){reviewer_error_msg}' || test $? -eq 1",
-            "git log {} ^{} | grep -q '\\({}\\)' || echo 'No reviewer information in commit message'".format(
-                head_ref, base_ref,
+            "grep -q '\\({}\\)' < <(git log {} ^{}) || echo 'No reviewer information in commit message".format(
                 '\\|'.join(self.REVIEWED_STRINGS),
+                head_ref, base_ref,
             ), "git log {} ^{} | grep '\\({}\\)' || true".format(
                 head_ref, base_ref,
                 '\\|'.join(self.REVIEWED_STRINGS[:3]),

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -8182,7 +8182,7 @@ class TestValidateCommitMessage(BuildStepMixinAdditions, unittest.TestCase):
                              logEnviron=False,
                              timeout=60,
                              command=['/bin/bash', '--posix', '-o', 'pipefail', '-c',
-                                      "git log eng/pull-request-branch ^main | grep -q '\\(Reviewed by\\|Rubber-stamped by\\|Rubber stamped by\\|Unreviewed\\|Versioning.\\)' || echo 'No reviewer information in commit message'"])
+                                      "grep -q '\\(Reviewed by\\|Rubber-stamped by\\|Rubber stamped by\\|Unreviewed\\|Versioning.\\)' < <(git log eng/pull-request-branch ^main) || echo 'No reviewer information in commit message"])
             + 0, ExpectShell(workdir='wkdir',
                              logEnviron=False,
                              timeout=60,
@@ -8217,7 +8217,7 @@ class TestValidateCommitMessage(BuildStepMixinAdditions, unittest.TestCase):
             + 0, ExpectShell(workdir='wkdir',
                         logEnviron=False,
                         timeout=60,
-                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git log HEAD ^origin/main | grep -q '\\(Reviewed by\\|Rubber-stamped by\\|Rubber stamped by\\|Unreviewed\\|Versioning.\\)' || echo 'No reviewer information in commit message'"])
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "grep -q '\\(Reviewed by\\|Rubber-stamped by\\|Rubber stamped by\\|Unreviewed\\|Versioning.\\)' < <(git log HEAD ^origin/main) || echo 'No reviewer information in commit message"])
             + 0, ExpectShell(workdir='wkdir',
                         logEnviron=False,
                         timeout=60,
@@ -8277,7 +8277,7 @@ class TestValidateCommitMessage(BuildStepMixinAdditions, unittest.TestCase):
             + 0, ExpectShell(workdir='wkdir',
                         logEnviron=False,
                         timeout=60,
-                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git log eng/pull-request-branch ^main | grep -q '\\(Reviewed by\\|Rubber-stamped by\\|Rubber stamped by\\|Unreviewed\\|Versioning.\\)' || echo 'No reviewer information in commit message'"])
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "grep -q '\\(Reviewed by\\|Rubber-stamped by\\|Rubber stamped by\\|Unreviewed\\|Versioning.\\)' < <(git log eng/pull-request-branch ^main) || echo 'No reviewer information in commit message"])
             + 0, ExpectShell(workdir='wkdir',
                         logEnviron=False,
                         timeout=60,


### PR DESCRIPTION
#### 36d909e4c179d87ae813c8166ecbaa36548d99ad
<pre>
Reviewed-by validator fails intermittently with long commit messages
<a href="https://bugs.webkit.org/show_bug.cgi?id=296012">https://bugs.webkit.org/show_bug.cgi?id=296012</a>
<a href="https://rdar.apple.com/155614510">rdar://155614510</a>

Reviewed by Sam Sneddon.

Instead of piping the output of `git log`, save it to a temporary file. This forces
the entire output of `git log` to be emitted and grep should return as expected, no
matter the length of the commit message.

* Tools/CISupport/ews-build/steps.py:
(ValidateCommitMessage.run):
* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/297438@main">https://commits.webkit.org/297438@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0aeb6eb62c90ffcc72e82449c1aa4d68de6f3d11

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111759 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31422 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21900 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117784 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62001 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113722 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32109 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40006 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84906 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35595 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114706 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25635 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100581 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65344 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24963 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18714 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61614 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95017 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18786 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121032 "Hash 0aeb6eb6 for PR 48077 does not build (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38799 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28840 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/121032 "Hash 0aeb6eb6 for PR 48077 does not build (failure)") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/111255 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39179 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96837 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/121032 "Hash 0aeb6eb6 for PR 48077 does not build (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38774 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16562 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34821 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18007 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38694 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38340 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41666 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40052 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->