### PR TITLE
Use UncheckedKey containers in fewer places inside WTF/

### DIFF
--- a/Source/WTF/wtf/AggregateLogger.h
+++ b/Source/WTF/wtf/AggregateLogger.h
@@ -116,7 +116,7 @@ private:
         }
     }
 
-    UncheckedKeyHashSet<RefPtr<const Logger>> m_loggers;
+    HashSet<RefPtr<const Logger>> m_loggers;
 };
 
 } // namespace WTF

--- a/Source/WTF/wtf/JSONValues.h
+++ b/Source/WTF/wtf/JSONValues.h
@@ -176,7 +176,7 @@ private:
 class ObjectBase : public Value {
 private:
     friend class Value;
-    using DataStorage = UncheckedKeyHashMap<String, Ref<Value>>;
+    using DataStorage = HashMap<String, Ref<Value>>;
     using OrderStorage = Vector<String>;
 
 public:

--- a/Source/WTF/wtf/LoggingHashMap.h
+++ b/Source/WTF/wtf/LoggingHashMap.h
@@ -42,24 +42,24 @@ class LoggingHashMap final {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(LoggingHashMap);
 
 public:
-    typedef WTF::UncheckedKeyHashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg> UncheckedKeyHashMap;
+    typedef WTF::HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg> HashMap;
     
-    typedef typename UncheckedKeyHashMap::KeyType KeyType;
-    typedef typename UncheckedKeyHashMap::MappedType MappedType;
-    typedef typename UncheckedKeyHashMap::KeyValuePairType KeyValuePairType;
+    typedef typename HashMap::KeyType KeyType;
+    typedef typename HashMap::MappedType MappedType;
+    typedef typename HashMap::KeyValuePairType KeyValuePairType;
     
-    typedef typename UncheckedKeyHashMap::iterator iterator;
-    typedef typename UncheckedKeyHashMap::const_iterator const_iterator;
-    typedef typename UncheckedKeyHashMap::AddResult AddResult;
+    typedef typename HashMap::iterator iterator;
+    typedef typename HashMap::const_iterator const_iterator;
+    typedef typename HashMap::AddResult AddResult;
 
 private:
-    typedef typename UncheckedKeyHashMap::MappedTraits::PeekType MappedPeekType;
+    typedef typename HashMap::MappedTraits::PeekType MappedPeekType;
 
 public:
 
     LoggingHashMap()
     {
-        dataLog("auto* ", m_id, " = new UncheckedKeyHashMap<", typeArguments, ">();\n");
+        dataLog("auto* ", m_id, " = new HashMap<", typeArguments, ">();\n");
     }
     
     ~LoggingHashMap()
@@ -70,13 +70,13 @@ public:
     LoggingHashMap(const LoggingHashMap& other)
         : m_map(other.m_map)
     {
-        dataLog("auto* ", m_id, " = new UncheckedKeyHashMap(*", other.m_id, ");");
+        dataLog("auto* ", m_id, " = new HashMap(*", other.m_id, ");");
     }
     
     LoggingHashMap(LoggingHashMap&& other)
         : m_map(other.m_map)
     {
-        dataLog("auto* ", m_id, " = new UncheckedKeyHashMap(WTFMove(*", other.m_id, "));");
+        dataLog("auto* ", m_id, " = new HashMap(WTFMove(*", other.m_id, "));");
     }
     
     LoggingHashMap& operator=(const LoggingHashMap& other)
@@ -307,7 +307,7 @@ public:
     // FIXME: Implement the no-convert overloads.
     
 private:
-    UncheckedKeyHashMap m_map;
+    HashMap m_map;
     LoggingHashID m_id;
 };
 

--- a/Source/WTF/wtf/LoggingHashSet.h
+++ b/Source/WTF/wtf/LoggingHashSet.h
@@ -44,7 +44,7 @@ class LoggingHashSet final {
     typedef typename ValueTraits::TakeType TakeType;
     
 public:
-    typedef WTF::UncheckedKeyHashSet<ValueArg, HashArg, TraitsArg> HashSet;
+    typedef WTF::HashSet<ValueArg, HashArg, TraitsArg> HashSet;
     
     typedef typename HashSet::ValueType ValueType;
     typedef typename HashSet::iterator iterator;

--- a/Source/WTF/wtf/OrderMaker.h
+++ b/Source/WTF/wtf/OrderMaker.h
@@ -35,7 +35,7 @@ namespace WTF {
 // This is a collection that is meant to be used for building up lists in a certain order. It's
 // not an efficient data structure for storing lists, but if you need to build a list by doing
 // operations like insertBefore(existingValue, newValue), then this class is a good intermediate
-// helper. Note that the type it operates on must be usable as a UncheckedKeyHashMap key.
+// helper. Note that the type it operates on must be usable as a HashMap key.
 template<typename T>
 class OrderMaker {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(OrderMaker);
@@ -122,7 +122,7 @@ private:
         return result;
     }
     
-    UncheckedKeyHashMap<T, Node*> m_map;
+    HashMap<T, Node*> m_map;
     Bag<Node> m_nodes; // FIXME: We could just manually free the contents of the linked list.
     SentinelLinkedList<Node> m_list;
 };

--- a/Source/WTF/wtf/RefTrackerMixin.h
+++ b/Source/WTF/wtf/RefTrackerMixin.h
@@ -59,7 +59,7 @@ public:
     WTF_EXPORT_PRIVATE void logAllLiveReferences();
 
     Lock lock { };
-    UncheckedKeyHashMap<void*, std::unique_ptr<StackShot>> map WTF_GUARDED_BY_LOCK(lock) { };
+    HashMap<void*, std::unique_ptr<StackShot>> map WTF_GUARDED_BY_LOCK(lock) { };
     std::atomic<int> loggingDisabledDepth { };
 };
 

--- a/Source/WTF/wtf/Spectrum.h
+++ b/Source/WTF/wtf/Spectrum.h
@@ -35,8 +35,8 @@ template<typename T, typename CounterType = unsigned>
 class Spectrum {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(Spectrum);
 public:
-    typedef typename UncheckedKeyHashMap<T, CounterType>::iterator iterator;
-    typedef typename UncheckedKeyHashMap<T, CounterType>::const_iterator const_iterator;
+    typedef typename HashMap<T, CounterType>::iterator iterator;
+    typedef typename HashMap<T, CounterType>::const_iterator const_iterator;
     
     Spectrum() { }
     
@@ -45,7 +45,7 @@ public:
         Locker locker(m_lock);
         if (!count)
             return;
-        typename UncheckedKeyHashMap<T, CounterType>::AddResult result = m_map.add(key, count);
+        typename HashMap<T, CounterType>::AddResult result = m_map.add(key, count);
         if (!result.isNewEntry)
             result.iterator->value += count;
     }
@@ -118,14 +118,14 @@ public:
     void removeIf(const Functor& functor)
     {
         Locker locker(m_lock);
-        m_map.removeIf([&functor] (typename UncheckedKeyHashMap<T, CounterType>::KeyValuePairType& pair) {
+        m_map.removeIf([&functor] (typename HashMap<T, CounterType>::KeyValuePairType& pair) {
                 return functor(KeyAndCount(pair.key, pair.value));
             });
     }
     
 private:
     mutable Lock m_lock;
-    UncheckedKeyHashMap<T, CounterType> m_map;
+    HashMap<T, CounterType> m_map;
 };
 
 } // namespace WTF

--- a/Source/WTF/wtf/StatisticsManager.h
+++ b/Source/WTF/wtf/StatisticsManager.h
@@ -44,7 +44,7 @@ private:
     ~StatisticsManager() = default;
 
     mutable Lock m_lock;
-    UncheckedKeyHashMap<ASCIILiteral, Vector<double>> m_data WTF_GUARDED_BY_LOCK(m_lock);
+    HashMap<ASCIILiteral, Vector<double>> m_data WTF_GUARDED_BY_LOCK(m_lock);
 };
 
 } // namespace WTF

