### PR TITLE
AX: add debug option to detect differences between live tree structure and isolated tree

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -755,8 +755,9 @@ protected:
     CharacterOffset characterOffsetForPoint(const IntPoint&);
     LayoutRect localCaretRectForCharacterOffset(RenderObject*&, const CharacterOffset&);
     bool shouldSkipBoundary(const CharacterOffset&, const CharacterOffset&);
-private:
+public:
     AccessibilityObject* rootWebArea();
+private:
 
     // Returns the object or nearest render-tree ancestor object that is already created (i.e.
     // retrievable by |get|, not |getOrCreate|).

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -134,6 +134,7 @@ void AXIsolatedTree::createEmptyContent(AccessibilityObject& axRoot)
         Locker locker { m_changeLogLock };
         setPendingRootNodeIDLocked(axRoot.objectID());
         m_pendingFocusedNodeID = axWebArea->objectID();
+        setPendingTreeStructure();
     }
     queueAppendsAndRemovals({ rootAppend, webAreaAppend }, { });
 }
@@ -190,6 +191,8 @@ void AXIsolatedTree::applyPendingRootNodeLocked()
         if (RefPtr root = objectForID(m_pendingRootNodeID)) {
             m_rootNode = WTFMove(root);
             m_pendingRootNodeID = std::nullopt;
+        } else {
+            WTFLogAlways("Could not apply pending root node\n");
         }
     }
 }
@@ -301,8 +304,10 @@ std::optional<AXIsolatedTree::NodeChange> AXIsolatedTree::nodeChangeForObject(Re
     m_nodeMap.set(axObject->objectID(), ParentChildrenIDs { parentID, data.childrenIDs });
     NodeChange nodeChange { WTFMove(data), axObject->wrapper() };
 
-    if (!parentID && axObject->isScrollView())
+    if (!parentID && axObject->isScrollView()) {
         setPendingRootNodeID(axObject->objectID());
+        setPendingTreeStructure();
+    }
     return nodeChange;
 }
 
@@ -355,6 +360,7 @@ void AXIsolatedTree::addUnconnectedNode(Ref<AccessibilityObject> axObject)
     Locker locker { m_changeLogLock };
     m_pendingAppends.append(WTFMove(nodeChange));
     m_unconnectedNodes.add(objectID);
+    setPendingTreeStructure();
 }
 
 void AXIsolatedTree::queueRemovals(Vector<AXID>&& subtreeRemovals)
@@ -363,6 +369,7 @@ void AXIsolatedTree::queueRemovals(Vector<AXID>&& subtreeRemovals)
 
     Locker locker { m_changeLogLock };
     queueRemovalsLocked(WTFMove(subtreeRemovals));
+    setPendingTreeStructure();
 }
 
 void AXIsolatedTree::queueRemovalsLocked(Vector<AXID>&& subtreeRemovals)
@@ -435,6 +442,7 @@ void AXIsolatedTree::queueAppendsAndRemovals(Vector<NodeChange>&& appends, Vecto
     }
 
     queueRemovalsLocked(WTFMove(subtreeRemovals));
+    setPendingTreeStructure();
 }
 
 void AXIsolatedTree::collectNodeChangesForSubtree(AccessibilityObject& axObject)
@@ -521,6 +529,7 @@ void AXIsolatedTree::updateNode(AccessibilityObject& axObject)
     if (auto change = nodeChangeForObject(axObject)) {
         Locker locker { m_changeLogLock };
         queueChange(WTFMove(*change));
+        setPendingTreeStructure();
         return;
     }
 
@@ -535,6 +544,7 @@ void AXIsolatedTree::updateNode(AccessibilityObject& axObject)
     if (auto change = nodeChangeForObject(downcast<AccessibilityObject>(*axParent))) {
         Locker locker { m_changeLogLock };
         queueChange(WTFMove(*change));
+        setPendingTreeStructure();
     }
 }
 
