### PR TITLE
[iPadOS] [Liquid Glass] bsky.app: scroll pocket may get hidden indefinitely after failed element fullscreen presentation

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -241,8 +241,9 @@
 #import <pal/spi/ios/GraphicsServicesSPI.h>
 #import <wtf/cocoa/Entitlements.h>
 
-#define WKWEBVIEW_RELEASE_LOG(...) RELEASE_LOG(ViewState, __VA_ARGS__)
 #endif // PLATFORM(IOS_FAMILY)
+
+#define WKWEBVIEW_RELEASE_LOG(...) RELEASE_LOG(ViewState, __VA_ARGS__)
 
 #if PLATFORM(MAC)
 #import "AppKitSPI.h"
@@ -3393,11 +3394,26 @@ static WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::Fixe
     return view && ![view isHiddenOrFadingOut];
 }
 
+static ASCIILiteral descriptionForReason(WebKit::HideScrollPocketReason reason)
+{
+    switch (reason) {
+    case WebKit::HideScrollPocketReason::FullScreen:
+        return "FullScreen"_s;
+    case WebKit::HideScrollPocketReason::ScrolledToTop:
+        return "ScrolledToTop"_s;
+    case WebKit::HideScrollPocketReason::SiteSpecificQuirk:
+        return "SiteSpecificQuirk"_s;
+    }
+    ASSERT_NOT_REACHED();
+    return ""_s;
+}
+
 - (void)_addReasonToHideTopScrollPocket:(WebKit::HideScrollPocketReason)reason
 {
     if (_reasonsToHideTopScrollPocket.contains(reason))
         return;
 
+    WKWEBVIEW_RELEASE_LOG("%p Hide top scroll pocket (%s)", self, descriptionForReason(reason).characters());
     _reasonsToHideTopScrollPocket.add(reason);
 
     [self _updateHiddenScrollPocketEdges];
@@ -3408,6 +3424,7 @@ static WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::Fixe
     if (!_reasonsToHideTopScrollPocket.contains(reason))
         return;
 
+    WKWEBVIEW_RELEASE_LOG("%p Unhide top scroll pocket (%s)", self, descriptionForReason(reason).characters());
     _reasonsToHideTopScrollPocket.remove(reason);
 
     [self _updateHiddenScrollPocketEdges];

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -1604,6 +1604,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return;
     }
 
+    RetainPtr webView = [self _webView];
+#if HAVE(LIQUID_GLASS)
+    [webView _removeReasonToHideTopScrollPocket:WebKit::HideScrollPocketReason::FullScreen];
+#endif
+
     OBJC_ALWAYS_LOG(OBJC_LOGIDENTIFIER);
 
     _shouldReturnToFullscreenFromPictureInPicture = false;
@@ -1612,7 +1617,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _fullScreenState = WebKit::NotInFullScreen;
     _shouldReturnToFullscreenFromPictureInPicture = false;
 
-    auto* page = [self._webView _page].get();
+    RefPtr page = [webView _page].get();
     if (page)
         page->setSuppressVisibilityUpdates(true);
 

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -36,6 +36,7 @@
 #import "WKAPICast.h"
 #import "WKViewInternal.h"
 #import "WKViewPrivate.h"
+#import "WKWebViewInternal.h"
 #import "WebFullScreenManagerProxy.h"
 #import "WebPageProxy.h"
 #import "WebProcessProxy.h"
@@ -493,6 +494,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [_webViewPlaceholder setExitWarningVisible:NO];
     _fullScreenState = ExitingFullScreen;
     [self finishedExitFullScreenAnimationAndExitImmediately:YES];
+
+#if HAVE(LIQUID_GLASS)
+    if (RefPtr page = _page.get())
+        [page->cocoaView() _removeReasonToHideTopScrollPocket:WebKit::HideScrollPocketReason::FullScreen];
+#endif
 }
 
 - (void)requestExitFullScreen


### PR DESCRIPTION
#### f8605b5f37ee3836b29ce2329b5f14e6febc0e43
<pre>
[iPadOS] [Liquid Glass] bsky.app: scroll pocket may get hidden indefinitely after failed element fullscreen presentation
<a href="https://bugs.webkit.org/show_bug.cgi?id=296219">https://bugs.webkit.org/show_bug.cgi?id=296219</a>
<a href="https://rdar.apple.com/155245241">rdar://155245241</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

On iPadOS, it&apos;s possible to get into a state where the top scroll pocket is indefinitely suppressed
when attempting to play videos on the home feed in bsky.app. This happens because the web view gets
permanently stuck in a state where the fullscreen presentation state is `.entering` and only
`FullscreenClient::willEnterFullscreen` is called (not `didEnterFullscreen`, `willExitFullscreen` or
`didExitFullscreen`) and the fullscreen view controller never gets a chance to present (tracked in
<a href="https://rdar.apple.com/139744548">rdar://139744548</a>). This can be induced by immediately removing the fullscreen element from the
DOM immediately after requesting fullscreen presentation, e.g.:

```
playButton.addEventListener(&quot;click&quot;, async () =&gt; {
    // `container` is the fullscreen element container.
    // `video` is a video element inside the container.
    if (!document.webkitIsFullScreen &amp;&amp; container.webkitRequestFullscreen)
        container.webkitRequestFullscreen({ navigationUI: &quot;hide&quot; })
    video.play();
    await new Promise(requestAnimationFrame);
    container.remove();
});
```

...which causes us to call `-_exitFullscreenImmediately` which dismisses the view controller without
calling into the corresponding UI delegate methods or updating the fullscreen state. To fix this
bug, we add logic to un-hide the scroll pocket in this &quot;immediate exit&quot; codepath.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(descriptionForReason):
(-[WKWebView _addReasonToHideTopScrollPocket:]):
(-[WKWebView _removeReasonToHideTopScrollPocket:]):

Also add release logs to make it easier to triage similar issues in the future, where the scroll
pocket is stuck in a hidden state.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController _exitFullscreenImmediately]):
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
(-[WKFullScreenWindowController exitFullScreenImmediately]):

Call through to `-_removeReasonToHideTopScrollPocket:` when exiting fullscreen immediately.

Canonical link: <a href="https://commits.webkit.org/297642@main">https://commits.webkit.org/297642@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf645ebd50eab3d6797ce79487611082092c9923

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32119 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22596 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118466 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62770 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32771 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40682 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85377 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36083 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26156 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101114 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65808 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25451 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62311 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95540 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19327 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121792 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39461 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29379 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94183 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39842 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97354 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94009 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24039 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39257 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17052 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35511 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39349 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44837 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38984 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42321 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40727 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->