### PR TITLE
[Writing Tools] Support semantic HTML lists as input to Writing Tools

### DIFF
--- a/Source/WebCore/editing/cocoa/EditingHTMLConverter.h
+++ b/Source/WebCore/editing/cocoa/EditingHTMLConverter.h
@@ -40,6 +40,7 @@ enum class IncludedElement : uint8_t {
     Attachments = 1 << 1,
     PreservedContent = 1 << 2,
     NonRenderedContent = 1 << 3,
+    TextLists = 1 << 4,
 };
 
 WEBCORE_EXPORT AttributedString editingAttributedString(const SimpleRange&, OptionSet<IncludedElement> = { IncludedElement::Images });

--- a/Source/WebCore/page/writing-tools/WritingToolsController.mm
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.mm
@@ -207,6 +207,7 @@ void WritingToolsController::willBeginWritingToolsSession(const std::optional<Wr
         IncludedElement::Attachments,
         IncludedElement::PreservedContent,
         IncludedElement::NonRenderedContent,
+        IncludedElement::TextLists,
     };
 
     auto selectedTextRange = document->selection().selection().firstRange();

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -28,6 +28,7 @@ WKWebViewConfigurationExtras.mm
 
 cocoa/CGImagePixelReader.cpp
 cocoa/DaemonTestUtilities.mm
+cocoa/DecomposedAttributedText.mm
 cocoa/DragAndDropSimulator.mm
 cocoa/HostWindowManager.mm
 cocoa/ImageAnalysisTestingUtilities.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -744,9 +744,9 @@
 		A14FC58B1B89927100D107EB /* ContentFilteringPlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = A14FC5891B89927100D107EB /* ContentFilteringPlugIn.mm */; };
 		A170E3AA2ABA7857009EA799 /* VectorCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = A170E3A22ABA7857009EA799 /* VectorCocoa.mm */; };
 		A17191AD2CD2DB090088944E /* WKWebViewLogging.mm in Sources */ = {isa = PBXBuildFile; fileRef = A17191AC2CD2DB090088944E /* WKWebViewLogging.mm */; };
-		A176D24B2D6D2A4E00C63915 /* GPUExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2472D6D295400C63915 /* GPUExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		A176D24C2D6D2A4E00C63915 /* NetworkingExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2482D6D295400C63915 /* NetworkingExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		A176D24D2D6D2A4E00C63915 /* WebContentExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2492D6D295400C63915 /* WebContentExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A176D24B2D6D2A4E00C63915 /* GPUExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2472D6D295400C63915 /* GPUExtension.appex */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A176D24C2D6D2A4E00C63915 /* NetworkingExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2482D6D295400C63915 /* NetworkingExtension.appex */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A176D24D2D6D2A4E00C63915 /* WebContentExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2492D6D295400C63915 /* WebContentExtension.appex */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A1798B7F22431D2B000764BD /* libWebCoreTestSupport.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = A1798B7E22431D2B000764BD /* libWebCoreTestSupport.dylib */; };
 		A1798B8522433647000764BD /* WebProcessPlugInWithInternals.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1798B8422433647000764BD /* WebProcessPlugInWithInternals.mm */; };
 		A17991881E1C994E00A505ED /* SharedBuffer.mm in Sources */ = {isa = PBXBuildFile; fileRef = A17991861E1C994E00A505ED /* SharedBuffer.mm */; };
