### PR TITLE
[Grid][Baseline] Fix RowAxisPositioning for baseline alignment in grid layout.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-002-expected.txt
@@ -16,11 +16,15 @@ FAIL #target > div 1 assert_equals:
 offsetLeft expected 120 but got 0
 FAIL #target > div 2 assert_equals:
 <div data-offset-x="105">line1<br>line2</div>
-offsetLeft expected 105 but got 35
+offsetLeft expected 105 but got 140
 FAIL #target > div 3 assert_equals:
 <div data-offset-x="126">line1<br>line2</div>
-offsetLeft expected 126 but got 42
+offsetLeft expected 126 but got 168
 PASS #target > div 4
-PASS #target > div 5
-PASS #target > div 6
+FAIL #target > div 5 assert_equals:
+<div data-offset-x="35">line1<br>line2</div>
+offsetLeft expected 35 but got 140
+FAIL #target > div 6 assert_equals:
+<div data-offset-x="42">line1<br>line2</div>
+offsetLeft expected 42 but got 168
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-003-expected.txt
@@ -2,13 +2,11 @@
 
 
 
-FAIL #target > div 1 assert_equals:
-<div data-offset-y="40"><span></span><br><span></span></div>
-offsetTop expected 40 but got 0
+PASS #target > div 1
 FAIL #target > div 2 assert_equals:
 <div data-offset-y="20"><span></span><br><span></span></div>
-offsetTop expected 20 but got 40
+offsetTop expected 20 but got 60
 FAIL #target > div 3 assert_equals:
 <div data-offset-y="75"><span></span><br><span></span></div>
-offsetTop expected 75 but got 35
+offsetTop expected 75 but got 110
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-004-expected.txt
@@ -2,13 +2,11 @@
 
 
 
-FAIL #target > div 1 assert_equals:
-<div data-offset-y="40"><span></span><br><span></span></div>
-offsetTop expected 40 but got 0
+PASS #target > div 1
 FAIL #target > div 2 assert_equals:
 <div data-offset-y="20"><span></span><br><span></span></div>
-offsetTop expected 20 but got 40
+offsetTop expected 20 but got 60
 FAIL #target > div 3 assert_equals:
 <div data-offset-y="75"><span></span><br><span></span></div>
-offsetTop expected 75 but got 35
+offsetTop expected 75 but got 110
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-005-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-005-expected.txt
@@ -14,5 +14,5 @@ offsetLeft expected 100 but got 0
 PASS #target > div 3
 FAIL #target > div 4 assert_equals:
 <div style="grid-row: 4; grid-column: span 3; justify-self: last baseline;" data-offset-x="10">line1<br>line2</div>
-offsetLeft expected 10 but got 0
+offsetLeft expected 10 but got 110
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-009-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-009-expected.txt
@@ -6,39 +6,35 @@
 
 
 PASS .item 1
-FAIL .item 2 assert_equals:
-<div data-offset-x="237" class="item last">
-        <span></span><br><span></span>
-      </div>
-offsetLeft expected 237 but got 292
+PASS .item 2
 PASS .item 3
-FAIL .item 4 assert_equals:
-<div data-offset-x="57" class="item last">
-        <span></span><br><span></span>
-      </div>
-offsetLeft expected 57 but got 112
+PASS .item 4
 FAIL .item 5 assert_equals:
 <div data-offset-x="475" class="item first">
       <span></span><br><span></span>
     </div>
 offsetLeft expected 475 but got 420
-PASS .item 6
+FAIL .item 6 assert_equals:
+<div data-offset-x="420" class="item last">
+      <span></span><br><span></span>
+    </div>
+offsetLeft expected 420 but got 475
 FAIL .item 7 assert_equals:
 <div data-offset-x="177" class="item small first"></div>
 offsetLeft expected 177 but got 60
 FAIL .item 8 assert_equals:
 <div data-offset-x="102" class="item small last"></div>
-offsetLeft expected 102 but got 40
+offsetLeft expected 102 but got 182
 FAIL .item 9 assert_equals:
 <div data-offset-x="357" class="item small first"></div>
 offsetLeft expected 357 but got 272
 FAIL .item 10 assert_equals:
 <div data-offset-x="282" class="item small last"></div>
-offsetLeft expected 282 but got 252
+offsetLeft expected 282 but got 370
 FAIL .item 11 assert_equals:
 <div data-offset-x="540" class="item small first"></div>
 offsetLeft expected 540 but got 460
 FAIL .item 12 assert_equals:
 <div data-offset-x="465" class="item small last"></div>
-offsetLeft expected 465 but got 440
+offsetLeft expected 465 but got 570
 

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -2223,9 +2223,13 @@ GridAxisPosition RenderGrid::rowAxisPositionForGridItem(const RenderBox& gridIte
     case ItemPosition::Stretch:
         return GridAxisPosition::GridAxisStart;
     case ItemPosition::Baseline:
+        if (GridLayoutFunctions::isOrthogonalGridItem(*this, gridItem))
+            return GridAxisPosition::GridAxisStart;
+        return hasSameDirection ? GridAxisPosition::GridAxisStart : GridAxisPosition::GridAxisEnd;
     case ItemPosition::LastBaseline:
-        // FIXME: Implement the previous values. For now, we always 'start' align the grid item.
-        return GridAxisPosition::GridAxisStart;
+        if (GridLayoutFunctions::isOrthogonalGridItem(*this, gridItem))
+            return GridAxisPosition::GridAxisEnd;
+        return hasSameDirection ? GridAxisPosition::GridAxisEnd : GridAxisPosition::GridAxisStart;
     case ItemPosition::Legacy:
     case ItemPosition::Auto:
     case ItemPosition::Normal:


### PR DESCRIPTION
#### dd0313a45f6dd8e150d9e7d97276d5b4fef73eeb
<pre>
[Grid][Baseline] Fix RowAxisPositioning for baseline alignment in grid layout.
<a href="https://bugs.webkit.org/show_bug.cgi?id=295779">https://bugs.webkit.org/show_bug.cgi?id=295779</a>
&lt;<a href="https://rdar.apple.com/155323643">rdar://155323643</a>&gt;

Reviewed by NOBODY (OOPS!).

This PR sets the default alignment for first and last baseline
to `GridAxisPosition::GridAxisStart` and `GridAxisPosition::GridAxisEnd`

as per:

<a href="https://www.w3.org/TR/css-align-3/#baseline-values">https://www.w3.org/TR/css-align-3/#baseline-values</a>

This PR updates first/last baseline alignment to handle cases where
the internal flow of a grid item is in the opposite direction or
orthogonal to the grid container&apos;s such that the grid item&apos;s alignment
resolve to the same physical direction.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-004-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-005-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-009-expected.txt:
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::rowAxisPositionForGridItem const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd0313a45f6dd8e150d9e7d97276d5b4fef73eeb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111770 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31433 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21911 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117793 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62006 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113733 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32120 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40017 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84911 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35599 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114717 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25642 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100592 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65348 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24970 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18725 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61624 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95025 "Found 3 new API test failures: TestWebKitAPI.WKWebsiteDataStoreConfiguration.TotalQuotaRatioWithPersistedDomain, TestWebKitAPI.NowPlayingMetadataObserver.VideoTitle, TestWebKitAPI.NowPlayingSession.HasSessionInSubframe (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18797 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121045 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38807 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28843 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93794 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39187 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96848 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93616 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38777 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16570 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34828 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38703 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44198 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38347 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41672 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40060 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->