### PR TITLE
[visionOS] In fullscreen, unable to change subtitles after changing playback speed

### DIFF
--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
@@ -181,8 +181,17 @@
         return;
 
     NSUInteger index = audioTrack ? [player.audioTracks indexOfObject:audioTrack] : 0;
-    if (index != NSNotFound)
-        model->selectAudioMediaOption(index);
+    if (index == NSNotFound) {
+        RetainPtr indexSet = [player.audioTracks indexesOfObjectsPassingTest:^(WKSLinearMediaTrack *track, NSUInteger, BOOL*) {
+            return [track.localizedDisplayName isEqualToString:audioTrack.localizedDisplayName];
+        }];
+        ASSERT([indexSet count] < 2);
+        index = [indexSet firstIndex];
+        if (index == NSNotFound)
+            return;
+    }
+
+    model->selectAudioMediaOption(index);
 }
 
 - (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player setLegibleTrack:(WKSLinearMediaTrack * _Nullable)legibleTrack
@@ -192,8 +201,17 @@
         return;
 
     NSUInteger index = legibleTrack ? [player.legibleTracks indexOfObject:legibleTrack] : 0;
-    if (index != NSNotFound)
-        model->selectLegibleMediaOption(index);
+    if (index == NSNotFound) {
+        RetainPtr indexSet = [player.legibleTracks indexesOfObjectsPassingTest:^(WKSLinearMediaTrack *track, NSUInteger, BOOL*) {
+            return [track.localizedDisplayName isEqualToString:legibleTrack.localizedDisplayName];
+        }];
+        ASSERT([indexSet count] < 2);
+        index = [indexSet firstIndex];
+        if (index == NSNotFound)
+            return;
+    }
+
+    model->selectLegibleMediaOption(index);
 }
 
 - (void)linearMediaPlayerEnterFullscreen:(WKSLinearMediaPlayer *)player


### PR DESCRIPTION
#### b4e60928f6eb5d05ef136a6adef8894d4069fc3b
<pre>
[visionOS] In fullscreen, unable to change subtitles after changing playback speed
<a href="https://bugs.webkit.org/show_bug.cgi?id=296223">https://bugs.webkit.org/show_bug.cgi?id=296223</a>
<a href="https://rdar.apple.com/154874849">rdar://154874849</a>

Reviewed by Jer Noble.

When the user changes a legible or audio track in LMPlayableViewController, LinearMediaKit calls
setLegibleTrack(_:) or setAudioTrack(_:) on WebKit&apos;s Playable-conforming object. We expect the
Track passed to those functions to match (by object identity) one of the tracks we had previously
published in legibleTracksPublisher or audioTracksPublisher, but due to a bug that is not always
the case. When the Track object can&apos;t be found in the corresponding published array, we fail to
find an index for the new track and consequently fail to activate it.

Worked around this by falling back to matching the track by its localized display name when we
cannot match it by object identity.

* Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm:
(-[WKLinearMediaPlayerDelegate linearMediaPlayer:setAudioTrack:]):
(-[WKLinearMediaPlayerDelegate linearMediaPlayer:setLegibleTrack:]):

Canonical link: <a href="https://commits.webkit.org/297688@main">https://commits.webkit.org/297688@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e94660dc8cf4ffa789042b3f1c4ca8d737d28713

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112475 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32207 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22684 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118554 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62912 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32859 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40770 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85449 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36206 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115422 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26231 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101196 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65880 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25528 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62400 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95619 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19404 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121880 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29457 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94256 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39931 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97430 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94082 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24068 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39329 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17128 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35616 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39437 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44925 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39073 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42409 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40815 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->