@@ -2463,6 +2463,8 @@
 		0799C34A1EBA32F4003B7532 /* disableGetUserMedia.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = disableGetUserMedia.html; sourceTree = "<group>"; };
 		079D45F12A2A6BBE003830C7 /* Viewport.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = Viewport.mm; sourceTree = "<group>"; };
 		07A1DFFC2E2C1F20004E5C66 /* SwiftUI+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwiftUI+Extras.swift"; sourceTree = "<group>"; };
+		07A1E0222E2EB852004E5C66 /* DecomposedAttributedText.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DecomposedAttributedText.h; path = cocoa/DecomposedAttributedText.h; sourceTree = "<group>"; };
+		07A1E0232E2EB852004E5C66 /* DecomposedAttributedText.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = DecomposedAttributedText.mm; path = cocoa/DecomposedAttributedText.mm; sourceTree = "<group>"; };
 		07C02FD12D6D6FBC0004ED97 /* rtl-sideways-scrolling.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "rtl-sideways-scrolling.html"; sourceTree = "<group>"; };
 		07C046C91E42573E007201E7 /* CARingBufferTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CARingBufferTest.cpp; sourceTree = "<group>"; };
 		07CC7DFD2266330800E39181 /* MediaBufferingPolicy.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MediaBufferingPolicy.mm; sourceTree = "<group>"; };
@@ -4583,6 +4585,8 @@
 				5C157A082717C56600ED5280 /* DaemonTestUtilities.h */,
 				5C157A072717C56600ED5280 /* DaemonTestUtilities.mm */,
 				F47DFB2721A885E700021FB6 /* DataDetectorsCoreSPI.h */,
+				07A1E0222E2EB852004E5C66 /* DecomposedAttributedText.h */,
+				07A1E0232E2EB852004E5C66 /* DecomposedAttributedText.mm */,
 				F46128B4211C861A00D9FADB /* DragAndDropSimulator.h */,
 				3302A64D2A11B4410093FA2A /* DragAndDropSimulator.mm */,
 				F44D06481F3962E3001A0E29 /* EditingTestHarness.h */,

