### PR TITLE
REGRESSION(297392@main): Tentative build fix for Ubuntu 2204

### DIFF
--- a/Source/WebCore/platform/graphics/MediaReorderQueue.h
+++ b/Source/WebCore/platform/graphics/MediaReorderQueue.h
@@ -111,7 +111,7 @@ private:
 };
 
 struct MediaSampleReorderQueueComparator {
-    static bool operator()(const Ref<const MediaSample>& a, const Ref<const MediaSample>& b) { return a->presentationTime() <= b->presentationTime(); }
+    bool operator()(const Ref<const MediaSample>& a, const Ref<const MediaSample>& b) const { return a->presentationTime() <= b->presentationTime(); }
 };
 
 using MediaSampleReorderQueue = MediaReorderQueue<Ref<const MediaSample>, MediaSampleReorderQueueComparator>;


### PR DESCRIPTION
#### 487f949c233fa43f65298ce46fb8198d8fac947b
<pre>
REGRESSION(297392@main): Tentative build fix for Ubuntu 2204
<a href="https://bugs.webkit.org/show_bug.cgi?id=296047">https://bugs.webkit.org/show_bug.cgi?id=296047</a>

Reviewed by Gerald Squelart.

This should fix

  error: ‘static bool WebCore::MediaSampleReorderQueueComparator::operator()
  (const WTF::Ref&lt;const WebCore::MediaSample&gt;&amp;,
  const WTF::Ref&lt;const WebCore::MediaSample&gt;&amp;)’ must be a non-static member function

* Source/WebCore/platform/graphics/MediaReorderQueue.h:
(WebCore::MediaSampleReorderQueueComparator::operator() const):
(WebCore::MediaSampleReorderQueueComparator::operator()):

Canonical link: <a href="https://commits.webkit.org/297545@main">https://commits.webkit.org/297545@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21b0753ba62688f7a89ed223bf98f2dc9ceffcdd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112061 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31732 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118084 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62303 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114023 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32408 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40309 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85133 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35798 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115008 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25886 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100833 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65566 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25193 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18971 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61936 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95268 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19046 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121403 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39094 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29091 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93968 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39475 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97079 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93790 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23953 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39001 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16787 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35118 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38988 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44500 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38625 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41953 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40341 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->