### PR TITLE
Follow up to 297686@main: App may crash under CoreIPC[Array|Dictionary]::toID() when a page calls ApplePaySetup.begin()

### DIFF
--- a/Source/WebKit/Shared/Cocoa/CoreIPCArray.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCArray.mm
@@ -55,8 +55,10 @@ CoreIPCArray::CoreIPCArray(Vector<CoreIPCNSCFObject>&& array)
 RetainPtr<id> CoreIPCArray::toID() const
 {
     auto result = adoptNS([[NSMutableArray alloc] initWithCapacity:m_array.size()]);
-    for (auto& object : m_array)
-        [result addObject:object.toID().get()];
+    for (auto& object : m_array) {
+        if (RetainPtr objectID = object.toID())
+            [result addObject:objectID.get()];
+    }
     return result;
 }
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.mm
@@ -66,8 +66,13 @@ CoreIPCDictionary::CoreIPCDictionary(ValueType&& keyValuePairs)
 RetainPtr<id> CoreIPCDictionary::toID() const
 {
     auto result = adoptNS([[NSMutableDictionary alloc] initWithCapacity:m_keyValuePairs.size()]);
-    for (auto& keyValuePair : m_keyValuePairs)
-        [result setObject:keyValuePair.value.toID().get() forKey:keyValuePair.key.toID().get()];
+    for (auto& keyValuePair : m_keyValuePairs) {
+        RetainPtr keyID = keyValuePair.key.toID();
+        RetainPtr valueID = keyValuePair.value.toID();
+        if (!keyID || !valueID)
+            continue;
+        [result setObject:valueID.get() forKey:keyID.get()];
+    }
     return result;
 }
 


### PR DESCRIPTION
#### e789cb3cec19f17adac935a7c6c3e32bad386906
<pre>
Follow up to 297686@main: App may crash under CoreIPC[Array|Dictionary]::toID() when a page calls ApplePaySetup.begin()
<a href="https://bugs.webkit.org/show_bug.cgi?id=296281">https://bugs.webkit.org/show_bug.cgi?id=296281</a>
<a href="https://rdar.apple.com/156331133">rdar://156331133</a>

Reviewed by Alex Christensen.

In 297686@main, we opted out of using NSKU in the process hosting
WebPaymentCoordinatorProxy, and instead returned `nil` in
CoreIPCPKPaymentSetupFeature::toID(). This lead to downstream crashes in
CoreIPC[Array|Dictionary] later in IPC decoding though, because we were
adding these same `nil` values to NSMutable[Array|Dictionary] instances.

This patch alleviates said crashes by choosing not to add the nil values
in question.

* Source/WebKit/Shared/Cocoa/CoreIPCArray.mm:
(WebKit::CoreIPCArray::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCDictionary.mm:
(WebKit::CoreIPCDictionary::toID const):

Canonical link: <a href="https://commits.webkit.org/297713@main">https://commits.webkit.org/297713@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1caf80600e475a03af6b5462d1d5163507f055fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112580 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22790 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118779 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63042 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32964 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40875 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85685 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36306 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115527 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26309 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101279 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65989 "run-api-tests-without-change (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25606 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62538 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95699 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19489 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122000 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39654 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29541 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94557 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40036 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97515 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94294 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39408 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17209 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35742 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18135 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39542 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45030 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39179 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42514 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40920 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->