### PR TITLE
AX: Add remote element token information to debug snapshot

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -138,6 +138,10 @@
 #include <wtf/text/AtomString.h>
 #include <wtf/text/MakeString.h>
 
+#if PLATFORM(COCOA)
+#include <wtf/spi/darwin/OSVariantSPI.h>
+#endif
+
 namespace WebCore {
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(AXComputedObjectAttributeCache);
@@ -5947,5 +5951,18 @@ void AXObjectCache::onWidgetVisibilityChanged(RenderWidget& widget)
     UNUSED_PARAM(widget);
 #endif
 }
+
+#if PLATFORM(MAC)
+bool AXObjectCache::isAppleInternalInstall()
+{
+    static bool isInternal = false;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        isInternal = os_variant_allows_internal_security_policies("com.apple.Accessibility");
+    });
+
+    return isInternal;
+}
+#endif // PLATFORM(COCOA)
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -145,6 +145,8 @@ struct AXDebugInfo {
     bool isAccessibilityThreadInitialized;
     String liveTree;
     String isolatedTree;
+    uint64_t remoteTokenHash;
+    uint64_t webProcessLocalTokenHash;
 };
 
 #if PLATFORM(COCOA)
@@ -491,6 +493,9 @@ public:
 
     static void enableAccessibility();
     static void disableAccessibility();
+#if PLATFORM(MAC)
+    WEBCORE_EXPORT static bool isAppleInternalInstall();
+#endif
     static bool forceDeferredSpellChecking();
     static void setForceDeferredSpellChecking(bool);
 #if PLATFORM(MAC)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -9203,6 +9203,8 @@ header: <WebCore/AXObjectCache.h>
     bool isAccessibilityThreadInitialized;
     String liveTree;
     String isolatedTree;
+    uint64_t remoteTokenHash;
+    uint64_t webProcessLocalTokenHash;
 }
 
 header: <WebCore/ScriptTrackingPrivacyCategory.h>

--- a/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
+++ b/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
@@ -174,7 +174,11 @@ id <_WKFullscreenDelegate> WKPageGetFullscreenDelegate(WKPageRef page)
 
 NSDictionary *WKPageGetAccessibilityWebProcessDebugInfo(WKPageRef pageRef)
 {
+#if PLATFORM(MAC)
     return WebKit::toImpl(pageRef)->getAccessibilityWebProcessDebugInfo();
+#else
+    return nil;
+#endif
 }
 
 void WKPageAccessibilityClearIsolatedTree(WKPageRef pageRef)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -6338,6 +6338,18 @@ static Vector<Ref<API::TargetedElementInfo>> elementsFromWKElements(NSArray<_WKT
 #endif
 }
 
+#if PLATFORM(MAC)
+- (NSUInteger)accessibilityRemoteChildTokenHash
+{
+    return _impl->accessibilityRemoteChildTokenHash();
+}
+
+- (NSUInteger)accessibilityUIProcessLocalTokenHash
+{
+    return _impl->accessibilityUIProcessLocalTokenHash();
+}
+#endif // PLATFORM(MAC)
+
 @end
 
 @implementation WKWebView (WKDeprecated)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -621,6 +621,11 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 
 @property (nonatomic, setter=_setShouldSuppressTopColorExtensionView:) BOOL _shouldSuppressTopColorExtensionView WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
+#if TARGET_OS_OSX
+- (NSUInteger)accessibilityRemoteChildTokenHash;
+- (NSUInteger)accessibilityUIProcessLocalTokenHash;
+#endif
+
 @end
 
 #if TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1758,6 +1758,7 @@ String WebPageProxy::presentingApplicationBundleIdentifier() const
     return { };
 }
 
