### PR TITLE
Add missing includes

### DIFF
--- a/Source/JavaScriptCore/runtime/BufferMemoryHandle.h
+++ b/Source/JavaScriptCore/runtime/BufferMemoryHandle.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <atomic>
+
 #include "MemoryMode.h"
 #include "Options.h"
 #include "PageCount.h"

--- a/Source/WTF/wtf/CheckedPtr.h
+++ b/Source/WTF/wtf/CheckedPtr.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/CheckedRef.h>
+#include <wtf/RawPtrTraits.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -24,6 +24,7 @@
 
 #include <algorithm>
 #include <utility>
+#include <wtf/RawPtrTraits.h>
 #include <wtf/Ref.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/WeakPtrFactory.h
+++ b/Source/WTF/wtf/WeakPtrFactory.h
@@ -28,6 +28,7 @@
 
 #include <wtf/CompactRefPtrTuple.h>
 #include <wtf/Packed.h>
+#include <wtf/RefPtr.h>
 #include <wtf/WeakRef.h>
 
 namespace WTF {

--- a/Source/WebCore/platform/RectEdges.h
+++ b/Source/WebCore/platform/RectEdges.h
@@ -28,6 +28,7 @@
 #include "BoxSides.h"
 #include "WritingMode.h"
 #include <array>
+#include <concepts>
 #include <wtf/OptionSet.h>
 #include <wtf/text/TextStream.h>
 

--- a/Source/WebCore/platform/graphics/ColorMatrix.h
+++ b/Source/WebCore/platform/graphics/ColorMatrix.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <concepts>
 #include <math.h>
 #include <wtf/MathExtras.h>
 

--- a/Source/WebCore/platform/graphics/IntSize.h
+++ b/Source/WebCore/platform/graphics/IntSize.h
@@ -27,6 +27,7 @@
 
 #include "PlatformExportMacros.h"
 #include <algorithm>
+#include <cmath>
 #include <wtf/JSONValues.h>
 #include <wtf/Forward.h>
 


### PR DESCRIPTION
#### c27f4d44a78f9ac4d353e533fce8be99f25d3b45
<pre>
Add missing includes
<a href="https://bugs.webkit.org/show_bug.cgi?id=296125">https://bugs.webkit.org/show_bug.cgi?id=296125</a>
<a href="https://rdar.apple.com/156057537">rdar://156057537</a>

Reviewed by Richard Robinson

This adds some includes to make each of these header files self-contained,
which is necessary when we build them as clang modules. This will happen once
we enable Swift/C++ interop.

This is a reland without a change to TZoneMalloc.h, which triggered build
problems in modules within Safari. We can land that separately later as
necessary.

* Source/JavaScriptCore/runtime/BufferMemoryHandle.h:
* Source/WTF/wtf/CheckedPtr.h:
* Source/WTF/wtf/RefPtr.h:
* Source/WTF/wtf/WeakPtrFactory.h:
* Source/WebCore/platform/RectEdges.h:
* Source/WebCore/platform/graphics/ColorMatrix.h:
* Source/WebCore/platform/graphics/IntSize.h:

Canonical link: <a href="https://commits.webkit.org/297676@main">https://commits.webkit.org/297676@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64e6b568d3a32411ba044624caddec5fde814eb4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32261 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22739 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118727 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62980 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114491 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32913 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40824 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85644 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36261 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115476 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26264 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101238 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65946 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25568 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19370 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62487 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/105043 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95655 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19443 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121949 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/111143 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39603 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29494 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94510 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39985 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97469 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94250 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24057 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39360 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17167 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35688 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39491 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44979 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/135375 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39128 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36379 "Found 19 new JSC stress test failures: stress/arrowfunction-constructor.js.bytecode-cache, stress/arrowfunction-constructor.js.default, stress/arrowfunction-constructor.js.dfg-eager, stress/arrowfunction-constructor.js.dfg-eager-no-cjit-validate, stress/arrowfunction-constructor.js.eager-jettison-no-cjit, stress/arrowfunction-constructor.js.mini-mode, stress/arrowfunction-constructor.js.no-cjit-collect-continuously, stress/arrowfunction-constructor.js.no-cjit-validate-phases, stress/arrowfunction-constructor.js.no-llint, stress/builtin-function-is-construct-type-none.js.bytecode-cache ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42463 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40869 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->