### PR TITLE
Run video-suppress-hdr-fullscreen.html again on iPad

### DIFF
--- a/LayoutTests/media/video-suppress-hdr-fullscreen.html
+++ b/LayoutTests/media/video-suppress-hdr-fullscreen.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ SupportHDRDisplayEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner -->
 <html>
 <head>
     <title>video-suppress-hdr-fullscreen</title>
@@ -13,12 +13,16 @@
         if (CSS.supports("dynamic-range-limit", "no-limit")) {
             try {
                 let {success, observed} = compare(testFuncString, expected, '==');
-                if (!success)
-                    reportExpected(success, testFuncString, '==', expected, observed)
+                if (!success) {
+                    reportExpected(success, testFuncString, '==', expected, observed);
+                    return false;
+                }
             } catch (ex) {
                 consoleWrite(ex);
+                return false;
             }
         }
+        return true;
     }
 
     function go()
@@ -68,7 +72,9 @@
 
         testExpectedIfSupportsDynamicRangeLimit('internals.effectiveDynamicRangeLimitValue(video)', 1.0);
         run('internals.setPageShouldSuppressHDR(true)');
-        testExpectedIfSupportsDynamicRangeLimit('internals.effectiveDynamicRangeLimitValue(video)', shouldSuppressHDR ? 0.5 : 1.0);
+        const success = testExpectedIfSupportsDynamicRangeLimit('internals.effectiveDynamicRangeLimitValue(video)', shouldSuppressHDR ? 0.5 : 1.0);
+        if (!success)
+            consoleWrite("isFullscreen=" + isFullscreen + " isMac=" + isMac + " -> shouldSuppressHDR=" + shouldSuppressHDR);
         run('internals.setPageShouldSuppressHDR(false)');
         testExpectedIfSupportsDynamicRangeLimit('internals.effectiveDynamicRangeLimitValue(video)', 1.0);
 

--- a/LayoutTests/platform/ipad/TestExpectations
+++ b/LayoutTests/platform/ipad/TestExpectations
@@ -111,5 +111,3 @@ webkit.org/b/271712 fast/forms/datalist/datalist-textinput-dynamically-add-optio
 
 # webkit.org/b/269496 [ iOS17 ] fast/forms/datalist/datalist-option-labels.html is a flaky timeout
 fast/forms/datalist/datalist-option-labels.html [ Pass Timeout ]
-
-webkit.org/b/294218 media/video-suppress-hdr-fullscreen.html [ Failure ]


### PR DESCRIPTION
#### 464ce890a62d7f7b4a595865d1b7bf4ed36975c7
<pre>
Run video-suppress-hdr-fullscreen.html again on iPad
<a href="https://bugs.webkit.org/show_bug.cgi?id=296257">https://bugs.webkit.org/show_bug.cgi?id=296257</a>
<a href="https://rdar.apple.com/152860818">rdar://152860818</a>

Reviewed by Cameron McCormack.

The test expectation was incorrect when run on iPad, for yet-unknown
reasons. This patch will attempt to reduce the chance of incorrect runs,
while adding some extra logging that should help if it happens again.

* LayoutTests/platform/ipad/TestExpectations:
Remove [failure] expectation so that the test is run again.

* LayoutTests/media/video-suppress-hdr-fullscreen.html:
- Don&apos;t force SupportHDRDisplayEnabled, so the test will only really
  work on recent platforms that do support HDR display functionality.
- Add some extra logging if the error condition happens again, to help
  with future debugging if that&apos;s needed.

Canonical link: <a href="https://commits.webkit.org/297844@main">https://commits.webkit.org/297844@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5380b7595d7e23ad5a7c59cfcc791ce0c14c8bec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112484 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32216 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22693 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118649 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62924 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32868 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40779 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85618 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36217 "") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115431 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26241 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101205 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65912 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25538 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19339 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62436 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95630 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19413 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121903 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39558 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29467 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94484 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39940 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97439 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94224 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24157 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39336 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17137 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35627 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39446 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39083 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42418 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40824 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->