### PR TITLE
[CSS Tree Counting Functions] Allow in `@keyframes`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-font-style-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-font-style-dynamic-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Initially, the sibling-index() is 3 for #target assert_equals: expected "oblique 15deg" but got "normal"
-FAIL Removing a preceding sibling of #target reduces the sibling-index() assert_equals: expected "oblique 10deg" but got "normal"
+PASS Initially, the sibling-index() is 3 for #target
+FAIL Removing a preceding sibling of #target reduces the sibling-index() assert_equals: expected "oblique 10deg" but got "oblique 15deg"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-font-variation-settings-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-font-variation-settings-dynamic-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Initially, the sibling-index() is 3 for #target assert_equals: expected "\"wght\" 3" but got "normal"
-FAIL Removing a preceding sibling of #target reduces the sibling-index() assert_equals: expected "\"wght\" 2" but got "normal"
+PASS Initially, the sibling-index() is 3 for #target
+FAIL Removing a preceding sibling of #target reduces the sibling-index() assert_equals: expected "\"wght\" 2" but got "\"wght\" 3"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-font-weight-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-font-weight-dynamic-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Initially, the sibling-index() is 3 for #target assert_equals: expected "300" but got "400"
-FAIL Removing a preceding sibling of #target reduces the sibling-index() assert_equals: expected "200" but got "400"
+PASS Initially, the sibling-index() is 3 for #target
+FAIL Removing a preceding sibling of #target reduces the sibling-index() assert_equals: expected "200" but got "300"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-length-value-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-length-value-dynamic-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Initially, the sibling-index() is 2 for #target assert_equals: expected "200px" but got "13px"
-FAIL Removing a preceding sibling of #target reduces the sibling-index() assert_equals: expected "100px" but got "13px"
+PASS Initially, the sibling-index() is 2 for #target
+FAIL Removing a preceding sibling of #target reduces the sibling-index() assert_equals: expected "100px" but got "200px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-rotate-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-rotate-dynamic-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Initially, the sibling-index() is 3 for #target assert_equals: expected "x 30deg" but got "x 0deg"
-FAIL Removing a preceding sibling of #target reduces the sibling-index() assert_equals: expected "x 20deg" but got "x 0deg"
+PASS Initially, the sibling-index() is 3 for #target
+FAIL Removing a preceding sibling of #target reduces the sibling-index() assert_equals: expected "x 20deg" but got "x 30deg"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-scale-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-scale-dynamic-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Initially, the sibling-index() is 3 for #target assert_equals: expected "0.7 0.6" but got "1"
-FAIL Removing a preceding sibling of #target reduces the sibling-index() assert_equals: expected "0.7 0.4" but got "1"
+PASS Initially, the sibling-index() is 3 for #target
+FAIL Removing a preceding sibling of #target reduces the sibling-index() assert_equals: expected "0.7 0.4" but got "0.7 0.6"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-transform-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-transform-dynamic-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Initially, the sibling-index() is 3 for #target assert_equals: expected "matrix(1, 0, 0, 1, 30, 0)" but got "none"
-FAIL Removing a preceding sibling of #target reduces the sibling-index() assert_equals: expected "matrix(1, 0, 0, 1, 20, 0)" but got "none"
+PASS Initially, the sibling-index() is 3 for #target
+FAIL Removing a preceding sibling of #target reduces the sibling-index() assert_equals: expected "matrix(1, 0, 0, 1, 20, 0)" but got "matrix(1, 0, 0, 1, 30, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-value-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-value-dynamic-expected.txt
@@ -1,6 +1,6 @@
 You should see a green square below.
 
 
-FAIL Initially, the sibling-index() is 3 for #target assert_equals: expected "3" but got "auto"
-FAIL Removing a preceding sibling of #target reduces the sibling-index() assert_equals: expected "2" but got "auto"
+PASS Initially, the sibling-index() is 3 for #target
+FAIL Removing a preceding sibling of #target reduces the sibling-index() assert_equals: expected "2" but got "3"
 

--- a/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
@@ -1313,7 +1313,9 @@ std::optional<TypedChild> parseCalcFunction(CSSParserTokenRange& tokens, CSSValu
         //     - OUTPUT: <integer>
         if (!state.propertyParserState.context.cssTreeCountingFunctionsEnabled)
             return { };
-        if (state.propertyParserState.currentRule != StyleRuleType::Style || state.propertyParserState.currentProperty == CSSPropertyInvalid)
+        if (state.propertyParserState.currentRule != StyleRuleType::Style && state.propertyParserState.currentRule != StyleRuleType::Keyframe)
+            return { };
+        if (state.propertyParserState.currentProperty == CSSPropertyInvalid)
             return { };
         return consumeZeroArguments<SiblingCount>(tokens, depth, state);
 
@@ -1323,7 +1325,9 @@ std::optional<TypedChild> parseCalcFunction(CSSParserTokenRange& tokens, CSSValu
         //     - OUTPUT: <integer>
         if (!state.propertyParserState.context.cssTreeCountingFunctionsEnabled)
             return { };
-        if (state.propertyParserState.currentRule != StyleRuleType::Style || state.propertyParserState.currentProperty == CSSPropertyInvalid)
+        if (state.propertyParserState.currentRule != StyleRuleType::Style && state.propertyParserState.currentRule != StyleRuleType::Keyframe)
+            return { };
+        if (state.propertyParserState.currentProperty == CSSPropertyInvalid)
             return { };
         return consumeZeroArguments<SiblingIndex>(tokens, depth, state);
 


### PR DESCRIPTION
#### 872fee1cd6311444cd26e2fdc68f17d5c993bdc0
<pre>
[CSS Tree Counting Functions] Allow in `@keyframes`
<a href="https://bugs.webkit.org/show_bug.cgi?id=296086">https://bugs.webkit.org/show_bug.cgi?id=296086</a>
<a href="https://rdar.apple.com/155999583">rdar://155999583</a>

Reviewed by Sam Weinig.

This allows the tree counting functions in keyframes to actually parse and evaluate, instead of rejecting the declarations.

The second subtest is failing because the dynamic behavior when changing the sibling count is not implemented.

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-font-style-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-font-variation-settings-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-font-weight-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-length-value-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-rotate-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-scale-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-transform-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-value-dynamic-expected.txt:
* Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
(WebCore::CSSCalc::parseCalcFunction):

Canonical link: <a href="https://commits.webkit.org/297524@main">https://commits.webkit.org/297524@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e24772e269d470cf0b59296929025da300a07a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111978 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31648 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22134 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118001 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62213 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113940 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32325 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40226 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85067 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35742 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114925 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25818 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100760 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65499 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25136 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18897 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61849 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95205 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18973 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121337 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39011 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29024 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93927 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39392 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97015 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93744 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23938 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38932 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16728 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35033 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38905 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44417 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38542 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41870 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40258 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->