### PR TITLE
Use CheckedPtr for scrollingPerformanceData

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -5874,7 +5874,7 @@ static inline OptionSet<WebKit::FindOptions> toFindOptions(_WKFindOptions wkFind
 - (NSArray *)_scrollPerformanceData
 {
 #if PLATFORM(IOS_FAMILY)
-    if (WebKit::RemoteLayerTreeScrollingPerformanceData* scrollPerfData = _page->scrollingPerformanceData())
+    if (CheckedPtr scrollPerfData = _page->scrollingPerformanceData())
         return scrollPerfData->data();
 #endif
     return nil;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -1232,7 +1232,7 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
             [self _reinsertTopFixedColorExtensionViewIfNeeded];
 #endif
 
-        if (WebKit::RemoteLayerTreeScrollingPerformanceData* scrollPerfData =   _page->scrollingPerformanceData())
+        if (CheckedPtr scrollPerfData =   _page->scrollingPerformanceData())
             scrollPerfData->didCommitLayerTree([self visibleRectInViewCoordinates]);
     }
 
@@ -2536,7 +2536,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     [self _scheduleVisibleContentRectUpdateAfterScrollInView:scrollView];
 
-    if (WebKit::RemoteLayerTreeScrollingPerformanceData* scrollPerfData = _page->scrollingPerformanceData())
+    if (CheckedPtr scrollPerfData = _page->scrollingPerformanceData())
         scrollPerfData->didScroll([self visibleRectInViewCoordinates]);
 
     [_contentView updateSelection];

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.h
@@ -34,8 +34,9 @@ namespace WebKit {
 
 class RemoteLayerTreeDrawingAreaProxy;
 
-class RemoteLayerTreeScrollingPerformanceData {
+class RemoteLayerTreeScrollingPerformanceData : public CanMakeCheckedPtr<RemoteLayerTreeScrollingPerformanceData> {
     WTF_MAKE_TZONE_ALLOCATED(RemoteLayerTreeScrollingPerformanceData);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteLayerTreeScrollingPerformanceData);
 public:
     RemoteLayerTreeScrollingPerformanceData(RemoteLayerTreeDrawingAreaProxy&);
     ~RemoteLayerTreeScrollingPerformanceData();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -192,7 +192,7 @@ void RemoteScrollingCoordinatorProxy::sendScrollingTreeNodeUpdate()
 
         if (update.updateType == ScrollUpdateType::PositionUpdate) {
             webPageProxy->scrollingNodeScrollViewDidScroll(update.nodeID);
-            auto* scrollPerfData = webPageProxy->scrollingPerformanceData();
+            CheckedPtr scrollPerfData = webPageProxy->scrollingPerformanceData();
             // update.layoutViewportOrigin is set for frame scrolls.
             if (scrollPerfData && update.layoutViewportOrigin) {
                 auto layoutViewport = m_scrollingTree->layoutViewport();
@@ -361,7 +361,7 @@ void RemoteScrollingCoordinatorProxy::reportExposedUnfilledArea(MonotonicTime, u
 
 void RemoteScrollingCoordinatorProxy::reportSynchronousScrollingReasonsChanged(MonotonicTime timestamp, OptionSet<SynchronousScrollingReason> reasons)
 {
-    if (WebKit::RemoteLayerTreeScrollingPerformanceData* scrollPerfData = m_webPageProxy->scrollingPerformanceData())
+    if (CheckedPtr scrollPerfData = m_webPageProxy->scrollingPerformanceData())
         scrollPerfData->didChangeSynchronousScrollingReasons(timestamp, reasons.toRaw());
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -230,7 +230,7 @@ void RemoteLayerTreeDrawingAreaProxyMac::didCommitLayerTree(IPC::Connection&, co
     page->setScrollPerformanceDataCollectionEnabled(scrollingCoordinatorProxy->scrollingPerformanceTestingEnabled());
     
     if (transaction.createdLayers().size() > 0) {
-        if (WebKit::RemoteLayerTreeScrollingPerformanceData* scrollPerfData = page->scrollingPerformanceData())
+        if (CheckedPtr scrollPerfData = page->scrollingPerformanceData())
             scrollPerfData->didCommitLayerTree(LayoutRect(transaction.scrollPosition(),  transaction.baseLayoutViewportSize()));
     }
 


### PR DESCRIPTION
#### 1ff638af3544e703a2b3e7e47e3fe5b8cd34d321
<pre>
Use CheckedPtr for scrollingPerformanceData
<a href="https://bugs.webkit.org/show_bug.cgi?id=296098">https://bugs.webkit.org/show_bug.cgi?id=296098</a>
<a href="https://rdar.apple.com/156013265">rdar://156013265</a>

Reviewed by NOBODY (OOPS!).

Use CheckedPtr for scrollingPerformanceData.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _scrollPerformanceData]):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _didCommitLayerTree:]):
(-[WKWebView scrollViewDidScroll:]):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::sendScrollingTreeNodeUpdate):
(WebKit::RemoteScrollingCoordinatorProxy::reportSynchronousScrollingReasonsChanged):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::didCommitLayerTree):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ff638af3544e703a2b3e7e47e3fe5b8cd34d321

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112128 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31801 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22294 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118155 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62573 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32483 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40380 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85186 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35954 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115075 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25944 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100891 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65615 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25252 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62052 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95331 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19105 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121485 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39166 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29158 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94014 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39547 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97133 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93837 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39056 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16841 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35230 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39059 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44578 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38694 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42065 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40410 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->