### PR TITLE
[SwiftUI] Support more exported content types from WebPage

### DIFF
--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		078B044A2CF139BF00B453A6 /* Foundation+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B04492CF139BF00B453A6 /* Foundation+Extras.swift */; };
 		078B0CA92DF656BD00B3E569 /* TestPDFDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B0CA82DF656BD00B3E569 /* TestPDFDocument.swift */; };
 		079D45F22A2A6BBE003830C7 /* Viewport.mm in Sources */ = {isa = PBXBuildFile; fileRef = 079D45F12A2A6BBE003830C7 /* Viewport.mm */; };
+		07A1E0042E2C1F25004E5C66 /* SwiftUI+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A1DFFC2E2C1F20004E5C66 /* SwiftUI+Extras.swift */; };
 		07C02FD22D6D6FBC0004ED97 /* rtl-sideways-scrolling.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 07C02FD12D6D6FBC0004ED97 /* rtl-sideways-scrolling.html */; };
 		07C046CA1E4262A8007201E7 /* CARingBufferTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 07C046C91E42573E007201E7 /* CARingBufferTest.cpp */; };
 		07CE1CF31F06A7E000BF89F5 /* GetUserMediaNavigation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 07CE1CF21F06A7E000BF89F5 /* GetUserMediaNavigation.mm */; };
@@ -2459,6 +2460,7 @@
 		0794742C25CB33B000C597EE /* camera-to-canvas.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "camera-to-canvas.html"; sourceTree = "<group>"; };
 		0799C34A1EBA32F4003B7532 /* disableGetUserMedia.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = disableGetUserMedia.html; sourceTree = "<group>"; };
 		079D45F12A2A6BBE003830C7 /* Viewport.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = Viewport.mm; sourceTree = "<group>"; };
+		07A1DFFC2E2C1F20004E5C66 /* SwiftUI+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwiftUI+Extras.swift"; sourceTree = "<group>"; };
 		07C02FD12D6D6FBC0004ED97 /* rtl-sideways-scrolling.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "rtl-sideways-scrolling.html"; sourceTree = "<group>"; };
 		07C046C91E42573E007201E7 /* CARingBufferTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CARingBufferTest.cpp; sourceTree = "<group>"; };
 		07CC7DFD2266330800E39181 /* MediaBufferingPolicy.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MediaBufferingPolicy.mm; sourceTree = "<group>"; };
@@ -4486,6 +4488,7 @@
 			children = (
 				074E87E42CF920A20059E469 /* Bundle+Extras.swift */,
 				078B04492CF139BF00B453A6 /* Foundation+Extras.swift */,
+				07A1DFFC2E2C1F20004E5C66 /* SwiftUI+Extras.swift */,
 				070721102CE2F4B8004D9EC8 /* TestWebKitAPIBundle-Bridging-Header.h */,
 				078B04472CF118BD00B453A6 /* URLSchemeHandlerTests.swift */,
 				07DF05172E0531AD00007A1B /* WebPageNavigationTests.swift */,
@@ -8185,6 +8188,7 @@
 				078B044A2CF139BF00B453A6 /* Foundation+Extras.swift in Sources */,
 				A17C58472C9BF524009DD0B5 /* GoogleTests.mm in Sources */,
 				DD5698002DC1320500050321 /* rdar150228472.swift in Sources */,