+#if PLATFORM(MAC)
 NSDictionary *WebPageProxy::getAccessibilityWebProcessDebugInfo()
 {
     const Seconds messageTimeout(2);
@@ -1772,7 +1773,9 @@ NSDictionary *WebPageProxy::getAccessibilityWebProcessDebugInfo()
         @"axIsEnabled": [NSNumber numberWithBool:result.isAccessibilityEnabled],
         @"axIsThreadInitialized": [NSNumber numberWithBool:result.isAccessibilityThreadInitialized],
         @"axLiveTree": result.liveTree.createNSString().get(),
-        @"axIsolatedTree": result.isolatedTree.createNSString().get()
+        @"axIsolatedTree": result.isolatedTree.createNSString().get(),
+        @"axWebProcessRemoteHash": [NSNumber numberWithUnsignedInteger:result.remoteTokenHash],
+        @"axWebProcessLocalHash": [NSNumber numberWithUnsignedInteger:result.webProcessLocalTokenHash]
     };
 }
 
@@ -1784,6 +1787,7 @@ void WebPageProxy::clearAccessibilityIsolatedTree()
     });
 }
 #endif
+#endif // PLATFORM(MAC)
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1448,7 +1448,7 @@ public:
     void accessibilitySettingsDidChange();
     void enableAccessibilityForAllProcesses();
 
-#if PLATFORM(COCOA)
+#if PLATFORM(MAC)
     NSDictionary *getAccessibilityWebProcessDebugInfo();
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     void clearAccessibilityIsolatedTree();

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -501,6 +501,8 @@ public:
     void accessibilityRegisterUIProcessTokens();
     void updateRemoteAccessibilityRegistration(bool registerProcess);
     id accessibilityFocusedUIElement();
+    NSUInteger accessibilityRemoteChildTokenHash();
+    NSUInteger accessibilityUIProcessLocalTokenHash();
     bool accessibilityIsIgnored() const { return false; }
     id accessibilityHitTest(CGPoint);
     void enableAccessibilityIfNecessary(NSString *attribute = nil);
@@ -1004,6 +1006,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     bool m_allowsMagnification { false };
 
     RetainPtr<NSAccessibilityRemoteUIElement> m_remoteAccessibilityChild;
+    RetainPtr<NSData> m_remoteAccessibilityChildToken;
+    RetainPtr<NSData> m_remoteAccessibilityTokenGeneratedByUIProcess;
     RetainPtr<NSMutableDictionary> m_remoteAccessibilityFrameCache;
 
     RefPtr<WebCore::Image> m_promisedImage;

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -3703,8 +3703,19 @@ void WebViewImpl::setAccessibilityWebProcessToken(NSData *data, pid_t pid)
 {
     if (pid == m_page->legacyMainFrameProcess().processID()) {
         m_remoteAccessibilityChild = data.length ? adoptNS([[NSAccessibilityRemoteUIElement alloc] initWithRemoteToken:data]) : nil;
+        m_remoteAccessibilityChildToken = data;
         updateRemoteAccessibilityRegistration(true);
     }
+}
+
+NSUInteger WebViewImpl::accessibilityRemoteChildTokenHash()
+{
+    return [m_remoteAccessibilityChildToken hash];
+}
+
+NSUInteger WebViewImpl::accessibilityUIProcessLocalTokenHash()
+{
+    return [m_remoteAccessibilityTokenGeneratedByUIProcess hash];
 }
 
 void WebViewImpl::updateRemoteAccessibilityRegistration(bool registerProcess)
@@ -3718,6 +3729,7 @@ void WebViewImpl::updateRemoteAccessibilityRegistration(bool registerProcess)
     else if (!registerProcess) {
         pid = [m_remoteAccessibilityChild processIdentifier];
         m_remoteAccessibilityChild = nil;
+        m_remoteAccessibilityChildToken = nil;
     }
     if (!pid)
         return;
@@ -3732,6 +3744,7 @@ void WebViewImpl::accessibilityRegisterUIProcessTokens()
 {
     // Initialize remote accessibility when the window connection has been established.
     RetainPtr remoteElementToken = [NSAccessibilityRemoteUIElement remoteTokenForLocalUIElement:m_view.getAutoreleased()];
+    m_remoteAccessibilityTokenGeneratedByUIProcess = remoteElementToken.get();
     RetainPtr remoteWindowToken = [NSAccessibilityRemoteUIElement remoteTokenForLocalUIElement:[m_view window]];
     m_page->registerUIProcessAccessibilityTokens(span(remoteElementToken.get()), span(remoteWindowToken.get()));
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2736,31 +2736,6 @@ void WebPage::enableAccessibility()
         WebCore::AXObjectCache::enableAccessibility();
 }
 
