### PR TITLE
dNR: fix sub_frame resourceType allowAllRequests rules

### DIFF
--- a/Source/WebCore/contentextensions/ContentExtensionCompiler.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionCompiler.cpp
@@ -347,6 +347,7 @@ std::error_code compileRuleList(ContentExtensionCompilationClient& client, Strin
                 break;
             case ActionCondition::IfFrameURL:
             case ActionCondition::UnlessFrameURL:
+            case ActionCondition::IfAncestorSubframeURL:
                 status = frameURLFilterParser.addPattern(condition, trigger.frameURLFilterIsCaseSensitive, actionLocationAndFlags);
                 if (status == URLFilterParser::MatchesEverything) {
                     frameURLUniversalActions.add(actionLocationAndFlags);

--- a/Source/WebCore/contentextensions/ContentExtensionParser.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionParser.cpp
@@ -210,6 +210,9 @@ static Expected<Trigger, std::error_code> loadTrigger(const JSON::Object& ruleOb
     if (auto error = checkCondition("unless-frame-url"_s, getStringList, ActionCondition::UnlessFrameURL))
         return makeUnexpected(error);
 
+    if (auto error = checkCondition("if-ancestor-subframe-url"_s, getStringList, ActionCondition::IfAncestorSubframeURL))
+        return makeUnexpected(error);
+
     trigger.checkValidity();
     return trigger;
 }

--- a/Source/WebCore/contentextensions/ContentExtensionRule.h
+++ b/Source/WebCore/contentextensions/ContentExtensionRule.h
@@ -57,7 +57,7 @@ struct Trigger {
         if (topURLFilterIsCaseSensitive)
             ASSERT(actionCondition == ActionCondition::IfTopURL || actionCondition == ActionCondition::UnlessTopURL);
         if (frameURLFilterIsCaseSensitive)
-            ASSERT(actionCondition == ActionCondition::IfFrameURL || actionCondition == ActionCondition::UnlessFrameURL);
+            ASSERT(actionCondition == ActionCondition::IfFrameURL || actionCondition == ActionCondition::UnlessFrameURL || actionCondition == ActionCondition::IfAncestorSubframeURL);
     }
 
     bool isEmpty() const

--- a/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
@@ -128,6 +128,17 @@ auto ContentExtensionsBackend::actionsFromContentRuleList(const ContentExtension
             return !frameURLActions.contains(actionAndFlags);
         case ActionCondition::UnlessFrameURL:
             return frameURLActions.contains(actionAndFlags);
+        case ActionCondition::IfAncestorSubframeURL:
+            if (frameURLActions.contains(actionAndFlags))
+                return false;
+
+            for (const auto& ancestorURL : resourceLoadInfo.ancestorSubframeURLs) {
+                auto& ancestorURLActions = contentExtension.frameURLActions(ancestorURL);
+                if (ancestorURLActions.contains(actionAndFlags))
+                    return false;
+            }
+
+            return true;
         }
         ASSERT_NOT_REACHED();
         return false;
@@ -245,10 +256,17 @@ ContentRuleListResults ContentExtensionsBackend::processContentRuleListsForLoad(
     URL frameURL;
     bool mainFrameContext = false;
     RequestMethod requestMethod = readRequestMethod(initiatingDocumentLoader.request().httpMethod()).value_or(RequestMethod::None);
+    Vector<URL> ancestorSubframeURLs;
 
-    if (auto* frame = initiatingDocumentLoader.frame()) {
+    if (RefPtr frame = initiatingDocumentLoader.frame()) {
         mainFrameContext = frame->isMainFrame();
         currentDocument = frame->document();
+
+        // FIXME: <https://bugs.webkit.org/show_bug.cgi?id=296294> dNR: allowAllRequests with sub_frame resource type will only work with a URL filter acting on the origin of the URL
+        for (RefPtr<Frame> ancestor = frame; ancestor && !ancestor->isMainFrame(); ancestor = ancestor->tree().parent()) {
+            if (RefPtr origin = ancestor->frameDocumentSecurityOrigin())
+                ancestorSubframeURLs.append(URL { origin->toString() });
+        }
 
         if (initiatingDocumentLoader.isLoadingMainResource()
             && frame->isMainFrame()
@@ -263,7 +281,7 @@ ContentRuleListResults ContentExtensionsBackend::processContentRuleListsForLoad(
     else
         frameURL = url;
 
-    ResourceLoadInfo resourceLoadInfo { url, mainDocumentURL, frameURL, resourceType, mainFrameContext, requestMethod };
+    ResourceLoadInfo resourceLoadInfo { url, mainDocumentURL, frameURL, resourceType, mainFrameContext, requestMethod, ancestorSubframeURLs };
     auto actions = actionsForResourceLoad(resourceLoadInfo, ruleListFilter);
 
     ContentRuleListResults results;

--- a/Source/WebCore/loader/ResourceLoadInfo.h
+++ b/Source/WebCore/loader/ResourceLoadInfo.h
@@ -30,6 +30,7 @@
 #include "CachedResource.h"
 #include <wtf/OptionSet.h>
 #include <wtf/URL.h>
+#include <wtf/Vector.h>
 
 namespace WebCore::ContentExtensions {
 
@@ -38,7 +39,8 @@ enum class ActionCondition : uint32_t {
     IfTopURL = 0x40000,
     UnlessTopURL = 0x80000,
     IfFrameURL = 0x140000,
-    UnlessFrameURL = 0x180000
+    UnlessFrameURL = 0x180000,
+    IfAncestorSubframeURL = 0x1C0000
 };
 static constexpr uint32_t ActionConditionMask = 0x1C0000;
 
@@ -110,6 +112,7 @@ struct ResourceLoadInfo {
     OptionSet<ResourceType> type;
     bool mainFrameContext { false };
     RequestMethod requestMethod { RequestMethod::None };
+    Vector<URL> ancestorSubframeURLs { };
 
     bool isThirdParty() const;
     ResourceFlags getResourceFlags() const;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm
@@ -863,6 +863,12 @@ static BOOL isArrayOfRequestMethodsValid(NSArray<NSString *> *requestMethods)
 
     [convertedRules addObject:[self _webKitRuleWithWebKitActionType:webKitActionType chromeActionType:chromeActionType condition:condition]];
 
+    if ([condition[declarativeNetRequestRuleConditionResourceTypeKey] containsObject:@"main_frame"] && [condition[declarativeNetRequestRuleConditionResourceTypeKey] containsObject:@"sub_frame"]) {
+        NSMutableDictionary *modifiedCondition = [condition mutableCopy];
+        modifiedCondition[declarativeNetRequestRuleConditionResourceTypeKey] = @[ @"sub_frame" ];
+        [convertedRules addObject:[self _webKitRuleWithWebKitActionType:webKitActionType chromeActionType:chromeActionType condition:modifiedCondition]];
+    }
+
     if ([webKitActionType isEqualToString:@"make-https"])
         [convertedRules addObject:[self _webKitRuleWithWebKitActionType:@"ignore-following-rules" chromeActionType:chromeActionType condition:condition]];
 
@@ -884,11 +890,8 @@ static BOOL isArrayOfRequestMethodsValid(NSArray<NSString *> *requestMethods)
 
         if ([condition[declarativeNetRequestRuleConditionResourceTypeKey] containsObject:@"main_frame"])
             triggerDictionary[@"if-top-url"] = @[ [self _regexURLFilterForChromeURLFilter:condition[declarativeNetRequestRuleConditionURLFilterKey]] ?: condition[declarativeNetRequestRuleConditionRegexFilterKey] ?: @".*" ];
-        else {
-            // FIXME: rdar://154124673 (dNR: fix sub_frame resourceType allowAllRequests rules)
-            triggerDictionary[@"if-frame-url"] = @[ [self _regexURLFilterForChromeURLFilter:condition[declarativeNetRequestRuleConditionURLFilterKey]] ?: condition[declarativeNetRequestRuleConditionRegexFilterKey] ?: @".*" ];
-            triggerDictionary[@"load-context"] = @[ @"child-frame" ];
-        }
+        else
+            triggerDictionary[@"if-ancestor-subframe-url"] = @[ [self _regexURLFilterForChromeURLFilter:condition[declarativeNetRequestRuleConditionURLFilterKey]] ?: condition[declarativeNetRequestRuleConditionRegexFilterKey] ?: @".*" ];
 
         return [convertedRule copy];
     }

--- a/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
@@ -208,9 +208,9 @@ static ResourceLoadInfo subResourceRequest(ASCIILiteral url, ASCIILiteral mainDo
     return { URL { url }, mainDocumentURL, mainDocumentURL, resourceType };
 }
 
-static ResourceLoadInfo requestInTopAndFrameURLs(ASCIILiteral url, ASCIILiteral topURL, ASCIILiteral frameURL, ResourceType resourceType = ResourceType::TopDocument)
+static ResourceLoadInfo requestInTopAndFrameURLs(ASCIILiteral url, ASCIILiteral topURL, ASCIILiteral frameURL, ResourceType resourceType = ResourceType::TopDocument, Vector<URL> ancestorFrameURLs = { })
 {
-    return { URL { url }, URL { topURL }, URL { frameURL }, resourceType };
+    return { URL { url }, URL { topURL }, URL { frameURL }, resourceType, false, RequestMethod::None, ancestorFrameURLs };
 }
 
 ContentExtensions::ContentExtensionsBackend makeBackend(String&& json)
@@ -1587,6 +1587,12 @@ TEST_F(ContentExtensionTest, InvalidJSON)
     checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"if-domain\":[\"a\"],\"if-top-url\":[\"a\"]}}]"_s, ContentExtensionError::JSONMultipleConditions);
     checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"if-top-url\":[],\"unless-domain\":[\"a\"]}}]"_s, ContentExtensionError::JSONMultipleConditions);
     checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"if-top-url\":[\"a\"],\"if-domain\":[\"a\"]}}]"_s, ContentExtensionError::JSONMultipleConditions);
+    checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"if-ancestor-subframe-url\":[\"a\"],\"if-frame-url\":[\"a\"]}}]"_s, ContentExtensionError::JSONMultipleConditions);
+    checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"if-ancestor-subframe-url\":[\"a\"],\"unless-frame-url\":[\"a\"]}}]"_s, ContentExtensionError::JSONMultipleConditions);
+    checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"if-ancestor-subframe-url\":[\"a\"],\"if-domain\":[\"a\"]}}]"_s, ContentExtensionError::JSONMultipleConditions);
+    checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"if-ancestor-subframe-url\":[\"a\"],\"unless-domain\":[\"a\"]}}]"_s, ContentExtensionError::JSONMultipleConditions);
+    checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"if-ancestor-subframe-url\":[\"a\"],\"if-top-url\":[\"a\"]}}]"_s, ContentExtensionError::JSONMultipleConditions);
+    checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"if-ancestor-subframe-url\":[\"a\"],\"unless-top-url\":[\"a\"]}}]"_s, ContentExtensionError::JSONMultipleConditions);
     checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"if-top-url\":[\"a\"]}}, {\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"if-domain\":[\"a\"]}}]"_s, { });
     checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"if-top-url\":[\"a\"]}}, {\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"webkit.org\",\"unless-domain\":[\"a\"]}}]"_s, { });
     checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"test\\\\.html\", \"unless-top-url\":[\"[\"]}}]"_s, ContentExtensionError::JSONInvalidRegex);