--- a/Tools/TestWebKitAPI/cocoa/DecomposedAttributedText.h
+++ b/Tools/TestWebKitAPI/cocoa/DecomposedAttributedText.h
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#import <wtf/ObjectIdentifier.h>
+#import <wtf/Variant.h>
+#import <wtf/Vector.h>
+#import <wtf/text/TextStream.h>
+#import <wtf/text/WTFString.h>
+
+@class NSAttributedString;
+
+struct _DecomposedAttributedTextBold;
+struct _DecomposedAttributedTextItalic;
+struct _DecomposedAttributedTextOrderedList;
+struct _DecomposedAttributedTextUnorderedList;
+
+struct DecomposedAttributedText {
+    enum class ListMarker: uint8_t {
+        Circle,
+        Decimal,
+        Disc,
+        LowercaseRoman,
+    };
+
+    enum class ListIDTag { };
+    using ListID = ObjectIdentifier<ListIDTag>;
+
+    using Bold = _DecomposedAttributedTextBold;
+    using Italic = _DecomposedAttributedTextItalic;
+    using OrderedList = _DecomposedAttributedTextOrderedList;
+    using UnorderedList = _DecomposedAttributedTextUnorderedList;
+
+    using Element = Variant<Bold, Italic, OrderedList, UnorderedList, String>;
+
+    Vector<Element> children;
+};
+
+struct _DecomposedAttributedTextBold {
+    Vector<DecomposedAttributedText::Element> children;
+
+    explicit _DecomposedAttributedTextBold(Vector<DecomposedAttributedText::Element>&& children)
+        : children(children)
+    {
+    }
+};
+
+struct _DecomposedAttributedTextItalic {
+    Vector<DecomposedAttributedText::Element> children;
+
+    explicit _DecomposedAttributedTextItalic(Vector<DecomposedAttributedText::Element>&& children)
+        : children(children)
+    {
+    }
+};
+
+struct _DecomposedAttributedTextOrderedList {
+    DecomposedAttributedText::ListID identifier { MarkableTraits<DecomposedAttributedText::ListID>::emptyValue() };
+    DecomposedAttributedText::ListMarker marker { DecomposedAttributedText::ListMarker::Decimal };
+    int startingItemNumber { 1 };
+    Vector<DecomposedAttributedText::Element> children;
+
+    explicit _DecomposedAttributedTextOrderedList(const DecomposedAttributedText::ListID& identifier)
+        : identifier(identifier)
+    {
+    }
+
+    _DecomposedAttributedTextOrderedList(int startingItemNumber, DecomposedAttributedText::ListMarker marker, Vector<DecomposedAttributedText::Element>&& children)
+        : marker(marker)
+        , startingItemNumber(startingItemNumber), children(children)
+    {
+    }
+
+    explicit _DecomposedAttributedTextOrderedList(Vector<DecomposedAttributedText::Element>&& children)
+        : children(children)
+    {
+    }
+};
+
+struct _DecomposedAttributedTextUnorderedList {
+    DecomposedAttributedText::ListID identifier { MarkableTraits<DecomposedAttributedText::ListID>::emptyValue() };
+    DecomposedAttributedText::ListMarker marker { DecomposedAttributedText::ListMarker::Disc };
+    Vector<DecomposedAttributedText::Element> children;
+
+    explicit _DecomposedAttributedTextUnorderedList(const DecomposedAttributedText::ListID& identifier)
+        : identifier(identifier)
+    {
+    }
+
+    _DecomposedAttributedTextUnorderedList(DecomposedAttributedText::ListMarker marker, Vector<DecomposedAttributedText::Element>&& children)
+        : marker(marker)
+        , children(children)
+    {
+    }
+
+    explicit _DecomposedAttributedTextUnorderedList(Vector<DecomposedAttributedText::Element>&& children)
+        : children(children)
+    {
+    }
+};
+
+DecomposedAttributedText decompose(NSAttributedString *);
+
+TextStream& operator<<(TextStream&, const DecomposedAttributedText::ListMarker&);
+
+TextStream& operator<<(TextStream&, const DecomposedAttributedText::Bold&);
+
+TextStream& operator<<(TextStream&, const DecomposedAttributedText::Italic&);
+
+TextStream& operator<<(TextStream&, const DecomposedAttributedText::OrderedList&);
+
+TextStream& operator<<(TextStream&, const DecomposedAttributedText::UnorderedList&);
+
+TextStream& operator<<(TextStream&, const DecomposedAttributedText&);
+
+bool operator==(const DecomposedAttributedText::Bold&, const DecomposedAttributedText::Bold&);
+
+bool operator==(const DecomposedAttributedText::Italic&, const DecomposedAttributedText::Italic&);
+
+bool operator==(const DecomposedAttributedText::OrderedList&, const DecomposedAttributedText::OrderedList&);
+
+bool operator==(const DecomposedAttributedText::UnorderedList&, const DecomposedAttributedText::UnorderedList&);
+
+bool operator==(const DecomposedAttributedText&, const DecomposedAttributedText&);
+
+

