### PR TITLE
Video playback in Slack.com fails

### DIFF
--- a/LayoutTests/media/video-setSinkId-default-expected.txt
+++ b/LayoutTests/media/video-setSinkId-default-expected.txt
@@ -1,0 +1,16 @@
+Test default sinkId with an MP4 source
+RUN(video.setSinkId("default"))
+Promise resolved OK
+RUN(video.src = "content/test.mp4")
+EVENT(canplay)
+PASS
+-
+Test default sinkId with a WebM source
+RUN(video.setSinkId("default"))
+Promise resolved OK
+RUN(video.src = "content/test-vp8.webm")
+EVENT(canplay)
+PASS
+-
+END OF TEST
+

--- a/LayoutTests/media/video-setSinkId-default.html
+++ b/LayoutTests/media/video-setSinkId-default.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>video-setSinkId-default</title>
+    <script src="video-test.js"></script>
+    <script>
+    async function runTest() {
+        await runMP4Test();
+        await runWebMTest();
+    }
+
+    function runSetDefaultSinkId(sinkId) {
+        return new Promise(resolve => {
+            runWithKeyDown(() => {
+                run('video.setSinkId("default")').then(resolve);
+            })
+        });
+    }
+
+    async function runMP4Test() {
+        consoleWrite('Test default sinkId with an MP4 source');
+        video = document.body.appendChild(document.createElement('video'));
+        await shouldResolve(runSetDefaultSinkId())
+        run('video.src = "content/test.mp4"');
+        waitFor(video, 'error').then(failTest);
+        await waitFor(video, 'canplay');
+        consoleWrite('PASS');
+        consoleWrite('-');
+        document.body.removeChild(video);
+        video = null;
+    }
+
+    async function runWebMTest() {
+        consoleWrite('Test default sinkId with a WebM source');
+        video = document.body.appendChild(document.createElement('video'));
+        await shouldResolve(runSetDefaultSinkId())
+        run('video.src = "content/test-vp8.webm"');
+        waitFor(video, 'error').then(failTest);
+        await waitFor(video, 'canplay');
+        document.body.removeChild(video);
+        consoleWrite('PASS');
+        consoleWrite('-');
+        video = null;
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    })
+    </script>
+</head>
+<body>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -3162,3 +3162,6 @@ webkit.org/b/295119  imported/w3c/web-platform-tests/css/css-fonts/font-size-adj
 # imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-number.html [ Failure ]
 # platform/mac/fast/text/line-break-locale.html [ Failure ]
 # fast/forms/appearance-default-button.html [ ImageOnlyFailure ]
+
+# setSinkId is not enabled on WK1
+media/video-setSinkId-default.html [ Skip ]

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -31,6 +31,7 @@
 #import "AVAssetMIMETypeCache.h"
 #import "AVAssetTrackUtilities.h"
 #import "AVTrackPrivateAVFObjCImpl.h"
+#import "AudioMediaStreamTrackRenderer.h"
 #import "AudioSourceProviderAVFObjC.h"
 #import "AudioTrackPrivateAVFObjC.h"
 #import "AuthenticationChallenge.h"
@@ -1120,7 +1121,7 @@ void MediaPlayerPrivateAVFoundationObjC::createAVPlayer()
 #if HAVE(AUDIO_OUTPUT_DEVICE_UNIQUE_ID)
     auto audioOutputDeviceId = player->audioOutputDeviceIdOverride();
     if (!audioOutputDeviceId.isNull()) {
-        if (audioOutputDeviceId.isEmpty())
+        if (audioOutputDeviceId.isEmpty() || audioOutputDeviceId == AudioMediaStreamTrackRenderer::defaultDeviceID())
             m_avPlayer.get().audioOutputDeviceUniqueID = nil;
         else
             m_avPlayer.get().audioOutputDeviceUniqueID = audioOutputDeviceId.createNSString().get();
@@ -4031,7 +4032,7 @@ void MediaPlayerPrivateAVFoundationObjC::audioOutputDeviceChanged()
     if (!m_avPlayer || !player)
         return;
     auto deviceId = player->audioOutputDeviceId();
-    if (deviceId.isEmpty())
+    if (deviceId.isEmpty() || deviceId == AudioMediaStreamTrackRenderer::defaultDeviceID())
         m_avPlayer.get().audioOutputDeviceUniqueID = nil;
     else
         m_avPlayer.get().audioOutputDeviceUniqueID = deviceId.createNSString().get();


### PR DESCRIPTION
#### 12c51b34beded53df3751a0967b6e879c13ca750
<pre>
Video playback in Slack.com fails
<a href="https://rdar.apple.com/155821418">rdar://155821418</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=296078">https://bugs.webkit.org/show_bug.cgi?id=296078</a>

Reviewed by Andy Estes.

Slack.com will set the audio output device of all video and audio elements to the string &quot;default&quot;.
We handle this non-standardized convention for media stream playback, but not yet for file or MSE
playback. Add a carve out for the &quot;default&quot; string, and meanwhile handle some exception cases where
AVSampleBufferAudioRenderer will throw an exception when a &apos;nil&apos; value is set via
-setAudioOutputDeviceUniqueID:.

* LayoutTests/media/video-setSinkId-default-expected.txt: Added.
* LayoutTests/media/video-setSinkId-default.html: Added.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVPlayer):
(WebCore::MediaPlayerPrivateAVFoundationObjC::audioOutputDeviceChanged):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::audioOutputDeviceChanged):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::addAudioRenderer):

Canonical link: <a href="https://commits.webkit.org/297528@main">https://commits.webkit.org/297528@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d51e817a2e8656752351f4e4547dd1dad05d136a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112002 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31672 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22158 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118025 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62239 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113964 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32349 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40250 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85085 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35756 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114949 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25838 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100782 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65518 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25154 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18923 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61877 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95222 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18999 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121344 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39035 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29044 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93933 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39416 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97041 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93750 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23941 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38955 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16744 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35057 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38929 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44441 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38566 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41894 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40282 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->