@@ -866,6 +876,7 @@ void AXIsolatedTree::updateNodeProperties(AccessibilityObject& axObject, const A
 
     Locker locker { m_changeLogLock };
     m_pendingPropertyChanges.append({ axObject.objectID(), WTFMove(properties) });
+    setPendingTreeStructure();
 }
 
 void AXIsolatedTree::overrideNodeProperties(AXID axID, AXPropertyVector&& properties)
@@ -877,6 +888,7 @@ void AXIsolatedTree::overrideNodeProperties(AXID axID, AXPropertyVector&& proper
 
     Locker locker { m_changeLogLock };
     m_pendingPropertyChanges.append({ axID, WTFMove(properties) });
+    setPendingTreeStructure();
 }
 
 void AXIsolatedTree::updateDependentProperties(AccessibilityObject& axObject)
@@ -1146,10 +1158,43 @@ RefPtr<AXIsolatedObject> AXIsolatedTree::rootWebArea()
     }) : nullptr;
 }
 
+static void buildTreeStructure(Vector<TreeStructureNode>& treeStructure, AXCoreObject* obj)
+{
+    TreeStructureNode structureNode(obj->objectID());
+    structureNode.role = obj->role();
+
+    auto children = obj->children();
+    for (auto& child : children) {
+        structureNode.children.append(child->objectID());
+    }
+    treeStructure.append(structureNode);
+
+    for (auto& child : children) {
+        buildTreeStructure(treeStructure, &child.get());
+    }
+}
+
+void AXIsolatedTree::setPendingTreeStructure()
+{
+    if (!isMainThread())
+    {
+        return;
+    }
+
+    if (!axObjectCache() || !axObjectCache()->rootWebArea() || !axObjectCache()->rootWebArea()->parentObject())
+    {
+        return;
+    }
+
+    m_pendingTreeStructure.clear();
+    buildTreeStructure(m_pendingTreeStructure, axObjectCache()->rootWebArea()->parentObject());
+}
+
 void AXIsolatedTree::setPendingRootNodeID(AXID axID)
 {
     Locker locker { m_changeLogLock };
     setPendingRootNodeIDLocked(axID);
+    setPendingTreeStructure();
 }
 
 void AXIsolatedTree::setPendingRootNodeIDLocked(AXID axID)
@@ -1169,6 +1214,7 @@ void AXIsolatedTree::setFocusedNodeID(std::optional<AXID> axID)
 
     Locker locker { m_changeLogLock };
     m_pendingFocusedNodeID = axID;
+    setPendingTreeStructure();
 }
 
 void AXIsolatedTree::updateRelations(HashMap<AXID, AXRelations>&& relations)
@@ -1179,6 +1225,7 @@ void AXIsolatedTree::updateRelations(HashMap<AXID, AXRelations>&& relations)
     m_relationsNeedUpdate = false;
     Locker locker { m_changeLogLock };
     m_pendingRelations = WTFMove(relations);
+    setPendingTreeStructure();
 }
 
 void AXIsolatedTree::setSelectedTextMarkerRange(AXTextMarkerRange&& range)
@@ -1188,6 +1235,7 @@ void AXIsolatedTree::setSelectedTextMarkerRange(AXTextMarkerRange&& range)
 
     Locker locker { m_changeLogLock };
     m_pendingSelectedTextMarkerRange = WTFMove(range);
+    setPendingTreeStructure();
 }
 
 void AXIsolatedTree::updateLoadingProgress(double newProgressValue)
@@ -1213,6 +1261,7 @@ void AXIsolatedTree::updateFrame(AXID axID, IntRect&& newFrame)
     properties.append({ AXProperty::InitialFrameRect, FloatRect() });
     Locker locker { m_changeLogLock };
     m_pendingPropertyChanges.append({ axID, WTFMove(properties) });
+    setPendingTreeStructure();
 }
 
 void AXIsolatedTree::updateRootScreenRelativePosition()
@@ -1293,6 +1342,7 @@ void AXIsolatedTree::applyPendingChanges()
 {
     Locker locker { m_changeLogLock };
     applyPendingChangesLocked();
+    setPendingTreeStructure();
 }
 
 void AXIsolatedTree::applyPendingChangesUnlessQueuedForDestruction()
