### PR TITLE
[Form Control Refresh] [macOS] Stepper button should not use tint color

### DIFF
--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -1700,15 +1700,13 @@ bool RenderThemeCocoa::paintInnerSpinButtonStyleForVectorBasedControls(const Ren
     const auto isEnabled = controlStates.contains(ControlStyle::State::Enabled);
     const auto isPressed = controlStates.contains(ControlStyle::State::Pressed);
     const auto isSpinningUp = controlStates.contains(ControlStyle::State::SpinUp);
-#if PLATFORM(MAC)
     const auto isWindowActive = controlStates.contains(ControlStyle::State::WindowActive);
-    auto indicatorColor = isWindowActive ? controlTintColor(box.style(), styleColorOptions) : systemColor(CSSValueAppleSystemSecondaryLabel, styleColorOptions);
-#else
-    auto indicatorColor = controlTintColor(box.style(), styleColorOptions);
-#endif
+
+    const auto cssValueForIndicatorColor = isWindowActive ? CSSValueAppleSystemLabel : CSSValueAppleSystemSecondaryLabel;
 
     auto backgroundColor = systemColor(CSSValueAppleSystemQuinaryLabel, styleColorOptions);
     auto dividerColor = systemColor(CSSValueAppleSystemQuaternaryLabel, styleColorOptions);
+    auto indicatorColor = systemColor(cssValueForIndicatorColor, styleColorOptions);
 
     if (!isEnabled) {
         backgroundColor = backgroundColor.colorWithAlphaMultipliedBy(kDisabledControlAlpha);


### PR DESCRIPTION
#### 4403550c24f3dd31d1d93b98c1155da4b5a87322
<pre>
[Form Control Refresh] [macOS] Stepper button should not use tint color
<a href="https://bugs.webkit.org/show_bug.cgi?id=296228">https://bugs.webkit.org/show_bug.cgi?id=296228</a>
<a href="https://rdar.apple.com/156200612">rdar://156200612</a>

Reviewed by Abrar Rahman Protyasha.

When the window is active, the stepper button indicator now uses color
`CSSValueAppleSystemLabel` rather than tint color in order to match
the system stepper button.

* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::RenderThemeCocoa::paintInnerSpinButtonStyleForVectorBasedControls):

Canonical link: <a href="https://commits.webkit.org/297636@main">https://commits.webkit.org/297636@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bfbe74f8202b5927619c9c799e5d27ba99a230a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112391 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32123 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22600 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118470 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62781 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114353 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32775 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40686 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85381 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36096 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115338 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26159 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101117 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65812 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25454 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19255 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62315 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95544 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19330 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121796 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39465 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29383 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94189 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39846 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97357 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94014 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24035 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39258 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17055 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/35515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39353 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44841 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38988 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42325 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40731 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->