### PR TITLE
[Win] WebKitTestRunnerWS not found running win-tests

### DIFF
--- a/Source/WebCore/platform/graphics/win/PlatformDisplayWin.cpp
+++ b/Source/WebCore/platform/graphics/win/PlatformDisplayWin.cpp
@@ -38,8 +38,11 @@ std::unique_ptr<PlatformDisplayWin> PlatformDisplayWin::create()
         // Disable debug layers that makes some tests fail because
         // ANGLE fills uninitialized buffers with
         // kDebugColorInitClearValue in debug builds.
-        EGL_PLATFORM_ANGLE_DEBUG_LAYERS_ENABLED_ANGLE,
-        EGL_FALSE,
+        EGL_PLATFORM_ANGLE_DEBUG_LAYERS_ENABLED_ANGLE, EGL_FALSE,
+        // TESTING - Force use of Windows software rasterizer
+        // Windows Advanced Rasterization Platform (WARP)
+        EGL_PLATFORM_ANGLE_TYPE_ANGLE, EGL_PLATFORM_ANGLE_TYPE_D3D11_ANGLE,
+        EGL_PLATFORM_ANGLE_DEVICE_TYPE_ANGLE, EGL_PLATFORM_ANGLE_DEVICE_TYPE_D3D_WARP_ANGLE,
         EGL_NONE,
     };
     auto glDisplay = GLDisplay::create(eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE, EGL_DEFAULT_DISPLAY, attributes));

--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -1183,11 +1183,7 @@ class Port(object):
 
     def _path_to_driver(self, configuration=None):
         """Returns the full path to the test driver (DumpRenderTree)."""
-        local_driver_path = self._build_path(self.driver_name())
-        if sys.platform.startswith('win'):
-            base = os.path.splitext(local_driver_path)[0]
-            local_driver_path = base + ".exe"
-        return local_driver_path
+        return self._build_path(self.driver_name())
 
     def _driver_tempdir(self, target_host=None):
         host = target_host or self.host

--- a/Tools/Scripts/webkitpy/port/win.py
+++ b/Tools/Scripts/webkitpy/port/win.py
@@ -167,8 +167,24 @@ class WinPort(ApplePort):
         _log.error('Could not find apache in the expected location. (path=%s)' % path)
         return None
 
+    def _path_to_driver(self, configuration=None):
+        local_driver_path = self._build_path(self.driver_name())
+        if local_driver_path.startswith('/'):
+            # Need to convert from a mingw / msys style path to a Windows path
+            second_slash_index = local_driver_path.index('/', 1)
+            local_driver_path = os.path.abspath(local_driver_path[second_slash_index:])
+        base = os.path.splitext(local_driver_path)[0]
+        local_driver_path = base + ".exe"
+        return local_driver_path
+
+
     def _path_to_default_image_diff(self):
-        return self._build_path('ImageDiff.exe')
+        image_diff_path = self._build_path('ImageDiff.exe')
+        if image_diff_path.startswith('/'):
+            # Need to convert from a mingw / msys style path to a Windows path
+            second_slash_index = image_diff_path.index('/', 1)
+            image_diff_path = os.path.abspath(image_diff_path[second_slash_index:])
+        return image_diff_path
 
     API_TEST_BINARY_NAMES = ['TestWTF.exe', 'TestWebCore.exe', 'TestWebKit.exe']
 

--- a/Tools/WebKitTestRunner/win/WebKitTestRunnerWS.cpp
+++ b/Tools/WebKitTestRunner/win/WebKitTestRunnerWS.cpp
@@ -73,6 +73,9 @@ int wmain()
     STARTUPINFO startupInfo { };
     startupInfo.cb = sizeof(startupInfo);
     startupInfo.lpDesktop = desktop ? desktopName.data() : nullptr;
+    startupInfo.dwFlags = STARTF_USESIZE;
+    startupInfo.dwXSize = 1920;
+    startupInfo.dwYSize = 1080;
     if (!CreateProcess(0, cmd.data(), nullptr, nullptr, true, 0, 0, 0, &startupInfo, &processInformation)) {
         std::wcout << L"CreateProcess failed: " << GetLastError() << std::endl;
         return EXIT_FAILURE;


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=296131

Reviewed by NOBODY (OOPS!).

We're running under mingw bash; need to convert to a windows style path
for the driver and imagediff paths. Move windows specific logic into the
windows port file.
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73e0b8dcafe5db89f018c4e1272fff4b6ab8438b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113085 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32820 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23298 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119292 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63681 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115047 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33472 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41383 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86072 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36735 "Found 60 new test failures: animations/animation-hit-test-transform.html animations/animation-hit-test.html animations/opacity-transform-animation.html compositing/animation/busy-indicator.html compositing/checkerboard.html compositing/framesets/composited-frame-alignment.html compositing/geometry/horizontal-scroll-composited.html compositing/geometry/tall-page-composited.html compositing/geometry/vertical-scroll-composited.html compositing/iframes/compositing-for-scrollable-iframe.html ... (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116032 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26726 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101725 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66385 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/112517 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26005 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19856 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63047 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96113 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19929 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122510 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40163 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29954 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94916 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40547 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97944 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94658 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39800 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17611 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36288 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40049 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45548 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39690 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43023 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41427 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->