### PR TITLE
Web Inspector: add toggle for Site Isolation Debug Overlay in Engineering Settings

### DIFF
--- a/Source/JavaScriptCore/inspector/protocol/Page.json
+++ b/Source/JavaScriptCore/inspector/protocol/Page.json
@@ -20,7 +20,8 @@
                 "ScriptEnabled",
                 "ShowDebugBorders",
                 "ShowRepaintCounter",
-                "WebSecurityEnabled"
+                "WebSecurityEnabled",
+                "SiteIsolationDebugOverlay"
             ]
         },
         {

--- a/Source/WebCore/inspector/InspectorBackendClient.h
+++ b/Source/WebCore/inspector/InspectorBackendClient.h
@@ -45,6 +45,7 @@ enum class InspectorBackendClientDeveloperPreference : uint8_t {
     ITPDebugModeEnabled,
     MockCaptureDevicesEnabled,
     NeedsSiteSpecificQuirks,
+    SiteIsolationDebugOverlay,
 };
 
 class InspectorBackendClient {

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -411,6 +411,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::disable()
     m_client->setDeveloperPreferenceOverride(InspectorBackendClient::DeveloperPreference::ITPDebugModeEnabled, std::nullopt);
     m_client->setDeveloperPreferenceOverride(InspectorBackendClient::DeveloperPreference::MockCaptureDevicesEnabled, std::nullopt);
     m_client->setDeveloperPreferenceOverride(InspectorBackendClient::DeveloperPreference::NeedsSiteSpecificQuirks, std::nullopt);
+    m_client->setDeveloperPreferenceOverride(InspectorBackendClient::DeveloperPreference::SiteIsolationDebugOverlay, std::nullopt);
 
     return { };
 }
@@ -511,6 +512,10 @@ Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::overrideSetting(Ins
 
     case Inspector::Protocol::Page::Setting::ShowRepaintCounter:
         inspectedPageSettings.setShowRepaintCounterInspectorOverride(value);
+        return { };
+
+    case Inspector::Protocol::Page::Setting::SiteIsolationDebugOverlay:
+        m_client->setDeveloperPreferenceOverride(InspectorBackendClient::DeveloperPreference::SiteIsolationDebugOverlay, value);
         return { };
 
     case Inspector::Protocol::Page::Setting::WebSecurityEnabled:

--- a/Source/WebCore/page/DebugPageOverlays.cpp
+++ b/Source/WebCore/page/DebugPageOverlays.cpp
@@ -715,16 +715,17 @@ void SiteIsolationOverlay::drawRect(PageOverlay&, GraphicsContext& context, cons
     fontDescription.setWeight(FontSelectionValue(500));
     FontCascade font(WTFMove(fontDescription));
     font.update(nullptr);
+    context.setFillColor(Color::black);
 
     for (RefPtr frame = page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
         if (!frame->virtualView())
             continue;
         auto frameView = frame->virtualView();
-        auto debugStr = makeString(is<RemoteFrame>(frame) ? "remote("_s : "local("_s, frame->frameID().toUInt64(), ')');
-        TextRun textRun = TextRun(debugStr);
-        context.setFillColor(Color::black);
 
-        context.drawText(font, textRun, FloatPoint { static_cast<float>(frameView->x()), static_cast<float>(frameView->y() + 12) });
+        if (RefPtr localFrame = dynamicDowncast<LocalFrame>(*frame)) {
+            auto textRun = TextRun(makeString("frameID="_s, frame->frameID().toUInt64(), ", processID="_s, getCurrentProcessID(), ", url="_s, localFrame->document()->url().string()));
+            context.drawText(font, textRun, FloatPoint { static_cast<float>(frameView->x()), static_cast<float>(frameView->y() + 12) });
+        }
     }
 }
 

--- a/Source/WebInspectorUI/UserInterface/Base/Main.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Main.js
@@ -237,6 +237,12 @@ WI.contentLoaded = function()
     WI.settings.resourceCachingDisabled.addEventListener(WI.Setting.Event.Changed, WI._resourceCachingDisabledSettingChanged, WI);
     WI.settings.experimentalAllowInspectingInspector.addEventListener(WI.Setting.Event.Changed, WI._allowInspectingInspectorSettingChanged, WI);
 
+    if (WI.engineeringSettingsAllowed()) {
+        WI.settings.engineeringShowSiteIsolationDebugOverlay.addEventListener(WI.Setting.Event.Changed, function() {
+            WI.mainTarget.PageAgent.overrideSetting(InspectorBackend.Enum.Page.Setting.SiteIsolationDebugOverlay, WI.settings.engineeringShowSiteIsolationDebugOverlay.value);
+        });
+    }
+
     function setTabSize() {
         document.body.style.tabSize = WI.settings.tabSize.value;
     }
@@ -632,6 +638,10 @@ WI.initializeTarget = function(target)
                 // FIXME <rdar://105244623> iOS platforms without a matching legacy protocol definition will fall back to the local macOS protocol definition.
                 console.error(error);
             });
+
+        // COMPATIBILITY (iOS 18.0): Page.Setting.SiteIsolationDebugOverlay did not yet exist.
+        if (target.hasCommand("Page.overrideSetting") && InspectorBackend.Enum.Page.Setting.SiteIsolationDebugOverlay)
+            target.PageAgent.overrideSetting(InspectorBackend.Enum.Page.Setting.SiteIsolationDebugOverlay, WI.settings.engineeringShowSiteIsolationDebugOverlay.value);
     }
 };
 

