### PR TITLE
Misc VMTraps improvements.

### DIFF
--- a/Source/JavaScriptCore/interpreter/FrameTracers.h
+++ b/Source/JavaScriptCore/interpreter/FrameTracers.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -43,12 +43,12 @@ public:
         , m_savedLastException(vm.m_lastException, nullptr)
     {
         if (m_exceptionWasSet)
-            m_vm.traps().clearTrapBit(VMTraps::NeedExceptionHandling);
+            m_vm.traps().clearTrap(VMTraps::NeedExceptionHandling);
     }
     ~SuspendExceptionScope()
     {
         if (m_exceptionWasSet)
-            m_vm.traps().setTrapBit(VMTraps::NeedExceptionHandling);
+            m_vm.traps().fireTrap(VMTraps::NeedExceptionHandling);
     }
 private:
     VM& m_vm;

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2008 Cameron Zwarich <cwzwarich@uwaterloo.ca>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -1119,11 +1119,6 @@ failedJSONP:
     if (error) [[unlikely]]
         return throwException(globalObject, throwScope, error);
 
-    if (vm.traps().needHandling(VMTraps::NonDebuggerAsyncEvents)) [[unlikely]] {
-        if (vm.hasExceptionsAfterHandlingTraps())
-            return throwScope.exception();
-    }
-
     if (scope->structure()->isUncacheableDictionary())
         scope->flattenDictionaryObject(vm);
 
