### PR TITLE
[css-anchor-position-1] Changed anchor names doesn't re-run anchor resolution on anchor-positioned elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-in-anchor-positioned-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-in-anchor-positioned-expected.txt
@@ -1,0 +1,4 @@
+
+PASS .target 1
+PASS .target 2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-in-anchor-positioned.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-in-anchor-positioned.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+
+<title>Tests that anchors in anchor-positioned elements are discoverable</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#determining">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<script src="support/test-common.js"></script>
+
+<style>
+  .containing-block {
+    border: 1px solid black;
+
+    position: relative;
+    width: 200px;
+    height: 150px;
+  }
+
+  .box {
+    width: 50px;
+    height: 50px;
+  }
+
+  #anchor-1 {
+    position: absolute;
+    top: 50px;
+    left: 50px;
+
+    anchor-name: --anchor-1;
+
+    background: green;
+  }
+
+  #anchor-positioned-1 {
+    position: absolute;
+    position-anchor: --anchor-1;
+    position-area: top right;
+  }
+
+  #anchor-2 {
+    anchor-name: --anchor-2;
+    background: blue;
+  }
+
+  #anchor-positioned-2 {
+    position: absolute;
+    position-anchor: --anchor-2;
+    position-area: bottom right;
+
+    background: cyan;
+  }
+</style>
+
+<body onload="checkLayoutForAnchorPos('.target')">
+  <div class="containing-block">
+    <div class="box" id="anchor-1"></div>
+
+    <div class="box target" id="anchor-positioned-1" data-offset-x="100" data-offset-y="0">
+      <div class="box" id="anchor-2"></div>
+    </div>
+
+    <div class="box target" id="anchor-positioned-2" data-offset-x="150" data-offset-y="50"></div>
+  </div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-in-popover-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-in-popover-expected.txt
@@ -1,0 +1,4 @@
+
+PASS .target 1
+PASS .target 2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-in-popover.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-in-popover.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+
+<title>Tests that anchors in a popover are discoverable</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#determining">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<script src="support/test-common.js"></script>
+
+<style>
+  body {
+    margin: 0;
+  }
+
+  #containing-block {
+    position: relative;
+    width: 100px;
+    height: 100px;
+
+    border: 1px black solid;
+  }
+
+  #anchor-1 {
+    width: 50px;
+    height: 50px;
+
+    position: absolute;
+    top: 25px;
+    left: 25px;
+
+    background: green;
+
+    anchor-name: --anchor-1;
+  }
+
+  #popover-1 {
+    margin: 0;
+    border: 1px black solid;
+    padding: 0;
+
+    width: 100px;
+    height: 100px;
+
+    position: absolute;
+    position-anchor: --anchor-1;
+    position-area: bottom right;
+  }
+
+  #anchor-2 {
+    width: 50px;
+    height: 50px;
+
+    position: absolute;
+    top: 25px;
+    left: 25px;
+
+    background: cyan;
+
+    anchor-name: --anchor-2;
+  }
+
+  #popover-2 {
+    margin: 0;
+    border: 1px black solid;
+    padding: 0;
+
+    width: 100px;
+    height: 100px;
+
+    position: absolute;
+    position-anchor: --anchor-2;
+    position-area: bottom right;
+  }
+</style>
+
+<body>
+  <div id="containing-block">
+    <div id="anchor-1"></div>
+  </div>
+
+  <!--
+    1px border of #containing-block
+  + 25px gap between #containing-block and #anchor-1
+  + 50px width of #anchor-1
+  = 76px
+  -->
+  <div class="target" id="popover-1" popover data-offset-x="76" data-offset-y="76">
+    <div id="anchor-2">
+      <!--
+        76px left offset of #anchor-1
+      + 1px border of #popover-2
+      + 25px gap between #popover-2 and #anchor-2
+      + 50px width of #anchor-2
+      = 152px
+      -->
+
+      <!-- #popover-2 has to be here to trigger a bug in Safari -->
+      <div class="target" id="popover-2" popover data-offset-x="152" data-offset-y="152"></div>
+    </div>
+  </div>
+
+
+  <script>
+    const popover1 = document.getElementById("popover-1");
+    const popover2 = document.getElementById("popover-2");
+
+    popover1.showPopover();
+    popover2.showPopover();
+
+    checkLayoutForAnchorPos('.target');
+  </script>
+</body>

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -978,7 +978,10 @@ void AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayou
                         .name = anchorNameAndElement.key
                     });
                 }
-                document.styleScope().anchorPositionedToAnchorMap().set(*element, WTFMove(anchors));
+                document.styleScope().anchorPositionedToAnchorMap().set(*element, AnchorPositionedToAnchorEntry {
+                    .key = elementAndState.key,
+                    .anchors = WTFMove(anchors)
+                });
             }
             state.stage = renderer && renderer->style().usesAnchorFunctions() ? AnchorPositionResolutionStage::ResolveAnchorFunctions : AnchorPositionResolutionStage::Resolved;
             continue;
