### PR TITLE
REGRESSION(296337@main): currentcolor used in custom property no longer resolves correctly

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-computation-color-006-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-computation-color-006-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<style>
+div {
+  background-color: green;
+  width: 100px;
+  height: 100px;
+}
+</style>
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-computation-color-006.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-computation-color-006.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-properties-values-api/#calculation-of-computed-values" />
+<link rel="author" title="Sam Weinig" href="sam@webkit.org">
+<link rel="match" href="registered-property-computation-color-001-ref.html">
+<style>
+@property --x {
+  inherits: true;
+  initial-value: currentcolor;
+  syntax: "<color>";
+}
+:root {
+  color: green;
+}
+div {
+  background-color: var(--x);
+  width: 100px;
+  height: 100px;
+}
+</style>
+<div></div>

--- a/Source/WebCore/style/StyleCustomProperty.h
+++ b/Source/WebCore/style/StyleCustomProperty.h
@@ -115,6 +115,9 @@ private:
     {
     }
 
+    String propertyValueSerializationForTokenization(const CSS::SerializationContext&, const RenderStyle&) const;
+    void propertyValueSerializationForTokenization(StringBuilder&, const CSS::SerializationContext&, const RenderStyle&) const;
+
     const AtomString m_name;
     const Kind m_value;
     mutable RefPtr<CSSVariableData> m_cachedTokens;

--- a/Source/WebCore/style/values/color/StyleColor.cpp
+++ b/Source/WebCore/style/values/color/StyleColor.cpp
@@ -294,6 +294,16 @@ bool containsCurrentColor(const Color& value)
 
 // MARK: - Serialization
 
+String serializationForCSSTokenization(const CSS::SerializationContext& context, const Color& value)
+{
+    return WTF::switchOn(value, [&](const auto& kind) { return WebCore::Style::serializationForCSSTokenization(context, kind); });
+}
+
+void serializationForCSSTokenization(StringBuilder& builder, const CSS::SerializationContext& context, const Color& value)
+{
+    WTF::switchOn(value, [&](const auto& kind) { WebCore::Style::serializationForCSSTokenization(builder, context, kind); });
+}
+
 void Serialize<Color>::operator()(StringBuilder& builder, const CSS::SerializationContext&, const RenderStyle& style, const Color& value)
 {
     // NOTE: The specialization of Style::Serialize is used for computed value serialization, so the resolved "used" value is used.

--- a/Source/WebCore/style/values/color/StyleColor.h
+++ b/Source/WebCore/style/values/color/StyleColor.h
@@ -164,6 +164,9 @@ private:
 WebCore::Color resolveColor(const Color&, const WebCore::Color& currentColor);
 bool containsCurrentColor(const Color&);
 
+void serializationForCSSTokenization(StringBuilder&, const CSS::SerializationContext&, const Color&);
+String serializationForCSSTokenization(const CSS::SerializationContext&, const Color&);
+
 template<> struct Serialize<Color> {
     void operator()(StringBuilder&, const CSS::SerializationContext&, const RenderStyle&, const Color&);
 };

--- a/Source/WebCore/style/values/color/StyleColorLayers.cpp
+++ b/Source/WebCore/style/values/color/StyleColorLayers.cpp
@@ -28,7 +28,7 @@
 #include "StyleColorLayers.h"
 
 #include "CSSColorLayersResolver.h"
-#include "CSSSerializationContext.h"
+#include "CSSPrimitiveValueMappings.h"
 #include "ColorSerialization.h"
 #include "StyleBuilderState.h"
 #include "StyleColorResolutionState.h"
@@ -90,6 +90,29 @@ bool containsCurrentColor(const ColorLayers& colorLayers)
     return std::ranges::any_of(colorLayers.colors, [&](auto& color) {
         return WebCore::Style::containsCurrentColor(color);
     });
+}
+
+// MARK: - Serialization
+
+void serializationForCSSTokenization(StringBuilder& builder, const CSS::SerializationContext& context, const ColorLayers& value)
+{
+    builder.append("color-layers("_s);
+
+    if (value.blendMode != BlendMode::Normal)
+        builder.append(nameLiteralForSerialization(toCSSValueID(value.blendMode)), ", "_s);
+
+    builder.append(interleave(value.colors, [&](auto& builder, auto& color) {
+        serializationForCSSTokenization(builder, context, color);
+    }, ", "_s));
+
+    builder.append(')');
+}
+
+String serializationForCSSTokenization(const CSS::SerializationContext& context, const ColorLayers& colorLayers)
+{
+    StringBuilder builder;
+    serializationForCSSTokenization(builder, context, colorLayers);
+    return builder.toString();
 }
 
 // MARK: - TextStream

