### PR TITLE
Add a quirk to disable DOMAudioSession on descript.com

### DIFF
--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.idl
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.idl
@@ -42,6 +42,7 @@ enum DOMAudioSessionType {
     ActiveDOMObject,
     Conditional=DOM_AUDIO_SESSION,
     EnabledBySetting=DOMAudioSessionEnabled,
+    DisabledByQuirk=shouldDisableDOMAudioSession,
     Exposed=Window,
     InterfaceName=AudioSession,
 ] interface DOMAudioSession : EventTarget {

--- a/Source/WebCore/Modules/audiosession/Navigator+AudioSession.idl
+++ b/Source/WebCore/Modules/audiosession/Navigator+AudioSession.idl
@@ -27,6 +27,6 @@
     Conditional=DOM_AUDIO_SESSION,
     ImplementedBy=NavigatorAudioSession
 ] partial interface Navigator {
-    [EnabledBySetting=DOMAudioSessionEnabled] readonly attribute DOMAudioSession audioSession;
+    [EnabledBySetting=DOMAudioSessionEnabled, DisabledByQuirk=shouldDisableDOMAudioSession] readonly attribute DOMAudioSession audioSession;
 };
 

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1936,6 +1936,11 @@ bool Quirks::shouldDelayReloadWhenRegisteringServiceWorker() const
     return needsQuirks() && m_quirksData.shouldDelayReloadWhenRegisteringServiceWorker;
 }
 
+bool Quirks::shouldDisableDOMAudioSessionQuirk() const
+{
+    return needsQuirks() && m_quirksData.shouldDisableDOMAudioSession;
+}
+
 URL Quirks::topDocumentURL() const
 {
     if (!m_topDocumentURLForTesting.isEmpty()) [[unlikely]]
@@ -2431,6 +2436,17 @@ static void handleBungalowQuirks(QuirksData& quirksData, const URL& quirksURL, c
     UNUSED_PARAM(documentURL);
     // bungalow.com rdar://61658940
     quirksData.shouldBypassAsyncScriptDeferring = true;
+}
+
+static void handleDescriptQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "descript.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // descript.com rdar://156024693
+    quirksData.shouldDisableDOMAudioSession = true;
 }
 
 static void handleESPNQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
@@ -2974,6 +2990,7 @@ void Quirks::determineRelevantQuirks()
         { "digitaltrends"_s, &handleDigitalTrendsQuirks },
         { "steampowered"_s, &handleSteamQuirks },
 #endif
+        { "descript"_s, &handleDescriptQuirks },
 #if PLATFORM(IOS_FAMILY)
         { "disneyplus"_s, &handleDisneyPlusQuirks },
 #endif

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -272,6 +272,8 @@ public:
 
     bool shouldEnterNativeFullscreenWhenCallingElementRequestFullscreenQuirk() const;
 
+    bool shouldDisableDOMAudioSessionQuirk() const;
+
 private:
     bool needsQuirks() const;
     bool isDomain(const String&) const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -192,6 +192,7 @@ struct WEBCORE_EXPORT QuirksData {
     bool needsMediaRewriteRangeRequestQuirk : 1 { false };
     bool shouldEnterNativeFullscreenWhenCallingElementRequestFullscreen : 1 { false };
     bool shouldDelayReloadWhenRegisteringServiceWorker : 1 { false };
+    bool shouldDisableDOMAudioSession : 1 { false };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### a9496387e4092290807b414ab98e934df47a8abb
<pre>
Add a quirk to disable DOMAudioSession on descript.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=296158">https://bugs.webkit.org/show_bug.cgi?id=296158</a>
<a href="https://rdar.apple.com/156024693">rdar://156024693</a>

Reviewed by Jer Noble.

Descript uses the DOMAudioSession API to set the session type to &quot;playback&quot;, but this has the side
effect of making the page&apos;s audio session not compatible with audio capture (concretely, the
promise returned by getUserMedia() is rejected with an exception and the user is never prompted for
microphone access). This is likely not the behavior the site intended when they adopted
DOMAudioSession, and since this is still an experimental API, this patch disables it on descript to
restore microphone capture functionality.

* Source/WebCore/Modules/audiosession/DOMAudioSession.idl:
* Source/WebCore/Modules/audiosession/Navigator+AudioSession.idl:
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldDisableDOMAudioSessionQuirk const):
(WebCore::handleDescriptQuirks):
(WebCore::Quirks::determineRelevantQuirks):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:

Canonical link: <a href="https://commits.webkit.org/297571@main">https://commits.webkit.org/297571@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33678bd579e431f346e91860a2ea909e6a0ac18f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112189 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22398 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118266 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62489 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114151 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40484 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85226 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/35900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25989 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100942 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65657 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25295 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19078 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62111 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95375 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19155 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121592 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39263 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29205 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94046 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39644 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97183 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93869 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23998 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39096 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16888 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35291 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39151 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44639 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38786 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42123 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40529 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->