--- a/Tools/TestWebKitAPI/cocoa/DecomposedAttributedText.mm
+++ b/Tools/TestWebKitAPI/cocoa/DecomposedAttributedText.mm
@@ -1,0 +1,214 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "DecomposedAttributedText.h"
+
+#import <wtf/cocoa/VectorCocoa.h>
+
+static DecomposedAttributedText::ListMarker convertMarker(NSTextListMarkerFormat marker)
+{
+    if ([marker isEqualToString:NSTextListMarkerDecimal])
+        return DecomposedAttributedText::ListMarker::Decimal;
+    if ([marker isEqualToString:NSTextListMarkerDisc])
+        return DecomposedAttributedText::ListMarker::Disc;
+    if ([marker isEqualToString:NSTextListMarkerCircle])
+        return DecomposedAttributedText::ListMarker::Circle;
+    if ([marker isEqualToString:NSTextListMarkerLowercaseRoman])
+        return DecomposedAttributedText::ListMarker::LowercaseRoman;
+
+    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("unexpected marker type %@", marker);
+}
+
+#if PLATFORM(MAC)
+using PlatformFont = NSFont;
+using PlatformFontDescriptorSymbolicTraits = NSFontDescriptorSymbolicTraits;
+
+constexpr auto PlatformFontDescriptorTraitBold = NSFontDescriptorTraitBold;
+constexpr auto PlatformFontDescriptorTraitItalic = NSFontDescriptorTraitItalic;
+#else
+using PlatformFont = UIFont;
+using PlatformFontDescriptorSymbolicTraits = UIFontDescriptorSymbolicTraits;
+
+constexpr auto PlatformFontDescriptorTraitBold = UIFontDescriptorTraitBold;
+constexpr auto PlatformFontDescriptorTraitItalic = UIFontDescriptorTraitItalic;
+#endif
+
+static void decomposeChildren(HashMap<NSTextList *, DecomposedAttributedText::ListID>& textListToIdentifiers, NSDictionary<NSAttributedStringKey, id> *attributes, size_t index, Vector<DecomposedAttributedText::Element>& children, NSString *text)
+{
+    RetainPtr<NSArray<NSTextList *>> textLists = [attributes[NSParagraphStyleAttributeName] textLists];
+    RetainPtr<PlatformFont> font = attributes[NSFontAttributeName];
+
+    if (!textLists || index == [textLists count]) {
+        PlatformFontDescriptorSymbolicTraits traits = [font fontDescriptor].symbolicTraits;
+
+        DecomposedAttributedText::Element child = text;
+        if (traits & PlatformFontDescriptorTraitBold)
+            child = DecomposedAttributedText::Bold { { child } };
+        if (traits & PlatformFontDescriptorTraitItalic)
+            child = DecomposedAttributedText::Italic { { child } };
+
+        children.append(child);
+        return;
+    }
+
+    auto textList = [textLists objectAtIndex:index];
+    if (textListToIdentifiers.find(textList) == textListToIdentifiers.end()) {
+        auto identifier = DecomposedAttributedText::ListID::generate();
+        textListToIdentifiers.set(textList, identifier);
+
+        std::optional<DecomposedAttributedText::Element> element;
+
+        if (textList.isOrdered) {
+            DecomposedAttributedText::OrderedList list { identifier };
+            list.startingItemNumber = textList.startingItemNumber;
+            list.marker = convertMarker(textList.markerFormat);
+            element = list;
+        } else {
+            DecomposedAttributedText::UnorderedList list { identifier };
+            list.marker = convertMarker(textList.markerFormat);
+            element = list;
+        }
+
+        children.append(*element);
+    }
+
+    auto listID = textListToIdentifiers.get(textList);
+    for (auto& child : children) {
+        if (auto *ul = std::get_if<DecomposedAttributedText::UnorderedList>(&child); ul && ul->identifier == listID)
+            decomposeChildren(textListToIdentifiers, attributes, index + 1, ul->children, text);
+        else if (auto *ol = std::get_if<DecomposedAttributedText::OrderedList>(&child); ol && ol->identifier == listID)
+            decomposeChildren(textListToIdentifiers, attributes, index + 1, ol->children, text);
+    }
+}
+
+using Runs = Vector<std::pair<NSString *, NSDictionary<NSAttributedStringKey, id> *>>;
+
+DecomposedAttributedText decomposeAttributedTextRuns(const Runs& runs)
+{
+    HashMap<NSTextList *, DecomposedAttributedText::ListID> listToId;
+    Vector<DecomposedAttributedText::Element> children;
+
+    for (const auto& [text, attributes] : runs)
+        decomposeChildren(listToId, attributes, 0, children, text);
+
+    return { children };
+}
+
+Runs runsForAttributedText(NSAttributedString *string)
+{
+    __block Runs allTextAttributes;
+    [string enumerateAttributesInRange:NSMakeRange(0, [string length]) options:0 usingBlock:^(NSDictionary<NSAttributedStringKey, id> *attributes, NSRange range, BOOL *) {
+        RetainPtr trimmedSubstring = [[[string string] substringWithRange:range] stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+        allTextAttributes.append(std::pair { trimmedSubstring, attributes });
+    }];
+    return allTextAttributes;
+}
+
+DecomposedAttributedText decompose(NSAttributedString *string)
+{
+    return decomposeAttributedTextRuns(runsForAttributedText(string));
+}
+
+bool operator==(const DecomposedAttributedText::OrderedList& lhs, const DecomposedAttributedText::OrderedList& rhs)
+{
+    return lhs.marker == rhs.marker && lhs.startingItemNumber == rhs.startingItemNumber && lhs.children == rhs.children;
+}
+
+bool operator==(const DecomposedAttributedText::UnorderedList& lhs, const DecomposedAttributedText::UnorderedList& rhs)
+{
+    return lhs.marker == rhs.marker && lhs.children == rhs.children;
+}
+
+bool operator==(const DecomposedAttributedText::Bold& lhs, const DecomposedAttributedText::Bold& rhs)
+{
+    return lhs.children == rhs.children;
+}
+
+bool operator==(const DecomposedAttributedText::Italic& lhs, const DecomposedAttributedText::Italic& rhs)
+{
+    return lhs.children == rhs.children;
+}
+
+bool operator==(const DecomposedAttributedText& lhs, const DecomposedAttributedText& rhs)
+{
+    return lhs.children == rhs.children;
+}
+
+TextStream& operator<<(TextStream& stream, const DecomposedAttributedText::Bold& value)
+{
+    stream << "b";
+    stream.dumpProperty("children", value.children);
+    return stream;
+}
+
+TextStream& operator<<(TextStream& stream, const DecomposedAttributedText::Italic& value)
+{
+    stream << "i";
+    stream.dumpProperty("children", value.children);
+    return stream;
+}
+
+TextStream& operator<<(TextStream& stream, const DecomposedAttributedText::OrderedList& value)
+{
+    stream << "ol";
+    stream.dumpProperty("marker", value.marker);
+    stream.dumpProperty("start", value.startingItemNumber);
+    stream.dumpProperty("children", value.children);
+    return stream;
+}
+
+TextStream& operator<<(TextStream& stream, const DecomposedAttributedText::UnorderedList& value)
+{
+    stream << "ul";
+    stream.dumpProperty("marker", value.marker);
+    stream.dumpProperty("children", value.children);
+    return stream;
+}
+
+TextStream& operator<<(TextStream& stream, const DecomposedAttributedText& value)
+{
+    stream << value.children;
+    return stream;
+}
+
+TextStream& operator<<(TextStream& stream, const DecomposedAttributedText::ListMarker& value)
+{
+    switch (value) {
+    case DecomposedAttributedText::ListMarker::Circle:
+        stream << "circle";
+        break;
+    case DecomposedAttributedText::ListMarker::Decimal:
+        stream << "decimal";
+        break;
+    case DecomposedAttributedText::ListMarker::Disc:
+        stream << "disc";
+        break;
+    case DecomposedAttributedText::ListMarker::LowercaseRoman:
+        stream << "lowercase-roman";
+        break;
+    }
+    return stream;
+}


### PR DESCRIPTION
#### 86b2ec59d30c53e20e5ba5fbe434a2a2b0e3004a
<pre>
[Writing Tools] Support semantic HTML lists as input to Writing Tools
<a href="https://bugs.webkit.org/show_bug.cgi?id=296301">https://bugs.webkit.org/show_bug.cgi?id=296301</a>
<a href="https://rdar.apple.com/146968196">rdar://146968196</a>

Reviewed by Wenson Hsieh.

When gathering the text context for Writing Tools, the resulting NSAttributedString needs
to have its relevant paragraph styles marked with NSTextLists so that Writing Tools can understand
that the content has lists in it and can preserve them.

To facilitate this, a new option is added to EditingHTMLConverter which enables extracting NSTextLists.
This is done by recursively traversing upwards from each element to find the containing list elements,
and then convert them to NSTextLists. The algorithm also employs caching and memoization to optimize
the amount of traversals needed.

* Source/WebCore/editing/cocoa/EditingHTMLConverter.h:

Add a `TextLists` option so that clients can opt-in to this new behavior.

* Source/WebCore/editing/cocoa/EditingHTMLConverter.mm:
(WebCore::enclosingElement):
(WebCore::enclosingLinkElement):
(WebCore::enclosingListElement):

Generalize the `enclosingLinkElement` function so that it can be reused for any arbitrary predicate,
in this case for determining if something is a list element or not.

(WebCore::associateElementWithTextLists):

The primary function used to do the extraction using a recursive algorithm; the output of the algorithm
is mutations to the `textListsForListElements` parameter. More details can be found in the inline comments.

(WebCore::updateAttributes):
(WebCore::editingAttributedStringInternal):

Modify the paragraph style of the attributes to account for the NSTextLists.

* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::WritingToolsController::willBeginWritingToolsSession):

