### PR TITLE
REGRESSION(291932@main): App may crash when a page calls ApplePaySetup.begin()

### DIFF
--- a/Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentSetupFeature.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentSetupFeature.mm
@@ -40,8 +40,9 @@ CoreIPCPKPaymentSetupFeature::CoreIPCPKPaymentSetupFeature(PKPaymentSetupFeature
 
 RetainPtr<id> CoreIPCPKPaymentSetupFeature::toID() const
 {
+    if (!isInWebProcess())
+        return nil;
     RetainPtr data = toNSDataNoCopy(m_data.span(), FreeWhenDone::No);
-    RELEASE_ASSERT(isInWebProcess());
     return [NSKeyedUnarchiver unarchivedObjectOfClass:PAL::getPKPaymentSetupFeatureClass() fromData:data.get() error:nil];
 }
 


### PR DESCRIPTION
#### 5e6dcc23b3084c2c140be03517c28ab43e38498a
<pre>
REGRESSION(291932@main): App may crash when a page calls ApplePaySetup.begin()
<a href="https://bugs.webkit.org/show_bug.cgi?id=296122">https://bugs.webkit.org/show_bug.cgi?id=296122</a>
<a href="https://rdar.apple.com/155350256">rdar://155350256</a>

Reviewed by Alex Christensen.

In 291932@main, we introduced a CoreIPC wrapper for
PKPaymentSetupFeature and introduced a web process assertion since we do
not want NSKU usage outside of the web process. While this still holds
true, it turns out that ApplePaySetup.begin() produces an IPC message to
WebPaymentCoordinatorProxy with a message containing
PKPaymentSetupFeature. This means the Apple Pay API in question easily
crashes the proxy hosting process (either UI or Networking).

In this patch, we make the codepath less crash happy by removing the
process assertion, calling into NSKU only while we&apos;re in the web
process, and simply returning `nil` if we are in some other process.

* Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentSetupFeature.mm:
(WebKit::CoreIPCPKPaymentSetupFeature::toID const):

Canonical link: <a href="https://commits.webkit.org/297686@main">https://commits.webkit.org/297686@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f481483a7e0f4d142e62f1f34df551e918ab736

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112430 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118509 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62833 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32814 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40725 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85407 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36137 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115377 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26185 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101144 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65838 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25481 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62354 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95572 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19354 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121835 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39504 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29415 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94215 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39886 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97381 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94040 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39292 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17079 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35565 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18125 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39392 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44880 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39027 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42364 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40770 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->