### PR TITLE
GameControllerGamepadProvider/UIGamepadProvider against double disconnect notifications

### DIFF
--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm
@@ -159,6 +159,13 @@ void GameControllerGamepadProvider::controllerDidDisconnect(GCController *contro
     auto removedGamepad = m_gamepadMap.take((__bridge CFTypeRef)controller);
     ASSERT(removedGamepad);
 
+    // FIXME (rdar://155968049) - We may get disconnect notifications for a no-longer-connected controller.
+    // Return early to avoid weird side effects downstream.
+    if (!removedGamepad) {
+        RELEASE_LOG_ERROR(Gamepad, "Disconnected a GCController that we didn't know about");
+        return;
+    }
+
     auto i = m_gamepadVector.find(removedGamepad.get());
     if (i != notFound)
         m_gamepadVector[i] = nullptr;


### PR DESCRIPTION
#### bea8be8adf2e65194bca2e768134bc0a3fc77dd6
<pre>
GameControllerGamepadProvider/UIGamepadProvider against double disconnect notifications
<a href="https://rdar.apple.com/155322918">rdar://155322918</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=296015">https://bugs.webkit.org/show_bug.cgi?id=296015</a>

Reviewed by Alex Christensen, Chris Dumez, and Andy Estes.

GameController framework might notify us of a GCController disconnect more than once.
This is similar to the GCMouse issue resolved in <a href="https://commits.webkit.org/296926@main">https://commits.webkit.org/296926@main</a>

For GCControllers, we cannot apply the same fix of &quot;just get the array of controllers&quot;, as the
ordering and history of connects and disconnects for controllers matter.
WebKit&apos;s array of connected controllers can correctly be different than the GameController array.

So for now, we just directly detect an unexpected disconnect and turn it into a no-op.

I also took the opportunity to harden UIGamepadProvider against a few other possibilities we
had considered when exploring this, including sending back specific data for one crash condition.

* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm:
(WebCore::GameControllerGamepadProvider::controllerDidDisconnect): For now, it is expected
  we get a disconnect for a non-connected controller. So just turn that into an early return.

* Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp:
(WebKit::UIGamepadProvider::platformGamepadConnected):
(WebKit::UIGamepadProvider::platformGamepadDisconnected):
(WebKit::UIGamepadProvider::processPoolStartedUsingGamepads):
(WebKit::UIGamepadProvider::processPoolStoppedUsingGamepads):
(WebKit::UIGamepadProvider::startMonitoringGamepads):
(WebKit::UIGamepadProvider::stopMonitoringGamepads):

Canonical link: <a href="https://commits.webkit.org/297486@main">https://commits.webkit.org/297486@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fef88cf42da117d3a1288647241ef77321f2cc9f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31620 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22106 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/117979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/62184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113912 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32297 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40198 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/117979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/62184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25789 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100735 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/117979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/25114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18870 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/61820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/95182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18946 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/121282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38983 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29002 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/121282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39364 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96988 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/121282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23923 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38913 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/16707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/35004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38877 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/44389 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/38514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41842 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/40230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->