### PR TITLE
anchor() fails to account for position-area

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-getComputedStyle-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-getComputedStyle-002-expected.txt
@@ -2,5 +2,5 @@ Lorem ipsum dolor sit amet.
 Lorem ipsum dolor sit amet.
 
 FAIL getComputedStyle() with fragmented containing block in multicolumn layout assert_equals: expected "25px" but got "135px"
-FAIL getComputedStyle() with fragmented containing block in inline layout assert_equals: expected "0px" but got "20px"
+FAIL getComputedStyle() with fragmented containing block in inline layout assert_equals: expected "-120px" but got "0px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-borders-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-borders-002-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL anchor-position-borders-002 assert_array_equals: expected property 0 to be 726 but got 711 (expected array [726, 26, 742, 42] got [711, 26, 742, 57])
-FAIL anchor-position-borders-002 1 assert_array_equals: expected property 0 to be 720 but got 705 (expected array [720, 88, 736, 104] got [705, 88, 736, 119])
+FAIL anchor-position-borders-002 assert_array_equals: expected property 0 to be 726 but got 711 (expected array [726, 26, 757, 57] got [711, 26, 742, 57])
+FAIL anchor-position-borders-002 1 assert_array_equals: expected property 0 to be 720 but got 705 (expected array [720, 88, 751, 119] got [705, 88, 736, 119])
 PASS anchor-position-borders-002 2
-FAIL anchor-position-borders-002 3 assert_array_equals: expected property 0 to be 720 but got 705 (expected array [720, 224, 736, 240] got [705, 224, 736, 255])
-FAIL anchor-position-borders-002 4 assert_array_equals: expected property 0 to be 714 but got 699 (expected array [714, 296, 730, 312] got [699, 296, 730, 327])
+FAIL anchor-position-borders-002 3 assert_array_equals: expected property 0 to be 720 but got 705 (expected array [720, 224, 751, 255] got [705, 224, 736, 255])
+FAIL anchor-position-borders-002 4 assert_array_equals: expected property 0 to be 714 but got 699 (expected array [714, 296, 745, 327] got [699, 296, 730, 327])
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-grid-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-grid-001-expected.txt
@@ -5,7 +5,9 @@
 FAIL .target 1 assert_equals:
 <div class="target target1-l" data-offset-x="100" data-expected-height="100"></div>
 offsetLeft expected 100 but got 200
-PASS .target 2
+FAIL .target 2 assert_equals:
+<div class="target target1-r" data-offset-x="404" data-expected-height="100"></div>
+offsetLeft expected 404 but got 504
 FAIL .target 3 assert_equals:
 <div class="target target1-t" data-offset-y="0" data-expected-width="310"></div>
 width expected 310 but got 100

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-inline-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-inline-004-expected.txt
@@ -7,7 +7,7 @@ a1 345
 
 FAIL .target 1 assert_equals:
 <span class="target target1-pos" data-offset-x="30" data-offset-y="0" data-expected-width="20" data-expected-height="10"></span>
-width expected 20 but got 0
+offsetLeft expected 30 but got 50
 FAIL .target 2 assert_equals:
 <span class="target target1-size" data-offset-x="30" data-offset-y="0" data-expected-width="20" data-expected-height="10"></span>
 offsetLeft expected 30 but got 50
@@ -17,7 +17,7 @@ PASS .target 5
 PASS .target 6
 FAIL .target 7 assert_equals:
 <span class="target target1-pos" data-offset-x="-20" data-offset-y="0" data-expected-width="100" data-expected-height="20"></span>
-width expected 100 but got 40
+offsetLeft expected -20 but got 0
 FAIL .target 8 assert_equals:
 <span class="target target1-size" data-offset-x="-20" data-offset-y="0" data-expected-width="100" data-expected-height="20"></span>
 offsetLeft expected -20 but got 0
@@ -27,7 +27,7 @@ PASS .target 11
 PASS .target 12
 FAIL .target 13 assert_equals:
 <span class="target target1-pos" data-offset-x="-20" data-offset-y="0" data-expected-width="70" data-expected-height="20"></span>
-width expected 70 but got 10
+offsetLeft expected -20 but got 0
 FAIL .target 14 assert_equals:
 <span class="target target1-size" data-offset-x="-20" data-offset-y="0" data-expected-width="70" data-expected-height="20"></span>
 offsetLeft expected -20 but got 0
