### PR TITLE
Add logging when mouse events are ignored in WebViewImpl

### DIFF
--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1470,6 +1470,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)_setIgnoresNonWheelEvents:(BOOL)ignoresNonWheelEvents
 {
+    RELEASE_LOG(MouseHandling, "[pageProxyID=%lld] [WKWebView _setIgnoresNonWheelEvents:%d]", _page->identifier().toUInt64(), ignoresNonWheelEvents);
     _impl->setIgnoresNonWheelEvents(ignoresNonWheelEvents);
 }
 
@@ -1810,6 +1811,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)_setIgnoresAllEvents:(BOOL)ignoresAllEvents
 {
+    RELEASE_LOG(MouseHandling, "[pageProxyID=%lld] [WKWebView _setIgnoresAllEvents:%d]", _page->identifier().toUInt64(), ignoresAllEvents);
     _impl->setIgnoresAllEvents(ignoresAllEvents);
 }
 


### PR DESCRIPTION
#### 256512ca68fc3e953520d2ce7c0850adc128c550
<pre>
Add logging when mouse events are ignored in WebViewImpl
<a href="https://bugs.webkit.org/show_bug.cgi?id=296077">https://bugs.webkit.org/show_bug.cgi?id=296077</a>
<a href="https://rdar.apple.com/156036130">rdar://156036130</a>

Reviewed by Chris Dumez.

We are seeing some reports where users are unable to interact with the WKWebView using the mouse.
From looking at traces, I suspect this is caused by early returns in WebViewImpl::scrollWheel and
WebViewImpl::nativeMouseEventHandler. To confirm this when we get new reports of this issue, this
patch adds logging when returning early from these methods. Returning early from these methods is
unexpected. A possible cause of early return in these methods is a memory corruption bug, which
sets the member variable m_ignoresAllEvents to true. I am currently investigating this by building
with ASAN enabled.

* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _setIgnoresNonWheelEvents:]):
(-[WKWebView _setIgnoresAllEvents:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::setIgnoresNonWheelEvents):
(WebKit::WebViewImpl::setIgnoresAllEvents):
(WebKit::WebViewImpl::scrollWheel):
(WebKit::WebViewImpl::nativeMouseEventHandler):

Canonical link: <a href="https://commits.webkit.org/297578@main">https://commits.webkit.org/297578@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ed519c30b53d324a5fda4da75ca893e3c6115cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31896 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22374 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118242 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62509 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32549 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40460 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85209 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/35905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115112 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25977 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100923 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65639 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25283 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62087 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95363 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19137 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121568 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39239 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29189 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94030 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39620 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97165 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93853 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39082 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16872 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35267 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18086 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39127 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44615 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38762 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42099 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40505 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->