### PR TITLE
Disable some noJIT tests on Debug due to timeouts

### DIFF
--- a/JSTests/microbenchmarks/global-this-access-get.js
+++ b/JSTests/microbenchmarks/global-this-access-get.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 globalThis.value = 42;
 
 function test()

--- a/JSTests/microbenchmarks/global-this-access-put.js
+++ b/JSTests/microbenchmarks/global-this-access-put.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 globalThis.value = 42;
 
 function test(v)

--- a/JSTests/microbenchmarks/regexp-match-alphanumeric.js
+++ b/JSTests/microbenchmarks/regexp-match-alphanumeric.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 (function() {
     var result = 0;
     var n = 10000000;

--- a/JSTests/microbenchmarks/regexp-match-multiple-single-chars.js
+++ b/JSTests/microbenchmarks/regexp-match-multiple-single-chars.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 (function() {
     var result = 0;
     var n = 10000000;

--- a/JSTests/microbenchmarks/regexp-match-separators.js
+++ b/JSTests/microbenchmarks/regexp-match-separators.js
@@ -1,3 +1,4 @@
+//@ skip if $buildType == "debug"
 (function() {
     var result = 0;
     var n = 1000000;

--- a/JSTests/stress/array-prototype-concat-of-long-spliced-arrays.js
+++ b/JSTests/stress/array-prototype-concat-of-long-spliced-arrays.js
@@ -1,4 +1,4 @@
-//@ $skipModes << :lockdown if $memoryLimited
+//@ $skipModes << :lockdown if $memoryLimited  or $buildType == "debug"
 
 function shouldEqual(actual, expected) {
     if (actual != expected) {

--- a/JSTests/stress/array-prototype-concat-of-long-spliced-arrays2.js
+++ b/JSTests/stress/array-prototype-concat-of-long-spliced-arrays2.js
@@ -1,4 +1,4 @@
-//@ $skipModes << :lockdown if $memoryLimited
+//@ $skipModes << :lockdown if $memoryLimited or $buildType == "debug"
 
 function shouldEqual(actual, expected) {
     if (actual != expected) {

--- a/JSTests/stress/loop-osr-with-inlined-create-rest.js
+++ b/JSTests/stress/loop-osr-with-inlined-create-rest.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 function bar(...a) {
   return a;
 }

--- a/JSTests/stress/string-prototype-replace-should-throw-out-of-memory-error-when-using-too-much-memory.js
+++ b/JSTests/stress/string-prototype-replace-should-throw-out-of-memory-error-when-using-too-much-memory.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ skip if $memoryLimited or $buildType == "debug"
 //@ runFTLNoCJIT("--timeoutMultiplier=1.5") if !$memoryLimited
 //@ slow!
 // This test should not crash or fail any assertions.

--- a/JSTests/wasm/function-tests/memory-access-past-4gib.js
+++ b/JSTests/wasm/function-tests/memory-access-past-4gib.js
@@ -1,3 +1,5 @@
+//@ $skipModes << "wasm-no-jit".to_sym if $buildType == "debug"
+
 import Builder from '../Builder.js';
 import * as assert from '../assert.js';
 import * as LLB from '../LowLevelBinary.js';

--- a/JSTests/wasm/js-api/memory-grow.js
+++ b/JSTests/wasm/js-api/memory-grow.js
@@ -1,3 +1,5 @@
+//@ $skipModes << "wasm-no-jit".to_sym if $buildType == "debug"
+
 import { eq as assertEq, throws as assertThrows } from "../assert.js";
 const pageSize = 64*1024;
 

--- a/JSTests/wasm/references/multitable.js
+++ b/JSTests/wasm/references/multitable.js
@@ -1,4 +1,6 @@
 //@ if $memoryLimited then skip else requireOptions("--verifyGC=0") end
+//@ $skipModes << "wasm-no-jit".to_sym if $buildType == "debug"
+
 import * as assert from '../assert.js';
 import Builder from '../Builder.js';
 

--- a/JSTests/wasm/stress/big-try.js
+++ b/JSTests/wasm/stress/big-try.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWasmSIMD=1")
-//@ skip if !$isSIMDPlatform
+//@ skip if !$isSIMDPlatform or $buildType == "debug"
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/exports-getter-fold.js
+++ b/JSTests/wasm/stress/exports-getter-fold.js
@@ -1,3 +1,6 @@
+//@ $skipModes << "wasm-no-wasm-jit".to_sym if $buildType == "debug"
+//@ $skipModes << "wasm-no-jit".to_sym if $buildType == "debug"
+
 import { instantiate } from "../wabt-wrapper.js";
 
 var object = { };

--- a/JSTests/wasm/stress/exports-getter.js
+++ b/JSTests/wasm/stress/exports-getter.js
@@ -1,3 +1,6 @@
+//@ $skipModes << "wasm-no-wasm-jit".to_sym if $buildType == "debug"
+//@ $skipModes << "wasm-no-jit".to_sym if $buildType == "debug"
+
 import { instantiate } from "../wabt-wrapper.js";
 
 function bench(instance)


### PR DESCRIPTION
#### 2cde251213d2882cf4b67dbb2199f131a2d99df2
<pre>
Disable some noJIT tests on Debug due to timeouts
<a href="https://bugs.webkit.org/show_bug.cgi?id=296149">https://bugs.webkit.org/show_bug.cgi?id=296149</a>
<a href="https://rdar.apple.com/155988745">rdar://155988745</a>

Reviewed by Yusuke Suzuki.

Running noJIT and Debug leads to some tests hitting timeouts during Debug tests. noJIT/Debug
is very slow so we should just skip these to avoid constant failures.

* JSTests/microbenchmarks/global-this-access-get.js:
* JSTests/microbenchmarks/global-this-access-put.js:
* JSTests/microbenchmarks/regexp-match-alphanumeric.js:
* JSTests/microbenchmarks/regexp-match-multiple-single-chars.js:
* JSTests/microbenchmarks/regexp-match-separators.js:
* JSTests/stress/array-prototype-concat-of-long-spliced-arrays.js:
* JSTests/stress/array-prototype-concat-of-long-spliced-arrays2.js:
* JSTests/stress/loop-osr-with-inlined-create-rest.js:
* JSTests/stress/string-prototype-replace-should-throw-out-of-memory-error-when-using-too-much-memory.js:
* JSTests/wasm/function-tests/memory-access-past-4gib.js:
* JSTests/wasm/js-api/memory-grow.js:
* JSTests/wasm/references/multitable.js:
* JSTests/wasm/stress/big-try.js:
* JSTests/wasm/stress/exports-getter-fold.js:
* JSTests/wasm/stress/exports-getter.js:

Canonical link: <a href="https://commits.webkit.org/297563@main">https://commits.webkit.org/297563@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e101bd65c3d3934a87b90586cc21a875988e6103

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112156 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31886 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22371 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118233 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62446 "Build is in progress. Recent messages:") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40451 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/85210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/62446 "Build is in progress. Recent messages:") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115103 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/25971 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100919 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/65640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25277 "Passed tests") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/62078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/104671 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95356 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/19134 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/121559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/110772 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39230 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29183 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/121559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39611 "Hash e101bd65 for PR 48207 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97162 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/121559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23992 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16869 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/35258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39118 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/135001 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38753 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36305 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention.js.default (failure)") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/42090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40496 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->