### PR TITLE
REGRESSION(292932@main): [GTK][WPE] Output audio device enumeration does not work

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/PipeWireCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/PipeWireCaptureDeviceManager.cpp
@@ -54,6 +54,10 @@ void PipeWireCaptureDeviceManager::computeCaptureDevices(CompletionHandler<void(
         return;
     }
 
+#if PLATFORM(WPE)
+    callback();
+    return;
+#endif
     if (!m_pipewireDeviceProvider || !gstObjectHasProperty(GST_OBJECT_CAST(m_pipewireDeviceProvider.get()), "fd"_s)) {
         GST_WARNING("PipeWire Device Provider is missing or too old. Please install PipeWire >= 0.3.64.");
         callback();
@@ -69,8 +73,10 @@ void PipeWireCaptureDeviceManager::computeCaptureDevices(CompletionHandler<void(
         return;
     }
 
+    GST_DEBUG("Attempting to access the camera");
     portal->accessCamera([this, callback = WTFMove(callback)](auto fd) mutable {
         if (!fd) {
+            GST_DEBUG("Camera access unavailable");
             callback();
             return;
         }


### PR DESCRIPTION
#### 04d2f39a0b7924afd3de78310c80fbc8b6109fd8
<pre>
REGRESSION(292932@main): [GTK][WPE] Output audio device enumeration does not work
<a href="https://bugs.webkit.org/show_bug.cgi?id=296007">https://bugs.webkit.org/show_bug.cgi?id=296007</a>

Reviewed by Xabier Rodriguez-Calvar.

Disable Camera portal support in WPE. This is expected to work only in apps packaged as Flatpak
anyway. For that reason it doesn&apos;t work in builds produced with the legacy BuildStream SDK either.

* Source/WebCore/platform/mediastream/gstreamer/PipeWireCaptureDeviceManager.cpp:
(WebCore::PipeWireCaptureDeviceManager::computeCaptureDevices):

Canonical link: <a href="https://commits.webkit.org/297669@main">https://commits.webkit.org/297669@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43dfb148824564af0888c9af7a7b3d3944179d84

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112254 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; check-webkit-style") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22463 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118331 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62593 "Built successfully") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114216 "Build is in progress. Recent messages:Running configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed bindings tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32638 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40549 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85279 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35967 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115201 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26044 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101001 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65709 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/111686 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25348 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19137 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62178 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95428 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19216 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121658 "Built successfully") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39328 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29262 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94091 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39709 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97243 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93915 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24053 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16946 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35357 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39216 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44704 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38851 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42188 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40594 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Checked out pull request; Compiled WebKit (warnings)") | | | 
<!--EWS-Status-Bubble-End-->