### PR TITLE
Use std::unique_ptr instead of MallocPtr in ConcurrentBuffer and SegmentedVector

### DIFF
--- a/Source/WTF/wtf/FastMalloc.h
+++ b/Source/WTF/wtf/FastMalloc.h
@@ -378,6 +378,14 @@ struct FastFree<T[]> {
     }
 };
 
+template<typename T, typename Malloc>
+struct NonDestructingDeleter {
+    void operator()(T* pointer) const
+    {
+        Malloc::free(const_cast<typename std::remove_cv<T>::type*>(pointer));
+    }
+};
+
 } // namespace WTF
 
 #if !defined(NDEBUG)

--- a/Source/WTF/wtf/SegmentedVector.h
+++ b/Source/WTF/wtf/SegmentedVector.h
@@ -28,7 +28,6 @@
 
 #pragma once
 
-#include <wtf/MallocPtr.h>
 #include <wtf/Vector.h>
 
 namespace WTF {
@@ -225,6 +224,8 @@ namespace WTF {
             T m_entries[0];
         };
 
+        using SegmentPtr = std::unique_ptr<Segment, NonDestructingDeleter<Segment, Malloc>>;
+
         void destroyAllItems()
         {
             for (size_t i = 0; i < m_size; ++i)
@@ -264,11 +265,12 @@ namespace WTF {
 
         void allocateSegment()
         {
-            m_segments.append(MallocPtr<Segment, Malloc>::malloc(sizeof(T) * SegmentSize));
+            auto* ptr = static_cast<Segment*>(Malloc::malloc(sizeof(T) * SegmentSize));
+            m_segments.append(SegmentPtr(ptr, { }));
         }
 
         size_t m_size { 0 };
-        Vector<MallocPtr<Segment>, 0, CrashOnOverflow, 16, Malloc> m_segments;
+        Vector<SegmentPtr, 0, CrashOnOverflow, 16, Malloc> m_segments;
     };
 
 } // namespace WTF


### PR DESCRIPTION
#### 002b94dcc58e517cd72e919162fdd55982092e92
<pre>
Use std::unique_ptr instead of MallocPtr in ConcurrentBuffer and SegmentedVector
<a href="https://bugs.webkit.org/show_bug.cgi?id=296166">https://bugs.webkit.org/show_bug.cgi?id=296166</a>
<a href="https://rdar.apple.com/156121020">rdar://156121020</a>

Reviewed by Keith Miller.

We are about to harden MallocPtr by requiring the parameter type to be trivially
destructible. That will prevent accidental memory leaks, when a type is used with
MallocPtr under the assumption it does not need a destructor call, but is later changed to
require non-trivial destruction (e.g. <a href="https://rdar.apple.com/152574864">rdar://152574864</a>).

So that MallocPtr can be hardened as intended, this patch changes two recently added
usages of MallocPtr to instead use std::unique_ptr with a deleter that disposes of the
pointer the same way MallocPtr would.

Canonical link: <a href="https://commits.webkit.org/297601@main">https://commits.webkit.org/297601@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9d2135d02f5aee3ed22b0e00a3b89762182249b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112218 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31949 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22427 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118295 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62629 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32602 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40513 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85261 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/35998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115165 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26014 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100971 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65691 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25318 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19108 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62140 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/104732 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95398 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19187 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121622 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/110832 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39292 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29230 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94069 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39673 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97214 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93893 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24017 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39123 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16917 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/35320 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39180 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44668 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/135063 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38815 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36311 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42152 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40558 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->