@@ -1304,6 +1354,129 @@ void AXIsolatedTree::applyPendingChangesUnlessQueuedForDestruction()
     if (m_queuedForDestruction)
         return;
     applyPendingChangesLocked();
+    setPendingTreeStructure();
+}
+
+static void dumpStructureTree(HashMap<AXID, TreeStructureNode *>& idMap, Vector<TreeStructureNode>& treeStructure, int depth, AXID structureId)
+{
+    for (int i = 0; i < depth; i++)
+        fprintf(stderr, "  ");
+    TreeStructureNode *structureNode = idMap.get(structureId);
+    if (structureNode) {
+        WTFLogAlways("%d %s", (int)structureId.toRawValue(), accessibilityRoleToString(structureNode->role).utf8().data());
+        for (int i = 0; i < (int)structureNode->children.size(); i++) {
+            AXID childStructureId = structureNode->children[i];
+            dumpStructureTree(idMap, treeStructure, depth + 1, childStructureId);
+        }
+    } else {
+        WTFLogAlways("%d ERR", (int)structureId.toRawValue());
+    }
+}
+
+static void dumpIsolatedTree(int depth, AXCoreObject* node)
+{
+    for (int i = 0; i < depth; i++)
+        fprintf(stderr, "  ");
+    WTFLogAlways("%d %s", (int)node->objectID().toRawValue(), accessibilityRoleToString(node->role()).utf8().data());
+    auto nodeChildren = node->children();
+    for (int i = 0; i < (int)nodeChildren.size(); i++) {
+        auto& isolatedNode = nodeChildren[i];
+        dumpIsolatedTree(depth + 1, &isolatedNode.get());
+    }
+}
+
+static bool walkTreeStructure(HashMap<AXID, TreeStructureNode *>& idMap, Vector<TreeStructureNode>& treeStructure, bool output, int depth, AXID structureId, AXCoreObject* node)
+{
+    bool good = true;
+    if (output) {
+        for (int i = 0; i < depth; i++)
+            fprintf(stderr, "  ");
+        TreeStructureNode *structureNode = idMap.get(structureId);
+        if (!structureNode) {
+            WTFLogAlways("%d ERR structure node missing", (int)structureId.toRawValue());
+            good = false;
+        }
+        else {
+            if (structureId != node->objectID()) {
+                WTFLogAlways("%d %s (structure id) : %d %s (isolated tree) childCount %d : %d - ERR ids do not match",
+                             (int)structureId.toRawValue(),
+                             accessibilityRoleToString(structureNode->role).utf8().data(),
+                             (int)node->objectID().toRawValue(),
+                             accessibilityRoleToString(node->role()).utf8().data(),
+                             (int)structureNode->children.size(), (int)node->children().size());
+                good = false;
+            } else if ((int)structureNode->children.size() != (int)node->children().size()) {
+                WTFLogAlways("%d child counts %d (structure) : %d (isolated tree) - ERR child counts do not match",
+                             (int)structureId.toRawValue(),
+                             (int)structureNode->children.size(), (int)node->children().size());
+                good = false;
+            }
+            else {
+                WTFLogAlways("%d %s", (int)structureId.toRawValue(), accessibilityRoleToString(structureNode->role).utf8().data());
+                auto nodeChildren = node->children();
+                for (int i = 0; i < (int)structureNode->children.size(); i++) {
+                    if (i >= (int)nodeChildren.size()) {
+                        WTFLogAlways("walkTreeStructure: ERR child index %d out of bounds (size: %d)", i, (int)nodeChildren.size());
+                        good = false;
+                        break;
+                    }
+                    
+                    AXID childStructureId = structureNode->children[i];
+                    auto& isolatedNode = nodeChildren[i];
+                    if (isolatedNode->parentObject() != node) {
+                        WTFLogAlways("ERR bad parent\n");
+                        good = false;
+                        break;
+                    }
+
+                    bool result = walkTreeStructure(idMap, treeStructure, output, depth + 1, childStructureId, &isolatedNode.get());
+                    if (!result) {
+                        good = false;
+                    }
+                }
+            }
+        }
+    }
+    return good;
+}
+
+static void walkTreeStructure(Vector<TreeStructureNode>& treeStructure, RefPtr<AXIsolatedObject> rootNode)
+{
+    // Early return if no tree structure or no root node
+    if (treeStructure.size() == 0 || !rootNode) {
+        WTFLogAlways("walkTreeStructure: empty structure or null root node");
+        return;
+    }
+
+    HashMap<AXID, TreeStructureNode *> idMap;
+    TreeStructureNode* root = nullptr;
+
+    // Build the ID map and find the root
+    for (auto& structureNode : treeStructure) {
+        idMap.set(structureNode.axid, &structureNode);
+        if (!root) {
+            root = &structureNode;
+        }
+    }
+
+    if (!root) {
+        WTFLogAlways("walkTreeStructure: no valid root found");
+        return;
+    }
+
+    AXID rootId = root->axid;
+
+    bool okay = walkTreeStructure(idMap, treeStructure, false, 0, rootId, rootNode.get());
+    if (okay) {
+        WTFLogAlways("walkTreeStructure: %d nodes okay", (int)treeStructure.size());
+    } else {
+        walkTreeStructure(idMap, treeStructure, true, 0, rootId, rootNode.get());
+
+        WTFLogAlways("*** structure tree ***");
+        dumpStructureTree(idMap, treeStructure, 0, rootId);
+        WTFLogAlways("*** isolated tree ***");
+        dumpIsolatedTree(0, rootNode.get());
+    }
 }
 
 void AXIsolatedTree::applyPendingChangesLocked()
