### PR TITLE
[Style] Finish adoption of conformance definition macros

### DIFF
--- a/Source/WebCore/css/values/CSSValueAggregates.h
+++ b/Source/WebCore/css/values/CSSValueAggregates.h
@@ -151,6 +151,10 @@ template<typename T> inline constexpr ASCIILiteral SerializationSeparatorString 
     DEFINE_RANGE_LIKE_CONFORMANCE(t) \
     template<> inline constexpr WebCore::SerializationSeparatorType WebCore::SerializationSeparator<t> = WebCore::SerializationSeparatorType::Slash;
 
+// Helper to define an empty-like conformance for a type.
+#define DEFINE_EMPTY_LIKE_CONFORMANCE(t) \
+    template<> inline constexpr auto WebCore::TreatAsEmptyLike<t> = true;
+
 // MARK: - Conforming Existing Types
 
 // - Optional-like
@@ -631,6 +635,11 @@ template<typename List, typename Defaulter> inline constexpr auto SerializationS
 
 // Concept to constrain types to only those that derive from `ListOrDefault`.
 template<typename T> concept ListOrDefaultDerived = WTF::IsBaseOfTemplate<ListOrDefault, T>::value;
+
+// Helper to define a range-like conformance for a type that derives from `ListOrDefault`.
+#define DEFINE_RANGE_LIKE_CONFORMANCE_FOR_LIST_OR_DEFAULT_DERIVED_TYPE(t) \
+    DEFINE_RANGE_LIKE_CONFORMANCE(t) \
+    template<> inline constexpr auto WebCore::SerializationSeparator<t> = WebCore::SerializationSeparator<typename t::List>;
 
 // Wraps a fixed size list of elements of a single type, semantically marking them as serializing as "space separated".
 template<typename T, size_t N> struct SpaceSeparatedArray {

--- a/Source/WebCore/css/values/color/CSSColor.h
+++ b/Source/WebCore/css/values/color/CSSColor.h
@@ -212,4 +212,4 @@ struct MarkableTraits<WebCore::CSS::Color> {
 
 } // namespace WTF
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Color> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::CSS::Color)

--- a/Source/WebCore/css/values/color/CSSDynamicRangeLimit.h
+++ b/Source/WebCore/css/values/color/CSSDynamicRangeLimit.h
@@ -83,4 +83,4 @@ template<typename... F> decltype(auto) DynamicRangeLimit::switchOn(F&&... f) con
 } // namespace CSS
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::DynamicRangeLimit> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::CSS::DynamicRangeLimit)

--- a/Source/WebCore/css/values/easing/CSSEasingFunction.h
+++ b/Source/WebCore/css/values/easing/CSSEasingFunction.h
@@ -66,4 +66,4 @@ struct EasingFunction {
 } // namespace CSS
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::EasingFunction> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::CSS::EasingFunction)

--- a/Source/WebCore/css/values/filter-effects/CSSAppleColorFilterProperty.h
+++ b/Source/WebCore/css/values/filter-effects/CSSAppleColorFilterProperty.h
@@ -59,4 +59,4 @@ struct AppleColorFilterProperty : ListOrNone<AppleColorFilterValueList> { using 
 } // namespace CSS
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::AppleColorFilterProperty> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::CSS::AppleColorFilterProperty)

--- a/Source/WebCore/css/values/filter-effects/CSSAppleInvertLightnessFunction.h
+++ b/Source/WebCore/css/values/filter-effects/CSSAppleInvertLightnessFunction.h
@@ -38,4 +38,4 @@ using AppleInvertLightnessFunction = FunctionNotation<CSSValueAppleInvertLightne
 } // namespace CSS
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsEmptyLike<WebCore::CSS::AppleInvertLightness> = true;
+DEFINE_EMPTY_LIKE_CONFORMANCE(WebCore::CSS::AppleInvertLightness)

--- a/Source/WebCore/css/values/filter-effects/CSSFilterProperty.h
+++ b/Source/WebCore/css/values/filter-effects/CSSFilterProperty.h
@@ -61,4 +61,4 @@ struct FilterProperty : ListOrNone<FilterValueList> { using ListOrNone<FilterVal
 } // namespace CSS
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::FilterProperty> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::CSS::FilterProperty)

--- a/Source/WebCore/style/ScopedName.h
+++ b/Source/WebCore/style/ScopedName.h
@@ -61,4 +61,4 @@ WTF::TextStream& operator<<(WTF::TextStream&, const ScopedName&);
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::ScopedName> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::ScopedName)

