### PR TITLE
[macOS] PiP has initially incorrect play/pause state

### DIFF
--- a/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
@@ -120,6 +120,7 @@ public:
     virtual double bufferedTime() const = 0;
 
     using PlaybackState = PlaybackSessionModelPlaybackState;
+    virtual OptionSet<PlaybackState> playbackState() const = 0;
 
     virtual bool isPlaying() const = 0;
     virtual bool isStalled() const = 0;

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
@@ -110,6 +110,7 @@ public:
     double duration() const final;
     double currentTime() const final;
     double bufferedTime() const final;
+    OptionSet<PlaybackState> playbackState() const final;
     bool isPlaying() const final;
     bool isStalled() const final;
     bool isScrubbing() const final { return false; }

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
@@ -569,12 +569,7 @@ void PlaybackSessionModelMediaElement::maybeUpdateVideoMetadata()
 
 void PlaybackSessionModelMediaElement::updateRate()
 {
-    OptionSet<PlaybackSessionModel::PlaybackState> playbackState;
-    if (isPlaying())
-        playbackState.add(PlaybackSessionModel::PlaybackState::Playing);
-    if (isStalled())
-        playbackState.add(PlaybackSessionModel::PlaybackState::Stalled);
-
+    auto playbackState = this->playbackState();
     double playbackRate =  this->playbackRate();
     double defaultPlaybackRate = this->defaultPlaybackRate();
     for (auto& client : m_clients)
@@ -647,6 +642,16 @@ double PlaybackSessionModelMediaElement::bufferedTime() const
     if (RefPtr mediaElement = m_mediaElement)
         return mediaElement->maxBufferedTime();
     return 0;
+}
+
+auto PlaybackSessionModelMediaElement::playbackState() const -> OptionSet<PlaybackState>
+{
+    OptionSet<PlaybackSessionModel::PlaybackState> playbackState;
+    if (isPlaying())
+        playbackState.add(PlaybackSessionModel::PlaybackState::Playing);
+    if (isStalled())
+        playbackState.add(PlaybackSessionModel::PlaybackState::Stalled);
+    return playbackState;
 }
 
 bool PlaybackSessionModelMediaElement::isPlaying() const

--- a/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
+++ b/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
@@ -155,6 +155,7 @@ private:
     double playbackStartedTime() const override { return 0; }
     double currentTime() const override;
     double bufferedTime() const override;
+    OptionSet<PlaybackState> playbackState() const override;
     bool isPlaying() const override;
     bool isStalled() const override;
     bool isScrubbing() const override { return false; }
@@ -905,6 +906,14 @@ double VideoFullscreenControllerContext::bufferedTime() const
 {
     ASSERT(isUIThread());
     return m_playbackModel ? m_playbackModel->bufferedTime() : 0;
+}
+
+auto VideoFullscreenControllerContext::playbackState() const -> OptionSet<PlaybackState>
+{
+    ASSERT(isUIThread());
+    if (m_playbackModel)
+        return m_playbackModel->playbackState();
+    return { };
 }
 
 bool VideoFullscreenControllerContext::isPlaying() const

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm
@@ -673,17 +673,9 @@ WebVideoPresentationInterfaceMacObjC *VideoPresentationInterfaceMac::videoPresen
 
         auto model = m_playbackSessionInterface->playbackSessionModel();
 
-        AVPlayerTimeControlStatus timeControlStatus = AVPlayerTimeControlStatusPaused;
-        if (model->isStalled() && model->isPlaying())
-            timeControlStatus = AVPlayerTimeControlStatusWaitingToPlayAtSpecifiedRate;
-        else if (model->isPlaying())
-            timeControlStatus = AVPlayerTimeControlStatusPlaying;
-
-        [videoPresentationInterfaceObjC() updateRate:model->playbackRate() andTimeControlStatus:timeControlStatus];
-
         durationChanged(model->duration());
         currentTimeChanged(model->currentTime(), [[NSProcessInfo processInfo] systemUptime]);
-        rateChanged({ }, model->playbackRate(), model->defaultPlaybackRate());
+        rateChanged(model->playbackState(), model->playbackRate(), model->defaultPlaybackRate());
     }
 
     return m_webVideoPresentationInterfaceObjC.get();

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -160,6 +160,7 @@ private:
     double duration() const final { return m_duration; }
     double currentTime() const final { return m_currentTime; }
     double bufferedTime() const final { return m_bufferedTime; }
+    OptionSet<PlaybackState> playbackState() const final { return m_playbackState; }
     bool isPlaying() const final { return m_playbackState.contains(PlaybackState::Playing); }
     bool isStalled() const final { return m_playbackState.contains(PlaybackState::Stalled); }
     bool isScrubbing() const final { return m_isScrubbing; }


### PR DESCRIPTION
#### a571c8031068e6fa1858d2796553f4cc87a46fc9
<pre>
[macOS] PiP has initially incorrect play/pause state
<a href="https://rdar.apple.com/155295121">rdar://155295121</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=296089">https://bugs.webkit.org/show_bug.cgi?id=296089</a>

Reviewed by Andy Estes.

We are initially passing an empty OptionSet for PlaybackState when creating the
`VideoPresentationInterfaceObjC` object, which causes PiP to start out believing the media is
paused. Refactor `PlaybackSessionModel` and its subclasses to expose a `playbackState()` accessor,
and pass in that playback state in the creation method for `VideoPresentationInterfaceObjC`.

* Source/WebCore/platform/cocoa/PlaybackSessionModel.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm:
(WebCore::PlaybackSessionModelMediaElement::updateRate):
(WebCore::PlaybackSessionModelMediaElement::playbackState const):
* Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm:
(VideoFullscreenControllerContext::playbackState const):
* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm:
(WebCore::VideoPresentationInterfaceMac::videoPresentationInterfaceObjC):
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:

Canonical link: <a href="https://commits.webkit.org/297546@main">https://commits.webkit.org/297546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1eda60bc7729d9c7cd765c34a6bbc63c3598d0b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112013 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31684 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22169 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118036 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62250 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113975 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40261 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85092 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35759 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114960 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25844 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100787 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65525 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25160 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18928 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61888 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95230 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19004 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121355 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39046 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29049 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93934 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39427 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97046 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93751 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23954 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38963 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16749 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35068 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38940 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44452 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38577 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41905 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40293 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->