### PR TITLE
[Site Isolation] Add the most basic support for sharing a web process across sites

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7146,6 +7146,21 @@ SiteIsolationEnabled:
       default: false
   sharedPreferenceForWebProcess: true
 
+SiteIsolationSharedProcessEnabled:
+  type: bool
+  status: unstable
+  category: security
+  humanReadableName: "Shared process for Site Isolation"
+  humanReadableDescription: "Put cross-site frames in a shared Web process"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+  sharedPreferenceForWebProcess: true
+
 # FIXME: This is handled via WebView SPI rather than WebPreferences for WebKitLegacy. We should change the SPI to lookup the WebPreferences value instead.
 SmartInsertDeleteEnabled:
   type: bool

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.h
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.h
@@ -25,10 +25,15 @@
 
 #pragma once
 
+#include "WebProcessProxy.h"
 #include <WebCore/Site.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/WeakHashMap.h>
 #include <wtf/WeakListHashSet.h>
+
+namespace API {
+class PageConfiguration;
+}
 
 namespace IPC {
 class Connection;
@@ -41,7 +46,9 @@ class ProvisionalPageProxy;
 class RemotePageProxy;
 class WebPageProxy;
 class WebPreferences;
-class WebProcessProxy;
+class WebProcessPool;
+
+enum class IsMainFrame : bool;
 
 enum class InjectBrowsingContextIntoProcess : bool { No, Yes };
 
@@ -50,6 +57,7 @@ public:
     static Ref<BrowsingContextGroup> create() { return adoptRef(*new BrowsingContextGroup()); }
     ~BrowsingContextGroup();
 
+    RefPtr<FrameProcess> sharedProcessForSite(WebsiteDataStore&, const WebPreferences&, const WebCore::Site&, WebProcessProxy::LockdownMode, API::PageConfiguration&, IsMainFrame);
     Ref<FrameProcess> ensureProcessForSite(const WebCore::Site&, WebProcessProxy&, const WebPreferences&, InjectBrowsingContextIntoProcess = InjectBrowsingContextIntoProcess::Yes);
     FrameProcess* processForSite(const WebCore::Site&);
     void addFrameProcess(FrameProcess&);
@@ -72,6 +80,9 @@ public:
 
 private:
     BrowsingContextGroup();
+
+    WeakPtr<FrameProcess> m_sharedProcess;
+    HashSet<WebCore::Site> m_sharedProcessSites;
 
     HashMap<WebCore::Site, WeakPtr<FrameProcess>> m_processMap;
     WeakListHashSet<WebPageProxy> m_pages;

--- a/Source/WebKit/UIProcess/FrameProcess.cpp
+++ b/Source/WebKit/UIProcess/FrameProcess.cpp
@@ -34,7 +34,7 @@
 
 namespace WebKit {
 
-FrameProcess::FrameProcess(WebProcessProxy& process, BrowsingContextGroup& group, const WebCore::Site& site, const WebPreferences& preferences, InjectBrowsingContextIntoProcess injectBrowsingContextIntoProcess)
+FrameProcess::FrameProcess(WebProcessProxy& process, BrowsingContextGroup& group, const std::optional<WebCore::Site>& site, const WebPreferences& preferences, InjectBrowsingContextIntoProcess injectBrowsingContextIntoProcess)
     : m_process(process)
     , m_browsingContextGroup(group)
     , m_site(site)

--- a/Source/WebKit/UIProcess/FrameProcess.h
+++ b/Source/WebKit/UIProcess/FrameProcess.h
@@ -42,18 +42,22 @@ class FrameProcess : public RefCountedAndCanMakeWeakPtr<FrameProcess> {
 public:
     ~FrameProcess();
 
-    const WebCore::Site& site() const { return m_site; }
+    const std::optional<WebCore::Site>& site() const { return m_site; }
     const WebProcessProxy& process() const { return m_process.get(); }
     WebProcessProxy& process() { return m_process.get(); }
+    bool isSharedProcess() const { return !m_site; }
 
 private:
     friend class BrowsingContextGroup; // FrameProcess should not be created except by BrowsingContextGroup.
-    static Ref<FrameProcess> create(WebProcessProxy& process, BrowsingContextGroup& group, const WebCore::Site& site, const WebPreferences& preferences, InjectBrowsingContextIntoProcess injectBrowsingContextIntoProcess) { return adoptRef(*new FrameProcess(process, group, site, preferences, injectBrowsingContextIntoProcess)); }
-    FrameProcess(WebProcessProxy&, BrowsingContextGroup&, const WebCore::Site&, const WebPreferences&, InjectBrowsingContextIntoProcess);
+    static Ref<FrameProcess> create(WebProcessProxy& process, BrowsingContextGroup& group, const std::optional<WebCore::Site>& site, const WebPreferences& preferences, InjectBrowsingContextIntoProcess injectBrowsingContextIntoProcess)
+    {
+        return adoptRef(*new FrameProcess(process, group, site, preferences, injectBrowsingContextIntoProcess));
+    }
+    FrameProcess(WebProcessProxy&, BrowsingContextGroup&, const std::optional<WebCore::Site>&, const WebPreferences&, InjectBrowsingContextIntoProcess);
 
     const Ref<WebProcessProxy> m_process;
     WeakPtr<BrowsingContextGroup> m_browsingContextGroup;
-    const WebCore::Site m_site;
+    const std::optional<WebCore::Site> m_site;
 };
 
 }


### PR DESCRIPTION
#### 0885d2d33b76ff339fc9d1987cc54b28bd838feb
<pre>
[Site Isolation] Add the most basic support for sharing a web process across sites
<a href="https://bugs.webkit.org/show_bug.cgi?id=296260">https://bugs.webkit.org/show_bug.cgi?id=296260</a>

Reviewed by Alex Christensen.

For performance reasons, it&apos;s desirable to be able to bundle websites in cross-site iframes into
a single Web process shared across sites even when site isolation is enabled. This PR introduces
a new runtime flag and implements the support for the most basic version of this concept. We create
at most one shared process for each BrowsingContextGroup.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml: Added a new runtime flag.
* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::BrowsingContextGroup::sharedBucketProcessForSite): Added. Returns the shared Web process
if it&apos;s applicable to this site and frame kind.
(WebKit::BrowsingContextGroup::ensureProcessForSite): Return the shared process&apos;s FrameProcess
if this is called with the shared process.
(WebKit::BrowsingContextGroup::processForSite):
(WebKit::BrowsingContextGroup::addFrameProcessAndInjectPageContextIf): Added the support for the
shared process.
(WebKit::BrowsingContextGroup::removeFrameProcess): Ditto.
* Source/WebKit/UIProcess/BrowsingContextGroup.h:
* Source/WebKit/UIProcess/FrameProcess.cpp:
(WebKit::FrameProcess::FrameProcess): Now takes const std::optional&lt;Site&gt;&amp; instead of const Site&amp;.
* Source/WebKit/UIProcess/FrameProcess.h:
(WebKit::FrameProcess::isSharedProcess const): Added.
(WebKit::FrameProcess::create): Reformatted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision): Use the shared process returned by
BrowsingContextGroup::sharedProcessForSite.
(WebKit::WebPageProxy::createNewPage): Fixed the code for the shared process.
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::didStartProvisionalLoadForMainFrame): Set m_site to an unexpected value
when there are multiple sites loaded in the process for one reason or another.
(WebKit::WebProcessProxy::didStartUsingProcessForSiteIsolation): Set m_site to
SiteState::SharedProcess if site is std::nullopt.
* Source/WebKit/UIProcess/WebProcessProxy.h:
(WebKit::WebProcessProxy::site):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::enableFeature):
(TestWebKitAPI::enableSiteIsolation):
(TestWebKitAPI::siteIsolatedViewAndDelegate):
(TestWebKitAPI::siteIsolatedViewWithSharedProcess): Added.
(TestWebKitAPI::(SiteIsolation, SharedProcessMostBasic)):

Canonical link: <a href="https://commits.webkit.org/297753@main">https://commits.webkit.org/297753@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c5a189e15b424e3fd4efeee72becf64f5df77ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112728 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32463 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22941 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118931 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63230 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114690 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33115 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41026 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/85800 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36444 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115675 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26428 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101417 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66104 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25728 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19547 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62690 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/105245 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95822 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19623 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122152 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/111344 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39806 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29675 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94662 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/112224 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40189 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/97644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94400 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39521 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17333 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35909 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18153 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39692 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45189 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/135574 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39331 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36425 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42665 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41070 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->