### PR TITLE
AX: Accessibility text runs don't traverse `InlineIterator::TextBox`s in logical order, causing assistive technologies to output incorrect text for LTR-RTL mixed content

### DIFF
--- a/LayoutTests/accessibility-isolated-tree/TestExpectations
+++ b/LayoutTests/accessibility-isolated-tree/TestExpectations
@@ -38,7 +38,7 @@ accessibility/mac/style-range.html [ Pass ]
 # Flaky: https://bugs.webkit.org/show_bug.cgi?id=290946
 accessibility/datetime/input-date-field-labels-and-value-changes.html [ Pass Failure ]
 
-# Failures in ITM since introduced.
+# Fails in ITM since introduced.
 accessibility/text-marker/text-marker-bidi-element-arabic.html [ Failure ]
 accessibility/text-marker/text-marker-bidi-element-hebrew.html [ Failure ]
 
@@ -61,7 +61,6 @@ accessibility/mac/text-markers-for-input-with-placeholder.html [ Failure ]
 accessibility/mac/textmarker-range-for-range.html [ Failure ]
 accessibility/native-text-control-attributed-string.html [ Failure ]
 accessibility/search-misspellings.html [ Failure ]
-accessibility/text-marker/text-marker-bidi-inline-cite.html [ Failure ]
 accessibility/text-marker/text-marker-previous-next.html [ Failure ]
 accessibility/mac/text-marker-for-index-2.html [ Failure ]
 accessibility/mac/text-marker-word-nav.html [ Failure ]

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -2104,10 +2104,7 @@ void AXObjectCache::onAccessibilityPaintFinished()
 
     for (auto iterator = m_mostRecentlyPaintedText.begin(); iterator != m_mostRecentlyPaintedText.end(); ++iterator) {
         const auto& renderText = iterator->key;
-        // FIXME: Use InlineIteratorLogicalOrderTraversal instead. Otherwise we'll do the wrong thing for mixed direction
-        // content. We should do this at the same time AccessibilityRenderObject::textRuns switches to this function.
-        // Tracked by: https://bugs.webkit.org/show_bug.cgi?id=294632
-        if (auto textBox = InlineIterator::lineLeftmostTextBoxFor(renderText)) {
+        if (auto textBox = InlineIterator::firstTextBoxInLogicalOrderFor(renderText).first) {
             // The line index from TextBox::lineIndex is relative to the containing block, which count lines from
             // other renderers. The LineRange struct we have built expects the start and end line indices to be
             // relative to just this renderer, so normalize them by getting the first line index for this renderer.

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -74,6 +74,7 @@
 #include "HitTestResult.h"
 #include "Image.h"
 #include "InlineIteratorBoxInlines.h"
+#include "InlineIteratorLogicalOrderTraversal.h"
 #include "InlineIteratorTextBoxInlines.h"
 #include "LegacyRenderSVGRoot.h"
 #include "LegacyRenderSVGShape.h"
@@ -1587,9 +1588,7 @@ AXTextRuns AccessibilityRenderObject::textRuns()
     };
 
     Vector<std::array<uint16_t, 2>> textRunDomOffsets;
-    // FIXME: Use InlineIteratorLogicalOrderTraversal instead. Otherwise we'll do the wrong thing for mixed direction content.
-    // Tracked by: https://bugs.webkit.org/show_bug.cgi?id=294632
-    auto textBox = InlineIterator::lineLeftmostTextBoxFor(*renderText);
+    auto [textBox, orderCache] = InlineIterator::firstTextBoxInLogicalOrderFor(*renderText);
     size_t currentLineIndex = textBox ? textBox->lineIndex() : 0;
 
     bool containsOnlyASCII = true;
@@ -1637,7 +1636,7 @@ AXTextRuns AccessibilityRenderObject::textRuns()
 
         // Within each iteration of this loop, we are looking at the *next* text box to compare to the current.
         // So, we need to set the textRunDomOffsets after the line index comparison, in order to assign the right DOM offsets per text box.
-        textBox.traverseNextTextBox();
+        textBox = InlineIterator::nextTextBoxInLogicalOrder(textBox, orderCache);
         textRunDomOffsets.append({ startDOMOffset, endDOMOffset });
     }
 

--- a/Source/WebCore/editing/VisiblePosition.cpp
+++ b/Source/WebCore/editing/VisiblePosition.cpp
@@ -706,7 +706,8 @@ void VisiblePosition::debugPosition(ASCIILiteral msg) const
 
 String VisiblePosition::debugDescription() const
 {
-    return m_deepPosition.debugDescription();
+    // Only log affinity when it's the non-default value of upstream.
+    return makeString(m_deepPosition.debugDescription(), ", affinity: "_s, m_affinity == Affinity::Upstream ? "upstream"_s : ""_s);
 }
 
 void VisiblePosition::showTreeForThis() const


### PR DESCRIPTION
#### bf58fd66fc92c28c9785ba176c018db29f812cb8
<pre>
AX: Accessibility text runs don&apos;t traverse `InlineIterator::TextBox`s in logical order, causing assistive technologies to output incorrect text for LTR-RTL mixed content
<a href="https://bugs.webkit.org/show_bug.cgi?id=294632">https://bugs.webkit.org/show_bug.cgi?id=294632</a>
<a href="https://rdar.apple.com/153673920">rdar://153673920</a>

Reviewed by Joshua Hoffman.

Traverse in `InlineIterator::TextBox`s in logical order so we output correct text for LTR-RTL mixed direction content.
Fixes accessibility/text-marker/text-marker-bidi-inline-cite.html in ITM.

* LayoutTests/accessibility-isolated-tree/TestExpectations:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::onAccessibilityPaintFinished):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::textRuns):
* Source/WebCore/editing/VisiblePosition.cpp:
(WebCore::VisiblePosition::debugDescription const):
Drive-by change to output affinity in debug description, something I&apos;ve found useful multiple times.

Canonical link: <a href="https://commits.webkit.org/297490@main">https://commits.webkit.org/297490@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7a19b42ac00e664ac92db5310444aa0ee7415f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111940 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31610 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22096 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117960 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62174 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113902 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40188 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85043 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35721 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114887 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25783 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100726 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65475 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25108 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18861 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61810 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95176 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18937 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121276 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38973 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28996 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/93903 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39354 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96979 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93720 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23926 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38907 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16699 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34994 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38867 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44379 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38504 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41832 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40220 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->