### PR TITLE
Use Copy File build phases instead of rsync to copy testapiScripts

### DIFF
--- a/Source/JavaScriptCore/API/tests/testapiScripts/README.md
+++ b/Source/JavaScriptCore/API/tests/testapiScripts/README.md
@@ -1,0 +1,10 @@
+**IMPORTANT**: when a script file required by tests is added to this directory or its subdirectory,
+it needs to be manually added to the corresponding `Copy Files` build phase in the `testapi` target
+in `Source/JavaScriptCore/JavaScriptCore.xcodeproj`.
+
+1. Open `Source/JavaScriptCore/JavaScriptCore.xcodeproj` in Xcode.
+2. Select `JavaScriptCore` (top project item) in the Project Navigator.
+3. Select the `testapi` target.
+4. Select the `Build Phases` tab.
+5. Expand the `Copy Files` build phase for `testapiScripts` or `testapiScripts/dependencyListTests`
+   and add the new file(s) to the list.

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -790,6 +790,17 @@
 		14F7256614EE265E00B1652B /* WeakHandleOwner.h in Headers */ = {isa = PBXBuildFile; fileRef = 14F7256414EE265E00B1652B /* WeakHandleOwner.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		14F79F70216EAFD200046D39 /* Opcode.h in Headers */ = {isa = PBXBuildFile; fileRef = 969A07950ED1D3AE00F1F681 /* Opcode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1A28D4A8177B71C80007FA3C /* JSStringRefPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A28D4A7177B71C80007FA3C /* JSStringRefPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		233D76752E288A2F00EB9FFB /* basic.js in CopyFiles */ = {isa = PBXBuildFile; fileRef = 53C3D5E421ECE6CE0087FDFC /* basic.js */; };
+		233D76762E288A2F00EB9FFB /* foo.js in CopyFiles */ = {isa = PBXBuildFile; fileRef = 52D1308F221CE03A009C836C /* foo.js */; };
+		233D76882E288AD500EB9FFB /* testapi.js in CopyFiles */ = {isa = PBXBuildFile; fileRef = 233D767F2E288A8600EB9FFB /* testapi.js */; };
+		233D76892E288AD500EB9FFB /* testapi-function-overrides.js in CopyFiles */ = {isa = PBXBuildFile; fileRef = 233D76802E288A8600EB9FFB /* testapi-function-overrides.js */; };
+		233D768B2E288BCA00EB9FFB /* badModuleImportId.js in CopyFiles */ = {isa = PBXBuildFile; fileRef = 233D76772E288A8600EB9FFB /* badModuleImportId.js */; };
+		233D768C2E288BCA00EB9FFB /* bar.js in CopyFiles */ = {isa = PBXBuildFile; fileRef = 233D76782E288A8600EB9FFB /* bar.js */; };
+		233D768D2E288BCA00EB9FFB /* dependenciesEntry.js in CopyFiles */ = {isa = PBXBuildFile; fileRef = 233D76792E288A8600EB9FFB /* dependenciesEntry.js */; };
+		233D768E2E288BCA00EB9FFB /* foo.js in CopyFiles */ = {isa = PBXBuildFile; fileRef = 233D767A2E288A8600EB9FFB /* foo.js */; };
+		233D768F2E288BCA00EB9FFB /* missingImport.js in CopyFiles */ = {isa = PBXBuildFile; fileRef = 233D767B2E288A8600EB9FFB /* missingImport.js */; };
+		233D76902E288BCA00EB9FFB /* referenceError.js in CopyFiles */ = {isa = PBXBuildFile; fileRef = 233D767C2E288A8600EB9FFB /* referenceError.js */; };
+		233D76912E288BCA00EB9FFB /* syntaxError.js in CopyFiles */ = {isa = PBXBuildFile; fileRef = 233D767D2E288A8600EB9FFB /* syntaxError.js */; };
 		2600B5A7152BAAA70091EE5F /* JSStringJoiner.h in Headers */ = {isa = PBXBuildFile; fileRef = 2600B5A5152BAAA70091EE5F /* JSStringJoiner.h */; };
 		262D85B71C0D650F006ACB61 /* AirFixPartialRegisterStalls.h in Headers */ = {isa = PBXBuildFile; fileRef = 262D85B51C0D650F006ACB61 /* AirFixPartialRegisterStalls.h */; };
 		2684D4381C00161C0081D663 /* AirLiveness.h in Headers */ = {isa = PBXBuildFile; fileRef = 2684D4371C00161C0081D663 /* AirLiveness.h */; };
@@ -2568,6 +2579,35 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		233D76732E28893100EB9FFB /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = testapiScripts;
+			dstSubfolderSpec = 7;
+			files = (
+				233D76752E288A2F00EB9FFB /* basic.js in CopyFiles */,
+				233D76762E288A2F00EB9FFB /* foo.js in CopyFiles */,
+				233D76892E288AD500EB9FFB /* testapi-function-overrides.js in CopyFiles */,
+				233D76882E288AD500EB9FFB /* testapi.js in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		233D768A2E288B6900EB9FFB /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = testapiScripts/dependencyListTests;
+			dstSubfolderSpec = 7;
+			files = (
+				233D768B2E288BCA00EB9FFB /* badModuleImportId.js in CopyFiles */,
+				233D768C2E288BCA00EB9FFB /* bar.js in CopyFiles */,
+				233D768D2E288BCA00EB9FFB /* dependenciesEntry.js in CopyFiles */,
+				233D768E2E288BCA00EB9FFB /* foo.js in CopyFiles */,
+				233D768F2E288BCA00EB9FFB /* missingImport.js in CopyFiles */,
+				233D76902E288BCA00EB9FFB /* referenceError.js in CopyFiles */,
+				233D76912E288BCA00EB9FFB /* syntaxError.js in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		446997032AFED699008B930C /* Product Dependencies */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -3846,6 +3886,15 @@
 		1CAA8B4A0D32C39A0041BCFF /* JavaScript.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JavaScript.h; sourceTree = "<group>"; };
 		1CAA8B4B0D32C39A0041BCFF /* JavaScriptCore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JavaScriptCore.h; sourceTree = "<group>"; };
 		20ECB15EFC524624BC2F02D5 /* ModuleNamespaceAccessCase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ModuleNamespaceAccessCase.cpp; sourceTree = "<group>"; };
+		233D76772E288A8600EB9FFB /* badModuleImportId.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = badModuleImportId.js; sourceTree = "<group>"; };
+		233D76782E288A8600EB9FFB /* bar.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = bar.js; sourceTree = "<group>"; };
+		233D76792E288A8600EB9FFB /* dependenciesEntry.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = dependenciesEntry.js; sourceTree = "<group>"; };
+		233D767A2E288A8600EB9FFB /* foo.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = foo.js; sourceTree = "<group>"; };
+		233D767B2E288A8600EB9FFB /* missingImport.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = missingImport.js; sourceTree = "<group>"; };
+		233D767C2E288A8600EB9FFB /* referenceError.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = referenceError.js; sourceTree = "<group>"; };
+		233D767D2E288A8600EB9FFB /* syntaxError.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = syntaxError.js; sourceTree = "<group>"; };
+		233D767F2E288A8600EB9FFB /* testapi.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = testapi.js; sourceTree = "<group>"; };
+		233D76802E288A8600EB9FFB /* testapi-function-overrides.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "testapi-function-overrides.js"; sourceTree = "<group>"; };
 		2600B5A4152BAAA70091EE5F /* JSStringJoiner.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSStringJoiner.cpp; sourceTree = "<group>"; };
 		2600B5A5152BAAA70091EE5F /* JSStringJoiner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSStringJoiner.h; sourceTree = "<group>"; };
 		262D85B41C0D650F006ACB61 /* AirFixPartialRegisterStalls.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AirFixPartialRegisterStalls.cpp; path = b3/air/AirFixPartialRegisterStalls.cpp; sourceTree = "<group>"; };
@@ -7439,6 +7488,20 @@
 			tabWidth = 4;
 			usesTabs = 0;
 		};
+		233D767E2E288A8600EB9FFB /* dependencyListTests */ = {
+			isa = PBXGroup;
+			children = (
+				233D76772E288A8600EB9FFB /* badModuleImportId.js */,
+				233D76782E288A8600EB9FFB /* bar.js */,
+				233D76792E288A8600EB9FFB /* dependenciesEntry.js */,
+				233D767A2E288A8600EB9FFB /* foo.js */,
+				233D767B2E288A8600EB9FFB /* missingImport.js */,
+				233D767C2E288A8600EB9FFB /* referenceError.js */,
+				233D767D2E288A8600EB9FFB /* syntaxError.js */,
+			);
+			path = dependencyListTests;
+			sourceTree = "<group>";
+		};
 		4487DB802AF8257200AFECAE /* fuzzilli */ = {
 			isa = PBXGroup;
 			children = (
@@ -7673,8 +7736,11 @@
 		53C3D5E321ECE68E0087FDFC /* testapiScripts */ = {
 			isa = PBXGroup;
 			children = (
+				233D767E2E288A8600EB9FFB /* dependencyListTests */,
 				53C3D5E421ECE6CE0087FDFC /* basic.js */,
 				52D1308F221CE03A009C836C /* foo.js */,
+				233D76802E288A8600EB9FFB /* testapi-function-overrides.js */,
+				233D767F2E288A8600EB9FFB /* testapi.js */,
 			);
 			name = testapiScripts;
 			path = API/tests/testapiScripts;
@@ -12222,7 +12288,8 @@
 				E3D6F6EE25D78CF600C20EB4 /* Generate Entitlements */,
 				14BD59BC0A3E8F9000BAF59C /* Sources */,
 				14BD59BD0A3E8F9000BAF59C /* Frameworks */,
-				5366FDB222D5485B00BF94AF /* Copy Support Scripts */,
+				233D76732E28893100EB9FFB /* CopyFiles */,
+				233D768A2E288B6900EB9FFB /* CopyFiles */,
 			);
 			buildRules = (
 			);
@@ -12532,24 +12599,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "Scripts/check-xcfilelists.sh && touch \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-		};
-		5366FDB222D5485B00BF94AF /* Copy Support Scripts */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Support Scripts";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "rsync -r ${SRCROOT}/API/tests/testapiScripts ${BUILT_PRODUCTS_DIR}\n";
 		};
 		539966E3237CD6740033B0D2 /* Create Versions/Current/Helpers symlink */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
#### 9347e5999f88c45525dc3eae21cc9b54a756fae3
<pre>
Use Copy File build phases instead of rsync to copy testapiScripts
<a href="https://bugs.webkit.org/show_bug.cgi?id=296148">https://bugs.webkit.org/show_bug.cgi?id=296148</a>
<a href="https://rdar.apple.com/151903358">rdar://151903358</a>

Reviewed by Yusuke Suzuki.

Internal bot failures reported in the radar were caused by the `testapiScripts` directory
not being included in some `build-root` configurations into the built artifacts. That was
because the scripts were copied using `rsync` into the location where `build-root` did not
expect them.

The patch changes the project to use the built-in `Copy Files` build phase.
`build-root` is aware of that phase and will include the copied files into the artifacts
as expected.

The downside of this solution is that new scripts added to that directory subtree need
to be manually added to the `Copy Files` build phases. I added a README to point that
out and explain the process.

Canonical link: <a href="https://commits.webkit.org/297740@main">https://commits.webkit.org/297740@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0e26672841ed656de9b1e610fddd0e05df76b45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112594 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32326 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22804 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118793 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63058 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32978 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40889 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85694 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36318 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115541 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26315 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101287 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65998 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25612 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19422 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62552 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/105108 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95711 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19497 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122014 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/111208 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39668 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29550 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94562 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40051 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97523 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94299 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24094 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39416 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17217 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/35756 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39556 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45044 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/135440 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39194 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36395 "Found 2 new JSC stress test failures: stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint, wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42528 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40934 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->