### PR TITLE
Fixed memory unsafe cast safercpp errors in UserMediaController.h

### DIFF
--- a/Source/WebCore/Modules/mediastream/UserMediaController.h
+++ b/Source/WebCore/Modules/mediastream/UserMediaController.h
@@ -64,9 +64,11 @@ public:
     void voiceActivityDetected();
 
     WEBCORE_EXPORT static ASCIILiteral supplementName();
-    static UserMediaController* from(Page* page) { return static_cast<UserMediaController*>(Supplement<Page>::from(page, supplementName())); }
+    static UserMediaController* from(Page* page) { return downcast<UserMediaController>(Supplement<Page>::from(page, supplementName())); }
 
 private:
+    bool isUserMediaController() const final { return true; }
+
     RefPtr<UserMediaClient> m_client;
 
     WeakHashSet<Document, WeakPtrImplWithEventTargetData> m_voiceActivityDocuments;
@@ -91,7 +93,6 @@ inline void UserMediaController::enumerateMediaDevices(Document& document, UserM
         mediaClient->enumerateMediaDevices(document, WTFMove(completionHandler));
 }
 
-
 inline UserMediaClient::DeviceChangeObserverToken UserMediaController::addDeviceChangeObserver(Function<void()>&& observer)
 {
     if (RefPtr mediaClient = m_client)
@@ -112,5 +113,9 @@ inline void UserMediaController::updateCaptureState(const Document& document, bo
 }
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::UserMediaController)
+    static bool isType(const WebCore::SupplementBase& supplement) { return supplement.isUserMediaController(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -18,7 +18,6 @@ Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.cpp
 Modules/mediasession/NavigatorMediaSession.cpp
 Modules/mediastream/NavigatorMediaDevices.cpp
 Modules/mediastream/PeerConnectionBackend.cpp
-Modules/mediastream/UserMediaController.h
 Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
 Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp
 Modules/mediastream/libwebrtc/LibWebRTCRtpTransformBackend.cpp

--- a/Source/WebCore/platform/Supplementable.h
+++ b/Source/WebCore/platform/Supplementable.h
@@ -83,6 +83,7 @@ public:
     virtual bool isNavigatorClipboard() const { return false; }
     virtual bool isNavigatorCookieConsent() const { return false; }
     virtual bool isNavigatorGamepad() const { return false; }
+    virtual bool isUserMediaController() const { return false; }
 };
 
 template<typename T>


### PR DESCRIPTION
#### 2ee8608c8ac2db628ef036be40dc9bc9937ff22d
<pre>
Fixed memory unsafe cast safercpp errors in UserMediaController.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=296013">https://bugs.webkit.org/show_bug.cgi?id=296013</a>
<a href="https://rdar.apple.com/155914874">rdar://155914874</a>

Reviewed by Eric Carlson and Rupin Mittal.

Fix unsafe cast warning.

Source/WebCore/Modules/mediastream/UserMediaController.h
Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
Source/WebCore/platform/Supplementable.h

Canonical link: <a href="https://commits.webkit.org/297801@main">https://commits.webkit.org/297801@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ea4efd023fe8a0e4321e5be4608c780e6a4e367

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112880 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32615 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23093 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119084 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63410 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114842 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33267 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41178 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85906 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36572 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115827 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26552 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101541 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66211 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25841 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19673 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62842 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95946 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19747 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122305 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39958 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29795 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94774 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40342 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97761 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94512 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24133 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39638 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17449 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/36071 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39844 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45342 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39484 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42817 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41222 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->