### PR TITLE
[css-anchor-position-1] Wrong anchor-center behavior when target is absolute child of fixed element

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/no-anchor-anchor-center-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/no-anchor-anchor-center-expected.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<title>Tests that 'anchor-center' behaves as 'center' when no anchor in containing block</title>
+<style>
+.anchor {
+  background: orange;
+  width: 100px;
+  background-color: orange;
+}
+.container {
+  position: fixed;
+  top: 20px;
+  left: 50px;
+  width: 300px;
+  height: 200px;
+  display: flex;
+  background: green;
+  justify-content: center;
+}
+.target {
+  position: absolute;
+  margin: 0 auto;
+  width: 80px;
+  border: 1px #000 solid;
+  background: lime;
+}
+</style>
+<div class="anchor">anchor</div> 
+<div class="container"> 
+  <div class="target">target 1</div>
+</div>    

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/no-anchor-anchor-center-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/no-anchor-anchor-center-ref.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<title>Tests that 'anchor-center' behaves as 'center' when no anchor in containing block</title>
+<style>
+.anchor {
+  background: orange;
+  width: 100px;
+  background-color: orange;
+}
+.container {
+  position: fixed;
+  top: 20px;
+  left: 50px;
+  width: 300px;
+  height: 200px;
+  display: flex;
+  background: green;
+  justify-content: center;
+}
+.target {
+  position: absolute;
+  margin: 0 auto;
+  width: 80px;
+  border: 1px #000 solid;
+  background: lime;
+}
+</style>
+<div class="anchor">anchor</div> 
+<div class="container"> 
+  <div class="target">target 1</div>
+</div>    

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/no-anchor-anchor-center.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/no-anchor-anchor-center.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<title>Tests that 'anchor-center' behaves as 'center' when no anchor in containing block</title>
+<link rel="match" href="anchor-center-visibility-change-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#valdef-justify-self-anchor-center">
+<style>
+.anchor {
+  anchor-name: --dropdownAnchor;
+  background: orange;
+  width: 100px;
+  background-color: orange;
+}
+.container {
+  position: fixed;
+  top: 20px;
+  left: 50px;
+  width: 300px;
+  height: 200px;
+  background: green;
+}
+.target {
+  position-anchor: --dropdownAnchor;
+  display: flow;
+  left: 10px;
+  right: 10px;
+  position: absolute;
+  justify-self: anchor-center;
+  width: 80px;
+  border: 1px #000 solid;
+  background: lime;
+}
+</style>
+<div class="anchor">anchor</div> 
+<div class="container"> 
+  <div class="target">target 1</div>
+</div>    

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
@@ -487,7 +487,10 @@ ItemPosition PositionedLayoutConstraints::resolveAlignmentValue() const
     }();
 
     if (m_style.positionArea() && ItemPosition::Normal == alignmentPosition)
-        return m_style.positionArea()->defaultAlignmentForAxis(m_physicalAxis, m_containingWritingMode, m_writingMode);
+        alignmentPosition = m_style.positionArea()->defaultAlignmentForAxis(m_physicalAxis, m_containingWritingMode, m_writingMode);
+
+    if (!m_defaultAnchorBox && alignmentPosition == ItemPosition::AnchorCenter)
+        return ItemPosition::Center;
     return alignmentPosition;
 }
 


### PR DESCRIPTION
#### d19f4a9df5a6ce6802a25ae028ef2cc86d673ede
<pre>
[css-anchor-position-1] Wrong anchor-center behavior when target is absolute child of fixed element
<a href="https://bugs.webkit.org/show_bug.cgi?id=295504">https://bugs.webkit.org/show_bug.cgi?id=295504</a>

Reviewed by Alan Baradlay.

When anchor-center is used on an anchored element,
the anchor must be in the same containing block as the anchored element in order to center element using anchor center position.
If no anchor exists in the containing block, the behavior should fallback to justify: center,
as listed in the specifications.

<a href="https://drafts.csswg.org/css-anchor-position-1/#target">https://drafts.csswg.org/css-anchor-position-1/#target</a>:

&quot;Both elements are in the same top layer and have the same containing block,
 and are both absolutely positioned,
 and possible anchor is earlier in flat tree order than positioned el.&quot;

&quot;Both elements are in the same top layer and have the same containing block,
 but possible anchor isn’t absolutely positioned.&quot;

<a href="https://drafts.csswg.org/css-anchor-position-1/#anchor-center">https://drafts.csswg.org/css-anchor-position-1/#anchor-center</a>:

&quot;If the box is not absolutely positioned,
 or does not have a default anchor box,
 this value behaves as center and has no additional effect on how inset properties resolve.&quot;

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/no-anchor-anchor-center-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/no-anchor-anchor-center.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/no-anchor-anchor-center-expected.html: Added.
* Source/WebCore/rendering/PositionedLayoutConstraints.cpp:
(WebCore::PositionedLayoutConstraints::resolvePosition const):

Canonical link: <a href="https://commits.webkit.org/298766@main">https://commits.webkit.org/298766@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55f7caf8a0a70091ad2f920fd0f6f79e34682dec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36267 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26828 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122676 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/67174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118492 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36965 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44856 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/88559 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/67174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119552 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29488 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/104610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69024 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/28555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22716 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66344 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/98868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22875 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125813 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43502 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32678 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/97234 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43866 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100812 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97027 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42340 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/20275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/39464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18614 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43388 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48983 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42854 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46194 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44560 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->