Use the `TextLists` option.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:
(htmlToAttributedString):
(runTest):
(TEST(WritingToolsContextGeneration, ContextWithBasicOrderedList)):
(ContextWithCustomizedOrderedList)):
((WritingToolsContextGeneration, ContextWithNestedLists)):
((WritingToolsContextGeneration, ContextWithDiscontiguousLists)):
((WritingToolsContextGeneration, ContextWithBasicUnorderedList)):
((WritingToolsContextGeneration, ContextWithStyledContentChildrenInList)):

Add a lot of tests in a unique test suite for validation of the algorithm for different content.

* Tools/TestWebKitAPI/cocoa/DecomposedAttributedText.h: Added.
(_DecomposedAttributedTextBold::_DecomposedAttributedTextBold):
(_DecomposedAttributedTextItalic::_DecomposedAttributedTextItalic):
(_DecomposedAttributedTextOrderedList::_DecomposedAttributedTextOrderedList):
(_DecomposedAttributedTextUnorderedList::_DecomposedAttributedTextUnorderedList):
* Tools/TestWebKitAPI/cocoa/DecomposedAttributedText.mm: Added.
(convertMarker):
(decomposeChildren):
(decomposeAttributedTextRuns):
(runsForAttributedText):
(decompose):
(operator==):
(operator&lt;&lt;):