@@ -37,7 +37,7 @@ PASS .target 17
 PASS .target 18
 FAIL .target 19 assert_equals:
 <span class="target target1-pos" data-offset-x="30" data-offset-y="-40" data-expected-width="80" data-expected-height="50"></span>
-width expected 80 but got 150
+width expected 80 but got 210
 FAIL .target 20 assert_equals:
 <span class="target target1-size" data-offset-x="30" data-offset-y="-40" data-expected-width="80" data-expected-height="50"></span>
 width expected 80 but got 100

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-001-expected.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<title>anchor() resolution in position-area</title>
+
+<link rel="help" href="https://www.w3.org/TR/css-anchor-position/#position-area">
+<link rel="match" href="position-area-anchor-001-ref.html">
+<link rel="author" name="Elika J. Etemad" href="http://fantasai.inkedblade.net/contact">
+
+<style>
+  .container {
+    width: 100px; height: 100px;
+    border: solid gray;
+    margin: 6px;
+    position: relative;
+    anchor-scope: all;
+    float: left;
+  }
+
+  .block {
+    background: silver;
+    height: 40px;
+    width: 40px;
+    margin: 10px;
+  }
+
+  .anchor {
+    position: absolute;
+    border: solid orange;
+    margin: 25px;
+  }
+  .controls .anchor,
+  .pull-up .anchor {
+    width: 5px;
+    height: 5px;
+  }
+  .push-down .anchor {
+    width: 40px;
+    height: 40px;
+  }
+
+  .anchored {
+    border: solid blue;
+    position: absolute;
+    inset: 0;
+    place-self: stretch;
+  }
+
+  body > div { clear: both; }
+</style>
+
+<div class=pull-up>
+  <div class=container>
+    <div class=anchor></div>
+    <div class=block></div>
+    <div class=anchored style="top: 36px; left: 36px;"></div>
+  </div>
+
+  <div class=container>
+    <div class=anchor></div>
+    <div class=block></div>
+    <div class=anchored style="top: 36px; left: 50px;"></div>
+  </div>
+</div>
+
+<div class=push-down>
+  <div class=container>
+    <div class=anchor></div>
+    <div class=block></div>
+    <div class=anchored style="top: 71px; left: 71px"></div>
+  </div>
+
+  <div class=container>
+    <div class=anchor></div>
+    <div class=block></div>
+    <div class=anchored style="top: 71px; left: 50px"></div>
+  </div>
+</div>
+
+<div class=controls>
+  <div class=container>
+    <div class=anchor></div>
+    <div class=block></div>
+    <div class=anchored style="top: 36px"></div>
+  </div>
+  <div class=container>
+    <div class=anchor></div>
+    <div class=block></div>
+    <div class=anchored style="top: 25px; left: 36px"></div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-001-ref.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<title>anchor() resolution in position-area</title>
+
+<link rel="help" href="https://www.w3.org/TR/css-anchor-position/#position-area">
+<link rel="match" href="position-area-anchor-001-ref.html">
+<link rel="author" name="Elika J. Etemad" href="http://fantasai.inkedblade.net/contact">
+
+<style>
+  .container {
+    width: 100px; height: 100px;
+    border: solid gray;
+    margin: 6px;
+    position: relative;
+    anchor-scope: all;
+    float: left;
+  }
+
+  .block {
+    background: silver;
+    height: 40px;
+    width: 40px;
+    margin: 10px;
+  }
+
+  .anchor {
+    position: absolute;
+    border: solid orange;
+    margin: 25px;
+  }
+  .controls .anchor,
+  .pull-up .anchor {
+    width: 5px;
+    height: 5px;
+  }
+  .push-down .anchor {
+    width: 40px;
+    height: 40px;
+  }
+
+  .anchored {
+    border: solid blue;
+    position: absolute;
+    inset: 0;
+    place-self: stretch;
+  }
+
+  body > div { clear: both; }
+</style>
+
+<div class=pull-up>
+  <div class=container>
+    <div class=anchor></div>
+    <div class=block></div>
+    <div class=anchored style="top: 36px; left: 36px;"></div>
+  </div>
+
+  <div class=container>
+    <div class=anchor></div>
+    <div class=block></div>
+    <div class=anchored style="top: 36px; left: 50px;"></div>
+  </div>
+</div>
+
+<div class=push-down>
+  <div class=container>
+    <div class=anchor></div>
+    <div class=block></div>
+    <div class=anchored style="top: 71px; left: 71px"></div>
+  </div>
+
+  <div class=container>
+    <div class=anchor></div>
+    <div class=block></div>
+    <div class=anchored style="top: 71px; left: 50px"></div>
+  </div>
+</div>
+
+<div class=controls>
+  <div class=container>
+    <div class=anchor></div>
+    <div class=block></div>
+    <div class=anchored style="top: 36px"></div>
+  </div>
+  <div class=container>
+    <div class=anchor></div>
+    <div class=block></div>
+    <div class=anchored style="top: 25px; left: 36px"></div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-001.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<title>anchor() resolution in position-area</title>
+
+<link rel="help" href="https://www.w3.org/TR/css-anchor-position/#position-area">
+<link rel="match" href="position-area-anchor-001-ref.html">
+<link rel="author" name="Elika J. Etemad" href="http://fantasai.inkedblade.net/contact">
+
+<style>
+  .container {
+    width: 100px; height: 100px;
+    border: solid gray;
+    margin: 6px;
+    position: relative;
+    anchor-scope: all;
+    float: left;
+  }
+
+  .block {
+    background: silver;
+    height: 40px;
+    width: 40px;
+    margin: 10px;
+  }
+
+  .anchor {
+    position: absolute;
+    border: solid orange;
+    margin: 25px;
+  }
+  .controls .anchor,
+  .pull-up .anchor {
+    width: 5px;
+    height: 5px;
+  }
+  .push-down .anchor {
+    width: 40px;
+    height: 40px;
+  }
+
+  .anchored {
+    border: solid blue;
+    position: absolute;
+    position-area: span-bottom right;
+    inset: 0;
+    place-self: stretch;
+  }
+
+  body > div { clear: both; }
+</style>
+
+<div class=pull-up>
+  <div class=container>
+    <div class=anchor style="anchor-name: --foo"></div>
+    <div class=block></div>
+    <div class=anchored style="top: anchor(bottom); position-anchor: --foo"></div>
+  </div>
+
+  <div class=container>
+    <div class=anchor style="anchor-name: --foo"></div>
+    <div class=block style="anchor-name: --bar"></div>
+    <div class=anchored style="top: anchor(--foo bottom); position-anchor: --bar"></div>
+  </div>
+</div>
+
+<div class=push-down>
+  <div class=container>
+    <div class=anchor style="anchor-name: --foo"></div>
+    <div class=block></div>
+    <div class=anchored style="top: anchor(bottom); position-anchor: --foo"></div>
+  </div>
+
+  <div class=container>
+    <div class=anchor style="anchor-name: --foo"></div>
+    <div class=block style="anchor-name: --bar"></div>
+    <div class=anchored style="top: anchor(--foo bottom); position-anchor: --bar"></div>
+  </div>
+</div>
+
+<div class=controls>
+  <div class=container>
+    <div class=anchor style="anchor-name: --foo"></div>
+    <div class=block></div>
+    <div class=anchored style="top: anchor(--foo bottom)"></div>
+  </div>
+  <div class=container>
+    <div class=anchor style="anchor-name: --foo"></div>
+    <div class=block></div>
+    <div class=anchored style="position-anchor: --foo"></div>
+  </div>
+</div>

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.h
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.h
@@ -42,12 +42,16 @@ public:
 
     /*** The following are available without calling computeInsets(). ***/
 
