### PR TITLE
Use JS API setUserInfo to attach metadata to an element during form submission

### DIFF
--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleScriptWorld.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleScriptWorld.cpp
@@ -66,6 +66,11 @@ void WKBundleScriptWorldDisableOverrideBuiltinsBehavior(WKBundleScriptWorldRef s
     WebKit::toImpl(scriptWorldRef)->disableOverrideBuiltinsBehavior();
 }
 
+void WKBundleScriptWorldSetAllowElementUserInfo(WKBundleScriptWorldRef scriptWorldRef)
+{
+    WebKit::toImpl(scriptWorldRef)->setAllowElementUserInfo();
+}
+
 WKStringRef WKBundleScriptWorldCopyName(WKBundleScriptWorldRef scriptWorldRef)
 {
     return WebKit::toCopiedAPI(WebKit::toImpl(scriptWorldRef)->name());

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleScriptWorld.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleScriptWorld.h
@@ -40,6 +40,7 @@ WK_EXPORT void WKBundleScriptWorldClearWrappers(WKBundleScriptWorldRef scriptWor
 WK_EXPORT void WKBundleScriptWorldMakeAllShadowRootsOpen(WKBundleScriptWorldRef scriptWorld);
 WK_EXPORT void WKBundleScriptWorldExposeClosedShadowRootsForExtensions(WKBundleScriptWorldRef scriptWorld);
 WK_EXPORT void WKBundleScriptWorldDisableOverrideBuiltinsBehavior(WKBundleScriptWorldRef scriptWorld);
+WK_EXPORT void WKBundleScriptWorldSetAllowElementUserInfo(WKBundleScriptWorldRef scriptWorld);
 WK_EXPORT WKStringRef WKBundleScriptWorldCopyName(WKBundleScriptWorldRef scriptWorld);
 
 #ifdef __cplusplus

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -48,6 +48,7 @@
 #include "WKBundleAPICast.h"
 #include "WebAutomationSessionProxy.h"
 #include "WebBackForwardListProxy.h"
+#include "WebChromeClient.h"
 #include "WebErrors.h"
 #include "WebEvent.h"
 #include "WebFrame.h"
@@ -1115,6 +1116,14 @@ void WebLocalFrameLoaderClient::dispatchWillSubmitForm(FormState& formState, Com
 
     RefPtr<API::Object> userData;
     webPage->injectedBundleFormClient().willSubmitForm(webPage.get(), form.ptr(), m_frame.ptr(), sourceFrame.get(), values, userData);
+
+    if (!userData) {
+        auto userInfo = form->userInfo();
+        if (!userInfo.isNull()) {
+            if (auto data = JSON::Value::parseJSON(userInfo))
+                userData = userDataFromJSONData(*data);
+        }
+    }
 
     webPage->sendWithAsyncReply(Messages::WebPageProxy::WillSubmitForm(m_frame->frameID(), sourceFrame->frameID(), values, UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get())), WTFMove(completionHandler));
 }


### PR DESCRIPTION
#### 50e8add8f41ac813e0d4c20666232f324651667f
<pre>
Use JS API setUserInfo to attach metadata to an element during form submission
<a href="https://rdar.apple.com/155269655">rdar://155269655</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=296279">https://bugs.webkit.org/show_bug.cgi?id=296279</a>

Reviewed by Alex Christensen.

When calling _WKInputDelegate.willSubmitFormValues
FormClient.willSubmitForm (and related), the only way to set the
userObject currently, is to use injected bundle.

Instead, we attach the userInfo object. This will allow scripts in
worlds with with the allowElementUserInfo to attach metadata to the
form.

Also, we expose setAllowElementUserInfo configuration to injected bundle
world, to allow applications still using injected bundle to switch to
this new API.

* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleScriptWorld.cpp:
(WKBundleScriptWorldSetAllowElementUserInfo):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleScriptWorld.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchWillSubmitForm):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UserContentController.mm:
(-[InputDelegateForFormSubmission _webView:willSubmitFormValues:userObject:submissionHandler:]):
(TEST(WKUserContentController, FormSubmissionWithUserInfo)):

Canonical link: <a href="https://commits.webkit.org/297743@main">https://commits.webkit.org/297743@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a07938ce2725e3e1912de24abf8edcae1106ff4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112572 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118771 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63125 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114534 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32956 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40867 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85681 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36349 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115519 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26301 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101277 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65983 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25600 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19411 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62530 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95693 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19486 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121992 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39646 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29534 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94548 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40028 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97512 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94285 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39406 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17207 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/35734 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18150 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39534 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45022 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39171 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42506 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40912 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->