+				07A1E0042E2C1F25004E5C66 /* SwiftUI+Extras.swift in Sources */,
 				078B0CA92DF656BD00B3E569 /* TestPDFDocument.swift in Sources */,
 				078B04482CF118BD00B453A6 /* URLSchemeHandlerTests.swift in Sources */,
 				07DF05182E0531AD00007A1B /* WebPageNavigationTests.swift in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/SwiftUI+Extras.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/SwiftUI+Extras.swift
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Apple Inc. All rights reserved.
+// Copyright (C) 2025 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -21,28 +21,20 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.0)
+import SwiftUI
 
-import Foundation
+extension Font {
+    #if canImport(UIKit)
+    typealias CocoaAttributes = AttributeScopes.UIKitAttributes
+    #else
+    typealias CocoaAttributes = AttributeScopes.AppKitAttributes
+    #endif
 
-extension RangeReplaceableCollection {
-    init<Failure>(
-        _ sequence: some AsyncSequence<Element, Failure>,
-        isolation: isolated (any Actor)? = #isolation
-    ) async throws(Failure) where Failure: Error {
-        self.init()
-
-        for try await element in sequence {
-            append(element)
+    init?(_ font: CocoaAttributes.FontAttribute.Value?) {
+        guard let font else {
+            return nil
         }
+
+        self = Font(font as CTFont)
     }
 }
-
-extension AsyncSequence {
-    func wait(isolation: isolated (any Actor)? = #isolation) async throws(Failure) {
-        for try await _ in self {
-        }
-    }
-}
-
-#endif // ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.0)

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTransferableTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTransferableTests.swift
@@ -33,8 +33,9 @@ import SwiftUI
 struct WebPageTransferableTests {
     @Test
     func transferableContentTypes() async throws {
+        let expectedTypes: [UTType] = [.webArchive, .pdf, .png, .url, .flatRTFD, .rtf, .utf8PlainText]
         let exportedContentTypes = WebPage.exportedContentTypes()
-        #expect(exportedContentTypes == [.webArchive, .pdf, .image, .url])
+        #expect(exportedContentTypes == expectedTypes)
 
         let importedContentTypes = WebPage.importedContentTypes()
         #expect(importedContentTypes.isEmpty)
@@ -42,7 +43,7 @@ struct WebPageTransferableTests {
         let webPage = WebPage()
 
         let instanceExportedContentTypes = webPage.exportedContentTypes()
-        #expect(instanceExportedContentTypes == [.webArchive, .pdf, .image, .url])
+        #expect(instanceExportedContentTypes == expectedTypes)
 
         let instanceImportedContentTypes = webPage.importedContentTypes()
         #expect(instanceImportedContentTypes.isEmpty)
@@ -51,13 +52,7 @@ struct WebPageTransferableTests {
     @Test
     func exportToPDFWithFullContent() async throws {
         let webPage = WebPage()
-        webPage.load(
-            html: "<meta name='viewport' content='width=device-width'><body bgcolor=#00ff00>Hello</body>",
-            baseURL: .aboutBlank
-        )
-
-        // FIXME: Remove this when possible.
-        try await Task.sleep(for: .seconds(10))
+        try await webPage.load(html: "<meta name='viewport' content='width=device-width'><body bgcolor=#00ff00>Hello</body>").wait()
 
         let data = try await webPage.exported(as: .pdf)
         let pdf = TestPDFDocument(from: data)
@@ -73,13 +68,7 @@ struct WebPageTransferableTests {
     @Test
     func exportToPDFWithSubRegion() async throws {
         let webPage = WebPage()
-        webPage.load(
-            html: "<meta name='viewport' content='width=device-width'><body bgcolor=#00ff00>Hello</body>",
-            baseURL: .aboutBlank
-        )
-
-        // FIXME: Remove this when possible.
-        try await Task.sleep(for: .seconds(10))
+        try await webPage.load(html: "<meta name='viewport' content='width=device-width'><body bgcolor=#00ff00>Hello</body>").wait()
 
         let region = CGRect(x: 200, y: 150, width: 400, height: 300)
         let data = try await webPage.exported(as: .pdf(region: .rect(region)))
@@ -95,46 +84,41 @@ struct WebPageTransferableTests {
 
     @Test
     func exportToPDFWithoutLoadingAnyWebContentFails() async throws {
+        // FIXME: Either make both macOS and iOS throw an error, or have neither throw an error.
+        #if os(macOS)
         let webPage = WebPage()
 
-        // FIXME: This should be `TransferableError.self`, but that type is not API.
         await #expect(throws: (any Error).self) {
             let _ = try await webPage.exported(as: .pdf)
         }
+        #endif // os(macOS)
     }
 
     @Test
     func exportToURL() async throws {
         let webPage = WebPage()
-        webPage.load(
-            html: "<meta name='viewport' content='width=device-width'><body bgcolor=#00ff00>Hello</body>",
-            baseURL: .aboutBlank
-        )
-
-        // FIXME: Remove this when possible.
-        try await Task.sleep(for: .seconds(10))
+        try await webPage.load(html: "<meta name='viewport' content='width=device-width'><body bgcolor=#00ff00>Hello</body>").wait()
 
         let data = try await webPage.exported(as: .url)
         let actualURL = try await URL(importing: data, contentType: .url)
 
-        #expect(actualURL == .aboutBlank)
+        #expect(actualURL == URL(string: "about:blank"))
     }
 
-    @Test
-    func exportToImage() async throws {
+    @Test(arguments: [UTType.png, UTType.image])
+    func exportToImage(type: UTType) async throws {
         let defaultFrame = CGRect(x: 0, y: 0, width: 1024, height: 768)
+
+        #if os(macOS)
         let scaleFactor: CGFloat = 2
+        #else
+        let scaleFactor: CGFloat = 3
+        #endif
 
         let webPage = WebPage()
-        webPage.load(
-            html: "<body style='background-color: red;'></body>",
-            baseURL: .aboutBlank
-        )
+        try await webPage.load(html: "<body style='background-color: red;'></body>").wait()
 
-        // FIXME: Remove this when possible.
-        try await Task.sleep(for: .seconds(10))
-
-        let imageData = try await webPage.exported(as: .image)
+        let imageData = try await webPage.exported(as: type)
 
         #if os(macOS)
         let image = try await NSImage(importing: imageData, contentType: .image)
@@ -144,6 +128,54 @@ struct WebPageTransferableTests {
 
         #expect(image.size.width == defaultFrame.size.width * scaleFactor)
         #expect(image.size.height == defaultFrame.size.height * scaleFactor)
+    }
+
+    @Test(arguments: [UTType.plainText, UTType.utf8PlainText])
+    func exportToPlainText(type: UTType) async throws {
+        let webPage = WebPage()
+        try await webPage.load(
+            html: """
+                <body>
+                    <div>beep <b>bop</b></div>
+                    <iframe srcdoc='meep'>herp</iframe>
+                    <iframe srcdoc='moop'>derp</iframe>
+                </body>
+                """
+        )
+        .wait()
+
+        let expected = "beep bop\n  \n\nmeep\n\nmoop"
+
+        let textData = try await webPage.exported(as: type)
+        let string = try await String(importing: textData, contentType: type)
+        #expect(string == expected)
+    }
+
+    @Test(arguments: [UTType.flatRTFD, UTType.rtf])
+    func exportToRichText(type: UTType) async throws {
+        let webPage = WebPage()
+        try await webPage.load(html: "<body style='font-family: system-ui; font-size: 16px;'>Hello <b>World!</b>").wait()
+
+        let textData = try await webPage.exported(as: type)
+        let attributedString = try await AttributedString(importing: textData, contentType: type)
+
+        let context = EnvironmentValues().fontResolutionContext
+
+        #if os(macOS)
+        let expectedFontSize: CGFloat = 16
+        #else
+        let expectedFontSize: CGFloat = 23
+        #endif
+
+        let firstRange = try #require(attributedString.range(of: "Hello "))
+        let firstFont = try #require(Font(attributedString[firstRange].font)).resolve(in: context)
+        #expect(!firstFont.isBold)
+        #expect(firstFont.pointSize == expectedFontSize)
+
+        let secondRange = try #require(attributedString.range(of: "World!"))
+        let secondFont = try #require(Font(attributedString[secondRange].font)).resolve(in: context)
+        #expect(secondFont.isBold)
+        #expect(secondFont.pointSize == expectedFontSize)
     }
 }
 


### PR DESCRIPTION
#### 248632b107f495370f87b9a8f658366f742e4dce
<pre>
[SwiftUI] Support more exported content types from WebPage
<a href="https://bugs.webkit.org/show_bug.cgi?id=296233">https://bugs.webkit.org/show_bug.cgi?id=296233</a>
<a href="https://rdar.apple.com/156225187">rdar://156225187</a>

Reviewed by Wenson Hsieh.

Add support for exporting the contents of a WebPage as plain text and rich text

* Source/WebKit/UIProcess/API/Swift/WebPage+Transferable.swift:
(transferRepresentation):

- Refine the `.image` export representation to `.png`, which is more specific and
usually more useful (for example, it can infer a file extension).

- Expose additional representations for `.flatRTFD`, `.rtf`, and `.utf8PlainText`

(WebPage.plainTextRepresentation):

- Use existing WebKit functionality to get the contents of all frames as a String, a
nd use its data for the export.

(WebPage.richTextRepresentation(_:)):

- Use existing WebKit functionality to get the contents of the page as an NSAttributedString
with a specified document type, and then use its data for the export along with the relevant
document attributes.

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit Swift/Foundation+Extras.swift:
(AsyncSequence.wait(_:)):
(URL.aboutBlank): Deleted.

- Fix some formatting
- Replace the Array extension with the RangeReplaceableCollection extension since having both
was redundant
- Add a convenience extension function to AsyncSequence to wait until the sequence is finished.
- No need for an `aboutBlank` property anymore now that the API supports default values for base URLs.

* Tools/TestWebKitAPI/Tests/WebKit Swift/SwiftUI+Extras.swift: Added.

- Make it easier to convert between an AttributedString&apos;s CocoaAttributes&apos; fonts values and SwiftUI&apos;s
`Font` type.

* Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageNavigationTests.swift:
(WebPageNavigationTests.basicNavigationProducesExpectedNavigationEvents):
(WebPageNavigationTests.failedNavigationProducesExpectedNavigationError):
(WebPageNavigationTests.explicitlyStopLoadingProgrammaticNavigation):
(WebPageNavigationTests.stopLoadingProgrammaticNavigationViaTaskCancellation):
(WebPageNavigationTests.failedNavigationWithWebContentProcessTerminated):
(WebPageNavigationTests.navigationProceedsAfterDiscardingNavigationStream):

- Use the updated convenience APIs to simplify some of the code
- Fix formatting/linting issues

* Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTransferableTests.swift:
(WebPageTransferableTests.transferableContentTypes):
(WebPageTransferableTests.exportToPDFWithFullContent):
(WebPageTransferableTests.exportToPDFWithSubRegion):
(WebPageTransferableTests.exportToURL):
(WebPageTransferableTests.exportToImage(_:)):
(WebPageTransferableTests.exportToPlainText(_:)):
(WebPageTransferableTests.exportToRichTextWithDocumentAttributes(_:)):
(WebPageTransferableTests.exportToImage): Deleted.

Add tests for all the new exportable content types.

Canonical link: <a href="https://commits.webkit.org/297658@main">https://commits.webkit.org/297658@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdde402284fad211c6572ead7f06e2f4a191837f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112433 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32165 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22642 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118512 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62836 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114395 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32817 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40728 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85409 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115380 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26192 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101155 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; 1 api test failed or timed out; re-run-api-tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65840 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25488 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19290 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62357 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95579 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19365 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121838 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39507 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29417 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/94217 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39889 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97392 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94042 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24046 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39289 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17090 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/35568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39395 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44883 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39030 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42367 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40773 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->