### PR TITLE
[view-transitions] Inherit more animation properties in the pseudo-element tree

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/style-inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/style-inheritance-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL style inheritance of pseudo elements assert_equals: wrapper expected "linear" but got "ease"
+PASS style inheritance of pseudo elements
 

--- a/Source/WebCore/css/viewTransitions.css
+++ b/Source/WebCore/css/viewTransitions.css
@@ -45,10 +45,6 @@
 :root::view-transition-image-pair(*) {
     position: absolute;
     inset: 0;
-
-    animation-duration: inherit;
-    animation-fill-mode: inherit;
-    animation-delay: inherit;
 }
 
 :root::view-transition-old(*),
@@ -57,10 +53,18 @@
     inset-block-start: 0;
     inline-size: 100%;
     block-size: auto;
+}
 
+:root::view-transition-image-pair(*),
+:root::view-transition-old(*),
+:root::view-transition-new(*) {
     animation-duration: inherit;
     animation-fill-mode: inherit;
     animation-delay: inherit;
+    animation-timing-function: inherit;
+    animation-iteration-count: inherit;
+    animation-direction: inherit;
+    animation-play-state: inherit;
 }
 
 /* Default cross-fade transition */


### PR DESCRIPTION
#### 034ea2b46cf59930bb89c0b2165af0f044496cf5
<pre>
[view-transitions] Inherit more animation properties in the pseudo-element tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=296174">https://bugs.webkit.org/show_bug.cgi?id=296174</a>
<a href="https://rdar.apple.com/156131284">rdar://156131284</a>

Reviewed by Anne van Kesteren.

Based on <a href="https://github.com/w3c/csswg-drafts/issues/11546#issuecomment-3005503138">https://github.com/w3c/csswg-drafts/issues/11546#issuecomment-3005503138</a>

Start inheriting these properties:
- animation-timing-function
- animation-play-state
- animation-iteration-count
- animation-direction

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/style-inheritance-expected.txt:
* Source/WebCore/css/viewTransitions.css:
(:root::view-transition-image-pair(*)):
(:root::view-transition-old(*),):
(:root::view-transition-image-pair(*),):

Canonical link: <a href="https://commits.webkit.org/297581@main">https://commits.webkit.org/297581@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6ef9e2c0b1c52f081e8ccf2daaec87d2550ae1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112240 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31971 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22449 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118317 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62566 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114202 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32624 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40535 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85267 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/35947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115187 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26029 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100985 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65697 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25334 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19121 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62163 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95413 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19200 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121644 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39314 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29248 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94080 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39695 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97227 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93904 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24006 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39139 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16930 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35342 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39202 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44690 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38837 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42174 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40580 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->