### PR TITLE
Update argument validation for texSubImage2D

### DIFF
--- a/LayoutTests/webgl/webgl2-tex2subimage2d-nocrash-expected.txt
+++ b/LayoutTests/webgl/webgl2-tex2subimage2d-nocrash-expected.txt
@@ -1,0 +1,11 @@
+Test that calls to texSubImage2D with bad arguments don't crash.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+TEST COMPLETE: 2 PASS, 0 FAIL
+
+PASS Did not crash.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webgl/webgl2-tex2subimage2d-nocrash.html
+++ b/LayoutTests/webgl/webgl2-tex2subimage2d-nocrash.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="resources/webgl_test_files/resources/js-test-style.css" />
+    <script src="resources/webgl_test_files/js/js-test-pre.js"></script>
+    <script src="resources/webgl_test_files/js/webgl-test-utils.js"></script>
+</head>
+<body onload="test()">
+    <div id="description"></div>
+    <div id="console"></div>
+    <img id="img" src="data:image/gif;base64,R0lGODlhIAAgAPIBAGbMzP///wAAADOZZpn"></img>
+    <script>
+        "use strict";
+        description("Test that calls to texSubImage2D with bad arguments don't crash.");
+        var wtu = WebGLTestUtils;
+        var gl;
+        function runTest() {
+            const canvas = document.createElement("canvas");
+            const gl = canvas.getContext("webgl2");
+            const level = 0;
+            const xoffset = 0;
+            const yoffset = 0;
+            const badValue = 0;
+            gl.texSubImage2D(gl.TEXTURE_2D, level, xoffset, yoffset, badValue, gl.UNSIGNED_BYTE, img);
+            gl.texSubImage2D(gl.TEXTURE_2D, level, xoffset, yoffset, gl.RGBA, badValue, img);
+
+            const height = 800;
+            const width = 600;
+            gl.texSubImage2D(gl.TEXTURE_2D, level, xoffset, yoffset, height, width, badValue, gl.UNSIGNED_BYTE, img);
+            gl.texSubImage2D(gl.TEXTURE_2D, level, xoffset, yoffset, height, width, gl.RGBA, badValue, img);
+            testPassed(`Did not crash.`);
+        }
+
+        function test() {
+            runTest();
+            finishTest();
+        }
+    </script>
+</body>
+</html>

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -3942,18 +3942,18 @@ bool WebGLRenderingContextBase::validateTexImageSourceFormatAndType(TexImageFunc
     else
         addExtensionSupportedFormatsAndTypesWebGL2();
 
-    if (internalformat && !m_supportedTexImageSourceInternalFormats.contains(internalformat)) {
+    if (m_supportedTexImageSourceInternalFormats.isValidValue(internalformat) && !m_supportedTexImageSourceInternalFormats.contains(internalformat)) {
         if (functionType == TexImageFunctionType::TexImage)
             synthesizeGLError(GraphicsContextGL::INVALID_VALUE, functionName, "invalid internalformat"_s);
         else
             synthesizeGLError(GraphicsContextGL::INVALID_ENUM, functionName, "invalid internalformat"_s);
         return false;
     }
-    if (!m_supportedTexImageSourceFormats.contains(format)) {
+    if (!m_supportedTexImageSourceFormats.isValidValue(format) || !m_supportedTexImageSourceFormats.contains(format)) {
         synthesizeGLError(GraphicsContextGL::INVALID_ENUM, functionName, "invalid format"_s);
         return false;
     }
-    if (!m_supportedTexImageSourceTypes.contains(type)) {
+    if (!m_supportedTexImageSourceTypes.isValidValue(type) || !m_supportedTexImageSourceTypes.contains(type)) {
         synthesizeGLError(GraphicsContextGL::INVALID_ENUM, functionName, "invalid type"_s);
         return false;
     }


### PR DESCRIPTION
#### 6e50dfb9ef21e84f9e47026fbfbf142a3bc5f57a
<pre>
Update argument validation for texSubImage2D
<a href="https://bugs.webkit.org/show_bug.cgi?id=296033">https://bugs.webkit.org/show_bug.cgi?id=296033</a>
<a href="https://rdar.apple.com/155792551">rdar://155792551</a>

Reviewed by Dan Glastonbury.

Validate arguments to texSubImage2D by checking if format and type are
&apos;empty&apos; to avoid crashing when they are used as keys for WTF::HashSet.

* LayoutTests/webgl/webgl2-tex2subimage2d-nocrash-expected.txt: Added.
* LayoutTests/webgl/webgl2-tex2subimage2d-nocrash.html: Added.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::validateTexImageSourceFormatAndType):

Canonical link: <a href="https://commits.webkit.org/297786@main">https://commits.webkit.org/297786@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75745697c4337a9bbdea351c758be12327a7e7a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32526 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23004 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118994 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63299 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114753 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33178 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41089 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85837 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36477 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115738 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26476 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101469 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66149 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25770 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19600 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62753 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95870 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19675 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122215 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39869 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29719 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94699 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40252 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97689 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94437 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24118 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39561 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17380 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36042 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39755 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45253 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39394 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42728 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41133 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->