### PR TITLE
Fix CSS zoom not applying to word-spacing values

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7770,7 +7770,6 @@ imported/w3c/web-platform-tests/css/css-viewport/zoom/svg.html [ ImageOnlyFailur
 imported/w3c/web-platform-tests/css/css-viewport/zoom/text-indent.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/text-shadow.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/text-stroke-width.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-viewport/zoom/word-spacing.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/border.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/bottom.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/container-queries.html [ ImageOnlyFailure ]

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -189,17 +189,33 @@ float FontCascade::letterSpacing() const
 
 float FontCascade::wordSpacing() const
 {
+    float spacing = 0;
     switch (m_spacing.word.type()) {
     case LengthType::Fixed:
-        return m_spacing.word.value();
+        spacing = m_spacing.word.value();
+        break;
     case LengthType::Percent:
+        // NO zoom for percentages per spec
         return m_spacing.word.percent() / 100 * size();
     case LengthType::Calculated:
-        return m_spacing.word.nonNanCalculatedValue(size());
-    default:
+        spacing = m_spacing.word.nonNanCalculatedValue(size());
+        break;
+    case LengthType::Relative:
+    case LengthType::Auto:
+    case LengthType::MinContent:
+    case LengthType::MaxContent:
+    case LengthType::FitContent:
+    case LengthType::Undefined:
+    case LengthType::Content:
+    case LengthType::Intrinsic:
+    case LengthType::MinIntrinsic:
+    case LengthType::Normal:
+    case LengthType::FillAvailable:
         ASSERT_NOT_REACHED();
         return 0;
     }
+
+    return spacing * m_fontDescription.usedZoom();
 }
 
 FloatSize FontCascade::drawText(GraphicsContext& context, const TextRun& run, const FloatPoint& point, unsigned from, std::optional<unsigned> to, CustomFontNotReadyAction customFontNotReadyAction) const

--- a/Source/WebCore/platform/graphics/FontCascadeDescription.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.cpp
@@ -56,6 +56,7 @@ struct SameSizeAsFontCascadeDescription {
     unsigned bitfields2 : 22;
     void* array;
     float size2;
+    float size3;
     unsigned bitfields3 : 10;
 };
 static_assert(sizeof(FontCascadeDescription) == sizeof(SameSizeAsFontCascadeDescription), "FontCascadeDescription should stay small");

--- a/Source/WebCore/platform/graphics/FontCascadeDescription.h
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.h
@@ -74,6 +74,7 @@ public:
     FontSelectionValue bolderWeight() const { return bolderWeight(weight()); }
     static FontSelectionValue lighterWeight(FontSelectionValue);
     static FontSelectionValue bolderWeight(FontSelectionValue);
+    float usedZoom() const { return m_zoom; }
 
     // only use fixed default size when there is only one font family, and that family is "monospace"
     bool useFixedDefaultSize() const { return familyCount() == 1 && firstFamily() == monospaceFamily; }
@@ -110,6 +111,7 @@ public:
     }
     void setFontSmoothing(FontSmoothingMode smoothing) { m_fontSmoothing = static_cast<unsigned>(smoothing); }
     void setIsSpecifiedFont(bool isSpecifiedFont) { m_isSpecifiedFont = isSpecifiedFont; }
+    void setUsedZoom(float zoom) { m_zoom = zoom; }
 
 #if ENABLE(TEXT_AUTOSIZING)
     bool familiesEqualForTextAutoSizing(const FontCascadeDescription& other) const;
@@ -165,6 +167,7 @@ private:
     unsigned m_fontSmoothing : 2; // FontSmoothingMode
     // True if a web page specifies a non-generic font family as the first font family.
     unsigned m_isSpecifiedFont : 1;
+    float m_zoom { 1.0f };
 };
 
 inline bool FontCascadeDescription::operator==(const FontCascadeDescription& other) const
@@ -176,7 +179,8 @@ inline bool FontCascadeDescription::operator==(const FontCascadeDescription& oth
         && m_kerning == other.m_kerning
         && m_keywordSize == other.m_keywordSize
         && m_fontSmoothing == other.m_fontSmoothing
-        && m_isSpecifiedFont == other.m_isSpecifiedFont;
+        && m_isSpecifiedFont == other.m_isSpecifiedFont
+        && m_zoom == other.m_zoom;
 }
 
 WTF::TextStream& operator<<(WTF::TextStream&, const FontCascadeDescription&);

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -233,6 +233,7 @@ void BuilderState::updateFontForZoomChange()
         return;
 
     setFontDescriptionFontSize(m_style.fontDescription().specifiedSize());
+    m_style.mutableFontDescriptionWithoutUpdate().setUsedZoom(m_style.usedZoom());
 }
 
 void BuilderState::updateFontForGenericFamilyChange()


### PR DESCRIPTION
#### b841a3064608
<pre>
Fix CSS zoom not applying to word-spacing values
<a href="https://bugs.webkit.org/show_bug.cgi?id=296165">https://bugs.webkit.org/show_bug.cgi?id=296165</a>
<a href="https://rdar.apple.com/156118978">rdar://156118978</a>

Reviewed by NOBODY (OOPS!).

Word-spacing values were not being transformed by the CSS zoom factor,
causing incorrect spacing in zoomed elements.

This fix passes the used zoom through FontCascade so it can be applied
during render-time.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b841a306460841e51cc6329ff4907fb0a754abfa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112593 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32325 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22803 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118792 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63057 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114555 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32977 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40888 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85699 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36312 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115540 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26319 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101291 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66004 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25616 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19427 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62551 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95709 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19502 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122013 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39667 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29548 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94565 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40050 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97528 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94302 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39417 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17221 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35755 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39555 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45043 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39193 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42527 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40933 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->