Add a testing mechanism to make it easier to compare HTML string converted to an NSAttributedString
value, and some expected value expressed as an HTML-like structure DSL.

Canonical link: <a href="https://commits.webkit.org/297769@main">https://commits.webkit.org/297769@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b3351e86b957c076dd367bd03d56f20dfd65b1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112718 "12 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22928 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118917 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63214 "Built successfully") | [✅ 🛠 ios-apple](https://apple.com) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114680 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33102 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41013 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85792 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36430 "") | [⏳ 🛠 mac-apple ](url) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115665 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26414 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101402 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66094 "Found 141 new API test failures: /WPE/TestLoaderClient:/webkit/WebKitWebView/loading-status, /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification, /WPE/TestWebKitFindController:/webkit/WebKitFindController/options, /WPE/TestLoaderClient:/webkit/WebKitWebView/reload, /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/script-message-received, /WPE/TestWebKitWebView:/webkit/WebKitWebView/run-javascript, /WPE/TestWebKitWebView:/webkit/WebKitWebView/disable-web-security, /WPE/TestLoaderClient:/webkit/WebKitWebView/load-plain-text, /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification-initial-permission-allowed, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme ... (failure)") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25719 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19532 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62676 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95813 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19609 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122138 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39792 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29665 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94657 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40175 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97635 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94394 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24109 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39509 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17319 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35895 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39680 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45181 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39319 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42652 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41058 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->