@@ -1216,11 +1211,6 @@ ALWAYS_INLINE JSValue Interpreter::executeCallImpl(VM& vm, JSObject* function, c
 
     if (vm.disallowVMEntryCount) [[unlikely]]
         return checkVMEntryPermission();
-
-    if (vm.traps().needHandling(VMTraps::NonDebuggerAsyncEvents)) [[unlikely]] {
-        if (vm.hasExceptionsAfterHandlingTraps())
-            return scope.exception();
-    }
 
     RefPtr<JSC::JITCode> jitCode;
     ProtoCallFrame protoCallFrame;
@@ -1318,11 +1308,6 @@ JSObject* Interpreter::executeConstruct(JSObject* constructor, const CallData& c
         return globalObject->globalThis();
     }
 
-    if (vm.traps().needHandling(VMTraps::NonDebuggerAsyncEvents)) [[unlikely]] {
-        if (vm.hasExceptionsAfterHandlingTraps())
-            return nullptr;
-    }
-
     RefPtr<JSC::JITCode> jitCode;
     ProtoCallFrame protoCallFrame;
     {
@@ -1395,11 +1380,6 @@ JSValue Interpreter::executeEval(EvalExecutable* eval, JSValue thisValue, JSScop
     JSGlobalObject* globalObject = scope->globalObject();
     if (!vm.isSafeToRecurseSoft()) [[unlikely]]
         return throwStackOverflowError(globalObject, throwScope);
-
-    if (vm.traps().needHandling(VMTraps::NonDebuggerAsyncEvents)) [[unlikely]] {
-        if (vm.hasExceptionsAfterHandlingTraps())
-            return throwScope.exception();
-    }
 
     auto topLevelFunctionDecls = eval->topLevelFunctionDecls();
     auto variables = eval->variables();
@@ -1606,11 +1586,6 @@ JSValue Interpreter::executeModuleProgram(JSModuleRecord* record, ModuleProgramE
 
     if (vm.disallowVMEntryCount) [[unlikely]]
         return checkVMEntryPermission();
-
-    if (vm.traps().needHandling(VMTraps::NonDebuggerAsyncEvents)) [[unlikely]] {
-        if (vm.hasExceptionsAfterHandlingTraps())
-            return throwScope.exception();
-    }
 
     if (scope->structure()->isUncacheableDictionary())
         scope->flattenDictionaryObject(vm);

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -936,7 +936,7 @@ void VM::setException(Exception* exception)
     m_exception = exception;
     m_lastException = exception;
     if (exception)
-        traps().setTrapBit(VMTraps::NeedExceptionHandling);
+        traps().fireTrap(VMTraps::NeedExceptionHandling);
 }
 
 void VM::throwTerminationException()

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -1009,7 +1009,7 @@ private:
         m_throwingThread = nullptr;
 #endif
         m_exception = nullptr;
-        traps().clearTrapBit(VMTraps::NeedExceptionHandling);
+        traps().clearTrap(VMTraps::NeedExceptionHandling);
     }
 
     JS_EXPORT_PRIVATE void setException(Exception*);

--- a/Source/JavaScriptCore/runtime/VMTraps.cpp
+++ b/Source/JavaScriptCore/runtime/VMTraps.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -41,6 +41,7 @@
 #include "WaiterListManager.h"
 #include "Watchdog.h"
 #include <wtf/ProcessID.h>
+#include <wtf/Scope.h>
 #include <wtf/ThreadMessage.h>
 #include <wtf/threads/Signals.h>
 
@@ -175,10 +176,10 @@ void VMTraps::invalidateCodeBlocksOnStack(CallFrame* topCallFrame)
     
 void VMTraps::invalidateCodeBlocksOnStack(Locker<Lock>&, CallFrame* topCallFrame)
 {
-    if (!m_needToInvalidatedCodeBlocks)
+    if (!m_needToInvalidateCodeBlocks)
         return;
 
-    m_needToInvalidatedCodeBlocks = false;
+    m_needToInvalidateCodeBlocks = false;
 
     EntryFrame* entryFrame = vm().topEntryFrame;
     CallFrame* callFrame = topCallFrame;
@@ -376,31 +377,61 @@ void VMTraps::willDestroyVM()
 #endif
 }
 
-void VMTraps::fireTrap(VMTraps::Event event)
+void VMTraps::cancelThreadStopIfNeeded()
 {
-    ASSERT(!vm().currentThreadIsHoldingAPILock());
-    ASSERT(onlyContainsAsyncEvents(event));
-    {
-        Locker locker { *m_lock };
-        ASSERT(!m_isShuttingDown);
-        setTrapBit(event);
-        m_needToInvalidatedCodeBlocks = true;
+    Locker locker { *m_lock };
+
+    // We need to confirm that there are no pending async events before cancelling the
+    // thread stop request. This is because:
+    // 1. The AsyncEvent being cleared may not be the only one needing threads to stop, or
+    // 2. A new AsyncEvent may have been set by another thread before we get here, and we
+    //    we need to keep the thread stop request.
+    if (needHandling(AsyncEvents)) {
+        RELEASE_ASSERT(m_threadStopRequested);
+        return;
     }
-    
+    if (!m_threadStopRequested)
+        return; // Cancel was already processed due to another thread. Nothing more to do.
+
+    // Nothing else to do to cancel thread stopping for now.
+
+    m_threadStopRequested = false;
+}
+
+void VMTraps::requestThreadStopIfNeeded(VMTraps::Event event)
+{
+    Locker locker { *m_lock };
+    ASSERT(!m_isShuttingDown);
+
+    // We got here because an AsyncEvent was set. Because this is an asynchronous event,
+    // it may have already been cleared by another thread before we get here. So, we
+    // need to confirm that an async event is still pending before requesting a thread stop.
+    if (!needHandling(AsyncEvents)) {
+        RELEASE_ASSERT(!m_threadStopRequested);
+        return;
+    }
+
+    if (m_threadStopRequested)
+        return; // Stop requested was already processed due to another AsyncEvent source. Nothing more to do.
+
+    VM& vm = this->vm();
+    m_needToInvalidateCodeBlocks = true;
+
 #if ENABLE(SIGNAL_BASED_VM_TRAPS)
     if (!Options::usePollingTraps()) {
         // sendSignal() can loop until it has confirmation that the mutator thread
         // has received the trap request. We'll call it from another thread so that
-        // fireTrap() does not block.
-        Locker locker { *m_lock };
+        // requestThreadStopIfNeeded() does not block.
         if (!m_signalSender)
-            m_signalSender = adoptRef(new SignalSender(locker, vm()));
+            m_signalSender = adoptRef(new SignalSender(locker, vm));
         m_signalSender->notify(locker);
     }
 #endif
 
     if (event == NeedTermination)
-        vm().syncWaiter()->condition().notifyOne();
+        vm.syncWaiter()->condition().notifyOne();
+
+    m_threadStopRequested = true;
 }
 
 void VMTraps::handleTraps(VMTraps::BitField mask)
@@ -409,7 +440,9 @@ void VMTraps::handleTraps(VMTraps::BitField mask)
     auto scope = DECLARE_THROW_SCOPE(vm);
     ASSERT(onlyContainsAsyncEvents(mask));
     ASSERT(needHandling(mask));
-    ASSERT(!hasTrapBit(DeferTrapHandling));
+
+    if (m_trapsDeferred)
+        return; // We'll service them on the next opportunity after deferring has stopped.
 
     if (isDeferringTermination())
         mask &= ~NeedTermination;
@@ -422,6 +455,25 @@ void VMTraps::handleTraps(VMTraps::BitField mask)
                 codeBlock->jettison(Profiler::JettisonDueToVMTraps);
         });
     }
