### PR TITLE
[WPE] No focus handling in WPEQtView

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -5274,6 +5274,38 @@ WebKitEditorState* webkit_web_view_get_editor_state(WebKitWebView *webView)
     return webView->priv->editorState.get();
 }
 
+#if PLATFORM(WPE)
+/**
+ * webkit_web_view_set_focus:
+ * @web_view: a #WebKitWebView
+ * @focus: focus state which should be set
+ *
+ * Set focus state for the view.
+ */
+void webkit_web_view_set_focus(WebKitWebView *webView, gboolean focus)
+{
+    if (focus)
+        webView->priv->view->addState(WebCore::ActivityState::IsFocused);
+    else
+        webView->priv->view->removeState(WebCore::ActivityState::IsFocused);
+}
+
+/**
+ * webkit_web_view_set_active:
+ * @web_view: a #WebKitWebView
+ * @active: activity state, which should be set
+ *
+ * Set activity state for the view.
+ */
+void webkit_web_view_set_active(WebKitWebView *webView, gboolean active)
+{
+    if (active)
+        webView->priv->view->addState(WebCore::ActivityState::WindowIsActive);
+    else
+        webView->priv->view->removeState(WebCore::ActivityState::WindowIsActive);
+}
+#endif
+
 /**
  * webkit_web_view_get_session_state:
  * @web_view: a #WebKitWebView

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -830,6 +830,16 @@ webkit_web_view_set_editable                         (WebKitWebView             
 WEBKIT_API WebKitEditorState *
 webkit_web_view_get_editor_state                     (WebKitWebView             *web_view);
 
+#if PLATFORM(WPE)
+WEBKIT_API void
+webkit_web_view_set_focus                            (WebKitWebView             *web_view,
+                                                      gboolean                  focus);
+
+WEBKIT_API void
+webkit_web_view_set_active                           (WebKitWebView             *web_view,
+                                                      gboolean                  active);
+#endif
+
 WEBKIT_API WebKitWebViewSessionState *
 webkit_web_view_get_session_state                    (WebKitWebView             *web_view);
 

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp
@@ -136,6 +136,20 @@ void View::close()
     m_pageProxy->close();
 }
 
+void View::addState(WebCore::ActivityState state)
+{
+    m_viewStateFlags.add(state);
+    OptionSet<WebCore::ActivityState> flags = { state };
+    m_pageProxy->activityStateDidChange(flags);
+}
+
+void View::removeState(WebCore::ActivityState state)
+{
+    m_viewStateFlags.remove(state);
+    OptionSet<WebCore::ActivityState> flags = { state };
+    m_pageProxy->activityStateDidChange(flags);
+}
+
 #if ENABLE(FULLSCREEN_API)
 bool View::isFullScreen() const
 {

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebView.h
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebView.h
@@ -89,6 +89,9 @@ public:
     const WebCore::IntSize& size() const { return m_size; }
     OptionSet<WebCore::ActivityState> viewState() const { return m_viewStateFlags; }
 
+    void addState(WebCore::ActivityState);
+    void removeState(WebCore::ActivityState);
+
     virtual struct wpe_view_backend* backend() const { return nullptr; }
 #if ENABLE(WPE_PLATFORM)
     virtual WPEView* wpeView() const { return nullptr; }

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp
@@ -586,10 +586,31 @@ void WPEQtView::keyReleaseEvent(QKeyEvent* event)
 void WPEQtView::touchEvent(QTouchEvent* event)
 {
     Q_D(WPEQtView);
+    forceActiveFocus();
     if (!d->m_webView)
         return;
     auto* wpeView = webkit_web_view_get_wpe_view(d->m_webView.get());
     wpe_view_dispatch_touch_event(WPE_VIEW_QTQUICK(wpeView), event);
+}
+
+void WPEQtView::focusInEvent(QFocusEvent *e)
+{
+    webkit_web_view_set_focus(webView(), true);
+    webkit_web_view_set_active(webView(), true);
+
+    setFocus(true);
+
+    e->accept();
+}
+
+void WPEQtView::focusOutEvent(QFocusEvent *e)
+{
+    webkit_web_view_set_focus(webView(), false);
+    webkit_web_view_set_active(webView(), false);
+
+    setFocus(false);
+
+    e->accept();
 }
 
 WebKitWebView* WPEQtView::webView() const

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.h
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.h
@@ -105,6 +105,9 @@ protected:
 
     void touchEvent(QTouchEvent*) override;
 
+    void focusInEvent(QFocusEvent*) override;
+    void focusOutEvent(QFocusEvent*) override;
+
 private Q_SLOTS:
     void configureWindow();
     void createWebView();


### PR DESCRIPTION

<pre>
[WPE] No focus handling in WPEQtView
https://bugs.webkit.org/show_bug.cgi?id=296038

Reviewed by NOBODY (OOPS!).

Add focus handling to WPEQtView.
Add focus forwarding from WPEWebView to a page.

* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
* Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
* Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp:
(WKWPE::View)
* Source/WebKit/UIProcess/API/wpe/WPEWebView.h:
(WKWPE::View)
* Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp:
(WPEQtView)
* Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.h:
(WPEQtView)
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/628c0c6d66bd82299703a968f0cb29c4dd74f6f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111862 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31525 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22002 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117881 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62091 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32206 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40106 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84973 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35659 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114809 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25715 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100661 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65412 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25037 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61721 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95095 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18867 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121154 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38890 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28916 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93844 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39271 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96918 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93667 "Found 3 new API test failures: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestResources:/webkit/WebKitWebResource/get-data-error, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38848 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16635 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/34903 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38788 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44285 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38426 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41752 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40142 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->