### PR TITLE
Adopt smart pointers in WebWheelEventCoalescer, SpeechRecognitionRealtimeMediaSourceManager, WebServiceWorkerFetchTaskClient

### DIFF
--- a/Source/WebCore/Modules/fetch/FormDataConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FormDataConsumer.cpp
@@ -113,11 +113,12 @@ void FormDataConsumer::consumeBlob(const URL& blobURL)
         if (auto data = loader->arrayBufferResult())
             protectedThis->consume(data->span());
     });
-
-    m_blobLoader->start(blobURL, m_context.get(), FileReaderLoader::ReadAsArrayBuffer);
-
-    if (!m_blobLoader || !m_blobLoader->isLoading())
-        didFail(Exception { ExceptionCode::InvalidStateError, "Unable to read form data blob"_s });
+    if (CheckedPtr blobLoader = m_blobLoader.get()) {
+        blobLoader->start(blobURL, m_context.get(), FileReaderLoader::ReadAsArrayBuffer);
+        if (blobLoader->isLoading())
+            return;
+    }
+    didFail(Exception { ExceptionCode::InvalidStateError, "Unable to read form data blob"_s });
 }
 
 void FormDataConsumer::consume(std::span<const uint8_t> content)

--- a/Source/WebCore/fileapi/Blob.cpp
+++ b/Source/WebCore/fileapi/Blob.cpp
@@ -231,7 +231,7 @@ Blob::~Blob()
 {
     ThreadableBlobRegistry::unregisterBlobURL(m_internalURL, std::nullopt);
     while (!m_blobLoaders.isEmpty())
-        (*m_blobLoaders.begin())->cancel();
+        CheckedPtr { (*m_blobLoaders.begin()).get() }->cancel();
 }
 
 Ref<Blob> Blob::slice(long long start, long long end, const String& contentType) const