+
+    auto takeTopPriorityTrap = [&] (VMTraps::BitField mask) -> Event {
+        Locker locker { *m_lock };
+
+        // Note: the EventBitShift is already sorted in highest to lowest priority
+        // i.e. a bit shift of 0 is highest priority, etc.
+        for (unsigned i = 0; i < NumberOfEvents; ++i) {
+            Event event = static_cast<Event>(1 << i);
+            if (hasTrapBit(event, mask)) {
+                clearTrapWithoutCancellingThreadStop(event);
+                return event;
+            }
+        }
+        return NoEvent;
+    };
+
+    auto cancelThreadStop = makeScopeExit([&] {
+        cancelThreadStopIfNeeded();
+    });
 
     while (needHandling(mask)) {
         auto event = takeTopPriorityTrap(mask);
@@ -451,27 +503,10 @@ void VMTraps::handleTraps(VMTraps::BitField mask)
             return;
 
         case NeedExceptionHandling:
-        case DeferTrapHandling:
         default:
             RELEASE_ASSERT_NOT_REACHED();
         }
     }
-}
-
-auto VMTraps::takeTopPriorityTrap(VMTraps::BitField mask) -> Event
-{
-    Locker locker { *m_lock };
-
-    // Note: the EventBitShift is already sorted in highest to lowest priority
-    // i.e. a bit shift of 0 is highest priority, etc.
-    for (unsigned i = 0; i < NumberOfEvents; ++i) {
-        Event event = static_cast<Event>(1 << i);
-        if (hasTrapBit(event, mask)) {
-            clearTrapBit(event);
-            return event;
-        }
-    }
-    return NoEvent;
 }
 
 void VMTraps::deferTerminationSlow(DeferAction)
@@ -479,8 +514,12 @@ void VMTraps::deferTerminationSlow(DeferAction)
     ASSERT(m_deferTerminationCount == 1);
 
     VM& vm = this->vm();
-    if (vm.hasPendingTerminationException()) {
-        ASSERT(vm.hasTerminationRequest());
+    if (vm.hasPendingTerminationException()) [[unlikely]] {
+        RELEASE_ASSERT(vm.hasTerminationRequest());
+        // While we clear the TerminationExeption here, hasTerminationRequest() remains true and
+        // is how we remember that we still need a TerminationException when we stop deferring.
+        // hasTerminationRequest() will eventually trigger a re-throw of TerminationExeption
+        // after we stop deferring.
         vm.clearException();
         m_suspendedTerminationException = true;
     }
@@ -496,7 +535,7 @@ void VMTraps::undoDeferTerminationSlow(DeferAction deferAction)
         vm.throwTerminationException();
         m_suspendedTerminationException = false;
     } else if (deferAction == DeferAction::DeferForAWhile)
-        setTrapBit(NeedTermination); // Let the next trap check handle it.
+        fireTrap(NeedTermination); // Let the next trap check handle it.
 }
 
 VMTraps::VMTraps()

--- a/Source/JavaScriptCore/runtime/VMTraps.h
+++ b/Source/JavaScriptCore/runtime/VMTraps.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -150,8 +150,7 @@ public:
     v(NeedTermination) \
     v(NeedWatchdogCheck) \
     v(NeedDebuggerBreak) \
