### PR TITLE
ReferenceError doesn't include variable name in error message

### DIFF
--- a/JSTests/ChakraCore/test/EH/try.bug188541.v5.baseline-jsc
+++ b/JSTests/ChakraCore/test/EH/try.bug188541.v5.baseline-jsc
@@ -9,7 +9,7 @@ Caught e=10
 
 foo3():
 Caught e=foo error
-Caught expected err=ReferenceError: Cannot access uninitialized variable.
+Caught expected err=ReferenceError: Cannot access 'e' before initialization.
 Caught e=20
 Caught e=10
 
@@ -20,7 +20,7 @@ Caught e=foo error
 
 foo5():
 Caught e=foo error
-Caught expected err=ReferenceError: Cannot access uninitialized variable.
+Caught expected err=ReferenceError: Cannot access 'e' before initialization.
 Caught e=20
 Caught e=10
 

--- a/JSTests/ChakraCore/test/LetConst/AssignmentToConst.baseline-jsc
+++ b/JSTests/ChakraCore/test/LetConst/AssignmentToConst.baseline-jsc
@@ -35,7 +35,7 @@ TypeError: Attempted to assign to readonly property.
 test 18
 passed
 test 19
-ReferenceError: Cannot access uninitialized variable.
+ReferenceError: Cannot access 'x' before initialization.
 test 20
 TypeError: Attempted to assign to readonly property.
 test 21
@@ -43,6 +43,6 @@ TypeError: Attempted to assign to readonly property.
 test 22
 TypeError: Attempted to assign to readonly property.
 test 23
-ReferenceError: Cannot access uninitialized variable.
+ReferenceError: Cannot access 'x' before initialization.
 test 24
-ReferenceError: Cannot access uninitialized variable.
+ReferenceError: Cannot access 'x' before initialization.

--- a/JSTests/ChakraCore/test/LetConst/defer2.baseline-jsc
+++ b/JSTests/ChakraCore/test/LetConst/defer2.baseline-jsc
@@ -1,4 +1,4 @@
 Exception: TypeError: Attempted to assign to readonly property.
-g@defer2.js:7:15
+g@defer2.js:9:10
 f@defer2.js:11:6
 global code@defer2.js:13:2

--- a/JSTests/ChakraCore/test/LetConst/defer5.baseline-jsc
+++ b/JSTests/ChakraCore/test/LetConst/defer5.baseline-jsc
@@ -1,4 +1,4 @@
-Exception: ReferenceError: Cannot access uninitialized variable.
+Exception: ReferenceError: Cannot access 'bar' before initialization.
 foo@defer5.js:11:12
 test@defer5.js:14:8
 global code@defer5.js:18:5

--- a/JSTests/ChakraCore/test/LetConst/storeundecl_eval.baseline-jsc
+++ b/JSTests/ChakraCore/test/LetConst/storeundecl_eval.baseline-jsc
@@ -1,2 +1,2 @@
-ReferenceError: Cannot access uninitialized variable.
-ReferenceError: Cannot access uninitialized variable.
+ReferenceError: Cannot access 'x' before initialization.
+ReferenceError: Cannot access 'x' before initialization.

--- a/JSTests/ChakraCore/test/LetConst/storeundecl_multiscript.baseline-jsc
+++ b/JSTests/ChakraCore/test/LetConst/storeundecl_multiscript.baseline-jsc
@@ -1,2 +1,2 @@
-ReferenceError: Cannot access uninitialized variable.
-ReferenceError: Cannot access uninitialized variable.
+ReferenceError: Cannot access 'x' before initialization.
+ReferenceError: Cannot access 'x' before initialization.

--- a/JSTests/ChakraCore/test/LetConst/tdz1.baseline-jsc
+++ b/JSTests/ChakraCore/test/LetConst/tdz1.baseline-jsc
@@ -1,48 +1,48 @@
-ReferenceError: Cannot access uninitialized variable.
+ReferenceError: Cannot access 'x' before initialization.
 local x
-ReferenceError: Cannot access uninitialized variable.
+ReferenceError: Cannot access 'x' before initialization.
 local x
-ReferenceError: Cannot access uninitialized variable.
+ReferenceError: Cannot access 'a' before initialization.
 a is a string
 did not delete a
 did not delete a
-ReferenceError: Cannot access uninitialized variable.
-ReferenceError: Cannot access uninitialized variable.
+ReferenceError: Cannot access 't' before initialization.
+ReferenceError: Cannot access 't' before initialization.
 undefined
-ReferenceError: Cannot access uninitialized variable.
-ReferenceError: Cannot access uninitialized variable.
-ReferenceError: Cannot access uninitialized variable.
-ReferenceError: Cannot access uninitialized variable.
-ReferenceError: Cannot access uninitialized variable.
-ReferenceError: Cannot access uninitialized variable.
-ReferenceError: Cannot access uninitialized variable.
-ReferenceError: Cannot access uninitialized variable.
-ReferenceError: Cannot access uninitialized variable.
-ReferenceError: Cannot access uninitialized variable.
+ReferenceError: Cannot access 'foo' before initialization.
+ReferenceError: Cannot access 'foo' before initialization.
+ReferenceError: Cannot access 'foo' before initialization.
+ReferenceError: Cannot access 'foo' before initialization.
+ReferenceError: Cannot access 'a' before initialization.
+ReferenceError: Cannot access 'a' before initialization.
+ReferenceError: Cannot access 'a' before initialization.
+ReferenceError: Cannot access 'a' before initialization.
+ReferenceError: Cannot access 'a' before initialization.
+ReferenceError: Cannot access 'a' before initialization.
 false