--- a/Source/WebCore/style/values/color/StyleColorLayers.h
+++ b/Source/WebCore/style/values/color/StyleColorLayers.h
@@ -57,6 +57,9 @@ Color toStyleColor(const CSS::ColorLayers&, ColorResolutionState&);
 WebCore::Color resolveColor(const ColorLayers&, const WebCore::Color& currentColor);
 bool containsCurrentColor(const ColorLayers&);
 
+void serializationForCSSTokenization(StringBuilder&, const CSS::SerializationContext&, const ColorLayers&);
+String serializationForCSSTokenization(const CSS::SerializationContext&, const ColorLayers&);
+
 WTF::TextStream& operator<<(WTF::TextStream&, const ColorLayers&);
 
 } // namespace Style

--- a/Source/WebCore/style/values/color/StyleColorMix.cpp
+++ b/Source/WebCore/style/values/color/StyleColorMix.cpp
@@ -111,6 +111,83 @@ bool containsCurrentColor(const ColorMix& colorMix)
         || WebCore::Style::containsCurrentColor(colorMix.mixComponents2.color);
 }
 
+// MARK: - Serialization
+
+namespace ColorMixSerializationDetails {
+
+static bool sumTo100Percent(const ColorMix::Component::Percentage& a, const ColorMix::Component::Percentage& b)
+{
+    return a.value + b.value == 100.0;
+}
+
+static std::optional<ColorMix::Component::Percentage> subtractFrom100Percent(const ColorMix::Component::Percentage& percentage)
+{
+    return ColorMix::Component::Percentage { 100.0 - percentage.value };
+}
+
+static void serializeColorMixPercentage(StringBuilder& builder, const CSS::SerializationContext& context, const ColorMix::Component::Percentage& percentage)
+{
+    CSS::serializationForCSS(builder, context, CSS::PercentageRaw<> { percentage.value });
+}
+
+static void serializationForColorMixPercentage1(StringBuilder& builder, const CSS::SerializationContext& context, const ColorMix& value)
+{
+    if (value.mixComponents1.percentage && value.mixComponents2.percentage) {
+        if (*value.mixComponents1.percentage == 50_css_percentage && *value.mixComponents2.percentage == 50_css_percentage)
+            return;
+        builder.append(' ');
+        serializeColorMixPercentage(builder, context, *value.mixComponents1.percentage);
+    } else if (value.mixComponents1.percentage) {
+        if (*value.mixComponents1.percentage == 50_css_percentage)
+            return;
+        builder.append(' ');
+        serializeColorMixPercentage(builder, context, *value.mixComponents1.percentage);
+    } else if (value.mixComponents2.percentage) {
+        if (*value.mixComponents2.percentage == 50_css_percentage)
+            return;
+
+        auto subtractedPercent = subtractFrom100Percent(*value.mixComponents2.percentage);
+        if (!subtractedPercent)
+            return;
+
+        builder.append(' ');
+        serializeColorMixPercentage(builder, context, *subtractedPercent);
+    }
+}
+
+static void serializationForColorMixPercentage2(StringBuilder& builder, const CSS::SerializationContext& context, const ColorMix& value)
+{
+    if (value.mixComponents1.percentage && value.mixComponents2.percentage) {
+        if (sumTo100Percent(*value.mixComponents1.percentage, *value.mixComponents2.percentage))
+            return;
+
+        builder.append(' ');
+        serializeColorMixPercentage(builder, context, *value.mixComponents2.percentage);
+    }
+}
+
+} // namespace ColorMixSerializationDetails
+
+void serializationForCSSTokenization(StringBuilder& builder, const CSS::SerializationContext& context, const ColorMix& colorMix)
+{
+    builder.append("color-mix(in "_s);
+    WebCore::serializationForCSS(builder, colorMix.colorInterpolationMethod);
+    builder.append(", "_s);
+    serializationForCSSTokenization(builder, context, colorMix.mixComponents1.color);
+    ColorMixSerializationDetails::serializationForColorMixPercentage1(builder, context, colorMix);
+    builder.append(", "_s);
+    serializationForCSSTokenization(builder, context, colorMix.mixComponents2.color);
+    ColorMixSerializationDetails::serializationForColorMixPercentage2(builder, context, colorMix);
+    builder.append(')');
+}
+
+String serializationForCSSTokenization(const CSS::SerializationContext& context, const ColorMix& colorMix)
+{
+    StringBuilder builder;
+    serializationForCSSTokenization(builder, context, colorMix);
+    return builder.toString();
+}
+
 // MARK: - TextStream
 
 static WTF::TextStream& operator<<(WTF::TextStream& ts, const ColorMix::Component& component)