+    const RenderBoxModelObject& container() const { return *m_container; }
     LayoutUnit containingSize() const { return m_containingRange.size(); }
     LayoutUnit containingInlineSize() const { return m_containingInlineSize; }
+    LayoutRange containingRange() const { return m_containingRange; }
+    LayoutRange extractRange(LayoutRect);
+
     BoxAxis physicalAxis() const { return m_physicalAxis; }
     LogicalBoxAxis containingAxis() const { return m_containingAxis; }
     WritingMode containingWritingMode() const { return m_containingWritingMode; }
-    const RenderBoxModelObject& container() const { return *m_container; }
+    WritingMode selfWritingMode() const { return m_writingMode; }
 
     bool needsAnchor() const;
     const RenderBoxModelObject* defaultAnchorBox() const { return m_defaultAnchorBox.get(); }
@@ -56,6 +60,7 @@ public:
     bool alignmentAppliesStretch(ItemPosition normalAlignment) const;
 
     bool isOrthogonal() const { return m_containingWritingMode.isOrthogonal(m_writingMode); }
+    inline bool isOpposing() const;
     bool isBlockOpposing() const { return m_containingWritingMode.isBlockOpposing(m_writingMode); }
     bool isBlockFlipped() const { return m_containingWritingMode.isBlockFlipped(); }
     bool startIsBefore() const { return m_containingAxis == LogicalBoxAxis::Block || m_containingWritingMode.isLogicalLeftInlineStart(); }