-void WebPage::getAccessibilityWebProcessDebugInfo(CompletionHandler<void(WebCore::AXDebugInfo)>&& completionHandler)
-{
-    if (auto treeData = protectedCorePage()->accessibilityTreeData(IncludeDOMInfo::No)) {
-#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-        completionHandler({ WebCore::AXObjectCache::accessibilityEnabled(), WebCore::AXObjectCache::isAXThreadInitialized(), treeData->liveTree, treeData->isolatedTree });
-#else
-        completionHandler({ WebCore::AXObjectCache::accessibilityEnabled(), false, treeData->liveTree, treeData->isolatedTree });
-#endif
-        return;
-    }
-#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    completionHandler({ WebCore::AXObjectCache::accessibilityEnabled(), WebCore::AXObjectCache::isAXThreadInitialized(), { }, { } });
-#else
-    completionHandler({ WebCore::AXObjectCache::accessibilityEnabled(), false, { }, { } });
-#endif
-}
-
-#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-void WebPage::clearAccessibilityIsolatedTree()
-{
-    if (RefPtr page = m_page)
-        page->clearAccessibilityIsolatedTree();
-}
-#endif
-
 void WebPage::screenPropertiesDidChange()
 {
     protectedCorePage()->screenPropertiesDidChange();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -826,10 +826,12 @@ public:
     void enableAccessibilityForAllProcesses();
     void enableAccessibility();
 
+#if PLATFORM(MAC)
     void getAccessibilityWebProcessDebugInfo(CompletionHandler<void(WebCore::AXDebugInfo)>&&);
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     void clearAccessibilityIsolatedTree();
 #endif
+#endif // PLATFORM(MAC)
 
     void screenPropertiesDidChange();
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -509,9 +509,11 @@ messages -> WebPage WantsAsyncDispatchMessage {
     ResolveAccessibilityHitTestForTesting(WebCore::FrameIdentifier frameID, WebCore::IntPoint point) -> (String result)
     EnableAccessibility()
 
+#if PLATFORM(MAC)
     GetAccessibilityWebProcessDebugInfo() -> (struct WebCore::AXDebugInfo result) Synchronous
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     ClearAccessibilityIsolatedTree()
+#endif
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h
@@ -58,6 +58,7 @@ class AXIsolatedTree;
     Lock m_parentLock;
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     RetainPtr<id> m_parent;
+    RetainPtr<NSData> m_remoteToken;
     bool m_hasMainFramePlugin;
     std::optional<WebCore::FrameIdentifier> m_frameID;
 }
@@ -70,7 +71,7 @@ class AXIsolatedTree;
 - (void)setWindow:(id)window;
 - (void)_buildIsolatedTreeIfNeeded;
 #endif
-- (void)setRemoteParent:(id)parent;
+- (void)setRemoteParent:(id)parent token:(NSData *)token;
 - (void)setRemoteFrameOffset:(WebCore::IntPoint)offset;
 - (void)setHasMainFramePlugin:(bool)hasPlugin;
 - (void)setFrameIdentifier:(const WebCore::FrameIdentifier&)frameID;
@@ -79,5 +80,6 @@ class AXIsolatedTree;
 - (id)accessibilityFocusedUIElement;
 - (WebCore::IntPoint)accessibilityRemoteFrameOffset;
 - (WebCore::LocalFrame *)focusedLocalFrame;
+- (NSUInteger)remoteTokenHash;
 
 @end

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
@@ -217,7 +217,7 @@ namespace ax = WebCore::Accessibility;
     return m_remoteFrameOffset;
 }
 