--- a/Source/WebCore/style/values/color/StyleColorMix.h
+++ b/Source/WebCore/style/values/color/StyleColorMix.h
@@ -68,6 +68,9 @@ Color toStyleColor(const CSS::ColorMix&, ColorResolutionState&);
 WebCore::Color resolveColor(const ColorMix&, const WebCore::Color& currentColor);
 bool containsCurrentColor(const ColorMix&);
 
+void serializationForCSSTokenization(StringBuilder&, const CSS::SerializationContext&, const ColorMix&);
+String serializationForCSSTokenization(const CSS::SerializationContext&, const ColorMix&);
+
 WTF::TextStream& operator<<(WTF::TextStream&, const ColorMix&);
 
 } // namespace Style

--- a/Source/WebCore/style/values/color/StyleContrastColor.cpp
+++ b/Source/WebCore/style/values/color/StyleContrastColor.cpp
@@ -26,6 +26,8 @@
 #include "StyleContrastColor.h"
 
 #include "CSSContrastColorResolver.h"
+#include "CSSSerializationContext.h"
+#include "ColorSerialization.h"
 #include "StyleBuilderState.h"
 #include "StyleColorResolutionState.h"
 #include <wtf/text/TextStream.h>
@@ -72,6 +74,22 @@ WebCore::Color resolveColor(const ContrastColor& contrastColor, const WebCore::C
 bool containsCurrentColor(const ContrastColor& contrastColor)
 {
     return WebCore::Style::containsCurrentColor(contrastColor.color);
+}
+
+// MARK: - Serialization
+
+void serializationForCSSTokenization(StringBuilder& builder, const CSS::SerializationContext& context, const ContrastColor& contrastColor)
+{
+    builder.append("contrast-color("_s);
+    serializationForCSSTokenization(builder, context, contrastColor.color);
+    builder.append(')');
+}
+
+String serializationForCSSTokenization(const CSS::SerializationContext& context, const ContrastColor& contrastColor)
+{
+    StringBuilder builder;
+    serializationForCSSTokenization(builder, context, contrastColor);
+    return builder.toString();
 }
 
 // MARK: - TextStream

--- a/Source/WebCore/style/values/color/StyleContrastColor.h
+++ b/Source/WebCore/style/values/color/StyleContrastColor.h
@@ -53,6 +53,9 @@ Color toStyleColor(const CSS::ContrastColor&, ColorResolutionState&);
 WebCore::Color resolveColor(const ContrastColor&, const WebCore::Color& currentColor);
 bool containsCurrentColor(const ContrastColor&);
 
+void serializationForCSSTokenization(StringBuilder&, const CSS::SerializationContext&, const ContrastColor&);
+String serializationForCSSTokenization(const CSS::SerializationContext&, const ContrastColor&);
+
 WTF::TextStream& operator<<(WTF::TextStream&, const ContrastColor&);
 
 } // namespace Style

--- a/Source/WebCore/style/values/color/StyleCurrentColor.cpp
+++ b/Source/WebCore/style/values/color/StyleCurrentColor.cpp
@@ -32,6 +32,18 @@
 namespace WebCore {
 namespace Style {
 
+// MARK: - Serialization
+
+void serializationForCSSTokenization(StringBuilder& builder, const CSS::SerializationContext&, const CurrentColor&)
+{
+    builder.append("currentcolor"_s);
+}
+
+String serializationForCSSTokenization(const CSS::SerializationContext&, const CurrentColor&)
+{
+    return "currentcolor"_s;
+}
+
 // MARK: - TextStream
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, const CurrentColor&)

--- a/Source/WebCore/style/values/color/StyleCurrentColor.h
+++ b/Source/WebCore/style/values/color/StyleCurrentColor.h
@@ -51,6 +51,9 @@ constexpr bool containsCurrentColor(const CurrentColor&)
     return true;
 }
 
