### PR TITLE
Add missing includes

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -15,6 +15,7 @@ dfg/DFGFinalizer.h
 dfg/DFGLazyJSValue.h
 dfg/DFGNode.h
 dfg/DFGPropertyTypeKey.h
+dfg/DFGSpeculativeJIT.h
 ftl/FTLOSRExitHandle.h
 heap/Heap.h
 heap/HeapSnapshotBuilder.h

--- a/Source/JavaScriptCore/runtime/BufferMemoryHandle.h
+++ b/Source/JavaScriptCore/runtime/BufferMemoryHandle.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <atomic>
+
 #include "MemoryMode.h"
 #include "Options.h"
 #include "PageCount.h"

--- a/Source/WTF/wtf/CheckedPtr.h
+++ b/Source/WTF/wtf/CheckedPtr.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/CheckedRef.h>
+#include <wtf/RawPtrTraits.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <utility>
 #include <wtf/FastMalloc.h>
+#include <wtf/RawPtrTraits.h>
 #include <wtf/Ref.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/TZoneMalloc.h
+++ b/Source/WTF/wtf/TZoneMalloc.h
@@ -107,6 +107,7 @@
 #else // !USE(SYSTEM_MALLOC) && USE(TZONE_MALLOC)
 
 #include <bmalloc/TZoneHeap.h>
+#include <bmalloc/bmalloc.h>
 
 #if !BUSE(TZONE)
 #error "TZones enabled in WTF, but not enabled in bmalloc"

--- a/Source/WTF/wtf/WeakPtrFactory.h
+++ b/Source/WTF/wtf/WeakPtrFactory.h
@@ -28,6 +28,7 @@
 
 #include <wtf/CompactRefPtrTuple.h>
 #include <wtf/Packed.h>
+#include <wtf/RefPtr.h>
 #include <wtf/WeakRef.h>
 
 namespace WTF {

--- a/Source/WebCore/platform/RectEdges.h
+++ b/Source/WebCore/platform/RectEdges.h
@@ -28,6 +28,7 @@
 #include "BoxSides.h"
 #include "WritingMode.h"
 #include <array>
+#include <concepts>
 #include <wtf/OptionSet.h>
 #include <wtf/text/TextStream.h>
 

--- a/Source/WebCore/platform/graphics/ColorMatrix.h
+++ b/Source/WebCore/platform/graphics/ColorMatrix.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <concepts>
 #include <math.h>
 #include <wtf/MathExtras.h>
 

--- a/Source/WebCore/platform/graphics/IntSize.h
+++ b/Source/WebCore/platform/graphics/IntSize.h
@@ -27,6 +27,7 @@
 
 #include "PlatformExportMacros.h"
 #include <algorithm>
+#include <cmath>
 #include <wtf/JSONValues.h>
 #include <wtf/Forward.h>
 


### PR DESCRIPTION
#### ed216eb3add10f6b788b365dfb7b1798392176a0
<pre>
Add missing includes
<a href="https://bugs.webkit.org/show_bug.cgi?id=296125">https://bugs.webkit.org/show_bug.cgi?id=296125</a>
<a href="https://rdar.apple.com/156057537">rdar://156057537</a>

Reviewed by Richard Robinson.

This adds some includes to make each of these header files self-contained,
which is necessary when we build them as clang modules. This will happen once
we enable Swift/C++ interop.

These additional includes provide extra visibility to the clang static analysis
checkers that there is an uncounted StringImpl* variable inside a JSC JIT-
related file. This PR therefore adds an extra safer C++ exception for that file.
I briefly looked at fixing it instead, but it would have required switching
StringImpl* for Ref&lt;StringImpl&gt; across multiple JIT-related files and should
be done by someone more skilled in making these changes inside JSC.

* Source/JavaScriptCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/JavaScriptCore/runtime/BufferMemoryHandle.h:
* Source/WTF/wtf/CheckedPtr.h:
* Source/WTF/wtf/RefPtr.h:
* Source/WTF/wtf/TZoneMalloc.h:
* Source/WTF/wtf/WeakPtrFactory.h:
* Source/WebCore/platform/RectEdges.h:
* Source/WebCore/platform/graphics/ColorMatrix.h:
* Source/WebCore/platform/graphics/IntSize.h:

Canonical link: <a href="https://commits.webkit.org/297582@main">https://commits.webkit.org/297582@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6bef860850cdabe83a8ca50fbeed3d1c7ad92117

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31963 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22441 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118309 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62555 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114194 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32616 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40527 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85266 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115179 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26025 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100982 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65696 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25328 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19118 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62154 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/104746 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95409 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19197 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121636 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/110846 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39306 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29242 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94076 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39687 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97224 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93900 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24008 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39131 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16927 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35334 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39194 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44682 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/135077 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38829 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36312 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42166 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40572 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->