### PR TITLE
Fix WPT text-decoration-computed: it should observe short serialization rule

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-decoration-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-decoration-computed-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Property text-decoration value 'none' assert_equals: expected "rgb(0, 0, 255)" but got "none"
-FAIL Property text-decoration value 'line-through' assert_equals: expected "line-through rgb(0, 0, 255)" but got "line-through"
+PASS Property text-decoration value 'none'
+PASS Property text-decoration value 'line-through'
 FAIL Property text-decoration value 'solid' assert_true: 'solid' is a supported value for text-decoration. expected true got false
 FAIL Property text-decoration value 'currentcolor' assert_true: 'currentcolor' is a supported value for text-decoration. expected true got false
 FAIL Property text-decoration value 'double overline underline' assert_true: 'double overline underline' is a supported value for text-decoration. expected true got false

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-decoration-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-decoration-computed.html
@@ -19,12 +19,12 @@
 <script>
 'use strict';
 const currentColor = "rgb(0, 0, 255)";
-test_computed_value("text-decoration", "none", currentColor);
-test_computed_value("text-decoration", "line-through", "line-through " + currentColor);
-test_computed_value("text-decoration", "solid", currentColor);
-test_computed_value("text-decoration", "currentcolor", currentColor);
+test_computed_value("text-decoration", "none");
+test_computed_value("text-decoration", "line-through");
+test_computed_value("text-decoration", "solid", "none");
+test_computed_value("text-decoration", "currentcolor", "none");
 
-test_computed_value("text-decoration", "double overline underline", "underline overline double " + currentColor);
+test_computed_value("text-decoration", "double overline underline", "underline overline double");
 test_computed_value("text-decoration", "underline overline line-through red", "underline overline line-through rgb(255, 0, 0)");
 test_computed_value("text-decoration", "rgba(10, 20, 30, 0.4) dotted", "dotted rgba(10, 20, 30, 0.4)");
 
@@ -35,8 +35,8 @@ test_computed_value("text-decoration", "underline overline line-through blink", 
 test_computed_value("text-decoration", "underline overline line-through blink red", ["underline overline line-through rgb(255, 0, 0)", "underline overline line-through blink rgb(255, 0, 0)"]);
 
 // Add text-decoration-thickness in [css-text-decor-4].
-test_computed_value("text-decoration", "auto", currentColor);
-test_computed_value("text-decoration", "from-font", "from-font " + currentColor);
-test_computed_value("text-decoration", "10px", "10px " + currentColor);
+test_computed_value("text-decoration", "auto", "none");
+test_computed_value("text-decoration", "from-font");
+test_computed_value("text-decoration", "10px");
 test_computed_value("text-decoration", "underline red from-font", "underline from-font rgb(255, 0, 0)");
 </script>


### PR DESCRIPTION
#### 2090eeb3e467bdfe55f4be7733668dbc3b660210
<pre>
Fix WPT text-decoration-computed: it should observe short serialization rule
<a href="https://bugs.webkit.org/show_bug.cgi?id=296213">https://bugs.webkit.org/show_bug.cgi?id=296213</a>
<a href="https://rdar.apple.com/156180788">rdar://156180788</a>

Reviewed by Oriol Brufau.

Computed value should observe short serialization rule and canonical order.

Issue was originally discussed in [1] and most recently in [2].

[1] <a href="https://github.com/w3c/csswg-drafts/issues/8155">https://github.com/w3c/csswg-drafts/issues/8155</a>
[2] <a href="https://github.com/w3c/csswg-drafts/issues/12486">https://github.com/w3c/csswg-drafts/issues/12486</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-decoration-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-decoration-computed.html:

Canonical link: <a href="https://commits.webkit.org/297715@main">https://commits.webkit.org/297715@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c0c98f760612f869bcea1806504208ea0486656

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32317 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22795 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118784 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/63087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32969 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40880 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85693 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36307 "Unexpected infrastructure issue, retrying build") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115532 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26311 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101280 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65997 "Found 136 new API test failures: /WPE/TestLoaderClient:/webkit/WebKitWebView/loading-status, /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification, /WPE/TestWebKitFindController:/webkit/WebKitFindController/options, /WPE/TestLoaderClient:/webkit/WebKitWebView/reload, /WPE/TestWebKitWebView:/webkit/WebKitWebView/run-javascript, /WPE/TestWebKitWebView:/webkit/WebKitWebView/disable-web-security, /WPE/TestLoaderClient:/webkit/WebKitWebView/load-plain-text, /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification-initial-permission-allowed, /WPE/TestOptionMenu:/webkit/WebKitWebView/option-menu-simple, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme ... (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25608 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19415 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62543 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/105099 "Build is in progress. Recent messages:") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95701 "Found 4 new API test failures: TestWebKitAPI.WebKit2.EnumerateDevicesAfterMuting, TestWebKitAPI.WebKit2.CaptureMute, TestWebKitAPI.WebKit2.CrashGPUProcessAfterApplyingConstraints, TestWebKitAPI.WebKit.InterruptionBetweenSameProcessPages (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19490 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122005 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39659 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29544 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94558 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40042 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97516 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94295 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24082 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39409 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17210 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35747 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39547 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39188 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42519 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40925 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->