@@ -120,5 +125,13 @@ private:
     Style::InsetEdge m_insetAfter;
     bool m_useStaticPosition { false };
 };
+
+inline bool PositionedLayoutConstraints::isOpposing() const
+{
+    return m_containingAxis == LogicalBoxAxis::Inline
+        ? m_containingWritingMode.isInlineOpposing(m_writingMode)
+        : m_containingWritingMode.isBlockOpposing(m_writingMode);
+
+}
 
 }


### PR DESCRIPTION
#### 440717a86ea194ba04c56366ff9be4af26631a6f
<pre>
anchor() fails to account for position-area
<a href="https://bugs.webkit.org/show_bug.cgi?id=295936">https://bugs.webkit.org/show_bug.cgi?id=295936</a>
<a href="https://rdar.apple.com/155826872">rdar://155826872</a>

Reviewed by Alan Baradlay.

Re-use PositionedLayoutConstraints to calculate the containing block when
computing anchor() functions so that we get its handling of position-area,
etc.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-getComputedStyle-002-expected.txt:

Update expectations. We fail slightly less. :)

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-borders-002-expected.txt:

Update expectations. We would now pass this if it were LTR; see bug 295964 for the remainder.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-grid-001-expected.txt:

Update expectations. We are now more consistent about our mistakes, at least.
Sizes should now be correct; positions are consistently off.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-inline-004-expected.txt:

Update expectations. We now size correctly, though position is still off.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-001-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-001.html: Added.

Add new test. <a href="https://github.com/web-platform-tests/wpt/pull/53874">https://github.com/web-platform-tests/wpt/pull/53874</a>

* Source/WebCore/rendering/PositionedLayoutConstraints.cpp:
(WebCore::PositionedLayoutConstraints::extractRange):
(WebCore::PositionedLayoutConstraints::captureAnchorGeometry):

Separate out the logic for getting an anchor range with respect to
the absolute positioning containing block.

* Source/WebCore/rendering/PositionedLayoutConstraints.h:
(WebCore::PositionedLayoutConstraints::container const):
(WebCore::PositionedLayoutConstraints::containingRange const):
(WebCore::PositionedLayoutConstraints::selfWritingMode const):
(WebCore::PositionedLayoutConstraints::isOpposing const):

Expose some more data to users of PositionedLayoutArea.

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::mapInsetPropertyToLogicalAxis):
(WebCore::Style::isInsetPropertyContainerStartSide):
(WebCore::Style::getOppositeInset):

Add new helper methods.

(WebCore::Style::applyTryTacticsToInset):
(WebCore::Style::computeInsetValue):

Rewrite inset calculations to use PositionedLayoutConstraints.

(WebCore::Style::mapInsetPropertyToPhysicalSide): Deleted.
(WebCore::Style::flipBoxSide): Deleted.
(WebCore::Style::swapSideForTryTactics): Deleted.
(WebCore::Style::computeStartEndBoxSide): Deleted.
(WebCore::Style::removeBorderForInsetValue): Deleted.

Remove newly unused helper methods.

Canonical link: <a href="https://commits.webkit.org/297723@main">https://commits.webkit.org/297723@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/543bac8e93da2e039a50e99f6c59b536f3a5e80b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112606 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32338 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22816 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118805 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63072 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114568 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32990 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40901 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85702 "Found 2 new test failures: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36320 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115553 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26331 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101300 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66007 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25627 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19437 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62564 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95720 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19512 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122026 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39680 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29556 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94568 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40063 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97538 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94305 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24084 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39420 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17228 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35768 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39568 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45056 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39206 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42540 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40946 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->