### PR TITLE
REGRESSION (iOS 26): Occasionally can't scroll or refresh a webpage after navigating back

### DIFF
--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -179,6 +179,8 @@ public:
 
     bool canSwipeInDirection(SwipeDirection, DeferToConflictingGestures) const;
 
+    bool hasActiveSwipeGesture() const { return m_activeGestureType == ViewGestureType::Swipe; }
+
     WebCore::Color backgroundColorForCurrentSnapshot() const { return m_backgroundColorForCurrentSnapshot; }
 
     void didStartProvisionalLoadForMainFrame();

--- a/Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm
@@ -108,6 +108,9 @@ static const float swipeSnapshotRemovalRenderTreeSizeTargetFraction = 0.5;
 
 - (BOOL)shouldBeginInteractiveTransition:(_UINavigationInteractiveTransitionBase *)transition
 {
+    if (_gestureController->hasActiveSwipeGesture())
+        return NO;
+
     using enum WebKit::ViewGestureController::DeferToConflictingGestures;
     auto deferToConflictingGestures = transition.gestureRecognizer.state == UIGestureRecognizerStateFailed ? Yes : No;
     return _gestureController->canSwipeInDirection([self directionForTransition:transition], deferToConflictingGestures);


### PR DESCRIPTION
#### 641034aef871f490ca5f72721a7bf5ed1e815cd4
<pre>
REGRESSION (iOS 26): Occasionally can&apos;t scroll or refresh a webpage after navigating back
<a href="https://bugs.webkit.org/show_bug.cgi?id=296168">https://bugs.webkit.org/show_bug.cgi?id=296168</a>
<a href="https://rdar.apple.com/153082752">rdar://153082752</a>

Reviewed by Wenson Hsieh and Abrar Rahman Protyasha.

With changes to the navigation swipe on iOS 26, it is much easier for users to
attempt to start a new navigation swipe while the current swipe is not yet
completed. In this scenario, it is possible to get UIKit logic into a state
where the completion handler is never called for cancelled swipes.

Specifically, WebKit’s `_UINavigationInteractiveTransitionBaseDelegate` (used
with a `_UIViewControllerOneToOneTransitionContext`) may gets the
`notifyWhenInteractionChangesUsingBlock` callback with context.canceled=1, but
the `_UIViewControllerOneToOneTransitionContext` completionHandler is never
called. Consequently, `ViewGestureController::endSwipeGesture` never gets called
and the swipe snapshot is left stuck on the screen, giving the appearance of
a non-interactive webpage.

While the underlying issue appears to be in UIKit, work around the issue in
WebKit, by preventing a new navigation swipe from starting if one is already
active.

* Source/WebKit/UIProcess/ViewGestureController.h:
* Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm:
(-[WKSwipeTransitionController shouldBeginInteractiveTransition:]):

Note that `ViewGestureController::beginSwipeGesture` already bails
early if there is *any* active gesture. However, that is too late, since that
method is called downstream of `-[WKSwipeTransitionController startInteractiveTransition:]`.
By that point the transition has already started from UIKit&apos;s perspective. As
a result, it is necessary to prevent the transition from starting at all, via
`-[WKSwipeTransitionController shouldBeginInteractiveTransition:]`.

Canonical link: <a href="https://commits.webkit.org/297603@main">https://commits.webkit.org/297603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c9c10308331f6e199930eef13d5c798317959ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112216 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22425 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118293 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62600 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40511 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85247 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35975 "Build is in progress. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115163 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26010 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100964 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65677 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25314 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62138 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95394 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19177 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121620 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39290 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29226 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94063 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39671 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97205 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93887 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39114 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16910 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35318 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18096 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39178 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44666 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38813 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42150 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40556 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->