### PR TITLE
Remove unused `*Padding` functions from `HitTestLocation.h`

### DIFF
--- a/Source/WebCore/rendering/HitTestLocation.h
+++ b/Source/WebCore/rendering/HitTestLocation.h
@@ -47,11 +47,6 @@ public:
     bool isRectBasedTest() const { return m_isRectBased; }
     bool isRectilinear() const { return m_isRectilinear; }
     LayoutRect boundingBox() const { return m_boundingBox; }
-    
-    int topPadding() const { return roundedPoint().y() - m_boundingBox.y(); }
-    int rightPadding() const { return m_boundingBox.maxX() - roundedPoint().x() - 1; }
-    int bottomPadding() const { return m_boundingBox.maxY() - roundedPoint().y() - 1; }
-    int leftPadding() const { return roundedPoint().x() - m_boundingBox.x(); }
 
     WEBCORE_EXPORT bool intersects(const LayoutRect&) const;
     bool intersects(const FloatRect&) const;


### PR DESCRIPTION
#### 4c09f90dd700e5c1cb2fd1a3760d12d123f297a0
<pre>
Remove unused `*Padding` functions from `HitTestLocation.h`
<a href="https://bugs.webkit.org/show_bug.cgi?id=296022">https://bugs.webkit.org/show_bug.cgi?id=296022</a>
<a href="https://rdar.apple.com/155921692">rdar://155921692</a>

Reviewed by Simon Fraser.

This patch removes unused &apos;*Padding&apos; functions from `HitTestLocation.h`.

* Source/WebCore/rendering/HitTestLocation.h:
(WebCore::HitTestLocation::topPadding const): Deleted.
(WebCore::HitTestLocation::rightPadding const): Deleted.
(WebCore::HitTestLocation::bottomPadding const): Deleted.
(WebCore::HitTestLocation::leftPadding const): Deleted.

Canonical link: <a href="https://commits.webkit.org/297440@main">https://commits.webkit.org/297440@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc44f375d172d8ec6101272497764ab5c80c5456

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111796 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21935 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117816 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62030 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113759 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32142 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40041 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84931 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/35619 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114743 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25660 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100607 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65370 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24987 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18742 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61648 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95042 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18814 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121075 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38828 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28863 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93809 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39208 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96865 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93631 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23879 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38798 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16584 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34848 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38725 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44220 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38367 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41692 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40080 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->