### PR TITLE
Make WTF_MAKE_COMPACT_TZONE_ALLOCATED set allowCompactPointers and re-enable TZone compactness inheritance

### DIFF
--- a/Source/WTF/wtf/TZoneMalloc.h
+++ b/Source/WTF/wtf/TZoneMalloc.h
@@ -126,8 +126,12 @@
 #define WTF_MAKE_TZONE_ALLOCATED_TEMPLATE_EXPORT(name, exportMacro) MAKE_BTZONE_MALLOCED_TEMPLATE(name, NonCompact, exportMacro)
 
 // special class (e.g. those used with CompactPtr) allocators with FastMalloc fallback if TZoneHeap is enabled.
-#define WTF_MAKE_COMPACT_TZONE_ALLOCATED(name) MAKE_BTZONE_MALLOCED(name, Compact, WTF_NOEXPORT)
-#define WTF_MAKE_COMPACT_TZONE_ALLOCATED_EXPORT(name, exportMacro) MAKE_BTZONE_MALLOCED(name, Compact, exportMacro)
+#define WTF_MAKE_COMPACT_TZONE_ALLOCATED(name) \
+    WTF_ALLOW_COMPACT_POINTERS; \
+    MAKE_BTZONE_MALLOCED(name, Compact, WTF_NOEXPORT)
+#define WTF_MAKE_COMPACT_TZONE_ALLOCATED_EXPORT(name, exportMacro) \
+    WTF_ALLOW_COMPACT_POINTERS; \
+    MAKE_BTZONE_MALLOCED(name, Compact, exportMacro)
 
 // IsoHeap fallback allocators
 


### PR DESCRIPTION
#### e4bf6e21542a7a7c082a6223c7dee6fb9d8e33a5
<pre>
Make WTF_MAKE_COMPACT_TZONE_ALLOCATED set allowCompactPointers and re-enable TZone compactness inheritance
<a href="https://bugs.webkit.org/show_bug.cgi?id=296072">https://bugs.webkit.org/show_bug.cgi?id=296072</a>
<a href="https://rdar.apple.com/155980834">rdar://155980834</a>

Reviewed by Keith Miller.

Makes it so a type declared with WTF_MAKE_COMPACT_TZONE_ALLOCATED will still
declare that it allows compact pointers, and re-lands inheritable compactness
in the TZone malloc implementation. Also unifies requiresCompactPointers() and
compactAllocationMode() so that there aren&apos;t two parallel mechanisms of
detecting compactness for a type.

* Source/WTF/wtf/TZoneMalloc.h:
* Source/bmalloc/bmalloc/TZoneHeap.h:
(bmalloc::api::compactAllocationMode):
(bmalloc::api::requiresCompactPointers): Deleted.
* Source/bmalloc/bmalloc/TZoneHeapInlines.h:

Canonical link: <a href="https://commits.webkit.org/297621@main">https://commits.webkit.org/297621@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d321ac267441e0ad8515bcba2675970816ab6c92

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111938 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31608 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22094 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117958 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62172 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32285 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40186 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85042 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35720 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114885 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25786 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100733 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65474 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25111 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18868 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61808 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/104426 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95179 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18944 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121301 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/110497 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38971 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28994 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93915 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39352 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96986 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93732 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24025 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38911 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16705 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34992 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38865 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44377 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/134757 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38502 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36267 "Found 2 new JSC stress test failures: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js.default, wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41830 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40218 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->