### PR TITLE
[macOS 26] Using Writing tools in Quip fails when replacing text in a list after changing selection

### DIFF
--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -114,6 +114,19 @@ enum class MailBlockquoteHandling : bool {
     IgnoreBlockquote,
 };
 
+enum class ClipboardEventKind : uint8_t {
+    Copy,
+    CopyFont,
+    Cut,
+    Paste,
+    PasteFont,
+    PasteAsPlainText,
+    PasteAsQuotation,
+    BeforeCopy,
+    BeforeCut,
+    BeforePaste,
+};
+
 enum class AllowTextReplacement : bool { No, Yes };
 
 #if ENABLE(ATTACHMENT_ELEMENT)
@@ -653,6 +666,9 @@ private:
     void pasteAsPlainTextWithPasteboard(Pasteboard&);
     void pasteWithPasteboard(Pasteboard*, OptionSet<PasteOption>);
     String plainTextFromPasteboard(const PasteboardPlainText&);
+
+    bool dispatchClipboardEvent(RefPtr<Element>&&, ClipboardEventKind);
+    bool dispatchClipboardEvent(RefPtr<Element>&&, ClipboardEventKind, Ref<DataTransfer>&&);
 
     void platformCopyFont();
     void platformPasteFont();


### PR DESCRIPTION
#### a727a61dccf7fb4a31a353c869e1a9325c304ef3
<pre>
[macOS 26] Using Writing tools in Quip fails when replacing text in a list after changing selection
<a href="https://bugs.webkit.org/show_bug.cgi?id=296020">https://bugs.webkit.org/show_bug.cgi?id=296020</a>
<a href="https://rdar.apple.com/153077184">rdar://153077184</a>

Reviewed by Abrar Rahman Protyasha.

In macOS 26, WritingToolsUI now uses `-[WKWebView readSelectionFromPasteboard:]` to simulate a paste
with rich text, when using Rewrite and Proofreading functionality in Safari, passing a unique
pasteboard to the web view.

However, this breaks Writing Tools when editing documents in Quip, which intercepts and prevents the
`paste` event in order to sanitize the DOM (and importantly, enforce a consistent DOM structure
necessary for their editor to save content properly). This is because, in this codepath that
triggers `Editor::readSelectionFromPasteboard`, we currently skip dispatching the `paste` event
altogether, and instead just read a document fragment from the pasteboard and insert it into the
DOM.

To fix this, align `readSelectionFromPasteboard` with other methods that are responsible for
triggering paste (`Editor::pasteAsQuotation`, `Editor::pasteAsPlainText`, `Editor::paste`) and call
`dispatchClipboardEvent` with an early return in the case where the page prevents default.

* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::dispatchClipboardEvent):
(WebCore::dispatchClipboardEvent): Deleted.

Turn this into a private static helper methods in `Editor`, so that we can call it from
`EditorCocoa.mm` below.

* Source/WebCore/editing/Editor.h:
* Source/WebCore/editing/cocoa/EditorCocoa.mm:
(WebCore::Editor::readSelectionFromPasteboard):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteHTML.mm:
(TEST(PasteHTML, ReadSelectionFromPasteboardDispatchesPaste)):

Add an API test to exercise this change by using `-readSelectionFromPasteboard:` in a webpage that
intercepts `paste`, prevents default, and dumps the `DataTransfer` as plain text in the page.

Canonical link: <a href="https://commits.webkit.org/297439@main">https://commits.webkit.org/297439@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbdac63f351158f1f37e722ea97f4bf043444e8b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111795 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31457 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117815 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62029 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113758 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32141 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40040 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84928 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/35621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114742 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25661 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100606 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65367 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24988 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18741 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61646 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95043 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18813 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/121098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38827 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28861 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/121098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39207 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96864 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/121098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23878 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38797 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16583 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34847 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38724 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44219 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38366 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41691 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40079 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->