@@ -1049,7 +1052,7 @@ auto AnchorPositionEvaluator::makeAnchorPositionedForAnchorMap(AnchorPositionedT
 
     for (auto elementAndAnchors : toAnchorMap) {
         CheckedRef anchorPositionedElement = elementAndAnchors.key;
-        for (auto& anchor : elementAndAnchors.value) {
+        for (auto& anchor : elementAndAnchors.value.anchors) {
             if (!anchor.renderer)
                 continue;
             map.ensure(*anchor.renderer, [&] {
@@ -1296,7 +1299,7 @@ CheckedPtr<RenderBoxModelObject> AnchorPositionEvaluator::defaultAnchorForBox(co
 
     auto anchorName = ResolvedScopedName::createFromScopedName(element, defaultAnchorName(box.style()));
 
-    for (auto& anchor : it->value) {
+    for (auto& anchor : it->value.anchors) {
         if (anchorName == anchor.name)
             return anchor.renderer.get();
     }

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -93,7 +93,17 @@ struct ResolvedAnchor {
     ResolvedScopedName name;
 };
 
-using AnchorPositionedToAnchorMap = WeakHashMap<Element, Vector<ResolvedAnchor>, WeakPtrImplWithEventTargetData>;
+struct AnchorPositionedToAnchorEntry {
+    // This key can be used to access the AnchorPositionedState struct of the current element
+    // in an AnchorPositionedStates map.
+    AnchorPositionedKey key;
+
+    Vector<ResolvedAnchor> anchors;
+
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED(AnchorPositionedToAnchorEntry);
+};
+
+using AnchorPositionedToAnchorMap = WeakHashMap<Element, AnchorPositionedToAnchorEntry, WeakPtrImplWithEventTargetData>;
 using AnchorToAnchorPositionedMap = SingleThreadWeakHashMap<const RenderBoxModelObject, Vector<Ref<Element>>>;
 
 class AnchorPositionEvaluator {

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -1107,7 +1107,7 @@ void Scope::updateAnchorPositioningStateAfterStyleResolution()
     AnchorPositionEvaluator::updateSnapshottedScrollOffsets(m_document);
 
     m_anchorPositionedToAnchorMap.removeIf([](auto& elementAndState) {
-        return elementAndState.value.isEmpty();
+        return elementAndState.value.anchors.isEmpty();
     });
 }
 


### PR DESCRIPTION
#### 1996b78d76bfc40feffbf1d41bf33ebcb39867c9
<pre>
[css-anchor-position-1] Changed anchor names doesn&apos;t re-run anchor resolution on anchor-positioned elements
<a href="https://rdar.apple.com/150975368">rdar://150975368</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=292754">https://bugs.webkit.org/show_bug.cgi?id=292754</a>

Reviewed by Alan Baradlay.

Consider this pseudo-HTML:

&lt;div anchor-name: --a /&gt; // A
&lt;div position-anchor: --a position-area: top left&gt; // B
  &lt;div anchor-name: --c &gt;&lt;/div&gt; // C
&lt;/div&gt;

&lt;div position-anchor: --c position-area: top right /&gt; // D

On the first style resolution pass:

* A is an anchor named --a
* B is anchor-positioned to --a. There&apos;s an optimization where we skip descending
  into an anchor-positioned element until it&apos;s resolved, so we don&apos;t descend into B.
  This means C is not discovered as an anchor.
* D is anchor-positioned to --c.

After the first style resolution pass:

* B is resolved, such that --a refers to A
* D is anchored to --c, but there&apos;re no anchors named --c (NOTE that C hasn&apos;t
  been discovered yet, since we skip visiting C until B is resolved). So D
  is resolved as &quot;anchor --c not found&quot;

On the second style resolution pass, we descend into B (since B is resolved),
and discover C as an anchor named --c.

After the second style resolution pass, B and D don&apos;t get re-resolved because
they&apos;re marked as &quot;resolved&quot;. This is wrong, because D should be re-resolved
to pick up C as potential anchor for name --c. The result is that D won&apos;t
anchor to C, even though it should.

The fix is to mark anchor-positioned elements as unresolved when an anchor name
it refers to changes. This signals that anchor resolution should be run again
to pick up the new changes.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-in-anchor-positioned-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-in-anchor-positioned.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-in-popover-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-in-popover.html: Added.
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayout):
(WebCore::Style::AnchorPositionEvaluator::makeAnchorPositionedForAnchorMap):
(WebCore::Style::AnchorPositionEvaluator::defaultAnchorForBox):
* Source/WebCore/style/AnchorPositionEvaluator.h:
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::updateAnchorPositioningStateAfterStyleResolution):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolve):
    - When invalidating anchor-positioned element because of anchor name changes,
      only invalidate it once.
    - In addition to invalidating anchor-positioned elements, also reset its stage
      in AnchorPositionState to FindAnchor.

Canonical link: <a href="https://commits.webkit.org/297797@main">https://commits.webkit.org/297797@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94b784c406405ad5b5bc5a6bbd17932b1c78aab5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112799 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32534 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23012 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119002 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63309 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114761 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33186 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41097 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85844 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36486 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115746 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26485 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101472 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66150 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25778 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19603 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62761 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95879 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19678 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122223 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39877 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29728 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94708 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40260 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97692 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94446 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24126 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39570 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17383 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35980 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39763 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45261 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39402 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42736 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41141 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->