### PR TITLE
Refactor `foreignObject` viewport calculation to use computed style lengths

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/extensibility/foreignObject/properties-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/extensibility/foreignObject/properties-expected.txt
@@ -1,6 +1,6 @@
 
 PASS width and height default to auto (which computes to "0px")
-FAIL style rules are applied assert_equals: expected "30px" but got "0px"
+PASS style rules are applied
 PASS attributes set properties
-FAIL style rules override attributes assert_equals: expected "30px" but got "70px"
+PASS style rules override attributes
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/height-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/height-computed-expected.txt
@@ -24,8 +24,8 @@ PASS SVG Geometry Properties: getComputedStyle().height, <image> inline style bu
 PASS SVG Geometry Properties: getComputedStyle().height, <foreignObject> initial
 PASS SVG Geometry Properties: getComputedStyle().height, <foreignObject> presentation attribute
 PASS SVG Geometry Properties: getComputedStyle().height, <foreignObject> inline style (auto)
-FAIL SVG Geometry Properties: getComputedStyle().height, <foreignObject> inline style (pixels) assert_equals: inline style (pixels) expected "75px" but got "0px"
-FAIL SVG Geometry Properties: getComputedStyle().height, <foreignObject> inline style (percentage) assert_equals: inline style (percentage) expected "50px" but got "0px"
+PASS SVG Geometry Properties: getComputedStyle().height, <foreignObject> inline style (pixels)
+PASS SVG Geometry Properties: getComputedStyle().height, <foreignObject> inline style (percentage)
 PASS SVG Geometry Properties: getComputedStyle().height, <foreignObject> inline style but "display: none"
 FAIL SVG Geometry Properties: getComputedStyle().height, <svg> initial assert_equals: initial expected "100px" but got "auto"
 PASS SVG Geometry Properties: getComputedStyle().height, <svg> presentation attribute

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/width-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/width-computed-expected.txt
@@ -23,9 +23,9 @@ PASS SVG Geometry Properties: getComputedStyle().width, <image> inline style (pi
 PASS SVG Geometry Properties: getComputedStyle().width, <image> inline style but "display: none"
 PASS SVG Geometry Properties: getComputedStyle().width, <foreignObject> initial
 PASS SVG Geometry Properties: getComputedStyle().width, <foreignObject> presentation attribute
-FAIL SVG Geometry Properties: getComputedStyle().width, <foreignObject> inline style (percentage) assert_equals: inline style (percentage) expected "100px" but got "0px"
+PASS SVG Geometry Properties: getComputedStyle().width, <foreignObject> inline style (percentage)
 PASS SVG Geometry Properties: getComputedStyle().width, <foreignObject> inline style (auto)
-FAIL SVG Geometry Properties: getComputedStyle().width, <foreignObject> inline style (pixels) assert_equals: inline style (pixels) expected "75px" but got "0px"
+PASS SVG Geometry Properties: getComputedStyle().width, <foreignObject> inline style (pixels)
 PASS SVG Geometry Properties: getComputedStyle().width, <foreignObject> inline style but "display: none"
 FAIL SVG Geometry Properties: getComputedStyle().width, <svg> initial assert_equals: initial expected "200px" but got "auto"
 PASS SVG Geometry Properties: getComputedStyle().width, <svg> presentation attribute

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/geometry/parsing/height-computed-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/geometry/parsing/height-computed-expected.txt
@@ -24,8 +24,8 @@ PASS SVG Geometry Properties: getComputedStyle().height, <image> inline style bu
 PASS SVG Geometry Properties: getComputedStyle().height, <foreignObject> initial
 PASS SVG Geometry Properties: getComputedStyle().height, <foreignObject> presentation attribute
 PASS SVG Geometry Properties: getComputedStyle().height, <foreignObject> inline style (auto)
-FAIL SVG Geometry Properties: getComputedStyle().height, <foreignObject> inline style (pixels) assert_equals: inline style (pixels) expected "75px" but got "0px"
-FAIL SVG Geometry Properties: getComputedStyle().height, <foreignObject> inline style (percentage) assert_equals: inline style (percentage) expected "50px" but got "0px"
+PASS SVG Geometry Properties: getComputedStyle().height, <foreignObject> inline style (pixels)
+PASS SVG Geometry Properties: getComputedStyle().height, <foreignObject> inline style (percentage)
 PASS SVG Geometry Properties: getComputedStyle().height, <foreignObject> inline style but "display: none"
 FAIL SVG Geometry Properties: getComputedStyle().height, <svg> initial assert_equals: initial expected "100px" but got "auto"
 PASS SVG Geometry Properties: getComputedStyle().height, <svg> presentation attribute

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/geometry/parsing/width-computed-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/geometry/parsing/width-computed-expected.txt
@@ -23,9 +23,9 @@ PASS SVG Geometry Properties: getComputedStyle().width, <image> inline style (pi
 PASS SVG Geometry Properties: getComputedStyle().width, <image> inline style but "display: none"
 PASS SVG Geometry Properties: getComputedStyle().width, <foreignObject> initial
 PASS SVG Geometry Properties: getComputedStyle().width, <foreignObject> presentation attribute
-FAIL SVG Geometry Properties: getComputedStyle().width, <foreignObject> inline style (percentage) assert_equals: inline style (percentage) expected "100px" but got "0px"
+PASS SVG Geometry Properties: getComputedStyle().width, <foreignObject> inline style (percentage)
 PASS SVG Geometry Properties: getComputedStyle().width, <foreignObject> inline style (auto)
-FAIL SVG Geometry Properties: getComputedStyle().width, <foreignObject> inline style (pixels) assert_equals: inline style (pixels) expected "75px" but got "0px"
+PASS SVG Geometry Properties: getComputedStyle().width, <foreignObject> inline style (pixels)
 PASS SVG Geometry Properties: getComputedStyle().width, <foreignObject> inline style but "display: none"
 FAIL SVG Geometry Properties: getComputedStyle().width, <svg> initial assert_equals: initial expected "200px" but got "auto"
 PASS SVG Geometry Properties: getComputedStyle().width, <svg> presentation attribute

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp
@@ -137,8 +137,10 @@ void LegacyRenderSVGForeignObject::layout()
     // Cache viewport boundaries
     Ref foreignObjectElement = this->foreignObjectElement();
     SVGLengthContext lengthContext(foreignObjectElement.ptr());
-    FloatPoint viewportLocation(foreignObjectElement->x().value(lengthContext), foreignObjectElement->y().value(lengthContext));
-    m_viewport = FloatRect(viewportLocation, FloatSize(foreignObjectElement->width().value(lengthContext), foreignObjectElement->height().value(lengthContext)));
+    FloatPoint viewportLocation(lengthContext.valueForLength(style().x(), SVGLengthMode::Width),
+        lengthContext.valueForLength(style().y(), SVGLengthMode::Height));
+    m_viewport = FloatRect(viewportLocation, FloatSize(lengthContext.valueForLength(style().width(), SVGLengthMode::Width),
+        lengthContext.valueForLength(style().height(), SVGLengthMode::Height)));
     if (!updateCachedBoundariesInParents)
         updateCachedBoundariesInParents = oldViewport != m_viewport;
 


### PR DESCRIPTION
#### 28658025e219663a66b7c5614e68936319f7b2af
<pre>
Refactor `foreignObject` viewport calculation to use computed style lengths
<a href="https://bugs.webkit.org/show_bug.cgi?id=296024">https://bugs.webkit.org/show_bug.cgi?id=296024</a>
<a href="https://rdar.apple.com/155924550">rdar://155924550</a>

Reviewed by NOBODY (OOPS!).

This patch refactors `foreignObject` viewport calculation to use computed
style lengths by replacing direct calls from &apos;foreignObjectElement.x|y&apos; to
&apos;svgStyle().x|y&apos; with relevant LengthMode . It is also consistent with
other use cases i.e., LegacyRenderSVGRect (updateShapeFromElement()).

* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp:
(WebCore::LegacyRenderSVGForeignObject::layout):
* LayoutTests/imported/w3c/web-platform-tests/svg/extensibility/foreignObject/properties-expected.txt: Progressions
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/height-computed-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/width-computed-expected.txt: Ditto
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/geometry/parsing/height-computed-expected.txt: Ditto
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/geometry/parsing/width-computed-expected.txt: Ditto
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28658025e219663a66b7c5614e68936319f7b2af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39063 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135627 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79720 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5b7fa247-8a03-49ab-bc4c-aa1dfd71bd13) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130103 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/445 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/386 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97610 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-conditional/container-queries/svg-foreignobject-no-size-container.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65517 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/399f78cc-16bc-464a-a7fc-5bb300d6c0c6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131179 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/285 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114874 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78207 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4c83f4c1-962c-41a4-96ef-e106abae1802) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/275 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-conditional/container-queries/svg-foreignobject-no-size-container.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32982 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-conditional/container-queries/svg-foreignobject-no-size-container.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78905 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108653 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33466 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138079 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/366 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/341 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106152 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-conditional/container-queries/svg-foreignobject-no-size-container.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/398 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111216 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105928 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/286 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29770 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-conditional/container-queries/svg-foreignobject-no-size-container.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52644 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/411 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63175 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/319 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/390 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/376 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->