### PR TITLE
[JSC] Annotate Yarr thunks with JITDump names

### DIFF
--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -5842,7 +5842,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> tryReadUnicodeCharThunkGenerator(VM
 
     LinkBuffer patchBuffer(jit, GLOBAL_THUNK_ID, LinkBuffer::Profile::Thunk);
 
-    return FINALIZE_THUNK(patchBuffer, JITThunkPtrTag, nullptr, "YARR tryReadUnicodeChar thunk");
+    return FINALIZE_THUNK(patchBuffer, JITThunkPtrTag, "Yarr tryReadUnicodeChar"_s, "YARR tryReadUnicodeChar thunk");
 }
 
 #if ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
@@ -5860,7 +5860,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> tryReadUnicodeCharIncForNonBMPThunk
 
     LinkBuffer patchBuffer(jit, GLOBAL_THUNK_ID, LinkBuffer::Profile::Thunk);
 
-    return FINALIZE_THUNK(patchBuffer, JITThunkPtrTag, nullptr, "YARR tryReadUnicodeChar w/Inc for non-BMP thunk");
+    return FINALIZE_THUNK(patchBuffer, JITThunkPtrTag, "Yarr tryReadUnicodeChar w/Inc for non-BMP"_s, "YARR tryReadUnicodeChar w/Inc for non-BMP thunk");
 }
 #endif
 #endif
@@ -5945,7 +5945,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> areCanonicallyEquivalentThunkGenera
 
     LinkBuffer patchBuffer(jit, GLOBAL_THUNK_ID, LinkBuffer::Profile::Thunk);
 
-    return FINALIZE_THUNK(patchBuffer, JITThunkPtrTag, nullptr, "YARR areCanonicallyEquivalent call");
+    return FINALIZE_THUNK(patchBuffer, JITThunkPtrTag, "Yarr areCanonicallyEquivalent", "YARR areCanonicallyEquivalent call");
 }
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationAreCanonicallyEquivalent, bool, (unsigned a, unsigned b, CanonicalMode canonicalMode))


### PR DESCRIPTION
#### 447cf5bc5d34ebaa8f5b319c035e66528796aa2b
<pre>
[JSC] Annotate Yarr thunks with JITDump names
<a href="https://bugs.webkit.org/show_bug.cgi?id=296160">https://bugs.webkit.org/show_bug.cgi?id=296160</a>
<a href="https://rdar.apple.com/156112016">rdar://156112016</a>

Reviewed by Mark Lam.

Let&apos;s annotate these YarrJIT thunk names in JITDump to make it
debuggable.

* Source/JavaScriptCore/yarr/YarrJIT.cpp:
(JSC::Yarr::tryReadUnicodeCharThunkGenerator):
(JSC::Yarr::tryReadUnicodeCharIncForNonBMPThunkGenerator):
(JSC::Yarr::areCanonicallyEquivalentThunkGenerator):

Canonical link: <a href="https://commits.webkit.org/297598@main">https://commits.webkit.org/297598@main</a>
</pre>