-- (void)setRemoteParent:(id)parent
+- (void)setRemoteParent:(id)parent token:(NSData *)token
 {
     ASSERT(isMainRunLoop());
 
@@ -225,6 +225,12 @@ namespace ax = WebCore::Accessibility;
     Locker lock { m_parentLock };
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     m_parent = parent;
+    m_remoteToken = token;
+}
+
+- (NSUInteger)remoteTokenHash
+{
+    return [m_remoteToken.get() hash];
 }
 
 - (void)setFrameIdentifier:(const WebCore::FrameIdentifier&)frameID

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -452,7 +452,7 @@ void WebPage::registerRemoteFrameAccessibilityTokens(pid_t pid, std::span<const 
     auto remoteElement = [elementTokenData length] ? adoptNS([[NSAccessibilityRemoteUIElement alloc] initWithRemoteToken:elementTokenData.get()]) : nil;
 
     createMockAccessibilityElement(pid);
-    [accessibilityRemoteObject() setRemoteParent:remoteElement.get()];
+    [accessibilityRemoteObject() setRemoteParent:remoteElement.get() token:elementTokenData.get()];
     [accessibilityRemoteObject() setFrameIdentifier:frameID];
 }
 
@@ -466,7 +466,7 @@ void WebPage::registerUIProcessAccessibilityTokens(std::span<const uint8_t> elem
     [remoteElement setWindowUIElement:remoteWindow.get()];
     [remoteElement setTopLevelUIElement:remoteWindow.get()];
     [accessibilityRemoteObject() setWindow:remoteWindow.get()];
-    [accessibilityRemoteObject() setRemoteParent:remoteElement.get()];
+    [accessibilityRemoteObject() setRemoteParent:remoteElement.get() token:elementTokenData.get()];
 }
 
 void WebPage::getStringSelectionForPasteboard(CompletionHandler<void(String&&)>&& completionHandler)


### PR DESCRIPTION
#### fc2377eb1a1bd58feeb5de992390cc63f684cc9b
<pre>
AX: Add remote element token information to debug snapshot
<a href="https://bugs.webkit.org/show_bug.cgi?id=296155">https://bugs.webkit.org/show_bug.cgi?id=296155</a>
<a href="https://rdar.apple.com/156104885">rdar://156104885</a>

Reviewed by Tyler Wilcock.

This patch adds more information about the remote elements connecting
the UI process and the web process of the main frame.

Four new pieces of information are captured and output in the snapshot:
- The token hash that the UI process generates
- The token hash that the Web Process generates
- The current remote element&apos;s token hash in the UI process
- The current remote element&apos;s token hash in the web process

By comparing these numbers, we can look for any mismatch that might have
happened.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::isAppleInternalInstall):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm:
(WKPageGetAccessibilityWebProcessDebugInfo):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView accessibilityRemoteChildTokenHash]):
(-[WKWebView accessibilityUIProcessLocalTokenHash]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::getAccessibilityWebProcessDebugInfo):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::setAccessibilityWebProcessToken):
(WebKit::WebViewImpl::accessibilityRemoteChildTokenHash):
(WebKit::WebViewImpl::accessibilityUIProcessLocalTokenHash):
(WebKit::WebViewImpl::updateRemoteAccessibilityRegistration):
(WebKit::WebViewImpl::accessibilityRegisterUIProcessTokens):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::getAccessibilityWebProcessDebugInfo):
(WebKit::WebPage::clearAccessibilityIsolatedTree):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::getAccessibilityWebProcessDebugInfo): Deleted.
(WebKit::WebPage::clearAccessibilityIsolatedTree): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h:
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm:
(-[WKAccessibilityWebPageObjectBase setRemoteParent:token:]):
(-[WKAccessibilityWebPageObjectBase remoteTokenHash]):
(-[WKAccessibilityWebPageObjectBase setRemoteParent:]): Deleted.
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::registerRemoteFrameAccessibilityTokens):
(WebKit::WebPage::registerUIProcessAccessibilityTokens):

Canonical link: <a href="https://commits.webkit.org/297648@main">https://commits.webkit.org/297648@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8530eb177fcfd3d6fbf01c7d7c275a783815c15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112293 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32024 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22502 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118371 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62657 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114255 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32677 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40588 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85307 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/62657 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115240 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26071 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101030 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65737 "Passed tests") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25376 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19166 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62217 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95456 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19245 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121697 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/110907 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39367 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29296 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94115 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/111788 "Build is in progress. Recent messages:") | [⏳ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-Build-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97272 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93939 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24042 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39178 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16974 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35428 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39255 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44743 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38890 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42227 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40633 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->