### PR TITLE
Implement _WKSerializedNode for more Node types

### DIFF
--- a/Source/WebCore/dom/Attr.cpp
+++ b/Source/WebCore/dom/Attr.cpp
@@ -119,6 +119,18 @@ Ref<Node> Attr::cloneNodeInternal(Document& document, CloningOperation, CustomEl
     return adoptRef(*new Attr(document, qualifiedName(), value()));
 }
 
+SerializedNode Attr::serializeNode(CloningOperation) const
+{
+    return {
+        SerializedNode::Attr {
+            prefix(),
+            localName(),
+            namespaceURI(),
+            value()
+        }
+    };
+}
+
 CSSStyleProperties* Attr::style()
 {
     // This is not part of the DOM API, and therefore not available to webpages. However, WebKit SPI
@@ -154,11 +166,6 @@ void Attr::attachToElement(Element& element)
     m_element = element;
     m_standaloneValue = nullAtom();
     setTreeScopeRecursively(element.treeScope());
-}
-
-SerializedNode Attr::serializeNode(CloningOperation) const
-{
-    return { };
 }
 
 }

--- a/Source/WebCore/dom/CDATASection.cpp
+++ b/Source/WebCore/dom/CDATASection.cpp
@@ -53,7 +53,7 @@ Ref<Node> CDATASection::cloneNodeInternal(Document& document, CloningOperation, 
 
 SerializedNode CDATASection::serializeNode(CloningOperation) const
 {
-    return { };
+    return { SerializedNode::CDATASection { data() } };
 }
 
 Ref<Text> CDATASection::virtualCreate(String&& data)

--- a/Source/WebCore/dom/Comment.cpp
+++ b/Source/WebCore/dom/Comment.cpp
@@ -52,7 +52,7 @@ Ref<Node> Comment::cloneNodeInternal(Document& document, CloningOperation, Custo
 
 SerializedNode Comment::serializeNode(CloningOperation) const
 {
-    return { };
+    return { SerializedNode::Comment { data() } };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5469,7 +5469,8 @@ Ref<Node> Document::cloneNodeInternal(Document&, CloningOperation type, CustomEl
 
 SerializedNode Document::serializeNode(CloningOperation) const
 {
-    return { };
+    // FIXME: Implement.
+    return { SerializedNode::Document { } };
 }
 
 Ref<Document> Document::cloneDocumentWithoutChildren() const

--- a/Source/WebCore/dom/DocumentFragment.cpp
+++ b/Source/WebCore/dom/DocumentFragment.cpp
@@ -134,7 +134,8 @@ Element* DocumentFragment::getElementById(const AtomString& id) const
 
 SerializedNode DocumentFragment::serializeNode(CloningOperation) const
 {
-    return { };
+    // FIXME: Implement.
+    return { SerializedNode::DocumentFragment { } };
 }
 
 }

--- a/Source/WebCore/dom/DocumentType.cpp
+++ b/Source/WebCore/dom/DocumentType.cpp
@@ -53,7 +53,7 @@ Ref<Node> DocumentType::cloneNodeInternal(Document& document, CloningOperation, 
 
 SerializedNode DocumentType::serializeNode(CloningOperation) const
 {
-    return { };
+    return { SerializedNode::DocumentType { m_name, m_publicId, m_systemId } };
 }
 
 }

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -638,7 +638,8 @@ Ref<Node> Element::cloneNodeInternal(Document& document, CloningOperation type, 
 
 SerializedNode Element::serializeNode(CloningOperation) const
 {
-    return { };
+    // FIXME: Implement.
+    return { SerializedNode::Element { } };
 }
 
 void Element::cloneShadowTreeIfPossible(Element& newHost, CustomElementRegistry* registry) const

--- a/Source/WebCore/dom/ProcessingInstruction.cpp
+++ b/Source/WebCore/dom/ProcessingInstruction.cpp
@@ -83,7 +83,7 @@ Ref<Node> ProcessingInstruction::cloneNodeInternal(Document& document, CloningOp
 
 SerializedNode ProcessingInstruction::serializeNode(CloningOperation) const
 {
-    return { };
+    return { SerializedNode::ProcessingInstruction { { data() }, m_target } };
 }
 
 void ProcessingInstruction::checkStyleSheet()

--- a/Source/WebCore/dom/SerializedNode.h
+++ b/Source/WebCore/dom/SerializedNode.h
@@ -30,7 +30,43 @@
 namespace WebCore {
 
 struct SerializedNode {
-    String text;
+    struct Attr {
+        String prefix;
+        String localName;
+        String namespaceURI;
+        String value;
+    };
+    struct Document {
+        // FIXME: Implement.
+    };
+    struct DocumentFragment {
+        // FIXME: Implement.
+    };
+    struct DocumentType {
+        String name;
+        String publicId;
+        String systemId;
+    };
+    struct Element {
+        // FIXME: Implement.
+    };
+    struct ShadowRoot {
+        // FIXME: Implement.
+    };
+    struct HTMLTemplateElement {
+        // FIXME: Implement.
+    };
+    struct CharacterData {
+        String data;
+    };
+    struct Comment : public CharacterData { };
+    struct Text : public CharacterData { };
+    struct CDATASection : public Text { };
+    struct ProcessingInstruction : public CharacterData {
+        String target;
+    };
+
+    Variant<Attr, CDATASection, Comment, Document, DocumentFragment, DocumentType, Element, ProcessingInstruction, ShadowRoot, Text, HTMLTemplateElement> data;
 };
 
 }

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -303,7 +303,8 @@ Ref<Node> ShadowRoot::cloneNodeInternal(Document& document, CloningOperation typ
 
 SerializedNode ShadowRoot::serializeNode(CloningOperation) const
 {
-    return { };
+    // FIXME: Implement.
+    return { SerializedNode::ShadowRoot { } };
 }
 
 void ShadowRoot::removeAllEventListeners()

--- a/Source/WebCore/dom/Text.cpp
+++ b/Source/WebCore/dom/Text.cpp
@@ -159,7 +159,7 @@ Ref<Node> Text::cloneNodeInternal(Document& document, CloningOperation, CustomEl
 
 SerializedNode Text::serializeNode(CloningOperation) const
 {
-    return { data() };
+    return { SerializedNode::Text { data() } };
 }
 
 static bool isSVGShadowText(const Text& text)

--- a/Source/WebCore/html/HTMLTemplateElement.cpp
+++ b/Source/WebCore/html/HTMLTemplateElement.cpp
@@ -130,7 +130,8 @@ Ref<Node> HTMLTemplateElement::cloneNodeInternal(Document& document, CloningOper
 
 SerializedNode HTMLTemplateElement::serializeNode(CloningOperation) const
 {
-    return { };
+    // FIXME: Implement.
+    return { SerializedNode::HTMLTemplateElement { } };
 }
 
 void HTMLTemplateElement::didMoveToNewDocument(Document& oldDocument, Document& newDocument)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -9222,6 +9222,40 @@ header: <WebCore/ScriptTrackingPrivacyCategory.h>
     FormControls,
 };
 
+[Nested] struct WebCore::SerializedNode::Attr {
+    String prefix;
+    String localName;
+    String namespaceURI;
+    String value;
+};
+[Nested] struct WebCore::SerializedNode::CharacterData {
+    String data;
+};
+[Nested] struct WebCore::SerializedNode::Document {
+};
+[Nested] struct WebCore::SerializedNode::DocumentFragment {
+};
+[Nested] struct WebCore::SerializedNode::DocumentType {
+    String name;
+    String publicId;
+    String systemId;
+};
+[Nested] struct WebCore::SerializedNode::Element {
+};
+[Nested] struct WebCore::SerializedNode::Comment : WebCore::SerializedNode::CharacterData {
+};
+[Nested] struct WebCore::SerializedNode::Text : WebCore::SerializedNode::CharacterData {
+};
+[Nested] struct WebCore::SerializedNode::CDATASection : WebCore::SerializedNode::Text {
+};
+[Nested] struct WebCore::SerializedNode::ProcessingInstruction : WebCore::SerializedNode::CharacterData {
+    String target;
+};
+[Nested] struct WebCore::SerializedNode::ShadowRoot {
+};
+[Nested] struct WebCore::SerializedNode::HTMLTemplateElement {
+};
+
 struct WebCore::SerializedNode {
-    String text;
+    Variant<WebCore::SerializedNode::Attr, WebCore::SerializedNode::CDATASection, WebCore::SerializedNode::Comment, WebCore::SerializedNode::Document, WebCore::SerializedNode::DocumentFragment, WebCore::SerializedNode::DocumentType, WebCore::SerializedNode::Element, WebCore::SerializedNode::ProcessingInstruction, WebCore::SerializedNode::ShadowRoot, WebCore::SerializedNode::Text, WebCore::SerializedNode::HTMLTemplateElement> data;
 }


### PR DESCRIPTION
#### 90a2c4a82bf83409efba2236f83be47eca99fa51
<pre>
Implement _WKSerializedNode for more Node types
<a href="https://bugs.webkit.org/show_bug.cgi?id=296299">https://bugs.webkit.org/show_bug.cgi?id=296299</a>
<a href="https://rdar.apple.com/156350776">rdar://156350776</a>

Reviewed by Ryosuke Niwa.

This expands from just Text nodes to all the nodes that
are easy to implement serialization of.

* Source/WebCore/dom/Attr.cpp:
(WebCore::Attr::serializeNode const):
* Source/WebCore/dom/CDATASection.cpp:
(WebCore::CDATASection::serializeNode const):
* Source/WebCore/dom/Comment.cpp:
(WebCore::Comment::serializeNode const):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::serializeNode const):
* Source/WebCore/dom/DocumentFragment.cpp:
(WebCore::DocumentFragment::serializeNode const):
* Source/WebCore/dom/DocumentType.cpp:
(WebCore::DocumentType::serializeNode const):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::serializeNode const):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::deserializeNode):
* Source/WebCore/dom/ProcessingInstruction.cpp:
(WebCore::ProcessingInstruction::serializeNode const):
* Source/WebCore/dom/SerializedNode.h:
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::serializeNode const):
* Source/WebCore/dom/Text.cpp:
(WebCore::Text::serializeNode const):
* Source/WebCore/html/HTMLTemplateElement.cpp:
(WebCore::HTMLTemplateElement::serializeNode const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NodeInfo.mm:
(TestWebKitAPI::TEST(SerializedNode, Basic)):

Canonical link: <a href="https://commits.webkit.org/297722@main">https://commits.webkit.org/297722@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e49a2cb14bb91cdcdff2e70d44edb23baa70df18

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112650 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32382 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22860 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118849 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63124 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114612 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33034 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40945 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85727 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36352 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115597 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26356 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101333 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66035 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25651 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19469 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62608 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95743 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19544 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122070 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39724 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29595 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94592 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40107 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97570 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94334 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39451 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17259 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35812 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18141 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39612 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45100 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39251 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42584 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40990 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->