### PR TITLE
Need a short description (OOPS!).

### DIFF
--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -32,6 +32,7 @@
 #include "GridArea.h"
 #include "GridLayoutFunctions.h"
 #include "GridPositionsResolver.h"
+#include "RenderChildIterator.h"
 #include "RenderElementInlines.h"
 #include "RenderGrid.h"
 #include "RenderObjectInlines.h"
@@ -2128,6 +2129,17 @@ void GridTrackSizingAlgorithm::run(GridTrackSizingDirection direction, unsigned 
 {
     setup(direction, numTracks, sizingOperation, availableSpace);
 
+    Vector<const RenderBox *> gridItemsToReset;
+    if (m_sizingState == SizingState::ColumnSizingFirstIteration && hasAllLengthRowSizes()) {
+        for (auto& gridItem : childrenOfType<RenderBox>(*m_renderGrid)) {
+            if (gridItem.isOutOfFlowPositioned() || gridItem.isLegend())
+                continue;
+            auto estimatedRowSizes = estimatedGridAreaBreadthForGridItem(gridItem, GridTrackSizingDirection::ForRows);
+            const_cast<RenderBox&>(gridItem).setGridAreaContentLogicalHeight(estimatedRowSizes);
+            gridItemsToReset.append(&gridItem);
+        }
+    }
+
     StateMachine stateMachine(*this);
 
     if (m_renderGrid->isMasonry(m_direction))
@@ -2163,6 +2175,11 @@ void GridTrackSizingAlgorithm::run(GridTrackSizingDirection direction, unsigned 
 
     // Step 5.
     stretchAutoTracks();
+
+
+        for (auto* gridItem : gridItemsToReset) {
+            const_cast<RenderBox&>(*gridItem).clearGridAreaContentLogicalHeight();
+        }
 }
 
 void GridTrackSizingAlgorithm::reset()

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
@@ -31,6 +31,7 @@
 #include "InlineIteratorBoxInlines.h"
 #include "InlineIteratorInlineBox.h"
 #include "PositionArea.h"
+#include "RenderAncestorIterator.h"
 #include "RenderGrid.h"
 #include "RenderInline.h"
 #include "RenderLayer.h"
@@ -266,6 +267,30 @@ LayoutRange PositionedLayoutConstraints::adjustForPositionArea(const LayoutRange
 
 // MARK: - Resolving margins and alignment (after sizing).
 
+bool PositionedLayoutConstraints::isEligibleForStaticRangeAlignment(const RenderBlock& formattingContextRootForStaticPositioning) const
+{
+    ASSERT(formattingContextRootForStaticPositioning.createsNewFormattingContext()
+        && ((m_renderer->parent() == &formattingContextRootForStaticPositioning) ||  RenderElement::formattingContextRoot(*m_renderer->parent()) == &formattingContextRootForStaticPositioning));
+
+
+    if (m_containingAxis == LogicalBoxAxis::Inline)
+        return false;
+
+    if (formattingContextRootForStaticPositioning.isRenderBlockFlow())
+        return false;
+
+    if (formattingContextRootForStaticPositioning.isRenderFlexibleBox())
+        return false;
+
+    if (formattingContextRootForStaticPositioning.isRenderGrid())
+        return false;
+
+    // We can hit this in certain pieces of content (e.g. see mathml/crashtests/fixed-pos-children.html),
+    // but the spec has no definition for a static position rectangle.
+    return false;
+
+}
+
 void PositionedLayoutConstraints::resolvePosition(RenderBox::LogicalExtentComputedValues& computedValues) const
 {
     // Static position should have resolved one of our insets by now.
@@ -313,6 +338,23 @@ void PositionedLayoutConstraints::resolvePosition(RenderBox::LogicalExtentComput
         // Align into remaining space.
         if (!hasAutoBeforeInset && !hasAutoAfterInset && !hasAutoBeforeMargin && !hasAutoAfterMargin && remainingSpace)
             return resolveAlignmentShift(remainingSpace, computedValues.m_extent + usedMarginBefore + usedMarginAfter);
+
+        if (m_useStaticPosition) {
+            auto formattingContextRoot = [&] {
+                auto* parent = m_renderer->parent();
+                const auto* parentRenderBlock = dynamicDowncast<RenderBlock>(parent);
+                if (!parentRenderBlock || !parentRenderBlock->createsNewFormattingContext())
+                    return RenderElement::formattingContextRoot(*parent);
+                return parentRenderBlock;
+            }();
+
+            ASSERT(formattingContextRoot);
+
+            if (isEligibleForStaticRangeAlignment(*formattingContextRoot)) {
+                ASSERT_NOT_IMPLEMENTED_YET();
+                return { };
+            }
+        }
 
         if (hasAutoBeforeInset)
             return remainingSpace;

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.h
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.h
@@ -91,6 +91,7 @@ private:
     void captureAnchorGeometry();
     LayoutRange adjustForPositionArea(const LayoutRange rangeToAdjust, const LayoutRange anchorArea, const BoxAxis containerAxis);
 
+    bool isEligibleForStaticRangeAlignment(const RenderBlock& formattingContextRootForStaticPositioning) const;
     void computeStaticPosition();
     void computeInlineStaticDistance();
     void computeBlockStaticDistance();

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2724,4 +2724,14 @@ void RenderElement::layoutIfNeeded()
     layout();
 }
 
+const RenderBlock* RenderElement::formattingContextRoot(const RenderElement& renderElement)
+{
+    for (auto& ancestorRenderBlock : ancestorsOfType<RenderBlock>(renderElement)) {
+        if (ancestorRenderBlock.createsNewFormattingContext())
+            return &ancestorRenderBlock;
+    }
+    ASSERT_NOT_REACHED();
+    return { };
+}
+
 }

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -105,6 +105,8 @@ public:
     Layout::ElementBox* layoutBox();
     const Layout::ElementBox* layoutBox() const;
 
+    static const RenderBlock* formattingContextRoot(const RenderElement&);
+
     // Note that even if these 2 "canContain" functions return true for a particular renderer, it does not necessarily mean the renderer is the containing block (see containingBlockForAbsolute(Fixed)Position).
     inline bool canContainFixedPositionObjects(const RenderStyle* styleToUse = nullptr) const;
     inline bool canContainAbsolutelyPositionedObjects(const RenderStyle* styleToUse = nullptr) const;

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -783,6 +783,9 @@ void RenderGrid::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, Layo
         cacheBaselineAlignedGridItems(*this, algorithm, { GridTrackSizingDirection::ForColumns }, emptyCallback, !isSubgridRows());
     }
 
+    if (auto logicalHeight = availableLogicalHeightForContentBox())
+        algorithm.setFreeSpace(GridTrackSizingDirection::ForRows, logicalHeight);
+
     computeTrackSizesForIndefiniteSize(algorithm, GridTrackSizingDirection::ForColumns, gridLayoutState, &minLogicalWidth, &maxLogicalWidth);
 
     if (isMasonry(GridTrackSizingDirection::ForColumns)) {


### PR DESCRIPTION
#### 1e5c90c4d0b56787d621a8ea7e27facd2c15af84
<pre>
Need a short description (OOPS!).
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithm::run):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::computeIntrinsicLogicalWidths const):
</pre>
----------------------------------------------------------------------
#### a51cbbb48d54ae54f9baefffa5ffd499ae7213e6
<pre>
[Absolute Positioning] Add skeleton code for alignment within static position rectangle.
<a href="https://bugs.webkit.org/show_bug.cgi?id=295922">https://bugs.webkit.org/show_bug.cgi?id=295922</a>
<a href="https://rdar.apple.com/problem/155818136">rdar://problem/155818136</a>

Reviewed by NOBODY (OOPS!).

css-align defines how the self-alignment properties are supposed to work
in regards to absolutely positioned boxes.

<a href="https://drafts.csswg.org/css-align-3/#justify-abspos">https://drafts.csswg.org/css-align-3/#justify-abspos</a>
<a href="https://drafts.csswg.org/css-align-3/#align-abspos">https://drafts.csswg.org/css-align-3/#align-abspos</a>

When the inset properties in the respective axis are both set to auto,
then the alignment container for the subject, which is the absolutely
positioned box&apos;s margin box, is supposed to be the static position
rectangle.

<a href="https://drafts.csswg.org/css-align-3/#static-position-rectangle">https://drafts.csswg.org/css-align-3/#static-position-rectangle</a>

It does not look like our alignment code in PositionedLayoutConstraints
has any sort of logic to handle this type of alignment, so this patch
serves as a first step towards that goal by introducing some skeleton
code that will be implemented piecemeal.

* Source/WebCore/rendering/PositionedLayoutConstraints.cpp:
(WebCore::PositionedLayoutConstraints::isEligibleForStaticRangeAlignment const):
This will be the primary function that determines whether or not the
content is eligible to use the new logic. Since the definition of the
static position rectangle is dependent upon the formatting context the
box would have participated in, this is the main gate that will make any
other additional restrictions. For example, items that would have
participated in a Grid Formatting Context would fall into the RenderGrid
case, and that branch may have additional criteria specific to it which
may impact the eligibility.

(WebCore::PositionedLayoutConstraints::resolvePosition const):
This is where we will call into the eligibility code and build up our
logic as we allow more content to take this path. From a cursory look, we
should be able to hook into resolveAlignmentShift to compute the correct
for the box&apos;s alignment, but we will do this on a case-by-case basis.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e5c90c4d0b56787d621a8ea7e27facd2c15af84

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111763 "Failed to checkout and rebase branch from PR 48079") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/31426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21904 "Failed to checkout and rebase branch from PR 48079") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/117788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/62003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113726 "Failed to checkout and rebase branch from PR 48079") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/32113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/40010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/117788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/62003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114710 "Failed to checkout and rebase branch from PR 48079") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/32113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/21904 "Failed to checkout and rebase branch from PR 48079") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/117788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/32113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/21904 "Failed to checkout and rebase branch from PR 48079") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/61619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/32113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/21904 "Failed to checkout and rebase branch from PR 48079") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/121036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/38802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/40010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/121036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/39182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/21904 "Failed to checkout and rebase branch from PR 48079") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/121036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/21904 "Failed to checkout and rebase branch from PR 48079") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/34823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/38698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44191 "Failed to checkout and rebase branch from PR 48079") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/38342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/41668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/40055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->