--- a/Source/WebCore/style/values/align/StyleGapGutter.h
+++ b/Source/WebCore/style/values/align/StyleGapGutter.h
@@ -38,4 +38,4 @@ struct GapGutter : LengthWrapperBase<LengthPercentage<CSS::Nonnegative>, CSS::Ke
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::GapGutter> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::GapGutter)

--- a/Source/WebCore/style/values/anchor-position/StyleAnchorName.h
+++ b/Source/WebCore/style/values/anchor-position/StyleAnchorName.h
@@ -44,4 +44,4 @@ struct AnchorNames : ListOrNone<AnchorNameList> { using ListOrNone<AnchorNameLis
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::AnchorNames> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::AnchorNames)

--- a/Source/WebCore/style/values/borders/StyleBoxShadow.h
+++ b/Source/WebCore/style/values/borders/StyleBoxShadow.h
@@ -105,4 +105,4 @@ inline LayoutUnit paintingSpread(const BoxShadow& shadow)
 } // namespace WebCore
 
 DEFINE_SPACE_SEPARATED_TUPLE_LIKE_CONFORMANCE(WebCore::Style::BoxShadow, 5)
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::BoxShadows> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::BoxShadows)

--- a/Source/WebCore/style/values/borders/StyleCornerShapeValue.h
+++ b/Source/WebCore/style/values/borders/StyleCornerShapeValue.h
@@ -83,4 +83,4 @@ template<> struct Blending<CornerShapeValue> {
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::CornerShapeValue> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::CornerShapeValue)

--- a/Source/WebCore/style/values/box/StyleMargin.h
+++ b/Source/WebCore/style/values/box/StyleMargin.h
@@ -44,4 +44,4 @@ using MarginBox = MinimallySerializingSpaceSeparatedRectEdges<MarginEdge>;
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::MarginEdge> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::MarginEdge)

--- a/Source/WebCore/style/values/box/StylePadding.h
+++ b/Source/WebCore/style/values/box/StylePadding.h
@@ -42,4 +42,4 @@ using PaddingBox = MinimallySerializingSpaceSeparatedRectEdges<PaddingEdge>;
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::PaddingEdge> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::PaddingEdge)

--- a/Source/WebCore/style/values/color/StyleColor.h
+++ b/Source/WebCore/style/values/color/StyleColor.h
@@ -238,4 +238,4 @@ struct MarkableTraits<WebCore::Style::Color> {
 
 }
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::Color> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::Color)

--- a/Source/WebCore/style/values/color/StyleDynamicRangeLimit.h
+++ b/Source/WebCore/style/values/color/StyleDynamicRangeLimit.h
@@ -153,4 +153,4 @@ template<> struct Blending<DynamicRangeLimit> {
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::DynamicRangeLimit> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::DynamicRangeLimit)

--- a/Source/WebCore/style/values/contain/StyleContainerName.h
+++ b/Source/WebCore/style/values/contain/StyleContainerName.h
@@ -44,4 +44,4 @@ struct ContainerNames : ListOrNone<ContainerNameList> { using ListOrNone<Contain
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::ContainerNames> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::ContainerNames)

--- a/Source/WebCore/style/values/flexbox/StyleFlexBasis.h
+++ b/Source/WebCore/style/values/flexbox/StyleFlexBasis.h
@@ -43,4 +43,4 @@ struct FlexBasis : LengthWrapperBase<LengthPercentage<CSS::Nonnegative>, CSS::Ke
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::FlexBasis> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::FlexBasis)

--- a/Source/WebCore/style/values/grid/StyleGridTrackSizes.h
+++ b/Source/WebCore/style/values/grid/StyleGridTrackSizes.h
@@ -53,5 +53,4 @@ struct GridTrackSizes : ListOrDefault<GridTrackSizeList, GridTrackSizeDefaulter>
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsRangeLike<WebCore::Style::GridTrackSizes> = true;
-template<> inline constexpr auto WebCore::SerializationSeparator<WebCore::Style::GridTrackSizes> = WebCore::SerializationSeparator<typename WebCore::Style::GridTrackSizes::List>;
+DEFINE_RANGE_LIKE_CONFORMANCE_FOR_LIST_OR_DEFAULT_DERIVED_TYPE(WebCore::Style::GridTrackSizes)

--- a/Source/WebCore/style/values/masking/StyleClipPath.h
+++ b/Source/WebCore/style/values/masking/StyleClipPath.h
@@ -149,4 +149,4 @@ template<> struct Blending<ClipPath> {
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::ClipPath> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::ClipPath)

