### PR TITLE
[JSC] Fix swapped metadata fields in LLIntPrototypeLoadAdaptiveStructureWatchpoint

### DIFF
--- a/Source/JavaScriptCore/bytecode/LLIntPrototypeLoadAdaptiveStructureWatchpoint.cpp
+++ b/Source/JavaScriptCore/bytecode/LLIntPrototypeLoadAdaptiveStructureWatchpoint.cpp
@@ -111,10 +111,10 @@ void LLIntPrototypeLoadAdaptiveStructureWatchpoint::fireInternal(VM& vm, const F
         auto& metadata = instruction->as<OpInstanceof>().metadata(m_owner.get());
         switch (m_bytecodeIndex.get().checkpoint()) {
         case OpInstanceof::getPrototype:
-            clearLLIntGetByIdCache(metadata.m_hasInstanceModeMetadata);
+            clearLLIntGetByIdCache(metadata.m_prototypeModeMetadata);
             break;
         case OpInstanceof::instanceof:
-            clearLLIntGetByIdCache(metadata.m_prototypeModeMetadata);
+            clearLLIntGetByIdCache(metadata.m_hasInstanceModeMetadata);
             break;
         default:
             RELEASE_ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### 8b9ba07813004b387c97e5ad5d57953ffad18ca8
<pre>
[JSC] Fix swapped metadata fields in LLIntPrototypeLoadAdaptiveStructureWatchpoint
<a href="https://bugs.webkit.org/show_bug.cgi?id=296225">https://bugs.webkit.org/show_bug.cgi?id=296225</a>
<a href="https://rdar.apple.com/156195508">rdar://156195508</a>

Reviewed by NOBODY (OOPS!).

OpInstanceof::getPrototype should clear m_prototypeModeMetadata, not m_hasInstanceModeMetadata.
OpInstanceof::instanceof should clear m_hasInstanceModeMetadata, not m_prototypeModeMetadata.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b9ba07813004b387c97e5ad5d57953ffad18ca8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112383 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22592 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118462 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62763 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32767 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40678 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85373 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115330 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/26151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101109 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65804 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/25446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19248 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62307 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/104897 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/95535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19323 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121788 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/110997 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39457 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29375 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94181 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39838 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97350 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94007 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39251 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17048 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/35507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39345 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44833 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/135228 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38980 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36341 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42317 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40723 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->