-ReferenceError: Cannot access uninitialized variable.
-false
-string
-false
-ReferenceError: Cannot access uninitialized variable.
+ReferenceError: Cannot access 'glo_a' before initialization.
 false
 string
-ReferenceError: Cannot access uninitialized variable.
+false
+ReferenceError: Cannot access 'glo_b' before initialization.
+false
+string
+ReferenceError: Cannot access 'x' before initialization.
 function () { write(y = 123); }
 123
 123
-ReferenceError: Cannot access uninitialized variable.
+ReferenceError: Cannot access 'y' before initialization.
 function () { write(y = 123); }
 123
 123
-ReferenceError: Cannot access uninitialized variable.
+ReferenceError: Cannot access 'y' before initialization.
 function
-ReferenceError: Cannot access uninitialized variable.
+ReferenceError: Cannot access 'y' before initialization.
 function
-ReferenceError: Cannot access uninitialized variable.
+ReferenceError: Cannot access 'y' before initialization.
 function () { write(y); }
-ReferenceError: Cannot access uninitialized variable.
+ReferenceError: Cannot access 'y' before initialization.
 function () { write(y); }
-ReferenceError: Cannot access uninitialized variable.
-ReferenceError: Cannot access uninitialized variable.
-ReferenceError: Cannot access uninitialized variable.
+ReferenceError: Cannot access 'y' before initialization.
+ReferenceError: Cannot access 'y' before initialization.
+ReferenceError: Cannot access 'y' before initialization.

--- a/JSTests/ChakraCore/test/LetConst/with.baseline-jsc
+++ b/JSTests/ChakraCore/test/LetConst/with.baseline-jsc
@@ -1,8 +1,8 @@
 0
 0
 0
-ReferenceError: Cannot access uninitialized variable.
-ReferenceError: Cannot access uninitialized variable.
+ReferenceError: Cannot access 'x' before initialization.
+ReferenceError: Cannot access 'x' before initialization.
 1
-ReferenceError: Cannot access uninitialized variable.
+ReferenceError: Cannot access 'x' before initialization.
 string

--- a/JSTests/ChakraCore/test/UnitTestFramework/UnitTestFramework.js
+++ b/JSTests/ChakraCore/test/UnitTestFramework/UnitTestFramework.js
@@ -322,6 +322,11 @@ var assert = function assert() {
             }
             var validationErrorMessage = exception instanceof Error ? exception.message : undefined;
 
