### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in WTF::SmallSet

### DIFF
--- a/Source/WTF/wtf/SmallSet.h
+++ b/Source/WTF/wtf/SmallSet.h
@@ -29,10 +29,9 @@
 #include <wtf/Assertions.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/HashFunctions.h>
+#include <wtf/MallocSpan.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/StdLibExtras.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WTF {
 
@@ -91,33 +90,30 @@ public:
     class iterator {
         WTF_DEPRECATED_MAKE_FAST_ALLOCATED(iterator);
     public:
-        iterator()
-        { }
+        iterator() = default;
 
-        iterator(unsigned index, unsigned capacity, T* buffer)
+        iterator(unsigned index, std::span<T> buffer)
             : m_index(index)
-            , m_capacity(capacity)
             , m_buffer(buffer)
         { }
 
         iterator& operator++()
         {
-            m_index++;
-            ASSERT(m_index <= m_capacity);
-            while (m_index < m_capacity && m_buffer[m_index] == emptyValue())
-                m_index++;
+            ++m_index;
+            ASSERT(m_index <= m_buffer.size());
+            while (m_index < m_buffer.size() && m_buffer[m_index] == emptyValue())
+                ++m_index;
             return *this;
         }
         
-        T& operator*() { ASSERT(m_index < m_capacity); return static_cast<T&>(m_buffer[m_index]); }
-        T operator*() const { ASSERT(m_index < m_capacity); return static_cast<T>(m_buffer[m_index]); }
-        bool operator==(const iterator& other) const { ASSERT(m_buffer == other.m_buffer); return m_index == other.m_index; }
+        T& operator*() { return m_buffer[m_index]; }
+        T operator*() const { return m_buffer[m_index]; }
+        bool operator==(const iterator& other) const { ASSERT(m_buffer.data() == other.m_buffer.data()); return m_index == other.m_index; }
 
     private:
         template<typename U, typename H, unsigned S> friend class WTF::SmallSet;
         unsigned m_index;
-        unsigned m_capacity;
-        T* m_buffer;
+        std::span<T> m_buffer;
     };
 
     struct AddResult {
@@ -132,13 +128,13 @@ public:
         if (isSmall()) {
             for (unsigned i = 0; i < m_size; i++) {
                 if (equal(m_inline.smallStorage[i], value))
-                    return { iterator { i, m_capacity, m_inline.smallStorage }, false };
+                    return { iterator { i, std::span { m_inline.smallStorage } }, false };
             }
 
             if (m_size < SmallArraySize) {
                 m_inline.smallStorage[m_size] = value;
                 ++m_size;
-                return { iterator { m_size - 1, m_capacity, m_inline.smallStorage }, true };
+                return { iterator { m_size - 1, std::span { m_inline.smallStorage } }, true };
             }
 
             grow(std::max(64u, SmallArraySize * 2));
@@ -155,9 +151,9 @@ public:
         if (!equal(*bucket, value)) {
             *bucket = value;
             ++m_size;
-            return { iterator { static_cast<unsigned>(bucket - m_inline.buffer), m_capacity, m_inline.buffer }, true };
+            return { iterator { static_cast<unsigned>(bucket - m_inline.buffer), unsafeMakeSpan(m_inline.buffer, m_capacity) }, true };
         }
-        return { iterator { static_cast<unsigned>(bucket - m_inline.buffer), m_capacity, m_inline.buffer }, false };
+        return { iterator { static_cast<unsigned>(bucket - m_inline.buffer), unsafeMakeSpan(m_inline.buffer, m_capacity) }, false };
     }
 
     inline bool contains(T value) const
@@ -180,14 +176,9 @@ public:
     {
         iterator it;
         it.m_index = std::numeric_limits<unsigned>::max();
-        it.m_capacity = m_capacity;
-        if (isSmall())
-            it.m_buffer = const_cast<T*>(m_inline.smallStorage);
-        else
-            it.m_buffer = m_inline.buffer;
+        it.m_buffer = spanConstCast<T>(buffer());
 
         ++it;
-
         return it;
     }
 
@@ -195,12 +186,7 @@ public:
     {
         iterator it;
         it.m_index = m_capacity;
-        it.m_capacity = m_capacity;
-        if (isSmall())
-            it.m_buffer = const_cast<T*>(m_inline.smallStorage);
-        else
-            it.m_buffer = m_inline.buffer;
-
+        it.m_buffer = spanConstCast<T>(buffer());
         return it;
     }
 
@@ -249,7 +235,7 @@ private:
     {
         m_size = 0;
         m_capacity = SmallArraySize;
-        memset(static_cast<void*>(m_inline.smallStorage), -1, sizeof(T) * SmallArraySize);
+        memsetSpan(std::span { m_inline.smallStorage }, -1);
         ASSERT(isSmall());
     }
 
@@ -272,53 +258,56 @@ private:
 #endif
 
         size_t allocationSize = sizeof(T) * size;
-        bool wasSmall = isSmall();
-        T* oldBuffer = wasSmall ? m_inline.smallStorage : m_inline.buffer;
+        auto oldBuffer = buffer();
+
         unsigned oldCapacity = m_capacity;
-        T* newBuffer = static_cast<T*>(SmallSetMalloc::malloc(allocationSize));
-        memset(static_cast<void*>(newBuffer), -1, allocationSize);
+        auto newBuffer = MallocSpan<T, SmallSetMalloc>::malloc(allocationSize);
+        memsetSpan(newBuffer.mutableSpan(), -1);
         m_capacity = size;
 
         for (unsigned i = 0; i < oldCapacity; i++) {
             if (isValidEntry(oldBuffer[i])) {
-                T* ptr = bucketInBuffer(newBuffer, static_cast<T>(oldBuffer[i]));
+                T* ptr = bucketInBuffer(newBuffer.mutableSpan(), static_cast<T>(oldBuffer[i]));
                 *ptr = oldBuffer[i];
             }
         }
 
-        if (!wasSmall)
-            SmallSetMalloc::free(oldBuffer);
+        if (oldCapacity != SmallArraySize)
+            SmallSetMalloc::free(oldBuffer.data());
 
-        m_inline.buffer = newBuffer;
+        m_inline.buffer = newBuffer.leakSpan().data();
     }
 
     inline T* bucket(T target) const
     {
         ASSERT(!isSmall());
-        return bucketInBuffer(m_inline.buffer, target);
+        return bucketInBuffer(unsafeMakeSpan(m_inline.buffer, m_capacity), target);
     }
 
