### PR TITLE
[JSC] Make `Intl.DateTimeFormat` Throw `RangeError` for Legacy Non-IANA Timezones to Align with TC39

### DIFF
--- a/JSTests/stress/intl-timezone-legacy-non-iana.js
+++ b/JSTests/stress/intl-timezone-legacy-non-iana.js
@@ -1,0 +1,45 @@
+function shouldThrowRangeError(func) {
+    try {
+        func();
+    } catch (err) {
+        if (err instanceof RangeError) {
+            return;
+        }
+    }
+    throw new Error("should throw RangeError");
+}
+
+// https://github.com/unicode-org/icu/blob/main/icu4c/source/tools/tzcode/icuzones
+const invalidTimeZones = [
+    "ACT",
+    "AET",
+    "AGT",
+    "ART",
+    "AST",
+    "BET",
+    "BST",
+    "CAT",
+    "CNT",
+    "CST",
+    "CTT",
+    "EAT",
+    "ECT",
+    "IET",
+    "IST",
+    "JST",
+    "MIT",
+    "NET",
+    "NST",
+    "PLT",
+    "PNT",
+    "PRT",
+    "PST",
+    "SST",
+    "VST",
+];
+
+for (const timeZone of invalidTimeZones) {
+    shouldThrowRangeError(() => {
+        new Intl.DateTimeFormat(undefined, { timeZone });
+    });
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -526,9 +526,6 @@ test/intl402/DateTimeFormat/prototype/formatToParts/temporal-objects-not-overlap
 test/intl402/DateTimeFormat/prototype/formatToParts/temporal-zoneddatetime-not-supported.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, timeZone)')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, timeZone)')"
-test/intl402/DateTimeFormat/timezone-legacy-non-iana.js:
-  default: 'Test262Error: Time zone: ACT Expected a RangeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: Time zone: ACT Expected a RangeError to be thrown but no exception was thrown at all'
 test/intl402/Intl/supportedValuesOf/calendars-accepted-by-DateTimeFormat.js:
   default: 'RangeError: calendar is not a well-formed calendar value'
   strict mode: 'RangeError: calendar is not a well-formed calendar value'

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -121,7 +121,7 @@ static String availableNamedTimeZoneIdentifier(StringView timeZoneName)
             break;
 
         StringView ianaTimeZoneView(std::span(ianaTimeZone, ianaTimeZoneLength));
-        if (!equalIgnoringASCIICase(timeZoneName, ianaTimeZoneView))
+        if (!equalIgnoringASCIICase(timeZoneName, ianaTimeZoneView) || isNonIANA(ianaTimeZoneView))
             continue;
         return ianaTimeZoneView.toString();
     } while (true);

--- a/Source/JavaScriptCore/runtime/JSDateMath.h
+++ b/Source/JavaScriptCore/runtime/JSDateMath.h
@@ -206,6 +206,39 @@ ALWAYS_INLINE bool isUTCEquivalent(StringView timeZone)
     return timeZone == "Etc/UTC"_s || timeZone == "Etc/GMT"_s || timeZone == "GMT"_s;
 }
 
+// non-IANA timezones
+// https://github.com/unicode-org/icu/blob/main/icu4c/source/tools/tzcode/icuzones
+ALWAYS_INLINE bool isNonIANA(StringView timeZone)
+{
+    return (
+        timeZone == "ACT"_s
+        || timeZone == "AET"_s
+        || timeZone == "AGT"_s
+        || timeZone == "ART"_s
+        || timeZone == "AST"_s
+        || timeZone == "BET"_s
+        || timeZone == "BST"_s
+        || timeZone == "CAT"_s
+        || timeZone == "CNT"_s
+        || timeZone == "CST"_s
+        || timeZone == "CTT"_s
+        || timeZone == "EAT"_s
+        || timeZone == "ECT"_s
+        || timeZone == "IET"_s
+        || timeZone == "IST"_s
+        || timeZone == "JST"_s
+        || timeZone == "MIT"_s
+        || timeZone == "NET"_s
+        || timeZone == "NST"_s
+        || timeZone == "PLT"_s
+        || timeZone == "PNT"_s
+        || timeZone == "PRT"_s
+        || timeZone == "PST"_s
+        || timeZone == "SST"_s
+        || timeZone == "VST"_s
+    );
+}
+
 } // namespace JSC
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### 12b12bf772973f3ed125ad07e9aaeec13929bbf7
<pre>
[JSC] Make `Intl.DateTimeFormat` Throw `RangeError` for Legacy Non-IANA Timezones to Align with TC39
<a href="https://bugs.webkit.org/show_bug.cgi?id=296248">https://bugs.webkit.org/show_bug.cgi?id=296248</a>

Reviewed by Yusuke Suzuki.

This patch fixes the behavior of `Intl.DateTimeFormat` constructor [1] to throw RangeError
for legacy non-IANA timezones to align with TC39 [2].

[1]: <a href="https://tc39.es/ecma402/#sec-createdatetimeformat">https://tc39.es/ecma402/#sec-createdatetimeformat</a>
[2]: <a href="https://tc39.es/ecma402/#sec-use-of-iana-time-zone-database">https://tc39.es/ecma402/#sec-use-of-iana-time-zone-database</a>

* JSTests/stress/intl-timezone-legacy-non-iana.js: Added.
(shouldThrowRangeError):
(const.timeZone.of.invalidTimeZones.shouldThrowRangeError):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp:
(JSC::availableNamedTimeZoneIdentifier):
* Source/JavaScriptCore/runtime/JSDateMath.h:
(JSC::isNonIANA):

Canonical link: <a href="https://commits.webkit.org/302447@main">https://commits.webkit.org/302447@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1e976a4c75e213dfd407b9de0eb7b8e6f17bffe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128958 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1211 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136337 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80315 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1090 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98180 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66088 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131905 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/883 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115519 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78808 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/811 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33632 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79618 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120949 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109251 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34129 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138804 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/127408 "Found 6 new JSC stress test failures: mozilla-tests.yaml/ecma/Date/15.9.5.8.js.mozilla, mozilla-tests.yaml/ecma/Date/15.9.5.8.js.mozilla-baseline, mozilla-tests.yaml/ecma/Date/15.9.5.8.js.mozilla-dfg-eager-no-cjit-validate-phases, mozilla-tests.yaml/ecma/Date/15.9.5.8.js.mozilla-ftl-eager-no-cjit-validate-phases, mozilla-tests.yaml/ecma/Date/15.9.5.8.js.mozilla-llint, mozilla-tests.yaml/ecma/Date/15.9.5.8.js.mozilla-no-ftl (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1012 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/987 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106713 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1073 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111857 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106534 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/842 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30378 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/53482 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20159 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1088 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64408 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/160426 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/922 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40044 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/975 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1019 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->