### PR TITLE
Do not allow WorkerDedicatedRunLoop::run to spin tight loops that never handle tasks (message queue requests only ever timeout)

### DIFF
--- a/Source/WebCore/workers/WorkerRunLoop.cpp
+++ b/Source/WebCore/workers/WorkerRunLoop.cpp
@@ -34,7 +34,10 @@
 
 #include "JSDOMExceptionHandling.h"
 #include "JSDOMGlobalObject.h"
+#include "Logging.h"
+#include "SWServer.h"
 #include "ScriptExecutionContext.h"
+#include "ServiceWorkerGlobalScope.h"
 #include "SharedTimer.h"
 #include "ThreadGlobalData.h"
 #include "ThreadTimers.h"
@@ -47,6 +50,10 @@
 #include <JavaScriptCore/JSRunLoopTimer.h>
 #include <wtf/AutodrainedPool.h>
 #include <wtf/TZoneMallocInlines.h>
+
+#if PLATFORM(COCOA)
+#include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#endif
 
 #if USE(GLIB)
 #include <glib.h>
@@ -162,8 +169,63 @@ void WorkerDedicatedRunLoop::run(WorkerOrWorkletGlobalScope* context)
     RunLoopSetup setup(*this, RunLoopSetup::IsForDebugging::No);
     ModePredicate modePredicate(defaultMode(), false);
     MessageQueueWaitResult result;
+    auto timeStampOfFirstTimeoutResultInARow = MonotonicTime::infinity();
+
     do {
         result = runInMode(context, modePredicate);
+
+        // <rdar://155433911> - ServiceWorkers sometimes end up spinning their worker runloop endlessly,
+        // repeatedly timing out getting a task from the message queue, then firing a CFRunLoopTimer that
+        // does very little (or nothing).
+        // This spinning is wasteful and apparently unproductive.
+        // So - for ServiceWorkers only - we will kill the message queue after a certain amount of time spinning
+        // The requirements are:
+        // 1 - The runloop must spin at least twice
+        // 2 - Each time it spins it must result in a MessageQueueTimeout, meaning no actual service worker task
+        //     handled.
+        // 3 - The monotomic time passed between the first MessageQueueTimeout spin and the last is at least
+        //     "defaultTerminationDelay" seconds
+        //
+        // FIXME: Refactor CFRunLoopTimers to be able to provide logging details on which timers are scheduled
+        // so we can further diagnose this.
+
+        if (!is<ServiceWorkerGlobalScope>(context))
+            continue;
+
+        // The MessageQueue successfully handled a task, so reset our spin tracking.
+        if (result != MessageQueueWaitResult::MessageQueueTimeout) {
+            timeStampOfFirstTimeoutResultInARow = MonotonicTime::infinity();
+            continue;
+        }
+
+        auto now = MonotonicTime::now();
+
+        // If the most recent spin of the runloop did not result in MessageQueueTimeout, then this spin
+        // should only start the clock.
+        if (timeStampOfFirstTimeoutResultInARow.isInfinity()) {
+            timeStampOfFirstTimeoutResultInARow = now;
+            continue;
+        }
+
+        if (now - timeStampOfFirstTimeoutResultInARow < SWServer::defaultTerminationDelay)
+            continue;
+
+        String cfRunLoopTimerLoggingString;
+#if USE(CF)
+        CFAbsoluteTime nextCFRunLoopTimerFireDate = CFRunLoopGetNextTimerFireDate(RetainPtr { CFRunLoopGetCurrent() }.get(), kCFRunLoopDefaultMode);
+        auto cfRunLoopTimerDelay = nextCFRunLoopTimerFireDate - CFAbsoluteTimeGetCurrent();
+        cfRunLoopTimerLoggingString = makeString(" CFRunLoopTimer will fire in "_s, cfRunLoopTimerDelay, " seconds."_s);
+#endif
+
+        auto reason = makeString("Killing ServiceWorker message queue after "_s, (now - timeStampOfFirstTimeoutResultInARow).seconds(), " seconds of multiple timeouts. Shared timer firing in "_s, m_sharedTimer->fireTimeDelay().seconds(), "seconds."_s, cfRunLoopTimerLoggingString);
+        RELEASE_LOG(ServiceWorker, "%s", reason.utf8().data());
+
+#if PLATFORM(COCOA)
+        if (WTF::CocoaApplication::isAppleApplication() && !((rand() * 100) % 100))
+            os_fault_with_payload(OS_REASON_WEBKIT, 0, nullptr, 0, reason.utf8().data(), 0);
+#endif
+
+        m_messageQueue.kill();
     } while (result != MessageQueueTerminated);
     runCleanupTasks(context);
 }


### PR DESCRIPTION
#### f1a70b983e25923831225cd60d868031de9cd26e
<pre>
Do not allow WorkerDedicatedRunLoop::run to spin tight loops that never handle tasks (message queue requests only ever timeout)
<a href="https://rdar.apple.com/155433911">rdar://155433911</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=296163">https://bugs.webkit.org/show_bug.cgi?id=296163</a>

Reviewed by NOBODY (OOPS!).

We have metrics showing ServiceWorkers getting caught in a tight loop of spinning over and over,
never actually handling a service worker task from the message queue, but instead firing a CFRunLoopTimer
over and over. Additionally, the CFRunLoopTimer isn&apos;t obviously doing any useful work.

This is expending power for a service worker that is mostly just idle.

We currently don&apos;t have a way to track down what CFRunLoopTimer is causing this, but we can detected
a service worker that has done nothing but timeout trying to handle a service worker task multiple times
in a row, and has done so for &quot;defaultTerminationDelay&quot; seconds.

This patch detects such misbehavior, logs it, causes a simulated fault with that info, and terminates the SW.

In a standalone followup I hope to change our RunLoop/RunLoopTimer implementation to track which timers are
installed and to be able to log useful information about them.

* Source/WebCore/workers/WorkerRunLoop.cpp:
(WebCore::WorkerDedicatedRunLoop::run): If the spin of the runloop results in multiple MessageQueueTimeout
  results in a row, and has done so for more than &quot;defaultTerminationDelay&quot; seconds, then terminate the SW.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1a70b983e25923831225cd60d868031de9cd26e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112622 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32354 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118821 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63092 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114584 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33006 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40917 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85712 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36342 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26341 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101310 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66017 "Found 143 new API test failures: /WPE/TestLoaderClient:/webkit/WebKitWebView/loading-status, /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification, /WPE/TestWebKitFindController:/webkit/WebKitFindController/options, /WPE/TestLoaderClient:/webkit/WebKitWebView/reload, /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/script-message-received, /WPE/TestWebKitWebView:/webkit/WebKitWebView/run-javascript, /WPE/TestWebKitWebView:/webkit/WebKitWebView/disable-web-security, /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification-initial-permission-allowed, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme, /WPE/TestSSL:/webkit/WebKitWebView/tls-subresource ... (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25637 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19447 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62580 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95729 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19522 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122042 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39696 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29572 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94584 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40079 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97548 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94325 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39438 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17238 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35784 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39584 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45072 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39223 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42556 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40962 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->