-    v(NeedExceptionHandling) \
-    v(DeferTrapHandling) // Must come last in the enum. This defers all events except NeedExceptionHandling.
+    v(NeedExceptionHandling)
 
 #define DECLARE_VMTRAPS_EVENT_BIT_SHIFT(event__)  event__##BitShift,
     enum EventBitShift {
@@ -161,8 +160,7 @@ public:
 
 
 #define COUNT_EVENT(event) + 1
-    static constexpr BitField NumberOfEvents = FOR_EACH_VMTRAPS_EVENTS(COUNT_EVENT) - 1; // Don't count DeferTrapHandling.
-    static constexpr BitField NumberOfEventsIncludingDefer = FOR_EACH_VMTRAPS_EVENTS(COUNT_EVENT);
+    static constexpr BitField NumberOfEvents = FOR_EACH_VMTRAPS_EVENTS(COUNT_EVENT);
 #undef COUNT_EVENT
 
     using Event = BitField;
@@ -177,12 +175,16 @@ public:
 
     static constexpr Event NoEvent = 0;
 
-    static_assert(NumberOfEventsIncludingDefer <= bitsInBitField);
+    static_assert(NumberOfEvents <= bitsInBitField);
     static constexpr BitField AllEvents = (1ull << NumberOfEvents) - 1;
-    static constexpr BitField AllEventsIncludingDefer = (1ull << NumberOfEventsIncludingDefer) - 1;
     static constexpr BitField AsyncEvents = AllEvents & ~NeedExceptionHandling;
     static constexpr BitField NonDebuggerEvents = AllEvents & ~NeedDebuggerBreak;
     static constexpr BitField NonDebuggerAsyncEvents = AsyncEvents & ~NeedDebuggerBreak;
+
+    static constexpr bool isAsyncEvent(BitField event)
+    {
+        return AsyncEvents & event;
+    }
 
     static constexpr bool onlyContainsAsyncEvents(BitField events)
     {
@@ -198,10 +200,7 @@ public:
 
     ALWAYS_INLINE bool needHandling(BitField mask) const
     {
-        auto maskedValue = m_trapBits.loadRelaxed() & (mask | DeferTrapHandling);
-        if (maskedValue) [[unlikely]]
-            return (maskedValue & NeedExceptionHandling) || !(maskedValue & DeferTrapHandling);
-        return false;
+        return m_trapBits.loadRelaxed() & mask;
     }
     // Designed to be a fast check to rule out if we might need handling, and we need to ensure needHandling on the slow path.
     ALWAYS_INLINE bool maybeNeedHandling() const { return m_trapBits.loadRelaxed(); }
@@ -232,14 +231,20 @@ public:
         BitField maskedBits = event & mask;
         return m_trapBits.loadRelaxed() & maskedBits;
     }
-    void clearTrapBit(Event event) { m_trapBits.exchangeAnd(~event); }
-    void setTrapBit(Event event)
+    ALWAYS_INLINE void clearTrap(Event event)
     {
-        ASSERT((event & ~AllEventsIncludingDefer) == 0);
+        clearTrapWithoutCancellingThreadStop(event);
+        if (isAsyncEvent(event))
+            cancelThreadStopIfNeeded();
+    }
+    ALWAYS_INLINE void fireTrap(Event event)
+    {
+        ASSERT((event & ~AllEvents) == 0);
         m_trapBits.exchangeOr(event);
+        if (isAsyncEvent(event))
+            requestThreadStopIfNeeded(event);
     }
 
-    JS_EXPORT_PRIVATE void fireTrap(Event);
     void handleTraps(BitField mask = AsyncEvents);
 
 #if ENABLE(SIGNAL_BASED_VM_TRAPS)
@@ -252,9 +257,16 @@ public:
 private:
     VM& vm() const;
 
+    ALWAYS_INLINE void clearTrapWithoutCancellingThreadStop(Event event)
+    {
+        m_trapBits.exchangeAnd(~event);
+    }
+
+    JS_EXPORT_PRIVATE void cancelThreadStopIfNeeded();
+    JS_EXPORT_PRIVATE void requestThreadStopIfNeeded(Event);
+
     JS_EXPORT_PRIVATE void deferTerminationSlow(DeferAction);
     JS_EXPORT_PRIVATE void undoDeferTerminationSlow(DeferAction);
-    Event takeTopPriorityTrap(BitField mask);
 
 #if ENABLE(SIGNAL_BASED_VM_TRAPS)
     class SignalSender;
@@ -275,9 +287,11 @@ private:
 
     Atomic<BitField> m_trapBits { 0 };
     unsigned m_deferTerminationCount { 0 };
-    bool m_needToInvalidatedCodeBlocks { false };
+    bool m_needToInvalidateCodeBlocks { false };
     bool m_isShuttingDown { false };
     bool m_suspendedTerminationException { false };
+    bool m_threadStopRequested { false };
+    bool m_trapsDeferred { false };
 
     Box<Lock> m_lock;
     Box<Condition> m_condition;
@@ -288,6 +302,7 @@ private:
 
     friend class LLIntOffsetsExtractor;
     friend class SignalSender;
+    friend class DeferTraps;
 };
 
 class DeferTraps {
@@ -296,7 +311,7 @@ public:
     ~DeferTraps();
 private:
     VMTraps& m_traps;
-    bool m_isActive;
+    bool m_previousTrapsDeferred;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/VMTrapsInlines.h
+++ b/Source/JavaScriptCore/runtime/VMTrapsInlines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,6 +38,11 @@ inline void VMTraps::deferTermination(DeferAction deferAction)
 {
     auto originalCount = m_deferTerminationCount++;
     ASSERT(m_deferTerminationCount < UINT_MAX);
+    // Strictly speaking, we're only interested in vm.hasPendingTerminationException() here.
+    // However, vm.exception() is a necessary condition for vm.hasPendingTerminationException().
+    // Since this checks is intended to be cheap, we'll just do the cheaper check of vm.exception()
+    // which itself rarely returns true. We'll let the slow path do the full
+    // vm.hasPendingTerminationException() check instead.
     if (!originalCount && vm().exception()) [[unlikely]]
         deferTerminationSlow(deferAction);
 }
@@ -52,16 +57,14 @@ inline void VMTraps::undoDeferTermination(DeferAction deferAction)
 
 ALWAYS_INLINE DeferTraps::DeferTraps(VM& vm)
     : m_traps(vm.traps())
-    , m_isActive(!m_traps.hasTrapBit(VMTraps::DeferTrapHandling))
+    , m_previousTrapsDeferred(m_traps.m_trapsDeferred)
 {
-    if (m_isActive)
-        m_traps.setTrapBit(VMTraps::DeferTrapHandling);
+    m_traps.m_trapsDeferred = true;
 }
 
 ALWAYS_INLINE DeferTraps::~DeferTraps()
 {
-    if (m_isActive)
-        m_traps.clearTrapBit(VMTraps::DeferTrapHandling);
+    m_traps.m_trapsDeferred = m_previousTrapsDeferred;
 }
 
 } // namespace JSC


