### PR TITLE
[Liquid Glass] [iOS] Fixed color extensions are sometimes obscured by web content after rubber-banding and zooming

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -2447,10 +2447,9 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
     if (!topColorExtensionView || [topColorExtensionView isHidden])
         return;
 
-    auto refreshControlIndex = NSNotFound;
-    auto topColorExtensionViewIndex = NSNotFound;
-    auto contentViewIndex = NSNotFound;
-    BOOL foundAllViews = NO;
+    std::optional<NSInteger> refreshControlIndex;
+    std::optional<NSInteger> topColorExtensionViewIndex;
+    std::optional<NSInteger> contentViewIndex;
 
     NSInteger index = 0;
     RetainPtr refreshControl = [_scrollView refreshControl];
@@ -2462,21 +2461,19 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
         else if (subview == _contentView)
             contentViewIndex = index;
 
-        if (refreshControlIndex != NSNotFound && topColorExtensionViewIndex != NSNotFound && contentViewIndex != NSNotFound) {
-            foundAllViews = YES;
+        if (refreshControlIndex && topColorExtensionViewIndex && contentViewIndex)
             break;
-        }
 
         index++;
     }
 
-    if (!foundAllViews)
+    if (!topColorExtensionViewIndex)
         return;
 
     BOOL scrolledBeyondTopExtent = [_scrollView _wk_isScrolledBeyondTopExtent];
-    if (scrolledBeyondTopExtent && refreshControlIndex < topColorExtensionViewIndex)
+    if (scrolledBeyondTopExtent && refreshControlIndex && *refreshControlIndex < *topColorExtensionViewIndex)
         [_scrollView insertSubview:topColorExtensionView.get() belowSubview:refreshControl.get()];
-    else if (!scrolledBeyondTopExtent && topColorExtensionViewIndex < contentViewIndex)
+    else if (!scrolledBeyondTopExtent && contentViewIndex && *topColorExtensionViewIndex < *contentViewIndex)
         [_scrollView insertSubview:topColorExtensionView.get() aboveSubview:_contentView.get()];
 }
 


### PR DESCRIPTION
#### d2a0e0d9747a65754559c90e7cf7e096fb5b9b77
<pre>
[Liquid Glass] [iOS] Fixed color extensions are sometimes obscured by web content after rubber-banding and zooming
<a href="https://bugs.webkit.org/show_bug.cgi?id=296235">https://bugs.webkit.org/show_bug.cgi?id=296235</a>
<a href="https://rdar.apple.com/156144657">rdar://156144657</a>

Reviewed by Richard Robinson.

It&apos;s possible for the top fixed color extension view to get stuck underneath `WKContentView` (and
thus, become obscured by web content) in the following scenario:

1.  There&apos;s a top fixed-position header on the page, with a corresponding top color extension view.
    The top scroll pocket is suppressed in this case, such that only the color extension is visible.

2.  The web view&apos;s scroll view rubber-bands past the top content offset while the `UIScrollView`
    has a refresh control, causing us to shuffle the color extension view *behind* the refresh
    control so that the refresh control won&apos;t get obscured by the solid color.

3.  The refresh control is removed from the scroll view, such that we end up returning early in
    `-_reinsertTopFixedColorExtensionViewIfNeeded` due to the refresh control subview index being
    `NSNotFound`.

4.  The web view then ends rubber-banding, and scrolls past the top content offset.

Because `-_reinsertTopFixedColorExtensionViewIfNeeded` requires all three subviews (refresh control,
content view and top color extension view) to be present, we skip restoring the color extension view
and it ends up being obscured. With the scroll edge effect hidden and the top fixed color extension
view obscured, the page content becomes fully visible behind the top obscured inset area.

In Safari, this happens when pinch-zooming in immediately after rubber-banding against the top of
the page. Only while the view is in unstable state (i.e. the user is still in the middle of a pinch
gesture), Safari removes `WKScrollView`&apos;s refresh control, causing the color extension view to be
temporarily obscured.

To fix this, we handle the case where the refresh control was previously in the scroll view, but had
since been removed. Instead of returning early if any of the three views are absent, only bail if
there is no top color extension; handle the case where the refresh control is absent below, only
when checking whether we should reinsert the top color extension view behind the refresh control.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _reinsertTopFixedColorExtensionViewIfNeeded]):

See above for more details.

* Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm:
(TestWebKitAPI::TEST(WKScrollViewTests, TopColorExtensionViewAfterRemovingRefreshControl)):

Add an API test to exercise this fix.

Canonical link: <a href="https://commits.webkit.org/297653@main">https://commits.webkit.org/297653@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2773c1a09f53f727e38e5beab94b94e67a504e7f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112412 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32144 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22621 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118491 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62812 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114374 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32796 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40707 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85396 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36117 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115359 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26173 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101133 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65827 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25469 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19269 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62336 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95559 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19344 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121817 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39486 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29401 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94203 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39867 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97371 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94028 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24044 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39273 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17069 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35544 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39374 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44862 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39009 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42346 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40752 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->