### PR TITLE
[IndexedDB] Reclaim freed SQLite filesystem space

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
@@ -871,6 +871,7 @@ IDBError SQLiteIDBBackingStore::getOrEstablishDatabaseInfo(IDBDatabaseInfo& info
         return IDBError { ExceptionCode::UnknownError, "Unable to open database file on disk"_s };
 
     m_sqliteDB->disableThreadingChecks();
+    m_sqliteDB->turnOnIncrementalAutoVacuum();
     m_sqliteDB->enableAutomaticWALTruncation();
 
     m_sqliteDB->setCollationFunction("IDBKEY"_s, [](int aLength, const void* a, int bLength, const void* b) {
@@ -919,6 +920,10 @@ IDBError SQLiteIDBBackingStore::getOrEstablishDatabaseInfo(IDBDatabaseInfo& info
 
     m_databaseInfo = WTFMove(databaseInfo);
     info = *m_databaseInfo;
+
+    // Check if we are able to free up some space on the file system
+    incrementalVacuumIfNeeded();
+
     return IDBError { };
 }
 
@@ -2706,6 +2711,21 @@ void SQLiteIDBBackingStore::forEachObjectStoreRecord(const IDBResourceIdentifier
         IDBError error { ExceptionCode::UnknownError, "Error advancing cursor when iterating object store records"_s };
         apply(makeUnexpected(WTFMove(error)));
         return;
+    }
+}
+
+void SQLiteIDBBackingStore::incrementalVacuumIfNeeded()
+{
+    ASSERT(m_sqliteDB);
+    ASSERT(m_sqliteDB->isOpen());
+
+    const auto freeSpaceSize = m_sqliteDB->freeSpaceSize();
+    const auto totalSize = m_sqliteDB->totalSize();
+
+    if (totalSize <= 10 * freeSpaceSize) {
+        const auto result = m_sqliteDB->runIncrementalVacuumCommand();
+        if (result != SQLITE_DONE)
+            LOG_ERROR("Failed to perform incremental vacuum on database for path '%s'\n", fullDatabasePath().utf8().data());
     }
 }
 

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.h
@@ -204,6 +204,8 @@ private:
     SQLiteStatementAutoResetScope cachedStatement(SQL, ASCIILiteral);
     SQLiteStatementAutoResetScope cachedStatementForGetAllObjectStoreRecords(const IDBGetAllRecordsData&);
 
+    void incrementalVacuumIfNeeded();
+
     std::array<std::unique_ptr<SQLiteStatement>, static_cast<size_t>(SQL::Invalid)> m_cachedStatements;
 
     IDBDatabaseIdentifier m_identifier;


### PR DESCRIPTION
#### 66b5189729378af33e55bb8d054ae8eb261671ca
<pre>
[IndexedDB] Reclaim freed SQLite filesystem space
<a href="https://bugs.webkit.org/show_bug.cgi?id=296040">https://bugs.webkit.org/show_bug.cgi?id=296040</a>

Reviewed by NOBODY (OOPS!).

When data is removed from a SQLite database, pages are marked as free instead of being
release back to the OS / filesystem. Consequently, when an app uses a lot of IndexedDB
space at some point in time, even if the database contents are deleted afterwards, the
database file size will remain with the max size so far. This can cause filesystem space
to get exhausted in constrained environments where small volume sizes are used for storage.
It can also cause issues with the database operations when full volume capacity was
reached (e.g. multiple domains, local storage usage) despite not using the full &quot;real&quot;
quota and WAL is being used.

These changes attempt to mitigate this issue by running the incremental auto vacuum
whenever some amount of free space is available to be released. This is currently done
on database open. While not ideal, as there is no guarantee that the database will be
opened again to free that space, there is also no guarantee that the database close
method ( SQLiteIDBBackingStore::close() ) will be invoked in all cases. The cleanup can
also not be run in sqlite hooks, as it would not be safe due potential conflict with
ongoing transactions.

Original author: filipe-norte-red
See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1532">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1532</a>

* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp:
(WebCore::IDBServer::SQLiteIDBBackingStore::getOrEstablishDatabaseInfo):
(WebCore::IDBServer::SQLiteIDBBackingStore::incrementalVacuumIfNeeded):
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66b5189729378af33e55bb8d054ae8eb261671ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111894 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31557 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22034 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117912 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62122 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113857 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40138 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85002 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35692 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114841 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25745 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100694 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65451 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25066 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18829 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61756 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95124 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18900 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121193 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38921 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28943 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93868 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39302 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96951 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93776 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38879 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16666 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34938 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38819 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44314 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38456 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41781 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40171 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->