### PR TITLE
[WPE] Add documentation relevant for Android builds

### DIFF
--- a/Source/WebKit/wpe/android.md
+++ b/Source/WebKit/wpe/android.md
@@ -1,0 +1,57 @@
+Title: Android Support
+Slug: android
+
+WPE WebKit supports running on [Android](https://www.android.com), which is
+considerably different from other Linux-based systems.
+
+## Building 
+
+Compiling WPE WebKit for Android requires a suitable toolchain configured
+to use a “sysroot” which includes the needed dependencies—including
+their development files.
+
+Currently, the preferred method to build WPE WebKit for Android is using
+[wpe-android-cerbero](https://github.com/Igalia/wpe-android-cerbero/). This is
+a fork of the [Cerbero](https://gitlab.freedesktop.org/gstreamer/cerbero/)
+build system used to cross-compile the GStreamer multimedia libraries for a
+number of targets—Android included—, with the needed changes to compile WPE
+WebKit. Note that this produces the *native* libraries that are part of a
+WebKit build, and their *native* dependencies.
+
+
+## View Widget
+
+A web view widget that integrates with the Android
+[View](https://developer.android.com/reference/android/view/View)-based GUI
+toolkit and may be used as part of an application written in Java™ or Kotlin
+is provided by the separate
+[WPE Android](https://github.com/Igalia/wpe-android) project.
+
+Prebuilt packages produced by the WPE Android project are readily available
+as
+[org.wpewebkit.wpeview](https://central.sonatype.com/artifact/org.wpewebkit.wpeview/wpeview)
+at the [Maven Central](https://central.sonatype.com/) repository. Using these
+package is the recommended way of using WPE WebKit to develop Android
+applications that embed WPE WebKit web views.
+
+
+## Logging
+
+WPE WebKit integrates with the Android `logd` system service, and uses
+the `WPEWebKit` tag. This means that logging is configured using system
+properties, and `logcat` may be used to read log entries:
+
+```sh
+adb shell setprop log.tag.WPEWebKit VERBOSE
+adb logcat -s WPEWebKit
+```
+
+The `WEBKIT_DEBUG` [environment variable](environment.html) is replaced by the
+`debug.log.WPEWebKit` system property to configure logging channels:
+
+```sh
+adb shell setprop debug.log.WPEWebKit 'Process,Media=error'
+```
+
+Using the `persist.` prefix may be added to system properties to store
+settings across device reboots.

--- a/Source/WebKit/wpe/wpewebkit.toml.in
+++ b/Source/WebKit/wpe/wpewebkit.toml.in
@@ -39,4 +39,5 @@ content_files = [
     "environment-variables.md",
     "profiling.md",
     "remote-inspector.md",
+    "android.md",
 ]


### PR DESCRIPTION
#### 54ba4967b8c8e079044e62f388a8535120f3c93a
<pre>
[WPE] Add documentation relevant for Android builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=296283">https://bugs.webkit.org/show_bug.cgi?id=296283</a>

Reviewed by Patrick Griffis.

Add a new additional documentation with some information about using
Cerbero to build, a link to WPE Android (and its Maven Central
prebuilt packages) for the web view widget usable with the Android
View-based GUI, and notes about how to setup logging.

* Source/WebKit/wpe/android.md: Added.
* Source/WebKit/wpe/wpewebkit.toml.in:

Canonical link: <a href="https://commits.webkit.org/297760@main">https://commits.webkit.org/297760@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c26f09a929f3bc2a5fb6bc7fb5a4a32c010fbce3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112752 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/32487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22965 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/118955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/63257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33139 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41050 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/118955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/63257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115699 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/26445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/101431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/118955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/25745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/62714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/95839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/19637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/122175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39830 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/29694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/122175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40213 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/97653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/122175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/39535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/17346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/35933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18157 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/39716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45213 "Failed to checkout and rebase branch from PR 48340") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/39355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/42689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/41094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->