### PR TITLE
Prevent heap allocation of Ref and RefPtr but allow placement new of these types.

### DIFF
--- a/Source/WTF/wtf/CompactPtr.h
+++ b/Source/WTF/wtf/CompactPtr.h
@@ -27,6 +27,7 @@
 
 #include <cstdint>
 #include <utility>
+#include <wtf/FastMalloc.h>
 #include <wtf/Forward.h>
 #include <wtf/GetPtr.h>
 #include <wtf/HashFunctions.h>

--- a/Source/WTF/wtf/ForbidHeapAllocation.h
+++ b/Source/WTF/wtf/ForbidHeapAllocation.h
@@ -40,5 +40,19 @@ private: \
     void* operator new[](size_t, void*) = delete; \
     void* operator new(size_t) = delete; \
     void* operator new[](size_t size) = delete; \
-    void* operator new(size_t, NotNullTag, void* location) = delete; \
+    void* operator new(size_t, NotNullTag, void*) = delete; \
     typedef int __thisIsHereToForceASemicolonAfterThisForbidHeapAllocationMacro
+
+#define WTF_FORBID_HEAP_ALLOCATION_ALLOWING_PLACEMENT_NEW \
+public: \
+    void* operator new(size_t, NotNullTag, void* location) \
+    { \
+        ASSERT(location); \
+        return location; \
+    } \
+    void* operator new(size_t, void* location) { return location; } \
+    void* operator new[](size_t, void* location)  { return location; } \
+private: \
+    void* operator new(size_t) = delete; \
+    void* operator new[](size_t size) = delete; \
+    typedef int __thisIsHereToForceASemicolonAfterThisForbidHeapAllocationAllowingPlacementNewMacro

--- a/Source/WTF/wtf/KeyValuePair.h
+++ b/Source/WTF/wtf/KeyValuePair.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <type_traits>
+#include <wtf/FastMalloc.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/Ref.h
+++ b/Source/WTF/wtf/Ref.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/Assertions.h>
+#include <wtf/ForbidHeapAllocation.h>
 #include <wtf/Forward.h>
 #include <wtf/GetPtr.h>
 #include <wtf/RawPtrTraits.h>
@@ -68,6 +69,7 @@ template<typename T, typename PtrTraits = RawPtrTraits<T>, typename RefDerefTrai
 
 template<typename T, typename _PtrTraits, typename RefDerefTraits>
 class Ref {
+    WTF_FORBID_HEAP_ALLOCATION_ALLOWING_PLACEMENT_NEW;
 public:
     using PtrTraits = _PtrTraits;
     static constexpr bool isRef = true;

--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -24,7 +24,6 @@
 
 #include <algorithm>
 #include <utility>
-#include <wtf/FastMalloc.h>
 #include <wtf/Ref.h>
 
 namespace WTF {
@@ -34,7 +33,7 @@ template<typename T, typename PtrTraits = RawPtrTraits<T>, typename RefDerefTrai
 
 template<typename T, typename _PtrTraits, typename _RefDerefTraits>
 class RefPtr {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(RefPtr);
+    WTF_FORBID_HEAP_ALLOCATION_ALLOWING_PLACEMENT_NEW;
 public:
     using PtrTraits = _PtrTraits;
     using RefDerefTraits = _RefDerefTraits;

--- a/Tools/TestWebKitAPI/Tests/WTF/Lock.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Lock.cpp
@@ -45,7 +45,7 @@ void runLockTest(unsigned numThreadGroups, unsigned numThreadsPerGroup, unsigned
 {
     std::unique_ptr<LockType[]> locks = makeUniqueWithoutFastMallocCheck<LockType[]>(numThreadGroups);
     auto words = makeUniqueArray<double>(numThreadGroups);
-    std::unique_ptr<RefPtr<Thread>[]> threads = makeUniqueWithoutFastMallocCheck<RefPtr<Thread>[]>(numThreadGroups * numThreadsPerGroup);
+    auto threads = Vector<RefPtr<Thread>>(numThreadGroups * numThreadsPerGroup);
 
     for (unsigned threadGroupIndex = numThreadGroups; threadGroupIndex--;) {
         words[threadGroupIndex] = 0;


### PR DESCRIPTION
#### 55659fc19d4876aefed3818dfb8b231fb0c12edd
<pre>
Prevent heap allocation of Ref and RefPtr but allow placement new of these types.
<a href="https://bugs.webkit.org/show_bug.cgi?id=296217">https://bugs.webkit.org/show_bug.cgi?id=296217</a>
<a href="https://rdar.apple.com/156185263">rdar://156185263</a>

Reviewed by Simon Fraser.

It doesn&apos;t make a lot of sense to heap allocate a Ref or RefPtr directly
such as with auto p = new RefPtr&lt;T&gt;();. So we should no longer fast malloc RefPtr.
But we still want to be able to store a Ref or RefPtr in a Vector so let&apos;s allow
placement new.

* Source/WTF/wtf/CompactPtr.h:
        Header shuffle.

* Source/WTF/wtf/ForbidHeapAllocation.h:
        Create a variant of WTF_FORBID_HEAP_ALLOCATION which allows
        placement new but disallows the other operator new&apos;s.

* Source/WTF/wtf/KeyValuePair.h:
        Header shuffle.

* Source/WTF/wtf/Ref.h:
* Source/WTF/wtf/RefPtr.h:

* Tools/TestWebKitAPI/Tests/WTF/Lock.cpp:
(TestWebKitAPI::runLockTest):
        std::unique_ptr&lt;RefPtr&lt;Thread&gt;[]&gt; is a unique pointer to a dynamically
        sized array of RefPtrs. That&apos;s conceptually the same thing as a Vector&lt;RefPtr&lt;Thread&gt;&gt;
        so use that instead.

Canonical link: <a href="https://commits.webkit.org/297639@main">https://commits.webkit.org/297639@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc609b275c4790de4a90568a959f245f7a25028f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112365 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32097 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22574 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118444 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62774 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114327 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32749 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40660 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85365 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36093 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115312 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101096 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65796 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25432 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19233 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62289 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/104879 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95522 "Found 1 new API test failure: TestWebKitAPI.GPUProcess.ExitsUnderMemoryPressureWebAudioCase (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19310 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121770 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/110979 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39439 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29360 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94170 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39820 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97337 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93996 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24037 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39238 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17035 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35489 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39327 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44815 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/135210 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38962 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36334 "Found 2 new JSC stress test failures: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js.default, wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42299 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40705 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->