### PR TITLE
UnifiedPDFPlugin::isFull[Main]FramePlugin() can have non-trivial overhead when we do lots of coordinate conversions

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -524,6 +524,8 @@ protected:
     CompletionHandler<void(const String&, const URL&, std::span<const uint8_t>)> m_pendingSaveCompletionHandler;
     CompletionHandler<void(const String&, std::optional<FrameInfoData>&&, std::span<const uint8_t>)> m_pendingOpenCompletionHandler;
 #endif
+
+    mutable std::optional<bool> m_cachedIsFullFramePlugin;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -246,14 +246,20 @@ void PDFPluginBase::createPDFDocument()
 
 bool PDFPluginBase::isFullFramePlugin() const
 {
-    // <object> or <embed> plugins will appear to be in their parent frame, so we have to
-    // check whether our frame's widget is exactly our PluginView.
-    RefPtr frame = m_frame.get();
-    if (!frame || !frame->coreLocalFrame())
-        return false;
+    if (!m_cachedIsFullFramePlugin) [[unlikely]] {
+        m_cachedIsFullFramePlugin = [&] {
+            // <object> or <embed> plugins will appear to be in their parent frame,
+            // so we have to check whether our frame's widget is exactly our PluginView.
+            RefPtr frame = m_frame.get();
+            if (!frame || !frame->coreLocalFrame())
+                return false;
 
-    RefPtr document = dynamicDowncast<PluginDocument>(frame->coreLocalFrame()->document());
-    return document && document->pluginWidget() == m_view;
+            RefPtr document = dynamicDowncast<PluginDocument>(frame->coreLocalFrame()->document());
+            return document && document->pluginWidget() == m_view;
+        }();
+    }
+
+    return *m_cachedIsFullFramePlugin;
 }
 
 bool PDFPluginBase::handlesPageScaleFactor() const

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -740,6 +740,8 @@ private:
 #endif
 
     HashMap<WebFoundTextRange::PDFData, RetainPtr<PDFSelection>> m_webFoundTextRangePDFDataSelectionMap;
+
+    mutable std::optional<bool> m_cachedIsFullMainFramePlugin;
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, RepaintRequirement);

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -1645,7 +1645,17 @@ DelegatedScrollingMode UnifiedPDFPlugin::scrollingMode() const
 
 bool UnifiedPDFPlugin::isFullMainFramePlugin() const
 {
-    return protectedFrame()->isMainFrame() && isFullFramePlugin();
+    if (!m_cachedIsFullMainFramePlugin) [[unlikely]] {
+        m_cachedIsFullMainFramePlugin = [&] {
+            RefPtr frame = m_frame.get();
+            if (!frame)
+                return false;
+
+            return frame->isMainFrame() && isFullFramePlugin();
+        }();
+    }
+
+    return *m_cachedIsFullMainFramePlugin;
 }
 
 bool UnifiedPDFPlugin::shouldCachePagePreviews() const


### PR DESCRIPTION
#### f8030f8d2bbf1dd4d4a52988758eafa0554e0dbb
<pre>
UnifiedPDFPlugin::isFull[Main]FramePlugin() can have non-trivial overhead when we do lots of coordinate conversions
<a href="https://bugs.webkit.org/show_bug.cgi?id=296100">https://bugs.webkit.org/show_bug.cgi?id=296100</a>
<a href="https://rdar.apple.com/156012417">rdar://156012417</a>

Reviewed by Wenson Hsieh.

In some recent profiling, we have observed that isFull[Main]FramePlugin()
executions aggregate to a non-trivial execution time for flows that
require lots of coordinate conversions, such as find-in-page on a large
document. This patch tries to shave off some of that cost by caching the
results in question.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::isFullFramePlugin const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::isFullMainFramePlugin const):

Canonical link: <a href="https://commits.webkit.org/297615@main">https://commits.webkit.org/297615@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6af692cb30b89e16ba24c19b533a7a7dda5c5ceb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112031 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22187 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118054 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62270 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32378 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40279 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85103 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35780 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114978 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25858 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100805 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65536 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25172 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61906 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95242 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19020 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121373 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39064 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29066 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93947 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39445 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97061 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93764 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24021 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38976 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16764 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35086 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38958 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44470 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38595 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41923 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40311 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->