--- a/Source/WTF/wtf/StringHashDumpContext.h
+++ b/Source/WTF/wtf/StringHashDumpContext.h
@@ -40,7 +40,7 @@ public:
     
     CString getID(const T* value)
     {
-        typename UncheckedKeyHashMap<const T*, CString>::iterator iter = m_forwardMap.find(value);
+        typename HashMap<const T*, CString>::iterator iter = m_forwardMap.find(value);
         if (iter != m_forwardMap.end())
             return iter->value;
         
@@ -81,7 +81,7 @@ public:
         Vector<CString> keys;
         unsigned maxKeySize = 0;
         for (
-            typename UncheckedKeyHashMap<CString, const T*>::const_iterator iter = m_backwardMap.begin();
+            typename HashMap<CString, const T*>::const_iterator iter = m_backwardMap.begin();
             iter != m_backwardMap.end();
             ++iter) {
             keys.append(iter->key);
@@ -109,8 +109,8 @@ public:
         return out.toCString();
     }
     
-    UncheckedKeyHashMap<const T*, CString> m_forwardMap;
-    UncheckedKeyHashMap<CString, const T*> m_backwardMap;
+    HashMap<const T*, CString> m_forwardMap;
+    HashMap<CString, const T*> m_backwardMap;
 };
 
 } // namespace WTF

