### PR TITLE
Sync `html/obsolete` from WPT upstream

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8037,3 +8037,6 @@ imported/w3c/web-platform-tests/focus/iframe-focuses-parent-different-site.html 
 imported/w3c/web-platform-tests/visual-viewport/resize-event-order.html [ Pass Failure ]
 
 webkit.org/b/294105 webanimations/document-teardown-due-to-last-reference-crash.html [ Pass Timeout Failure ]
+
+# Passes on WPT dashboard while fails locally
+imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-with-trusted-types.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -11123,6 +11123,8 @@
         "web-platform-tests/html/interaction/focus/document-level-focus-apis/support/test.html",
         "web-platform-tests/html/interaction/focus/processing-model/support/preventScroll-helper.html",
         "web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-min-intrinsic-size-ref.html",
+        "web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-with-trusted-types-alternate-ref.html",
+        "web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-with-trusted-types-ref.html",
         "web-platform-tests/html/rendering/bidi-rendering/slot-no-isolate-001-ref.html",
         "web-platform-tests/html/rendering/bindings/the-button-element/button-type-menu-historical-ref.html",
         "web-platform-tests/html/rendering/bindings/the-input-element-as-a-text-entry-widget/unrecognized-type-should-fallback-as-text-type-ref.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-with-trusted-types-alternate-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-with-trusted-types-alternate-ref.html
@@ -1,0 +1,8 @@
+<!doctype html>
+
+<!-- See https://github.com/whatwg/html/issues/10249 -->
+<!-- This reference matches Blink's and WebKit's current styles -->
+
+<div style="display: inline-block;">
+  <div style="width: 10px; height: 10px; background-color: green;"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-with-trusted-types-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-with-trusted-types-expected.html
@@ -1,0 +1,8 @@
+<!doctype html>
+
+<!-- See https://github.com/whatwg/html/issues/10249 -->
+<!-- This reference matches Gecko's current styles -->
+
+<div style="vertical-align: text-bottom; display: inline-block;">
+  <div style="width: 10px; height: 10px; background-color: green;"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-with-trusted-types-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-with-trusted-types-ref.html
@@ -1,0 +1,8 @@
+<!doctype html>
+
+<!-- See https://github.com/whatwg/html/issues/10249 -->
+<!-- This reference matches Gecko's current styles -->
+
+<div style="vertical-align: text-bottom; display: inline-block;">
+  <div style="width: 10px; height: 10px; background-color: green;"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-with-trusted-types.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-with-trusted-types.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<link rel="help" href="github.com/whatwg/html/issues/10249">
+<meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'">
+<link rel="match" href="marquee-with-trusted-types-ref.html">
+<link rel="match" href="marquee-with-trusted-types-alternate-ref.html">
+
+<marquee scrollamount="0">
+  <div style="width: 10px; height: 10px; background-color: green;"></div>
+</marquee>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/w3c-import.log
@@ -23,3 +23,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-overflow.html
 /LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-scrollamount.html
 /LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-scrolldelay.html
+/LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-with-trusted-types-alternate-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-with-trusted-types-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-with-trusted-types-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-with-trusted-types.html


### PR DESCRIPTION
#### a9b763e2fad2f292f87aa32e8ac2b98eeaee9883
<pre>
Sync `html/obsolete` from WPT upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=296252">https://bugs.webkit.org/show_bug.cgi?id=296252</a>

Reviewed by Anne van Kesteren.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/930052c66388ba6d2d0ce8e6dd2532dd13b85296">https://github.com/web-platform-tests/wpt/commit/930052c66388ba6d2d0ce8e6dd2532dd13b85296</a>

* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-with-trusted-types-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-with-trusted-types-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-with-trusted-types.html:
* LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-with-trusted-types-alternate-ref.html:
* LayoutTests/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/297738@main">https://commits.webkit.org/297738@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0e94d5024e5119cc975640a6eab48c3559259b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112683 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32415 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22893 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118882 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63175 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33067 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40978 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85760 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36395 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115630 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26383 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101371 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66068 "Found 138 new API test failures: /WPE/TestLoaderClient:/webkit/WebKitWebView/loading-status, /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification, /WPE/TestWebKitFindController:/webkit/WebKitFindController/options, /WPE/TestLoaderClient:/webkit/WebKitWebView/reload, /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/script-message-received, /WPE/TestWebKitWebView:/webkit/WebKitWebView/run-javascript, /WPE/TestWebKitWebView:/webkit/WebKitWebView/disable-web-security, /WPE/TestLoaderClient:/webkit/WebKitWebView/load-plain-text, /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification-initial-permission-allowed, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme ... (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25682 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19506 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62641 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95771 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19580 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122103 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39757 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29628 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94625 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40140 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97606 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94367 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24093 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39478 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17295 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35855 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39645 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39284 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42617 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41023 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->