### PR DESCRIPTION
#### 874696af9d4376277356d27dfd2b7637244ef405
<pre>
Misc VMTraps improvements.
<a href="https://bugs.webkit.org/show_bug.cgi?id=296224">https://bugs.webkit.org/show_bug.cgi?id=296224</a>
<a href="https://rdar.apple.com/156193538">rdar://156193538</a>

Reviewed by Yijia Huang.

1. There are clearTrapBit(), setTrapBit(), and fireTrap() methods.  fireTrap() is conceptually like
   setTrapBit(), except that it can be called asynchronously from other threads.  clearTrapBit()
   and setTrapBit() are only meant to be called from the mutator.  It is not clear from the names
   that this is the nature of their roles, and it&apos;s easy for client code to use the wrong method.

   We can improve this by changing them into a more intuitive symmetrical pair of functions:
   clearTrap() and fireTrap().  We can also make them  more robust and thread-safe, while still
   keeping them performant.  More on that below.

2. Drop &quot;Bit&quot; from the name because it communicates an implementation detail and not the purpose
   of the method.  This is an unnecessary, and can be distracting.

3. The portion of fireTraps() that need to be thread-safe is the part which actually requests
   thread stopping.  We can factor this part out into a requestThreadStopIfNeeded() method.
   fireTrap() will only need to call requestThreadStopIfNeeded() if the trap event is an async event.
   For non-async events, we can skip this.  In all cases where fireTrap() needs to be fast, the trap
   event is constant and non-async.  Hence, the isAsyncEvent() check can be constant folded, and the
   call to requestThreadStopIfNeeded() will be completely elided.

   Also introduce a cancelThreadStopIfNeeded() method to keep the symmetry, and the logic easier to
   understand.  Currently, cancelThreadStopIfNeeded() doesn&apos;t really do anything that interesting.
   However, in the future, when we add other thread stopping mechanisms, their hooks or
   implementations can go into these 2 methods to request and cancel stoppage.

   Similarly, in all cases where clearTrap() needs to be fast, the trap event is also constant and
   non-async.  Hence, the analogous call to cancelThreadStopIfNeeded() will be elided,