+void serializationForCSSTokenization(StringBuilder&, const CSS::SerializationContext&, const CurrentColor&);
+String serializationForCSSTokenization(const CSS::SerializationContext&, const CurrentColor&);
+
 WTF::TextStream& operator<<(WTF::TextStream&, const CurrentColor&);
 
 } // namespace Style

--- a/Source/WebCore/style/values/color/StyleResolvedColor.cpp
+++ b/Source/WebCore/style/values/color/StyleResolvedColor.cpp
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "StyleResolvedColor.h"
 
+#include "ColorSerialization.h"
 #include "StyleColor.h"
 #include <wtf/text/TextStream.h>
 
@@ -38,6 +39,18 @@ namespace Style {
 Color toStyleColor(const CSS::ResolvedColor& unresolved, ColorResolutionState&)
 {
     return Color { ResolvedColor { unresolved.value } };
+}
+
+// MARK: - Serialization
+
+void serializationForCSSTokenization(StringBuilder& builder, const CSS::SerializationContext&, const ResolvedColor& absoluteColor)
+{
+    builder.append(WebCore::serializationForCSS(absoluteColor.color));
+}
+
+String serializationForCSSTokenization(const CSS::SerializationContext&, const ResolvedColor& absoluteColor)
+{
+    return WebCore::serializationForCSS(absoluteColor.color);
 }
 
 // MARK: - TextStream

--- a/Source/WebCore/style/values/color/StyleResolvedColor.h
+++ b/Source/WebCore/style/values/color/StyleResolvedColor.h
@@ -56,6 +56,9 @@ constexpr bool containsCurrentColor(const ResolvedColor&)
     return false;
 }
 
+void serializationForCSSTokenization(StringBuilder&, const CSS::SerializationContext&, const ResolvedColor&);
+String serializationForCSSTokenization(const CSS::SerializationContext&, const ResolvedColor&);
+
 WTF::TextStream& operator<<(WTF::TextStream&, const ResolvedColor&);
 
 } // namespace Style


### PR DESCRIPTION
#### 6496fbaca29d34171082af8e739f6b36e8c6522a
<pre>
REGRESSION(296337@main): currentcolor used in custom property no longer resolves correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=296134">https://bugs.webkit.org/show_bug.cgi?id=296134</a>
<a href="https://rdar.apple.com/156076502">rdar://156076502</a>

Reviewed by Tim Nguyen.

Performs a partial revert of 296337@main, maintaining the CSS side of things,
but adding back the secondary serialization of the color Style types. To make
things work, the new secondary serialization functions all needed a new name.
`serializationForCSSTokenization` was chosen to clarify these are really only
for the tokenization needs.

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-computation-color-006-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-computation-color-006.html: Added.
* Source/WebCore/style/StyleCustomProperty.cpp:
* Source/WebCore/style/StyleCustomProperty.h:
* Source/WebCore/style/values/color/StyleColor.cpp:
* Source/WebCore/style/values/color/StyleColor.h:
* Source/WebCore/style/values/color/StyleColorLayers.cpp:
* Source/WebCore/style/values/color/StyleColorLayers.h:
* Source/WebCore/style/values/color/StyleColorMix.cpp:
* Source/WebCore/style/values/color/StyleColorMix.h:
* Source/WebCore/style/values/color/StyleContrastColor.cpp:
* Source/WebCore/style/values/color/StyleContrastColor.h:
* Source/WebCore/style/values/color/StyleCurrentColor.cpp:
* Source/WebCore/style/values/color/StyleCurrentColor.h:
* Source/WebCore/style/values/color/StyleRelativeColor.h:
* Source/WebCore/style/values/color/StyleResolvedColor.cpp:
* Source/WebCore/style/values/color/StyleResolvedColor.h:

Canonical link: <a href="https://commits.webkit.org/297600@main">https://commits.webkit.org/297600@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/756be6780f7dbfb3b8fd1d707d9423526a9e926e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112132 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31805 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22298 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118159 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62604 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114094 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32487 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40384 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85195 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/35980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115079 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25951 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100897 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65624 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25258 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19036 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62051 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95337 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19112 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121490 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39170 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29164 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94018 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39551 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97140 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93841 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24016 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39060 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16847 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35234 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39063 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44582 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38698 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42064 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40414 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->