-    inline T* bucketInBuffer(T* buffer, T target) const
+    inline T* bucketInBuffer(std::span<T> buffer, T target) const
     {
         ASSERT(!(m_capacity & (m_capacity - 1)));
         unsigned bucket = Hash::hash(target) & (m_capacity - 1);
         unsigned index = 0;
         while (true) {
-            T* ptr = buffer + bucket;
+            T* ptr = buffer.subspan(bucket).data();
             if (!isValidEntry(*ptr))
                 return ptr;
             if (equal(*ptr, target))
                 return ptr;
-            index++;
+            ++index;
             bucket = (bucket + index) & (m_capacity - 1);
         }
     }
+
+    std::span<T> buffer() { return isSmall() ? std::span<T> { m_inline.smallStorage } : unsafeMakeSpan(m_inline.buffer, m_capacity); }
+    std::span<const T> buffer() const { return isSmall() ? std::span<const T> { m_inline.smallStorage } : unsafeMakeSpan(m_inline.buffer, m_capacity); }
 
     unsigned m_size;
     unsigned m_capacity;
     union U {
         T* buffer;
-        T smallStorage[SmallArraySize];
+        std::array<T, SmallArraySize> smallStorage;
         U() { };
     } m_inline;
 };
@@ -326,5 +315,3 @@ private:
 } // namespace WTF
 
 using WTF::SmallSet;
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -1082,7 +1082,7 @@ template<typename T, std::size_t Extent>
 void memsetSpan(std::span<T, Extent> destination, uint8_t byte)
 {
     static_assert(std::is_trivially_copyable_v<T>);
-    memset(destination.data(), byte, destination.size_bytes()); // NOLINT
+    memset(static_cast<void*>(destination.data()), byte, destination.size_bytes()); // NOLINT
 }
 
 template<typename T, std::size_t Extent>


### PR DESCRIPTION
#### fb82086de07573df924377cadec9481eeb32df78
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in WTF::SmallSet
<a href="https://bugs.webkit.org/show_bug.cgi?id=296143">https://bugs.webkit.org/show_bug.cgi?id=296143</a>

Reviewed by Darin Adler.

This tested as performance neutral on Speedometer and JetStream.

* Source/WTF/wtf/SmallSet.h:

Canonical link: <a href="https://commits.webkit.org/297659@main">https://commits.webkit.org/297659@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04b1ff4e469e5d72c72bc4d3778b3a63d5461d35

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32158 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118505 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62840 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32810 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40721 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85405 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36142 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115373 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26188 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101149 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65836 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25485 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19284 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62350 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/104940 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95575 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19359 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121831 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/111040 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39500 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29410 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94222 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39882 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97386 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94047 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24048 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39284 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17084 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35561 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39388 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44876 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/135271 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39023 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36348 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42360 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40766 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->