### PR TITLE
[Grid][Baseline] Fix RowAxisPositioning for baseline alignment in grid layout.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1671,7 +1671,6 @@ webkit.org/b/216146 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-
 webkit.org/b/216145 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-item-no-aspect-ratio-stretch-5.html [ ImageOnlyFailure ]
 webkit.org/b/216145 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-item-no-aspect-ratio-stretch-6.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-content-distribution-029.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-002-b.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-horiz-007.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-002-expected.txt
@@ -14,12 +14,8 @@ line2
 FAIL #target > div 1 assert_equals:
 <div data-offset-x="120">line1<br>line2</div>
 offsetLeft expected 120 but got 0
-FAIL #target > div 2 assert_equals:
-<div data-offset-x="105">line1<br>line2</div>
-offsetLeft expected 105 but got 35
-FAIL #target > div 3 assert_equals:
-<div data-offset-x="126">line1<br>line2</div>
-offsetLeft expected 126 but got 42
+PASS #target > div 2
+PASS #target > div 3
 PASS #target > div 4
 PASS #target > div 5
 PASS #target > div 6

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-003-expected.txt
@@ -2,13 +2,7 @@
 
 
 
-FAIL #target > div 1 assert_equals:
-<div data-offset-y="40"><span></span><br><span></span></div>
-offsetTop expected 40 but got 0
-FAIL #target > div 2 assert_equals:
-<div data-offset-y="20"><span></span><br><span></span></div>
-offsetTop expected 20 but got 40
-FAIL #target > div 3 assert_equals:
-<div data-offset-y="75"><span></span><br><span></span></div>
-offsetTop expected 75 but got 35
+PASS #target > div 1
+PASS #target > div 2
+PASS #target > div 3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-004-expected.txt
@@ -2,13 +2,7 @@
 
 
 
-FAIL #target > div 1 assert_equals:
-<div data-offset-y="40"><span></span><br><span></span></div>
-offsetTop expected 40 but got 0
-FAIL #target > div 2 assert_equals:
-<div data-offset-y="20"><span></span><br><span></span></div>
-offsetTop expected 20 but got 40
-FAIL #target > div 3 assert_equals:
-<div data-offset-y="75"><span></span><br><span></span></div>
-offsetTop expected 75 but got 35
+PASS #target > div 1
+PASS #target > div 2
+PASS #target > div 3
 


### PR DESCRIPTION
#### d4c256af46387fe6ffb9119c724407b38fc67fef
<pre>
[Grid][Baseline] Fix RowAxisPositioning for baseline alignment in grid layout.
<a href="https://bugs.webkit.org/show_bug.cgi?id=296058">https://bugs.webkit.org/show_bug.cgi?id=296058</a>
&lt;<a href="https://rdar.apple.com/155967278">rdar://155967278</a>&gt;

Reviewed by Sammy Gill.

This PR fixes 9 WPTs by adding first-baseline and last-baseline row axis
alignment to grid items.

Per:

<a href="https://www.w3.org/TR/css-align-3/#baseline-values">https://www.w3.org/TR/css-align-3/#baseline-values</a>

`The fallback alignment for first baseline is safe self-start (for self-alignment)
or safe start (for content-distribution).

The fallback alignment for last baseline is safe self-end (for self-alignment)
or safe end (for content-distribution).`

This PR also handles opposite flow grid items to resolve to the
correct physical direction for different writing modes.

This PR also fixes an issue where rowAxisOffsetForGridItem() failed
to account for rowAxisBaselineOffset when determining the offset for
GridAxisEnd items.

Note that non-inline matching orthogonal grid items are not handled properly.
We are defaulting back to the previous broken behavior as many WPTs are currently
dependendent on that broken behavior to pass.

Combined changes:

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-004-expected.txt:
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::rowAxisPositionForGridItem const):
(WebCore::RenderGrid::columnAxisOffsetForGridItem const):
(WebCore::RenderGrid::rowAxisOffsetForGridItem const):

Canonical link: <a href="https://commits.webkit.org/299933@main">https://commits.webkit.org/299933@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4587c4c6cc3687a801d09c2f2f37723a786f0a67

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120212 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39906 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30557 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126566 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72285 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6c52a2a1-a899-4aaf-baef-a851df5452de) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122088 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40602 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48483 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91287 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60583 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4705fa7e-fd86-448f-a480-97db310d6625) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123164 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32426 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107777 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71841 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31460 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25882 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70192 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101906 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26068 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129466 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47132 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35759 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99907 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47961 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103962 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99749 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25422 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45560 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23234 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43763 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46994 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52700 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46462 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49809 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48146 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->