### PR TITLE
REGRESSION(291932@main): App may crash when a page calls ApplePaySetup.begin()

### DIFF
--- a/Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentSetupFeature.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentSetupFeature.mm
@@ -41,7 +41,6 @@ CoreIPCPKPaymentSetupFeature::CoreIPCPKPaymentSetupFeature(PKPaymentSetupFeature
 RetainPtr<id> CoreIPCPKPaymentSetupFeature::toID() const
 {
     RetainPtr data = toNSDataNoCopy(m_data.span(), FreeWhenDone::No);
-    RELEASE_ASSERT(isInWebProcess());
     return [NSKeyedUnarchiver unarchivedObjectOfClass:PAL::getPKPaymentSetupFeatureClass() fromData:data.get() error:nil];
 }
 


### PR DESCRIPTION
#### 69bd8fec23df9d2d4ad6fba4e000d31602ca5eea
<pre>
REGRESSION(291932@main): App may crash when a page calls ApplePaySetup.begin()
<a href="https://bugs.webkit.org/show_bug.cgi?id=296122">https://bugs.webkit.org/show_bug.cgi?id=296122</a>
<a href="https://rdar.apple.com/155350256">rdar://155350256</a>

Reviewed by NOBODY (OOPS!).

We added a wrong (or, at least, too strict) process assertion in
291932@main. BeginApplePaySetup is a UI (or Networking) process bound
IPC message and hence CoreIPCPKPaymentSetupFeature::toID() will
naturally be called by a non-web-process receiver.

This patch removes said assertion.

* Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentSetupFeature.mm:
(WebKit::CoreIPCPKPaymentSetupFeature::toID const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69bd8fec23df9d2d4ad6fba4e000d31602ca5eea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112070 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31741 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118093 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62321 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32417 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40318 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85141 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35815 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115017 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25895 "Found 1 new test failure: http/tests/dom/noreferrer-window-not-targetable.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100842 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65574 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25201 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61945 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95278 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19055 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121412 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39103 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29100 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93976 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39484 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97088 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93798 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39010 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16796 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35131 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38997 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44509 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38634 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41962 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40350 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->