--- a/Source/WebInspectorUI/UserInterface/Base/Setting.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Setting.js
@@ -257,6 +257,7 @@ WI.settings = {
     engineeringShowInternalObjectsInHeapSnapshot: new WI.EngineeringSetting("engineering-show-internal-objects-in-heap-snapshot", false),
     engineeringShowPrivateSymbolsInHeapSnapshot: new WI.EngineeringSetting("engineering-show-private-symbols-in-heap-snapshot", false),
     engineeringAllowEditingUserAgentShadowTrees: new WI.EngineeringSetting("engineering-allow-editing-user-agent-shadow-trees", false),
+    engineeringShowSiteIsolationDebugOverlay: new WI.EngineeringSetting("engineering-show-site-isolation-debug-overlay", false),
 
     // Debug
     debugShowConsoleEvaluations: new WI.DebugSetting("debug-show-console-evaluations", false),

--- a/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
@@ -499,6 +499,11 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
         heapSnapshotGroup.addSetting(WI.settings.engineeringShowInternalObjectsInHeapSnapshot, WI.unlocalizedString("Show Internal Objects"));
         heapSnapshotGroup.addSetting(WI.settings.engineeringShowPrivateSymbolsInHeapSnapshot, WI.unlocalizedString("Show Private Symbols"));
 
+        engineeringSettingsView.addSeparator();
+
+        let siteIsolationGroup = engineeringSettingsView.addGroup(WI.unlocalizedString("Site Isolation:"));
+        siteIsolationGroup.addSetting(WI.settings.engineeringShowSiteIsolationDebugOverlay, WI.unlocalizedString("Show Debug Overlay"));
+
         this.addSettingsView(engineeringSettingsView);
     }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8025,6 +8025,7 @@ enum class WebCore::InspectorBackendClientDeveloperPreference : uint8_t {
     ITPDebugModeEnabled,
     MockCaptureDevicesEnabled,
     NeedsSiteSpecificQuirks,
+    SiteIsolationDebugOverlay,
 };
 
 [AdditionalEncoder=StreamConnectionEncoder, RefCounted] class WebCore::SystemImage subclasses {

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
@@ -50,6 +50,7 @@
 #include "WebProcessPool.h"
 #include "WebProcessProxy.h"
 #include <WebCore/CertificateInfo.h>
+#include <WebCore/DebugOverlayRegions.h>
 #include <WebCore/MockRealtimeMediaSourceCenter.h>
 #include <WebCore/NotImplemented.h>
 #include <pal/text/TextEncoding.h>
@@ -793,6 +794,19 @@ void WebInspectorUIProxy::setDeveloperPreferenceOverride(WebCore::InspectorBacke
     case InspectorBackendClient::DeveloperPreference::NeedsSiteSpecificQuirks:
         if (RefPtr inspectedPage = m_inspectedPage.get())
             inspectedPage->protectedPreferences()->setNeedsSiteSpecificQuirksInspectorOverride(overrideValue);
+        return;
+
+    case InspectorBackendClient::DeveloperPreference::SiteIsolationDebugOverlay:
+        if (RefPtr inspectedPage = m_inspectedPage.get()) {
+            auto siteIsolationRegion = static_cast<uint32_t>(DebugOverlayRegions::SiteIsolationRegion);
+            auto debugOverlayRegions = inspectedPage->protectedPreferences()->visibleDebugOverlayRegions();
+            if (overrideValue && overrideValue.value())
+                debugOverlayRegions |= siteIsolationRegion;
+            else
+                debugOverlayRegions &= ~siteIsolationRegion;
+
+            inspectedPage->protectedPreferences()->setVisibleDebugOverlayRegions(debugOverlayRegions);
+        }
         return;
     }
 


### PR DESCRIPTION
#### dba688ca0a87a68ccc2e850296935dd2c41a2b92
<pre>
Web Inspector: add toggle for Site Isolation Debug Overlay in Engineering Settings
<a href="https://bugs.webkit.org/show_bug.cgi?id=296076">https://bugs.webkit.org/show_bug.cgi?id=296076</a>
<a href="https://rdar.apple.com/155984834">rdar://155984834</a>

Reviewed by NOBODY (OOPS!).

Hook up the engineering UI setting to SetDeveloperPreferenceOverrides in UIProcess. The setting gets synced
to each frame/WebProcess and those processes are responsible for drawing overlays representing local frames.

* Source/JavaScriptCore/inspector/protocol/Page.json:
* Source/WebCore/inspector/InspectorBackendClient.h:
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::disable):
(WebCore::InspectorPageAgent::overrideSetting):
* Source/WebCore/page/DebugPageOverlays.cpp:
(WebCore::SiteIsolationOverlay::drawRect):
Print the frameID, pid, and URL of each frame in the upper left corner.

* Source/WebInspectorUI/UserInterface/Base/Main.js:
(WI.initializeTarget):
Restore developer override for backend target from frontend when initializing backend target.

* Source/WebInspectorUI/UserInterface/Base/Setting.js: Add new setting.

* Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js:
(WI.SettingsTabContentView.prototype._createEngineeringSettingsView):
Add new Site Isolation section to Engineering Settings.

* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp:
(WebKit::WebInspectorUIProxy::setDeveloperPreferenceOverride):
Add new developer override.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dba688ca0a87a68ccc2e850296935dd2c41a2b92

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112173 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31904 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22382 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118250 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62605 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114135 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32557 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40468 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85214 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35977 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115120 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25980 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100928 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65644 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25286 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19064 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62095 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/104687 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95366 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19141 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121576 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/110787 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39247 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29193 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94034 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39628 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97169 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93857 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39086 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16876 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35275 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39135 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44623 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/135018 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38770 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36307 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42107 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40513 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->