### PR TITLE
REGRESSION(296716@main): Switching focused form field with tab key crashes the web content process

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -4056,8 +4056,9 @@ void UnifiedPDFPlugin::setActiveAnnotation(SetActiveAnnotationParams&& setActive
                 return;
             }
 
-            m_activeAnnotation = PDFPluginAnnotation::create(annotation.get(), this);
-            protectedActiveAnnotation()->attach(m_annotationContainer.get());
+            RefPtr newActiveAnnotation = PDFPluginAnnotation::create(annotation.get(), this);
+            newActiveAnnotation->attach(m_annotationContainer.get());
+            m_activeAnnotation = WTFMove(newActiveAnnotation);
             revealAnnotation(protectedActiveAnnotation()->annotation());
         } else
             m_activeAnnotation = nullptr;

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -912,6 +912,7 @@
 		A17C46F62C98E54B0023F3C7 /* test-without-audio-track.mp4 in Copy Resources */ = {isa = PBXBuildFile; fileRef = C95984F61E36BCD7002C0D45 /* test-without-audio-track.mp4 */; };
 		A17C46F72C98E54B0023F3C7 /* test.mp4 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 524BBCA019E30C63002F1AF1 /* test.mp4 */; };
 		A17C46F82C98E54B0023F3C7 /* test.pdf in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7AE9E5081AE5AE8B00CF874B /* test.pdf */; };
+		A17C46F92C98E54B0023F3C8 /* test_form.pdf in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7AE9E5091AE5AE8B00CF874C /* test_form.pdf */; };
 		A17C46F92C98E54B0023F3C7 /* test.xml in Copy Resources */ = {isa = PBXBuildFile; fileRef = 44D3F8422BE1DAD800BE0218 /* test.xml */; };
 		A17C46FA2C98E54B0023F3C7 /* UserInstalledAhem.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1C51534B261596BD00FBC4FE /* UserInstalledAhem.html */; };
 		A17C46FB2C98E54B0023F3C7 /* video-with-play-button.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C9C9A91C21DED79400FDE96E /* video-with-play-button.html */; };
@@ -2295,6 +2296,7 @@
 				A17C480A2C98E5C20023F3C7 /* test.pages in Copy Resources */,
 				A17C46F82C98E54B0023F3C7 /* test.pdf in Copy Resources */,
 				A17C46F92C98E54B0023F3C7 /* test.xml in Copy Resources */,
+				A17C46F92C98E54B0023F3C8 /* test_form.pdf in Copy Resources */,
 				A17C47012C98E58C0023F3C7 /* test_print.pdf in Copy Resources */,
 				A17C480B2C98E5C20023F3C7 /* TestModalContainerControls.mlmodelc in Copy Resources */,
 				A17C480C2C98E5C20023F3C7 /* text-and-password-inputs.html in Copy Resources */,
@@ -3343,6 +3345,7 @@
 		7AC7B57220D9BAF0002C09A0 /* CustomBundleObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CustomBundleObject.h; sourceTree = "<group>"; };
 		7AD3FE8D1D75FB8D00B169A4 /* TransformationMatrix.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TransformationMatrix.cpp; sourceTree = "<group>"; };
 		7AE9E5081AE5AE8B00CF874B /* test.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = test.pdf; sourceTree = "<group>"; };
+		7AE9E5091AE5AE8B00CF874C /* test_form.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = test_form.pdf; sourceTree = "<group>"; };
 		7AEAD47C1E20113800416EFE /* CrossPartitionFileSchemeAccess.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CrossPartitionFileSchemeAccess.mm; sourceTree = "<group>"; };
 		7AEAD47D1E20114E00416EFE /* CrossPartitionFileSchemeAccess.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = CrossPartitionFileSchemeAccess.html; path = Tests/mac/CrossPartitionFileSchemeAccess.html; sourceTree = SOURCE_ROOT; };
 		7AFEA30F2CB838FF007EFE75 /* element-targeting-11.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "element-targeting-11.html"; sourceTree = "<group>"; };
@@ -6530,6 +6533,7 @@
 				524BBCA019E30C63002F1AF1 /* test.mp4 */,
 				7AE9E5081AE5AE8B00CF874B /* test.pdf */,
 				44D3F8422BE1DAD800BE0218 /* test.xml */,