--- a/Source/WebCore/style/values/motion/StyleOffsetAnchor.h
+++ b/Source/WebCore/style/values/motion/StyleOffsetAnchor.h
@@ -95,4 +95,4 @@ template<> struct ToPlatform<OffsetAnchor> { auto operator()(const OffsetAnchor&
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::OffsetAnchor> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::OffsetAnchor)

--- a/Source/WebCore/style/values/motion/StyleOffsetDistance.h
+++ b/Source/WebCore/style/values/motion/StyleOffsetDistance.h
@@ -38,4 +38,4 @@ struct OffsetDistance : LengthWrapperBase<LengthPercentage<>> {
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::OffsetDistance> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::OffsetDistance)

--- a/Source/WebCore/style/values/motion/StyleOffsetPath.h
+++ b/Source/WebCore/style/values/motion/StyleOffsetPath.h
@@ -163,4 +163,4 @@ template<> struct ToPlatform<OffsetPath> { auto operator()(const OffsetPath&) ->
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::OffsetPath> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::OffsetPath)

--- a/Source/WebCore/style/values/motion/StyleOffsetPosition.h
+++ b/Source/WebCore/style/values/motion/StyleOffsetPosition.h
@@ -107,4 +107,4 @@ template<> struct ToPlatform<OffsetPosition> { auto operator()(const OffsetPosit
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::OffsetPosition> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::OffsetPosition)

--- a/Source/WebCore/style/values/motion/StyleOffsetRotate.h
+++ b/Source/WebCore/style/values/motion/StyleOffsetRotate.h
@@ -79,4 +79,4 @@ WTF::TextStream& operator<<(WTF::TextStream&, const OffsetRotate&);
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::OffsetRotate> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::OffsetRotate)

--- a/Source/WebCore/style/values/position/StyleInset.h
+++ b/Source/WebCore/style/values/position/StyleInset.h
@@ -42,4 +42,4 @@ using InsetBox = MinimallySerializingSpaceSeparatedRectEdges<InsetEdge>;
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::InsetEdge> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::InsetEdge)

--- a/Source/WebCore/style/values/scroll-animations/StyleProgressTimelineAxes.h
+++ b/Source/WebCore/style/values/scroll-animations/StyleProgressTimelineAxes.h
@@ -64,5 +64,4 @@ struct ProgressTimelineAxes : ListOrDefault<ProgressTimelineAxisList, ProgressTi
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsRangeLike<WebCore::Style::ProgressTimelineAxes> = true;
-template<> inline constexpr auto WebCore::SerializationSeparator<WebCore::Style::ProgressTimelineAxes> = WebCore::SerializationSeparator<typename WebCore::Style::ProgressTimelineAxes::List>;
+DEFINE_RANGE_LIKE_CONFORMANCE_FOR_LIST_OR_DEFAULT_DERIVED_TYPE(WebCore::Style::ProgressTimelineAxes)

--- a/Source/WebCore/style/values/scroll-animations/StyleProgressTimelineName.h
+++ b/Source/WebCore/style/values/scroll-animations/StyleProgressTimelineName.h
@@ -55,4 +55,4 @@ template<> struct CSSValueConversion<ProgressTimelineName> { auto operator()(Bui
 } // namespace WebCore
 
 DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::ProgressTimelineName, 1)
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::ProgressTimelineNames> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::ProgressTimelineNames)

--- a/Source/WebCore/style/values/scroll-animations/StyleViewTimelineInsets.h
+++ b/Source/WebCore/style/values/scroll-animations/StyleViewTimelineInsets.h
@@ -68,5 +68,4 @@ template<> struct Serialize<ViewTimelineInsetItem> { void operator()(StringBuild
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsRangeLike<WebCore::Style::ViewTimelineInsets> = true;
-template<> inline constexpr auto WebCore::SerializationSeparator<WebCore::Style::ViewTimelineInsets> = WebCore::SerializationSeparator<typename WebCore::Style::ViewTimelineInsets::List>;
+DEFINE_RANGE_LIKE_CONFORMANCE_FOR_LIST_OR_DEFAULT_DERIVED_TYPE(WebCore::Style::ViewTimelineInsets)

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h
@@ -123,4 +123,4 @@ WTF::TextStream& operator<<(WTF::TextStream&, const ScrollMarginEdge&);
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::ScrollMarginEdge> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::ScrollMarginEdge)

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h
@@ -60,4 +60,4 @@ LayoutBoxExtent extentForRect(const ScrollPaddingBox&, const LayoutRect&);
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::ScrollPaddingEdge> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::ScrollPaddingEdge)