@@ -1422,6 +1595,8 @@ void AXIsolatedTree::applyPendingChangesLocked()
     // Do this at the end because it requires looking up the root node by ID, so doing it at the end
     // ensures all additions to m_readerThreadNodeMap have been made by now.
     applyPendingRootNodeLocked();
+
+    walkTreeStructure(m_pendingTreeStructure, m_rootNode);
 }
 
 void AXIsolatedTree::sortedLiveRegionsDidChange(Vector<AXID> liveRegionIDs)
@@ -1430,6 +1605,7 @@ void AXIsolatedTree::sortedLiveRegionsDidChange(Vector<AXID> liveRegionIDs)
 
     Locker locker { m_changeLogLock };
     m_pendingSortedLiveRegionIDs = WTFMove(liveRegionIDs);
+    setPendingTreeStructure();
 }
 
 void AXIsolatedTree::sortedNonRootWebAreasDidChange(Vector<AXID> webAreaIDs)
@@ -1441,6 +1617,7 @@ void AXIsolatedTree::sortedNonRootWebAreasDidChange(Vector<AXID> webAreaIDs)
     // not ad-hoc whenever the main-thread changes them. Otherwise we could sync IDs to the accessibility thread that don't have isolated objects
     // until the next actual tree-update cycle.
     m_pendingSortedNonRootWebAreaIDs = WTFMove(webAreaIDs);
+    setPendingTreeStructure();
 }
 
 AXTreePtr findAXTree(Function<bool(AXTreePtr)>&& match)
@@ -1560,6 +1737,7 @@ void AXIsolatedTree::processQueuedNodeUpdates()
         Locker lock { m_changeLogLock };
         m_pendingMostRecentlyPaintedText = cache->mostRecentlyPaintedText();
         m_mostRecentlyPaintedTextIsDirty = false;
+        setPendingTreeStructure();
     }
 
     queueRemovalsAndUnresolvedChanges();

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -392,6 +392,14 @@ struct IsolatedObjectData {
     }
 };
 