+				7AE9E5091AE5AE8B00CF874C /* test_form.pdf */,
 				1C51534B261596BD00FBC4FE /* UserInstalledAhem.html */,
 				C9C9A91C21DED79400FDE96E /* video-with-play-button.html */,
 				07CD32F72065B72A0064A4BE /* video.html */,

--- a/Tools/TestWebKitAPI/Tests/WebKit/test_form.pdf
+++ b/Tools/TestWebKitAPI/Tests/WebKit/test_form.pdf
@@ -1,0 +1,163 @@
+%PDF-1.4
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<</Type /Encoding /Differences [24 /breve /caron /circumflex /dotaccent /hungarumlaut /ogonek /ring /tilde 39 /quotesingle 96 /grave 128 /bullet /dagger /daggerdbl /ellipsis /emdash /endash /florin /fraction /guilsinglleft /guilsinglright /minus /perthousand /quotedblbase /quotedblleft /quotedblright /quoteleft /quoteright /quotesinglbase /trademark /fi /fl /Lslash /OE /Scaron /Ydieresis /Zcaron /dotlessi /lslash /oe /scaron /zcaron 160 /Euro 164 /currency 166 /brokenbar 168 /dieresis /copyright /ordfeminine 172 /logicalnot /.notdef /registered /macron /degree /plusminus /twosuperior /threesuperior /acute /mu 183 /periodcentered /cedilla /onesuperior /ordmasculine 188 /onequarter /onehalf /threequarters 192 /Agrave /Aacute /Acircumflex /Atilde /Adieresis /Aring /AE /Ccedilla /Egrave /Eacute /Ecircumflex /Edieresis /Igrave /Iacute /Icircumflex /Idieresis /Eth /Ntilde /Ograve /Oacute /Ocircumflex /Otilde /Odieresis /multiply /Oslash /Ugrave /Uacute /Ucircumflex /Udieresis /Yacute /Thorn /germandbls /agrave /aacute /acircumflex /atilde /adieresis /aring /ae /ccedilla /egrave /eacute /ecircumflex /edieresis /igrave /iacute /icircumflex /idieresis /eth /ntilde /ograve /oacute /ocircumflex /otilde /odieresis /divide /oslash /ugrave /uacute /ucircumflex /udieresis /yacute /thorn /ydieresis]>>
+endobj
+4 0 obj
+<< /BaseFont /Helvetica /Subtype /Type1 /Name /Helv /Type /Font /Encoding 3 0 R >>
+endobj
+5 0 obj
+<<
+/BBox [ 0 0 200 20 ] /Filter [ /FlateDecode ] /FormType 1 /Length 143 /Matrix [ 1 0 0 1 0 0 ] /Resources << /ProcSet [/PDF /Text] /Font <</Helv 4 0 R>> >> 
+  /Subtype /Form /Type /XObject
+>>
+stream
+xœM±Â0D÷ûŠû‚§¤$+êÔ„ÄĞ.‰v€ÏÇN¨ÄàËI¹w²]¢Kû†Âe‚§gğ6\îá¢—NÌ¦™HÎ›I”¤&lOPUîC.XMÎÕQ´æŒÿ-cY@xé5÷†w‘6¿İhÅîúáqèˆW)‘ÜRZûºá©´ĞãŒÓĞá4½*Úendstream
+endobj
+6 0 obj
+<<
+/AP <<
+/N 5 0 R
+>> /BS <<
+/S /I /W 1
+>> /DA (/Helv 12 Tf 0 0 0 rg) /DV () /F 4 /FT /Tx 
+  /Ff 0 /MK <<
+/BC [ 0 0 1 ] /BG [ .8 .843 1 ]
+>> /MaxLen 100 /P 13 0 R /Rect [ 150 250 350 270 ] /Subtype /Widget 
+  /T (firstName) /TU (Enter your first name) /Type /Annot /V ()
+>>
+endobj
+7 0 obj
+<< /BaseFont /Helvetica /Subtype /Type1 /Name /Helv /Type /Font /Encoding 3 0 R >>
+endobj
+8 0 obj
+<<
+/BBox [ 0 0 200 20 ] /Filter [ /FlateDecode ] /FormType 1 /Length 143 /Matrix [ 1 0 0 1 0 0 ] /Resources << /ProcSet [/PDF /Text] /Font <</Helv 7 0 R>> >> 
+  /Subtype /Form /Type /XObject
+>>
+stream
+xœM±Â0D÷ûŠû‚§¤$+êÔ„ÄĞ.‰v€ÏÇN¨ÄàËI¹w²]¢Kû†Âe‚§gğ6\îá¢—NÌ¦™HÎ›I”¤&lOPUîC.XMÎÕQ´æŒÿ-cY@xé5÷†w‘6¿İhÅîúáqèˆW)‘ÜRZûºá©´ĞãŒÓĞá4½*Úendstream
+endobj
+9 0 obj
+<<
+/AP <<
+/N 8 0 R
+>> /BS <<
+/S /I /W 1
+>> /DA (/Helv 12 Tf 0 0 0 rg) /DV () /F 4 /FT /Tx 
+  /Ff 0 /MK <<
+/BC [ 0 0 1 ] /BG [ .8 .843 1 ]
+>> /MaxLen 100 /P 13 0 R /Rect [ 150 200 350 220 ] /Subtype /Widget 
+  /T (lastName) /TU (Enter your last name) /Type /Annot /V ()
+>>
+endobj
+10 0 obj
+<< /BaseFont /Helvetica /Subtype /Type1 /Name /Helv /Type /Font /Encoding 3 0 R >>
+endobj
+11 0 obj
+<<
+/BBox [ 0 0 200 20 ] /Filter [ /FlateDecode ] /FormType 1 /Length 143 /Matrix [ 1 0 0 1 0 0 ] /Resources << /ProcSet [/PDF /Text] /Font <</Helv 10 0 R>> >> 
+  /Subtype /Form /Type /XObject
+>>
+stream
+xœM±Â0D÷ûŠû‚§¤$+êÔ„ÄĞ.‰v€ÏÇN¨ÄàËI¹w²]¢Kû†Âe‚§gğ6\îá¢—NÌ¦™HÎ›I”¤&lOPUîC.XMÎÕQ´æŒÿ-cY@xé5÷†w‘6¿İhÅîúáqèˆW)‘ÜRZûºá©´ĞãŒÓĞá4½*Úendstream
+endobj
+12 0 obj
+<<
+/AP <<
+/N 11 0 R
+>> /BS <<
+/S /I /W 1
+>> /DA (/Helv 12 Tf 0 0 0 rg) /DV () /F 4 /FT /Tx 
+  /Ff 0 /MK <<
+/BC [ 0 0 1 ] /BG [ .8 .843 1 ]
+>> /MaxLen 100 /P 13 0 R /Rect [ 150 150 350 170 ] /Subtype /Widget 
+  /T (email) /TU (Enter your email address) /Type /Annot /V ()
+>>
+endobj
+13 0 obj
+<<
+/Annots [ 6 0 R 9 0 R 12 0 R ] /Contents 17 0 R /MediaBox [ 0 0 500 400 ] /Parent 16 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 
+  /Trans <<
+
+>> /Type /Page
+>>
+endobj
+14 0 obj
+<<
+/AcroForm 18 0 R /PageMode /UseNone /Pages 16 0 R /Type /Catalog
+>>
+endobj
+15 0 obj
+<<
+/Author (Abrar Rahman Protyasha) /CreationDate (D:20250721142044-07'00') /Creator (Abrar Rahman Protyasha) /Keywords () /ModDate (D:20250721142044-07'00') /Producer (Abrar Rahman Protyasha) 
+  /Subject (Test PDF Form) /Title (Test PDF Form) /Trapped /False
+>>
+endobj
+16 0 obj
+<<
+/Count 1 /Kids [ 13 0 R ] /Type /Pages
+>>
+endobj
+17 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 277
+>>
+stream
+Gatmt6#+:k&4Q=S`EtN0W#EWmm4:ukCeSQ#/g).E<JVV=S)jD\MG)`6kb:Mi_#2/u1EqYE./(X]V8?_2+:6SM;P$5*fI6HY5K1:nnt+<da97g&Pf&,/rIELBL$IaT!pTcN9IVdi.7K8]&)0THF6WsH],nC"N7Z<^0*Z8YUUB6on+ho/7)f(mo(aW2X:KZlBP1?Z_O8f\:C6'Hh1E*fj#M@U0#QW)=U3(PcQH_qU'Lp@:aU#QdlAILl[Mfi?^3I>\T-=Es/;^'$c,"-LKf9#~>endstream
+endobj
+18 0 obj
+<<
+/DA (/Helv 0 Tf 0 g) /DR << /Encoding
+<<
+/RLAFencoding
+3 0 R
+>>
+/Font << /Helv 4 0 R >>
+>> /Fields [ 6 0 R 9 0 R 12 0 R ]
+>>
+endobj
+xref
+0 19
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000001533 00000 n 
+0000001631 00000 n 
+0000002000 00000 n 
+0000002289 00000 n 
+0000002387 00000 n 
+0000002756 00000 n 
+0000003043 00000 n 
+0000003142 00000 n 
+0000003513 00000 n 
+0000003803 00000 n 
+0000004030 00000 n 
+0000004117 00000 n 
+0000004414 00000 n 
+0000004475 00000 n 
+0000004843 00000 n 
+trailer
+<<
+/ID 
+[<6ccbfd8906c6e4ce6270db4571a7d6f3><6ccbfd8906c6e4ce6270db4571a7d6f3>]
+
+/Info 15 0 R
+/Root 14 0 R
+/Size 19
+>>
+startxref
+4987
+%%EOF


