### PR TITLE
[Site Isolation] Make window.open run through WKContentRuleList in site isolated iframes with non-local main frames

### DIFF
--- a/LayoutTests/http/tests/contentextensions/cross-origin-content-rules-expected.txt
+++ b/LayoutTests/http/tests/contentextensions/cross-origin-content-rules-expected.txt
@@ -1,0 +1,7 @@
+CONSOLE MESSAGE: Content blocker prevented frame displaying http://127.0.0.1:8000/contentextensions/cross-origin-content-rules.html from loading a resource from about:blank
+ALERT: PASS: window.open() in 127.0.0.1 returned null as expected.
+ALERT: Iframe loaded in localhost. Attempting to open popup...
+CONSOLE MESSAGE: Content blocker prevented frame displaying http://127.0.0.1:8000/contentextensions/cross-origin-content-rules.html from loading a resource from about:blank
+ALERT: PASS: window.open() in localhost returned null as expected.
+ALERT: PASS: window.open() in localhost returned a valid Window object as expected.
+

--- a/LayoutTests/http/tests/contentextensions/cross-origin-content-rules.html
+++ b/LayoutTests/http/tests/contentextensions/cross-origin-content-rules.html
@@ -1,0 +1,23 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<body>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+            const popup = window.open("about:blank");
+            const hostname = window.location.hostname;
+            if (!popup) {
+                alert(`PASS: window.open() in ${hostname} returned null as expected.`);
+            } else {
+                alert(`FAIL: window.open() in ${hostname} returned a valid Window object.`);
+                popup.close();
+            }
+            const iframe = document.createElement('iframe');
+            iframe.src = "http://localhost:8000/contentextensions/resources/iframe-that-opens-popup.html";
+            document.body.appendChild(iframe);
+        }
+    </script>
+</body>
+</html>

--- a/LayoutTests/http/tests/contentextensions/cross-origin-content-rules.html.json
+++ b/LayoutTests/http/tests/contentextensions/cross-origin-content-rules.html.json
@@ -1,0 +1,11 @@
+[
+    {
+        "action": {
+            "type": "block"
+        },
+        "trigger": {
+            "url-filter": "about",
+            "resource-type":["popup"]
+        }
+    }
+]

--- a/LayoutTests/http/tests/contentextensions/resources/iframe-that-opens-popup.html
+++ b/LayoutTests/http/tests/contentextensions/resources/iframe-that-opens-popup.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <script>
+        if (window.testRunner) {
+            const hostname = window.location.hostname;
+            alert(`Iframe loaded in ${hostname}. Attempting to open popup...`);
+            try {
+                const blockedPopup = window.open("about:blank");
+                if (!blockedPopup) {
+                    alert(`PASS: window.open() in ${hostname} returned null as expected.`);
+                } else {
+                    alert(`FAIL: window.open() in ${hostname} returned a valid Window object.`);
+                    blockedPopup.close();
+                }
+                const validPopup = window.open("data:text/html, hello");
+                if (!validPopup) {
+                    alert(`FAIL: window.open() in ${hostname} returned null.`);
+                } else {
+                    alert(`PASS: window.open() in ${hostname} returned a valid Window object as expected.`);
+                    validPopup.close();
+                }
+            } catch (e) {
+                alert(`FAIL: An unexpected error occurred: ${e}`);
+            }
+            testRunner.notifyDone();
+        } else {
+            document.body.textContent = "Test requires window.testRunner.";
+        }
+    </script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3029,6 +3029,7 @@ fast/zooming/ios [ Skip ]
 
 # Needs site isolation drawing implementation
 http/tests/site-isolation [ Skip ]
+http/tests/contentextensions/cross-origin-content-rules.html [ Skip ]
 
 # Tests behavior specific to MediaSessionManagerCocoa
 media/audio-session-category.html [ Skip ]

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2686,13 +2686,12 @@ ExceptionOr<RefPtr<WindowProxy>> LocalDOMWindow::open(LocalDOMWindow& activeWind
 
     RefPtr localFrame = dynamicDowncast<LocalFrame>(firstFrame->mainFrame());
 
-    // FIXME: <rdar://118280717> Make WKContentRuleLists apply in this case.
-    RefPtr mainFrameDocument = localFrame ? localFrame->document() : nullptr;
-    RefPtr mainFrameDocumentLoader = mainFrameDocument ? mainFrameDocument->loader() : nullptr;
-    if (firstFrameDocument && page && mainFrameDocumentLoader) {
-        auto results = page->protectedUserContentProvider()->processContentRuleListsForLoad(*page, firstFrameDocument->completeURL(urlString), ContentExtensions::ResourceType::Popup, *mainFrameDocumentLoader);
-        if (results.shouldBlock())
-            return RefPtr<WindowProxy> { nullptr };
+    if (firstFrameDocument && page) {
+        if (RefPtr firstFrameDocumentLoader = firstFrameDocument->loader()) {
+            auto results = page->protectedUserContentProvider()->processContentRuleListsForLoad(*page, firstFrameDocument->completeURL(urlString), ContentExtensions::ResourceType::Popup, *firstFrameDocumentLoader);
+            if (results.shouldBlock())
+                return RefPtr<WindowProxy> { nullptr };
+        }
     }
 #endif
 


### PR DESCRIPTION
#### 71d4b8d514243ef5ee3b147a2eab131a2dfd6266
<pre>
[Site Isolation] Make window.open run through WKContentRuleList in site isolated iframes with non-local main frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=296157">https://bugs.webkit.org/show_bug.cgi?id=296157</a>
<a href="https://rdar.apple.com/118280717">rdar://118280717</a>

Reviewed by Alex Christensen.

Previously when site isolation was enabled, non-local main frames would not respect existing WKContentRuleLists. This patch fixes that by having every frame inherit rules from the first frame. LayoutTests are included to verify that this behavior occurs when SiteIsolationEnabled=true with this patch but not without it.

* LayoutTests/http/tests/contentextensions/cross-origin-content-rules-expected.txt: Added.
* LayoutTests/http/tests/contentextensions/cross-origin-content-rules.html: Added.
* LayoutTests/http/tests/contentextensions/cross-origin-content-rules.html.json: Added.
* LayoutTests/http/tests/contentextensions/resources/iframe-that-opens-popup.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::open):

Canonical link: <a href="https://commits.webkit.org/297990@main">https://commits.webkit.org/297990@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90fb67b8fbf7081323903ab15164ecc4c427f7a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112318 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32049 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22527 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118397 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62769 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114280 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32702 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40613 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85325 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36082 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115265 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26090 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101045 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65756 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25394 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19182 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; Passed layout tests; 21 flakes") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62242 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95474 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19260 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121722 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39392 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29317 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94131 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39773 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97287 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93956 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39195 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16988 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/35441 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18251 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39280 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44768 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38915 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42252 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40658 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->