+struct TreeStructureNode {
+    TreeStructureNode(AXID axid_) : axid(axid_) { }
+
+    AXID axid;
+    Vector<AXID> children;
+    AccessibilityRole role;
+};
+
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(AXIsolatedTree);
 class AXIsolatedTree : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<AXIsolatedTree>
     , public AXTreeStore<AXIsolatedTree> {
@@ -494,6 +502,7 @@ public:
     // Both setPendingRootNodeLocked and setFocusedNodeID are called during the generation
     // of the IsolatedTree.
     // Focused node updates in AXObjectCache use setFocusNodeID.
+    void setPendingTreeStructure();
     void setPendingRootNodeID(AXID);
     void setPendingRootNodeIDLocked(AXID) WTF_REQUIRES_LOCK(m_changeLogLock);
     void setFocusedNodeID(std::optional<AXID>);
@@ -630,6 +639,7 @@ private:
     RefPtr<AXIsolatedObject> m_rootNode;
 
     // Written to by main thread under lock, accessed and applied by AX thread.
+    Vector<TreeStructureNode> m_pendingTreeStructure;
     Markable<AXID> m_pendingRootNodeID WTF_GUARDED_BY_LOCK(m_changeLogLock);
     Vector<NodeChange> m_pendingAppends WTF_GUARDED_BY_LOCK(m_changeLogLock); // Nodes to be added to the tree and platform-wrapped.
     Vector<AXPropertyChange> m_pendingPropertyChanges WTF_GUARDED_BY_LOCK(m_changeLogLock);


### PR DESCRIPTION
#### a94836385a6ec5790b31ffd266002df32e025ba8
<pre>
AX: add debug option to detect differences between live tree structure and isolated tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=296063">https://bugs.webkit.org/show_bug.cgi?id=296063</a>
<a href="https://rdar.apple.com/155971638">rdar://155971638</a>

Reviewed by NOBODY (OOPS!).

Early proof of concept.

At the time we&apos;re making an update to the isolated tree, make a
snapshot of the live tree - just the tree structure with AXIDs and
roles. After updating the isolated tree, run a check to make sure we
got the same result.

* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::createEmptyContent):
(WebCore::AXIsolatedTree::applyPendingRootNodeLocked):
(WebCore::AXIsolatedTree::nodeChangeForObject):
(WebCore::AXIsolatedTree::addUnconnectedNode):
(WebCore::AXIsolatedTree::queueRemovals):
(WebCore::AXIsolatedTree::queueAppendsAndRemovals):
(WebCore::AXIsolatedTree::updateNode):
(WebCore::AXIsolatedTree::updateNodeProperties):
(WebCore::AXIsolatedTree::overrideNodeProperties):
(WebCore::buildTreeStructure):
(WebCore::AXIsolatedTree::setPendingTreeStructure):
(WebCore::AXIsolatedTree::setPendingRootNodeID):
(WebCore::AXIsolatedTree::setFocusedNodeID):
(WebCore::AXIsolatedTree::updateRelations):
(WebCore::AXIsolatedTree::setSelectedTextMarkerRange):
(WebCore::AXIsolatedTree::updateFrame):
(WebCore::AXIsolatedTree::applyPendingChanges):
(WebCore::AXIsolatedTree::applyPendingChangesUnlessQueuedForDestruction):
(WebCore::dumpStructureTree):
(WebCore::dumpIsolatedTree):
(WebCore::walkTreeStructure):
(WebCore::AXIsolatedTree::applyPendingChangesLocked):
(WebCore::AXIsolatedTree::sortedLiveRegionsDidChange):
(WebCore::AXIsolatedTree::sortedNonRootWebAreasDidChange):
(WebCore::AXIsolatedTree::processQueuedNodeUpdates):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
(WebCore::TreeStructureNode::TreeStructureNode):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a94836385a6ec5790b31ffd266002df32e025ba8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111915 "49 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22077 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117967 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62196 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113878 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32259 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40160 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85049 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35735 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114862 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25762 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100715 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65481 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25093 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18850 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61782 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95161 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18926 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121226 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38945 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28979 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93891 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39325 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96968 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93708 "Found 2 new API test failures: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38895 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16690 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34966 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38840 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44358 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38477 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41804 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40193 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->