4. takeTopPriorityTrap() is only called from handleTraps().  So, move it in there as a lambda to
   communicate this fact.  takeTopPriorityTrap() will clear bits in VMTraps::m_trapBits without
   calling cancelThreadStopIfNeeded().

5. Add a call to cancelThreadStopIfNeeded() on exit from handleTraps().  This ensures that we can
   cancel thread stoppage if takeTopPriorityTrap() has cleared every event bit for async events i.e.
   if there are no more async events to service.

6. Also fix a typo in the VMTraps:: m_needToInvalidateCodeBlocks field name.

7. Remove unnecessary VMTraps checks in Interpreter::executeProgram(), Interpreter::executeCallImpl,
   Interpreter::executeConstruct(), Interpreter::executeEval(), and Interpreter::executeModuleProgram().
   These checks are for NonDebuggerAsyncEvents, which rarely ever manifest.  There&apos;s no urgency to
   check for these traps here.

8. Simplify the implementation of DeterTraps to just set and clear a VMTraps::m_trapsDeferred flag.
   VMTraps::handleTraps() returns early if m_trapsDeferred is set.  For performance reasons, the
   previous approach aims to avoid triggering calls into VMTraps::handleTraps() when a DeferTraps
   scope is in effect.  However, this is misguided.  VMTraps are extremely rare.  Hence, it will
   not hurt performance with any significance to just allow VMTraps::handleTraps() to be called,
   and have it return early.  Again, this will only happen  under the rare circumstance when we
   both are in a DeferTraps scope and have an VMTraps fired at the same time.

   This new implementation removes the DeferTrapHandling bit, and makes it possible to enter and
   exit a DeferTraps scope without having to carefully manipulate VMTraps::m_trapBits.  Hence,
   this keeps the implementation of fireTraps() and clearTraps() simpler without needing to deal
   with the complications of deferring and restoring traps.

* Source/JavaScriptCore/interpreter/FrameTracers.h:
(JSC::SuspendExceptionScope::SuspendExceptionScope):
(JSC::SuspendExceptionScope::~SuspendExceptionScope):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::executeProgram):
(JSC::Interpreter::executeCallImpl):
(JSC::Interpreter::executeConstruct):
(JSC::Interpreter::executeEval):
(JSC::Interpreter::executeModuleProgram):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::setException):
* Source/JavaScriptCore/runtime/VM.h:
(JSC::VM::clearException):
* Source/JavaScriptCore/runtime/VMTraps.cpp:
(JSC::VMTraps::invalidateCodeBlocksOnStack):
(JSC::VMTraps::cancelThreadStopIfNeeded):
(JSC::VMTraps::requestThreadStopIfNeeded):
(JSC::VMTraps::handleTraps):
(JSC::VMTraps::deferTerminationSlow):
(JSC::VMTraps::undoDeferTerminationSlow):
(JSC::VMTraps::fireTrap): Deleted.
(JSC::VMTraps::takeTopPriorityTrap): Deleted.
* Source/JavaScriptCore/runtime/VMTraps.h:
(JSC::VMTraps::isAsyncEvent):
(JSC::VMTraps::needHandling const):
(JSC::VMTraps::clearTrap):
(JSC::VMTraps::fireTrap):
(JSC::VMTraps::clearTrapWithoutCancellingThreadStop):
(JSC::VMTraps::clearTrapBit): Deleted.
(JSC::VMTraps::setTrapBit): Deleted.
* Source/JavaScriptCore/runtime/VMTrapsInlines.h:
(JSC::VMTraps::deferTermination):
(JSC::DeferTraps::DeferTraps):
(JSC::DeferTraps::~DeferTraps):

Canonical link: <a href="https://commits.webkit.org/298039@main">https://commits.webkit.org/298039@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d56b6b4a3e98c79f96b53148ac93be09b52a847

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113986 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33738 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24196 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120153 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64763 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42299 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86633 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116934 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27357 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102379 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67015 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26542 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20510 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63861 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/106420 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96722 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20627 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123413 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/112549 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30549 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95492 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41397 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98591 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95273 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24287 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40380 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18189 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37141 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40896 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46396 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/136754 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40524 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36626 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43824 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42279 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->