+            const jscReferenceErrorMessageRegexp = /Cannot access '\w+' before initialization\./
+            if (expectedException instanceof ReferenceError && jscReferenceErrorMessageRegexp.test(validationErrorMessage)) {
+                return;
+            }
+
             // Remap Chakra exception expectations to JSC exception expectations.
             var jscReplacements = [
                 {
@@ -429,13 +434,14 @@ var assert = function assert() {
                     replStr: "Proxy 'setPrototypeOf' returned false indicating it could not set the prototype value. The operation was expected to succeed"
                 }
             ];
+
             for (let idx = 0; idx < jscReplacements.length; idx++) {
                 if (jscReplacements[idx].regexp.test(expectedErrorMessage)) {
                     expectedErrorMessage = expectedErrorMessage.replace(jscReplacements[idx].regexp, jscReplacements[idx].replStr);
                     break;
                 }
             }
-            
+
             if (validationPart !== expectedException || (expectedErrorMessage && validationErrorMessage !== expectedErrorMessage)) {
                 var expectedString = expectedException !== undefined ?
                   expectedException.toString().replace(/\n/g, "").replace(/.*function (.*)\(.*/g, "$1") :

--- a/JSTests/ChakraCore/test/es6/letconst_global_shadow_builtins.baseline-jsc
+++ b/JSTests/ChakraCore/test/es6/letconst_global_shadow_builtins.baseline-jsc
@@ -1,6 +1,6 @@
 [object Math]
-ReferenceError: Cannot access uninitialized variable.
-ReferenceError: Cannot access uninitialized variable.
+ReferenceError: Cannot access 'Math' before initialization.
+ReferenceError: Cannot access 'Math' before initialization.
 [object Math]
 3.141592653589793
 undefined
@@ -8,8 +8,8 @@ undefined
 undefined
 delicious
 [object JSON]
-ReferenceError: Cannot access uninitialized variable.
-ReferenceError: Cannot access uninitialized variable.
+ReferenceError: Cannot access 'JSON' before initialization.
+ReferenceError: Cannot access 'JSON' before initialization.
 [object JSON]
 function stringify() {
     [native code]

--- a/JSTests/ChakraCore/test/es6/letconst_global_shadowing.baseline-jsc
+++ b/JSTests/ChakraCore/test/es6/letconst_global_shadowing.baseline-jsc
@@ -4,10 +4,10 @@
 
 Before x, y, z, w declarations and globals
 
-ReferenceError: Cannot access uninitialized variable.
-ReferenceError: Cannot access uninitialized variable.
-ReferenceError: Cannot access uninitialized variable.
-ReferenceError: Cannot access uninitialized variable.
+ReferenceError: Cannot access 'x' before initialization.
+ReferenceError: Cannot access 'y' before initialization.
+ReferenceError: Cannot access 'z' before initialization.
+ReferenceError: Cannot access 'w' before initialization.
 undefined
 undefined
 undefined
@@ -17,9 +17,9 @@ undefined
 After let x, this.y, const z, this.w
 
 let x
-ReferenceError: Cannot access uninitialized variable.
+ReferenceError: Cannot access 'y' before initialization.
 const z
-ReferenceError: Cannot access uninitialized variable.
+ReferenceError: Cannot access 'w' before initialization.
 undefined
 this.y
 undefined
@@ -48,7 +48,7 @@ this.w
 
 ==== Attributes on global properties should not be lost with let/const shadowing ====
 
-ReferenceError: Cannot access uninitialized variable.
+ReferenceError: Cannot access 'p' before initialization.
 this.p
 {
     value: this.p

--- a/JSTests/ChakraCore/test/es6/unicode_blue_533163_utf8.baseline-jsc
+++ b/JSTests/ChakraCore/test/es6/unicode_blue_533163_utf8.baseline-jsc
@@ -1,3 +1,3 @@
-Exception: ReferenceError: Cannot access uninitialized variable.
-testcase@unicode_blue_533163_utf8.js:6:18
+Exception: ReferenceError: Cannot access 'a' before initialization.
+testcase@unicode_blue_533163_utf8.js:8:14
 global code@unicode_blue_533163_utf8.js:11:9

--- a/JSTests/modules/cyclic-may-produce-tdz/1.js
+++ b/JSTests/modules/cyclic-may-produce-tdz/1.js
@@ -6,7 +6,7 @@ export let Cocoa = "Cocoa";
 // module "2" is not loaded yet, TDZ.
 shouldThrow(() => {
     Cappuccino;
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'Cappuccino' before initialization.`);
 
 // But "Matcha" is variable (not lexical variable). It is already initialized as undefined.
 shouldBe(Matcha, undefined);

--- a/JSTests/modules/exported-function-may-be-called-before-module-is-executed/1.js
+++ b/JSTests/modules/exported-function-may-be-called-before-module-is-executed/1.js
@@ -12,4 +12,4 @@ shouldThrow(() => {
     // raise function touches the lexical variable in the module "2", so TDZ
     // error should be raised.
     raise();
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'value' before initialization.`);

--- a/JSTests/modules/module-eval/A.js
+++ b/JSTests/modules/module-eval/A.js
@@ -5,4 +5,4 @@ export let A = "A";
 
 shouldThrow(() => {
     eval("B");
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'B' before initialization.`);

--- a/JSTests/modules/module-namespace-is-frozen.js
+++ b/JSTests/modules/module-namespace-is-frozen.js
@@ -3,7 +3,7 @@ import {shouldThrow} from "./resources/assert.js"
 
 shouldThrow(() => {
     Object.isFrozen(ns);
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'a' before initialization.`);
 
 export let a;
 export function b () { }

--- a/JSTests/modules/module-namespace-is-sealed.js
+++ b/JSTests/modules/module-namespace-is-sealed.js
@@ -3,7 +3,7 @@ import {shouldThrow} from "./resources/assert.js"
 
 shouldThrow(() => {
     Object.isSealed(ns);
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'a' before initialization.`);
 
 export let a;
 export function b () { }

--- a/JSTests/modules/namespace-empty.js
+++ b/JSTests/modules/namespace-empty.js
@@ -10,7 +10,7 @@ noInline(access);
 for (var i = 0; i < 1e3; ++i) {
     shouldThrow(() => {
         access(ns);
-    }, `ReferenceError: Cannot access uninitialized variable.`);
+    }, `ReferenceError: Cannot access 'test' before initialization.`);
 }
 
 

--- a/JSTests/modules/namespace-object-get-property.js
+++ b/JSTests/modules/namespace-object-get-property.js
@@ -3,7 +3,7 @@ import * as ns from "./namespace-object-get-property.js"
 
 shouldThrow(() => {
     Reflect.get(ns, 'empty');
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'empty' before initialization.`);
 shouldBe(Reflect.get(ns, 'undefined'), undefined);
 
 export let empty;

--- a/JSTests/modules/namespace-tdz/B.js
+++ b/JSTests/modules/namespace-tdz/B.js
@@ -5,11 +5,11 @@ export const B = 256;
 
 shouldThrow(() => {
     print(namespace.A);
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'A' before initialization.`);
 
 shouldThrow(() => {
     Reflect.getOwnPropertyDescriptor(namespace, 'A');
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'A' before initialization.`);
 
 // Not throw any errors even if the field is not initialized yet.
 shouldBe('A' in namespace, true);

--- a/JSTests/stress/class-expression-should-be-tdz-in-heritage.js
+++ b/JSTests/stress/class-expression-should-be-tdz-in-heritage.js
@@ -17,4 +17,4 @@ function shouldThrow(func, errorMessage) {
 shouldThrow(function () {
     class A extends A {
     }
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'A' before initialization.`);

--- a/JSTests/stress/class-expression-should-store-result-at-last.js
+++ b/JSTests/stress/class-expression-should-store-result-at-last.js
@@ -19,4 +19,4 @@ shouldThrow(() => {
         {
         }
     };
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'a' before initialization.`);

--- a/JSTests/stress/const-lexical-binding-shadow-existing-global-property-tdz-ftl.js
+++ b/JSTests/stress/const-lexical-binding-shadow-existing-global-property-tdz-ftl.js
@@ -34,20 +34,20 @@ for (var i = 0; i < testLoopCount; ++i)
 shouldBe(bar, 4);
 shouldThrow(() => {
     $.evalScript('get(); const bar = 3;');
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'bar' before initialization.`);
 shouldThrow(() => {
     shouldBe(bar, 3);
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'bar' before initialization.`);
 shouldThrow(() => {
     shouldBe(get(), 3);
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'bar' before initialization.`);
 shouldThrow(() => {
     $.evalScript('bar;');
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'bar' before initialization.`);
 
 for (var i = 0; i < 1e3; ++i) {
     shouldThrow(() => {
         shouldBe(get(), 3);
-    }, `ReferenceError: Cannot access uninitialized variable.`);
+    }, `ReferenceError: Cannot access 'bar' before initialization.`);
 }
 

--- a/JSTests/stress/const-lexical-binding-shadow-existing-global-property-tdz.js
+++ b/JSTests/stress/const-lexical-binding-shadow-existing-global-property-tdz.js
@@ -32,13 +32,13 @@ shouldBe(get(), 4);
 shouldBe(bar, 4);
 shouldThrow(() => {
     $.evalScript('get(); const bar = 3;');
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'bar' before initialization.`);
 shouldThrow(() => {
     shouldBe(bar, 3);
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'bar' before initialization.`);
 shouldThrow(() => {
     shouldBe(get(), 3);
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'bar' before initialization.`);
 shouldThrow(() => {
     $.evalScript('bar;');
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'bar' before initialization.`);

--- a/JSTests/stress/for-of-tdz-with-try-catch.js
+++ b/JSTests/stress/for-of-tdz-with-try-catch.js
@@ -16,7 +16,7 @@ for (i = 0; i < 1000; i++) {
     try {
         test();
     } catch(e) {
-        if (e != "ReferenceError: Cannot access uninitialized variable.")
-            throw "Expected \"ReferenceError: Cannot access uninitialized variable.\", but got \"" + e +"\"";
+        if (e != "ReferenceError: Cannot access 'o' before initialization.")
+            throw "Expected \"ReferenceError: Cannot access 'o' before initialization.\", but got \"" + e +"\"";
     }
 }

--- a/JSTests/stress/function-constructor-reading-from-global-lexical-environment.js
+++ b/JSTests/stress/function-constructor-reading-from-global-lexical-environment.js
@@ -73,7 +73,7 @@ test(function() {
         f();
     } catch(e) {
         threw = true;
-        assert(e.toString() === "ReferenceError: Cannot access uninitialized variable.")
+        assert(e.toString() === "ReferenceError: Cannot access 'constTDZ' before initialization.")
     }
     assert(threw);
 });
@@ -85,7 +85,7 @@ test(function() {
         f();
     } catch(e) {
         threw = true;
-        assert(e.toString() === "ReferenceError: Cannot access uninitialized variable.")
+        assert(e.toString() === "ReferenceError: Cannot access 'constTDZ' before initialization.")
     }
     assert(threw);
 });
@@ -97,7 +97,7 @@ test(function() {
         f();
     } catch(e) {
         threw = true;
-        assert(e.toString() === "ReferenceError: Cannot access uninitialized variable.")
+        assert(e.toString() === "ReferenceError: Cannot access 'letTDZ' before initialization.")
     }
     assert(threw);
 });
@@ -109,7 +109,7 @@ test(function() {
         f();
     } catch(e) {
         threw = true;
-        assert(e.toString() === "ReferenceError: Cannot access uninitialized variable.")
+        assert(e.toString() === "ReferenceError: Cannot access 'letTDZ' before initialization.")
     }
     assert(threw);
 });
@@ -121,7 +121,7 @@ test(function() {
         f();
     } catch(e) {
         threw = true;
-        assert(e.toString() === "ReferenceError: Cannot access uninitialized variable.")
+        assert(e.toString() === "ReferenceError: Cannot access 'ClassTDZ' before initialization.")
     }
     assert(threw);
 });

--- a/JSTests/stress/generator-frame-empty.js
+++ b/JSTests/stress/generator-frame-empty.js
@@ -31,4 +31,4 @@ shouldThrow(function () {
     }
     for (let v of fib(true)) {
     }
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'c' before initialization.`);

--- a/JSTests/stress/jsonp-program-evaluate-path-must-handle-tdz.js
+++ b/JSTests/stress/jsonp-program-evaluate-path-must-handle-tdz.js
@@ -1,8 +1,8 @@
 disableRichSourceInfo();
 
-expectedError = "ReferenceError: Cannot access uninitialized variable.";
 
-function shouldThrow(func) {
+function shouldThrow(func, variableName) {
+    const expectedError = `ReferenceError: Cannot access '${variableName}' before initialization.`;
     var actualError = false;
     try {
         func();
@@ -82,23 +82,23 @@ function test16() {
     loadString("c.foo[0][0] = 42;");
 }
 
-shouldThrow(test1);
-shouldThrow(test2);
-shouldThrow(test3);
-shouldThrow(test4);
-shouldThrow(test5);
-shouldThrow(test6);
-shouldThrow(test7);
-shouldThrow(test8);
+shouldThrow(test1, 'a');
+shouldThrow(test2, 'a');
+shouldThrow(test3, 'a');
+shouldThrow(test4, 'a');
+shouldThrow(test5, 'a');
+shouldThrow(test6, 'a');
+shouldThrow(test7, 'a');
+shouldThrow(test8, 'a');
 
-shouldThrow(test9);
-shouldThrow(test10);
-shouldThrow(test11);
-shouldThrow(test12);
-shouldThrow(test13);
-shouldThrow(test14);
-shouldThrow(test15);
-shouldThrow(test16);
+shouldThrow(test9, 'c');
+shouldThrow(test10, 'c');
+shouldThrow(test11, 'c');
+shouldThrow(test12, 'c');
+shouldThrow(test13, 'c');
+shouldThrow(test14, 'c');
+shouldThrow(test15, 'c');
+shouldThrow(test16, 'c');
 
 let a;
 let b;

--- a/JSTests/stress/let-lexical-binding-shadow-existing-global-property-tdz-ftl.js
+++ b/JSTests/stress/let-lexical-binding-shadow-existing-global-property-tdz-ftl.js
@@ -34,20 +34,20 @@ for (var i = 0; i < testLoopCount; ++i)
 shouldBe(bar, 4);
 shouldThrow(() => {
     $.evalScript('get(); let bar = 3;');
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'bar' before initialization.`);
 shouldThrow(() => {
     shouldBe(bar, 3);
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'bar' before initialization.`);
 shouldThrow(() => {
     shouldBe(get(), 3);
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'bar' before initialization.`);
 shouldThrow(() => {
     $.evalScript('bar;');
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'bar' before initialization.`);
 
 for (var i = 0; i < 1e3; ++i) {
     shouldThrow(() => {
         shouldBe(get(), 3);
-    }, `ReferenceError: Cannot access uninitialized variable.`);
+    }, `ReferenceError: Cannot access 'bar' before initialization.`);
 }
 

--- a/JSTests/stress/let-lexical-binding-shadow-existing-global-property-tdz.js
+++ b/JSTests/stress/let-lexical-binding-shadow-existing-global-property-tdz.js
@@ -32,13 +32,13 @@ shouldBe(get(), 4);
 shouldBe(bar, 4);
 shouldThrow(() => {
     $.evalScript('get(); let bar = 3;');
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'bar' before initialization.`);
 shouldThrow(() => {
     shouldBe(bar, 3);
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'bar' before initialization.`);
 shouldThrow(() => {
     shouldBe(get(), 3);
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'bar' before initialization.`);
 shouldThrow(() => {
     $.evalScript('bar;');
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'bar' before initialization.`);

--- a/JSTests/stress/object-pattern-simple-fast-path.js
+++ b/JSTests/stress/object-pattern-simple-fast-path.js
@@ -36,14 +36,14 @@ shouldThrow(() => {
 
 shouldThrow(() => {
     const { data } = data;
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'data' before initialization.`);
 
 shouldThrow(() => {
     const { [throwing()]: data } = { data: 50 };
     function throwing() {
         data;
     }
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'data' before initialization.`);
 
 (function () {
     let data = 42;
@@ -58,18 +58,18 @@ shouldThrow(() => {
 
 shouldThrow(() => {
     let { data } = data;
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'data' before initialization.`);
 
 shouldThrow(() => {
     let { [throwing()]: data } = { data: 50 };
     function throwing() {
         data;
     }
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'data' before initialization.`);
 
 shouldThrow(() => {
     let { [data = 'data']: data } = { data: 50 };
-}, `ReferenceError: Cannot access uninitialized variable.`);
+}, `ReferenceError: Cannot access 'data' before initialization.`);
 
 (function () {
     let { [43]: data } = { 43: 50 };

--- a/JSTests/stress/parameter-scoping.js
+++ b/JSTests/stress/parameter-scoping.js
@@ -173,7 +173,7 @@ test(function() {
     try {
         foo(null, obj, [], {}, 20);
     } catch(e) {
-        assert(e.toString() === "ReferenceError: Cannot access uninitialized variable.");
+        assert(e.toString() === "ReferenceError: Cannot access 'e' before initialization.");
     }
 });
 

--- a/JSTests/stress/regress-185995.js
+++ b/JSTests/stress/regress-185995.js
@@ -8,6 +8,6 @@
         exception = e;
     }
 
-    if (exception != "ReferenceError: Cannot access uninitialized variable.")
+    if (exception != "ReferenceError: Cannot access 'x' before initialization.")
         throw "FAILED";
 })();

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/evaluation-error-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/evaluation-error-2-expected.txt
@@ -1,4 +1,4 @@
 
 FAIL Test that ill-founded cyclic dependencies cause ReferenceError during evaluation, which leads to error events on window, and that exceptions are remembered.
- assert_array_equals: lengths differ, expected array ["cycle-tdz-access-a", object "ReferenceError: Cannot access uninitialized variable.", "load", [...], "load", [...], "load"] length 7, got ["cycle-tdz-access-a", object "ReferenceError: Cannot access uninitialized variable.", "load", "load", "load"] length 5
+ assert_array_equals: lengths differ, expected array ["cycle-tdz-access-a", object "ReferenceError: Cannot access 'Y' before initialization.", "load", [...], "load", [...], "load"] length 7, got ["cycle-tdz-access-a", object "ReferenceError: Cannot access 'Y' before initialization.", "load", "load", "load"] length 5
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-events-and-exceptions-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-events-and-exceptions-expected.txt
@@ -2,5 +2,5 @@
 FAIL MediaRecorder events and exceptions assert_throws_dom: recorder should throw() with unsupported mimeType function "function() {
                         recorder = new MediaRecorder(
                           new MediaStream(), {mimeType : "video/invalid"});
-                      }" threw object "ReferenceError: Cannot access uninitialized variable." that is not a DOMException NotSupportedError: property "code" is equal to undefined, expected 9
+                      }" threw object "ReferenceError: Cannot access 'recorder' before initialization." that is not a DOMException NotSupportedError: property "code" is equal to undefined, expected 9
 

--- a/LayoutTests/js/arguments-iterator-expected.txt
+++ b/LayoutTests/js/arguments-iterator-expected.txt
@@ -3,7 +3,7 @@ This test checks the behavior of Arguments object iteration.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS (function (arguments) { for (var argument of arguments) {}})() threw exception TypeError: undefined is not an object (evaluating 'argument of arguments').
+PASS (function (arguments) { for (var argument of arguments) {}})() threw exception TypeError: undefined is not an object (evaluating 'arguments').
 PASS actualArgumentsLength is iteratedArgumentsLength
 PASS arg === realArg is true
 PASS actualArgumentsLength is iteratedArgumentsLength

--- a/LayoutTests/js/class-syntax-name-expected.txt
+++ b/LayoutTests/js/class-syntax-name-expected.txt
@@ -108,8 +108,8 @@ PASS 'use strict'; var VarA = class A { constructor() {} }; var VarB = class B e
 Class statement binding in other circumstances
 PASS var result = A; result:::ReferenceError: Can't find variable: A
 PASS 'use strict'; var result = A; result:::ReferenceError: Can't find variable: A
-PASS var result = A; class A {}; result:::ReferenceError: Cannot access uninitialized variable.
-PASS 'use strict'; var result = A; class A {}; result:::ReferenceError: Cannot access uninitialized variable.
+PASS var result = A; class A {}; result:::ReferenceError: Cannot access 'A' before initialization.
+PASS 'use strict'; var result = A; class A {}; result:::ReferenceError: Cannot access 'A' before initialization.
 PASS class A { constructor() { A = 1; } }; new A:::TypeError: Attempted to assign to readonly property.
 PASS 'use strict'; class A { constructor() { A = 1; } }; new A:::TypeError: Attempted to assign to readonly property.
 PASS class A { constructor() { } }; A = 1; A:::1

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -4645,7 +4645,7 @@ JSC_DEFINE_JIT_OPERATION(operationGetDynamicVar, EncodedJSValue, (JSGlobalObject
             // When we can't statically prove we need a TDZ check, we must perform the check on the slow path.
             JSValue result = slot.getValue(globalObject, ident);
             if (result == jsTDZValue()) {
-                throwException(globalObject, scope, createTDZError(globalObject));
+                throwException(globalObject, scope, createTDZError(globalObject, ident.string()));
                 return jsUndefined();
             }
             return result;
@@ -4670,7 +4670,7 @@ ALWAYS_INLINE static void putDynamicVar(JSGlobalObject* globalObject, VM& vm, JS
         PropertySlot slot(scope, PropertySlot::InternalMethodType::Get);
         JSGlobalLexicalEnvironment::getOwnPropertySlot(scope, globalObject, ident, slot);
         if (slot.getValue(globalObject, ident) == jsTDZValue()) {
-            throwException(globalObject, throwScope, createTDZError(globalObject));
+            throwException(globalObject, throwScope, createTDZError(globalObject, ident.string()));
             return;
         }
     }

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -1165,7 +1165,7 @@ JSValue Interpreter::executeProgram(const SourceCode& source, JSGlobalObject*, J
                     PropertySlot slot(scope, PropertySlot::InternalMethodType::Get);
                     JSGlobalLexicalEnvironment::getOwnPropertySlot(scope, globalObject, ident, slot);
                     if (slot.getValue(globalObject, ident) == jsTDZValue())
-                        return throwException(globalObject, throwScope, createTDZError(globalObject));
+                        return throwException(globalObject, throwScope, createTDZError(globalObject, ident.string()));
                     baseObject = scope;
                 }
             }

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -4524,7 +4524,7 @@ JSC_DEFINE_JIT_OPERATION(operationGetFromScope, EncodedJSValue, (JSGlobalObject*
             // When we can't statically prove we need a TDZ check, we must perform the check on the slow path.
             result = slot.getValue(globalObject, ident);
             if (result == jsTDZValue()) {
-                throwException(globalObject, scope, createTDZError(globalObject));
+                throwException(globalObject, scope, createTDZError(globalObject, ident.string()));
                 return jsUndefined();
             }
         }
@@ -4573,7 +4573,7 @@ JSC_DEFINE_JIT_OPERATION(operationPutToScope, void, (JSGlobalObject* globalObjec
         PropertySlot slot(jsScope, PropertySlot::InternalMethodType::Get);
         JSGlobalLexicalEnvironment::getOwnPropertySlot(jsScope, globalObject, ident, slot);
         if (slot.getValue(globalObject, ident) == jsTDZValue()) {
-            throwException(globalObject, scope, createTDZError(globalObject));
+            throwException(globalObject, scope, createTDZError(globalObject, ident.string()));
             OPERATION_RETURN(scope);
         }
     }

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -2405,7 +2405,7 @@ LLINT_SLOW_PATH_DECL(slow_path_get_from_scope)
             // When we can't statically prove we need a TDZ check, we must perform the check on the slow path.
             result = slot.getValue(globalObject, ident);
             if (result == jsTDZValue())
-                return throwException(globalObject, throwScope, createTDZError(globalObject));
+                return throwException(globalObject, throwScope, createTDZError(globalObject, ident.string()));
         }
 
         CommonSlowPaths::tryCacheGetFromScopeGlobal(globalObject, codeBlock, vm, bytecode, scope, slot, ident);
@@ -2446,7 +2446,7 @@ LLINT_SLOW_PATH_DECL(slow_path_put_to_scope)
         PropertySlot slot(scope, PropertySlot::InternalMethodType::Get);
         JSGlobalLexicalEnvironment::getOwnPropertySlot(scope, globalObject, ident, slot);
         if (slot.getValue(globalObject, ident) == jsTDZValue())
-            LLINT_THROW(createTDZError(globalObject));
+            LLINT_THROW(createTDZError(globalObject, ident.string()));
     }
 
     if (metadata.m_getPutInfo.resolveMode() == ThrowIfNotFound && !hasProperty)

--- a/Source/JavaScriptCore/parser/ASTBuilder.h
+++ b/Source/JavaScriptCore/parser/ASTBuilder.h
@@ -142,7 +142,7 @@ public:
     ExpressionNode* makeAssignNode(const JSTokenLocation&, ExpressionNode* left, Operator, ExpressionNode* right, bool leftHasAssignments, bool rightHasAssignments, const JSTextPosition& start, const JSTextPosition& divot, const JSTextPosition& end);
     ExpressionNode* makePrefixNode(const JSTokenLocation&, ExpressionNode*, Operator, const JSTextPosition& start, const JSTextPosition& divot, const JSTextPosition& end);
     ExpressionNode* makePostfixNode(const JSTokenLocation&, ExpressionNode*, Operator, const JSTextPosition& start, const JSTextPosition& divot, const JSTextPosition& end);
-    ExpressionNode* makeTypeOfNode(const JSTokenLocation&, ExpressionNode*);
+    ExpressionNode* makeTypeOfNode(const JSTokenLocation&, ExpressionNode*, const JSTextPosition& start, const JSTextPosition& divot, const JSTextPosition& end);
     ExpressionNode* makeDeleteNode(const JSTokenLocation&, ExpressionNode*, const JSTextPosition& start, const JSTextPosition& divot, const JSTextPosition& end);
     ExpressionNode* makeNegateNode(const JSTokenLocation&, ExpressionNode*);
     ExpressionNode* makeBitwiseNotNode(const JSTokenLocation&, ExpressionNode*);
@@ -1217,11 +1217,11 @@ private:
     int m_evalCount;
 };
 
-ExpressionNode* ASTBuilder::makeTypeOfNode(const JSTokenLocation& location, ExpressionNode* expr)
+ExpressionNode* ASTBuilder::makeTypeOfNode(const JSTokenLocation& location, ExpressionNode* expr, const JSTextPosition& start, const JSTextPosition& divot, const JSTextPosition& end)
 {
     if (expr->isResolveNode()) {
         ResolveNode* resolve = static_cast<ResolveNode*>(expr);
-        return new (m_parserArena) TypeOfResolveNode(location, resolve->identifier());
+        return new (m_parserArena) TypeOfResolveNode(location, resolve->identifier(), start, divot, end);
     }
     return new (m_parserArena) TypeOfValueNode(location, expr);
 }

--- a/Source/JavaScriptCore/parser/NodeConstructors.h
+++ b/Source/JavaScriptCore/parser/NodeConstructors.h
@@ -514,8 +514,9 @@ namespace JSC {
     {
     }
 
-    inline TypeOfResolveNode::TypeOfResolveNode(const JSTokenLocation& location, const Identifier& ident)
+    inline TypeOfResolveNode::TypeOfResolveNode(const JSTokenLocation& location, const Identifier& ident, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd)
         : ExpressionNode(location, ResultType::stringType())
+        , ThrowableExpressionData(divot, divotStart, divotEnd)
         , m_ident(ident)
     {
     }

--- a/Source/JavaScriptCore/parser/Nodes.h
+++ b/Source/JavaScriptCore/parser/Nodes.h
@@ -1184,9 +1184,9 @@ namespace JSC {
         ExpressionNode* m_expr;
     };
 
-    class TypeOfResolveNode final : public ExpressionNode {
+    class TypeOfResolveNode final : public ExpressionNode, public ThrowableExpressionData {
     public:
-        TypeOfResolveNode(const JSTokenLocation&, const Identifier&);
+        TypeOfResolveNode(const JSTokenLocation&, const Identifier&, const JSTextPosition&, const JSTextPosition&, const JSTextPosition&);
 
         const Identifier& identifier() const { return m_ident; }
 

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -5617,7 +5617,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseUnaryExpress
             m_parserState.assignmentCount++;
             break;
         case TYPEOF:
-            expr = context.makeTypeOfNode(location, expr);
+            expr = context.makeTypeOfNode(location, expr, subExprStart, subExprStart, end);
             break;
         case VOIDTOKEN:
             expr = context.createVoid(location, expr);

--- a/Source/JavaScriptCore/parser/SourceProvider.h
+++ b/Source/JavaScriptCore/parser/SourceProvider.h
@@ -74,7 +74,7 @@ public:
     virtual void updateCache(const UnlinkedFunctionExecutable*, const SourceCode&, CodeSpecializationKind, const UnlinkedFunctionCodeBlock*) const { }
     virtual void commitCachedBytecode() const { }
 
-    StringView getRange(int start, int end) const
+    StringView getRange(int start, int end) const LIFETIME_BOUND
     {
         return source().substring(start, end - start);
     }

--- a/Source/JavaScriptCore/parser/SyntaxChecker.h
+++ b/Source/JavaScriptCore/parser/SyntaxChecker.h
@@ -157,7 +157,7 @@ public:
     ExpressionType makeAssignNode(const JSTokenLocation&, ExpressionType, Operator, ExpressionType, bool, bool, int, int, int) { return AssignmentExpr; }
     ExpressionType makePrefixNode(const JSTokenLocation&, ExpressionType, Operator, int, int, int) { return PreExpr; }
     ExpressionType makePostfixNode(const JSTokenLocation&, ExpressionType, Operator, int, int, int) { return PostExpr; }
-    ExpressionType makeTypeOfNode(const JSTokenLocation&, ExpressionType) { return TypeofExpr; }
+    ExpressionType makeTypeOfNode(const JSTokenLocation&, ExpressionType, int, int, int) { return TypeofExpr; }
     ExpressionType makeDeleteNode(const JSTokenLocation&, ExpressionType, int, int, int) { return DeleteExpr; }
     ExpressionType makeNegateNode(const JSTokenLocation&, ExpressionType) { return UnaryExpr; }
     ExpressionType makeBitwiseNotNode(const JSTokenLocation&, ExpressionType) { return UnaryExpr; }

--- a/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
+++ b/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
@@ -340,6 +340,11 @@ JSObject* createErrorForInvalidGlobalVarDeclaration(JSGlobalObject* globalObject
     return createTypeError(globalObject, makeString("Can't declare global variable '"_s, ident.string(), "': global object must be extensible"_s));
 }
 
+JSObject* createTDZError(JSGlobalObject* globalObject, StringView ident)
+{
+    return createReferenceError(globalObject, makeString("Cannot access '"_s, ident, "' before initialization."_s));
+}
+
 JSObject* createTDZError(JSGlobalObject* globalObject)
 {
     return createReferenceError(globalObject, "Cannot access uninitialized variable."_s);

--- a/Source/JavaScriptCore/runtime/ExceptionHelpers.h
+++ b/Source/JavaScriptCore/runtime/ExceptionHelpers.h
@@ -45,6 +45,7 @@ String constructErrorMessage(JSGlobalObject*, JSValue, const String&);
 JS_EXPORT_PRIVATE JSObject* createError(JSGlobalObject*, JSValue, const String&, ErrorInstance::SourceAppender);
 JS_EXPORT_PRIVATE JSObject* createStackOverflowError(JSGlobalObject*);
 JSObject* createUndefinedVariableError(JSGlobalObject*, const Identifier&);
+JSObject* createTDZError(JSGlobalObject*, StringView);
 JSObject* createTDZError(JSGlobalObject*);
 JSObject* createNotAnObjectError(JSGlobalObject*, JSValue);
 JSObject* createInvalidFunctionApplyParameterError(JSGlobalObject*, JSValue);

--- a/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.cpp
@@ -53,7 +53,7 @@ void JSModuleNamespaceObject::finishCreation(JSGlobalObject* globalObject, Abstr
     //     The list is ordered as if an Array of those String values had been sorted using Array.prototype.sort using SortCompare as comparator.
     //
     // Sort the exported names by the code point order.
-    std::sort(resolutions.begin(), resolutions.end(), [] (const auto& lhs, const auto& rhs) {
+    std::sort(resolutions.begin(), resolutions.end(), [](const auto& lhs, const auto& rhs) {
         return codePointCompare(lhs.first.impl(), rhs.first.impl()) < 0;
     });
 
@@ -153,7 +153,8 @@ bool JSModuleNamespaceObject::getOwnPropertySlotCommon(JSGlobalObject* globalObj
         JSValue value = getValue(environment, exportEntry.localName, scopeOffset);
         // If the value is filled with TDZ value, throw a reference error.
         if (!value) {
-            throwVMError(globalObject, scope, createTDZError(globalObject));
+            RefPtr uid = propertyName.uid();
+            throwVMError(globalObject, scope, createTDZError(globalObject, *uid));
             return false;
         }
 


### PR DESCRIPTION
#### 412a6c047fa6e7ba2062e1bbd8afc707931b7cab
<pre>
ReferenceError doesn&apos;t include variable name in error message
<a href="https://bugs.webkit.org/show_bug.cgi?id=275143">https://bugs.webkit.org/show_bug.cgi?id=275143</a>
<a href="https://rdar.apple.com/129659300">rdar://129659300</a>

Reviewed by Keith Miller.

This improves the JSC `ReferenceError` caused by a tdz error by including the variable name in the message. Both Chrome and Firefox do this.
This is achieved by emitting `ExpressionInfo` in the bytecode that corresponds to the identifier. The `ExpressionInfo` is
then used when there is a tdz error. A majority of the changes are fixing tests to follow this format, and the most important changes are
in `NodesCodegen.cpp`

Canonical link: <a href="https://commits.webkit.org/300119@main">https://commits.webkit.org/300119@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a74c016dde76a90f9b6eff90734341e27f3cba3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121431 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31787 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127879 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/73514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41830 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49707 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/92238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/73514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124383 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/33400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/108789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/72914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/32414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26944 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71452 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/113561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/102894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27118 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130706 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/119951 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48359 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36769 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/100828 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48727 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105003 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100735 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25528 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/46145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/24215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/48217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53930 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/150113 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/47689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38194 "Found 1 new JSC stress test failure: stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51035 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/49371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->