### PR TITLE
AX: Dynamic page changes to iframes can cause their scroll-view to be set as the root, blocking assistive technologies from accessing the rest of the page content

### DIFF
--- a/LayoutTests/accessibility/mac/invalid-tree-root-at-iframe-expected.txt
+++ b/LayoutTests/accessibility/mac/invalid-tree-root-at-iframe-expected.txt
@@ -1,0 +1,12 @@
+This test ensures the scrollview of an iframe doesn't become the root of the tree after dynamic page changes.
+
+PASS: root.childAtIndex(0).role.toLowerCase().includes('webarea') === true
+PASS: webAreaText.includes('main-page-web-area') === true
+PASS: !webAreaText.includes('iframe-web-area') === true
+PASS: webAreaText.includes('main-page-web-area') === true
+PASS: !webAreaText.includes('iframe-web-area') === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/invalid-tree-root-at-iframe.html
+++ b/LayoutTests/accessibility/mac/invalid-tree-root-at-iframe.html
@@ -1,0 +1,82 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html aria-label="main-page-web-area">
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+
+<iframe id="iframe" onload="runTest()" aria-hidden="true" srcdoc="
+    <html aria-label='iframe-web-area'>
+        <button>Inside iframe</button>
+    </html>"
+>
+</iframe>
+<input id="checkbox" type="checkbox">
+
+<script>
+var output = "This test ensures the scrollview of an iframe doesn't become the root of the tree after dynamic page changes.\n\n";
+
+var webAreaText;
+function verifyWebAreaText() {
+    output += expect("webAreaText.includes('main-page-web-area')", "true");
+    output += expect("!webAreaText.includes('iframe-web-area')", "true");
+}
+
+var root;
+function runTest() {
+    window.jsTestIsAsync = true;
+    if (!window.accessibilityController)
+        return;
+
+    var gotCheckedNotification = false;
+    window.accessibilityController.addNotificationListener(function (target, notification) {
+        if (target && target.role.toLowerCase().includes("checkbox") && notification === "AXValueChanged")
+            gotCheckedNotification = true;
+    });
+
+    root = accessibilityController.rootElement;
+    touchAccessibilityTree(root);
+
+    output += expect("root.childAtIndex(0).role.toLowerCase().includes('webarea')", "true");
+    // Should include "main-page-web-area", indicating we're looking at the top-most web area for the page.
+    webAreaText = platformTextAlternatives(root.childAtIndex(0));
+    verifyWebAreaText();
+
+    setTimeout(async function() {
+        // Wait for page rendering to be complete in case it's not done yet.
+        await UIHelper.renderingUpdate();
+
+        // Make the object and all descendants become unignored. This causes a full-node update for this and all descendants
+        // in the isolated tree. The scroll-area descendant is the particular object we're trying to target, as if we behave
+        // incorrectly, when we create a node change for it in AXIsolatedTree::nodeChangeForObject, we will set it as the root.
+        document.getElementById("iframe").setAttribute("aria-hidden", "false");
+        // Force the iframe to lose its renderer. The bug this test was written for was caused by an iframe's scroll-area
+        // not returning a parent because it had no renderer, thus causing some of our code to think it was the root.
+        document.getElementById("iframe").style.display = "contents";
+        // Force layout to drop the renderer right now.
+        document.getElementById("checkbox").offsetHeight;
+        // Wait for the render tree update to be complete.
+        await UIHelper.renderingUpdate();
+
+        // Perform an action that will cause a platform notification to be posted, which will trigger an eager flush of
+        // any pending isolated tree updates (i.e. those queued up by the aria-hidden change).
+        document.getElementById("checkbox").checked = true;
+        // Assume that the isolated tree has been updated by the time the checked notification was disbursed to us.
+        await waitFor(() => gotCheckedNotification);
+        accessibilityController.removeNotificationListener();
+
+        // Ensure the root didn't get updated to an invalid value (the iframe scroll-area).
+        root = accessibilityController.rootElement;
+        webAreaText = platformTextAlternatives(root.childAtIndex(0));
+        verifyWebAreaText();
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -2882,8 +2882,8 @@ void AXObjectCache::handleRoleChanged(Element& element, const AtomString& oldVal
         return;
 
     // The class of an AX object created for an Element depends on the role attribute of that Element.
-    // Thus when the role changes, remove the existing AX object and force a ChildrenChanged on the parent so that the object is re-created.
-    // At the moment this is done only for table and row roles. Other roles may be added here if needed.
+    // Thus when the role changes, remove the existing AX object and force a ChildrenChanged on the parent
+    // so that the object is re-created.
     if (oldValue.isEmpty() || isTableOrRowRole(oldValue)
         || newValue.isEmpty() || isTableOrRowRole(newValue)) {
         if (auto* parent = object->parentObject()) {

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -693,12 +693,12 @@ public:
     WEBCORE_EXPORT static bool isIsolatedTreeEnabled();
     WEBCORE_EXPORT static void initializeAXThreadIfNeeded();
     WEBCORE_EXPORT static bool isAXThreadInitialized();
+    WEBCORE_EXPORT RefPtr<AXIsolatedTree> getOrCreateIsolatedTree();
 private:
     static bool clientSupportsIsolatedTree();
     // Propagates the root of the isolated tree back into the Core and WebKit.
     void setIsolatedTree(Ref<AXIsolatedTree>);
     void setIsolatedTreeFocusedObject(AccessibilityObject*);
-    RefPtr<AXIsolatedTree> getOrCreateIsolatedTree();
     void buildIsolatedTree();
     void updateIsolatedTree(AccessibilityObject&, AXNotification);
     void updateIsolatedTree(AccessibilityObject*, AXNotification);

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -123,6 +123,8 @@ public:
     bool isMediaTimeline() const { return false; }
     virtual bool isSliderThumb() const { return false; }
     bool isLabel() const { return isAccessibilityLabelInstance() || labelForObjects().size(); }
+    // FIXME: Re-evaluate what this means when site isolation is enabled (is this method name accurate?)
+    virtual bool isRoot() const { return false; }
 
     std::optional<InputType::Type> inputType() const final;
 

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -41,8 +41,8 @@ namespace WebCore {
     
 AccessibilityScrollView::AccessibilityScrollView(AXID axID, ScrollView& view)
     : AccessibilityObject(axID)
-    , m_scrollView(view)
     , m_childrenDirty(false)
+    , m_scrollView(view)
 {
     if (RefPtr localFrameView = dynamicDowncast<LocalFrameView>(view))
         m_frameOwnerElement = localFrameView->frame().ownerElement();
@@ -51,6 +51,26 @@ AccessibilityScrollView::AccessibilityScrollView(AXID axID, ScrollView& view)
 AccessibilityScrollView::~AccessibilityScrollView()
 {
     ASSERT(isDetached());
+}
+
+bool AccessibilityScrollView::isRoot() const
+{
+    RefPtr frameView = dynamicDowncast<FrameView>(m_scrollView.get());
+    return frameView && frameView->frame().isMainFrame();
+}
+
+String AccessibilityScrollView::ownerDebugDescription() const
+{
+    if (!m_frameOwnerElement) {
+        StringBuilder builder;
+        builder.append("null frame owner"_s);
+        if (isRoot())
+            builder.append(" (root)"_s);
+        return builder.toString();
+    }
+
+    CheckedPtr renderer = m_frameOwnerElement->renderer();
+    return renderer ? renderer->debugDescription() : m_frameOwnerElement->debugDescription();
 }
 
 void AccessibilityScrollView::detachRemoteParts(AccessibilityDetachmentType detachmentType)

--- a/Source/WebCore/accessibility/AccessibilityScrollView.h
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.h
@@ -49,6 +49,8 @@ public:
 
     RefPtr<AXRemoteFrame> remoteFrame() const { return m_remoteFrame; }
 
+    String ownerDebugDescription() const;
+
 private:
     explicit AccessibilityScrollView(AXID, ScrollView&);
     void detachRemoteParts(AccessibilityDetachmentType) final;
@@ -61,6 +63,7 @@ private:
     bool isEnabled() const final { return true; }
     bool hasRemoteFrameChild() const final { return m_remoteFrame; }
 
+    bool isRoot() const final;
     bool isAttachment() const final;
     PlatformWidget platformWidget() const final;
     Widget* widgetForAttachmentView() const final { return currentScrollView(); }
@@ -85,11 +88,11 @@ private:
     AccessibilityScrollbar* addChildScrollbar(Scrollbar*);
     void removeChildScrollbar(AccessibilityObject*);
 
+    bool m_childrenDirty;
     SingleThreadWeakPtr<ScrollView> m_scrollView;
     WeakPtr<HTMLFrameOwnerElement, WeakPtrImplWithEventTargetData> m_frameOwnerElement;
     RefPtr<AccessibilityObject> m_horizontalScrollbar;
     RefPtr<AccessibilityObject> m_verticalScrollbar;
-    bool m_childrenDirty;
     RefPtr<AXRemoteFrame> m_remoteFrame;
 };
     

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -211,9 +211,9 @@ void AXIsolatedTree::storeTree(AXObjectCache& cache, const Ref<AXIsolatedTree>& 
 {
     ASSERT(isMainThread());
 
-    // Once we set this tree in the AXTreeStore, the secondary thread can start using it,
-    // and we can no longer access AXIsolatedTree::rootNode off the main-thread. Set the
-    // root now while we still can.
+    // Once we've added this new tree to the AXTreeStore, clients will be able to use
+    // it off the main-thread. Make any final state mutations while we are the only thread
+    // that can touch this tree.
     cache.setIsolatedTree(tree);
     AXTreeStore::set(tree->treeID(), tree.ptr());
     tree->m_replacingTree = nullptr;
@@ -308,7 +308,7 @@ std::optional<AXIsolatedTree::NodeChange> AXIsolatedTree::nodeChangeForObject(Re
     m_nodeMap.set(axObject->objectID(), ParentChildrenIDs { parentID, data.childrenIDs });
     NodeChange nodeChange { WTFMove(data), axObject->wrapper() };
 
-    if (!parentID && axObject->isScrollView())
+    if (axObject->isRoot())
         setPendingRootNodeID(axObject->objectID());
     return nodeChange;
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFramePrivate.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFramePrivate.h
@@ -56,7 +56,7 @@ WK_EXPORT void WKBundleFrameFocus(WKBundleFrameRef frame);
 
 WK_EXPORT void _WKBundleFrameGenerateTestReport(WKBundleFrameRef, WKStringRef message, WKStringRef group);
 
-WK_EXPORT void* WKAccessibilityRootObject(WKBundleFrameRef frame);
+WK_EXPORT void* _WKAccessibilityRootObjectForTesting(WKBundleFrameRef frame);
 
 #ifdef __cplusplus
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityController.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityController.cpp
@@ -104,7 +104,10 @@ bool AccessibilityController::enhancedAccessibilityEnabled()
 
 Ref<AccessibilityUIElement> AccessibilityController::rootElement(JSContextRef context)
 {
-    auto root = static_cast<PlatformUIElement>(WKAccessibilityRootObject(WKBundleFrameForJavaScriptContext(context)));
+    PlatformUIElement root;
+    executeOnAXThreadAndWait([&] () {
+        root = static_cast<PlatformUIElement>(_WKAccessibilityRootObjectForTesting(WKBundleFrameForJavaScriptContext(context)));
+    });
     return AccessibilityUIElement::create(root);
 }
 

--- a/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityControllerAtspi.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityControllerAtspi.cpp
@@ -63,7 +63,7 @@ static WebCore::AccessibilityObjectAtspi* findAccessibleObjectById(WebCore::Acce
 
 RefPtr<AccessibilityUIElement> AccessibilityController::accessibleElementById(JSContextRef context, JSStringRef id)
 {
-    auto* rootObject = static_cast<WebCore::AccessibilityObjectAtspi*>(WKAccessibilityRootObject(WKBundleFrameForJavaScriptContext(context)));
+    auto* rootObject = static_cast<WebCore::AccessibilityObjectAtspi*>(_WKAccessibilityRootObjectForTesting(WKBundleFrameForJavaScriptContext(context)));
     if (!rootObject)
         return nullptr;
 
@@ -85,13 +85,13 @@ void AccessibilityController::injectAccessibilityPreference(JSStringRef domain, 
 
 Ref<AccessibilityUIElement> AccessibilityController::rootElement(JSContextRef context)
 {
-    auto* element = static_cast<WebCore::AccessibilityObjectAtspi*>(WKAccessibilityRootObject(WKBundleFrameForJavaScriptContext(context)));
+    auto* element = static_cast<WebCore::AccessibilityObjectAtspi*>(_WKAccessibilityRootObjectForTesting(WKBundleFrameForJavaScriptContext(context)));
     return AccessibilityUIElement::create(element);
 }
 
 RefPtr<AccessibilityUIElement> AccessibilityController::focusedElement(JSContextRef context)
 {
-    if (!WKAccessibilityRootObject(WKBundleFrameForJavaScriptContext(context)))
+    if (!_WKAccessibilityRootObjectForTesting(WKBundleFrameForJavaScriptContext(context)))
         return nullptr;
 
     WKBundlePageRef page = InjectedBundle::singleton().page()->page();

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityControllerIOS.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityControllerIOS.mm
@@ -41,7 +41,7 @@ namespace WTR {
 
 RefPtr<AccessibilityUIElement> AccessibilityController::focusedElement(JSContextRef context)
 {
-    PlatformUIElement root = static_cast<PlatformUIElement>(WKAccessibilityRootObject(WKBundleFrameForJavaScriptContext(context)));
+    PlatformUIElement root = static_cast<PlatformUIElement>(_WKAccessibilityRootObjectForTesting(WKBundleFrameForJavaScriptContext(context)));
     auto rootElement = AccessibilityUIElement::create(root);
     return rootElement->focusedElement();
 }
@@ -101,7 +101,7 @@ void AccessibilityController::injectAccessibilityPreference(JSStringRef, JSStrin
 
 RefPtr<AccessibilityUIElement> AccessibilityController::accessibleElementById(JSContextRef context, JSStringRef idAttribute)
 {
-    PlatformUIElement root = static_cast<PlatformUIElement>(WKAccessibilityRootObject(WKBundleFrameForJavaScriptContext(context)));
+    PlatformUIElement root = static_cast<PlatformUIElement>(_WKAccessibilityRootObjectForTesting(WKBundleFrameForJavaScriptContext(context)));
 
     id result = findAccessibleObjectById(root, [NSString stringWithJSStringRef:idAttribute]);
     if (result)

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm
@@ -59,7 +59,7 @@ void AccessibilityController::platformInitialize()
 
 RefPtr<AccessibilityUIElement> AccessibilityController::focusedElement(JSContextRef context)
 {
-    if (!WKAccessibilityRootObject(WKBundleFrameForJavaScriptContext(context)))
+    if (!_WKAccessibilityRootObjectForTesting(WKBundleFrameForJavaScriptContext(context)))
         return nullptr;
 
     RetainPtr<PlatformUIElement> focus;
@@ -134,7 +134,7 @@ void AccessibilityController::injectAccessibilityPreference(JSStringRef domain, 
 
 RefPtr<AccessibilityUIElement> AccessibilityController::accessibleElementById(JSContextRef context, JSStringRef idAttribute)
 {
-    PlatformUIElement root = static_cast<PlatformUIElement>(WKAccessibilityRootObject(WKBundleFrameForJavaScriptContext(context)));
+    PlatformUIElement root = static_cast<PlatformUIElement>(_WKAccessibilityRootObjectForTesting(WKBundleFrameForJavaScriptContext(context)));
 
     NSString *attributeName = [NSString stringWithJSStringRef:idAttribute];
     RetainPtr<id> result;
@@ -170,7 +170,7 @@ void AccessibilityController::overrideClient(JSStringRef clientType)
 
 void AccessibilityController::printTrees(JSContextRef context)
 {
-    PlatformUIElement root = static_cast<PlatformUIElement>(WKAccessibilityRootObject(WKBundleFrameForJavaScriptContext(context)));
+    PlatformUIElement root = static_cast<PlatformUIElement>(_WKAccessibilityRootObjectForTesting(WKBundleFrameForJavaScriptContext(context)));
     [root accessibilityPerformAction:@"AXLogTrees"];
 }
 


### PR DESCRIPTION
#### 6e9e17c1ad698a1bd5cb4989dc395f55df73f426
<pre>
AX: Dynamic page changes to iframes can cause their scroll-view to be set as the root, blocking assistive technologies from accessing the rest of the page content
<a href="https://bugs.webkit.org/show_bug.cgi?id=296298">https://bugs.webkit.org/show_bug.cgi?id=296298</a>
<a href="https://rdar.apple.com/156348748">rdar://156348748</a>

Reviewed by Joshua Hoffman.

Prior to <a href="https://commits.webkit.org/297651@main">https://commits.webkit.org/297651@main</a>, it was possible for an iframe&apos;s scroll-area child to be set as the
root of the isolated tree, preventing assistive technologies from accessing content outside of the iframe. This was
the sequence that caused this to happen:

  1. The iframe initially has a renderer, and is added to the isolated tree through normal means

  2. The iframe loses its renderer, e.g. via dynamic `display` change to `contents` or `none`

  3. Immediately after, something causes the scroll view child of the iframe to be queued up for a full isolated node
     update. One way this could happen is aria-hidden becoming false on the iframe, which would cause some or all descendants
     of the iframe to become unignored, which currently queues a full node update.

  4. Something initiates a flush of queued isolated tree updates, e.g. we are about to post a notification and need to
     flush queued updates to ensure we serve the request with an up-to-date tree.

  5. We run AXIsolatedTree::nodeChangeForObject. Because AccessibilityScrollView::parentObject used to return nullptr
     whenever its associated m_frameOwnerElement had no renderer, our scroll-view node change queued in step 3 thinks
     it has no parent. Prior to this commit, nodeChangeForObject used this as a signal that this was the root object,
     and set this iframe scroll-view as the root.

<a href="https://commits.webkit.org/297651@main">https://commits.webkit.org/297651@main</a> fixed this by making AccessibilityScrollView::parentObject more resilient. This
commit further strengthens our logic here by creating an explicit AccessibilityScrollView::isRoot() function, and using
that in nodeChangeForObject.

In order to test this, WKAccessibilityRootObject needed changes, as it always used the main-thread to get the root object,
meaning it wasn&apos;t ever actually testing the root that real clients see. This commit makes WKAccessibilityRootObject
threadsafe, and updates AccessibilityController::rootElement to call that function on the AX thread when available.
This commit also makes the fact that WKAccessibilityRootObject should only be used for testing explicit by renaming it
to _WKAccessibilityRootObjectForTesting. I did this because making this function threadsafe requires a synchronous main-thread
hit to use the AXObjectCache. Synchronous main-thread hits are OK for testing, but not for real clients, so this renaming
makes it clear that we don&apos;t need to try to move this usage off the main-thread.

With this new testing fixture in place, the added layout test (accessibility/mac/invalid-tree-root-at-iframe.html)
reproduced the bug 100% of the time.

This commit also cleans up a couple incorrect comments that confused me while debugging this issue (one in
AXObjectCache::handleRoleChanged and another in AXIsolatedTree::storeTree).

* LayoutTests/accessibility/mac/invalid-tree-root-at-iframe-expected.txt: Added.
* LayoutTests/accessibility/mac/invalid-tree-root-at-iframe.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::handleRoleChanged):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AccessibilityObject.h:
(WebCore::AccessibilityObject::isRoot const):
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::AccessibilityScrollView):
(WebCore::AccessibilityScrollView::isRoot const):
(WebCore::AccessibilityScrollView::ownerDebugDescription const):
* Source/WebCore/accessibility/AccessibilityScrollView.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::storeTree):
(WebCore::AXIsolatedTree::nodeChangeForObject):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp:
(_WKAccessibilityRootObjectForTesting):
(WKAccessibilityRootObject): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFramePrivate.h:
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityController.cpp:
(WTR::AccessibilityController::rootElement):
* Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityControllerAtspi.cpp:
(WTR::AccessibilityController::accessibleElementById):
(WTR::AccessibilityController::rootElement):
(WTR::AccessibilityController::focusedElement):
* Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityControllerIOS.mm:
(WTR::AccessibilityController::focusedElement):
(WTR::AccessibilityController::accessibleElementById):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm:
(WTR::AccessibilityController::focusedElement):
(WTR::AccessibilityController::accessibleElementById):
(WTR::AccessibilityController::printTrees):

Canonical link: <a href="https://commits.webkit.org/297755@main">https://commits.webkit.org/297755@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ae2ea4a403e5f6cc6aed49527e61fb712152ff7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112706 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22916 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118905 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63201 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114668 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33090 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41001 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85781 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36421 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115653 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26407 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101397 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66089 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25706 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19527 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62664 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95810 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19604 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122126 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39780 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29650 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94643 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40163 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97630 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94385 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24104 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39501 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17315 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35880 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39668 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45156 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39307 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42640 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41046 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->