### PR DESCRIPTION
#### ed72822eba9f67168aee76fec20ea54c91561b78
<pre>
REGRESSION(296716@main): Switching focused form field with tab key crashes the web content process
<a href="https://bugs.webkit.org/show_bug.cgi?id=296302">https://bugs.webkit.org/show_bug.cgi?id=296302</a>
<a href="https://rdar.apple.com/156352236">rdar://156352236</a>

Reviewed by Wenson Hsieh and Megan Gardner.

296716@main revealed a fault in how we swapped the active annotation for
a new one when switching focus. When a form annotation is in focus and a
tab key is pressed, the following sequence occurs:
- The existing annotation calls UnifiedPDFPlugin::focusNextAnnotation().
- The plugin sets a new active annotation, i.e. the one that should be
  focused post tab key, and attaches it to the annotation container.
- A change event is fired on the previous active annotation, which is
  still alive because we are still under the previous annotation&apos;s
  PDFPluginAnnotation::handleEvent() stack.
- The change event is handled by clearing out the active annotation in
  the plugin. However, this is no longer the _old_ active annotation we
  want to be clearing out.
- At the end of this sequence, m_activeAnnotation == nullptr in the
  plugin, and we crash with a null dereference whenever we use the
  annotation.

This patch fixes the crash by performing the second step on a temporary
annotation instance without replacing the plugin&apos;s active annotation.
Only after the temporary annotation is attached to the annotation
container can we safely swap the active annotation.

API test: UnifiedPDF.TabKeyOnPDFTextFieldShouldNotCrash

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::setActiveAnnotation):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/test_form.pdf: Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm:
(TestWebKitAPI::UNIFIED_PDF_TEST):

Canonical link: <a href="https://commits.webkit.org/297720@main">https://commits.webkit.org/297720@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19115abc0ba8d314e4ecb4afe68e7182261c683a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112635 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; check-webkit-style") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32367 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22845 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118834 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63106 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114597 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33019 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40930 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85718 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36339 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115582 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26349 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101323 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66025 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/112067 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25644 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19460 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62593 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95736 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19535 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122055 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39709 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29584 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94587 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40092 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97561 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94328 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39445 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17251 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/35797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18140 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39597 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45085 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39236 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42569 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40975 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->