### PR TITLE
Apply zoom to root-font-relative units during style resolution

### DIFF
--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
@@ -397,7 +397,7 @@ double computeNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, cons
     // We do not apply the zoom factor when we are computing the value of the font-size property. The zooming
     // for font sizes is much more complicated, since we have to worry about enforcing the minimum font size preference
     // as well as enforcing the implicit "smart minimum."
-    if (conversionData.computingFontSize() || isFontOrRootFontRelativeLength(lengthUnit))
+    if (conversionData.computingFontSize())
         return value;
 
     return value * conversionData.zoom();


### PR DESCRIPTION
#### 531d0f9b44f9
<pre>
Apply zoom to root-font-relative units during style resolution

Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

DO NOT REVIEW. TESTING WHAT BREAKS.

Currently, all relative units (including rem/rlh) skip zoom application
during style resolution. This forces zoom to be applied inconsistently
across different call sites, making the code error-prone
and difficult to maintain.

This change removes the blanket exclusion of relative units from zoom
application, allowing relative unit lengths to be zoomed during style building
while preserving the special handling for font size.

The exclusion of all relative units was introduced a decade ago.
97032@main
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/531d0f9b44f95567e05ed348c0862f63d91de654

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112630 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32362 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22840 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118829 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63152 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114592 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40925 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85715 "Found 19 new test failures: css3/calc/zoom-with-em.html fast/backgrounds/background-position-parsing.html fast/css/clip-zooming.html fast/css/line-height-basics.html fast/css/preserve-user-specified-zoom-level-on-reload.html fast/multicol/span/anonymous-style-inheritance.html fast/sub-pixel/zoomed-em-border.html fast/transforms/bounding-rect-zoom.html fast/transforms/transforms-with-zoom.html imported/w3c/web-platform-tests/css/css-viewport/zoom/relative-units.html ... (failure)") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36375 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115577 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26346 "Found 13 new test failures: css3/calc/zoom-with-em.html fast/backgrounds/background-position-parsing.html fast/css/clip-zooming.html fast/css/line-height-basics.html fast/css/preserve-user-specified-zoom-level-on-reload.html fast/forms/listbox-hit-test-zoomed.html fast/forms/search/search-zoom-computed-style-height.html fast/multicol/span/anonymous-style-inheritance.html fast/sub-pixel/zoomed-em-border.html fast/transforms/bounding-rect-zoom.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101313 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66022 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25641 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19450 "Found 21 new test failures: css3/calc/zoom-with-em.html fast/backgrounds/background-position-parsing.html fast/css/clip-zooming.html fast/css/line-height-basics.html fast/css/preserve-user-specified-zoom-level-on-reload.html fast/multicol/span/anonymous-style-inheritance.html fast/repaint/spanner-with-margin.html fast/sub-pixel/zoomed-em-border.html fast/transforms/bounding-rect-zoom.html fast/transforms/transforms-with-zoom.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62588 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95732 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19525 "Found 20 new test failures: css3/calc/zoom-with-em.html fast/backgrounds/background-position-parsing.html fast/css/clip-zooming.html fast/css/line-height-basics.html fast/css/preserve-user-specified-zoom-level-on-reload.html fast/multicol/span/anonymous-style-inheritance.html fast/repaint/spanner-with-margin.html fast/sub-pixel/zoomed-em-border.html fast/transforms/bounding-rect-zoom.html fast/transforms/transforms-with-zoom.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122050 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39704 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29576 "Found 20 new test failures: css3/calc/zoom-with-em.html fast/backgrounds/background-position-parsing.html fast/css/clip-zooming.html fast/css/line-height-basics.html fast/css/preserve-user-specified-zoom-level-on-reload.html fast/multicol/span/anonymous-style-inheritance.html fast/repaint/spanner-with-margin.html fast/sub-pixel/zoomed-em-border.html fast/transforms/bounding-rect-zoom.html fast/transforms/transforms-with-zoom.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94583 "Found 20 new test failures: css3/calc/zoom-with-em.html fast/css/clip-zooming.html fast/css/line-height-basics.html fast/css/preserve-user-specified-zoom-level-on-reload.html fast/forms/listbox-hit-test-zoomed.html fast/forms/search/search-zoom-computed-style-height.html fast/multicol/span/anonymous-style-inheritance.html fast/repaint/spanner-with-margin.html fast/sub-pixel/zoomed-em-border.html fast/transforms/bounding-rect-zoom.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40087 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97551 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94324 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39441 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17241 "Found 20 new test failures: css3/calc/zoom-with-em.html fast/backgrounds/background-position-parsing.html fast/css/clip-zooming.html fast/css/line-height-basics.html fast/css/preserve-user-specified-zoom-level-on-reload.html fast/multicol/span/anonymous-style-inheritance.html fast/repaint/spanner-with-margin.html fast/sub-pixel/zoomed-em-border.html fast/transforms/bounding-rect-zoom.html fast/transforms/transforms-with-zoom.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35792 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39592 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45080 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39231 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42564 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40970 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->