### PR TITLE
Remove unreachable code.

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ClipboardTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ClipboardTests.mm
@@ -98,16 +98,16 @@ static RetainPtr<TestWKWebView> createWebViewForClipboardTests()
 static void writeMultipleObjectsToPlatformPasteboard()
 {
 #if PLATFORM(MAC)
-    auto firstItem = adoptNS([[NSPasteboardItem alloc] init]);
+    RetainPtr firstItem = adoptNS([[NSPasteboardItem alloc] init]);
     [firstItem setString:@"Hello" forType:NSPasteboardTypeString];
 
-    auto secondItem = adoptNS([[NSPasteboardItem alloc] init]);
+    RetainPtr secondItem = adoptNS([[NSPasteboardItem alloc] init]);
     [secondItem setString:@"https://apple.com/" forType:NSPasteboardTypeURL];
 
-    auto thirdItem = adoptNS([[NSPasteboardItem alloc] init]);
+    RetainPtr thirdItem = adoptNS([[NSPasteboardItem alloc] init]);
     [thirdItem setString:@"<strong style='color: rgb(0, 255, 0);'>Hello world</strong>" forType:NSPasteboardTypeHTML];
 
-    auto fourthItem = adoptNS([[NSPasteboardItem alloc] init]);
+    RetainPtr fourthItem = adoptNS([[NSPasteboardItem alloc] init]);
     [fourthItem setString:@"WebKit" forType:NSPasteboardTypeString];
     [fourthItem setString:@"https://webkit.org/" forType:NSPasteboardTypeURL];
     [fourthItem setString:@"<a href='https://webkit.org/'>Hello world</a>" forType:NSPasteboardTypeHTML];
@@ -116,15 +116,15 @@ static void writeMultipleObjectsToPlatformPasteboard()
     [pasteboard clearContents];
     [pasteboard writeObjects:@[firstItem.get(), secondItem.get(), thirdItem.get(), fourthItem.get()]];
 #elif PLATFORM(IOS_FAMILY) && !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
-    auto firstItem = adoptNS([[NSItemProvider alloc] initWithObject:@"Hello"]);
-    auto secondItem = adoptNS([[NSItemProvider alloc] initWithObject:[NSURL URLWithString:@"https://apple.com/"]]);
-    auto thirdItem = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr firstItem = adoptNS([[NSItemProvider alloc] initWithObject:@"Hello"]);
+    RetainPtr secondItem = adoptNS([[NSItemProvider alloc] initWithObject:[NSURL URLWithString:@"https://apple.com/"]]);
+    RetainPtr thirdItem = adoptNS([[NSItemProvider alloc] init]);
     [thirdItem registerDataRepresentationForTypeIdentifier:(__bridge NSString *)kUTTypeHTML visibility:NSItemProviderRepresentationVisibilityAll loadHandler:[&] (void (^completionHandler)(NSData *, NSError *)) -> NSProgress * {
         completionHandler([@"<strong style='color: rgb(0, 255, 0);'>Hello world</strong>" dataUsingEncoding:NSUTF8StringEncoding], nil);
         return nil;
     }];
 
-    auto fourthItem = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr fourthItem = adoptNS([[NSItemProvider alloc] init]);
     [fourthItem registerObject:@"WebKit" visibility:NSItemProviderRepresentationVisibilityAll];
     [fourthItem registerObject:[NSURL URLWithString:@"https://webkit.org/"] visibility:NSItemProviderRepresentationVisibilityAll];
     [fourthItem registerDataRepresentationForTypeIdentifier:(__bridge NSString *)kUTTypeHTML visibility:NSItemProviderRepresentationVisibilityAll loadHandler:[&] (void (^completionHandler)(NSData *, NSError *)) -> NSProgress * {
@@ -153,7 +153,7 @@ TEST(ClipboardTests, DISABLED_ReadMultipleItems)
 TEST(ClipboardTests, ReadMultipleItems)
 #endif
 {
-    auto webView = createWebViewForClipboardTests();
+    RetainPtr webView = createWebViewForClipboardTests();
     writeMultipleObjectsToPlatformPasteboard();
     [webView readClipboard];
 
@@ -169,10 +169,10 @@ TEST(ClipboardTests, ReadMultipleItems)
 
 TEST(ClipboardTests, WriteSanitizedMarkup)
 {
-    auto webView = createWebViewForClipboardTests();
+    RetainPtr webView = createWebViewForClipboardTests();
     [webView writeString:@"<script>/* super secret */</script>This is a test." toClipboardWithType:@"text/html"];
 
-    auto writtenMarkup = readMarkupFromPasteboard();
+    RetainPtr writtenMarkup = readMarkupFromPasteboard();
     EXPECT_TRUE([writtenMarkup containsString:@"This is a test."]);
     EXPECT_FALSE([writtenMarkup containsString:@"super secret"]);
     EXPECT_FALSE([writtenMarkup containsString:@"<script>"]);
@@ -182,9 +182,6 @@ TEST(ClipboardTests, WriteSanitizedMarkup)
 
 static RetainPtr<TestWKWebView> createEphemeralWebViewForClipboardTests()
 {
-#if PLATFORM(IOS_FAMILY)
-    TestWebKitAPI::Util::instantiateUIApplicationIfNeeded();
-#endif
     RetainPtr ephemeralStore = [WKWebsiteDataStore nonPersistentDataStore];
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().websiteDataStore = ephemeralStore.get();
@@ -198,11 +195,11 @@ static RetainPtr<TestWKWebView> createEphemeralWebViewForClipboardTests()
 
 TEST(ClipboardTests, ConvertTIFFToPNGWhenPasting)
 {
-    auto webView = createWebViewForClipboardTests();
-    auto url = [NSBundle.test_resourcesBundle URLForResource:@"sunset-in-cupertino-100px" withExtension:@"tiff"];
+    RetainPtr webView = createWebViewForClipboardTests();
+    RetainPtr url = [NSBundle.test_resourcesBundle URLForResource:@"sunset-in-cupertino-100px" withExtension:@"tiff"];
     auto pasteboard = NSPasteboard.generalPasteboard;
     [pasteboard clearContents];
-    [pasteboard setData:[NSData dataWithContentsOfURL:url] forType:NSPasteboardTypeTIFF];
+    [pasteboard setData:[NSData dataWithContentsOfURL:url.get()] forType:NSPasteboardTypeTIFF];
     [webView readClipboard];
 
     EXPECT_WK_STREQ("", [webView stringByEvaluatingJavaScript:@"exception ? exception.message : ''"]);


### PR DESCRIPTION
#### 842e6448def6473eb1899951bdb59cf6ad5fd380
<pre>
Remove unreachable code.
<a href="https://bugs.webkit.org/show_bug.cgi?id=296105">https://bugs.webkit.org/show_bug.cgi?id=296105</a>
<a href="https://rdar.apple.com/156016294">rdar://156016294</a>

Reviewed by Abrar Rahman Protyasha.

Code was in a mac only area and only executed on iOS
meaning there was no situation in which it could possibly be
reached.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/ClipboardTests.mm:
(writeMultipleObjectsToPlatformPasteboard):
(TEST(ClipboardTests, ReadMultipleItems)):
(TEST(ClipboardTests, WriteSanitizedMarkup)):
(createEphemeralWebViewForClipboardTests):

Canonical link: <a href="https://commits.webkit.org/297536@main">https://commits.webkit.org/297536@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cedb6a793a64cfaeac2fe0c57972e2c2cf35f24b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112034 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31705 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22190 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118057 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62273 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113996 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32381 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40282 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85106 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35771 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114981 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25862 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100803 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65539 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25176 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18942 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61909 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95246 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19018 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121376 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39067 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29067 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93950 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39448 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97059 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93767 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23946 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38978 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16762 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35089 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38961 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38598 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41926 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40314 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->