--- a/Source/WTF/wtf/ThreadSafeWeakHashSet.h
+++ b/Source/WTF/wtf/ThreadSafeWeakHashSet.h
@@ -233,7 +233,7 @@ private:
         }
     }
 
-    mutable UncheckedKeyHashSet<std::pair<ControlBlockRefPtr, const T*>> m_set WTF_GUARDED_BY_LOCK(m_lock);
+    mutable HashSet<std::pair<ControlBlockRefPtr, const T*>> m_set WTF_GUARDED_BY_LOCK(m_lock);
     mutable unsigned m_operationCountSinceLastCleanup WTF_GUARDED_BY_LOCK(m_lock) { 0 };
     mutable unsigned m_maxOperationCountWithoutCleanup WTF_GUARDED_BY_LOCK(m_lock) { 0 };
     mutable Lock m_lock;

--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -173,9 +173,9 @@ public:
 #endif
 };
 
-UncheckedKeyHashSet<Thread*>& Thread::allThreads()
+HashSet<Thread*>& Thread::allThreads()
 {
-    static LazyNeverDestroyed<UncheckedKeyHashSet<Thread*>> allThreads;
+    static LazyNeverDestroyed<HashSet<Thread*>> allThreads;
     static std::once_flag onceKey;
     std::call_once(onceKey, [&] {
         allThreads.construct();

--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -144,7 +144,7 @@ public:
     static Thread& currentSingleton();
 
     // Set of all WTF::Thread created threads.
-    WTF_EXPORT_PRIVATE static UncheckedKeyHashSet<Thread*>& allThreads() WTF_REQUIRES_LOCK(allThreadsLock());
+    WTF_EXPORT_PRIVATE static HashSet<Thread*>& allThreads() WTF_REQUIRES_LOCK(allThreadsLock());
     WTF_EXPORT_PRIVATE static Lock& allThreadsLock() WTF_RETURNS_LOCK(s_allThreadsLock);
 
     WTF_EXPORT_PRIVATE unsigned numberOfThreadGroups();

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -1346,7 +1346,7 @@ bool isEqualIgnoringQueryAndFragments(const URL& a, const URL& b)
     return substringIgnoringQueryAndFragments(a) == substringIgnoringQueryAndFragments(b);
 }
 
-Vector<String> removeQueryParameters(URL& url, const UncheckedKeyHashSet<String>& keysToRemove)
+Vector<String> removeQueryParameters(URL& url, const HashSet<String>& keysToRemove)
 {
     if (keysToRemove.isEmpty())
         return { };

--- a/Source/WTF/wtf/URL.h
+++ b/Source/WTF/wtf/URL.h
@@ -304,7 +304,7 @@ WTF_EXPORT_PRIVATE Vector<KeyValuePair<String, String>> queryParameters(const UR
 WTF_EXPORT_PRIVATE bool isEqualIgnoringQueryAndFragments(const URL&, const URL&);
 
 // Returns the parameters that were removed (including duplicates), in the order that they appear in the URL.
-WTF_EXPORT_PRIVATE Vector<String> removeQueryParameters(URL&, const UncheckedKeyHashSet<String>&);
+WTF_EXPORT_PRIVATE Vector<String> removeQueryParameters(URL&, const HashSet<String>&);
 WTF_EXPORT_PRIVATE Vector<String> removeQueryParameters(URL&, NOESCAPE const Function<bool(const String&, const String&)>&);
 
 WTF_EXPORT_PRIVATE const URL& aboutBlankURL();

--- a/Source/WTF/wtf/text/StringView.cpp
+++ b/Source/WTF/wtf/text/StringView.cpp
@@ -510,9 +510,9 @@ StringView::UnderlyingString::UnderlyingString(const StringImpl& string)
 
 static Lock underlyingStringsLock;
 
-static UncheckedKeyHashMap<const StringImpl*, StringView::UnderlyingString*>& underlyingStrings() WTF_REQUIRES_LOCK(underlyingStringsLock)
+static HashMap<const StringImpl*, StringView::UnderlyingString*>& underlyingStrings() WTF_REQUIRES_LOCK(underlyingStringsLock)
 {
-    static NeverDestroyed<UncheckedKeyHashMap<const StringImpl*, StringView::UnderlyingString*>> map;
+    static NeverDestroyed<HashMap<const StringImpl*, StringView::UnderlyingString*>> map;
     return map;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/URL.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/URL.cpp
@@ -536,10 +536,10 @@ TEST_F(WTF_URL, URLRemoveQueryParameters)
     auto url14 = createURL("http://www.webkit.org/?u+v=x+%20y&key1=foo"_s);
     auto url15 = createURL("http://www.webkit.org/?u+v=x+%20y"_s);
 
-    UncheckedKeyHashSet<String> keyRemovalSet1 { "key"_s };
-    UncheckedKeyHashSet<String> keyRemovalSet2 { "key1"_s };
-    UncheckedKeyHashSet<String> keyRemovalSet3 { "key2"_s };
-    UncheckedKeyHashSet<String> keyRemovalSet4 { "key"_s, "key1"_s };
+    HashSet<String> keyRemovalSet1 { "key"_s };
+    HashSet<String> keyRemovalSet2 { "key1"_s };
+    HashSet<String> keyRemovalSet3 { "key2"_s };
+    HashSet<String> keyRemovalSet4 { "key"_s, "key1"_s };
 
     auto checkRemovedParameters = [](int lineNumber, const Vector<String>& removedParameters, std::initializer_list<String>&& expected) {
         Vector<String> expectedParameters { WTFMove(expected) };


### PR DESCRIPTION
#### c7a18028d9f1ee641d481acf2d5e3126ef8fa607
<pre>
Use UncheckedKey containers in fewer places inside WTF/
<a href="https://bugs.webkit.org/show_bug.cgi?id=296239">https://bugs.webkit.org/show_bug.cgi?id=296239</a>

Reviewed by Sam Weinig.

Use UncheckedKey containers in fewer places inside WTF/, for safety.
This tested as performance neutral on Speedometer and JetStream.

* Source/WTF/wtf/AggregateLogger.h:
* Source/WTF/wtf/JSONValues.h:
* Source/WTF/wtf/LoggingHashMap.h:
* Source/WTF/wtf/LoggingHashSet.h:
* Source/WTF/wtf/OrderMaker.h:
* Source/WTF/wtf/RefTrackerMixin.h:
(WTF::RefTracker::WTF_GUARDED_BY_LOCK):
* Source/WTF/wtf/Spectrum.h:
(WTF::Spectrum::add):
(WTF::Spectrum::removeIf):
* Source/WTF/wtf/StatisticsManager.h:
* Source/WTF/wtf/StringHashDumpContext.h:
(WTF::StringHashDumpContext::getID):
(WTF::StringHashDumpContext::dump const):
* Source/WTF/wtf/ThreadSafeWeakHashSet.h:
* Source/WTF/wtf/Threading.cpp:
* Source/WTF/wtf/Threading.h:
* Source/WTF/wtf/URL.cpp:
(WTF::removeQueryParameters):
* Source/WTF/wtf/URL.h:
* Source/WTF/wtf/text/StringView.cpp:
* Tools/TestWebKitAPI/Tests/WTF/URL.cpp:
(TestWebKitAPI::TEST_F(WTF_URL, URLRemoveQueryParameters)):

Canonical link: <a href="https://commits.webkit.org/297663@main">https://commits.webkit.org/297663@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25489672c5215d388a58e72a5622216f155b5d38

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32159 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118506 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62843 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114389 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40722 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85414 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36143 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115374 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26187 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101151 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65845 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25484 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19286 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62351 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/104941 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95574 "Found 1 new API test failure: TestWebKitAPI.GPUProcess.ExitsUnderMemoryPressureVideoCase (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19361 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121832 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/111041 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39501 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29412 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94221 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39883 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97388 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94046 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24050 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39286 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17086 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35562 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39389 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44877 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/135272 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39024 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36349 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42361 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40767 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->