### PR TITLE
[iOS] Upstream updated background and button layout for select-multiple controls

### DIFF
--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
@@ -916,14 +916,6 @@ static NSString *optionCellReuseIdentifier = @"WKSelectPickerTableViewCell";
     RetainPtr<UIBarButtonItem> _nextButton;
 }
 
-#if ENABLE(SELECT_MULTIPLE_ADJUSTMENTS)
-#import <WebKitAdditions/WKSelectPickerTableViewControllerAdditions.mm>
-#else
-- (void)performAdjustmentsIfNeeded
-{
-}
-#endif
-
 - (id)initWithView:(WKContentView *)view
 {
     if (!(self = [super initWithStyle:UITableViewStyleGrouped]))
@@ -938,11 +930,21 @@ static NSString *optionCellReuseIdentifier = @"WKSelectPickerTableViewCell";
 
 #if !PLATFORM(APPLETV)
     _previousButton = adoptNS([[UIBarButtonItem alloc] initWithImage:[UIImage systemImageNamed:@"chevron.up"] style:UIBarButtonItemStylePlain target:self action:@selector(previous:)]);
-    auto nextPreviousSpacer = adoptNS([[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace target:nil action:NULL]);
-    [nextPreviousSpacer setWidth:nextPreviousSpacerWidth];
     _nextButton = adoptNS([[UIBarButtonItem alloc] initWithImage:[UIImage systemImageNamed:@"chevron.down"] style:UIBarButtonItemStylePlain target:self action:@selector(next:)]);
 
-    self.navigationItem.leftBarButtonItems = @[ _previousButton.get(), nextPreviousSpacer.get(), _nextButton.get() ];
+    bool useGlassAppearance = false;
+#if HAVE(LIQUID_GLASS)
+    useGlassAppearance = isLiquidGlassEnabled();
+#endif
+
+    if (useGlassAppearance) {
+        self.tableView.backgroundColor = [UIColor clearColor];
+        self.navigationItem.leftBarButtonItems = @[ _previousButton.get(), _nextButton.get() ];
+    } else {
+        auto nextPreviousSpacer = adoptNS([[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace target:nil action:NULL]);
+        [nextPreviousSpacer setWidth:nextPreviousSpacerWidth];
+        self.navigationItem.leftBarButtonItems = @[ _previousButton.get(), nextPreviousSpacer.get(), _nextButton.get() ];
+    }
 #endif
 
     auto closeButton = adoptNS([[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemClose target:self action:@selector(close:)]);
@@ -955,8 +957,6 @@ static NSString *optionCellReuseIdentifier = @"WKSelectPickerTableViewCell";
         if (option.isGroup)
             _numberOfSections++;
     }
-
-    [self performAdjustmentsIfNeeded];
 
     return self;
 }

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectPopover.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectPopover.mm
@@ -376,14 +376,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     RetainPtr<WKSelectTableViewController> _tableViewController;
 }
 
-#if ENABLE(SELECT_MULTIPLE_ADJUSTMENTS)
-#import <WebKitAdditions/WKSelectPopoverAdditions.mm>
-#else
-- (void)performAdjustmentsIfNeeded
-{
-}
-#endif
-
 - (instancetype)initWithView:(WKContentView *)view hasGroups:(BOOL)hasGroups
 {
     if (!(self = [super initWithView:view]))
@@ -406,7 +398,10 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     self.popoverController = adoptNS([[UIPopoverController alloc] initWithContentViewController:popoverViewController.get()]).get();
 ALLOW_DEPRECATED_DECLARATIONS_END
 
-    [self performAdjustmentsIfNeeded];
+#if HAVE(LIQUID_GLASS)
+    if (isLiquidGlassEnabled())
+        [_tableViewController tableView].backgroundColor = [UIColor clearColor];
+#endif
 
     return self;
 }


### PR DESCRIPTION
#### bb06e8766671213dcb21feca3d00942d60fbd48d
<pre>
[iOS] Upstream updated background and button layout for select-multiple controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=296161">https://bugs.webkit.org/show_bug.cgi?id=296161</a>
<a href="https://rdar.apple.com/156112618">rdar://156112618</a>

Reviewed by Aditya Keerthi.

Upstream changes for the select multiple popover and picker on iOS and iPadOS.
These changes allow the liquid glass background to show, and allow the
&quot;next&quot; and &quot;previous&quot; buttons to share a single shape.

* Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm:
(-[WKSelectPickerTableViewController initWithView:]):
(-[WKSelectPickerTableViewController performAdjustmentsIfNeeded]): Deleted.
* Source/WebKit/UIProcess/ios/forms/WKFormSelectPopover.mm:
(-[WKSelectPopover initWithView:hasGroups:]):
(-[WKSelectPopover performAdjustmentsIfNeeded]): Deleted.

Canonical link: <a href="https://commits.webkit.org/297572@main">https://commits.webkit.org/297572@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59bda9a80a2c4bf717ea7101ff71c8e96f9e844e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112201 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22410 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118278 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62508 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32585 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40496 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85238 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/35909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115148 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25999 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100952 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65668 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25303 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62123 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95383 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19165 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121604 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39275 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29215 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94053 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39656 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97193 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93876 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23999 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39106 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16898 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35303 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39163 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44651 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38798 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42135 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40541 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->