### PR TITLE
[Buildstream SDK] Update ccache recipe

### DIFF
--- a/Tools/buildstream/elements/freedesktop-sdk.bst
+++ b/Tools/buildstream/elements/freedesktop-sdk.bst
@@ -30,3 +30,4 @@ config:
     components/dav1d.bst: sdk/dav1d.bst
     components/pango.bst: sdk/pango.bst
     components/noopenh264.bst: sdk/libopenh264.bst
+    components/ccache.bst: sdk/ccache.bst

--- a/Tools/buildstream/elements/sdk-platform.bst
+++ b/Tools/buildstream/elements/sdk-platform.bst
@@ -16,6 +16,7 @@ depends:
 - sdk/eigen.bst
 - sdk/enchant-2.bst
 - sdk/flite.bst
+- sdk/fmtlib.bst
 - sdk/gi-docgen.bst
 - sdk/graphviz.bst
 - sdk/gst-plugin-audiofx.bst
@@ -25,6 +26,7 @@ depends:
 - sdk/gst-plugin-livesync.bst
 - sdk/gst-plugin-rtp.bst
 - sdk/gtk.bst
+- sdk/hiredis.bst
 - sdk/icecc.bst
 - sdk/krb5.bst
 - sdk/libavif.bst

--- a/Tools/buildstream/elements/sdk/ccache.bst
+++ b/Tools/buildstream/elements/sdk/ccache.bst
@@ -1,0 +1,27 @@
+kind: cmake
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/buildsystem-cmake.bst
+- freedesktop-sdk.bst:components/asciidoc.bst
+- freedesktop-sdk.bst:components/git-minimal.bst
+- sdk/fmtlib.bst
+- freedesktop-sdk.bst:components/perl.bst
+
+depends:
+- freedesktop-sdk.bst:bootstrap-import.bst
+- freedesktop-sdk.bst:components/zstd.bst
+- sdk/hiredis.bst
+
+variables:
+  cmake-local: >-
+    -DREDIS_STORAGE_BACKEND=ON
+    -DCCACHE_DEV_MODE=OFF
+    -DFMT_LIBRARY="%{libdir}/libfmt.a"
+    -DENABLE_TESTING=OFF
+    -DENABLE_DOCUMENTATION=OFF
+
+sources:
+- kind: git_repo
+  url: github_com:ccache/ccache.git
+  track: v*
+  ref: v4.11.3-0-ga50f01935030e46fd6f35184ba7b1f11105967b7

--- a/Tools/buildstream/elements/sdk/fmtlib.bst
+++ b/Tools/buildstream/elements/sdk/fmtlib.bst
@@ -1,0 +1,18 @@
+kind: cmake
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/buildsystem-cmake.bst
+- freedesktop-sdk.bst:components/ninja.bst
+
+depends:
+- freedesktop-sdk.bst:bootstrap-import.bst
+
+variables:
+  cmake-local: >-
+    -DBUILD_SHARED_LIBS=OFF
+
+sources:
+- kind: git_repo
+  url: github_com:fmtlib/fmt.git
+  track: '*.*.*'
+  ref: 11.2.0-0-g40626af88bd7df9a5fb80be7b25ac85b122d6c21

--- a/Tools/buildstream/elements/sdk/hiredis.bst
+++ b/Tools/buildstream/elements/sdk/hiredis.bst
@@ -1,0 +1,19 @@
+kind: cmake
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/buildsystem-cmake.bst
+
+depends:
+- freedesktop-sdk.bst:bootstrap-import.bst
+
+variables:
+  cmake-local: >-
+    -DENABLE_NUGET=OFF
+    -DENABLE_SSL=ON
+    -DDISABLE_TESTS=ON
+
+sources:
+- kind: git_repo
+  url: github_com:redis/hiredis.git
+  track: master
+  ref: v1.3.0-4-g294782041ef5841293dea3acc8ca9a28597bedc8


### PR DESCRIPTION
#### 9b25e3bf00e9f8af2370eb46d2f20b08a0652a6b
<pre>
[Buildstream SDK] Update ccache recipe
<a href="https://bugs.webkit.org/show_bug.cgi?id=296180">https://bugs.webkit.org/show_bug.cgi?id=296180</a>

Reviewed by Carlos Alberto Lopez Perez.

Update to ccache 4.11.3 which requires a new dependency, fmtlib. Also enable redis support.

* Tools/buildstream/elements/freedesktop-sdk.bst:
* Tools/buildstream/elements/sdk-platform.bst:
* Tools/buildstream/elements/sdk/ccache.bst: Added.
* Tools/buildstream/elements/sdk/fmtlib.bst: Added.

Canonical link: <a href="https://commits.webkit.org/297672@main">https://commits.webkit.org/297672@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc7d38937de5e13300d288486ee86d36c1ca96ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112526 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32258 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22736 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118724 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62977 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114488 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32910 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40821 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/85640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36250 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115473 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/26261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/101233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/65942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/25559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/19365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62484 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/95652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/19438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121946 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39600 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29490 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/94506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39982 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/97464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/94246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/39358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/17162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35682 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18119 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39488 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39125 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42460 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40866 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->