@@ -3168,6 +3174,36 @@ TEST_F(ContentExtensionTest, UnlessFrameURL)
     auto matchingNothing = makeBackend("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"https\", \"unless-frame-url\":[\".*\"]}}]"_s);
     testRequest(matchingNothing, requestInTopAndFrameURLs("https://example.com/"_s, "https://webkit.org/"_s, "https://whatwg.org/"_s), { });
     testRequest(matchingNothing, requestInTopAndFrameURLs("http://example.com/"_s, "https://webkit.org/"_s, "https://webkit.org/"_s), { });
+}
+
+TEST_F(ContentExtensionTest, IfAncestorSubframeURL)
+{
+    auto basic = makeBackend("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\".*\", \"if-ancestor-subframe-url\":[\"whatwg\"]}}]"_s);
+    testRequest(basic, requestInTopAndFrameURLs("https://whatwg.org/"_s, "https://whatwg.org/"_s, "https://whatwg.org/"_s, ResourceType::TopDocument, { URL { "https://whatwg.org/"_s } }), { variantIndex<BlockLoadAction> });
+    testRequest(basic, requestInTopAndFrameURLs("https://example.com/"_s, "https://example.com/"_s, "https://example.com/"_s, ResourceType::TopDocument, { URL { "https://example.com/"_s } }), { });
+    testRequest(basic, requestInTopAndFrameURLs("https://example.com/"_s, "https://webkit.org/"_s, "https://whatwg.org/"_s, ResourceType::ChildDocument, { URL { "https://webkit.org/"_s }, URL { "https://whatwg.org/"_s } }), { variantIndex<BlockLoadAction> });
+    testRequest(basic, requestInTopAndFrameURLs("https://example.com/"_s, "https://webkit.org/"_s, "https://apple.com/"_s, ResourceType::ChildDocument, { URL { "https://webkit.org/"_s }, URL { "https://apple.com/"_s } }), { });
+
+    auto caseSensitivity = makeBackend("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\".*\", \"if-ancestor-subframe-url\":[\"whatwg\"],\"frame-url-filter-is-case-sensitive\":true}}]"_s);
+    auto caseSensitivityRequest = requestInTopAndFrameURLs("https://example.com/"_s, "https://webkit.org/"_s, "https://example.com/wHaTwG"_s);
+    testRequest(basic, caseSensitivityRequest, { variantIndex<BlockLoadAction> });
+    testRequest(caseSensitivity, caseSensitivityRequest, { });
+
+    auto otherFlags = makeBackend("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\".*\", \"if-ancestor-subframe-url\":[\"whatwg\"],\"resource-type\":[\"image\"]}}]"_s);
+    testRequest(otherFlags, requestInTopAndFrameURLs("https://example.com/"_s, "https://webkit.org/"_s, "https://whatwg.org/"_s, ResourceType::TopDocument, { URL { "https://webkit.org/"_s }, URL { "https://whatwg.org/"_s } }), { });
+    testRequest(otherFlags, requestInTopAndFrameURLs("https://example.com/"_s, "https://webkit.org/"_s, "https://whatwg.org/"_s, ResourceType::Image, { URL { "https://webkit.org/"_s }, URL { "https://whatwg.org/"_s } }), { variantIndex<BlockLoadAction> });
+
+    auto otherRulesWithConditions = makeBackend("["
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"https\", \"if-frame-url\":[\"whatwg\"]}},"
+        "{\"action\":{\"type\":\"block-cookies\"},\"trigger\":{\"url-filter\":\"https\", \"if-top-url\":[\"example\"]}}"
+    "]"_s);
+    testRequest(otherRulesWithConditions, requestInTopAndFrameURLs("https://example.com/"_s, "https://webkit.org/"_s, "https://whatwg.org/"_s, ResourceType::TopDocument, { URL { "https://webkit.org/"_s }, URL { "https://whatwg.org/"_s } }), { variantIndex<BlockLoadAction> });
+    testRequest(otherRulesWithConditions, requestInTopAndFrameURLs("https://example.com/"_s, "https://example.com/"_s, "https://webkit.org/"_s, ResourceType::TopDocument, { URL { "https://webkit.org/"_s }, URL { "https://whatwg.org/"_s } }), { variantIndex<BlockCookiesAction> });
+    testRequest(otherRulesWithConditions, requestInTopAndFrameURLs("https://example.com/"_s, "https://example.com/"_s, "https://whatwg.org/"_s, ResourceType::TopDocument, { URL { "https://webkit.org/"_s }, URL { "https://whatwg.org/"_s } }), { variantIndex<BlockLoadAction>, variantIndex<BlockCookiesAction> });
+
+    auto matchingEverything = makeBackend("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"https\", \"if-frame-url\":[\".*\"]}}]"_s);
+    testRequest(matchingEverything, requestInTopAndFrameURLs("https://example.com/"_s, "https://webkit.org/"_s, "https://whatwg.org/"_s, ResourceType::TopDocument, { URL { "https://webkit.org/"_s }, URL { "https://whatwg.org/"_s } }), { variantIndex<BlockLoadAction> });
+    testRequest(matchingEverything, requestInTopAndFrameURLs("http://example.com/"_s, "https://webkit.org/"_s, "https://webkit.org/"_s, ResourceType::TopDocument, { URL { "https://webkit.org/"_s }, URL { "https://whatwg.org/"_s } }), { });
 }
 
 TEST_F(ContentExtensionTest, RegexSubstitution)


