### PR TITLE
Implement `__Http-` and `__HostHttp-` cookie prefixes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__HostHttp.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__HostHttp.https-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL __HostHttp: Does not set via DOM 'Secure; Path=/' assert_equals: `__HostHttp-prefixtestcookie=foo1` in `document.cookie` expected false but got true
-FAIL __HostHttp: Does not set via DOM with Domain attribute 'Secure; Path=/; Domain=localhost' assert_equals: `__HostHttp-prefixtestcookie=foo2` in `document.cookie` expected false but got true
+PASS __HostHttp: Does not set via DOM 'Secure; Path=/'
+PASS __HostHttp: Does not set via DOM with Domain attribute 'Secure; Path=/; Domain=localhost'
 FAIL __HostHttp: Does not set via HTTP with 'Secure; Path=/' assert_equals: expected (undefined) undefined but got (string) "bar1"
 PASS __HostHttp: Set via HTTP with 'Secure; Path=/; httponly'
 FAIL __HostHttp: Does not set via HTTP with 'Secure; Path=/cookies/; httponly' assert_equals: expected (undefined) undefined but got (string) "bar3"

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__Http.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__Http.https-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL __Http: Does not set via DOM 'Path=/' assert_equals: `__Http-prefixtestcookie=foo1` in `document.cookie` expected false but got true
-FAIL __Http: Does not set via DOM 'Secure; Path=/' assert_equals: `__Http-prefixtestcookie=foo2` in `document.cookie` expected false but got true
+PASS __Http: Does not set via DOM 'Path=/'
+PASS __Http: Does not set via DOM 'Secure; Path=/'
 PASS __Http: Does not set via DOM 'Secure; Path=/; httponly'
 FAIL __Http: Does not set via HTTP with 'Path=/;' (without Secure) assert_equals: expected (undefined) undefined but got (string) "bar1"
 FAIL __Http: Does not set via HTTP with 'Secure; Path=/' assert_equals: expected (undefined) undefined but got (string) "bar2"

--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -429,6 +429,11 @@ void CookieStore::set(CookieInit&& options, Ref<DeferredPromise>&& promise)
         }
     }
 
+    if (cookie.name.startsWithIgnoringASCIICase("__Http-"_s) || cookie.name.startsWithIgnoringASCIICase("__HostHttp-"_s)) {
+        promise->reject(Exception { ExceptionCode::TypeError, "An __Http or __HostHttp cookie cannot be set by the CookieStore API."_s });
+        return;
+    }
+
     if (cookie.name.startsWithIgnoringASCIICase("__Host-"_s)) {
         if (!options.domain.isNull()) {
             promise->reject(Exception { ExceptionCode::TypeError, "If the cookie name begins with \"__Host-\", the domain must not be specified."_s });

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7004,6 +7004,9 @@ ExceptionOr<void> Document::setCookie(const String& value)
     if (page() && !page()->settings().cookieEnabled())
         return { };
 
+    if (value.startsWithIgnoringASCIICase("__Http-"_s) || value.startsWithIgnoringASCIICase("__HostHttp-"_s))
+        return { };
+
     if (isCookieAverse())
         return { };
 

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -65,6 +65,9 @@ void NetworkStorageSession::setCookie(const Cookie& cookie)
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies) || m_isInMemoryCookieStore);
 
+    if (!cookie.httpOnly && (cookie.name.startsWithIgnoringASCIICase("__Http-"_s) || cookie.name.startsWithIgnoringASCIICase("__HostHttp-"_s)))
+        return;
+
     BEGIN_BLOCK_OBJC_EXCEPTIONS
     [nsCookieStorage() setCookie:(NSHTTPCookie *)cookie];
     END_BLOCK_OBJC_EXCEPTIONS

--- a/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
+++ b/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
@@ -432,6 +432,9 @@ void NetworkStorageSession::setCookiesFromDOM(const URL& firstParty, const SameS
         if (!cookie)
             continue;
 
+        if (cookie.name.startsWithIgnoringASCIICase("__Http-"_s) || cookie.name.startsWithIgnoringASCIICase("__HostHttp-"_s))
+            continue;
+
         // Make sure the cookie is not httpOnly since such cookies should not be set from JavaScript.
         if (soup_cookie_get_http_only(cookie.get()))
             continue;

--- a/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
+++ b/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
@@ -435,6 +435,7 @@ void NetworkStorageSession::setCookiesFromDOM(const URL& firstParty, const SameS
         auto cookieName = String::fromUTF8(soup_cookie_get_name(cookie.get()));
         if (cookieName.startsWithIgnoringASCIICase("__Http-"_s) || cookieName.startsWithIgnoringASCIICase("__HostHttp-"_s))
             continue;
+
         // Make sure the cookie is not httpOnly since such cookies should not be set from JavaScript.
         if (soup_cookie_get_http_only(cookie.get()))
             continue;

--- a/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
+++ b/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
@@ -432,9 +432,9 @@ void NetworkStorageSession::setCookiesFromDOM(const URL& firstParty, const SameS
         if (!cookie)
             continue;
 
-        if (cookie.name.startsWithIgnoringASCIICase("__Http-"_s) || cookie.name.startsWithIgnoringASCIICase("__HostHttp-"_s))
+        auto cookieName = String::fromUTF8(soup_cookie_get_name(cookie.get()));
+        if (cookieName.startsWithIgnoringASCIICase("__Http-"_s) || cookieName.startsWithIgnoringASCIICase("__HostHttp-"_s))
             continue;
-
         // Make sure the cookie is not httpOnly since such cookies should not be set from JavaScript.
         if (soup_cookie_get_http_only(cookie.get()))
             continue;


### PR DESCRIPTION
#### 660b968a3e705cb6a1e6dc55cafc104a432767f4
<pre>
Implement `__Http-` and `__HostHttp-` cookie prefixes
<a href="https://bugs.webkit.org/show_bug.cgi?id=296267">https://bugs.webkit.org/show_bug.cgi?id=296267</a>

Reviewed by NOBODY (OOPS!).

This PR prevents cookie APIs (CookieStore and document.cookie) from
setting a cookie with an `__Http-` or `__HostHttp-` prefix.

* LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__HostHttp.https-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__Http.https-expected.txt: progression.
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::set): Prevent setting Http prefixed cookies.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setCookie): Prevent setting Http prefixed cookies.
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::setCookie): Prevent setting Http prefixed cookies.
* Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp:
(WebCore::NetworkStorageSession::setCookiesFromDOM const): Prevent setting Http prefixed cookies.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4c97a7f3292c0ff93f44353f470a816f87f10d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112598 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32330 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22808 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118797 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63110 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114560 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32982 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40893 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85695 "Found 3 new test failures: imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.html imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.serviceworker.html imported/w3c/web-platform-tests/cookies/prefix/__HostHttp.https.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36343 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115545 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26321 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101292 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIDevTools.PortMessagePassingFromPanelToDevToolsBackground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65999 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25618 "Found 2 new test failures: imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.html imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.serviceworker.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19428 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62556 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95712 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19503 "Found 2 new test failures: imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.html imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.serviceworker.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122018 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39672 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29552 "Found 2 new test failures: imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.html imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.serviceworker.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94564 "Found 3 new test failures: imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.html imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.serviceworker.html imported/w3c/web-platform-tests/cookies/prefix/__HostHttp.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40055 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97529 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94301 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39423 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17222 "Found 2 new test failures: imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.html imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.serviceworker.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35760 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39560 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45048 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39198 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42532 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40938 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->