### PR TITLE
[CSS random()] Allow in `@keyframes`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-in-keyframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-in-keyframe-expected.txt
@@ -1,0 +1,3 @@
+
+PASS random() is not ignored in keyframe
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-in-keyframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-in-keyframe.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<title>CSS Values and Units Test: random() in @keyframes</title>
+<link rel="help" href="https://drafts.csswg.org/css-values-5/#random">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  @keyframes --anim {
+    from {
+        translate: 0px;
+        translate: random(2px, 200px);
+    }
+    to {
+        translate: 0px;
+    }
+  }
+  #target {
+    animation: --anim 1000s step-end;
+  }
+</style>
+<div id="target"></div>
+<script>
+  test(() => {
+    assert_not_equals(getComputedStyle(target).translate, "0px");
+  }, "random() is not ignored in keyframe");
+</script>

--- a/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
@@ -741,7 +741,7 @@ static std::optional<TypedChild> consumeRandom(CSSParserTokenRange& tokens, int 
     if (!state.propertyParserState.context.cssRandomFunctionEnabled)
         return { };
 
-    if (state.propertyParserState.currentRule != StyleRuleType::Style)
+    if (state.propertyParserState.currentRule != StyleRuleType::Style && state.propertyParserState.currentRule != StyleRuleType::Keyframe)
         return { };
     if (state.propertyParserState.currentProperty == CSSPropertyInvalid)
         return { };


### PR DESCRIPTION
#### e16ac11ad5129416c47ea699ce756d05d0169352
<pre>
[CSS random()] Allow in `@keyframes`
<a href="https://bugs.webkit.org/show_bug.cgi?id=296250">https://bugs.webkit.org/show_bug.cgi?id=296250</a>
<a href="https://rdar.apple.com/156267827">rdar://156267827</a>

Reviewed by Sam Weinig.

Stop blocking `random()` in keyframes at parse-time.

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-in-keyframe-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-in-keyframe.html: Added.
* Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
(WebCore::CSSCalc::consumeRandom):

Canonical link: <a href="https://commits.webkit.org/297680@main">https://commits.webkit.org/297680@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f88481531e9111bc10a1be6afb87af97dc8e285

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32201 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118548 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62909 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114431 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32853 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40764 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85443 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36207 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115416 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26223 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101188 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65874 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25520 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19322 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62394 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95611 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19396 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121874 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39543 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29452 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94250 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39925 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97422 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94076 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24061 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39323 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17120 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35608 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39431 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44919 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39067 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42403 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40809 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->