### PR TITLE
[WebCodec] Perf test for VideoFrame(pixelBuffer).

### DIFF
--- a/PerformanceTests/VideoFrame/video-frame-construct-from-pixel-buffer-bgra.html
+++ b/PerformanceTests/VideoFrame/video-frame-construct-from-pixel-buffer-bgra.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../resources/runner.js"></script>
+<script>
+const dimension = 1920;
+const pixelBuffer = new Uint8Array(dimension * dimension * 4);
+const pixelFormat = "BGRA";
+
+PerfTestRunner.measureRunsPerSecond({
+    description: `Construct VideoFrame from ${pixelFormat} buffer of image ${dimension}x${dimension}`,
+    run: () => {
+        const videoFrame = new VideoFrame(pixelBuffer, {
+            format: pixelFormat,
+            codedHeight: dimension,
+            codedWidth: dimension,
+            timestamp: performance.now(),
+        });
+        videoFrame.close();
+    }
+});
+</script>
+</body>
+</html>

--- a/PerformanceTests/VideoFrame/video-frame-construct-from-pixel-buffer-bgrx.html
+++ b/PerformanceTests/VideoFrame/video-frame-construct-from-pixel-buffer-bgrx.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../resources/runner.js"></script>
+<script>
+const dimension = 1920;
+const pixelBuffer = new Uint8Array(dimension * dimension * 4);
+const pixelFormat = "BGRX";
+
+PerfTestRunner.measureRunsPerSecond({
+    description: `Construct VideoFrame from ${pixelFormat} buffer of image ${dimension}x${dimension}`,
+    run: () => {
+        const videoFrame = new VideoFrame(pixelBuffer, {
+            format: pixelFormat,
+            codedHeight: dimension,
+            codedWidth: dimension,
+            timestamp: performance.now(),
+        });
+        videoFrame.close();
+    }
+});
+</script>
+</body>
+</html>

--- a/PerformanceTests/VideoFrame/video-frame-construct-from-pixel-buffer-rgba.html
+++ b/PerformanceTests/VideoFrame/video-frame-construct-from-pixel-buffer-rgba.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../resources/runner.js"></script>
+<script>
+const dimension = 1920;
+const pixelBuffer = new Uint8Array(dimension * dimension * 4);
+const pixelFormat = "RGBA";
+
+PerfTestRunner.measureRunsPerSecond({
+    description: `Construct VideoFrame from ${pixelFormat} buffer of image ${dimension}x${dimension}`,
+    run: () => {
+        const videoFrame = new VideoFrame(pixelBuffer, {
+            format: pixelFormat,
+            codedHeight: dimension,
+            codedWidth: dimension,
+            timestamp: performance.now(),
+        });
+        videoFrame.close();
+    }
+});
+</script>
+</body>
+</html>

--- a/PerformanceTests/VideoFrame/video-frame-construct-from-pixel-buffer-rgbx.html
+++ b/PerformanceTests/VideoFrame/video-frame-construct-from-pixel-buffer-rgbx.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../resources/runner.js"></script>
+<script>
+const dimension = 1920;
+const pixelBuffer = new Uint8Array(dimension * dimension * 4);
+const pixelFormat = "RGBX";
+
+PerfTestRunner.measureRunsPerSecond({
+    description: `Construct VideoFrame from ${pixelFormat} buffer of image ${dimension}x${dimension}`,
+    run: () => {
+        const videoFrame = new VideoFrame(pixelBuffer, {
+            format: pixelFormat,
+            codedHeight: dimension,
+            codedWidth: dimension,
+            timestamp: performance.now(),
+        });
+        videoFrame.close();
+    }
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 7907f9efc385aa1e80861bed731c0e160576aa45
<pre>
[WebCodec] Perf test for VideoFrame(pixelBuffer).
<a href="https://bugs.webkit.org/show_bug.cgi?id=296145">https://bugs.webkit.org/show_bug.cgi?id=296145</a>

Reviewed by NOBODY (OOPS!).

Tests to demonstrate dramatic difference in performance of construction
of VideoFrame from pixel buffer depending on pixel buffer format.

* PerformanceTests/VideoFrame/video-frame-construct-from-pixel-buffer-bgra.html: Added.
* PerformanceTests/VideoFrame/video-frame-construct-from-pixel-buffer-bgrx.html: Added.
* PerformanceTests/VideoFrame/video-frame-construct-from-pixel-buffer-rgba.html: Added.
* PerformanceTests/VideoFrame/video-frame-construct-from-pixel-buffer-rgbx.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7907f9efc385aa1e80861bed731c0e160576aa45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112149 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31890 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22369 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118226 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62564 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32534 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40447 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85204 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35944 "Build is in progress. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115096 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25966 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100918 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65634 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25272 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62071 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95351 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19133 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121552 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39226 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29180 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94033 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39608 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97161 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93856 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39076 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16868 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/35251 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39110 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38746 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42083 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40487 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->