### PR TITLE
[Liquid Glass] [iOS] Scroll pockets disappear after ending a navigation swipe

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1251,6 +1251,18 @@ typedef NS_ENUM(NSUInteger, _UIScrollDeviceCategory) {
 @property (nonatomic, readonly, getter=isInteractivelyResizing) BOOL interactivelyResizing;
 @end
 
+#if HAVE(LIQUID_GLASS)
+
+@interface _UIScrollPocket : UIView
+- (void)invalidateAllElements;
+@end
+
+@interface UIScrollView (ScrollPocket_IPI)
+- (_UIScrollPocket *)_pocketForEdge:(UIRectEdge)edge makeIfNeeded:(BOOL)makeIfNeeded;
+@end
+
+#endif // HAVE(LIQUID_GLASS)
+
 WTF_EXTERN_C_BEGIN
 
 BOOL UIKeyboardEnabledInputModesAllowOneToManyShortcuts(void);

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -3547,7 +3547,38 @@ static WebCore::IntDegrees activeOrientation(WKWebView *webView)
             [_contentView becomeFirstResponder];
         _contentViewShouldBecomeFirstResponderAfterNavigationGesture = NO;
     }
+
+#if HAVE(LIQUID_GLASS)
+    [self _forceScrollPocketsToRecomputeElementRegions];
+#endif
 }
+
+#if HAVE(LIQUID_GLASS)
+
+- (void)_forceScrollPocketsToRecomputeElementRegions
+{
+    if (![_scrollView respondsToSelector:@selector(_pocketForEdge:makeIfNeeded:)])
+        return;
+
+    // FIXME: This is a temporary workaround for rdar://156271879, where the scroll pocket's
+    // element region does not update after the scroll view is reparented from the live swipe
+    // view back to the web view after a navigation swipe. This can be removed once
+    // rdar://156271879 is fixed.
+
+    for (auto edge : WebKit::allUIRectEdges) {
+        RetainPtr scrollPocket = [_scrollView _pocketForEdge:edge makeIfNeeded:NO];
+        if (!scrollPocket)
+            continue;
+
+        static BOOL canInvalidateAllElements = [scrollPocket respondsToSelector:@selector(invalidateAllElements)];
+        if (!canInvalidateAllElements)
+            return;
+
+        [scrollPocket invalidateAllElements];
+    }
+}
+
+#endif // HAVE(LIQUID_GLASS)
 
 - (void)_showPasswordViewWithDocumentName:(NSString *)documentName passwordHandler:(void (^)(NSString *))passwordHandler
 {

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.h
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.h
@@ -89,6 +89,13 @@ UIScrollView *scrollViewForTouches(NSSet<UITouch *> *);
 UIRectEdge uiRectEdgeForSide(WebCore::BoxSide);
 UIEdgeInsets maxEdgeInsets(const UIEdgeInsets&, const UIEdgeInsets&);
 
+static constexpr auto allUIRectEdges = std::array {
+    UIRectEdgeTop,
+    UIRectEdgeLeft,
+    UIRectEdgeBottom,
+    UIRectEdgeRight
+};
+
 } // namespace WebKit
 
 #endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 0a7fbd0e87756615ec98e0f674be8886bbac17ab
<pre>
[Liquid Glass] [iOS] Scroll pockets disappear after ending a navigation swipe
<a href="https://bugs.webkit.org/show_bug.cgi?id=296254">https://bugs.webkit.org/show_bug.cgi?id=296254</a>
<a href="https://rdar.apple.com/156274449">rdar://156274449</a>

Reviewed by Abrar Rahman Protyasha.

Work around another case where scroll pockets disappear on iOS, when swiping backwards/forwards.
After recent changes in UIKit, pocketed element bounds are cached per scroll pocket, but these
bounds are (sometimes) not invalidated when scroll views change positions/transforms or are
reparented in the view hierarchy. One of these cases is when swiping back/forwards, where
`WKScrollView` is temporarily parented under the `LiveSwipeViewClipping` layer before being moved
back under the `WKWebView` after the swipe is complete. The end result is that scroll pockets are
*removed* from the view hierarchy, since UIKit determines they aren&apos;t necessary, due to the fact
that the pocketed element rects don&apos;t intersect with the scroll view&apos;s frame right after the swipe
finishes, since the scroll view is offscreen.

As a temporary workaround, we forcibly invalidate the scroll pockets&apos; cached geometries after a
navigation swipe finishes. This change should be reverted once the fix for the underlying issue
lands, in <a href="https://rdar.apple.com/156271879">rdar://156271879</a>.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _navigationGestureDidEnd]):
(-[WKWebView _forceScrollPocketsToRecomputeElementRegions]):
* Source/WebKit/UIProcess/ios/UIKitUtilities.h:

Canonical link: <a href="https://commits.webkit.org/297668@main">https://commits.webkit.org/297668@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39f6ce8d1699ac37b29197776b961e33dcb8ccd0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112481 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32213 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22690 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118640 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62927 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32865 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40776 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/85619 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36219 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115428 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26236 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101200 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65898 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25533 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62423 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95625 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19408 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121901 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39555 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29463 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/94486 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39937 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97434 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94222 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24052 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39334 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17132 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35624 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39443 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44931 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/135327 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39080 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/135327 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42415 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40821 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->