### PR TITLE
Add layout option to only force layout of hidden until found items

### DIFF
--- a/Source/WebCore/dom/DocumentEnums.h
+++ b/Source/WebCore/dom/DocumentEnums.h
@@ -55,13 +55,14 @@ enum class LayoutOptions : uint8_t {
     IgnorePendingStylesheets = 1 << 1,
     TreatContentVisibilityHiddenAsVisible = 1 << 2,
     TreatContentVisibilityAutoAsVisible = 1 << 3,
-    UpdateCompositingLayers = 1 << 4,
-    DoNotLayoutAncestorDocuments = 1 << 5,
+    TreatRevealedWhenFoundAsVisible = 1 << 4,
+    UpdateCompositingLayers = 1 << 5,
+    DoNotLayoutAncestorDocuments = 1 << 6,
     // Doesn't call RenderLayer::recursiveUpdateLayerPositionsAfterLayout if
     // possible. The caller should use a LocalFrameView::AutoPreventLayerAccess
     // for the scope that layout is expected to be flushed to stop any access to
     // the stale RenderLayers.
-    CanDeferUpdateLayerPositions = 1 << 6
+    CanDeferUpdateLayerPositions = 1 << 7
 };
 
 enum class CanNavigateState : uint8_t {

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -369,13 +369,8 @@ TextIterator::TextIterator(const SimpleRange& range, TextIteratorBehaviors behav
     ASSERT(!m_behaviors.contains(TextIteratorBehavior::EmitsObjectReplacementCharacters) || !m_behaviors.contains(TextIteratorBehavior::EmitsObjectReplacementCharactersForImages));
 
     OptionSet<LayoutOptions> findInPageLayoutOptions;
-    if (m_behaviors.contains(TextIteratorBehavior::EntersSkippedContentRelevantToUser)) {
-        findInPageLayoutOptions.add(LayoutOptions::TreatContentVisibilityAutoAsVisible);
-
-        // FIXME: Use a more tailored layout option to avoid laying out all c-v: hidden subtrees.
-        if (range.start.protectedDocument()->settings().detailsAutoExpandEnabled())
-            findInPageLayoutOptions.add(LayoutOptions::TreatContentVisibilityHiddenAsVisible);
-    }
+    if (m_behaviors.contains(TextIteratorBehavior::EntersSkippedContentRelevantToUser))
+        findInPageLayoutOptions.add({ LayoutOptions::TreatContentVisibilityAutoAsVisible, LayoutOptions::TreatRevealedWhenFoundAsVisible });
     range.start.protectedDocument()->updateLayoutIgnorePendingStylesheets(findInPageLayoutOptions);
 
     m_startContainer = range.start.container.ptr();

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -675,7 +675,7 @@ void LocalFrameViewLayoutContext::addLayoutDelta(const LayoutSize& delta)
 
 bool LocalFrameViewLayoutContext::isSkippedContentForLayout(const RenderElement& renderer) const
 {
-    if (isVisiblityHiddenIgnored() || isVisiblityAutoIgnored()) {
+    if (isVisiblityHiddenIgnored() || isVisiblityAutoIgnored() || (isRevealedWhenFoundIgnored() && renderer.style().autoRevealsWhenFound())) {
         // In theory we should only descend into a hidden/auto subree when hidden/auto root is ignored (see isSkippedContentRootForLayout below).
         return false;
     }
@@ -692,6 +692,9 @@ bool LocalFrameViewLayoutContext::isSkippedContentRootForLayout(const RenderBox&
         return false;
 
     if (contentVisibility == ContentVisibility::Auto && isVisiblityAutoIgnored())
+        return false;
+
+    if (renderBox.style().autoRevealsWhenFound() && isRevealedWhenFoundIgnored())
         return false;
 
     return true;

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -212,6 +212,9 @@ private:
     bool isVisiblityAutoIgnored() const { return m_visiblityAutoIsIgnored; }
     void setIsVisiblityAutoIgnored(bool ignored) { m_visiblityAutoIsIgnored = ignored; }
 
+    bool isRevealedWhenFoundIgnored() const { return m_revealedWhenFoundIgnored; }
+    void setIsRevealedWhenFoundIgnored(bool ignored) { m_revealedWhenFoundIgnored = ignored; }
+
     void disablePercentHeightResolveFor(const RenderBox& flexItem);
     void enablePercentHeightResolveFor(const RenderBox& flexItem);
 
@@ -235,6 +238,7 @@ private:
     bool m_setNeedsLayoutWasDeferred { false };
     bool m_visiblityHiddenIsIgnored { false };
     bool m_visiblityAutoIsIgnored { false };
+    bool m_revealedWhenFoundIgnored { false };
     bool m_updateCompositingLayersIsPending { false };
     LayoutPhase m_layoutPhase { LayoutPhase::OutsideLayout };
     enum class LayoutNestedState : uint8_t  { NotInLayout, NotNested, Nested };

--- a/Source/WebCore/rendering/RenderLayoutState.cpp
+++ b/Source/WebCore/rendering/RenderLayoutState.cpp
@@ -358,12 +358,15 @@ ContentVisibilityOverrideScope::ContentVisibilityOverrideScope(LocalFrameViewLay
         layoutContext.setIsVisiblityHiddenIgnored(true);
     if (overrideTypes.contains(OverrideType::Auto))
         layoutContext.setIsVisiblityAutoIgnored(true);
+    if (overrideTypes.contains(OverrideType::RevealedWhenFound))
+        layoutContext.setIsRevealedWhenFoundIgnored(true);
 }
 
 ContentVisibilityOverrideScope::~ContentVisibilityOverrideScope()
 {
     m_layoutContext->setIsVisiblityHiddenIgnored(false);
     m_layoutContext->setIsVisiblityAutoIgnored(false);
+    m_layoutContext->setIsRevealedWhenFoundIgnored(false);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayoutState.h
+++ b/Source/WebCore/rendering/RenderLayoutState.h
@@ -209,7 +209,8 @@ class ContentVisibilityOverrideScope {
 public:
     enum class OverrideType {
         Hidden = 1 << 0,
-        Auto  = 1 << 1
+        Auto  = 1 << 1,
+        RevealedWhenFound = 1 << 2
     };
     ContentVisibilityOverrideScope(LocalFrameViewLayoutContext&, OptionSet<OverrideType>);
     ~ContentVisibilityOverrideScope();


### PR DESCRIPTION
#### 0622a4b75a89a289459cb175e99fa4d1acd12249
<pre>
Add layout option to only force layout of hidden until found items
<a href="https://bugs.webkit.org/show_bug.cgi?id=296094">https://bugs.webkit.org/show_bug.cgi?id=296094</a>
<a href="https://rdar.apple.com/156006491">rdar://156006491</a>

Reviewed by Alan Baradlay.

Instead of forcing the layout of _all_ content-visibility: hidden items, use a more tailored option for items that are revealed when found.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateLayout):
* Source/WebCore/dom/DocumentEnums.h:
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::TextIterator::TextIterator):
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::isSkippedContentForLayout const):
(WebCore::LocalFrameViewLayoutContext::isSkippedContentRootForLayout const):
* Source/WebCore/page/LocalFrameViewLayoutContext.h:
* Source/WebCore/rendering/RenderLayoutState.cpp:
(WebCore::ContentVisibilityOverrideScope::ContentVisibilityOverrideScope):
(WebCore::ContentVisibilityOverrideScope::~ContentVisibilityOverrideScope):
* Source/WebCore/rendering/RenderLayoutState.h:

Canonical link: <a href="https://commits.webkit.org/297564@main">https://commits.webkit.org/297564@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d18d90b8706bc85aafbfb21bac3a1bbb13e8999

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112166 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31897 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22375 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118243 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/62460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114128 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32550 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40461 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/85212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/62460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115113 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25974 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/100924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/65642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/25280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/19061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/62088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/95360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/19138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/121569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39240 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29188 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/121569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39621 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/97166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/121569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23991 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/39084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/16873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/35268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39128 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44616 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38763 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/42100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40506 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->