--- a/Source/WebCore/fileapi/BlobLoader.h
+++ b/Source/WebCore/fileapi/BlobLoader.h
@@ -37,8 +37,9 @@
 
 namespace WebCore {
 
-class BlobLoader final : public FileReaderLoaderClient {
+class BlobLoader final : public FileReaderLoaderClient, public CanMakeThreadSafeCheckedPtr<BlobLoader> {
     WTF_MAKE_TZONE_ALLOCATED(BlobLoader);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(BlobLoader);
 public:
     // CompleteCallback is always called except if BlobLoader is cancelled/deallocated.
     using CompleteCallback = Function<void(BlobLoader&)>;

--- a/Source/WebCore/fileapi/NetworkSendQueue.cpp
+++ b/Source/WebCore/fileapi/NetworkSendQueue.cpp
@@ -76,7 +76,7 @@ void NetworkSendQueue::enqueue(WebCore::Blob& blob)
     auto blobLoader = makeUniqueRef<BlobLoader>([this](BlobLoader&) {
         processMessages();
     });
-    auto* blobLoaderPtr = &blobLoader.get();
+    CheckedPtr blobLoaderPtr = &blobLoader.get();
     m_queue.append(WTFMove(blobLoader));
     blobLoaderPtr->start(blob, context.get(), FileReaderLoader::ReadAsArrayBuffer);
 }

--- a/Source/WebCore/page/ShareDataReader.cpp
+++ b/Source/WebCore/page/ShareDataReader.cpp
@@ -54,7 +54,7 @@ void ShareDataReader::start(Document* document, ShareDataWithParsedURL&& shareDa
         m_pendingFileLoads.append(makeUniqueRef<BlobLoader>([this, count, fileName = blob->name()](BlobLoader&) {
             this->didFinishLoading(count, fileName);
         }));
-        m_pendingFileLoads.last()->start(blob, document, FileReaderLoader::ReadAsArrayBuffer);
+        CheckedRef { m_pendingFileLoads.last().get() }->start(blob, document, FileReaderLoader::ReadAsArrayBuffer);
         if (m_pendingFileLoads.isEmpty()) {
             // The previous load failed synchronously and cancel() was called. We should not attempt to do any further loads.
             break;
@@ -77,7 +77,7 @@ void ShareDataReader::didFinishLoading(int loadIndex, const String& fileName)
         return;
     }
 
-    auto arrayBuffer = m_pendingFileLoads[loadIndex]->arrayBufferResult();
+    auto arrayBuffer = CheckedRef { m_pendingFileLoads[loadIndex].get() }->arrayBufferResult();
 
     RawFile file;
     file.fileName = fileName;

--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -4,7 +4,6 @@ NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
 Platform/IPC/ArgumentCoders.h
 Platform/cocoa/_WKWebViewTextInputNotifications.mm
 Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
-Shared/WebWheelEventCoalescer.cpp
 UIProcess/API/Cocoa/WKWebView.mm
 UIProcess/API/Cocoa/WKWebViewTesting.mm
 UIProcess/API/Cocoa/_WKInspectorExtension.mm
@@ -38,8 +37,6 @@ WebProcess/Network/webrtc/LibWebRTCDnsResolverFactory.cpp
 WebProcess/Network/webrtc/LibWebRTCNetwork.h
 WebProcess/Network/webrtc/LibWebRTCProvider.cpp
 WebProcess/Network/webrtc/LibWebRTCResolver.cpp
-WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
-WebProcess/Storage/WebServiceWorkerFetchTaskClient.cpp
 WebProcess/WebCoreSupport/WebChromeClient.cpp
 WebProcess/WebCoreSupport/mac/WebPopupMenuMac.mm
 WebProcess/WebPage/Cocoa/TextAnimationController.mm

--- a/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -2,4 +2,3 @@ Platform/IPC/ArgumentCoders.h
 WebProcess/FullScreen/WebFullScreenManager.cpp
 WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
 WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
-WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -99,7 +99,6 @@ WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
 WebProcess/InjectedBundle/InjectedBundlePageUIClient.cpp
 WebProcess/Inspector/WebInspectorUI.cpp
 WebProcess/Inspector/WebInspectorUIExtensionController.cpp
-WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
 WebProcess/Storage/WebSWClientConnection.cpp
 WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp
 WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.cpp

--- a/Source/WebKit/Shared/WebWheelEventCoalescer.cpp
+++ b/Source/WebKit/Shared/WebWheelEventCoalescer.cpp
@@ -125,10 +125,10 @@ std::optional<WebWheelEvent> WebWheelEventCoalescer::nextEventToDispatch()
 
     auto coalescedWebEvent = WebWheelEvent { coalescedNativeEvent };
 
-    while (!m_wheelEventQueue.isEmpty() && canCoalesce(coalescedWebEvent, m_wheelEventQueue.first())) {
+    while (!m_wheelEventQueue.isEmpty() && canCoalesce(coalescedWebEvent, CheckedRef { m_wheelEventQueue.first() })) {
         auto firstEvent = m_wheelEventQueue.takeFirst();
         coalescedSequence->append(firstEvent);
-        coalescedWebEvent = coalesce(coalescedWebEvent, WebWheelEvent { firstEvent });
+        SUPPRESS_UNCHECKED_ARG coalescedWebEvent = coalesce(coalescedWebEvent, WebWheelEvent { firstEvent });
     }
 
 #if !LOG_DISABLED

--- a/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.cpp
@@ -151,7 +151,7 @@ void WebServiceWorkerFetchTaskClient::didReceiveFormDataAndFinishInternal(Ref<Fo
         }
 
         m_blobLoader = makeUnique<BlobLoader>(*this);
-        auto loader = serviceWorkerThreadProxy->createBlobLoader(*m_blobLoader, blobURL);
+        auto loader = serviceWorkerThreadProxy->createBlobLoader(CheckedRef { *m_blobLoader }, blobURL);
         if (!loader) {
             m_blobLoader = nullptr;
             didFail(internalError(blobURL));


### PR DESCRIPTION
#### d3757cff5f3f43d667153f39de08f842bf90b5b0
<pre>
Adopt smart pointers in WebWheelEventCoalescer, SpeechRecognitionRealtimeMediaSourceManager, WebServiceWorkerFetchTaskClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=296119">https://bugs.webkit.org/show_bug.cgi?id=296119</a>
<a href="https://rdar.apple.com/156041248">rdar://156041248</a>

Reviewed by Basuke Suzuki.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

* Source/WebCore/Modules/fetch/FormDataConsumer.cpp:
(WebCore::FormDataConsumer::consumeBlob):
* Source/WebCore/fileapi/Blob.cpp:
(WebCore::Blob::~Blob):
* Source/WebCore/fileapi/BlobLoader.h:
* Source/WebCore/fileapi/NetworkSendQueue.cpp:
(WebCore::NetworkSendQueue::enqueue):
* Source/WebCore/page/ShareDataReader.cpp:
(WebCore::ShareDataReader::start):
(WebCore::ShareDataReader::didFinishLoading):
* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/Shared/WebWheelEventCoalescer.cpp:
(WebKit::WebWheelEventCoalescer::nextEventToDispatch):
* Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp:
(WebKit::SpeechRecognitionRealtimeMediaSourceManager::~SpeechRecognitionRealtimeMediaSourceManager):
(WebKit::SpeechRecognitionRealtimeMediaSourceManager::start):
(WebKit::SpeechRecognitionRealtimeMediaSourceManager::stop):
* Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.cpp:
(WebKit::WebServiceWorkerFetchTaskClient::didReceiveFormDataAndFinishInternal):

Canonical link: <a href="https://commits.webkit.org/298799@main">https://commits.webkit.org/298799@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d6f2a511b8ef1ef1330083656906caa1c2ff286

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116680 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36344 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26906 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122754 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67252 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/60cb2589-ce18-497a-b8eb-413342795358) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118569 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37042 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44933 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88612 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/43024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ba20327e-f241-421c-8020-5e2134c5b801) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119629 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29542 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104675 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69079 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28604 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22781 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66421 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98922 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22936 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125890 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43579 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/32732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97279 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43943 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100878 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97073 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42399 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20330 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/39541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18632 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43465 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49060 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42932 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46271 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44637 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->