--- a/Source/WebCore/style/values/shapes/StylePathOperationWrappers.h
+++ b/Source/WebCore/style/values/shapes/StylePathOperationWrappers.h
@@ -206,7 +206,7 @@ WTF::TextStream& operator<<(WTF::TextStream&, const BoxPath&);
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::RayPath> = true;
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::ReferencePath> = true;
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::BasicShapePath> = true;
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::BoxPath> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::RayPath)
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::ReferencePath)
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::BasicShapePath)
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::BoxPath)

--- a/Source/WebCore/style/values/sizing/StyleMaximumSize.h
+++ b/Source/WebCore/style/values/sizing/StyleMaximumSize.h
@@ -57,4 +57,4 @@ using MaximumSizePair = SpaceSeparatedSize<MaximumSize>;
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::MaximumSize> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::MaximumSize)

--- a/Source/WebCore/style/values/sizing/StyleMinimumSize.h
+++ b/Source/WebCore/style/values/sizing/StyleMinimumSize.h
@@ -62,4 +62,4 @@ using MinimumSizePair = SpaceSeparatedSize<MinimumSize>;
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::MinimumSize> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::MinimumSize)

--- a/Source/WebCore/style/values/sizing/StylePreferredSize.h
+++ b/Source/WebCore/style/values/sizing/StylePreferredSize.h
@@ -70,7 +70,7 @@ using PreferredSizePair = SpaceSeparatedSize<PreferredSize>;
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::PreferredSize> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::PreferredSize)
 
 namespace WTF {
 

--- a/Source/WebCore/style/values/svg/StyleSVGPaint.h
+++ b/Source/WebCore/style/values/svg/StyleSVGPaint.h
@@ -93,4 +93,4 @@ WTF::TextStream& operator<<(WTF::TextStream&, SVGPaintType);
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::SVGPaint> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::SVGPaint)

--- a/Source/WebCore/style/values/text-decoration/StyleTextShadow.h
+++ b/Source/WebCore/style/values/text-decoration/StyleTextShadow.h
@@ -97,4 +97,4 @@ constexpr LayoutUnit paintingSpread(const TextShadow&)
 } // namespace WebCore
 
 DEFINE_SPACE_SEPARATED_TUPLE_LIKE_CONFORMANCE(WebCore::Style::TextShadow, 3)
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::TextShadows> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::TextShadows)

--- a/Source/WebCore/style/values/text-decoration/StyleTextUnderlineOffset.h
+++ b/Source/WebCore/style/values/text-decoration/StyleTextUnderlineOffset.h
@@ -47,4 +47,4 @@ template<> struct Blending<TextUnderlineOffset> {
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::TextUnderlineOffset> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::TextUnderlineOffset)

--- a/Source/WebCore/style/values/transforms/StylePerspective.h
+++ b/Source/WebCore/style/values/transforms/StylePerspective.h
@@ -83,4 +83,4 @@ template<> struct Blending<Perspective> {
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::Perspective> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::Perspective)

--- a/Source/WebCore/style/values/transforms/StyleRotate.h
+++ b/Source/WebCore/style/values/transforms/StyleRotate.h
@@ -126,5 +126,5 @@ template<> struct ToPlatform<Rotate> { auto operator()(const Rotate&) -> RefPtr<
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::Rotate::Operation> = true;
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::Rotate> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::Rotate::Operation)
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::Rotate)

--- a/Source/WebCore/style/values/transforms/StyleScale.h
+++ b/Source/WebCore/style/values/transforms/StyleScale.h
@@ -117,5 +117,5 @@ template<> struct ToPlatform<Scale> { auto operator()(const Scale&) -> RefPtr<Sc
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::Scale::Operation> = true;
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::Scale> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::Scale::Operation)
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::Scale)

--- a/Source/WebCore/style/values/transforms/StyleTranslate.h
+++ b/Source/WebCore/style/values/transforms/StyleTranslate.h
@@ -116,5 +116,5 @@ template<> struct ToPlatform<Translate> { auto operator()(const Translate&) -> R
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::Translate::Operation> = true;
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::Translate> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::Translate::Operation)
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::Translate)

--- a/Source/WebCore/style/values/view-transitions/StyleViewTransitionClass.h
+++ b/Source/WebCore/style/values/view-transitions/StyleViewTransitionClass.h
@@ -44,4 +44,4 @@ struct ViewTransitionClasses : ListOrNone<ViewTransitionClassList> { using ListO
 } // namespace Style
 } // namespace WebCore
 
