### PR TITLE
AX: VoiceOver not announcing Entering or Leaving when navigating to or from a ordered list as role=listbox

### DIFF
--- a/LayoutTests/accessibility/mac/invalid-list-box-valid-list-expected.txt
+++ b/LayoutTests/accessibility/mac/invalid-list-box-valid-list-expected.txt
@@ -1,0 +1,13 @@
+This test ensures that if role='listbox' is used on what's clearly a static list, we interpret it as a list role instead.
+
+PASS: accessibilityController.accessibleElementById('listbox').role === 'AXRole: AXList'
+PASS: accessibilityController.accessibleElementById('listbox').subrole === 'AXSubrole: AXContentList'
+PASS: accessibilityController.accessibleElementById('listbox').role === 'AXRole: AXList'
+PASS: accessibilityController.accessibleElementById('listbox').subrole === 'AXSubrole: '
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Category A
+Category B
+Category C

--- a/LayoutTests/accessibility/mac/invalid-list-box-valid-list.html
+++ b/LayoutTests/accessibility/mac/invalid-list-box-valid-list.html
@@ -1,0 +1,37 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<ul id="listbox" role="listbox" aria-label="Unnecessary listbox role">
+    <li id="item0"><a href=#>Category A</a></li>
+    <li id="item1"><a href=#>Category B</a></li>
+    <li id="item2"><a href=#>Category C</a></li>
+</ul>
+
+<script>
+  var output = "This test ensures that if role='listbox' is used on what's clearly a static list, we interpret it as a list role instead.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    // The listbox in its initial state is invalid — it has no `option` descendants. We should map it to a content list.
+    output += expect("accessibilityController.accessibleElementById('listbox').role", "'AXRole: AXList'");
+    output += expect("accessibilityController.accessibleElementById('listbox').subrole", "'AXSubrole: AXContentList'");
+
+    // Change one descendant to an option and ensure the role is now reported to be a proper listbox.
+    document.getElementById("item1").setAttribute("role", "option");
+    setTimeout(async function() {
+        output += await expectAsync("accessibilityController.accessibleElementById('listbox').role", "'AXRole: AXList'");
+        output += await expectAsync("accessibilityController.accessibleElementById('listbox').subrole", "'AXSubrole: '");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -812,6 +812,13 @@ enum class TextEmissionBehavior : uint8_t {
     DoubleNewline
 };
 
+enum class ListBoxInterpretation : uint8_t {
+    ActuallyListBox,
+    ActuallyStaticList,
+    InvalidListBox,
+    NotListBox
+};
+
 class AXCoreObject : public RefCountedAndCanMakeWeakPtr<AXCoreObject> {
 public:
     virtual ~AXCoreObject() = default;
@@ -851,9 +858,8 @@ public:
     bool isCheckbox() const { return role() == AccessibilityRole::Checkbox; }
     bool isRadioButton() const { return role() == AccessibilityRole::RadioButton; }
     bool isListBox() const { return role() == AccessibilityRole::ListBox; }
-    // The children of listboxes must be of specific roles. Returns true if at least one of those is present.
-    bool isValidListBox() const;
-    bool isInvalidListBox() const { return isListBox() && !isValidListBox(); }
+    // For elements with role=listbox, checks its children to determine if it's actually a valid listbox, a static list, or neither.
+    ListBoxInterpretation listBoxInterpretation() const;
     bool isListBoxOption() const { return role() == AccessibilityRole::ListBoxOption; }
     virtual bool isAttachment() const = 0;
     bool isMenuRelated() const;

--- a/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
@@ -438,8 +438,21 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     } else if (role == AccessibilityRole::Canvas && firstUnignoredChild() && !containsOnlyStaticText()) {
         // If this is a canvas with fallback content (one or more non-text thing), re-map to group.
         role = AccessibilityRole::Group;
-    } else if (isInvalidListBox())
-        role = AccessibilityRole::Group;
+    } else {
+        switch (listBoxInterpretation()) {
+        case ListBoxInterpretation::ActuallyListBox:
+            role = AccessibilityRole::ListBox;
+            break;
+        case ListBoxInterpretation::ActuallyStaticList:
+            role = AccessibilityRole::List;
+            break;
+        case ListBoxInterpretation::InvalidListBox:
+            role = AccessibilityRole::Group;
+            break;
+        case ListBoxInterpretation::NotListBox:
+            break;
+        }
+    }
 
     return Accessibility::roleToPlatformString(role);
 }

--- a/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
+++ b/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
@@ -250,6 +250,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             return "AXDescriptionList"_s;
     }
 
+    if (listBoxInterpretation() == ListBoxInterpretation::ActuallyStaticList)
+        return "AXContentList"_s;
+
     // ARIA content subroles.
     switch (role) {
     case AccessibilityRole::Form:


### PR DESCRIPTION
#### 607b0dd8d379f756d33bd9f1d3d7394517de820c
<pre>
AX: VoiceOver not announcing Entering or Leaving when navigating to or from a ordered list as role=listbox
<a href="https://bugs.webkit.org/show_bug.cgi?id=296210">https://bugs.webkit.org/show_bug.cgi?id=296210</a>
<a href="https://rdar.apple.com/156178283">rdar://156178283</a>

Reviewed by Tyler Wilcock.

According to the spec, role=listbox should only be used with role=option as
children. To avoid breakage when role=listbox was used incorrectly, we mapped
it to AXGroup if there are no options. However, this was probably too extreme
when it was put on a static list like a &lt;ul&gt; or &lt;ol&gt; element with list items
as children. Make sure it maps to a static list role in those cases.

* LayoutTests/accessibility/mac/invalid-list-box-valid-list-expected.txt: Added.
* LayoutTests/accessibility/mac/invalid-list-box-valid-list.html: Added.
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::listBoxInterpretation const):
(WebCore::AXCoreObject::isValidListBox const): Deleted.
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::isInvalidListBox const): Deleted.
* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm:
(WebCore::AXCoreObject::rolePlatformString):
* Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm:
(WebCore::AccessibilityObject::subrolePlatformString const):

Canonical link: <a href="https://commits.webkit.org/297634@main">https://commits.webkit.org/297634@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb5d9fdfdc90b1f2ba01c58bd059daa998a184ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112382 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32114 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22591 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118461 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62760 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114344 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32766 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40677 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85372 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115329 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26150 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101107 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65803 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25445 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19246 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62306 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95534 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19321 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121787 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39456 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29374 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/94179 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39837 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97348 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94005 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24034 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39249 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17046 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/35506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39344 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44832 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38979 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42316 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40722 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->