### PR DESCRIPTION
#### ff2947d460d20c3c54097e4af20185854a6481d8
<pre>
dNR: fix sub_frame resourceType allowAllRequests rules
<a href="https://bugs.webkit.org/show_bug.cgi?id=295043">https://bugs.webkit.org/show_bug.cgi?id=295043</a>
<a href="https://rdar.apple.com/154124673">rdar://154124673</a>

Reviewed by NOBODY (OOPS!).

This patch re-introduces the fixes that were made to fix sub_frame resourceType allowAllRequests
rules, which were reverted because they wouldn&apos;t work with site isolation. Now, instead of assuming
local frames when traversing the frame hierarchy, we use the frame&apos;s URL origin, which is also
available for remote frames. The downside to this is that sub_frame resourceType allowAllRequests
rules that want to filter based on other parts of the URL won&apos;t work. I&apos;ve filed:

dNR: allowAllRequests with sub_frame resource type will only work with a URL filter acting on the
origin of the URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=296294">https://bugs.webkit.org/show_bug.cgi?id=296294</a>

Otherwise, this patch is exactly the same as before.

Also see:
<a href="https://bugs.webkit.org/show_bug.cgi?id=295541">https://bugs.webkit.org/show_bug.cgi?id=295541</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=295036">https://bugs.webkit.org/show_bug.cgi?id=295036</a>

* Source/WebCore/contentextensions/ContentExtensionCompiler.cpp:
* Source/WebCore/contentextensions/ContentExtensionParser.cpp:
* Source/WebCore/contentextensions/ContentExtensionRule.h:
* Source/WebCore/contentextensions/ContentExtensionsBackend.cpp:
* Source/WebCore/loader/ResourceLoadInfo.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm:
* Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff2947d460d20c3c54097e4af20185854a6481d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112616 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32348 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22826 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118815 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63146 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114578 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40911 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85709 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36366 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115563 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26336 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101305 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66014 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25632 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19442 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62574 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95725 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19517 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122036 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39690 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29564 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94576 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40073 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97543 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94313 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39431 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17233 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35778 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39578 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45066 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39216 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42550 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40956 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->