-template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::ViewTransitionClasses> = true;
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::ViewTransitionClasses)


### PR DESCRIPTION
#### f7aa5a1989499be550bc4733dc6a2f837378e9e4
<pre>
[Style] Finish adoption of conformance definition macros
<a href="https://bugs.webkit.org/show_bug.cgi?id=296275">https://bugs.webkit.org/show_bug.cgi?id=296275</a>

Reviewed by Darin Adler.

- Adopts the DEFINE_VARIANT_LIKE_CONFORMANCE macro for remaining holdouts.
- Adds and adopts DEFINE_EMPTY_LIKE_CONFORMANCE macro.
- Adds and adopts DEFINE_RANGE_LIKE_CONFORMANCE_FOR_LIST_OR_DEFAULT_DERIVED_TYPE macro.

* Source/WebCore/css/values/CSSValueAggregates.h:
* Source/WebCore/css/values/color/CSSColor.h:
* Source/WebCore/css/values/color/CSSDynamicRangeLimit.h:
* Source/WebCore/css/values/easing/CSSEasingFunction.h:
* Source/WebCore/css/values/filter-effects/CSSAppleColorFilterProperty.h:
* Source/WebCore/css/values/filter-effects/CSSAppleInvertLightnessFunction.h:
* Source/WebCore/css/values/filter-effects/CSSFilterProperty.h:
* Source/WebCore/style/ScopedName.h:
* Source/WebCore/style/values/align/StyleGapGutter.h:
* Source/WebCore/style/values/anchor-position/StyleAnchorName.h:
* Source/WebCore/style/values/borders/StyleBoxShadow.h:
* Source/WebCore/style/values/borders/StyleCornerShapeValue.h:
* Source/WebCore/style/values/box/StyleMargin.h:
* Source/WebCore/style/values/box/StylePadding.h:
* Source/WebCore/style/values/color/StyleColor.h:
* Source/WebCore/style/values/color/StyleDynamicRangeLimit.h:
* Source/WebCore/style/values/contain/StyleContainerName.h:
* Source/WebCore/style/values/flexbox/StyleFlexBasis.h:
* Source/WebCore/style/values/grid/StyleGridTrackSizes.h:
* Source/WebCore/style/values/masking/StyleClipPath.h:
* Source/WebCore/style/values/motion/StyleOffsetAnchor.h:
* Source/WebCore/style/values/motion/StyleOffsetDistance.h:
* Source/WebCore/style/values/motion/StyleOffsetPath.h:
* Source/WebCore/style/values/motion/StyleOffsetPosition.h:
* Source/WebCore/style/values/motion/StyleOffsetRotate.h:
* Source/WebCore/style/values/position/StyleInset.h:
* Source/WebCore/style/values/scroll-animations/StyleProgressTimelineAxes.h:
* Source/WebCore/style/values/scroll-animations/StyleProgressTimelineName.h:
* Source/WebCore/style/values/scroll-animations/StyleViewTimelineInsets.h:
* Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h:
* Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h:
* Source/WebCore/style/values/shapes/StylePathOperationWrappers.h:
* Source/WebCore/style/values/sizing/StyleMaximumSize.h:
* Source/WebCore/style/values/sizing/StyleMinimumSize.h:
* Source/WebCore/style/values/sizing/StylePreferredSize.h:
* Source/WebCore/style/values/svg/StyleSVGPaint.h:
* Source/WebCore/style/values/text-decoration/StyleTextShadow.h:
* Source/WebCore/style/values/text-decoration/StyleTextUnderlineOffset.h:
* Source/WebCore/style/values/transforms/StylePerspective.h:
* Source/WebCore/style/values/transforms/StyleRotate.h:
* Source/WebCore/style/values/transforms/StyleScale.h:
* Source/WebCore/style/values/transforms/StyleTranslate.h:
* Source/WebCore/style/values/view-transitions/StyleViewTransitionClass.h:

Canonical link: <a href="https://commits.webkit.org/297694@main">https://commits.webkit.org/297694@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73edbe67c14f4678947f691a7ba8e8ffd8803132

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112555 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118753 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/63041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114517 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32939 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40850 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85672 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36285 "Unexpected infrastructure issue, retrying build") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115502 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26289 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101259 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65972 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25588 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19392 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62513 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95680 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19465 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121975 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39629 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29518 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94537 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40011 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97491 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94274 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24070 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39386 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17189 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35717 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39517 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45005 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39154 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42489 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40895 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->