### PR TITLE
[macOS] Fullscreen animation on YouTube.com is missing

### DIFF
--- a/LayoutTests/fullscreen/fullscreen-zero-height-element-with-non-zero-children-expected.txt
+++ b/LayoutTests/fullscreen/fullscreen-zero-height-element-with-non-zero-children-expected.txt
@@ -1,0 +1,12 @@
+supportsFullScreen() == true
+enterFullScreenForElement()
+beganEnterFullScreen() - initialRect.size: {100, 100}, finalRect.size: {800, 600}
+exitFullScreenForElement()
+beganExitFullScreen() - initialRect.size: {800, 600}, finalRect.size: {100, 100}
+RUN(testRunner.dumpFullScreenCallbacks())
+RUN(target.webkitRequestFullScreen())
+EVENT(webkitfullscreenchange)
+RUN(document.webkitExitFullscreen())
+EVENT(webkitfullscreenchange)
+END OF TEST
+

--- a/LayoutTests/fullscreen/fullscreen-zero-height-element-with-non-zero-children.html
+++ b/LayoutTests/fullscreen/fullscreen-zero-height-element-with-non-zero-children.html
@@ -1,13 +1,16 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>fullscreen-enter-bottom-padding-animation</title>
+    <title>fullscreen-zero-height-element-with-non-zero-children</title>
     <style>
-        html, body { padding: 0; margin: 0; }
         #target { 
-            padding-bottom: 500px;
+            width: 100px;
+            height: 0;
+        }
+        #child { 
             width: 100px;
             height: 100px;
+            position: absolute;
         }
     </style>
     <script src="full-screen-test.js"></script>
@@ -33,6 +36,7 @@
 </head>
 <body>
 <div id="target">
+    <div id="child"></div>
 </div>
 </body>
 </html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1069,6 +1069,7 @@ http/tests/local/blob/navigate-blob.html [ Skip ]
 media/no-fullscreen-when-hidden.html [ Skip ]
 fullscreen/full-screen-enter-while-exiting-fully-mid-completion-handler.html [ Skip ]
 fullscreen/full-screen-enter-while-exiting-mid-completion-handler.html [ Skip ]
+fullscreen/fullscreen-zero-height-element-with-non-zero-children.html [ Skip ]
 
 # Multi-process test
 fullscreen/iframe-fullscreen-system-exit.html [ Skip ]

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -65,13 +65,31 @@ using namespace WebCore;
 
 using WebCore::FloatSize;
 
-static WebCore::IntRect screenRectOfContents(WebCore::Element* element)
+static WebCore::IntRect screenRectOfContents(WebCore::Element& element)
 {
-    ASSERT(element);
-    if (!element)
+    CheckedPtr renderer = element.renderer();
+    if (!renderer)
         return { };
 
-    return element->screenRect();
+    IntRect contentsRect = renderer->absoluteBoundingBoxRect();
+    if (contentsRect.isEmpty()) {
+        // A zero-height element may contain visible overflow contents. If the element
+        // itself is empty, traverse its children to find its visual content area.
+        LayoutRect topLevelRect;
+        contentsRect = snappedIntRect(renderer->paintingRootRect(topLevelRect));
+    }
+
+    if (contentsRect.isEmpty())
+        return { };
+
+    Ref frameView = renderer->view().frameView();
+
+    // The element may have contents which are far outside the viewport of the page.
+    // Clip the contents rect by the current viewport.
+    auto viewportRect = snappedIntRect(frameView->layoutViewportRect());
+    contentsRect.intersect(viewportRect);
+
+    return frameView->contentsToScreen(contentsRect);
 }
 
 Ref<WebFullScreenManager> WebFullScreenManager::create(WebPage& page)
@@ -281,7 +299,7 @@ void WebFullScreenManager::enterFullScreenForElement(Element& element, HTMLMedia
     }
 #endif
 
-    m_initialFrame = screenRectOfContents(m_element.get());
+    m_initialFrame = screenRectOfContents(element);
 
 #if ENABLE(VIDEO)
     updateMainVideoElement();
@@ -388,7 +406,7 @@ void WebFullScreenManager::willEnterFullScreen(Element& element, CompletionHandl
     m_page->hidePageBanners();
 #endif
     element.protectedDocument()->updateLayout();
-    m_finalFrame = screenRectOfContents(&element);
+    m_finalFrame = screenRectOfContents(element);
 
     m_page->sendWithAsyncReply(Messages::WebFullScreenManagerProxy::BeganEnterFullScreen(m_initialFrame, m_finalFrame), [this, protectedThis = Ref { *this }, mode, completionHandler = WTFMove(didEnterFullscreenCallback)] (bool success) mutable {
         if (!success && mode != WebCore::HTMLMediaElementEnums::VideoFullscreenModeInWindow) {
@@ -467,7 +485,7 @@ void WebFullScreenManager::willExitFullScreen(CompletionHandler<void()>&& comple
     setPIPStandbyElement(nullptr);
 #endif
 
-    m_finalFrame = screenRectOfContents(m_element.get());
+    m_finalFrame = screenRectOfContents(*m_element);
     if (!m_element->document().fullscreen().willExitFullscreen()) {
         close();
         return completionHandler();


### PR DESCRIPTION
#### baec4aed924e42ec28b55ec7d608cc13f7bdd9d1
<pre>
[macOS] Fullscreen animation on YouTube.com is missing
<a href="https://rdar.apple.com/155498665">rdar://155498665</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=296156">https://bugs.webkit.org/show_bug.cgi?id=296156</a>

Reviewed by Andy Estes.

In 296331@main, we tried to use a different mechanism to calculate the visual extents of the
element which was entering fullscreen, to account for overflow children of zero-height contents.
However, this caused issues on sites like weather.com and hulu.com, where this calculation lead
to buggy looking animations.

Instead, only use this more expansive screen rect calculation if element.screenRect() returns
an empty rect.

* LayoutTests/fullscreen/fullscreen-zero-height-element-with-non-zero-children-expected.txt: Added.
* LayoutTests/fullscreen/fullscreen-zero-height-element-with-non-zero-children.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::screenRectOfContents):
(WebKit::WebFullScreenManager::enterFullScreenForElement):
(WebKit::WebFullScreenManager::willEnterFullScreen):
(WebKit::WebFullScreenManager::willExitFullScreen):

Canonical link: <a href="https://commits.webkit.org/297687@main">https://commits.webkit.org/297687@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1550ead3edb18821db9557b2e078dcc01f240a04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112323 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32054 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22532 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118402 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62687 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32707 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40618 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85329 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36016 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Skipped layout-tests; layout-tests (failure); Uploaded test results; layout-tests (failure); Compiled WebKit (cancelled)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115270 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26096 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101057 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65760 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25398 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19194 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62247 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95480 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19272 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121727 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39397 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29323 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94136 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39778 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97299 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93962 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24066 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39204 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16999 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35446 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39285 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44773 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38920 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42257 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40663 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->