### PR TITLE
~LocalFrameView destructor does too much work

### DIFF
--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -242,16 +242,10 @@ Ref<LocalFrameView> LocalFrameView::create(LocalFrame& frame, const IntSize& ini
 LocalFrameView::~LocalFrameView()
 {
     removeFromAXObjectCache();
-    resetScrollbars();
 
-    // Custom scrollbars should already be destroyed at this point
-    ASSERT(!horizontalScrollbar() || !horizontalScrollbar()->isCustomScrollbar());
-    ASSERT(!verticalScrollbar() || !verticalScrollbar()->isCustomScrollbar());
-
-    setHasHorizontalScrollbar(false); // Remove native scrollbars now before we lose the connection to the HostWindow.
+    setHasHorizontalScrollbar(false);
     setHasVerticalScrollbar(false);
-    
-    ASSERT(!m_scrollCorner);
+    ASSERT(!m_scrollCorner && !horizontalScrollbar() && !verticalScrollbar());
 
     ASSERT(m_frame->view() != this || !m_frame->contentRenderer());
 }


### PR DESCRIPTION
#### ce392f5d35e766a89db5d395e3d205e5c0c820bc
<pre>
~LocalFrameView destructor does too much work
<a href="https://bugs.webkit.org/show_bug.cgi?id=296075">https://bugs.webkit.org/show_bug.cgi?id=296075</a>
<a href="https://rdar.apple.com/155984367">rdar://155984367</a>

Reviewed by NOBODY (OOPS!).

The call to resetScrollbars() does a bunch of updating that&apos;s necessary
when the view is live, but not when we&apos;re destroying it. Here, we just
need to delete the scrollbar objects, and the subsequent setHas*Scrollbar()
calls take care of that already.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::~LocalFrameView):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce392f5d35e766a89db5d395e3d205e5c0c820bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111957 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31627 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22113 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117980 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62191 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113919 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32304 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40205 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85055 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35755 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114904 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25797 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100748 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65487 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25120 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18948 "Found 60 new test failures: compositing/backing/child-layer-no-backing.html compositing/backing/layer-outside-tiled-parent.html compositing/backing/transition-extent.html compositing/direct-image-compositing.html compositing/geometry/fixed-in-composited.html compositing/geometry/fixed-position.html compositing/geometry/horizontal-scroll-composited.html compositing/geometry/limit-layer-bounds-clipping-ancestor.html compositing/geometry/limit-layer-bounds-fixed-positioned.html compositing/geometry/limit-layer-bounds-fixed.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61828 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95189 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18958 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121289 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38990 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29008 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93907 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39371 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97000 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93724 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38923 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16716 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35012 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38884 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44396 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38521 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41849 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40237 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->